### PR TITLE
Upgrade hs client to 0.6.2

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@elastic/ecs-pino-format": "1.4.0",
-    "@envio-dev/hypersync-client": "0.5.0",
+    "@envio-dev/hypersync-client": "0.6.2",
     "@glennsl/rescript-fetch": "0.2.0",
     "@rescript/react": "0.12.1",
     "@ryyppy/rescript-promise": "2.1.0",


### PR DESCRIPTION
Hs client < 0.6.2 took "Kind" as a field selection parameter for a transaction but would not serialize that into "type" for the actual query, so you would never get the value back. See this PR: https://github.com/enviodev/hypersync-client-node/pull/27