### PR TITLE
V2 Implement restart filter for partially processed block 

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
@@ -96,9 +96,8 @@ module EventSyncState = {
     arr->Belt.Array.get(0)
   }
 
-  let getLatestProcessedBlockNumber = async (~chainId) => {
-    let latestEventOpt = await sql->readLatestSyncedEventOnChainId(~chainId)
-    latestEventOpt->Belt.Option.map(event => event.blockNumber)
+  let getLatestProcessedEvent = (~chainId) => {
+    sql->readLatestSyncedEventOnChainId(~chainId)
   }
 
   @module("./DbFunctionsImplementation.js")


### PR DESCRIPTION
Closes https://linear.app/envio/issue/IDX-533/when-indexer-crashes-and-restarts-is-should-correctly-start-fetching