### PR TITLE
Refactor array slicing code to reversed arrays with pop

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
@@ -51,7 +51,7 @@
     "postgres": "3.4.1",
     "prom-client": "15.0.0",
     "react": "18.2.0",
-    "rescript": "11.1.0",
+    "rescript": "11.1.3",
     "rescript-envsafe": "4.2.0",
     "rescript-express": "0.4.1",
     "rescript-schema": "8.0.0",

--- a/codegenerator/cli/templates/dynamic/init_templates/shared/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/init_templates/shared/package.json.hbs
@@ -32,7 +32,7 @@
     "@rescript/react": "0.12.1", 
     "@glennsl/rescript-fetch": "0.2.0",
     "@ryyppy/rescript-promise": "2.1.0",
-    "rescript": "11.1.0",
+    "rescript": "11.1.3",
   {{/if}}
   {{#if is_typescript}}
     "@types/chai": "^4.3.11",    

--- a/codegenerator/cli/templates/static/codegen/src/Utils.res
+++ b/codegenerator/cli/templates/static/codegen/src/Utils.res
@@ -132,6 +132,31 @@ Helper to check if a value exists in an array
       [...head, ...tail]
     }
   }
+
+  let last = (arr: array<'a>): option<'a> => arr->Belt.Array.get(arr->Array.length - 1)
+
+  let findReverseWithIndex = (arr: array<'a>, fn: 'a => bool): option<('a, int)> => {
+    let rec loop = (index: int) => {
+      if index < 0 {
+        None
+      } else {
+        let item = arr[index]
+        if fn(item) {
+          Some((item, index))
+        } else {
+          loop(index - 1)
+        }
+      }
+    }
+    loop(arr->Array.length - 1)
+  }
+
+  /** 
+  Currently a bug in rescript if you ignore the return value of spliceInPlace 
+  https://github.com/rescript-lang/rescript-compiler/issues/6991
+  */
+  @send
+  external spliceInPlace: (array<'a>, ~pos: int, ~remove: int) => array<'a> = "splice"
 }
 
 /**

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -63,7 +63,6 @@ type noItemsInArray = NoItemsInArray
 
 let determineNextEvent = (
   fetchStatesMap: ChainMap.t<PartitionedFetchState.t>,
-  // ~maybeArbItem
   ~isUnorderedMultichainMode: bool,
 ): result<multiChainEventComparitor, noItemsInArray> => {
   let comparitorFunction = if isUnorderedMultichainMode {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -2,7 +2,7 @@ open Belt
 type t = {
   chainFetchers: ChainMap.t<ChainFetcher.t>,
   //Holds arbitrary events that were added when a batch ended processing early
-  //due to contract registration
+  //due to contract registration. Ordered from latest to earliest
   arbitraryEventQueue: array<Types.eventBatchQueueItem>,
   isUnorderedMultichainMode: bool,
 }
@@ -19,12 +19,12 @@ let getComparitorFromItem = (queueItem: Types.eventBatchQueueItem) => {
 
 type multiChainEventComparitor = {
   chain: ChainMap.Chain.t,
-  earliestEventResponse: PartitionedFetchState.earliestEventResponse,
+  earliestEvent: FetchState.queueItem,
 }
 
 let getQueueItemComparitor = (earliestQueueItem: FetchState.queueItem, ~chain) => {
   switch earliestQueueItem {
-  | Item(i) => i->getComparitorFromItem
+  | Item({item}) => item->getComparitorFromItem
   | NoItem({blockTimestamp, blockNumber}) => (
       blockTimestamp,
       chain->ChainMap.Chain.toChainId,
@@ -43,8 +43,8 @@ let priorityQueueComparitor = (a: Types.eventBatchQueueItem, b: Types.eventBatch
 }
 
 let isQueueItemEarlier = (a: multiChainEventComparitor, b: multiChainEventComparitor): bool => {
-  a.earliestEventResponse.earliestQueueItem->getQueueItemComparitor(~chain=a.chain) <
-    b.earliestEventResponse.earliestQueueItem->getQueueItemComparitor(~chain=b.chain)
+  a.earliestEvent->getQueueItemComparitor(~chain=a.chain) <
+    b.earliestEvent->getQueueItemComparitor(~chain=b.chain)
 }
 
 // This is similar to `chainFetcherPeekComparitorEarliestEvent`, but it prioritizes events over `NoItem` no matter what the timestamp of `NoItem` is.
@@ -52,7 +52,7 @@ let chainFetcherPeekComparitorEarliestEventPrioritizeEvents = (
   a: multiChainEventComparitor,
   b: multiChainEventComparitor,
 ): bool => {
-  switch (a.earliestEventResponse.earliestQueueItem, b.earliestEventResponse.earliestQueueItem) {
+  switch (a.earliestEvent, b.earliestEvent) {
   | (Item(_), NoItem(_)) => true
   | (NoItem(_), Item(_)) => false
   | _ => isQueueItemEarlier(a, b)
@@ -62,8 +62,9 @@ let chainFetcherPeekComparitorEarliestEventPrioritizeEvents = (
 type noItemsInArray = NoItemsInArray
 
 let determineNextEvent = (
-  ~isUnorderedMultichainMode: bool,
   fetchStatesMap: ChainMap.t<PartitionedFetchState.t>,
+  // ~maybeArbItem
+  ~isUnorderedMultichainMode: bool,
 ): result<multiChainEventComparitor, noItemsInArray> => {
   let comparitorFunction = if isUnorderedMultichainMode {
     chainFetcherPeekComparitorEarliestEventPrioritizeEvents
@@ -77,8 +78,8 @@ let determineNextEvent = (
     ->Array.reduce(None, (accum, (chain, partitionedFetchState)) => {
       // If the fetch state has reached the end block we don't need to consider it
       switch partitionedFetchState->PartitionedFetchState.getEarliestEvent {
-      | Some(earliestEventResponse) =>
-        let cmpA: multiChainEventComparitor = {chain, earliestEventResponse}
+      | Some(earliestEvent) =>
+        let cmpA: multiChainEventComparitor = {chain, earliestEvent}
         switch accum {
         | None => cmpA
         | Some(cmpB) =>
@@ -98,11 +99,9 @@ let determineNextEvent = (
   }
 }
 
-let makeFromConfig = (
-  ~config: Config.t,
-  ~maxAddrInPartition=Env.maxAddrInPartition,
-): t => {
-  let chainFetchers = config.chainMap->ChainMap.map(ChainFetcher.makeFromConfig(_, ~maxAddrInPartition))
+let makeFromConfig = (~config: Config.t, ~maxAddrInPartition=Env.maxAddrInPartition): t => {
+  let chainFetchers =
+    config.chainMap->ChainMap.map(ChainFetcher.makeFromConfig(_, ~maxAddrInPartition))
   {
     chainFetchers,
     arbitraryEventQueue: [],
@@ -188,41 +187,29 @@ let setChainFetcher = (self: t, chainFetcher: ChainFetcher.t) => {
   }
 }
 
-type earliestQueueItem =
-  | ArbitraryEventQueue(Types.eventBatchQueueItem, array<Types.eventBatchQueueItem>)
-  | EventFetchers(Types.eventBatchQueueItem, ChainMap.t<PartitionedFetchState.t>)
-
-let rec getFirstArbitraryEventsItemForChain = (
-  queue: array<Types.eventBatchQueueItem>,
-  ~index=0,
-  ~chain,
-) => {
-  switch queue[index] {
-  | None => None
-  | Some(first) =>
-    let nextIndex = index + 1
-    if first.chain == chain {
-      Some((first, () => queue->Utils.Array.removeAtIndex(index)))
-    } else {
-      queue->getFirstArbitraryEventsItemForChain(~chain, ~index=nextIndex)
-    }
-  }
-}
+let getFirstArbitraryEventsItemForChain = (queue: array<Types.eventBatchQueueItem>, ~chain) =>
+  queue
+  ->Utils.Array.findReverseWithIndex((item: Types.eventBatchQueueItem) => {
+    item.chain == chain
+  })
+  ->Option.map(((item, index)) => {
+    FetchState.item,
+    popItemOffQueue: () => queue->Utils.Array.spliceInPlace(~pos=index, ~remove=1)->ignore,
+  })
 
 let getFirstArbitraryEventsItem = (queue: array<Types.eventBatchQueueItem>) =>
-  switch queue[0] {
-  | None => None
-  | Some(first) => Some((first, () => Array.sliceToEnd(queue, 1)))
-  }
+  queue
+  ->Utils.Array.last
+  ->Option.map(item => {FetchState.item, popItemOffQueue: () => queue->Js.Array2.pop->ignore})
 
 let popBatchItem = (
   ~fetchStatesMap: ChainMap.t<PartitionedFetchState.t>,
   ~arbitraryEventQueue: array<Types.eventBatchQueueItem>,
   ~isUnorderedMultichainMode,
-): option<earliestQueueItem> => {
+): option<FetchState.itemWithPopFn> => {
   //Compare the peeked items and determine the next item
   switch fetchStatesMap->determineNextEvent(~isUnorderedMultichainMode) {
-  | Ok({chain, earliestEventResponse: {getUpdatedPartitionedFetchState, earliestQueueItem}}) =>
+  | Ok({chain, earliestEvent}) =>
     let maybeArbItem = if isUnorderedMultichainMode {
       arbitraryEventQueue->getFirstArbitraryEventsItemForChain(~chain)
     } else {
@@ -231,26 +218,17 @@ let popBatchItem = (
     switch maybeArbItem {
     //If there is item on the arbitray events queue, and it is earlier than
     //than the earlist event, take the item off from there
-    | Some((qItem, getUpdatedArbQueue))
-      if Item(qItem)->getQueueItemComparitor(~chain=qItem.chain) <
-        earliestQueueItem->getQueueItemComparitor(~chain) =>
-      Some(ArbitraryEventQueue(qItem, getUpdatedArbQueue()))
+    | Some(itemWithPopFn)
+      if Item(itemWithPopFn)->getQueueItemComparitor(~chain=itemWithPopFn.item.chain) <
+        earliestEvent->getQueueItemComparitor(~chain) =>
+      Some(itemWithPopFn)
     | _ =>
-      //Otherwise take the latest item from the fetchers
-      switch earliestQueueItem {
+      switch earliestEvent {
       | NoItem(_) => None
-      | Item(qItem) =>
-        let updatedFetchStatesMap =
-          fetchStatesMap->ChainMap.set(chain, getUpdatedPartitionedFetchState())
-        EventFetchers(qItem, updatedFetchStatesMap)->Some
+      | Item(itemWithPopFn) => Some(itemWithPopFn)
       }
     }
-  | Error(NoItemsInArray) =>
-    arbitraryEventQueue
-    ->getFirstArbitraryEventsItem
-    ->Option.map(((qItem, getUpdatedArbQueue)) => {
-      ArbitraryEventQueue(qItem, getUpdatedArbQueue())
-    })
+  | Error(NoItemsInArray) => arbitraryEventQueue->getFirstArbitraryEventsItem
   }
 }
 
@@ -258,12 +236,12 @@ let popBatchItem = (
 Simply calls popBatchItem in isolation using the chain manager without
 the context of a batch
 */
-let peakNextBatchItem = (self: t): option<earliestQueueItem> => {
+let nextItemIsNone = (self: t): bool => {
   popBatchItem(
     ~fetchStatesMap=self.chainFetchers->ChainMap.map(cf => cf.fetchState),
     ~arbitraryEventQueue=self.arbitraryEventQueue,
     ~isUnorderedMultichainMode=self.isUnorderedMultichainMode,
-  )
+  )->Option.isNone
 }
 
 type batchRes = {
@@ -272,59 +250,44 @@ type batchRes = {
   arbitraryEventQueue: array<Types.eventBatchQueueItem>,
 }
 
-let makeBatch = (~batch, ~fetchStatesMap, ~arbitraryEventQueue) => {
-  batch,
-  fetchStatesMap,
-  arbitraryEventQueue,
-}
-
-let rec createBatchInternal = (
+let createBatchInternal = (
   ~maxBatchSize,
   ~fetchStatesMap: ChainMap.t<PartitionedFetchState.t>,
   ~arbitraryEventQueue,
   ~isUnorderedMultichainMode,
-  ~batch=[],
 ) => {
-  if batch->Array.length >= maxBatchSize {
-    makeBatch(~batch, ~fetchStatesMap, ~arbitraryEventQueue)
-  } else {
-    switch popBatchItem(~fetchStatesMap, ~arbitraryEventQueue, ~isUnorderedMultichainMode) {
-    | None => makeBatch(~batch, ~fetchStatesMap, ~arbitraryEventQueue)
-    | Some(item) =>
-      let (arbitraryEventQueue, fetchStatesMap, nextItem) = switch item {
-      | ArbitraryEventQueue(item, arbitraryEventQueue) => (
-          arbitraryEventQueue,
-          fetchStatesMap,
-          item,
-        )
-      | EventFetchers(item, fetchStatesMap) => (arbitraryEventQueue, fetchStatesMap, item)
+  let batch = []
+  let rec loop = () =>
+    if batch->Array.length >= maxBatchSize {
+      batch
+    } else {
+      switch popBatchItem(~fetchStatesMap, ~arbitraryEventQueue, ~isUnorderedMultichainMode) {
+      | None => batch
+      | Some({item, popItemOffQueue}) =>
+        popItemOffQueue()
+        batch->Js.Array2.push(item)->ignore
+        loop()
       }
-      let _ = batch->Js.Array2.push(nextItem)
-      createBatchInternal(
-        ~batch,
-        ~maxBatchSize,
-        ~arbitraryEventQueue,
-        ~fetchStatesMap,
-        ~isUnorderedMultichainMode,
-      )
     }
-  }
+  loop()
 }
 
 let createBatch = (self: t, ~maxBatchSize: int) => {
   let refTime = Hrtime.makeTimer()
 
   let {arbitraryEventQueue, chainFetchers} = self
-  let fetchStatesMap = chainFetchers->ChainMap.map(cf => cf.fetchState)
+  //Make a copy of the queues and fetch states since we are going to mutate them
+  let arbitraryEventQueue = arbitraryEventQueue->Array.copy
+  let fetchStatesMap = chainFetchers->ChainMap.map(cf => cf.fetchState->PartitionedFetchState.copy)
 
-  let response = createBatchInternal(
+  let batch = createBatchInternal(
     ~maxBatchSize,
     ~fetchStatesMap,
     ~arbitraryEventQueue,
     ~isUnorderedMultichainMode=self.isUnorderedMultichainMode,
   )
 
-  let batchSize = response.batch->Array.length
+  let batchSize = batch->Array.length
 
   if batchSize > 0 {
     let fetchedEventsBuffer =
@@ -346,7 +309,7 @@ let createBatch = (self: t, ~maxBatchSize: int) => {
       "time taken (ms)": timeElapsed,
     })
 
-    Some(response)
+    Some({batch, fetchStatesMap, arbitraryEventQueue})
   } else {
     None
   }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -544,13 +544,6 @@ let makeNoItem = ({latestFetchedBlock}: t) => NoItem(latestFetchedBlock)
 
 let qItemLt = (a, b) => a->getCmpVal < b->getCmpVal
 
-type earliestEventResponse = {
-  //make this lazy to prevent extra array duplications
-  //before evaluation of earliestQueueItem
-  updateFetchStateMut: unit => unit,
-  earliestQueueItem: queueItem,
-}
-
 /**
 Returns queue item WITHOUT the updated fetch state. Used for checking values
 not updating state
@@ -562,16 +555,6 @@ let getEarliestEventInRegister = (self: t) => {
   | None => makeNoItem(self)
   }
 }
-
-/**
-Returns queue item WITH the updated fetch state. 
-*/
-let getEarliestEventInRegisterWithUpdatedQueue = (self: t) =>
-  switch self.fetchedEventQueue->Utils.Array.last {
-  | None => makeNoItem(self)
-  | Some(head) =>
-    Item({item: head, popItemOffQueue: () => self.fetchedEventQueue->Js.Array2.pop->ignore})
-  }
 
 /**
 Recurses through all registers and finds the register with the earliest queue item,
@@ -607,7 +590,7 @@ let rec popQItemAtRegisterId = (self: t, ~id) => {
   switch self.registerType {
   | RootRegister(_)
   | DynamicContractRegister(_) if id == self->getRegisterId =>
-    self->getEarliestEventInRegisterWithUpdatedQueue->Ok
+    self->getEarliestEventInRegister->Ok
   | DynamicContractRegister(_, nextRegister) => nextRegister->popQItemAtRegisterId(~id)
   | RootRegister(_) => Error(UnexpectedRegisterDoesNotExist(id))
   }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -89,6 +89,7 @@ up to the root.
 type fetchStateData = {
   latestFetchedBlock: blockNumberAndTimestamp,
   contractAddressMapping: ContractAddressingMap.mapping,
+  //Events ordered from latest to earliest
   fetchedEventQueue: array<Types.eventBatchQueueItem>,
   //Used to prune dynamic contract registrations in the event
   //of a rollback.
@@ -163,6 +164,28 @@ module Parent = {
   }
 }
 
+let shallowCopyRegister = (self: t) => {
+  ...self,
+  fetchedEventQueue: self.fetchedEventQueue->Array.copy,
+}
+
+let copy = (self: t) => {
+  let rec loop = (self: t, ~parent=?) =>
+    switch self.registerType {
+    | RootRegister(_) =>
+      let copied = self->shallowCopyRegister
+      switch parent {
+      | Some(parent) => parent->Parent.joinChild(copied)
+      | None => copied
+      }
+    | DynamicContractRegister(dynamicContractId, nextRegistered) =>
+      nextRegistered->loop(
+        ~parent=self->shallowCopyRegister->Parent.make(~dynamicContractId, ~parent),
+      )
+    }
+
+  loop(self)
+}
 /**
 Comapritor for two events from the same chain. No need for chain id or timestamp
 */
@@ -171,9 +194,9 @@ let getEventCmp = (event: Types.eventBatchQueueItem) => {
 }
 
 /**
-Returns the earliest of two events on the same chain
+Returns the latest of two events on the same chain
 */
-let eventCmp = (a, b) => a->getEventCmp <= b->getEventCmp
+let eventCmp = (a, b) => a->getEventCmp > b->getEventCmp
 
 /**
 Merges two event queues on a single event fetcher
@@ -252,6 +275,7 @@ events.
 let updateRegister = (
   self: t,
   ~latestFetchedBlock,
+  //Events ordered earliest to latest
   ~newFetchedEvents: array<Types.eventBatchQueueItem>,
   ~isFetchingAtHead,
 ) => {
@@ -264,7 +288,7 @@ let updateRegister = (
     isFetchingAtHead,
     latestFetchedBlock,
     firstEventBlockNumber,
-    fetchedEventQueue: Array.concat(self.fetchedEventQueue, newFetchedEvents),
+    fetchedEventQueue: Array.concat(newFetchedEvents->Array.reverse, self.fetchedEventQueue),
   }
 }
 
@@ -327,6 +351,8 @@ let rec pruneAndMergeNextRegistered = (self: t, ~isMerged=false) => {
 /**
 Updates node at given id with given values and checks to see if it can be merged into its next register.
 Returns Error if the node with given id cannot be found (unexpected)
+
+fetchedEvents are ordered earliest to latest (as they are returned from the worker)
 */
 let update = (self: t, ~id, ~latestFetchedBlock, ~fetchedEvents, ~currentBlockHeight): result<
   t,
@@ -488,12 +514,14 @@ let getNextQuery = (~eventFilters=?, ~currentBlockHeight, ~partitionId, self: t)
   }
 }
 
+type itemWithPopFn = {item: Types.eventBatchQueueItem, popItemOffQueue: unit => unit}
+
 /**
 Represents a fetchState registers head of the  fetchedEventQueue as either
 an existing item, or no item with latest fetched block data
 */
 type queueItem =
-  | Item(Types.eventBatchQueueItem)
+  | Item(itemWithPopFn)
   | NoItem(blockNumberAndTimestamp)
 
 /**
@@ -505,7 +533,7 @@ Note: on the chain manager, when comparing multi chain, the timestamp is the hig
 */
 let getCmpVal = qItem =>
   switch qItem {
-  | Item({blockNumber, logIndex}) => (blockNumber, logIndex)
+  | Item({item: {blockNumber, logIndex}}) => (blockNumber, logIndex)
   | NoItem({blockNumber}) => (blockNumber, 0)
   }
 
@@ -519,7 +547,7 @@ let qItemLt = (a, b) => a->getCmpVal < b->getCmpVal
 type earliestEventResponse = {
   //make this lazy to prevent extra array duplications
   //before evaluation of earliestQueueItem
-  getUpdatedFetchState: unit => t,
+  updateFetchStateMut: unit => unit,
   earliestQueueItem: queueItem,
 }
 
@@ -528,8 +556,9 @@ Returns queue item WITHOUT the updated fetch state. Used for checking values
 not updating state
 */
 let getEarliestEventInRegister = (self: t) => {
-  switch self.fetchedEventQueue[0] {
-  | Some(head) => Item(head)
+  switch self.fetchedEventQueue->Utils.Array.last {
+  | Some(head) =>
+    Item({item: head, popItemOffQueue: () => self.fetchedEventQueue->Js.Array2.pop->ignore})
   | None => makeNoItem(self)
   }
 }
@@ -537,17 +566,12 @@ let getEarliestEventInRegister = (self: t) => {
 /**
 Returns queue item WITH the updated fetch state. 
 */
-let getEarliestEventInRegisterWithUpdatedQueue = (self: t) => {
-  let (getUpdatedFetchState, earliestQueueItem) = switch self.fetchedEventQueue[0] {
-  | None => (() => self, makeNoItem(self))
-  | Some(head) => (
-      () => {...self, fetchedEventQueue: self.fetchedEventQueue->Array.sliceToEnd(1)},
-      Item(head),
-    )
+let getEarliestEventInRegisterWithUpdatedQueue = (self: t) =>
+  switch self.fetchedEventQueue->Utils.Array.last {
+  | None => makeNoItem(self)
+  | Some(head) =>
+    Item({item: head, popItemOffQueue: () => self.fetchedEventQueue->Js.Array2.pop->ignore})
   }
-
-  {getUpdatedFetchState, earliestQueueItem}
-}
 
 /**
 Recurses through all registers and finds the register with the earliest queue item,
@@ -579,21 +603,12 @@ fetch state with that item.
 
 Recurses through registers and Errors if ID does not exist
 */
-let rec popQItemAtRegisterId = (self: t, ~id, ~parent: option<Parent.t>=?) => {
+let rec popQItemAtRegisterId = (self: t, ~id) => {
   switch self.registerType {
   | RootRegister(_)
   | DynamicContractRegister(_) if id == self->getRegisterId =>
-    let updated = self->getEarliestEventInRegisterWithUpdatedQueue
-    switch parent {
-    | Some(parent) =>
-      {
-        ...updated,
-        getUpdatedFetchState: () => parent->Parent.joinChild(updated.getUpdatedFetchState()),
-      }->Ok
-    | None => Ok(updated)
-    }
-  | DynamicContractRegister(dynamicContractId, nextRegister) =>
-    nextRegister->popQItemAtRegisterId(~id, ~parent=self->Parent.make(~dynamicContractId, ~parent))
+    self->getEarliestEventInRegisterWithUpdatedQueue->Ok
+  | DynamicContractRegister(_, nextRegister) => nextRegister->popQItemAtRegisterId(~id)
   | RootRegister(_) => Error(UnexpectedRegisterDoesNotExist(id))
   }
 }
@@ -799,18 +814,19 @@ let checkContainsRegisteredContractAddress = (self: t, ~contractName, ~contractA
 */
 let getLatestFullyFetchedBlock = (self: t) => self.latestFetchedBlock
 
-let rec pruneQueuePastValidBlock = (
-  queue: array<Types.eventBatchQueueItem>,
-  ~index=0,
-  ~accum=[],
-  ~lastKnownValidBlock,
-) => {
-  switch queue[index] {
-  | Some(head) if head.blockNumber <= lastKnownValidBlock.blockNumber =>
-    let _ = accum->Js.Array2.push(head)
-    queue->pruneQueuePastValidBlock(~lastKnownValidBlock, ~accum, ~index=index + 1)
-  | _ => accum
+let pruneQueuePastValidBlock = (queue: array<Types.eventBatchQueueItem>, ~lastKnownValidBlock) => {
+  let prunedQueue = []
+  let rec loop = index => {
+    switch queue[index] {
+    | Some(head) =>
+      if head.blockNumber <= lastKnownValidBlock.blockNumber {
+        prunedQueue->Js.Array2.push(head)->ignore
+      }
+      loop(index + 1)
+    | None => prunedQueue
+    }
   }
+  loop(0)
 }
 
 let pruneDynamicContractAddressesPastValidBlock = (~lastKnownValidBlock, register: t) => {

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -136,8 +136,7 @@ Takes in a chain manager and sets all chains timestamp caught up to head
 when valid state lines up and returns an updated chain manager
 */
 let checkAndSetSyncedChains = (~nextQueueItemIsKnownNone=false, chainManager: ChainManager.t) => {
-  let nextQueueItemIsNone =
-    nextQueueItemIsKnownNone || chainManager->ChainManager.peakNextBatchItem->Option.isNone
+  let nextQueueItemIsNone = nextQueueItemIsKnownNone || chainManager->ChainManager.nextItemIsNone
 
   let allChainsAtHead =
     chainManager.chainFetchers
@@ -414,8 +413,8 @@ let actionReducer = (state: t, action: action) => {
       dynamicContractRegistrations: Some({registrations, unprocessedBatch}),
     }) =>
     let updatedArbQueue = Utils.Array.mergeSorted((a, b) => {
-      a->EventUtils.getEventComparatorFromQueueItem <= b->EventUtils.getEventComparatorFromQueueItem
-    }, unprocessedBatch, state.chainManager.arbitraryEventQueue)
+      a->EventUtils.getEventComparatorFromQueueItem > b->EventUtils.getEventComparatorFromQueueItem
+    }, unprocessedBatch->Array.reverse, state.chainManager.arbitraryEventQueue)
 
     let nextTasks = [
       UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -656,7 +655,13 @@ let checkAndFetchForChain = (
   ~dispatchAction,
 ) => async chain => {
   let chainFetcher = state.chainManager.chainFetchers->ChainMap.get(chain)
-  let {fetchState, chainConfig: {chainWorker}, logger, currentBlockHeight, isFetchingBatch} = chainFetcher
+  let {
+    fetchState,
+    chainConfig: {chainWorker},
+    logger,
+    currentBlockHeight,
+    isFetchingBatch,
+  } = chainFetcher
 
   if (
     !isFetchingBatch &&

--- a/scenarios/erc20_multichain_factory/package.json
+++ b/scenarios/erc20_multichain_factory/package.json
@@ -16,7 +16,7 @@
     "ethers": "6.8.0",
     "helpers": "../helpers",
     "mocha": "10.2.0",
-    "rescript": "11.1.0",
+    "rescript": "11.1.3",
     "rescript-schema": "8.0.0"
   },
   "optionalDependencies": {

--- a/scenarios/erc20_multichain_factory/pnpm-lock.yaml
+++ b/scenarios/erc20_multichain_factory/pnpm-lock.yaml
@@ -24,11 +24,11 @@ importers:
         specifier: 10.2.0
         version: 10.2.0
       rescript:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 11.1.3
+        version: 11.1.3
       rescript-schema:
         specifier: 8.0.0
-        version: 8.0.0(rescript@11.1.0)
+        version: 8.0.0(rescript@11.1.3)
     optionalDependencies:
       generated:
         specifier: ./generated
@@ -37,11 +37,11 @@ importers:
   ../helpers:
     dependencies:
       rescript:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 11.1.3
+        version: 11.1.3
       rescript-schema:
         specifier: 8.0.0
-        version: 8.0.0(rescript@11.1.0)
+        version: 8.0.0(rescript@11.1.3)
 
   generated:
     dependencies:
@@ -106,17 +106,17 @@ importers:
         specifier: 18.2.0
         version: 18.2.0
       rescript:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 11.1.3
+        version: 11.1.3
       rescript-envsafe:
         specifier: 4.2.0
-        version: 4.2.0(rescript-schema@8.0.0(rescript@11.1.0))(rescript@11.1.0)
+        version: 4.2.0(rescript-schema@8.0.0(rescript@11.1.3))(rescript@11.1.3)
       rescript-express:
         specifier: 0.4.1
         version: 0.4.1(express@4.19.2)
       rescript-schema:
         specifier: 8.0.0
-        version: 8.0.0(rescript@11.1.0)
+        version: 8.0.0(rescript@11.1.3)
       root:
         specifier: ../.
         version: link:..
@@ -1116,8 +1116,8 @@ packages:
     peerDependencies:
       rescript: 11.x
 
-  rescript@11.1.0:
-    resolution: {integrity: sha512-9la2Dv+ACylQ77I8s4spPu1JnLZXbH5WgxcLHLLUBWgFFSiv0wXqgzWztrBIZqwFgVX5BYcwldUqUVcEzdCyHg==}
+  rescript@11.1.3:
+    resolution: {integrity: sha512-bI+yxDcwsv7qE34zLuXeO8Qkc2+1ng5ErlSjnUIZdrAWKoGzHXpJ6ZxiiRBUoYnoMsgRwhqvrugIFyNgWasmsw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2275,20 +2275,20 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  rescript-envsafe@4.2.0(rescript-schema@8.0.0(rescript@11.1.0))(rescript@11.1.0):
+  rescript-envsafe@4.2.0(rescript-schema@8.0.0(rescript@11.1.3))(rescript@11.1.3):
     dependencies:
-      rescript: 11.1.0
-      rescript-schema: 8.0.0(rescript@11.1.0)
+      rescript: 11.1.3
+      rescript-schema: 8.0.0(rescript@11.1.3)
 
   rescript-express@0.4.1(express@4.19.2):
     dependencies:
       express: 4.19.2
 
-  rescript-schema@8.0.0(rescript@11.1.0):
+  rescript-schema@8.0.0(rescript@11.1.3):
     dependencies:
-      rescript: 11.1.0
+      rescript: 11.1.3
 
-  rescript@11.1.0: {}
+  rescript@11.1.3: {}
 
   restore-cursor@3.1.0:
     dependencies:

--- a/scenarios/helpers/package.json
+++ b/scenarios/helpers/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "rescript": "11.1.0",
+    "rescript": "11.1.3",
     "rescript-schema": "8.0.0"
   }
 }

--- a/scenarios/test_codegen/package.json
+++ b/scenarios/test_codegen/package.json
@@ -44,7 +44,7 @@
     "hardhat": "2.22.5",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
-    "rescript": "11.1.0",
+    "rescript": "11.1.3",
     "rescript-express": "0.4.1",
     "rescript-schema": "8.0.0",
     "sinon": "^15.0.4",

--- a/scenarios/test_codegen/pnpm-lock.yaml
+++ b/scenarios/test_codegen/pnpm-lock.yaml
@@ -80,14 +80,14 @@ importers:
         specifier: ^15.1.0
         version: 15.1.0
       rescript:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 11.1.3
+        version: 11.1.3
       rescript-express:
         specifier: 0.4.1
         version: 0.4.1(express@4.19.2)
       rescript-schema:
         specifier: 8.0.0
-        version: 8.0.0(rescript@11.1.0)
+        version: 8.0.0(rescript@11.1.3)
       sinon:
         specifier: ^15.0.4
         version: 15.2.0
@@ -98,11 +98,11 @@ importers:
   ../helpers:
     dependencies:
       rescript:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 11.1.3
+        version: 11.1.3
       rescript-schema:
         specifier: 8.0.0
-        version: 8.0.0(rescript@11.1.0)
+        version: 8.0.0(rescript@11.1.3)
 
   contracts:
     dependencies:
@@ -188,17 +188,17 @@ importers:
         specifier: 18.2.0
         version: 18.2.0
       rescript:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 11.1.3
+        version: 11.1.3
       rescript-envsafe:
         specifier: 4.2.0
-        version: 4.2.0(rescript-schema@8.0.0(rescript@11.1.0))(rescript@11.1.0)
+        version: 4.2.0(rescript-schema@8.0.0(rescript@11.1.3))(rescript@11.1.3)
       rescript-express:
         specifier: 0.4.1
         version: 0.4.1(express@4.19.2)
       rescript-schema:
         specifier: 8.0.0
-        version: 8.0.0(rescript@11.1.0)
+        version: 8.0.0(rescript@11.1.3)
       root:
         specifier: ../.
         version: link:..
@@ -3040,8 +3040,8 @@ packages:
     peerDependencies:
       rescript: 11.x
 
-  rescript@11.1.0:
-    resolution: {integrity: sha512-9la2Dv+ACylQ77I8s4spPu1JnLZXbH5WgxcLHLLUBWgFFSiv0wXqgzWztrBIZqwFgVX5BYcwldUqUVcEzdCyHg==}
+  rescript@11.1.3:
+    resolution: {integrity: sha512-bI+yxDcwsv7qE34zLuXeO8Qkc2+1ng5ErlSjnUIZdrAWKoGzHXpJ6ZxiiRBUoYnoMsgRwhqvrugIFyNgWasmsw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7369,10 +7369,10 @@ snapshots:
 
   requires-port@1.0.0: {}
 
-  rescript-envsafe@4.2.0(rescript-schema@8.0.0(rescript@11.1.0))(rescript@11.1.0):
+  rescript-envsafe@4.2.0(rescript-schema@8.0.0(rescript@11.1.3))(rescript@11.1.3):
     dependencies:
-      rescript: 11.1.0
-      rescript-schema: 8.0.0(rescript@11.1.0)
+      rescript: 11.1.3
+      rescript-schema: 8.0.0(rescript@11.1.3)
 
   rescript-express@0.4.1(express@4.19.2):
     dependencies:
@@ -7380,11 +7380,11 @@ snapshots:
 
   rescript-nodejs@16.0.0: {}
 
-  rescript-schema@8.0.0(rescript@11.1.0):
+  rescript-schema@8.0.0(rescript@11.1.3):
     dependencies:
-      rescript: 11.1.0
+      rescript: 11.1.3
 
-  rescript@11.1.0: {}
+  rescript@11.1.3: {}
 
   resolve-cwd@3.0.0:
     dependencies:

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -292,6 +292,7 @@ describe("determineNextEvent", () => {
         event: "SINGLE TEST EVENT"->Utils.magic,
       }
     }
+
     let makeMockFetchState = (~latestFetchedBlockTimestamp, ~item): FetchState.t => {
       isFetchingAtHead: false,
       registerType: RootRegister({endBlock: None}),
@@ -337,20 +338,18 @@ describe("determineNextEvent", () => {
             },
         )
 
-        let {earliestEventResponse: {earliestQueueItem}} =
-          determineNextEvent_unordered(fetchStatesMap)->Result.getExn
+        let {earliestEvent} = determineNextEvent_unordered(fetchStatesMap)->Result.getExn
 
         Assert.deepEqual(
-          earliestQueueItem,
-          Item(singleItem),
+          earliestEvent->FetchState_test.getItem,
+          Some(singleItem),
           ~message="Should have taken the single item",
         )
 
-        let {earliestEventResponse: {earliestQueueItem}} =
-          determineNextEvent_ordered(fetchStatesMap)->Result.getExn
+        let {earliestEvent} = determineNextEvent_ordered(fetchStatesMap)->Result.getExn
 
         Assert.deepEqual(
-          earliestQueueItem,
+          earliestEvent,
           earliestItem,
           ~message="Should return the `NoItem` that is earliest since it is earlier than the `Item`",
         )
@@ -394,20 +393,18 @@ describe("determineNextEvent", () => {
         //   NoItem(655 /* later timestamp than the test event */, {id:1}),
         // ]
 
-        let {earliestEventResponse: {earliestQueueItem}} =
-          determineNextEvent_unordered(fetchStatesMap)->Result.getExn
+        let {earliestEvent} = determineNextEvent_unordered(fetchStatesMap)->Result.getExn
 
         Assert.deepEqual(
-          earliestQueueItem,
-          Item(singleItem),
+          earliestEvent->FetchState_test.getItem,
+          Some(singleItem),
           ~message="Should have taken the single item",
         )
 
-        let {earliestEventResponse: {earliestQueueItem}} =
-          determineNextEvent_ordered(fetchStatesMap)->Result.getExn
+        let {earliestEvent} = determineNextEvent_ordered(fetchStatesMap)->Result.getExn
 
         Assert.deepEqual(
-          earliestQueueItem,
+          earliestEvent,
           makeNoItem(earliestItemTimestamp),
           ~message="Should return the `NoItem` that is earliest since it is earlier than the `Item`",
         )

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -3,6 +3,12 @@ open RescriptMocha
 open FetchState
 open Enums.ContractType
 
+let getItem = item =>
+  switch item {
+  | Item({item}) => item->Some
+  | NoItem(_) => None
+  }
+
 let mockAddress1 = TestHelpers.Addresses.mockAddresses[0]->Option.getExn
 let mockAddress2 = TestHelpers.Addresses.mockAddresses[1]->Option.getExn
 let mockAddress3 = TestHelpers.Addresses.mockAddresses[2]->Option.getExn
@@ -192,9 +198,9 @@ describe("FetchState.fetchState", () => {
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
       fetchedEventQueue: [
-        mockEvent(~blockNumber=1, ~logIndex=2),
-        mockEvent(~blockNumber=5),
         mockEvent(~blockNumber=6, ~logIndex=1),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=1, ~logIndex=2),
       ],
       registerType: DynamicContractRegister(
         dcId,
@@ -207,9 +213,9 @@ describe("FetchState.fetchState", () => {
           firstEventBlockNumber: None,
           dynamicContracts: DynamicContractsMap.empty,
           fetchedEventQueue: [
-            mockEvent(~blockNumber=1, ~logIndex=1),
-            mockEvent(~blockNumber=4),
             mockEvent(~blockNumber=6, ~logIndex=2),
+            mockEvent(~blockNumber=4),
+            mockEvent(~blockNumber=1, ~logIndex=1),
           ],
           registerType: RootRegister({endBlock: None}),
         },
@@ -226,12 +232,12 @@ describe("FetchState.fetchState", () => {
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
       fetchedEventQueue: [
-        mockEvent(~blockNumber=1, ~logIndex=1),
-        mockEvent(~blockNumber=1, ~logIndex=2),
-        mockEvent(~blockNumber=4),
-        mockEvent(~blockNumber=5),
-        mockEvent(~blockNumber=6, ~logIndex=1),
         mockEvent(~blockNumber=6, ~logIndex=2),
+        mockEvent(~blockNumber=6, ~logIndex=1),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=4),
+        mockEvent(~blockNumber=1, ~logIndex=2),
+        mockEvent(~blockNumber=1, ~logIndex=1),
       ],
       registerType: RootRegister({endBlock: None}),
     }
@@ -241,9 +247,9 @@ describe("FetchState.fetchState", () => {
 
   it("update register", () => {
     let currentEvents = [
-      mockEvent(~blockNumber=1, ~logIndex=1),
-      mockEvent(~blockNumber=1, ~logIndex=2),
       mockEvent(~blockNumber=4),
+      mockEvent(~blockNumber=1, ~logIndex=2),
+      mockEvent(~blockNumber=1, ~logIndex=1),
     ]
     let root = {
       latestFetchedBlock: getBlockData(~blockNumber=500),
@@ -276,7 +282,7 @@ describe("FetchState.fetchState", () => {
       ...root,
       latestFetchedBlock: getBlockData(~blockNumber=600),
       isFetchingAtHead: true,
-      fetchedEventQueue: Array.concat(currentEvents, newEvents),
+      fetchedEventQueue: Array.concat(newEvents->Array.reverse, currentEvents),
     }
 
     Assert.deepEqual(expected1, updated1)
@@ -345,7 +351,7 @@ describe("FetchState.fetchState", () => {
         dcId2,
         {
           ...fetchState1,
-          fetchedEventQueue: Array.concat(fetchState1.fetchedEventQueue, newEvents),
+          fetchedEventQueue: Array.concat(newEvents->Array.reverse, fetchState1.fetchedEventQueue),
           firstEventBlockNumber: Some(5),
           registerType: DynamicContractRegister(dcId1, root),
         },
@@ -368,9 +374,9 @@ describe("FetchState.fetchState", () => {
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
       fetchedEventQueue: [
-        mockEvent(~blockNumber=1, ~logIndex=2),
-        mockEvent(~blockNumber=5),
         mockEvent(~blockNumber=6, ~logIndex=1),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=1, ~logIndex=2),
       ],
       registerType: DynamicContractRegister(
         dcId,
@@ -383,18 +389,18 @@ describe("FetchState.fetchState", () => {
           firstEventBlockNumber: None,
           dynamicContracts: DynamicContractsMap.empty,
           fetchedEventQueue: [
-            mockEvent(~blockNumber=1, ~logIndex=1),
-            mockEvent(~blockNumber=4),
             mockEvent(~blockNumber=6, ~logIndex=2),
+            mockEvent(~blockNumber=4),
+            mockEvent(~blockNumber=1, ~logIndex=1),
           ],
           registerType: RootRegister({endBlock: None}),
         },
       ),
     }
 
-    let {earliestQueueItem} = fetchState->getEarliestEvent
+    let earliestQueueItem = fetchState->getEarliestEvent->getItem->Option.getExn
 
-    Assert.deepEqual(earliestQueueItem, Item(mockEvent(~blockNumber=1, ~logIndex=1)))
+    Assert.deepEqual(earliestQueueItem, mockEvent(~blockNumber=1, ~logIndex=1))
   })
 
   it("getNextQuery", () => {
@@ -408,9 +414,9 @@ describe("FetchState.fetchState", () => {
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty,
       fetchedEventQueue: [
-        mockEvent(~blockNumber=1, ~logIndex=1),
-        mockEvent(~blockNumber=4),
         mockEvent(~blockNumber=6, ~logIndex=2),
+        mockEvent(~blockNumber=4),
+        mockEvent(~blockNumber=1, ~logIndex=1),
       ],
       registerType: RootRegister({endBlock: None}),
     }
@@ -461,9 +467,9 @@ describe("FetchState.fetchState", () => {
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
       fetchedEventQueue: [
-        mockEvent(~blockNumber=1, ~logIndex=2),
-        mockEvent(~blockNumber=5),
         mockEvent(~blockNumber=6, ~logIndex=1),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=1, ~logIndex=2),
       ],
       registerType: DynamicContractRegister(
         dcId,
@@ -476,9 +482,9 @@ describe("FetchState.fetchState", () => {
           firstEventBlockNumber: None,
           dynamicContracts: DynamicContractsMap.empty,
           fetchedEventQueue: [
-            mockEvent(~blockNumber=1, ~logIndex=1),
-            mockEvent(~blockNumber=4),
             mockEvent(~blockNumber=6, ~logIndex=2),
+            mockEvent(~blockNumber=4),
+            mockEvent(~blockNumber=1, ~logIndex=1),
           ],
           registerType: RootRegister({endBlock: None}),
         },
@@ -503,7 +509,7 @@ describe("FetchState.fetchState", () => {
       isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty,
-      fetchedEventQueue: [mockEvent(~blockNumber=99), mockEvent(~blockNumber=140)],
+      fetchedEventQueue: [mockEvent(~blockNumber=140), mockEvent(~blockNumber=99)],
       registerType: RootRegister({endBlock: Some(150)}),
     }
 
@@ -554,7 +560,7 @@ describe("FetchState.fetchState", () => {
       isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty,
-      fetchedEventQueue: [mockEvent(~blockNumber=99), mockEvent(~blockNumber=140)],
+      fetchedEventQueue: [mockEvent(~blockNumber=140), mockEvent(~blockNumber=99)],
       registerType: RootRegister({endBlock: None}),
     }
 
@@ -579,9 +585,9 @@ describe("FetchState.fetchState", () => {
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId1, [mockAddress2]),
       fetchedEventQueue: [
-        mockEvent(~blockNumber=1, ~logIndex=2),
-        mockEvent(~blockNumber=5),
         mockEvent(~blockNumber=6, ~logIndex=1),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=1, ~logIndex=2),
       ],
       registerType: DynamicContractRegister(dcId1, register2),
     }
@@ -619,9 +625,9 @@ describe("FetchState.fetchState", () => {
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
       fetchedEventQueue: [
-        mockEvent(~blockNumber=1, ~logIndex=2),
-        mockEvent(~blockNumber=5),
         mockEvent(~blockNumber=6, ~logIndex=1),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=1, ~logIndex=2),
       ],
       registerType: DynamicContractRegister(
         dcId,
@@ -634,9 +640,9 @@ describe("FetchState.fetchState", () => {
           firstEventBlockNumber: None,
           dynamicContracts: DynamicContractsMap.empty,
           fetchedEventQueue: [
-            mockEvent(~blockNumber=1, ~logIndex=1),
-            mockEvent(~blockNumber=4),
             mockEvent(~blockNumber=6, ~logIndex=2),
+            mockEvent(~blockNumber=4),
+            mockEvent(~blockNumber=1, ~logIndex=1),
           ],
           registerType: RootRegister({endBlock: None}),
         },


### PR DESCRIPTION
- Reverses all the arrays that are event queue data structures so events are ordered from latest->earliest
- Shallow copy of values happens before createBatchInternal is called
- Individually popped items have a callback for mutating/popping the value off of it's queue
- After the earliest item is evaluated across these queues the pop function is called.