### PR TITLE
Remove envio-win32-x64 as an optional dep

### DIFF
--- a/codegenerator/cli/npm/envio/package.json.tmpl
+++ b/codegenerator/cli/npm/envio/package.json.tmpl
@@ -39,8 +39,7 @@
     "envio-linux-x64": "${version}",
     "envio-linux-arm64": "${version}",
     "envio-darwin-x64": "${version}",
-    "envio-darwin-arm64": "${version}",
-    "envio-win32-x64": "${version}"
+    "envio-darwin-arm64": "${version}"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
I discovered that trying to install envio with yarn, which will automatically install all peer deps and all optional deps. Yarn 🙄...

It breaks purely because the windows package doesn't exist. Lets remove it from the package.json until we are actually building for windows.