### PR TITLE
Fuel abi update to latest schema

### DIFF
--- a/codegenerator/Cargo.lock
+++ b/codegenerator/Cargo.lock
@@ -1461,9 +1461,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuel-abi-types"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e7e87f94417ff1a5d60e496906033c58bfe5367546621f131fe8cdabaa2671"
+checksum = "bce44ac13b1971be7cea024a2003cf944522093dafec454fea9ff792f0ff2577"
 dependencies = [
  "itertools 0.10.5",
  "lazy_static",

--- a/codegenerator/cli/Cargo.toml
+++ b/codegenerator/cli/Cargo.toml
@@ -41,7 +41,7 @@ sqlx = { version = "0.7.2", features = [
   "postgres",
 ] }
 thiserror = "1.0.50"
-fuel-abi-types = "0.5.2"
+fuel-abi-types = "0.7.0"
 schemars = { version = "1.0.0-alpha.2", features = ["preserve_order"] }
 convert_case = "0.6.0"
 # TODO: replace ethers with alloy and foundry-block-explorers since these are actively maintained

--- a/codegenerator/cli/src/fuel/abi.rs
+++ b/codegenerator/cli/src/fuel/abi.rs
@@ -278,10 +278,17 @@ impl Abi {
 
                 let event_name = {
                     // Since Event name doesn't consider the type children, there might be duplications.
-                    // Prevent it by adding a postfix when an even_name appears more than one time
+                    // Prevent it by adding a postfix when an event_name appears more than one time
                     let mut event_name = logged_type.get_event_name();
+                    // Extract only the last segment of the event name - NOTE: we can
+                    event_name = event_name
+                        .split("::")
+                        .last()
+                        .unwrap_or(&event_name)
+                        .to_string();
                     let event_name_count = names_count.get(&event_name).unwrap_or(&0);
                     let event_name_count = event_name_count + 1;
+                    // TODO: since we now have the namespace of these sway structs, we wouldn't need to append numbers at the end in future versions (we can use the namespace to differentiate them)
                     if event_name_count > 1 {
                         event_name = format!("{event_name}{}", event_name_count)
                     }


### PR DESCRIPTION
This seems to be mostly working - but is not well tested.

I was testing this with: `lenvio init fuel contract-import local -a ./exampleabi.json -n testing --contract-address 0x5b5e2102ab9b39e7f10928c5be1c31d2cfcd7555b0016ef4e2f41dca04323676 --contract-name "exampleTestContract" --api-token "123456" -l typescript -o ./test2 -d ./test2`

The abi file I was using to test is here: [Props721Edition-contract-abi.json](https://github.com/user-attachments/files/16726317/Props721Edition-contract-abi.json)
