### PR TITLE
Add unit tests for fetchstate

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -889,7 +889,7 @@ let rec rollback = (
     if updatedWithRemovedDynamicContracts.contractAddressMapping->ContractAddressingMap.isEmpty {
       //If the contractAddressMapping is empty after pruning dynamic contracts, then this
       //is a dead register. Simly return its next register rolled back
-      nextRegister->rollback(~lastKnownValidBlock)
+      nextRegister->rollback(~lastKnownValidBlock, ~parent?)
     } else {
       //If there are still values in the contractAddressMapping, we should keep the register but
       //prune queues and next register

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -924,7 +924,13 @@ let isActivelyIndexing = fetchState => {
   }
 }
 
-let getNumContracts = (self: t) => self.contractAddressMapping->ContractAddressingMap.addressCount
+let rec getNumContracts = (self: t, ~accum=0) => {
+  let accum = accum + self.contractAddressMapping->ContractAddressingMap.addressCount
+  switch self.registerType {
+  | RootRegister(_) => accum
+  | DynamicContractRegister(_, nextRegister) => nextRegister->getNumContracts(~accum)
+  }
+}
 
 /**
 Helper functions for debugging and printing

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -269,14 +269,6 @@ let updateRegister = (
 }
 
 /**
-Links next register to a dynamic contract register
-*/
-let addNextRegister = (register: t, ~nextRegister: t, ~dynamicContractId) => {
-  ...register,
-  registerType: DynamicContractRegister(dynamicContractId, nextRegister),
-}
-
-/**
 Updates node at the given id with the values passed.
 Errors if the node can't be found.
 */

--- a/scenarios/test_codegen/pnpm-lock.yaml
+++ b/scenarios/test_codegen/pnpm-lock.yaml
@@ -131,8 +131,8 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       '@envio-dev/hypersync-client':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.2
+        version: 0.6.2
       '@glennsl/rescript-fetch':
         specifier: 0.2.0
         version: 0.2.0
@@ -409,44 +409,44 @@ packages:
     resolution: {integrity: sha512-eCSBUTgl8KbPyxky8cecDRLCYu2C1oFV4AZ72bEsI+TxXEvaljaL2kgttfzfu7gW+M89eCz55s49uF2t+YMTWA==}
     engines: {node: '>=10'}
 
-  '@envio-dev/hypersync-client-darwin-arm64@0.5.0':
-    resolution: {integrity: sha512-gPL3MFjev2MfMU3Qg77+g3HNipaeEVY1AakW55jjsU8shnVRcFEfykT3AuBK5KO8aFT+itUR5yTZMqaKAY+VRg==}
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.2':
+    resolution: {integrity: sha512-dDIuQqEgARR1JYodbGkmck1i9qbYEidc4Kw4DOrRKQ0uZFwflI4o8wm3P+G/ofc1iXwp4pm7jqNUGzZDpK9pqA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@envio-dev/hypersync-client-darwin-x64@0.5.0':
-    resolution: {integrity: sha512-GuM+UODTThVbmRU/XywMCG549wJogDPah94DCiIHKe4Bw6LqWfdEKVXY4kdnerZ8l+7HoewJh+EAlCHAR8+fIQ==}
+  '@envio-dev/hypersync-client-darwin-x64@0.6.2':
+    resolution: {integrity: sha512-NGlgkmosAzlZ1EuQ5/djkg6sQI/dgVX+XGOLI6Zden0ca2zr/ByBRA7yCKxpwZHYynFN2FoMsMGSRY8jj6XQWw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@envio-dev/hypersync-client-linux-arm64-gnu@0.5.0':
-    resolution: {integrity: sha512-/5HwFJQlYiie62QpP7BUDEGEFHptTOBXq3F0NpLAlbR+TeeK3BXfZEHAR4qpzmJYWJQ21+f0YfuPFzig5ybyfA==}
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.2':
+    resolution: {integrity: sha512-p2LQSaOSgjVvvFHOGHnPHTnsDHCWNEG78J29guZyqWojmaxTaR4eGyFEknla7eO0w58EIUGEBTF0+EJ7duMimg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-linux-x64-gnu@0.5.0':
-    resolution: {integrity: sha512-heQPhCzQy3sDgDEguglGKMt6qmg3YbVjEC2SCsAxOV7YTCMmIF6QocIq+N5t3fikDIp1nfH0oGEdlmswnNQ4CQ==}
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.2':
+    resolution: {integrity: sha512-/kIL9Q0e5hM0g6cvdCHL93LMu+OCnwQAGKQHCj2TKKUjVpWFNb0Ki5PMgJhQ8mimEBFsJAnErVK+HrugLTlaVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-linux-x64-musl@0.5.0':
-    resolution: {integrity: sha512-eTbj91QaqRQXP0hKx0drs9RZFfAdhYurF79sLXp9TLQWBWnnqPF9R+0Fl6WDjVHvUhsvqYqYratNXx5rxuthPg==}
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.2':
+    resolution: {integrity: sha512-4r5hA/zyxUjWBDYYeXLCl5pBfSI9njEIPuLMFXajjVcAvSXRtBhmgVwa3JrjjCxZ8aLfqk9vvPkb/KgYfrbXXw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-win32-x64-msvc@0.5.0':
-    resolution: {integrity: sha512-rNpt57uYAabned7k+yhvwg5F+xNti65og1u+60H2Q/MqfARppA7A2ntHTCgI865H1fN+/HXEywwtjwLOkX4J2g==}
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.2':
+    resolution: {integrity: sha512-VgsSwmDAgvpgo9QsIiwIp9IN+h3g0U/7zrCrvNAMj+lsMHJPZ7L0cfN58dQUr84wL8domJGJrnMKUtu/Yf49ow==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@envio-dev/hypersync-client@0.5.0':
-    resolution: {integrity: sha512-BfYqU2LVTF2A8NdYmu7dedrmk8rC9rEnYCK53zVgmntbFrhEqWv5npl3P6U0IWPeYAt/0woC0jHO8pKpUsjvyQ==}
+  '@envio-dev/hypersync-client@0.6.2':
+    resolution: {integrity: sha512-wgp0UmblW8yn/q5NMkVYPFDvOmgHWPTibl/QJYyYK2KXqAMHssUjP07ayduiZCexQOZ94Agpv4SvmYxQNjGBIA==}
     engines: {node: '>= 10'}
 
   '@ethersproject/abi@5.7.0':
@@ -2644,6 +2644,80 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  npm@10.8.2:
+    resolution: {integrity: sha512-x/AIjFIKRllrhcb48dqUNAAZl0ig9+qMuN91RpZo3Cb2+zuibfh+KISl6+kVVyktDz230JKc208UkQwwMqyB+w==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+    bundledDependencies:
+      - '@isaacs/string-locale-compare'
+      - '@npmcli/arborist'
+      - '@npmcli/config'
+      - '@npmcli/fs'
+      - '@npmcli/map-workspaces'
+      - '@npmcli/package-json'
+      - '@npmcli/promise-spawn'
+      - '@npmcli/redact'
+      - '@npmcli/run-script'
+      - '@sigstore/tuf'
+      - abbrev
+      - archy
+      - cacache
+      - chalk
+      - ci-info
+      - cli-columns
+      - fastest-levenshtein
+      - fs-minipass
+      - glob
+      - graceful-fs
+      - hosted-git-info
+      - ini
+      - init-package-json
+      - is-cidr
+      - json-parse-even-better-errors
+      - libnpmaccess
+      - libnpmdiff
+      - libnpmexec
+      - libnpmfund
+      - libnpmhook
+      - libnpmorg
+      - libnpmpack
+      - libnpmpublish
+      - libnpmsearch
+      - libnpmteam
+      - libnpmversion
+      - make-fetch-happen
+      - minimatch
+      - minipass
+      - minipass-pipeline
+      - ms
+      - node-gyp
+      - nopt
+      - normalize-package-data
+      - npm-audit-report
+      - npm-install-checks
+      - npm-package-arg
+      - npm-pick-manifest
+      - npm-profile
+      - npm-registry-fetch
+      - npm-user-validate
+      - p-map
+      - pacote
+      - parse-conflict-json
+      - proc-log
+      - qrcode-terminal
+      - read
+      - semver
+      - spdx-expression-parse
+      - ssri
+      - supports-color
+      - tar
+      - text-table
+      - tiny-relative-date
+      - treeverse
+      - validate-npm-package-name
+      - which
+      - write-file-atomic
+
   nwsapi@2.2.10:
     resolution: {integrity: sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==}
 
@@ -3599,6 +3673,11 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yarn@1.22.22:
+    resolution: {integrity: sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -3863,32 +3942,35 @@ snapshots:
     dependencies:
       '@elastic/ecs-helpers': 1.1.0
 
-  '@envio-dev/hypersync-client-darwin-arm64@0.5.0':
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.2':
     optional: true
 
-  '@envio-dev/hypersync-client-darwin-x64@0.5.0':
+  '@envio-dev/hypersync-client-darwin-x64@0.6.2':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-arm64-gnu@0.5.0':
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.2':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-x64-gnu@0.5.0':
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.2':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-x64-musl@0.5.0':
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.2':
     optional: true
 
-  '@envio-dev/hypersync-client-win32-x64-msvc@0.5.0':
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.2':
     optional: true
 
-  '@envio-dev/hypersync-client@0.5.0':
+  '@envio-dev/hypersync-client@0.6.2':
+    dependencies:
+      npm: 10.8.2
+      yarn: 1.22.22
     optionalDependencies:
-      '@envio-dev/hypersync-client-darwin-arm64': 0.5.0
-      '@envio-dev/hypersync-client-darwin-x64': 0.5.0
-      '@envio-dev/hypersync-client-linux-arm64-gnu': 0.5.0
-      '@envio-dev/hypersync-client-linux-x64-gnu': 0.5.0
-      '@envio-dev/hypersync-client-linux-x64-musl': 0.5.0
-      '@envio-dev/hypersync-client-win32-x64-msvc': 0.5.0
+      '@envio-dev/hypersync-client-darwin-arm64': 0.6.2
+      '@envio-dev/hypersync-client-darwin-x64': 0.6.2
+      '@envio-dev/hypersync-client-linux-arm64-gnu': 0.6.2
+      '@envio-dev/hypersync-client-linux-x64-gnu': 0.6.2
+      '@envio-dev/hypersync-client-linux-x64-musl': 0.6.2
+      '@envio-dev/hypersync-client-win32-x64-msvc': 0.6.2
 
   '@ethersproject/abi@5.7.0':
     dependencies:
@@ -6956,6 +7038,8 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  npm@10.8.2: {}
+
   nwsapi@2.2.10: {}
 
   nyc@15.1.0:
@@ -7922,6 +8006,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yarn@1.22.22: {}
 
   yn@3.1.1: {}
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -37,6 +37,31 @@ let getDynContractId = (
 }
 
 describe("FetchState.fetchState", () => {
+  it("dynamic contract map", () => {
+    let makeDcId = (blockNumber, logIndex): dynamicContractId => {
+      blockNumber,
+      logIndex,
+    }
+    let dcId1 = makeDcId(5, 0)
+    let dcId2 = makeDcId(5, 1)
+    let dcId3 = makeDcId(6, 0)
+    let dcId4 = makeDcId(7, 0)
+    let addAddr = DynamicContractsMap.addAddress
+    let dcMap =
+      DynamicContractsMap.empty
+      ->addAddr(dcId1, mockAddress1)
+      ->addAddr(dcId2, mockAddress2)
+      ->addAddr(dcId3, mockAddress3)
+      ->addAddr(dcId4, mockAddress4)
+
+    let (_updatedMap, removedAddresses) =
+      dcMap->DynamicContractsMap.removeContractAddressesPastValidBlock(
+        ~lastKnownValidBlock={blockNumber: 5, blockTimestamp: 5 * 15},
+      )
+
+    Assert.deepEqual(removedAddresses, [mockAddress3, mockAddress4])
+  })
+
   it("dynamic contract registration", () => {
     let root = {
       registerType: RootRegister({endBlock: None}),
@@ -147,5 +172,389 @@ describe("FetchState.fetchState", () => {
     }
 
     Assert.deepEqual(updatedState3, expected3, ~message="3rd registration")
+  })
+
+  let mockEvent = (~blockNumber, ~logIndex=0, ~chainId=1): Types.eventBatchQueueItem => {
+    timestamp: blockNumber * 15,
+    chain: ChainMap.Chain.makeUnsafe(~chainId),
+    blockNumber,
+    logIndex,
+    eventMod: Utils.magic("Mock event mod in fetchstate test"),
+    event: Utils.magic("Mock event in fetchstate test"),
+  }
+
+  it("merge next register", () => {
+    let dcId: dynamicContractId = {blockNumber: 100, logIndex: 0}
+    let latestFetchedBlock = getBlockData(~blockNumber=500)
+
+    let fetchState = {
+      latestFetchedBlock,
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress2, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
+      fetchedEventQueue: [
+        mockEvent(~blockNumber=1, ~logIndex=2),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=6, ~logIndex=1),
+      ],
+      registerType: DynamicContractRegister(
+        dcId,
+        {
+          latestFetchedBlock,
+          contractAddressMapping: ContractAddressingMap.fromArray([
+            (mockAddress1, (Gravatar :> string)),
+          ]),
+          isFetchingAtHead: false,
+          firstEventBlockNumber: None,
+          dynamicContracts: DynamicContractsMap.empty,
+          fetchedEventQueue: [
+            mockEvent(~blockNumber=1, ~logIndex=1),
+            mockEvent(~blockNumber=4),
+            mockEvent(~blockNumber=6, ~logIndex=2),
+          ],
+          registerType: RootRegister({endBlock: None}),
+        },
+      ),
+    }
+
+    let expected = {
+      latestFetchedBlock,
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress2, (Gravatar :> string)),
+        (mockAddress1, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
+      fetchedEventQueue: [
+        mockEvent(~blockNumber=1, ~logIndex=1),
+        mockEvent(~blockNumber=1, ~logIndex=2),
+        mockEvent(~blockNumber=4),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=6, ~logIndex=1),
+        mockEvent(~blockNumber=6, ~logIndex=2),
+      ],
+      registerType: RootRegister({endBlock: None}),
+    }
+
+    Assert.deepEqual(fetchState->mergeIntoNextRegistered, expected)
+  })
+
+  it("update register", () => {
+    let currentEvents = [
+      mockEvent(~blockNumber=1, ~logIndex=1),
+      mockEvent(~blockNumber=1, ~logIndex=2),
+      mockEvent(~blockNumber=4),
+    ]
+    let fetchState = {
+      latestFetchedBlock: getBlockData(~blockNumber=500),
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress1, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: Some(1),
+      dynamicContracts: DynamicContractsMap.empty,
+      fetchedEventQueue: currentEvents,
+      registerType: RootRegister({endBlock: None}),
+    }
+
+    let newEvents = [
+      mockEvent(~blockNumber=5),
+      mockEvent(~blockNumber=6, ~logIndex=1),
+      mockEvent(~blockNumber=6, ~logIndex=2),
+    ]
+    let updated =
+      fetchState
+      ->update(
+        ~id=Root,
+        ~latestFetchedBlock=getBlockData(~blockNumber=600),
+        ~currentBlockHeight=600,
+        ~fetchedEvents=newEvents,
+      )
+      ->Utils.unwrapResultExn
+
+    let expected = {
+      ...fetchState,
+      latestFetchedBlock: getBlockData(~blockNumber=600),
+      isFetchingAtHead: true,
+      fetchedEventQueue: Array.concat(currentEvents, newEvents),
+    }
+
+    Assert.deepEqual(updated, expected)
+  })
+
+  it("getEarliest event", () => {
+    let dcId: dynamicContractId = {blockNumber: 100, logIndex: 0}
+    let latestFetchedBlock = getBlockData(~blockNumber=500)
+
+    let fetchState = {
+      latestFetchedBlock,
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress2, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
+      fetchedEventQueue: [
+        mockEvent(~blockNumber=1, ~logIndex=2),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=6, ~logIndex=1),
+      ],
+      registerType: DynamicContractRegister(
+        dcId,
+        {
+          latestFetchedBlock,
+          contractAddressMapping: ContractAddressingMap.fromArray([
+            (mockAddress1, (Gravatar :> string)),
+          ]),
+          isFetchingAtHead: false,
+          firstEventBlockNumber: None,
+          dynamicContracts: DynamicContractsMap.empty,
+          fetchedEventQueue: [
+            mockEvent(~blockNumber=1, ~logIndex=1),
+            mockEvent(~blockNumber=4),
+            mockEvent(~blockNumber=6, ~logIndex=2),
+          ],
+          registerType: RootRegister({endBlock: None}),
+        },
+      ),
+    }
+
+    let {earliestQueueItem} = fetchState->getEarliestEvent
+
+    Assert.deepEqual(earliestQueueItem, Item(mockEvent(~blockNumber=1, ~logIndex=1)))
+  })
+
+  it("getNextQuery", () => {
+    let latestFetchedBlock = getBlockData(~blockNumber=500)
+    let root = {
+      latestFetchedBlock,
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress1, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty,
+      fetchedEventQueue: [
+        mockEvent(~blockNumber=1, ~logIndex=1),
+        mockEvent(~blockNumber=4),
+        mockEvent(~blockNumber=6, ~logIndex=2),
+      ],
+      registerType: RootRegister({endBlock: None}),
+    }
+
+    let partitionId = 0
+    let currentBlockHeight = 600
+    let (nextQuery, _optUpdatedRoot) =
+      root->getNextQuery(~partitionId, ~currentBlockHeight)->Utils.unwrapResultExn
+
+    Assert.deepEqual(
+      nextQuery,
+      NextQuery({
+        fetchStateRegisterId: Root,
+        partitionId,
+        fromBlock: root.latestFetchedBlock.blockNumber + 1,
+        toBlock: currentBlockHeight,
+        contractAddressMapping: root.contractAddressMapping,
+        eventFilters: Utils.magic(%raw(`undefined`)), //assertions fail if this is not explicitly set to undefined
+      }),
+    )
+  })
+
+  it("check contains contract address", () => {
+    let dcId: dynamicContractId = {blockNumber: 100, logIndex: 0}
+    let latestFetchedBlock = getBlockData(~blockNumber=500)
+
+    let fetchState = {
+      latestFetchedBlock,
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress2, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
+      fetchedEventQueue: [
+        mockEvent(~blockNumber=1, ~logIndex=2),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=6, ~logIndex=1),
+      ],
+      registerType: DynamicContractRegister(
+        dcId,
+        {
+          latestFetchedBlock,
+          contractAddressMapping: ContractAddressingMap.fromArray([
+            (mockAddress1, (Gravatar :> string)),
+          ]),
+          isFetchingAtHead: false,
+          firstEventBlockNumber: None,
+          dynamicContracts: DynamicContractsMap.empty,
+          fetchedEventQueue: [
+            mockEvent(~blockNumber=1, ~logIndex=1),
+            mockEvent(~blockNumber=4),
+            mockEvent(~blockNumber=6, ~logIndex=2),
+          ],
+          registerType: RootRegister({endBlock: None}),
+        },
+      ),
+    }
+
+    Assert.equal(
+      fetchState->checkContainsRegisteredContractAddress(
+        ~contractAddress=mockAddress1,
+        ~contractName=(Gravatar :> string),
+      ),
+      true,
+    )
+  })
+
+  it("isActively indexing", () => {
+    let case1 = {
+      latestFetchedBlock: getBlockData(~blockNumber=150),
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress1, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty,
+      fetchedEventQueue: [mockEvent(~blockNumber=99), mockEvent(~blockNumber=140)],
+      registerType: RootRegister({endBlock: Some(150)}),
+    }
+
+    case1->isActivelyIndexing->Assert.equal(true)
+
+    let case2 = {
+      ...case1,
+      fetchedEventQueue: [],
+    }
+
+    case2->isActivelyIndexing->Assert.equal(false)
+
+    let case3 = {
+      ...case2,
+      registerType: DynamicContractRegister({blockNumber: 100, logIndex: 0}, case2),
+    }
+
+    case3->isActivelyIndexing->Assert.equal(true)
+
+    let case4 = {
+      ...case1,
+      registerType: RootRegister({endBlock: Some(151)}),
+    }
+
+    case4->isActivelyIndexing->Assert.equal(true)
+
+    let case5 = {
+      ...case1,
+      registerType: RootRegister({endBlock: None}),
+    }
+
+    case5->isActivelyIndexing->Assert.equal(true)
+  })
+
+  it("rolls back", () => {
+    let dcId1: dynamicContractId = {blockNumber: 100, logIndex: 0}
+    let dcId2: dynamicContractId = {blockNumber: 101, logIndex: 0}
+
+    let root = {
+      latestFetchedBlock: getBlockData(~blockNumber=150),
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress1, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty,
+      fetchedEventQueue: [mockEvent(~blockNumber=99), mockEvent(~blockNumber=140)],
+      registerType: RootRegister({endBlock: None}),
+    }
+
+    let register2 = {
+      latestFetchedBlock: getBlockData(~blockNumber=120),
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress3, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId2, [mockAddress3]),
+      fetchedEventQueue: [mockEvent(~blockNumber=110)],
+      registerType: DynamicContractRegister(dcId2, root),
+    }
+
+    let fetchState = {
+      latestFetchedBlock: getBlockData(~blockNumber=99),
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress2, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId1, [mockAddress2]),
+      fetchedEventQueue: [
+        mockEvent(~blockNumber=1, ~logIndex=2),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=6, ~logIndex=1),
+      ],
+      registerType: DynamicContractRegister(dcId1, register2),
+    }
+
+    let updated = fetchState->rollback(~lastKnownValidBlock=getBlockData(~blockNumber=100))
+
+    let expected = {
+      ...fetchState,
+      registerType: DynamicContractRegister(
+        dcId1,
+        {
+          ...root,
+          latestFetchedBlock: getBlockData(~blockNumber=100),
+          fetchedEventQueue: [mockEvent(~blockNumber=99)],
+        },
+      ),
+    }
+    Assert.deepEqual(
+      expected,
+      updated,
+      ~message="should have removed the second register and rolled back the others",
+    )
+  })
+
+  it("counts number of contracts correctly", () => {
+    let dcId: dynamicContractId = {blockNumber: 100, logIndex: 0}
+    let latestFetchedBlock = getBlockData(~blockNumber=500)
+
+    let fetchState = {
+      latestFetchedBlock,
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress2, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
+      fetchedEventQueue: [
+        mockEvent(~blockNumber=1, ~logIndex=2),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=6, ~logIndex=1),
+      ],
+      registerType: DynamicContractRegister(
+        dcId,
+        {
+          latestFetchedBlock,
+          contractAddressMapping: ContractAddressingMap.fromArray([
+            (mockAddress1, (Gravatar :> string)),
+          ]),
+          isFetchingAtHead: false,
+          firstEventBlockNumber: None,
+          dynamicContracts: DynamicContractsMap.empty,
+          fetchedEventQueue: [
+            mockEvent(~blockNumber=1, ~logIndex=1),
+            mockEvent(~blockNumber=4),
+            mockEvent(~blockNumber=6, ~logIndex=2),
+          ],
+          registerType: RootRegister({endBlock: None}),
+        },
+      ),
+    }
+
+    fetchState->getNumContracts->Assert.equal(2)
   })
 })

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1,0 +1,151 @@
+open Belt
+open RescriptMocha
+open FetchState
+open Enums.ContractType
+
+let mockAddress1 = TestHelpers.Addresses.mockAddresses[0]->Option.getExn
+let mockAddress2 = TestHelpers.Addresses.mockAddresses[1]->Option.getExn
+let mockAddress3 = TestHelpers.Addresses.mockAddresses[2]->Option.getExn
+let mockAddress4 = TestHelpers.Addresses.mockAddresses[3]->Option.getExn
+
+let getTimestamp = (~blockNumber) => blockNumber * 15
+let getBlockData = (~blockNumber) => {
+  blockNumber,
+  blockTimestamp: getTimestamp(~blockNumber),
+}
+
+let makeDynContractRegistration = (
+  ~contractAddress,
+  ~blockNumber,
+  ~logIndex=0,
+  ~chainId=1,
+  ~contractType=Gravatar,
+): TablesStatic.DynamicContractRegistry.t => {
+  {
+    chainId,
+    eventId: EventUtils.packEventIndex(~blockNumber, ~logIndex),
+    blockTimestamp: getTimestamp(~blockNumber),
+    contractAddress,
+    contractType,
+  }
+}
+
+let getDynContractId = (
+  d: TablesStatic.DynamicContractRegistry.t,
+): FetchState.dynamicContractId => {
+  EventUtils.unpackEventIndex(d.eventId)
+}
+
+describe("FetchState.fetchState", () => {
+  it("dynamic contract registration", () => {
+    let root = {
+      registerType: RootRegister({endBlock: None}),
+      latestFetchedBlock: getBlockData(~blockNumber=10_000),
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (mockAddress1, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty,
+      fetchedEventQueue: [],
+    }
+
+    let dc1 = makeDynContractRegistration(~contractAddress=mockAddress2, ~blockNumber=50)
+    let dcId1 = getDynContractId(dc1)
+
+    let updatedState1 =
+      root->registerDynamicContract(
+        ~registeringEventBlockNumber=dcId1.blockNumber,
+        ~registeringEventLogIndex=dcId1.logIndex,
+        ~dynamicContractRegistrations=[dc1],
+      )
+
+    let expected1 = {
+      latestFetchedBlock: {blockNumber: dcId1.blockNumber - 1, blockTimestamp: 0},
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (dc1.contractAddress, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(
+        dcId1,
+        [dc1.contractAddress],
+      ),
+      fetchedEventQueue: [],
+      registerType: DynamicContractRegister(dcId1, root),
+    }
+
+    Assert.deepEqual(updatedState1, expected1, ~message="1st registration")
+
+    let dc2 = makeDynContractRegistration(~contractAddress=mockAddress3, ~blockNumber=55)
+    let dcId2 = getDynContractId(dc2)
+
+    let updatedState2 =
+      updatedState1->registerDynamicContract(
+        ~registeringEventBlockNumber=dcId2.blockNumber,
+        ~registeringEventLogIndex=dcId2.logIndex,
+        ~dynamicContractRegistrations=[dc2],
+      )
+
+    let expected2ChildRegister = {
+      latestFetchedBlock: {blockNumber: dcId2.blockNumber - 1, blockTimestamp: 0},
+      contractAddressMapping: ContractAddressingMap.fromArray([
+        (dc2.contractAddress, (Gravatar :> string)),
+      ]),
+      isFetchingAtHead: false,
+      firstEventBlockNumber: None,
+      dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(
+        dcId2,
+        [dc2.contractAddress],
+      ),
+      fetchedEventQueue: [],
+      registerType: DynamicContractRegister(dcId2, root),
+    }
+
+    let expected2 = {
+      ...expected1,
+      registerType: DynamicContractRegister(dcId1, expected2ChildRegister),
+    }
+
+    Assert.deepEqual(updatedState2, expected2, ~message="2nd registration")
+
+    let dc3 = makeDynContractRegistration(~contractAddress=mockAddress3, ~blockNumber=60)
+    let dcId3 = getDynContractId(dc3)
+
+    let updatedState3 =
+      updatedState2->registerDynamicContract(
+        ~registeringEventBlockNumber=dcId3.blockNumber,
+        ~registeringEventLogIndex=dcId3.logIndex,
+        ~dynamicContractRegistrations=[dc3],
+      )
+
+    let expected3 = {
+      ...expected2,
+      registerType: DynamicContractRegister(
+        dcId1,
+        {
+          ...expected2ChildRegister,
+          registerType: DynamicContractRegister(
+            dcId2,
+            {
+              latestFetchedBlock: {blockNumber: dcId3.blockNumber - 1, blockTimestamp: 0},
+              contractAddressMapping: ContractAddressingMap.fromArray([
+                (dc3.contractAddress, (Gravatar :> string)),
+              ]),
+              isFetchingAtHead: false,
+              firstEventBlockNumber: None,
+              dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(
+                dcId3,
+                [dc3.contractAddress],
+              ),
+              fetchedEventQueue: [],
+              registerType: DynamicContractRegister(dcId3, root),
+            },
+          ),
+        },
+      ),
+    }
+
+    Assert.deepEqual(updatedState3, expected3, ~message="3rd registration")
+  })
+})


### PR DESCRIPTION
These new unit tests add about 77% coverage for FetchState

<img width="979" alt="Screenshot 2024-08-26 at 17 29 31" src="https://github.com/user-attachments/assets/7fdd9123-4a66-4ede-8c90-d883cd230949">

I managed to catch 2 bugs with them. One a problematic bug for rollbacks and one being non critical for calculating sizes of partitions.

There's still more to test but it's time consuming and I think this is already a good addition.