### PR TITLE
Refactor Lists to Arrays

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -296,7 +296,7 @@ let rec registerDynamicContracts = (
   ~dynamicContractRegistrations: option<dynamicContractRegistrations>=None,
   ~inMemoryStore,
 ) => {
-  switch eventBatch[0] {
+  switch eventBatch[index] {
   | None => (eventsBeforeDynamicRegistrations, dynamicContractRegistrations)->Ok
   // | list{eventBatchQueueItem, ...tail} =>
   | Some(eventBatchQueueItem) =>

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -298,7 +298,6 @@ let rec registerDynamicContracts = (
 ) => {
   switch eventBatch[index] {
   | None => (eventsBeforeDynamicRegistrations, dynamicContractRegistrations)->Ok
-  // | list{eventBatchQueueItem, ...tail} =>
   | Some(eventBatchQueueItem) =>
     let dynamicContractRegistrationsResult = if (
       eventBatchQueueItem.hasRegisteredDynamicContracts->Option.getWithDefault(false)

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -447,7 +447,7 @@ type batchProcessed = {
   dynamicContractRegistrations: option<dynamicContractRegistrations>,
 }
 let processEventBatch = (
-  ~eventBatch: list<Types.eventBatchQueueItem>,
+  ~eventBatch: array<Types.eventBatchQueueItem>,
   ~inMemoryStore: InMemoryStore.t,
   ~latestProcessedBlocks: EventsProcessed.t,
   ~checkContractIsRegistered,
@@ -455,7 +455,6 @@ let processEventBatch = (
   ~loadLayer,
   ~config,
 ) => {
-  let eventBatch = List.toArray(eventBatch)
   let logger = Logging.createChild(
     ~params={
       "context": "batch",

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -43,10 +43,8 @@ type dynamicContractRegistration = {
 }
 
 type dynamicContractRegistrations = {
-  //Its better to apply these in reverse so that we register them with
-  //the fetcher from latest to earliest. That way there are less recursions
-  registrationsReversed: list<dynamicContractRegistration>,
-  unprocessedBatchReversed: list<Types.eventBatchQueueItem>,
+  registrations: array<dynamicContractRegistration>,
+  unprocessedBatch: array<Types.eventBatchQueueItem>,
 }
 
 let addToDynamicContractRegistrations = (
@@ -54,16 +52,19 @@ let addToDynamicContractRegistrations = (
   ~dynamicContracts,
   ~registeringEventBlockNumber,
   ~registeringEventLogIndex,
-  ~registrationsReversed,
-  ~unprocessedBatchReversed,
+  ~registrations,
+  ~unprocessedBatch,
 ) => {
   //If there are any dynamic contract registrations, put this item in the unprocessedBatch flagged
   //with "hasRegisteredDynamicContracts" and return the same list of entitiesToLoad without the
   //current item
-  let unprocessedBatchReversed = unprocessedBatchReversed->List.add({
-    ...eventBatchQueueItem,
-    hasRegisteredDynamicContracts: true,
-  })
+  let unprocessedBatch = [
+    ...unprocessedBatch,
+    {
+      ...eventBatchQueueItem,
+      hasRegisteredDynamicContracts: true,
+    },
+  ]
 
   let dynamicContractRegistration = {
     dynamicContracts,
@@ -72,8 +73,8 @@ let addToDynamicContractRegistrations = (
     registeringEventChain: eventBatchQueueItem.chain,
   }
   {
-    unprocessedBatchReversed,
-    registrationsReversed: registrationsReversed->List.add(dynamicContractRegistration),
+    unprocessedBatch,
+    registrations: [...registrations, dynamicContractRegistration],
   }
 }
 
@@ -117,17 +118,13 @@ let runEventContractRegister = (
 
     let val = switch (dynamicContracts, dynamicContractRegistrations) {
     | ([], dynamicContractRegistrations) => dynamicContractRegistrations
-    | (dynamicContracts, Some({registrationsReversed, unprocessedBatchReversed})) =>
-      addToDynamicContractRegistrations(
-        ~dynamicContracts,
-        ~registrationsReversed,
-        ~unprocessedBatchReversed,
-      )->Some
+    | (dynamicContracts, Some({registrations, unprocessedBatch})) =>
+      addToDynamicContractRegistrations(~dynamicContracts, ~registrations, ~unprocessedBatch)->Some
     | (dynamicContracts, None) =>
       addToDynamicContractRegistrations(
         ~dynamicContracts,
-        ~registrationsReversed=list{},
-        ~unprocessedBatchReversed=list{},
+        ~registrations=[],
+        ~unprocessedBatch=[],
       )->Some
     }
 
@@ -222,7 +219,8 @@ let runEventHandler = (
   runAsyncEnv(async () => {
     let contextEnv = ContextEnv.make(~event, ~chain, ~logger, ~eventMod)
 
-    let loaderReturn = (await runEventLoader(~contextEnv, ~handler, ~inMemoryStore, ~loadLayer))->propogate
+    let loaderReturn =
+      (await runEventLoader(~contextEnv, ~handler, ~inMemoryStore, ~loadLayer))->propogate
 
     switch await handler.handler(
       contextEnv->ContextEnv.getHandlerArgs(~loaderReturn, ~inMemoryStore, ~loadLayer),
@@ -284,24 +282,24 @@ let addToUnprocessedBatch = (
 ) => {
   {
     ...dynamicContractRegistrations,
-    unprocessedBatchReversed: dynamicContractRegistrations.unprocessedBatchReversed->List.add(
-      eventBatchQueueItem,
-    ),
+    unprocessedBatch: [...dynamicContractRegistrations.unprocessedBatch, eventBatchQueueItem],
   }
 }
 
 let rec registerDynamicContracts = (
+  eventBatch: array<Types.eventBatchQueueItem>,
+  ~index=0,
   ~registeredEvents: RegisteredEvents.t,
   ~checkContractIsRegistered,
   ~logger,
   ~eventsBeforeDynamicRegistrations=[],
   ~dynamicContractRegistrations: option<dynamicContractRegistrations>=None,
   ~inMemoryStore,
-  eventBatch: list<Types.eventBatchQueueItem>,
 ) => {
-  switch eventBatch {
-  | list{} => (eventsBeforeDynamicRegistrations, dynamicContractRegistrations)->Ok
-  | list{eventBatchQueueItem, ...tail} =>
+  switch eventBatch[0] {
+  | None => (eventsBeforeDynamicRegistrations, dynamicContractRegistrations)->Ok
+  // | list{eventBatchQueueItem, ...tail} =>
+  | Some(eventBatchQueueItem) =>
     let dynamicContractRegistrationsResult = if (
       eventBatchQueueItem.hasRegisteredDynamicContracts->Option.getWithDefault(false)
     ) {
@@ -342,7 +340,8 @@ let rec registerDynamicContracts = (
         //Mutate for performance (could otherwise use concat?)
         eventsBeforeDynamicRegistrations->Js.Array2.push(eventBatchQueueItem)->ignore
       }
-      tail->registerDynamicContracts(
+      eventBatch->registerDynamicContracts(
+        ~index=index + 1,
         ~registeredEvents,
         ~checkContractIsRegistered,
         ~logger,
@@ -377,7 +376,9 @@ let runLoaders = (
         ->Option.map(
           handler => {
             let contextEnv = ContextEnv.make(~chain, ~eventMod, ~event, ~logger)
-            runEventLoader(~contextEnv, ~handler, ~inMemoryStore, ~loadLayer)->Promise.thenResolve(propogate)
+            runEventLoader(~contextEnv, ~handler, ~inMemoryStore, ~loadLayer)->Promise.thenResolve(
+              propogate,
+            )
           },
         )
       })
@@ -454,11 +455,12 @@ let processEventBatch = (
   ~loadLayer,
   ~config,
 ) => {
+  let eventBatch = List.toArray(eventBatch)
   let logger = Logging.createChild(
     ~params={
       "context": "batch",
-      "batch-size": eventBatch->List.length,
-      "first-event-timestamp": eventBatch->List.head->Option.map(v => v.timestamp),
+      "batch-size": eventBatch->Array.length,
+      "first-event-timestamp": eventBatch[0]->Option.map(v => v.timestamp),
     },
   )
 
@@ -482,7 +484,7 @@ let processEventBatch = (
       ->propogate
 
     (await eventsBeforeDynamicRegistrations
-    ->runLoaders(~registeredEvents, ~loadLayer, ~inMemoryStore,~logger))
+    ->runLoaders(~registeredEvents, ~loadLayer, ~inMemoryStore, ~logger))
     ->propogate
 
     let elapsedAfterLoad = timeRef->Hrtime.timeSince->Hrtime.toMillis->Hrtime.intFromMillis

--- a/codegenerator/cli/templates/static/codegen/src/Utils.res
+++ b/codegenerator/cli/templates/static/codegen/src/Utils.res
@@ -3,7 +3,7 @@ external magic: 'a => 'b = "%identity"
 @val external jsArrayCreate: int => array<'a> = "Array"
 
 /* Given a comaprator and two sorted lists, combine them into a single sorted list */
-let mergeSorted = (f: 'a => 'b, xs: array<'a>, ys: array<'a>) => {
+let mergeSorted = (f: ('a, 'a) => bool, xs: array<'a>, ys: array<'a>) => {
   if Array.length(xs) == 0 {
     ys
   } else if Array.length(ys) == 0 {
@@ -14,7 +14,7 @@ let mergeSorted = (f: 'a => 'b, xs: array<'a>, ys: array<'a>) => {
 
     let rec loop = (i, j, k) => {
       if i < Array.length(xs) && j < Array.length(ys) {
-        if f(xs[i]) <= f(ys[j]) {
+        if f(xs[i], ys[j]) {
           result[k] = xs[i]
           loop(i + 1, j, k + 1)
         } else {

--- a/codegenerator/cli/templates/static/codegen/src/Utils.res
+++ b/codegenerator/cli/templates/static/codegen/src/Utils.res
@@ -131,10 +131,19 @@ let awaitEach = async (arr: array<'a>, fn: 'a => promise<unit>) => {
 }
 
 module Array = {
-  let removeAtIndex = (array, ~index) => {
-    let head = array->Js.Array2.slice(~start=0, ~end_=index + 1)
-    let tail = array->Belt.Array.sliceToEnd(index + 1)
-    [...head, ...tail]
+  /**
+  Creates a new array removing the item at the given index
+
+  Index > array length or < 0 results in a copy of the array
+  */
+  let removeAtIndex = (array, index) => {
+    if index < 0 || index >= array->Array.length {
+      array->Array.copy
+    } else {
+      let head = array->Js.Array2.slice(~start=0, ~end_=index)
+      let tail = array->Belt.Array.sliceToEnd(index + 1)
+      [...head, ...tail]
+    }
   }
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/Utils.res
+++ b/codegenerator/cli/templates/static/codegen/src/Utils.res
@@ -130,4 +130,12 @@ let awaitEach = async (arr: array<'a>, fn: 'a => promise<unit>) => {
   }
 }
 
+module Array = {
+  let removeAtIndex = (array, ~index) => {
+    let head = array->Js.Array2.slice(~start=0, ~end_=index + 1)
+    let tail = array->Belt.Array.sliceToEnd(index + 1)
+    [...head, ...tail]
+  }
+}
+
 external queueMicrotask: (unit => unit) => unit = "queueMicrotask"

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -203,7 +203,7 @@ let rec getFirstArbitraryEventsItemForChain = (
   | Some(first) =>
     let nextIndex = index + 1
     if first.chain == chain {
-      Some((first, () => queue->Utils.Array.removeAtIndex(~index)))
+      Some((first, () => queue->Utils.Array.removeAtIndex(index)))
     } else {
       let _ = head->Js.Array2.push(first)
       queue->getFirstArbitraryEventsItemForChain(~chain, ~index=nextIndex, ~head)

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -195,7 +195,6 @@ type earliestQueueItem =
 let rec getFirstArbitraryEventsItemForChain = (
   queue: array<Types.eventBatchQueueItem>,
   ~index=0,
-  ~head=[],
   ~chain,
 ) => {
   switch queue[index] {
@@ -205,8 +204,7 @@ let rec getFirstArbitraryEventsItemForChain = (
     if first.chain == chain {
       Some((first, () => queue->Utils.Array.removeAtIndex(index)))
     } else {
-      let _ = head->Js.Array2.push(first)
-      queue->getFirstArbitraryEventsItemForChain(~chain, ~index=nextIndex, ~head)
+      queue->getFirstArbitraryEventsItemForChain(~chain, ~index=nextIndex)
     }
   }
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -100,24 +100,6 @@ type rec t = {
 and register = RootRegister({endBlock: option<int>}) | DynamicContractRegister(dynamicContractId, t)
 
 /**
-Merges two sorted/ordered lists. TCO
-
-Pass the shorter list into A for better performance
-*/
-let rec mergeSortedList = (~sortedRev=list{}, ~cmp, a, b) => {
-  switch (a, b) {
-  | (list{aHead, ...aTail}, list{bHead, ...bTail}) =>
-    let (nextA, nextB, nextItem) = if cmp(aHead, bHead) {
-      (aTail, b, aHead)
-    } else {
-      (bTail, a, bHead)
-    }
-    mergeSortedList(nextA, nextB, ~cmp, ~sortedRev=sortedRev->List.add(nextItem))
-  | (rest, list{}) | (list{}, rest) => List.reverseConcat(sortedRev, rest)
-  }
-}
-
-/**
 Comapritor for two events from the same chain. No need for chain id or timestamp
 */
 let getEventCmp = (event: Types.eventBatchQueueItem) => {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
@@ -209,7 +209,7 @@ let rollback = (self: t, ~lastKnownValidBlock) => {
 }
 
 type earliestEventResponse = {
-  updatedPartitionedFetchState: t,
+  getUpdatedPartitionedFetchState: unit => t,
   earliestQueueItem: FetchState.queueItem,
 }
 
@@ -231,11 +231,12 @@ let getEarliestEvent = (self: t) => {
       accum
     }
   })
-  ->Option.map((({earliestQueueItem, updatedFetchState}, partitionId)) => {
+  ->Option.map((({earliestQueueItem, getUpdatedFetchState}, partitionId)) => {
     {
-      updatedPartitionedFetchState: self
-      ->updatePartition(~fetchState=updatedFetchState, ~partitionId)
-      ->Utils.unwrapResultExn,
+      getUpdatedPartitionedFetchState: () =>
+        self
+        ->updatePartition(~fetchState=getUpdatedFetchState(), ~partitionId)
+        ->Utils.unwrapResultExn,
       earliestQueueItem,
     }
   })

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -48,7 +48,7 @@ let isRollingBack = state =>
   | _ => false
   }
 
-type arbitraryEventQueue = list<Types.eventBatchQueueItem>
+type arbitraryEventQueue = array<Types.eventBatchQueueItem>
 
 type shouldExit = ExitWithSuccess | NoExit
 type action =
@@ -192,7 +192,7 @@ let checkAndSetSyncedChains = (~nextQueueItemIsKnownNone=false, chainManager: Ch
         //All events have been processed on the chain fetchers queue
         //Other chains may be busy syncing
         let hasArbQueueEvents =
-          chainManager.arbitraryEventPriorityQueue
+          chainManager.arbitraryEventQueue
           ->ChainManager.getFirstArbitraryEventsItemForChain(~chain=cf.chainConfig.chain)
           ->Option.isSome //TODO this is more expensive than it needs to be
         let queueSize = cf.fetchState->PartitionedFetchState.queueSize
@@ -231,7 +231,7 @@ let updateLatestProcessedBlocks = (
       let {numEventsProcessed, latestProcessedBlock} = latestProcessedBlocks->ChainMap.get(chain)
 
       let hasArbQueueEvents =
-        state.chainManager.arbitraryEventPriorityQueue
+        state.chainManager.arbitraryEventQueue
         ->ChainManager.getFirstArbitraryEventsItemForChain(~chain)
         ->Option.isSome //TODO this is more expensive than it needs to be
       let queueSize = fetchState->PartitionedFetchState.queueSize
@@ -308,7 +308,7 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
       ->updateChainFetcherCurrentBlockHeight(~currentBlockHeight)
 
     let hasArbQueueEvents =
-      state.chainManager.arbitraryEventPriorityQueue
+      state.chainManager.arbitraryEventQueue
       ->ChainManager.getFirstArbitraryEventsItemForChain(~chain)
       ->Option.isSome //TODO this is more expensive than it needs to be
     let queueSize = chainFetcher.fetchState->PartitionedFetchState.queueSize
@@ -413,11 +413,9 @@ let actionReducer = (state: t, action: action) => {
       latestProcessedBlocks,
       dynamicContractRegistrations: Some({registrations, unprocessedBatch}),
     }) =>
-    let updatedArbQueue =
-      unprocessedBatch->List.fromArray->FetchState.mergeSortedList(~cmp=(a, b) => {
-        a->EventUtils.getEventComparatorFromQueueItem <
-          b->EventUtils.getEventComparatorFromQueueItem
-      }, state.chainManager.arbitraryEventPriorityQueue)
+    let updatedArbQueue = Utils.mergeSorted((a, b) => {
+      a->EventUtils.getEventComparatorFromQueueItem <= b->EventUtils.getEventComparatorFromQueueItem
+    }, unprocessedBatch, state.chainManager.arbitraryEventQueue)
 
     let nextTasks = [
       UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -497,7 +495,7 @@ let actionReducer = (state: t, action: action) => {
       let updatedChainManager: ChainManager.t = {
         ...state.chainManager,
         chainFetchers: updatedChainFetchers,
-        arbitraryEventPriorityQueue: updatedArbQueue,
+        arbitraryEventQueue: updatedArbQueue,
       }
 
       {
@@ -549,7 +547,7 @@ let actionReducer = (state: t, action: action) => {
         [UpdateChainMetaDataAndCheckForExit(shouldExit)],
       )
     }
-  | UpdateQueues(fetchStatesMap, arbitraryEventPriorityQueue) =>
+  | UpdateQueues(fetchStatesMap, arbitraryEventQueue) =>
     let chainFetchers = state.chainManager.chainFetchers->ChainMap.mapWithKey((chain, cf) => {
       {
         ...cf,
@@ -560,7 +558,7 @@ let actionReducer = (state: t, action: action) => {
     let chainManager = {
       ...state.chainManager,
       chainFetchers,
-      arbitraryEventPriorityQueue,
+      arbitraryEventQueue,
     }
 
     (

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -301,7 +301,7 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
         ~currentBlockHeight,
         ~latestFetchedBlockTimestamp,
         ~latestFetchedBlockNumber=heighestQueriedBlockNumber,
-        ~fetchedEvents=parsedQueueItems->List.fromArray,
+        ~fetchedEvents=parsedQueueItems,
         ~id={fetchStateId: fetchStateRegisterId, partitionId},
       )
       ->Utils.unwrapResultExn

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -411,10 +411,10 @@ let actionReducer = (state: t, action: action) => {
   | BlockRangeResponse(chain, response) => state->handleBlockRangeResponse(~chain, ~response)
   | EventBatchProcessed({
       latestProcessedBlocks,
-      dynamicContractRegistrations: Some({registrationsReversed, unprocessedBatchReversed}),
+      dynamicContractRegistrations: Some({registrations, unprocessedBatch}),
     }) =>
     let updatedArbQueue =
-      unprocessedBatchReversed->List.reverse->FetchState.mergeSortedList(~cmp=(a, b) => {
+      unprocessedBatch->List.fromArray->FetchState.mergeSortedList(~cmp=(a, b) => {
         a->EventUtils.getEventComparatorFromQueueItem <
           b->EventUtils.getEventComparatorFromQueueItem
       }, state.chainManager.arbitraryEventPriorityQueue)
@@ -425,7 +425,7 @@ let actionReducer = (state: t, action: action) => {
       NextQuery(CheckAllChains),
     ]
 
-    let nextState = registrationsReversed->List.reduce(state, (state, registration) => {
+    let nextState = registrations->Array.reduce(state, (state, registration) => {
       let {
         registeringEventBlockNumber,
         registeringEventLogIndex,

--- a/scenarios/test_codegen/test/Mock_test.res
+++ b/scenarios/test_codegen/test/Mock_test.res
@@ -67,7 +67,7 @@ describe_skip("E2E Db check", () => {
 
     let _ = await EventProcessing.processEventBatch(
       ~inMemoryStore,
-      ~eventBatch=MockEvents.eventBatchItems->List.fromArray,
+      ~eventBatch=MockEvents.eventBatchItems,
       ~checkContractIsRegistered=checkContractIsRegisteredStub,
       ~latestProcessedBlocks=EventProcessing.EventsProcessed.makeEmpty(~config),
       ~registeredEvents=RegisteredEvents.global,

--- a/scenarios/test_codegen/test/Utils_test.res
+++ b/scenarios/test_codegen/test/Utils_test.res
@@ -7,14 +7,14 @@ describe("Merge Sorted", () => {
   it("sorts integers based on identity", () => {
     Assert.deepEqual(
       [1, 2, 3, 4, 6, 7, 8, 10, 13, 19],
-      Utils.mergeSorted(x => x, [1, 3, 7, 13, 19], [2, 4, 6, 8, 10]),
+      Utils.mergeSorted((a, b) => a <= b, [1, 3, 7, 13, 19], [2, 4, 6, 8, 10]),
     )
   })
 
   it("sorts records based on a comparable key", () => {
     Assert.deepEqual(
       [{a: 1}, {a: 2}, {a: 3}],
-      Utils.mergeSorted(x => x.a, [{a: 1}, {a: 3}], [{a: 2}]),
+      Utils.mergeSorted((x, y) => x.a <= y.a, [{a: 1}, {a: 3}], [{a: 2}]),
     )
   })
 
@@ -22,7 +22,7 @@ describe("Merge Sorted", () => {
     Assert.deepEqual(
       [{blockNum: 1, logIndex: 0}, {blockNum: 1, logIndex: 2}, {blockNum: 2, logIndex: 0}],
       Utils.mergeSorted(
-        x => (x.blockNum, x.logIndex),
+        (x, y) => (x.blockNum, x.logIndex) <= (y.blockNum, y.logIndex),
         [{blockNum: 1, logIndex: 0}, {blockNum: 2, logIndex: 0}],
         [{blockNum: 1, logIndex: 2}],
       ),
@@ -32,7 +32,7 @@ describe("Merge Sorted", () => {
   it("does not allocate in degenerate cases", () => {
     let left = [1, 3, 7, 13, 19]
     let right = [2, 4, 6, 8, 10]
-    Assert.strictEqual(left, Utils.mergeSorted(x => x, left, []))
-    Assert.strictEqual(right, Utils.mergeSorted(x => x, [], right))
+    Assert.strictEqual(left, Utils.mergeSorted((x, y) => x <= y, left, []))
+    Assert.strictEqual(right, Utils.mergeSorted((x, y) => x <= y, [], right))
   })
 })

--- a/scenarios/test_codegen/test/Utils_test.res
+++ b/scenarios/test_codegen/test/Utils_test.res
@@ -36,3 +36,37 @@ describe("Merge Sorted", () => {
     Assert.strictEqual(right, Utils.mergeSorted((x, y) => x <= y, [], right))
   })
 })
+
+describe("Array removeIndex", () => {
+  it("array of length 1", () => {
+    let arr = [1]
+    Assert.deepEqual(
+      arr->Utils.Array.removeAtIndex(0),
+      [],
+      ~message="Should have removed single value",
+    )
+    Assert.deepEqual(arr, [1], ~message="Original array should not have changed")
+  })
+
+  it("array of length 0", () => {
+    let arr = []
+    Assert.deepEqual(arr->Utils.Array.removeAtIndex(0), [], ~message="Should remain empty")
+    Assert.deepEqual(arr, [], ~message="Original array should not have changed")
+  })
+
+  it("happy case", () => {
+    let arr = [1, 2, 3]
+    Assert.deepEqual(arr->Utils.Array.removeAtIndex(1), [1, 3])
+    Assert.deepEqual(arr, [1, 2, 3], ~message="Original array should not have changed")
+  })
+
+  it("index out of bounds", () => {
+    let arr = [1, 2, 3]
+    Assert.deepEqual(arr->Utils.Array.removeAtIndex(3), [1, 2, 3])
+  })
+
+  it("negative index", () => {
+    let arr = [1, 2, 3]
+    Assert.deepEqual(arr->Utils.Array.removeAtIndex(-2), [1, 2, 3])
+  })
+})


### PR DESCRIPTION
- Remove use of lists holding eventBatchQueueItem
- Where nodes of lists were returned, replace with a lazy computation on the original orray

