### PR TITLE
Evaluate rows on addEmptyIndex

### DIFF
--- a/scenarios/test_codegen/test/LoadLayer_test.res
+++ b/scenarios/test_codegen/test/LoadLayer_test.res
@@ -367,12 +367,7 @@ describe("LoadLayer", () => {
 
     let users = await getUsersWithId("1")
 
-    // FIXME: Should register indexes for entities set in the inMemoryStore before the index creation
-    // Assert.deepEqual(users, [user1])
-    // Assert.deepEqual(mock.loadEntitiesByIdsCalls, [])
-    // Assert.deepEqual(mock.loadEntitiesByFieldCalls, [])
-
-    Assert.deepEqual(users, [])
+    Assert.deepEqual(users, [user1])
     Assert.deepEqual(mock.loadEntitiesByIdsCalls, [])
     Assert.deepEqual(
       mock.loadEntitiesByFieldCalls,


### PR DESCRIPTION
Fixes edge case where values already exist in the inMemory store when the lookup by index gets run.