### PR TITLE
Opt out of rollback on reorg for templates

### DIFF
--- a/codegenerator/cli/npm/envio/evm.schema.json
+++ b/codegenerator/cli/npm/envio/evm.schema.json
@@ -69,7 +69,7 @@
       ]
     },
     "rollback_on_reorg": {
-      "description": "A flag to indicate if the indexer should rollback to the last known valid block on a reorg (default: true)",
+      "description": "A flag to indicate if the indexer should rollback to the last known valid block on a reorg. This currently incurs a performance hit on historical sync and is recommended to turn this off while developing (default: true)",
       "type": [
         "boolean",
         "null"

--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -150,7 +150,7 @@ pub mod evm {
                 networks: networks_map.into_values().sorted_by_key(|v| v.id).collect(),
                 unordered_multichain_mode: None,
                 event_decoder: None,
-                rollback_on_reorg: None,
+                rollback_on_reorg: Some(false),
                 save_full_history: None,
                 field_selection: None,
                 raw_events: None,

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -483,7 +483,8 @@ pub mod evm {
                                   will take precedence over what is defined in the json ABI")]
         pub event: String,
         #[schemars(
-            description = "Name of the event in the HyperIndex generated code. When ommitted, the event field will be used. Should be unique per contract"
+            description = "Name of the event in the HyperIndex generated code. When ommitted, the \
+                           event field will be used. Should be unique per contract"
         )]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub name: Option<String>,

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -146,7 +146,9 @@ pub mod evm {
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
             description = "A flag to indicate if the indexer should rollback to the last known \
-                           valid block on a reorg (default: true)"
+                           valid block on a reorg. This currently incurs a performance hit on \
+                           historical sync and is recommended to turn this off while developing \
+                           (default: true)"
         )]
         pub rollback_on_reorg: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -394,7 +394,7 @@ impl SystemConfig {
                         unique_hashmap::try_insert(&mut contracts, contract.name.clone(), contract)
                             .context(format!(
                                 "Failed inserting locally defined network contract at network id \
-                               {}",
+                                 {}",
                                 network.id,
                             ))?;
                     }
@@ -459,16 +459,16 @@ impl SystemConfig {
     pub fn parse_from_project_files(project_paths: &ParsedProjectPaths) -> Result<Self> {
         let human_config_string =
             std::fs::read_to_string(&project_paths.config).context(format!(
-          "EE104: Failed to resolve config path {0}. Make sure you're in the correct directory and \
-           that a config file with the name {0} exists",
-          &project_paths.config
-              .to_str()
-              .unwrap_or("{unknown}"),
-        ))?;
+                "EE104: Failed to resolve config path {0}. Make sure you're in the correct \
+                 directory and that a config file with the name {0} exists",
+                &project_paths.config.to_str().unwrap_or("{unknown}"),
+            ))?;
 
         let config_discriminant: human_config::ConfigDiscriminant =
-          serde_yaml::from_str(&human_config_string)
-                .context("EE105: Failed to deserialize config. The config.yaml file is either not a valid yaml or the \"ecosystem\" field is not a string.")?;
+            serde_yaml::from_str(&human_config_string).context(
+                "EE105: Failed to deserialize config. The config.yaml file is either not a valid \
+                 yaml or the \"ecosystem\" field is not a string.",
+            )?;
 
         let ecosystem = match config_discriminant.ecosystem.as_deref() {
             Some("evm") => Ecosystem::Evm,
@@ -486,16 +486,20 @@ impl SystemConfig {
             Ecosystem::Evm => {
                 let mut evm_config: EvmConfig = serde_yaml::from_str(&human_config_string)
                     .context(format!(
-                    "EE105: Failed to deserialize config. Visit the docs for more information {}",
-                    links::DOC_CONFIGURATION_FILE
-                ))?;
+                        "EE105: Failed to deserialize config. Visit the docs for more information \
+                         {}",
+                        links::DOC_CONFIGURATION_FILE
+                    ))?;
                 evm_config.name = strip_to_letters(&evm_config.name);
                 let schema = Schema::parse_from_file(&project_paths, &evm_config.schema)
                     .context("Parsing schema file for config")?;
                 Self::from_evm_config(evm_config, schema, project_paths)
             }
             Ecosystem::Fuel => {
-                return Err(anyhow!("EE105: Failed to deserialize config. It's not supported with the main envio package yet, please install the envio@fuel version."));
+                return Err(anyhow!(
+                    "EE105: Failed to deserialize config. It's not supported with the main envio \
+                     package yet, please install the envio@fuel version."
+                ));
                 // let mut fuel_config: FuelConfig = serde_yaml::from_str(&human_config_string)
                 //     .context(format!(
                 //     "EE105: Failed to deserialize config. Visit the docs for more information {}",
@@ -877,9 +881,12 @@ impl Event {
 
         let log = match event_config.log_id {
             None => {
-                let logged_type = fuel_abi.get_type_by_struct_name(event_config.name.clone()).context(
-                  "Failed to derive log ids from the event name. Use the lodId field to set it explicitely."
-                )?;
+                let logged_type = fuel_abi
+                    .get_type_by_struct_name(event_config.name.clone())
+                    .context(
+                        "Failed to derive log ids from the event name. Use the lodId field to set \
+                         it explicitely.",
+                    )?;
                 fuel_abi.get_log_by_type(logged_type.id)?
             }
             Some(log_id) => fuel_abi.get_log(&log_id)?,

--- a/codegenerator/cli/src/config_parsing/validation.rs
+++ b/codegenerator/cli/src/config_parsing/validation.rs
@@ -90,9 +90,15 @@ pub fn validate_names_valid_rescript(
     let detected_reserved_words = check_reserved_words(names_from_config);
     if !detected_reserved_words.is_empty() {
         return Err(anyhow!(
-            "EE102: The config contains reserved words for {} names: {}. They are used for the generated code and must be valid identifiers, containing only alphanumeric characters and underscores.",
+            "EE102: The config contains reserved words for {} names: {}. They are used for the \
+             generated code and must be valid identifiers, containing only alphanumeric \
+             characters and underscores.",
             part_of_config,
-            detected_reserved_words.iter().map(|w| format!("\"{}\"", w)).collect::<Vec<_>>().join(", "),
+            detected_reserved_words
+                .iter()
+                .map(|w| format!("\"{}\"", w))
+                .collect::<Vec<_>>()
+                .join(", "),
         ));
     }
 
@@ -104,9 +110,15 @@ pub fn validate_names_valid_rescript(
     }
     if !invalid_names.is_empty() {
         return Err(anyhow!(
-            "EE111: The config contains invalid characters for {} names: {}. They are used for the generated code and must be valid identifiers, containing only alphanumeric characters and underscores.",
-             part_of_config,
-             invalid_names.iter().map(|w| format!("\"{}\"", w)).collect::<Vec<_>>().join(", "),
+            "EE111: The config contains invalid characters for {} names: {}. They are used for \
+             the generated code and must be valid identifiers, containing only alphanumeric \
+             characters and underscores.",
+            part_of_config,
+            invalid_names
+                .iter()
+                .map(|w| format!("\"{}\"", w))
+                .collect::<Vec<_>>()
+                .join(", "),
         ));
     }
 
@@ -116,9 +128,9 @@ pub fn validate_names_valid_rescript(
 pub fn validate_deserialized_config_yaml(evm_config: &HumanConfig) -> anyhow::Result<()> {
     if !is_valid_postgres_db_name(&evm_config.name) {
         return Err(anyhow!(
-            "EE108: The 'name' field in your config file must have the following pattern: It \
-             must start with a letter or underscore. It can contain letters, numbers, and \
-             underscores (no spaces). It must have a maximum length of 63 characters",
+            "EE108: The 'name' field in your config file must have the following pattern: It must \
+             start with a letter or underscore. It can contain letters, numbers, and underscores \
+             (no spaces). It must have a maximum length of 63 characters",
         )
         .into());
     }
@@ -136,8 +148,8 @@ pub fn validate_deserialized_config_yaml(evm_config: &HumanConfig) -> anyhow::Re
         if let Some(&network_endblock) = network.end_block.as_ref() {
             if network_endblock < network.start_block {
                 return Err(anyhow!(
-                    "EE110: The config file has an endBlock that is less than the startBlock \
-                     for network id: {}. The endBlock must be greater than the startBlock.",
+                    "EE110: The config file has an endBlock that is less than the startBlock for \
+                     network id: {}. The endBlock must be greater than the startBlock.",
                     &network.id.to_string()
                 ));
             }
@@ -161,8 +173,8 @@ pub fn validate_deserialized_config_yaml(evm_config: &HumanConfig) -> anyhow::Re
     // Checking that contract names are non-unique
     if !are_contract_names_unique(&contract_names) {
         return Err(anyhow!(
-            "EE101: The config file cannot have duplicate contract names. All contract names \
-             need to be unique, regardless of network. Contract names are not case-sensitive.",
+            "EE101: The config file cannot have duplicate contract names. All contract names need \
+             to be unique, regardless of network. Contract names are not case-sensitive.",
         ));
     }
 
@@ -369,7 +381,12 @@ mod tests {
             ],
             "contract".to_string(),
         );
-        assert_eq!(reserved_names.unwrap_err().to_string(), "EE102: The config contains reserved words for contract names: \"module\", \"this\". They are used for the generated code and must be valid identifiers, containing only alphanumeric characters and underscores.");
+        assert_eq!(
+            reserved_names.unwrap_err().to_string(),
+            "EE102: The config contains reserved words for contract names: \"module\", \"this\". \
+             They are used for the generated code and must be valid identifiers, containing only \
+             alphanumeric characters and underscores."
+        );
 
         let invalid_names = super::validate_names_valid_rescript(
             &vec![
@@ -386,6 +403,12 @@ mod tests {
             ],
             "contract".to_string(),
         );
-        assert_eq!(invalid_names.unwrap_err().to_string(), "EE111: The config contains invalid characters for contract names: \"1StartsWithNumber\", \"Has-Hyphen\", \"Has.Dot\", \"Has Space\", \"Has\"Quote\". They are used for the generated code and must be valid identifiers, containing only alphanumeric characters and underscores.");
+        assert_eq!(
+            invalid_names.unwrap_err().to_string(),
+            "EE111: The config contains invalid characters for contract names: \
+             \"1StartsWithNumber\", \"Has-Hyphen\", \"Has.Dot\", \"Has Space\", \"Has\"Quote\". \
+             They are used for the generated code and must be valid identifiers, containing only \
+             alphanumeric characters and underscores."
+        );
     }
 }

--- a/codegenerator/cli/src/fuel/abi.rs
+++ b/codegenerator/cli/src/fuel/abi.rs
@@ -157,8 +157,8 @@ impl FuelAbi {
                                     //If the type_id is not a defined generic type it is
                                     //a named type
                                     RescriptTypeIdent::TypeApplication {
-                                      name: type_ident_name,
-                                      type_params: vec![]
+                                        name: type_ident_name,
+                                        type_params: vec![],
                                     },
                                     //if the type_id is in the generic_param_name_map
                                     //it is a generic param
@@ -173,8 +173,8 @@ impl FuelAbi {
                                                 //If the type_id is not a defined generic type it is
                                                 //a named type
                                                 RescriptTypeIdent::TypeApplication {
-                                                  name:mk_type_id_name(&ta.type_id),
-                                                  type_params: vec![]
+                                                    name: mk_type_id_name(&ta.type_id),
+                                                    type_params: vec![],
                                                 },
                                                 //if the type_id is in the generic_param_name_map
                                                 //it is a generic param
@@ -223,7 +223,8 @@ impl FuelAbi {
                         type_field if type_field.starts_with("struct ") => {
                             let record_fields = get_components_name_and_type_ident()
                                 .context(format!(
-                                    "Failed getting name and identifier from components for {type_field}",
+                                    "Failed getting name and identifier from components for \
+                                     {type_field}",
                                 ))?
                                 .into_iter()
                                 .map(|(name, type_ident)| {
@@ -235,7 +236,8 @@ impl FuelAbi {
                         type_field if type_field.starts_with("enum ") => {
                             let constructors = get_components_name_and_type_ident()
                                 .context(format!(
-                                    "Failed getting name and identifier from components for {type_field}",
+                                    "Failed getting name and identifier from components for \
+                                     {type_field}",
                                 ))?
                                 .into_iter()
                                 .map(|(name, type_ident)| {
@@ -247,7 +249,8 @@ impl FuelAbi {
                         type_field if type_field.starts_with("(_,") => {
                             let tuple_types = get_components_name_and_type_ident()
                                 .context(format!(
-                                    "Failed getting name and identifier from components for tuple {type_field}",
+                                    "Failed getting name and identifier from components for tuple \
+                                     {type_field}",
                                 ))?
                                 .into_iter()
                                 .map(|(_name, type_ident)| type_ident)
@@ -256,14 +259,15 @@ impl FuelAbi {
                             RescriptTypeIdent::Tuple(tuple_types).to_ok_expr()
                         }
                         type_field if type_field.starts_with("[_;") => {
-                            let components = get_components_name_and_type_ident().context(format!(
-                              "Failed getting name and identifier from components for {type_field}",
-                            ))?;
-                            let element_name_and_type_ident = components.first().ok_or(anyhow!("Missing array element type component"))?;
-                            Array(Box::new(
-                                element_name_and_type_ident.1.clone(),
-                            ))
-                            .to_ok_expr()
+                            let components =
+                                get_components_name_and_type_ident().context(format!(
+                                    "Failed getting name and identifier from components for \
+                                     {type_field}",
+                                ))?;
+                            let element_name_and_type_ident = components
+                                .first()
+                                .ok_or(anyhow!("Missing array element type component"))?;
+                            Array(Box::new(element_name_and_type_ident.1.clone())).to_ok_expr()
                         }
                         type_field => {
                             //Unknown
@@ -282,7 +286,7 @@ impl FuelAbi {
                                     .get(tp)
                                     .ok_or(anyhow!(
                                         "param name for type_id {tp} should exist in \
-                                       generic_param_name_map"
+                                         generic_param_name_map"
                                     ))
                                     .cloned()
                             })
@@ -381,7 +385,8 @@ impl FuelAbi {
         let raw = fs::read_to_string(&path_buf)
             .context(format!("Failed to read Fuel ABI file at \"{}\"", path))?;
         let program = Self::decode_program(&raw).context(format!(
-            "Failed to decode Fuel ABI file at \"{}\". Make sure you built your program with the forc v0.33.0 or higher.",
+            "Failed to decode Fuel ABI file at \"{}\". Make sure you built your program with the \
+             forc v0.33.0 or higher.",
             path
         ))?;
         let types = Self::decode_types(&program).context(format!(

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -368,16 +368,22 @@ impl EventTemplate {
 
         for (index, param) in indexed_params.into_iter().enumerate() {
             code.push_str(&format!(
-              "        {}: decodedEvent.indexed->Js.Array2.unsafe_get({})->HyperSyncClient.Decoder.toUnderlying->Utils.magic,\n",
-              RescriptRecordField::to_valid_res_name(&param.name), index
-          ));
+                "        {}: \
+                 decodedEvent.indexed->Js.Array2.unsafe_get({})->HyperSyncClient.Decoder.\
+                 toUnderlying->Utils.magic,\n",
+                RescriptRecordField::to_valid_res_name(&param.name),
+                index
+            ));
         }
 
         for (index, param) in body_params.into_iter().enumerate() {
             code.push_str(&format!(
-              "        {}: decodedEvent.body->Js.Array2.unsafe_get({})->HyperSyncClient.Decoder.toUnderlying->Utils.magic,\n",
-              RescriptRecordField::to_valid_res_name(&param.name), index
-          ));
+                "        {}: \
+                 decodedEvent.body->Js.Array2.unsafe_get({})->HyperSyncClient.Decoder.\
+                 toUnderlying->Utils.magic,\n",
+                RescriptRecordField::to_valid_res_name(&param.name),
+                index
+            ));
         }
 
         code.push_str("      }\n    }");
@@ -438,8 +444,10 @@ impl EventTemplate {
                 data_type: type_indent.to_string(),
                 data_schema_code: type_indent.to_rescript_schema(),
                 sighash: config_event.sighash.to_string(),
-                convert_hyper_sync_event_args_code:
-                    "(Utils.magic: HyperSyncClient.Decoder.decodedEvent => eventArgs)".to_string(),
+                convert_hyper_sync_event_args_code: "(Utils.magic: \
+                                                     HyperSyncClient.Decoder.decodedEvent => \
+                                                     eventArgs)"
+                    .to_string(),
                 decode_hyper_fuel_data_code: Self::DECODE_HYPER_FUEL_DATA_CODE.to_string(),
             }),
         }
@@ -1052,11 +1060,32 @@ mod test {
             name: "NewGravatar".to_string().to_capitalized_options(),
             sighash,
             params,
-            data_type: "{id: bigint, owner: Address.t, displayName: string, imageUrl: string}".to_string(),
-            convert_hyper_sync_event_args_code: "(decodedEvent: HyperSyncClient.Decoder.decodedEvent): eventArgs => {\n      {\n        id: decodedEvent.body->Js.Array2.unsafe_get(0)->HyperSyncClient.Decoder.toUnderlying->Utils.magic,\n        owner: decodedEvent.body->Js.Array2.unsafe_get(1)->HyperSyncClient.Decoder.toUnderlying->Utils.magic,\n        displayName: decodedEvent.body->Js.Array2.unsafe_get(2)->HyperSyncClient.Decoder.toUnderlying->Utils.magic,\n        imageUrl: decodedEvent.body->Js.Array2.unsafe_get(3)->HyperSyncClient.Decoder.toUnderlying->Utils.magic,\n      }\n    }".to_string(),
-            decode_hyper_fuel_data_code:
-                "(_) => Js.Exn.raiseError(\"HyperFuel decoder not implemented\")".to_string(),
-            data_schema_code: "S.object(s => {id: s.field(\"id\", BigInt.schema), owner: s.field(\"owner\", Address.schema), displayName: s.field(\"displayName\", S.string), imageUrl: s.field(\"imageUrl\", S.string)})".to_string(),
+            data_type: "{id: bigint, owner: Address.t, displayName: string, imageUrl: string}"
+                .to_string(),
+            convert_hyper_sync_event_args_code: "(decodedEvent: \
+                                                 HyperSyncClient.Decoder.decodedEvent): eventArgs \
+                                                 => {\n      {\n        id: \
+                                                 decodedEvent.body->Js.Array2.\
+                                                 unsafe_get(0)->HyperSyncClient.Decoder.\
+                                                 toUnderlying->Utils.magic,\n        owner: \
+                                                 decodedEvent.body->Js.Array2.\
+                                                 unsafe_get(1)->HyperSyncClient.Decoder.\
+                                                 toUnderlying->Utils.magic,\n        displayName: \
+                                                 decodedEvent.body->Js.Array2.\
+                                                 unsafe_get(2)->HyperSyncClient.Decoder.\
+                                                 toUnderlying->Utils.magic,\n        imageUrl: \
+                                                 decodedEvent.body->Js.Array2.\
+                                                 unsafe_get(3)->HyperSyncClient.Decoder.\
+                                                 toUnderlying->Utils.magic,\n      }\n    }"
+                .to_string(),
+            decode_hyper_fuel_data_code: "(_) => Js.Exn.raiseError(\"HyperFuel decoder not \
+                                          implemented\")"
+                .to_string(),
+            data_schema_code: "S.object(s => {id: s.field(\"id\", BigInt.schema), owner: \
+                               s.field(\"owner\", Address.schema), displayName: \
+                               s.field(\"displayName\", S.string), imageUrl: \
+                               s.field(\"imageUrl\", S.string)})"
+                .to_string(),
         }
     }
 
@@ -1082,10 +1111,13 @@ mod test {
                     .to_string(),
                 params: vec![],
                 data_type: "unit".to_string(),
-                convert_hyper_sync_event_args_code:
-                    "(Utils.magic: HyperSyncClient.Decoder.decodedEvent => eventArgs)".to_string(),
-                decode_hyper_fuel_data_code:
-                    "(_) => Js.Exn.raiseError(\"HyperFuel decoder not implemented\")".to_string(),
+                convert_hyper_sync_event_args_code: "(Utils.magic: \
+                                                     HyperSyncClient.Decoder.decodedEvent => \
+                                                     eventArgs)"
+                    .to_string(),
+                decode_hyper_fuel_data_code: "(_) => Js.Exn.raiseError(\"HyperFuel decoder not \
+                                              implemented\")"
+                    .to_string(),
                 data_schema_code: "S.literal(%raw(`null`))->S.variant(_ => ())".to_string(),
             }
         );

--- a/codegenerator/cli/src/hbs_templating/contract_import_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/contract_import_templates.rs
@@ -286,7 +286,8 @@ impl Event {
                 to_string_code
             ),
             false => format!(
-                "`${{{event_var_name}.chainId}}_${{{event_var_name}.block.number}}_${{{event_var_name}.logIndex{}}}`",
+                "`${{{event_var_name}.chainId}}_${{{event_var_name}.block.\
+                 number}}_${{{event_var_name}.logIndex{}}}`",
                 to_string_code
             ),
         }

--- a/codegenerator/cli/src/rescript_types.rs
+++ b/codegenerator/cli/src/rescript_types.rs
@@ -460,8 +460,8 @@ impl RescriptTypeIdent {
             Self::Unit => "undefined".to_string(),
             Self::Int | Self::Float => "0".to_string(),
             Self::BigInt => "0n".to_string(),
-            Self::BigDecimal => "// default value not required since BigDecimal \
-                                              doesn't exist on contracts for contract import"
+            Self::BigDecimal => "// default value not required since BigDecimal doesn't exist on \
+                                 contracts for contract import"
                 .to_string(),
             Self::Address => "Addresses.defaultAddress".to_string(),
             Self::String => "\"foo\"".to_string(),
@@ -625,7 +625,8 @@ mod tests {
                 RescriptRecordField::new("fieldB".to_string(), RescriptTypeIdent::Bool),
             ])
             .to_rescript_schema(),
-            "S.object(s => {fieldA: s.field(\"fieldA\", S.int), fieldB: s.field(\"fieldB\", S.bool)})"
+            "S.object(s => {fieldA: s.field(\"fieldA\", S.int), fieldB: s.field(\"fieldB\", \
+             S.bool)})"
                 .to_string()
         );
         assert_eq!(

--- a/codegenerator/cli/templates/static/erc20_template/javascript/config.yaml
+++ b/codegenerator/cli/templates/static/erc20_template/javascript/config.yaml
@@ -11,3 +11,6 @@ networks:
         events:
           - event: "Approval(address indexed owner, address indexed spender, uint256 value)"
           - event: "Transfer(address indexed from, address indexed to, uint256 value)"
+# Rollback on reorg mode currently incurs a performance hit on historical sync
+# while developing an indexer we recommend setting this to false
+rollback_on_reorg: false

--- a/codegenerator/cli/templates/static/erc20_template/rescript/config.yaml
+++ b/codegenerator/cli/templates/static/erc20_template/rescript/config.yaml
@@ -11,3 +11,6 @@ networks:
         events:
           - event: "Approval(address indexed owner, address indexed spender, uint256 value)"
           - event: "Transfer(address indexed from, address indexed to, uint256 value)"
+# Rollback on reorg mode currently incurs a performance hit on historical sync
+# while developing an indexer we recommend setting this to false
+rollback_on_reorg: false

--- a/codegenerator/cli/templates/static/erc20_template/typescript/config.yaml
+++ b/codegenerator/cli/templates/static/erc20_template/typescript/config.yaml
@@ -11,3 +11,6 @@ networks:
         events:
           - event: "Approval(address indexed owner, address indexed spender, uint256 value)"
           - event: "Transfer(address indexed from, address indexed to, uint256 value)"
+# Rollback on reorg mode currently incurs a performance hit on historical sync
+# while developing an indexer we recommend setting this to false
+rollback_on_reorg: false

--- a/codegenerator/cli/templates/static/greeter_template/javascript/config.yaml
+++ b/codegenerator/cli/templates/static/greeter_template/javascript/config.yaml
@@ -22,3 +22,6 @@ networks:
     contracts:
       - name: Greeter #A reference to the global contract definition
         address: "0xdEe21B97AB77a16B4b236F952e586cf8408CF32A"
+# Rollback on reorg mode currently incurs a performance hit on historical sync
+# while developing an indexer we recommend setting this to false
+rollback_on_reorg: false

--- a/codegenerator/cli/templates/static/greeter_template/rescript/config.yaml
+++ b/codegenerator/cli/templates/static/greeter_template/rescript/config.yaml
@@ -22,3 +22,6 @@ networks:
     contracts:
       - name: Greeter #A reference to the global contract definition
         address: 0xdEe21B97AB77a16B4b236F952e586cf8408CF32A
+# Rollback on reorg mode currently incurs a performance hit on historical sync
+# while developing an indexer we recommend setting this to false
+rollback_on_reorg: false

--- a/codegenerator/cli/templates/static/greeter_template/typescript/config.yaml
+++ b/codegenerator/cli/templates/static/greeter_template/typescript/config.yaml
@@ -22,3 +22,6 @@ networks:
     contracts:
       - name: Greeter #A reference to the global contract definition
         address: 0xdEe21B97AB77a16B4b236F952e586cf8408CF32A
+# Rollback on reorg mode currently incurs a performance hit on historical sync
+# while developing an indexer we recommend setting this to false
+rollback_on_reorg: false


### PR DESCRIPTION
Currently it incurs a performance hit on historical sync. For starting up and development we want to encourage people to turn it off until they deploy for production.