### PR TITLE
Update npm links to point to correct repo

### DIFF
--- a/codegenerator/cli/npm/envio/package.json.tmpl
+++ b/codegenerator/cli/npm/envio/package.json.tmpl
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/enviodev/indexer.git"
+    "url": "git+https://github.com/enviodev/hyperindex.git"
   },
   "keywords": [
     "blockchain",
@@ -25,9 +25,9 @@
   "author": "envio contributors <about@envio.dev>",
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/enviodev/indexer/issues"
+    "url": "https://github.com/enviodev/hyperindex/issues"
   },
-  "homepage": "https://github.com/enviodev/indexer#readme",
+  "homepage": "https://envio.dev",
   "devDependencies": {
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.48.0",

--- a/codegenerator/cli/npm/package.json.tmpl
+++ b/codegenerator/cli/npm/package.json.tmpl
@@ -4,7 +4,7 @@
   "description": "A ️latency and sync speed optimized, developer friendly blockchain data indexer.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/enviodev/indexer.git"
+    "url": "git+https://github.com/enviodev/hyperindex.git"
   },
   "keywords": [
     "blockchain",
@@ -16,9 +16,9 @@
   "author": "envio contributors <about@envio.dev>",
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/enviodev/indexer/issues"
+    "url": "https://github.com/enviodev/hyperindex/issues"
   },
-  "homepage": "https://github.com/enviodev/indexer#readme",
+  "homepage": "https://envio.dev",
   "os": [
     "${node_os}"
   ],


### PR DESCRIPTION
Maybe we can rename the repo twice so that the old link redirects correctly :thinking: 

![image](https://github.com/user-attachments/assets/dc7d9960-9e6f-4c4b-a297-ac174ffa6740)
