### PR TITLE
Add event lookup for wildcard indexing

### DIFF
--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -800,6 +800,20 @@ impl Contract {
 
         Ok(handler_path)
     }
+
+    pub fn get_chain_ids(&self, system_config: &SystemConfig) -> Vec<u64> {
+        system_config
+            .get_networks()
+            .iter()
+            .filter_map(|network| {
+                if network.contracts.iter().any(|c| c.name == self.name) {
+                    Some(network.id)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -460,6 +460,7 @@ pub struct ContractTemplate {
     pub codegen_events: Vec<EventTemplate>,
     pub abi: StringifiedAbi,
     pub event_signatures: Vec<String>,
+    pub chain_ids: Vec<u64>,
     pub handler: HandlerPathsTemplate,
 }
 
@@ -467,6 +468,7 @@ impl ContractTemplate {
     fn from_config_contract(
         contract: &system_config::Contract,
         project_paths: &ParsedProjectPaths,
+        config: &SystemConfig,
     ) -> Result<Self> {
         let name = contract.name.to_capitalized_options();
         let handler = HandlerPathsTemplate::from_contract(contract, project_paths)
@@ -483,12 +485,15 @@ impl ContractTemplate {
             .map(|event| event.get_event_signature())
             .collect();
 
+        let chain_ids = contract.get_chain_ids(config);
+
         Ok(ContractTemplate {
             name,
             handler,
             codegen_events,
             abi: contract.abi.raw.clone(),
             event_signatures,
+            chain_ids,
         })
     }
 }
@@ -708,7 +713,9 @@ impl ProjectTemplate {
         let codegen_contracts: Vec<ContractTemplate> = cfg
             .get_contracts()
             .iter()
-            .map(|cfg_contract| ContractTemplate::from_config_contract(cfg_contract, project_paths))
+            .map(|cfg_contract| {
+                ContractTemplate::from_config_contract(cfg_contract, project_paths, cfg)
+            })
             .collect::<Result<_>>()
             .context("Failed generating contract template types")?;
 

--- a/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
@@ -139,7 +139,6 @@ let registerContractHandlers = (
     {{/each}}
     ],
   )
-  Config.setGenerated(config)
 )
 
 let registerAllHandlers = () => {
@@ -150,5 +149,21 @@ let registerAllHandlers = () => {
     ~handlerPathRelativeToConfig="{{contract.handler.relative_to_config}}",
   )
 {{/each}}
+
+  //Get all wildcard events from registered events and set them to wildcard in the config
+  //so that it can be looked up by wildcard if need be
+  RegisteredEvents.getWildcardEventKeys()->Belt.Array.forEach(({contractName, topic0}) => {
+    config.events
+    ->EventLookup.setEventToWildcard(~contractName, ~topic0)
+    //This should never fail, during registration of the event, we should have already checked for wildcard collisions
+    ->EventLookup.unwrapAddEventResponse(
+      ~context="Wildcard event registered",
+      ~contractName,
+      ~eventName=topic0,
+    )
+  })
+
+  Config.setGenerated(config)
+
   config
 }

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -205,10 +205,10 @@ type eventLog<'a> = {
 type internalEventArgs
 
 module type Event = {
-  let key: string
+  let sighash: string // topic0 for Evm and rb for Fuel receipts
   let name: string
   let contractName: string
-  let sighash: string // topic0 for Evm and rb for Fuel receipts
+  let chains: array<ChainMap.Chain.t>
 
   type eventArgs
   let eventArgsSchema: S.schema<eventArgs>
@@ -223,12 +223,19 @@ external eventModWithoutArgTypeToInternal: module(Event) => module(InternalEvent
 
 {{#each codegen_contracts as | contract |}}
 module {{contract.name.capitalized}} = {
+  let contractName = "{{contract.name.capitalized}}"
+  let chains = [
+{{#each contract.chain_ids as | chain_id |}}
+  {{chain_id}},
+{{/each}}
+    ]->Belt.Array.map(chainId => ChainMap.Chain.makeUnsafe(~chainId))
 {{#each contract.codegen_events as | event |}}
   module {{event.name.capitalized}} = {
-    let key = "{{contract.name.capitalized}}_{{event.sighash}}"
-    let name = "{{event.name.capitalized}}"
-    let contractName = "{{contract.name.capitalized}}"
     let sighash = "{{event.sighash}}"
+    let name = "{{event.name.capitalized}}"
+    let contractName = contractName
+    let chains = chains
+
     @genType
     type eventArgs = {{data_type}}
     let eventArgsSchema = {{data_schema_code}}

--- a/codegenerator/cli/templates/static/codegen/src/EventFetching.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventFetching.res
@@ -127,7 +127,7 @@ let convertLogs = (
       ~block,
       ~config,
       ~contractInterfaceManager,
-      ~chainId=chain->ChainMap.Chain.toChainId,
+      ~chain,
       ~transaction=log->transactionFieldsFromLog(~logger),
     ) {
     | Error(exn) =>

--- a/codegenerator/cli/templates/static/codegen/src/EventLookup.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventLookup.res
@@ -1,0 +1,149 @@
+open Belt
+type eventMod = module(Types.InternalEvent)
+type contract = {
+  name: string,
+  chains: array<ChainMap.Chain.t>,
+}
+type registeredEvent<'a> = {contract: contract, event: 'a, mutable isWildcard: bool}
+type eventsAtTopic0<'a> = Single(registeredEvent<'a>) | Multiple(dict<registeredEvent<'a>>)
+
+type t<'a> = dict<eventsAtTopic0<'a>>
+
+let empty = () => Js.Dict.empty()
+
+exception WildcardEventCollision
+exception DuplicateEvent
+
+let hasWildcardNetworkCollision = (eventA, eventB) => {
+  (eventA.isWildcard || eventB.isWildcard) &&
+    eventA.contract.chains->Array.some(chain => eventB.contract.chains->Utils.Array.includes(chain))
+}
+
+let addEvent = (eventLookup: t<'a>, event: 'a, ~eventMod: eventMod, ~isWildcard=false) => {
+  let module(Event) = eventMod
+  let event = {contract: {name: Event.contractName, chains: Event.chains}, event, isWildcard}
+  switch eventLookup->Js.Dict.get(Event.sighash) {
+  | None =>
+    eventLookup->Js.Dict.set(Event.sighash, Single(event))
+    Ok()
+  //Overwrite single if it has a matching contractName
+  | Some(Single(existing)) if existing.contract.name == Event.contractName => Error(DuplicateEvent)
+  | Some(Single(existing)) =>
+    //Wildcard events cannot have collisions with other networks
+    if hasWildcardNetworkCollision(existing, event) {
+      Error(WildcardEventCollision)
+    } else {
+      let values =
+        [(existing.contract.name, existing), (Event.contractName, event)]->Js.Dict.fromArray
+      eventLookup->Js.Dict.set(Event.sighash, Multiple(values))
+      Ok()
+    }
+  | Some(Multiple(values)) =>
+    if values->Js.Dict.get(Event.contractName)->Option.isSome {
+      Error(DuplicateEvent)
+    } else if (
+      values
+      ->Js.Dict.values
+      ->Array.some(existing => hasWildcardNetworkCollision(existing, event))
+    ) {
+      Error(WildcardEventCollision)
+    } else {
+      values->Js.Dict.set(Event.contractName, event)
+      Ok()
+    }
+  }
+}
+
+let getEvent = (eventLookup: t<'a>, ~topic0, ~contractAddress, ~contractAddressMapping, ~chain) =>
+  switch eventLookup->Js.Dict.get(topic0) {
+  | Some(Single({event})) => Some(event)
+  | Some(Multiple(events)) =>
+    switch contractAddressMapping->ContractAddressingMap.getContractNameFromAddress(
+      ~contractAddress,
+    ) {
+    | Some(contractName) => events->Js.Dict.get(contractName)->Option.map(v => v.event)
+    | None =>
+      events
+      ->Js.Dict.values
+      ->Utils.Array.find(event =>
+        event.isWildcard && event.contract.chains->Utils.Array.includes(chain)
+      )
+      ->Option.map(v => v.event)
+    }
+  | None => None
+  }
+
+let getEventByKey = (eventLookup: t<'a>, ~topic0, ~contractName) =>
+  switch eventLookup->Js.Dict.get(topic0) {
+  | Some(Single({event, contract})) if contractName == contract.name => Some(event)
+  | Some(Multiple(values)) => values->Js.Dict.get(contractName)->Option.map(v => v.event)
+  | Some(Single(_)) | None => None
+  }
+
+type eventKey = {topic0: string, contractName: string}
+let getWildcardEventKeys = (eventLookup: t<'a>) => {
+  eventLookup
+  ->Js.Dict.entries
+  ->Array.flatMap(((topic0, registeredEvent)) => {
+    switch registeredEvent {
+    | Single({contract, isWildcard}) => isWildcard ? [{topic0, contractName: contract.name}] : []
+    | Multiple(dict) =>
+      dict
+      ->Js.Dict.values
+      ->Array.keepMap(({contract, isWildcard}) =>
+        isWildcard ? Some({topic0, contractName: contract.name}) : None
+      )
+    }
+  })
+}
+
+let setEventToWildcard = (eventLookup: t<'a>, ~topic0, ~contractName) => {
+  switch eventLookup->Js.Dict.get(topic0) {
+  | Some(Single(event)) if event.contract.name == contractName =>
+    event.isWildcard = true
+    Ok()
+  | Some(Multiple(events)) =>
+    switch events->Js.Dict.get(contractName) {
+    | Some(event) =>
+      event.isWildcard = true
+      if (
+        events
+        ->Js.Dict.values
+        ->Array.some(existing =>
+          existing.contract.name != contractName && hasWildcardNetworkCollision(existing, event)
+        )
+      ) {
+        event.isWildcard = false
+        Error(WildcardEventCollision)
+      } else {
+        Ok()
+      }
+    | None => Ok() //ignore undefined event
+    }
+  | Some(Single(_)) | None => Ok() //ignore undefined event
+  }
+}
+
+let unwrapAddEventResponse = (result, ~context, ~eventName, ~contractName) => {
+  let logger = Logging.createChild(
+    ~params={
+      "context": context,
+      "contractName": contractName,
+      "eventName": eventName,
+    },
+  )
+  switch result {
+  | Error(DuplicateEvent) =>
+    DuplicateEvent->ErrorHandling.mkLogAndRaise(
+      ~logger,
+      ~msg="Duplicate registration of event detected",
+    )
+  | Error(WildcardEventCollision) =>
+    WildcardEventCollision->ErrorHandling.mkLogAndRaise(
+      ~logger,
+      ~msg="Another event is already registered with the same signature that would interfer with wildcard filtering.",
+    )
+  | Error(exn) => exn->ErrorHandling.mkLogAndRaise(~msg="Unexpected error occurred")
+  | Ok() => ()
+  }
+}

--- a/codegenerator/cli/templates/static/codegen/src/EventLookup.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventLookup.res
@@ -65,7 +65,7 @@ let getEvent = (eventLookup: t<'a>, ~topic0, ~contractAddress, ~contractAddressM
     | None =>
       events
       ->Js.Dict.values
-      ->Utils.Array.find(event =>
+      ->Js.Array2.find(event =>
         event.isWildcard && event.contract.chains->Utils.Array.includes(chain)
       )
       ->Option.map(v => v.event)

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -134,7 +134,7 @@ let runEventContractRegister = (
 
 let runEventLoader = async (
   ~contextEnv,
-  ~handler: RegisteredEvents.registeredLoaderHandler<_>,
+  ~handler: RegisteredEvents.loaderHandler<_>,
   ~inMemoryStore,
   ~loadLayer,
 ) => {

--- a/codegenerator/cli/templates/static/codegen/src/LogSelection.res
+++ b/codegenerator/cli/templates/static/codegen/src/LogSelection.res
@@ -1,3 +1,4 @@
+open Belt
 type hexString = string
 type topicSelection = {
   topic0: array<hexString>,
@@ -34,7 +35,7 @@ let topicSelectionHasFilters = (topicSelection: topicSelection) =>
   | _ => true
   }
 
-let hasTopicFilters = ({topicSelections}: t) =>
-  topicSelections->Belt.Array.reduce(false, (accum, item) => {
-    accum || item->topicSelectionHasFilters
-  })
+let topicSelectionsHaveFilters = (topicSelections: array<topicSelection>) =>
+  topicSelections->Array.some(topicSelectionHasFilters)
+
+let hasTopicFilters = ({topicSelections}: t) => topicSelections->topicSelectionsHaveFilters

--- a/codegenerator/cli/templates/static/codegen/src/RegisteredEvents.res
+++ b/codegenerator/cli/templates/static/codegen/src/RegisteredEvents.res
@@ -17,106 +17,179 @@ type handlerArgs<'eventArgs, 'loaderReturn> = {
 
 type handler<'eventArgs, 'loaderReturn> = handlerArgs<'eventArgs, 'loaderReturn> => promise<unit>
 
-type registeredLoaderHandler<'eventArgs, 'loaderReturn> = {
+type loaderHandler<'eventArgs, 'loaderReturn> = {
   loader: loader<'eventArgs, 'loaderReturn>,
   handler: handler<'eventArgs, 'loaderReturn>,
 }
 
+type eventOptions = {
+  wildcard: bool,
+  topicSelections: array<LogSelection.topicSelection>,
+}
+
 type registeredEvent<'eventArgs, 'loaderReturn> = {
-  loaderHandler?: registeredLoaderHandler<'eventArgs, 'loaderReturn>,
+  loaderHandler?: loaderHandler<'eventArgs, 'loaderReturn>,
   contractRegister?: contractRegister<'eventArgs>,
+  eventOptions: eventOptions,
 }
 
 type t = {
-  loaderHandlers: dict<registeredLoaderHandler<unknown, unknown>>,
-  contractRegisters: dict<contractRegister<unknown>>,
+  loaderHandlers: EventLookup.t<loaderHandler<unknown, unknown>>,
+  contractRegisters: EventLookup.t<contractRegister<unknown>>,
+  eventOptionsMap: EventLookup.t<eventOptions>,
 }
 
 let make = () => {
-  loaderHandlers: Js.Dict.empty(),
-  contractRegisters: Js.Dict.empty(),
+  loaderHandlers: EventLookup.empty(),
+  contractRegisters: EventLookup.empty(),
+  eventOptionsMap: EventLookup.empty(),
+}
+
+let unwrapAddEventResponse = EventLookup.unwrapAddEventResponse
+let registerEventFunction = (
+  args,
+  ~context,
+  ~handlerMap,
+  ~eventOptionsMap,
+  ~eventMod,
+  ~eventOptions: option<eventOptions>,
+) => {
+  let module(Event: Types.InternalEvent) = eventMod
+
+  let handleAddEventResponse = unwrapAddEventResponse(
+    _,
+    ~context,
+    ~eventName=Event.name,
+    ~contractName=Event.contractName,
+  )
+
+  switch eventOptions {
+  | Some(eventOptions) =>
+    //add options to the event options map
+    //and handle failures for collisions
+    eventOptionsMap
+    ->EventLookup.addEvent(eventOptions, ~eventMod, ~isWildcard=eventOptions.wildcard)
+    ->handleAddEventResponse
+
+    //Once the option is added, get all the wildcard event keys from the mapping
+    //and update the handlerLoader map to handle any new wildcards that have been
+    //registered here or elsewhere
+    eventOptionsMap
+    ->EventLookup.getWildcardEventKeys
+    ->Belt.Array.forEach(({contractName, topic0}) => {
+      handlerMap
+      ->EventLookup.setEventToWildcard(~contractName, ~topic0)
+      ->handleAddEventResponse
+    })
+
+  | None => ()
+  }
+
+  //Add loaderHandlers
+  handlerMap
+  ->EventLookup.addEvent(
+    args,
+    ~eventMod,
+    ~isWildcard=?eventOptions->Belt.Option.map(opts => opts.wildcard),
+  )
+  ->handleAddEventResponse
 }
 
 let addLoaderHandler = (
-  registeredEvents: t,
+  {loaderHandlers, eventOptionsMap}: t,
   eventMod,
-  args: registeredLoaderHandler<'eventArgs, 'loadReturn>,
+  args: loaderHandler<'eventArgs, 'loadReturn>,
+  ~eventOptions: option<eventOptions>,
 ) => {
-  let module(Event: Types.InternalEvent) = eventMod
-  let key = Event.key
-
-  if registeredEvents.loaderHandlers->Js.Dict.get(key)->Belt.Option.isSome {
-    Js.Exn.raiseError(
-      `[envio] The event "${Event.name}" on contract "${Event.contractName}" is already registered.`,
-    )
-  } else {
-    registeredEvents.loaderHandlers->Js.Dict.set(
-      key,
-      args->(
-        Utils.magic: registeredLoaderHandler<'eventArgs, 'loadReturn> => registeredLoaderHandler<
-          unknown,
-          unknown,
-        >
-      ),
-    )
-  }
+  args
+  ->(Utils.magic: loaderHandler<'eventArgs, 'loadReturn> => loaderHandler<unknown, unknown>)
+  ->registerEventFunction(
+    ~handlerMap=loaderHandlers,
+    ~context="Add handler function",
+    ~eventOptionsMap,
+    ~eventOptions,
+    ~eventMod,
+  )
 }
 
-let addContractRegister = (registeredEvents: t, eventMod, args: contractRegister<'eventArgs>) => {
-  let module(Event: Types.InternalEvent) = eventMod
-  let key = Event.key
-
-  if registeredEvents.contractRegisters->Js.Dict.get(key)->Belt.Option.isSome {
-    Js.Exn.raiseError(
-      `[envio] The event "${Event.name}" on contract "${Event.contractName}" is alredy registered.`,
-    )
-  } else {
-    registeredEvents.contractRegisters->Js.Dict.set(
-      key,
-      args->(Utils.magic: contractRegister<'eventArgs> => contractRegister<unknown>),
-    )
-  }
+let addContractRegister = (
+  {contractRegisters, eventOptionsMap}: t,
+  eventMod,
+  args: contractRegister<'eventArgs>,
+  ~eventOptions: option<eventOptions>,
+) => {
+  args
+  ->(Utils.magic: contractRegister<'eventArgs> => contractRegister<unknown>)
+  ->registerEventFunction(
+    ~handlerMap=contractRegisters,
+    ~context="Add contractRegister function",
+    ~eventOptionsMap,
+    ~eventOptions,
+    ~eventMod,
+  )
 }
 
 // This set makes sure that the warning doesn't print for every event of a type, but rather only prints the first time.
 let hasPrintedWarning = Set.make()
 
+let getEventKey = eventMod => {
+  let module(Event: Types.InternalEvent) = eventMod
+  Event.contractName ++ "_" ++ Event.sighash
+}
+
+let getDefaultEventOptions = (eventMod): eventOptions => {
+  let module(Event: Types.InternalEvent) = eventMod
+  let topicSelection =
+    LogSelection.makeTopicSelection(~topic0=[Event.sighash])->Utils.unwrapResultExn
+  {
+    wildcard: false,
+    topicSelections: [topicSelection],
+  }
+}
+
 let get = (registeredEvents: t, eventMod) => {
   let module(Event: Types.InternalEvent) = eventMod
 
+  let get = EventLookup.getEventByKey(_, ~topic0=Event.sighash, ~contractName=Event.contractName)
+
   let registeredLoaderHandler =
     registeredEvents.loaderHandlers
-    ->Js.Dict.unsafeGet(Event.key)
+    ->get
     ->(
-      Utils.magic: registeredLoaderHandler<unknown, unknown> => option<
-        registeredLoaderHandler<'eventArgs, 'loadReturn>,
+      Utils.magic: option<loaderHandler<unknown, unknown>> => option<
+        loaderHandler<'eventArgs, 'loadReturn>,
       >
     )
 
   let contractRegister =
     registeredEvents.contractRegisters
-    ->Js.Dict.unsafeGet(Event.key)
-    ->(Utils.magic: contractRegister<unknown> => option<contractRegister<'eventArgs>>)
+    ->get
+    ->(Utils.magic: option<contractRegister<unknown>> => option<contractRegister<'eventArgs>>)
 
   switch (registeredLoaderHandler, contractRegister) {
   | (None, None) =>
-    if !(hasPrintedWarning->Set.has(Event.key)) {
+    let eventKey = eventMod->getEventKey
+    if !(hasPrintedWarning->Set.has(eventKey)) {
       // Here are docs on the 'terminal hyperlink' formatting that I use to link to the docs: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
       Logging.warn(
         `Skipped "${Event.name}" on contract "${Event.contractName}", as there is no handler registered. You need to implement the event "${Event.name}" register method in your handler file or ignore this warning if you don't intend to implement it. Here are our docs on this topic: \n\n https://docs.envio.dev/docs/event-handlers`,
       )
-      let _ = hasPrintedWarning->Set.add(Event.key)
+      let _ = hasPrintedWarning->Set.add(eventKey)
     }
     None
   | (loaderHandler, contractRegister) =>
     Some({
       ?loaderHandler,
       ?contractRegister,
+      eventOptions: getDefaultEventOptions(eventMod),
     })
   }
 }
 
 let global = make()
+
+let getWildcardEventKeys: unit => array<EventLookup.eventKey> = () =>
+  global.eventOptionsMap->EventLookup.getWildcardEventKeys
 
 let defaultAsyncFn = _ => Promise.resolve()
 
@@ -130,11 +203,12 @@ module MakeRegister = (Event: Types.Event) => {
         loader: defaultAsyncFn,
         handler,
       },
+      ~eventOptions=None,
     )
 
   let contractRegister: contractRegister<Event.eventArgs> => unit = contractRegister =>
-    global->addContractRegister(eventMod, contractRegister)
+    global->addContractRegister(eventMod, contractRegister, ~eventOptions=None)
 
-  let handlerWithLoader: registeredLoaderHandler<Event.eventArgs, 'loaderReturn> => unit = args =>
-    global->addLoaderHandler(eventMod, args)
+  let handlerWithLoader: loaderHandler<Event.eventArgs, 'loaderReturn> => unit = args =>
+    global->addLoaderHandler(eventMod, args, ~eventOptions=None)
 }

--- a/codegenerator/cli/templates/static/codegen/src/RegisteredEvents.resi
+++ b/codegenerator/cli/templates/static/codegen/src/RegisteredEvents.resi
@@ -25,28 +25,34 @@ type handlerArgs<'eventArgs, 'loaderReturn> = {
 type handler<'eventArgs, 'loaderReturn> = handlerArgs<'eventArgs, 'loaderReturn> => promise<unit>
 
 @genType
-type registeredLoaderHandler<'eventArgs, 'loaderReturn> = {
+type loaderHandler<'eventArgs, 'loaderReturn> = {
   loader: loader<'eventArgs, 'loaderReturn>,
   handler: handler<'eventArgs, 'loaderReturn>,
 }
 
+type eventOptions = {
+  wildcard: bool,
+  topicSelections: array<LogSelection.topicSelection>,
+}
+
 @genType
 type registeredEvent<'eventArgs, 'loaderReturn> = {
-  loaderHandler?: registeredLoaderHandler<'eventArgs, 'loaderReturn>,
+  loaderHandler?: loaderHandler<'eventArgs, 'loaderReturn>,
   contractRegister?: contractRegister<'eventArgs>,
+  eventOptions: eventOptions,
 }
 
 type t
 
 let make: unit => t
-
 let get: (t, module(Types.InternalEvent)) => option<registeredEvent<'eventArgs, 'loadReturn>>
 
 let global: t
+let getWildcardEventKeys: unit => array<EventLookup.eventKey>
 
 module MakeRegister: (E: Types.Event) =>
 {
   let handler: handler<E.eventArgs, unit> => unit
   let contractRegister: contractRegister<E.eventArgs> => unit
-  let handlerWithLoader: registeredLoaderHandler<E.eventArgs, 'loaderReturn> => unit
+  let handlerWithLoader: loaderHandler<E.eventArgs, 'loaderReturn> => unit
 }

--- a/codegenerator/cli/templates/static/codegen/src/Utils.res
+++ b/codegenerator/cli/templates/static/codegen/src/Utils.res
@@ -157,6 +157,14 @@ Helper to check if a value exists in an array
   */
   @send
   external spliceInPlace: (array<'a>, ~pos: int, ~remove: int) => array<'a> = "splice"
+
+  let rec find = (arr, fn, ~index=0) => {
+    open Belt
+    switch arr[index] {
+    | Some(item) => item->fn ? item->Some : arr->find(fn, ~index=index + 1)
+    | None => None
+    }
+  }
 }
 
 /**

--- a/codegenerator/cli/templates/static/codegen/src/Utils.res
+++ b/codegenerator/cli/templates/static/codegen/src/Utils.res
@@ -157,14 +157,6 @@ Helper to check if a value exists in an array
   */
   @send
   external spliceInPlace: (array<'a>, ~pos: int, ~remove: int) => array<'a> = "splice"
-
-  let rec find = (arr, fn, ~index=0) => {
-    open Belt
-    switch arr[index] {
-    | Some(item) => item->fn ? item->Some : arr->find(fn, ~index=index + 1)
-    | None => None
-    }
-  }
 }
 
 /**

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -261,7 +261,9 @@ module Make = (
               | LogData({rb}) => rb
               }
               let eventMod =
-                config->Config.getEventModOrThrow(~contractName, ~topic0=logId->Js.BigInt.toString)
+                config.events
+                ->EventLookup.getEventByKey(~contractName, ~topic0=logId->Js.BigInt.toString)
+                ->Option.getExn
               let module(Event) = eventMod
 
               (

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -280,11 +280,11 @@ module Make = (
           ->getNullableExn(~msg="Event was unexpectedly parsed as undefined", ~logger)
           ->Converters.convertHyperSyncEvent(
             ~config,
-            ~contractInterfaceManager,
+            ~contractAddressMapping,
             ~log=item.log,
             ~block,
             ~transaction,
-            ~chainId,
+            ~chain,
           ) {
           | Ok(v) => v
           | Error(exn) =>
@@ -314,7 +314,7 @@ module Make = (
             ~transaction=item.transaction,
             ~block=item.block,
             ~contractInterfaceManager,
-            ~chainId,
+            ~chain,
           ) {
           | Ok((event, eventMod)) =>
             (

--- a/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
@@ -1,7 +1,7 @@
 open Belt
 open RescriptMocha
 
-let config = Config.getGenerated()
+let config = RegisterHandlers.registerAllHandlers()
 
 module Mock = {
   /*

--- a/scenarios/helpers/src/ChainMocking.res
+++ b/scenarios/helpers/src/ChainMocking.res
@@ -209,6 +209,11 @@ module Make = (Indexer: Indexer.S) => {
     eventKeys: array<string>,
   }
 
+  let getEventKey = (eventMod: module(Types.InternalEvent)) => {
+    let module(Event) = eventMod
+    Event.contractName ++ "_" ++ Event.sighash
+  }
+
   let getLogsFromBlocks = (
     blocks: array<block>,
     ~addressesAndEventNames: array<contractAddressesAndEventNames>,
@@ -219,10 +224,7 @@ module Make = (Indexer: Indexer.S) => {
           false,
           (prev, {addresses, eventKeys}) => {
             prev ||
-            (addresses->arrayHas(l.srcAddress) && {
-                let module(Event) = l.eventMod
-                eventKeys->arrayHas(Event.key)
-              })
+            (addresses->arrayHas(l.srcAddress) && eventKeys->arrayHas(getEventKey(l.eventMod)))
           },
         )
         if isLogInConfig {
@@ -234,7 +236,10 @@ module Make = (Indexer: Indexer.S) => {
     )
   }
 
-  let executeQuery = (self: t, query: FetchState.nextQuery): ChainWorker.blockRangeFetchResponse => {
+  let executeQuery = (
+    self: t,
+    query: FetchState.nextQuery,
+  ): ChainWorker.blockRangeFetchResponse => {
     let unfilteredBlocks = self->getBlocks(~fromBlock=query.fromBlock, ~toBlock=query.toBlock)
     let heighstBlock = unfilteredBlocks->getLast->Option.getExn
     let firstBlockParentNumberAndHash =
@@ -251,8 +256,7 @@ module Make = (Indexer: Indexer.S) => {
       {
         addresses,
         eventKeys: c.events->Belt.Array.map(event => {
-          let module(Event) = event
-          Event.key
+          event->(Utils.magic: module(Types.Event) => module(Types.InternalEvent))->getEventKey
         }),
       }
     })

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -61,10 +61,10 @@ module type S = {
     }
 
     module type Event = {
-      let key: string
+      let sighash: string
       let name: string
       let contractName: string
-      let sighash: string
+      let chains: array<ChainMap.Chain.t>
       type eventArgs
       let eventArgsSchema: RescriptSchema.S.schema<eventArgs>
       let convertHyperSyncEventArgs: HyperSyncClient.Decoder.decodedEvent => eventArgs
@@ -105,7 +105,6 @@ module type S = {
       eventFilters?: eventFilters,
     }
   }
-
 
   module ReorgDetection: {
     type blockNumberAndHash = {

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -2,7 +2,7 @@ open Belt
 open RescriptMocha
 
 let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) => {
-  let config = Config.getGenerated()
+  let config = RegisterHandlers.registerAllHandlers()
   let allEvents = []
 
   let arbitraryEventPriorityQueue = ref([])
@@ -323,7 +323,7 @@ describe("determineNextEvent", () => {
         let singleItem = makeMockQItem(654, MockConfig.chain137)
         let earliestItem = makeNoItem(5) /* earlier timestamp than the test event */
 
-        let fetchStatesMap = Config.getGenerated().chainMap->ChainMap.mapWithKey(
+        let fetchStatesMap = RegisterHandlers.registerAllHandlers().chainMap->ChainMap.mapWithKey(
           (chain, _) =>
             switch chain->ChainMap.Chain.toChainId {
             | 1 =>
@@ -362,7 +362,7 @@ describe("determineNextEvent", () => {
         let singleItemTimestamp = 654
         let singleItem = makeMockQItem(singleItemTimestamp, MockConfig.chain137)
 
-        let fetchStatesMap = Config.getGenerated().chainMap->ChainMap.mapWithKey(
+        let fetchStatesMap = RegisterHandlers.registerAllHandlers().chainMap->ChainMap.mapWithKey(
           (chain, _) =>
             switch chain->ChainMap.Chain.toChainId {
             | 1 =>

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -21,7 +21,8 @@ type config = {networks: array<network_conf>}
 let configYaml: config = ConfigUtils.loadConfigYaml(~codegenConfigPath=configPathString)
 let firstNetworkConfig = configYaml.networks[0]
 
-let generatedChainConfig = Config.getGenerated().chainMap->ChainMap.get(MockConfig.chain1337)
+let generatedChainConfig =
+  RegisterHandlers.registerAllHandlers().chainMap->ChainMap.get(MockConfig.chain1337)
 let generatedSyncConfig = switch generatedChainConfig.syncSource {
 | Rpc({syncConfig}) => syncConfig
 | _ => Js.Exn.raiseError("Expected an rpc config")

--- a/scenarios/test_codegen/test/ContractInterfaceManager_test.res
+++ b/scenarios/test_codegen/test/ContractInterfaceManager_test.res
@@ -23,7 +23,8 @@ let registerStaticAddresses = (mapping, ~chainConfig: Config.chainConfig, ~logge
 describe("Test ContractInterfaceManager", () => {
   it("Full config contractInterfaceManager gets all topics and addresses for filters", () => {
     let logger = Logging.logger
-    let chainConfig = Config.getGenerated().chainMap->ChainMap.get(MockConfig.chain1337)
+    let chainConfig =
+      RegisterHandlers.registerAllHandlers().chainMap->ChainMap.get(MockConfig.chain1337)
     let contractAddressMapping = ContractAddressingMap.make()
     contractAddressMapping->registerStaticAddresses(~chainConfig, ~logger)
 
@@ -45,7 +46,8 @@ describe("Test ContractInterfaceManager", () => {
   })
 
   it("Single address config gets all topics and addresses for filters", () => {
-    let chainConfig = Config.getGenerated().chainMap->ChainMap.get(MockConfig.chain1337)
+    let chainConfig =
+      RegisterHandlers.registerAllHandlers().chainMap->ChainMap.get(MockConfig.chain1337)
     let contractAddress =
       "0x2B2f78c5BF6D9C12Ee1225D5F374aa91204580c3"->Address.Evm.fromStringOrThrow
 
@@ -75,7 +77,8 @@ describe("Test ContractInterfaceManager", () => {
   })
 
   it("Combined Interface Manager matches the values from single Interface Managers", () => {
-    let chainConfig = Config.getGenerated().chainMap->ChainMap.get(MockConfig.chain1337)
+    let chainConfig =
+      RegisterHandlers.registerAllHandlers().chainMap->ChainMap.get(MockConfig.chain1337)
     let gravatarAddress =
       "0x2B2f78c5BF6D9C12Ee1225D5F374aa91204580c3"->Address.Evm.fromStringOrThrow
 

--- a/scenarios/test_codegen/test/rollback/ChainDataHelpers.res
+++ b/scenarios/test_codegen/test/rollback/ChainDataHelpers.res
@@ -10,7 +10,8 @@ let makeTransaction = (~transactionIndex, ~transactionHash): Types.Transaction.t
 }
 module Gravatar = {
   let contractName = "Gravatar"
-  let chainConfig = Config.getGenerated().chainMap->ChainMap.get(MockConfig.chain1337)
+  let chainConfig =
+    RegisterHandlers.registerAllHandlers().chainMap->ChainMap.get(MockConfig.chain1337)
   let contract = chainConfig.contracts->Js.Array2.find(c => c.name == contractName)->Option.getExn
   let defaultAddress = contract.addresses[0]->Option.getExn
 

--- a/scenarios/test_codegen/test/rollback/MockChainData_test.res
+++ b/scenarios/test_codegen/test/rollback/MockChainData_test.res
@@ -3,7 +3,9 @@ open RescriptMocha
 
 describe("Check that MockChainData works as expected", () => {
   let mockChainDataInit = MockChainData.make(
-    ~chainConfig=Config.getGenerated().chainMap->ChainMap.get(MockConfig.chain1337),
+    ~chainConfig=RegisterHandlers.registerAllHandlers().chainMap->ChainMap.get(
+      MockConfig.chain1337,
+    ),
     ~maxBlocksReturned=3,
     ~blockTimestampInterval=25,
   )

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -1,7 +1,7 @@
 open Belt
 open RescriptMocha
 
-let config = Config.getGenerated()
+let config = RegisterHandlers.registerAllHandlers()
 
 module Mock = {
   let mockChainDataEmpty = MockChainData.make(


### PR DESCRIPTION
A new way of looking up events.

EventLookup supports:
1. Looking up by topic0 only if there is a single registration for the event
2. Looking up wildcard events without the address in contractAddress mapping
3. Looking up events when the address does exist in contractAddress mapping
4. Safe API for adding registrations with no collisions
5. Safe API for setting wildcard values after the fact without collisions