### PR TITLE
Use Viem for address parsing and remove checksum since it's done on the client

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
@@ -59,6 +59,10 @@ let getAddedDynamicContractRegistrations = (contextEnv: t<'eventArgs>) =>
 let makeDynamicContractRegisterFn = (~contextEnv: t<'eventArgs>, ~contractName, ~inMemoryStore) => (
   contractAddress: Address.t,
 ) => {
+  // Even though it's the Address.t on ReScript side, for TS side it's a string.
+  // So we need to ensure that it's a valid checksummed address.
+  let contractAddress = contractAddress->Address.Evm.fromAddressOrThrow
+
   let {event, chain, addedDynamicContractRegistrations} = contextEnv
 
   let eventId = event->getEventId

--- a/codegenerator/cli/templates/dynamic/init_templates/shared/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/init_templates/shared/package.json.hbs
@@ -41,15 +41,12 @@
     "ts-mocha": "^10.0.0",
     "ts-node": "10.9.1",
     "typescript": "5.2.2",
+    "chai": "4.3.10",
   {{/if}}    
     "mocha": "10.2.0"
   },
   "dependencies": {
-    {{#if is_typescript}}
-    "chai": "4.3.10",
-    {{/if}}    
-    "envio": "{{envio_version}}",
-    "ethers": "6.8.0"
+    "envio": "{{envio_version}}"
   },
   "optionalDependencies": {
     "generated": "{{relative_path_from_root_to_generated}}"

--- a/codegenerator/cli/templates/static/codegen/src/Address.res
+++ b/codegenerator/cli/templates/static/codegen/src/Address.res
@@ -13,12 +13,17 @@ module Evm = {
   // Reassign since the function might be used in the handler code
   // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
   // of generated code instead of adding it to the indexer project dependencies.
-  let fromStringOrThrow = fromStringOrThrow
+  // Also, we want a custom error message, which is searchable in our codebase.
+  let fromStringOrThrow = string => {
+    try {
+      fromStringOrThrow(string)
+    } catch {
+    | _ =>
+      Js.Exn.raiseError(
+        `Address "${string}" is invalid. Expected a 20-byte hex string starting with 0x.`,
+      )
+    }
+  }
 
-  @module("viem")
-  external fromAddressOrThrow: t => t = "getAddress"
-  // Reassign since the function might be used in the handler code
-  // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
-  // of generated code instead of adding it to the indexer project dependencies.
-  let fromAddressOrThrow = fromAddressOrThrow
+  let fromAddressOrThrow = address => address->toString->fromStringOrThrow
 }

--- a/codegenerator/cli/templates/static/codegen/src/Address.res
+++ b/codegenerator/cli/templates/static/codegen/src/Address.res
@@ -1,22 +1,13 @@
 @genType.import(("./OpaqueTypes.ts", "Address"))
 type t
 
-let schema =
-  S.string->S.setName("Address")->(Utils.magic: S.t<string> => S.t<t>)
+let schema = S.string->S.setName("Address")->(Utils.magic: S.t<string> => S.t<t>)
 
 external toString: t => string = "%identity"
 
 external unsafeFromString: string => t = "%identity"
 
 module Evm = {
-  @module("ethers") @scope("ethers")
+  @module("viem")
   external fromStringOrThrow: string => t = "getAddress"
-
-  /**
-  Same binding as getAddress from string 
-  but used when we receive and address that's not necessarily checksummed
-  */
-  @module("ethers")
-  @scope("ethers")
-  external checksum: t => t = "getAddress"
 }

--- a/codegenerator/cli/templates/static/codegen/src/Address.res
+++ b/codegenerator/cli/templates/static/codegen/src/Address.res
@@ -10,4 +10,15 @@ external unsafeFromString: string => t = "%identity"
 module Evm = {
   @module("viem")
   external fromStringOrThrow: string => t = "getAddress"
+  // Reassign since the function might be used in the handler code
+  // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
+  // of generated code instead of adding it to the indexer project dependencies.
+  let fromStringOrThrow = fromStringOrThrow
+
+  @module("viem")
+  external fromAddressOrThrow: t => t = "getAddress"
+  // Reassign since the function might be used in the handler code
+  // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
+  // of generated code instead of adding it to the indexer project dependencies.
+  let fromAddressOrThrow = fromAddressOrThrow
 }

--- a/codegenerator/cli/templates/static/codegen/src/ContractAddressingMap.res
+++ b/codegenerator/cli/templates/static/codegen/src/ContractAddressingMap.res
@@ -1,8 +1,5 @@
 type contractName = string
 
-exception UndefinedContractName(contractName, Types.chainId)
-exception UndefinedContractAddress(Address.t)
-
 // Currently this mapping append only, so we don't need to worry about
 // protecting static addresses from de-registration.
 
@@ -18,22 +15,6 @@ let addAddress = (map: mapping, ~name: string, ~address: Address.t) => {
     map.addressesByName->Js.Dict.get(name)->Belt.Option.getWithDefault(Belt.Set.String.empty)
   let newAddresses = oldAddresses->Belt.Set.String.add(address->Address.toString)
   map.addressesByName->Js.Dict.set(name, newAddresses)
-}
-
-/// This adds the address if it doesn't exist and returns a boolean to say if it already existed.
-let addAddressIfNotExists = (map: mapping, ~name: string, ~address: Address.t): bool => {
-  let addressIsNew =
-    map.nameByAddress
-    ->Js.Dict.get(address->Address.toString)
-    ->Belt.Option.mapWithDefault(true, expectedName => expectedName != name)
-
-  /* check the name, since differently named contracts can have the same address */
-
-  if addressIsNew {
-    addAddress(map, ~name, ~address)
-  }
-
-  addressIsNew
 }
 
 let getAddresses = (map: mapping, name: string) => {

--- a/codegenerator/cli/templates/static/codegen/src/ContractAddressingMap.res
+++ b/codegenerator/cli/templates/static/codegen/src/ContractAddressingMap.res
@@ -12,7 +12,6 @@ type mapping = {
 }
 
 let addAddress = (map: mapping, ~name: string, ~address: Address.t) => {
-  let address = address->Address.Evm.checksum
   map.nameByAddress->Js.Dict.set(address->Address.toString, name)
 
   let oldAddresses =
@@ -23,7 +22,6 @@ let addAddress = (map: mapping, ~name: string, ~address: Address.t) => {
 
 /// This adds the address if it doesn't exist and returns a boolean to say if it already existed.
 let addAddressIfNotExists = (map: mapping, ~name: string, ~address: Address.t): bool => {
-  let address = address->Address.Evm.checksum
   let addressIsNew =
     map.nameByAddress
     ->Js.Dict.get(address->Address.toString)
@@ -51,17 +49,12 @@ let make = () => {
   addressesByName: Js.Dict.empty(),
 }
 
-let getContractNameFromAddress = (mapping, ~contractAddress: Address.t): option<
-  contractName,
-> => {
+let getContractNameFromAddress = (mapping, ~contractAddress: Address.t): option<contractName> => {
   mapping->getName(contractAddress->Address.toString)
 }
 
 let stringsToAddresses: array<string> => array<Address.t> = Utils.magic
-let keyValStringToAddress: array<(string, string)> => array<(
-  Address.t,
-  string,
-)> = Utils.magic
+let keyValStringToAddress: array<(string, string)> => array<(Address.t, string)> = Utils.magic
 
 let getAddressesFromContractName = (mapping, ~contractName) => {
   switch mapping->getAddresses(contractName) {

--- a/codegenerator/cli/templates/static/codegen/src/bindings/Ethers.res
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/Ethers.res
@@ -21,7 +21,6 @@ let makeAbi = (abi: Js.Json.t): abi => abi->Utils.magic
 @genType.import(("./OpaqueTypes.ts", "Address"))
 type ethAddress = Address.t
 let getAddressFromStringUnsafe = Address.Evm.fromStringOrThrow
-let formatEthAddress = Address.Evm.checksum
 let ethAddressToString = Address.toString
 let ethAddressSchema = Address.schema
 

--- a/codegenerator/cli/templates/static/codegen/src/bindings/Viem.res
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/Viem.res
@@ -21,11 +21,3 @@ let decodeEventLog: eventLog => result<
   } catch {
   | exn => Error(ParseError(exn))
   }
-
-@module("viem") external getAddressUnsafe: string => Address.t = "getAddress"
-
-let getAddress = s =>
-  switch getAddressUnsafe(s) {
-  | exception exn => Error(exn)
-  | addr => Ok(addr)
-  }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -791,12 +791,7 @@ the given name and address
 */
 let checkContainsRegisteredContractAddress = (self: t, ~contractName, ~contractAddress) => {
   let allAddr = self->getAllAddressesForContract(~contractName)
-  allAddr->Set.String.has(
-    contractAddress
-    ->//run formatEthAddress to be sure that the address is checksummed
-    Address.Evm.checksum
-    ->Address.toString,
-  )
+  allAddr->Set.String.has(contractAddress->Address.toString)
 }
 
 /**


### PR DESCRIPTION
Potentially breaking: Removed internal `Ethers.formatEthAddress` which theoretically could be used by ReScript indexers