### PR TITLE
Sanitize addresses in contract registration

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
@@ -61,8 +61,7 @@ let makeDynamicContractRegisterFn = (~contextEnv: t<'eventArgs>, ~contractName, 
 ) => {
   // Even though it's the Address.t on ReScript side, for TS side it's a string.
   // So we need to ensure that it's a valid checksummed address.
-  let contractAddress = contractAddress->Address.Evm.fromAddressOrThrow
-
+  let contractAddress = Address.Evm.sanitizeOrThrow(contractAddress)
   let {event, chain, addedDynamicContractRegistrations} = contextEnv
 
   let eventId = event->getEventId

--- a/codegenerator/cli/templates/static/codegen/src/Address.res
+++ b/codegenerator/cli/templates/static/codegen/src/Address.res
@@ -15,10 +15,17 @@ module Evm = {
   // of generated code instead of adding it to the indexer project dependencies.
   let fromStringOrThrow = fromStringOrThrow
 
-  @module("viem")
-  external fromAddressOrThrow: t => t = "getAddress"
-  // Reassign since the function might be used in the handler code
-  // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
-  // of generated code instead of adding it to the indexer project dependencies.
-  let fromAddressOrThrow = fromAddressOrThrow
+  exception InvalidAddress({address: string, message: string})
+  let sanitizeOrThrow = (address: t): t => {
+    switch address->toString->fromStringOrThrow {
+    | exception _ =>
+      raise(
+        InvalidAddress({
+          address: address->toString,
+          message: "Unable to parse address. Expected a 20-byte hex string starting with 0x.",
+        }),
+      )
+    | address => address
+    }
+  }
 }

--- a/codegenerator/cli/templates/static/codegen/src/ContractAddressingMap.res
+++ b/codegenerator/cli/templates/static/codegen/src/ContractAddressingMap.res
@@ -1,8 +1,5 @@
 type contractName = string
 
-exception UndefinedContractName(contractName, Types.chainId)
-exception UndefinedContractAddress(Address.t)
-
 // Currently this mapping append only, so we don't need to worry about
 // protecting static addresses from de-registration.
 
@@ -18,22 +15,6 @@ let addAddress = (map: mapping, ~name: string, ~address: Address.t) => {
     map.addressesByName->Js.Dict.get(name)->Belt.Option.getWithDefault(Belt.Set.String.empty)
   let newAddresses = oldAddresses->Belt.Set.String.add(address->Address.toString)
   map.addressesByName->Js.Dict.set(name, newAddresses)
-}
-
-/// This adds the address if it doesn't exist and returns a boolean to say if it already existed.
-let addAddressIfNotExists = (map: mapping, ~name: string, ~address: Address.t): bool => {
-  let addressIsNew =
-    map.nameByAddress
-    ->Js.Dict.get(address->Address.toString)
-    ->Belt.Option.mapWithDefault(true, expectedName => expectedName != name)
-
-  /* check the name, since differently named contracts can have the same address */
-
-  if addressIsNew {
-    addAddress(map, ~name, ~address)
-  }
-
-  addressIsNew
 }
 
 let getAddresses = (map: mapping, name: string) => {


### PR DESCRIPTION
Hey @DZakh,

We do actually need to do sanitization of input passed by users (since in ts and js they can just pass any string). It's definitely better doing it in the actual registration function though since then you can get a meaningful exception that's tied to the handler. And we don't want to do the validation again once it's been sanitized