### PR TITLE
[3r] Make all db entity operation static and composeable

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/src/Context.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Context.res.hbs
@@ -1,6 +1,6 @@
 type entityGetters = {
 {{#each entities as | entity |}}
- get{{entity.name.capitalized}}: Types.id => promise<array<Types.{{entity.name.uncapitalized}}Entity>>,
+ get{{entity.name.capitalized}}: Types.id => promise<array<Entities.{{entity.name.capitalized}}.t>>,
 {{/each}}
 }
 

--- a/codegenerator/cli/templates/dynamic/codegen/src/EventProcessing.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/EventProcessing.res.hbs
@@ -177,9 +177,11 @@ let eventRouter = (
   }
 }
 
+let readEntity = (entityMod, id) => Entities.batchRead(DbFunctions.sql, [id], ~entityMod)
+
 let asyncGetters: Context.entityGetters = {
 {{#each entities as | entity |}}
- get{{entity.name.capitalized}}: id => DbFunctions.{{entity.name.capitalized}}.readEntities(DbFunctions.sql, [id]),
+ get{{entity.name.capitalized}}: readEntity(module(Entities.{{entity.name.capitalized}}), ...),
 {{/each}}
 }
 

--- a/codegenerator/cli/templates/dynamic/codegen/src/IO.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/IO.res.hbs
@@ -164,7 +164,7 @@ module InMemoryStore = {
   {{#each entities as | entity |}}
 
   module {{entity.name.capitalized}} = MakeStoreEntity({
-    type t = Types.{{entity.name.uncapitalized}}Entity
+    type t = Entities.{{entity.name.capitalized}}.t
     type key = string
     let hasher = Obj.magic
   })
@@ -462,14 +462,20 @@ let makeEntityExecuterComposer = (
 Specifically create an sql executor with async functionality
 */
 let makeSqlEntityExecuter = (
+  type entity,
+  ~entityMod: module(Entities.Entity with type t = entity),
   ~idsToLoad: LoadLayer.idsToLoad,
-  ~dbReadFn: (Postgres.sql, array<Belt.Set.String.value>) => Promise.t<Belt.Array.t<'a>>,
-  ~inMemStoreInitFn: (~allowOverWriteEntity: bool=?, ~key: 'c, ~entity: option<'a>, 'b) => unit,
-  ~store: 'b,
-  ~getEntiyId: 'a => 'c,
+  ~inMemStoreInitFn: (
+    ~allowOverWriteEntity: bool=?,
+    ~key: string,
+    ~entity: option<entity>,
+    'store,
+  ) => unit,
+  ~store: 'store,
+  ~getEntiyId: entity => string,
 ) => {
   makeEntityExecuterComposer(
-    ~dbReadFn=DbFunctions.sql->dbReadFn,
+    ~dbReadFn=Entities.batchRead(~entityMod, DbFunctions.sql),
     ~idsToLoad,
     ~getEntiyId,
     ~store,
@@ -487,7 +493,7 @@ let executeSqlLoadLayer = (~loadLayer: LoadLayer.t, ~inMemoryStore: InMemoryStor
   {{#each entities as | entity |}}
     makeSqlEntityExecuter(
       ~idsToLoad=loadLayer.{{entity.name.uncapitalized}}IdsToLoad,
-      ~dbReadFn=DbFunctions.{{entity.name.capitalized}}.readEntities,
+      ~entityMod=module(Entities.{{entity.name.capitalized}}),
       ~inMemStoreInitFn=InMemoryStore.{{entity.name.capitalized}}.initValue,
       ~store=inMemoryStore.{{entity.name.uncapitalized}},
       ~getEntiyId=entity => entity.id,
@@ -570,20 +576,22 @@ let getEntityHistoryItems = (entityUpdates, ~entitySchema, ~entityType) => {
 }
 
 let executeSetEntityWithHistory = (
+  type entity,
   sql: Postgres.sql,
-  ~rows: array<Types.inMemoryStoreRowEntity<'a>>,
-  ~dbFunctionSet: (Postgres.sql, array<'b>) => promise<unit>,
-  ~dbFunctionDelete: (Postgres.sql, array<string>) => promise<unit>,
-  ~entitySchema,
-  ~entityType,
+  ~rows: array<Types.inMemoryStoreRowEntity<entity>>,
+  ~entityMod: module(Entities.Entity with type t = entity),
 ): promise<unit> => {
+  let module(EntityMod) = entityMod
+  let {schema, table} = module(EntityMod)
   let (entitiesToSet, idsToDelete, entityHistoryItemsToSet) = rows->Belt.Array.reduce(
     ([], [], []),
     ((entitiesToSet, idsToDelete, entityHistoryItemsToSet), row) => {
       switch row {
       | Updated({latest, history}) =>
         let entityHistoryItems =
-          history->Belt.Array.concat([latest])->getEntityHistoryItems(~entitySchema, ~entityType)
+          history
+          ->Belt.Array.concat([latest])
+          ->getEntityHistoryItems(~entitySchema=schema, ~entityType=table.tableName)
 
         switch latest.entityUpdateAction {
         | Set(entity) => (
@@ -607,12 +615,12 @@ let executeSetEntityWithHistory = (
       ~entityHistoriesToSet=Belt.Array.concatMany(entityHistoryItemsToSet),
     ),
     if entitiesToSet->Array.length > 0 {
-      sql->dbFunctionSet(entitiesToSet)
+      sql->Entities.batchSet(entitiesToSet, ~entityMod)
     } else {
       Promise.resolve()
     },
     if idsToDelete->Array.length > 0 {
-      sql->dbFunctionDelete(idsToDelete)
+      sql->Entities.batchDelete(idsToDelete, ~entityMod)
     } else {
       Promise.resolve()
     },
@@ -622,12 +630,10 @@ let executeSetEntityWithHistory = (
 }
 
 let executeDbFunctionsEntity = (
+  type entity,
   sql: Postgres.sql,
-  ~rows: array<Types.inMemoryStoreRowEntity<'a>>,
-  ~dbFunctionSet: (Postgres.sql, array<'b>) => promise<unit>,
-  ~dbFunctionDelete: (Postgres.sql, array<string>) => promise<unit>,
-  ~entitySchema as _,
-  ~entityType as _,
+  ~rows: array<Types.inMemoryStoreRowEntity<entity>>,
+  ~entityMod: module(Entities.Entity with type t = entity),
 ): promise<unit> => {
   let (entitiesToSet, idsToDelete) = rows->Belt.Array.reduce(([], []), (
     (accumulatedSets, accumulatedDeletes),
@@ -647,8 +653,10 @@ let executeDbFunctionsEntity = (
   )
 
   let promises =
-    (entitiesToSet->Array.length > 0 ? [sql->dbFunctionSet(entitiesToSet)] : [])->Belt.Array.concat(
-      idsToDelete->Array.length > 0 ? [sql->dbFunctionDelete(idsToDelete)] : [],
+    (
+      entitiesToSet->Array.length > 0 ? [sql->Entities.batchSet(entitiesToSet, ~entityMod)] : []
+    )->Belt.Array.concat(
+      idsToDelete->Array.length > 0 ? [sql->Entities.batchDelete(idsToDelete, ~entityMod)] : [],
     )
 
   promises->Promise.all->Promise.thenResolve(_ => ())
@@ -676,11 +684,8 @@ let executeBatch = async (sql, ~inMemoryStore: InMemoryStore.t) => {
 
   {{#each entities as | entity |}}
   let set{{entity.name.capitalized}}s = entityDbExecutionComposer(
-    ~dbFunctionSet=DbFunctions.{{entity.name.capitalized}}.batchSet,
-    ~dbFunctionDelete=DbFunctions.{{entity.name.capitalized}}.batchDelete,
+    ~entityMod=module(Entities.{{entity.name.capitalized}}),
     ~rows=inMemoryStore.{{entity.name.uncapitalized}}->InMemoryStore.{{entity.name.capitalized}}.values,
-    ~entitySchema=Types.{{entity.name.uncapitalized}}EntitySchema,
-    ~entityType="{{entity.name.capitalized}}"
   )
 
   {{/each}}
@@ -727,7 +732,7 @@ module RollBack = {
     | Error(exn) =>
       exn
       ->DecodeError
-      ->ErrorHandling.logAndRaise(~msg="Failed to get rollback diff from entity history")
+      ->ErrorHandling.mkLogAndRaise(~msg="Failed to get rollback diff from entity history")
     }
 
     let rollBackEventIdentifier: Types.eventIdentifier = {

--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers_MockDb.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers_MockDb.res.hbs
@@ -61,7 +61,7 @@ type rec t = {
 @genType
 and entities = {
   {{#each entities as | entity |}}
-    @as("{{entity.name.original}}") {{entity.name.uncapitalized}}: entityStoreOperations<Types.{{entity.name.uncapitalized}}Entity>,
+    @as("{{entity.name.original}}") {{entity.name.uncapitalized}}: entityStoreOperations<Entities.{{entity.name.capitalized}}.t>,
   {{/each}}
   }
 // User defined entities always have a string for an id which is used as the

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -44,52 +44,11 @@ type dynamicContractRegistryEntity = {
 }
 
 
+//Re-exporting types for backwards compatability
 {{#each entities as | entity |}}
 @genType.as("{{entity.name.original}}Entity")
-type {{entity.name.uncapitalized}}Entity = {
-  {{#each entity.params as | param |}}
-  {{#unless param.is_derived_from }}{{param.field_name.uncapitalized}}{{#if param.is_entity_field}}_id{{/if}}: {{param.type_rescript}},{{/unless}}
-  {{/each}}
-}
-
-let {{entity.name.uncapitalized}}EntitySchema = S.object((. s) => {
-  {{#each entity.params as | param |}}
-  {{#unless param.is_derived_from }}{{param.field_name.uncapitalized}}{{#if param.is_entity_field}}_id{{/if}}: s.field("{{param.field_name.uncapitalized}}{{#if param.is_entity_field}}_id{{/if}}", {{param.type_rescript_schema}}),{{/unless}}
-  {{/each}}
-})
-let {{entity.name.uncapitalized}}EntitiesSchema = S.array({{entity.name.uncapitalized}}EntitySchema)
- 
+type {{entity.name.uncapitalized}}Entity = Entities.{{entity.name.capitalized}}.t
 {{/each}}
-type entity = 
-{{#each entities as | entity |}}
-  | {{entity.name.capitalized}}Entity({{entity.name.uncapitalized}}Entity)
-{{/each}}
-
-type entityName =
-{{#each entities as | entity |}}
-  | @as("{{entity.name.capitalized}}") {{entity.name.capitalized}}
-{{/each}}
-
-let entityNameSchema = 
-{{#if entities.1}}
-{{!-- If there are multiple entities --}}
-S.union([
-{{#each entities as | entity |}}
-  S.literal({{entity.name.capitalized}}), 
-{{/each}}
-])
-{{else}}
-{{#each entities as | entity |}}
-  S.literal({{entity.name.capitalized}})
-{{/each}}
-{{/if}}
-
-let getEntityParamsDecoder = entityName =>
-  switch entityName {
-{{#each entities as | entity |}}
-  | {{entity.name.capitalized}} => json => json->S.parseWith(. {{entity.name.uncapitalized}}EntitySchema)->Belt.Result.map(decoded => {{entity.name.capitalized}}Entity(decoded))
-{{/each}}
-  }
 
 type eventIdentifier = {
   chainId: int,
@@ -208,31 +167,31 @@ let eventArgsSchema =
       {{#if (eq entity.name.capitalized required_entity.name.capitalized)}}
         {{#if required_entity.labels}}
         {{#each required_entity.labels as |label| }}
-        {{label}}: option<{{required_entity.name.uncapitalized}}Entity>,
+        {{label}}: option<Entities.{{required_entity.name.capitalized}}.t>,
         {{/each}}
         {{/if}}
         {{#if required_entity.array_labels}}
         {{#each required_entity.array_labels as |array_label| }}
-        {{array_label}}: array<option<{{required_entity.name.uncapitalized}}Entity>>,
+        {{array_label}}: array<option<Entities.{{required_entity.name.capitalized}}.t>>,
         {{/each}}
         {{/if}}
-        get: id => option<{{required_entity.name.uncapitalized}}Entity>,
+        get: id => option<Entities.{{required_entity.name.capitalized}}.t>,
       {{/if}}
 
     {{/each}}
     {{#each entity.relational_params.filtered_not_derived_from as | entity_field |}}
-        get{{entity_field.relational_key.capitalized}}: {{entity.name.uncapitalized}}Entity => 
+        get{{entity_field.relational_key.capitalized}}: Entities.{{entity.name.capitalized}}.t => 
         {{#if entity_field.is_optional}}
-          option<{{entity_field.mapped_entity.uncapitalized}}Entity>
+          option<Entities.{{entity_field.mapped_entity.capitalized}}.t>
         {{else}}
           {{#if entity_field.is_array}}
-            array<{{entity_field.mapped_entity.uncapitalized}}Entity>
+            array<Entities.{{entity_field.mapped_entity.capitalized}}.t>
           {{else}}
-            {{entity_field.mapped_entity.uncapitalized}}Entity
+            Entities.{{entity_field.mapped_entity.capitalized}}.t
           {{/if}}
         {{/if}},
       {{/each}}
-      set: {{entity.name.uncapitalized}}Entity => unit,
+      set: Entities.{{entity.name.capitalized}}.t => unit,
       deleteUnsafe: id => unit,
     }
 
@@ -241,33 +200,33 @@ let eventArgsSchema =
       {{#if (eq entity.name.capitalized required_entity.name.capitalized)}}
         {{#if required_entity.labels}}
         {{#each required_entity.labels as |label| }}
-        {{label}}: option<{{required_entity.name.uncapitalized}}Entity>,
+        {{label}}: option<Entities.{{required_entity.name.capitalized}}.t>,
         {{/each}}
         {{/if}}
         {{#if required_entity.array_labels}}
         {{#each required_entity.array_labels as |array_label| }}
-        {{array_label}}: array<option<{{required_entity.name.uncapitalized}}Entity>>,
+        {{array_label}}: array<option<Entities.{{required_entity.name.capitalized}}.t>>,
         {{/each}}
         {{/if}}
-        get: id => promise<option<{{required_entity.name.uncapitalized}}Entity>>,
+        get: id => promise<option<Entities.{{required_entity.name.capitalized}}.t>>,
       {{/if}}
 
     {{/each}}
     {{#each entity.relational_params.filtered_not_derived_from as | entity_field |}}
-        get{{entity_field.relational_key.capitalized}}: {{entity.name.uncapitalized}}Entity => 
+        get{{entity_field.relational_key.capitalized}}: Entities.{{entity.name.capitalized}}.t => 
         promise<{{#if entity_field.is_optional}}
-          option<{{entity_field.mapped_entity.uncapitalized}}Entity>,
+          option<Entities.{{entity_field.mapped_entity.capitalized}}.t>,
         {{else}}
           {{#if entity_field.is_array}}
           {{!-- NOTE: this case is currently impossible. However, we should make this work for `derivedFrom` fields. - see: https://github.com/Float-Capital/indexer/issues/1168 --}}
-            array<{{entity_field.mapped_entity.uncapitalized}}Entity>,
+            array<Entities.{{entity_field.mapped_entity.capitalized}}.t>,
           {{else}}
-            {{entity_field.mapped_entity.uncapitalized}}Entity,
+            Entities.{{entity_field.mapped_entity.capitalized}}.t,
           {{/if}}
         {{/if}}
         >,
       {{/each}}
-      set: {{entity.name.uncapitalized}}Entity => unit,
+      set: Entities.{{entity.name.capitalized}}.t => unit,
       deleteUnsafe: id => unit,
     }
     {{/each}}

--- a/codegenerator/cli/templates/dynamic/codegen/src/db/Entities.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/db/Entities.res.hbs
@@ -1,15 +1,40 @@
 open Table
-open Types
+type id = string
 
 //shorthand for punning
 let isPrimaryKey = true
 let isNullable = true
 let isIndex = true
 
+module type Entity = {
+  type t
+  let schema: S.schema<t>
+  let rowsSchema: S.schema<array<t>>
+  let table: Table.table
+}
+
+let batchRead = (type entity, ~entityMod: module(Entity with type t = entity)) => {
+  let module(EntityMod) = entityMod
+  let {table, rowsSchema} = module(EntityMod)
+  DbFunctionsEntities.makeReadEntities(~table, ~rowsSchema)
+}
+
+let batchSet = (type entity, ~entityMod: module(Entity with type t = entity)) => {
+  let module(EntityMod) = entityMod
+  let {table, rowsSchema} = module(EntityMod)
+  DbFunctionsEntities.makeBatchSet(~table, ~rowsSchema)
+}
+
+let batchDelete = (type entity, ~entityMod: module(Entity with type t = entity)) => {
+  let module(EntityMod) = entityMod
+  let {table} = module(EntityMod)
+  DbFunctionsEntities.makeBatchDelete(~table)
+}
+
 {{#each entities as |entity|}}
 module {{entity.name.capitalized}} = {
   @genType
-  type row = {
+  type t = {
     {{#each entity.params as | param |}}
     {{#unless param.is_derived_from }}{{param.field_name.uncapitalized}}{{#if param.is_entity_field}}_id{{/if}}: {{param.type_rescript}},{{/unless}}
     {{/each}}
@@ -21,7 +46,7 @@ module {{entity.name.capitalized}} = {
     {{/each}}
   })
 
-  let rowsSchema = S.array({{entity.name.uncapitalized}}EntitySchema)
+  let rowsSchema = S.array(schema)
 
   let table = mkTable(
     "{{entity.name.original}}",
@@ -62,6 +87,36 @@ module {{entity.name.capitalized}} = {
  
 {{/each}}
 
+type entity = 
+{{#each entities as | entity |}}
+  | {{entity.name.capitalized}}Entity({{entity.name.capitalized}}.t)
+{{/each}}
+
+type entityName =
+{{#each entities as | entity |}}
+  | @as("{{entity.name.capitalized}}") {{entity.name.capitalized}}
+{{/each}}
+
+let entityNameSchema = 
+{{#if entities.1}}
+{{!-- If there are multiple entities --}}
+S.union([
+{{#each entities as | entity |}}
+  S.literal({{entity.name.capitalized}}), 
+{{/each}}
+])
+{{else}}
+{{#each entities as | entity |}}
+  S.literal({{entity.name.capitalized}})
+{{/each}}
+{{/if}}
+
+let getEntityParamsDecoder = entityName =>
+  switch entityName {
+{{#each entities as | entity |}}
+  | {{entity.name.capitalized}} => json => json->S.parseWith(. {{entity.name.capitalized}}.schema)->Belt.Result.map(decoded => {{entity.name.capitalized}}Entity(decoded))
+{{/each}}
+  }
 
 let allTables: array<table> = [
 {{#each entities as |entity|}}

--- a/codegenerator/cli/templates/static/codegen/src/ErrorHandling.res
+++ b/codegenerator/cli/templates/static/codegen/src/ErrorHandling.res
@@ -36,7 +36,12 @@ let raiseExn = (self: t) => {
   self->getExn->raise
 }
 
-let logAndRaise = (~logger=?, ~msg=?, exn) => {
+let mkLogAndRaise = (~logger=?, ~msg=?, exn) => {
   exn->make(~logger?, ~msg?)->log
   exn->raise
+}
+
+let logAndRaise = self => {
+  self->log
+  self->raiseExn
 }

--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsEntities.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsEntities.res
@@ -1,0 +1,72 @@
+type id = string
+@module("./DbFunctionsImplementation.js")
+external batchReadItemsInTable: (
+  ~table: Table.table,
+  ~sql: Postgres.sql,
+  ~ids: array<id>,
+) => promise<array<Js.Json.t>> = "batchReadItemsInTable"
+
+let makeReadEntities = (~table: Table.table, ~rowsSchema: S.t<array<'entityRow>>) =>
+  async (~logger=?, sql: Postgres.sql, ids: array<id>): array<'entityRow> => {
+    switch await batchReadItemsInTable(~table, ~sql, ~ids) {
+    | exception exn =>
+      exn->ErrorHandling.mkLogAndRaise(
+        ~logger?,
+        ~msg=`Failed during batch read of entity ${table.tableName}`,
+      )
+    | res =>
+      switch res->S.parseAnyOrRaiseWith(rowsSchema) {
+      | exception exn =>
+        exn->ErrorHandling.mkLogAndRaise(
+          ~logger?,
+          ~msg=`Failed to parse rows from database of entity ${table.tableName}`,
+        )
+      | entitys => entitys
+      }
+    }
+  }
+
+@module("./DbFunctionsImplementation.js")
+external batchSetItemsInTable: (
+  ~table: Table.table,
+  ~sql: Postgres.sql,
+  ~jsonRows: Js.Json.t,
+) => promise<unit> = "batchSetItemsInTable"
+
+let makeBatchSet = (~table: Table.table, ~rowsSchema: S.schema<array<'entityRow>>) =>
+  async (~logger=?, sql: Postgres.sql, entities: array<'entityRow>) => {
+    switch entities->S.serializeOrRaiseWith(rowsSchema) {
+    | exception exn =>
+      exn->ErrorHandling.mkLogAndRaise(
+        ~logger?,
+        ~msg=`Failed during batch serialization of entity ${table.tableName}`,
+      )
+    | jsonRows =>
+      switch await batchSetItemsInTable(~table, ~sql, ~jsonRows) {
+      | exception exn =>
+        exn->ErrorHandling.mkLogAndRaise(
+          ~logger?,
+          ~msg=`Failed during batch read of entity ${table.tableName}`,
+        )
+      | res => res
+      }
+    }
+  }
+
+@module("./DbFunctionsImplementation.js")
+external batchDeleteItemsInTable: (
+  ~table: Table.table,
+  ~sql: Postgres.sql,
+  ~ids: array<id>,
+) => promise<unit> = "batchDeleteItemsInTable"
+
+let makeBatchDelete = (~table) =>
+  async (~logger=?, sql, ids) =>
+    switch await batchDeleteItemsInTable(~table, ~sql, ~ids) {
+    | exception exn =>
+      exn->ErrorHandling.mkLogAndRaise(
+        ~logger?,
+        ~msg=`Failed during batch delete of entity ${table.tableName}`,
+      )
+    | res => res
+    }

--- a/codegenerator/cli/templates/static/codegen/src/db/Table.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/Table.res
@@ -11,6 +11,7 @@ type fieldType =
   | @as("SERIAL") Serial
   | @as("JSON") Json
   | @as("TIMESTAMP") Timestamp
+  | @as("TIMESTAMP WITH TIME ZONE NULL") TimestampWithTZNull
   | Enum(string)
 
 type field = {

--- a/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
@@ -4,6 +4,7 @@ open Enums
 //shorthand for punning
 let isPrimaryKey = true
 let isNullable = true
+let isIndex = true
 
 module EventSyncState = {
   type row = {
@@ -39,8 +40,9 @@ module ChainMetadata = {
     is_hyper_sync: bool,
     num_batches_fetched: int,
     latest_fetched_block_number: int,
-    timestamp_caught_up_to_head_or_endblock: Js.Date.t
+    timestamp_caught_up_to_head_or_endblock: Js.Date.t,
   }
+
   let table = mkTable(
     "chain_metadata",
     ~fields=[
@@ -54,11 +56,7 @@ module ChainMetadata = {
       mkField("is_hyper_sync", Boolean),
       mkField("num_batches_fetched", Integer),
       mkField("latest_fetched_block_number", Integer),
-      mkField(
-        "timestamp_caught_up_to_head_or_endblock",
-        Timestamp,
-        // ~with="TIME ZONE NULL"//TODO enable with field
-      ),
+      mkField("timestamp_caught_up_to_head_or_endblock", TimestampWithTZNull, ~isNullable),
     ],
   )
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -304,7 +304,7 @@ let rollbackLastBlockHashesToReorgLocation = async (
       switch res {
       | Ok(v) => v
       | Error(exn) =>
-        exn->ErrorHandling.logAndRaise(
+        exn->ErrorHandling.mkLogAndRaise(
           ~msg="Failed to fetch blockHashes for given blockNumbers during rollback",
         )
       }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -151,7 +151,7 @@ let fetchBlockRange = async (
   ~currentBlockHeight,
   ~setCurrentBlockHeight,
 ) => {
-  let logAndRaise = ErrorHandling.logAndRaise(~logger)
+  let mkLogAndRaise = ErrorHandling.mkLogAndRaise(~logger)
   try {
     let {chainConfig: {chain}, serverUrl} = self
     let {fetchStateRegisterId, fromBlock, contractAddressMapping, toBlock, ?eventFilters} = query
@@ -219,12 +219,12 @@ let fetchBlockRange = async (
           switch res {
           | Ok(Some(blockData)) => blockData
           | Ok(None) =>
-            logAndRaise(
+            mkLogAndRaise(
               Not_found,
               ~msg=`Failure, blockData for block ${heighestBlockQueried->Int.toString} unexpectedly returned None`,
             )
           | Error(e) =>
-            Helpers.ErrorMessage(HyperSync.queryErrorToMsq(e))->logAndRaise(
+            Helpers.ErrorMessage(HyperSync.queryErrorToMsq(e))->mkLogAndRaise(
               ~msg=`Failed to query blockData for block ${heighestBlockQueried->Int.toString}`,
             )
           }
@@ -242,7 +242,7 @@ let fetchBlockRange = async (
       ->ContractInterfaceManager.getAbiMapping
       ->HyperSyncClient.Decoder.make {
       | exception exn =>
-        exn->logAndRaise(
+        exn->mkLogAndRaise(
           ~msg="Failed to instantiate a decoder from hypersync client, please double check your ABI.",
         )
       | decoder => decoder
@@ -252,7 +252,7 @@ let fetchBlockRange = async (
         pageUnsafe.events,
       ) {
       | exception exn =>
-        exn->logAndRaise(
+        exn->mkLogAndRaise(
           ~msg="Failed to parse events using hypersync client, please double check your ABI.",
         )
       | parsedEvents => parsedEvents
@@ -284,7 +284,7 @@ let fetchBlockRange = async (
               ~logger,
               ~params={"chainId": chainId, "blockNumber": blockNumber, "logIndex": logIndex},
             )
-            exn->ErrorHandling.logAndRaise(~msg="Failed to convert decoded event", ~logger)
+            exn->ErrorHandling.mkLogAndRaise(~msg="Failed to convert decoded event", ~logger)
           },
         }
       })
@@ -319,7 +319,7 @@ let fetchBlockRange = async (
             "logIndex": logIndex,
           }
           let logger = Logging.createChildFrom(~logger, ~params)
-          exn->ErrorHandling.logAndRaise(
+          exn->ErrorHandling.mkLogAndRaise(
             ~msg="Failed to parse event with viem, please double check your ABI.",
             ~logger,
           )

--- a/scenarios/erc20_multichain_factory/src/EventHandlers.res
+++ b/scenarios/erc20_multichain_factory/src/EventHandlers.res
@@ -1,4 +1,5 @@
 open Types
+open Entities
 
 Handlers.ERC20FactoryContract.TokenCreated.loader(({event, context}) => {
   context.contractRegistration.addERC20(event.params.token)
@@ -14,7 +15,7 @@ let makeAccountTokenId = (~account_id, ~tokenAddress) => {
   account_id->join(tokenAddress)
 }
 
-let makeAccountToken = (~account_id, ~tokenAddress, ~balance): accountTokenEntity => {
+let makeAccountToken = (~account_id, ~tokenAddress, ~balance): AccountToken.t => {
   id: makeAccountTokenId(~account_id, ~tokenAddress),
   account_id,
   tokenAddress,
@@ -25,7 +26,7 @@ let makeApprovalId = (~tokenAddress, ~owner_id, ~spender_id) =>
   tokenAddress->join(owner_id)->join(spender_id)
 
 let makeApprivalEntity = (~tokenAddress, ~owner_id, ~spender_id, ~amount) => {
-  id: makeApprovalId(~tokenAddress, ~owner_id, ~spender_id),
+  Approval.id: makeApprovalId(~tokenAddress, ~owner_id, ~spender_id),
   amount,
   owner_id,
   spender_id,
@@ -38,7 +39,7 @@ let createNewAccountWithZeroBalance = (
   ~setAccount,
   ~setAccountToken,
 ) => {
-  let accountObject: accountEntity = {
+  let accountObject: Account.t = {
     id: account_id,
   }
   // setting the accountEntity with the new transfer field value
@@ -86,7 +87,7 @@ Handlers.ERC20Contract.Transfer.loader(({event, context}) => {
   context.accountToken.load(toAccountToken_id, ~loaders={})
 })
 
-let manipulateAccountTokenBalance = (fn, accountToken, amount) => {
+let manipulateAccountTokenBalance = (fn, accountToken: AccountToken.t, amount): AccountToken.t => {
   {...accountToken, balance: accountToken.balance->fn(amount)}
 }
 

--- a/scenarios/erc20_multichain_factory/test/Handler_Test.res
+++ b/scenarios/erc20_multichain_factory/test/Handler_Test.res
@@ -2,6 +2,7 @@ open RescriptMocha
 open Mocha
 open Belt
 open TestHelpers
+open Entities
 
 describe("Transfers", () => {
   it("Transfer subtracts the from account balance and adds to the to account balance", () => {
@@ -11,7 +12,7 @@ describe("Transfers", () => {
 
     let account_id = userAddress1->Ethers.ethAddressToString
     //Make a mock entity to set the initial state of the mock db
-    let mockAccountEntity: Types.accountEntity = {
+    let mockAccountEntity: Entities.Account.t = {
       id: account_id,
     }
     let tokenAddress = Ethers.Addresses.defaultAddress->Ethers.ethAddressToString

--- a/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
@@ -214,7 +214,7 @@ module Sql = {
     )
 
     res[0]
-    ->Option.map(v => v->S.parseWith(Types.accountTokenEntitySchema)->Result.getExn)
+    ->Option.map(v => v->S.parseWith(Entities.AccountToken.schema)->Result.getExn)
     ->Option.map(a => a.balance)
   }
 }


### PR DESCRIPTION
Removes generated db functions for entities and makes DbFunctions + implementation static files.

All entity types are now referenced via the the "Entities" module.