### PR TITLE
Make FetchState module tail recursive

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -262,17 +262,15 @@ let rec updateInternal = (
 If a fetchState register has caught up to its next regisered node. Merge them and recurse.
 If no merging happens, None is returned
 */
-let rec pruneAndMergeNextRegistered = (self: t, ~parentRegister=?) => {
+let rec pruneAndMergeNextRegistered = (self: t, ~isMerged=false) => {
+  let merged = isMerged ? Some(self) : None
   switch self.registerType {
-  | RootRegister(_) => parentRegister
+  | RootRegister(_) => merged
   | DynamicContractRegister(_, nextRegister)
-    if self.latestFetchedBlock.blockNumber <
-    nextRegister.latestFetchedBlock.blockNumber => parentRegister
+    if self.latestFetchedBlock.blockNumber < nextRegister.latestFetchedBlock.blockNumber => merged
   | DynamicContractRegister(_) =>
-    let mergedSelf = self->mergeIntoNextRegistered
-
-    // Recursively look for other merges, if they affect the state, return that merged state otherwise, return the `mergedSelf`
-    mergedSelf->pruneAndMergeNextRegistered
+    // Recursively look for other merges
+    self->mergeIntoNextRegistered->pruneAndMergeNextRegistered(~isMerged=true)
   }
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -257,20 +257,16 @@ let rec updateInternal = (
 If a fetchState register has caught up to its next regisered node. Merge them and recurse.
 If no merging happens, None is returned
 */
-let rec pruneAndMergeNextRegistered = (self: t) => {
+let rec pruneAndMergeNextRegistered = (self: t, ~previous=?) => {
   switch self.registerType {
-  | RootRegister(_) => None
+  | RootRegister(_) => previous
   | DynamicContractRegister(_, nextRegister)
-    if self.latestFetchedBlock.blockNumber < nextRegister.latestFetchedBlock.blockNumber =>
-    None
+    if self.latestFetchedBlock.blockNumber < nextRegister.latestFetchedBlock.blockNumber => previous
   | DynamicContractRegister(_) =>
     let mergedSelf = self->mergeIntoNextRegistered
 
     // Recursively look for other merges, if they affect the state, return that merged state otherwise, return the `mergedSelf`
-    switch mergedSelf->pruneAndMergeNextRegistered {
-    | Some(mergedNext) => Some(mergedNext)
-    | None => Some(mergedSelf)
-    }
+    mergedSelf->pruneAndMergeNextRegistered
   }
 }
 


### PR DESCRIPTION
Converts all functions in FetchState to use tail calls. There is no more possibility of max call stack exceeded bugs from this module.