### PR TITLE
Rename Types.Handlers to Types.HandlerTypes 

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
@@ -169,17 +169,17 @@ let getHandlerContext = (context, ~inMemoryStore: InMemoryStore.t, ~loadLayer) =
 }
 
 let getContractRegisterArgs = (contextEnv, ~inMemoryStore) => {
-  Types.Handlers.event: contextEnv.event,
+  Types.HandlerTypes.event: contextEnv.event,
   context: contextEnv->getContractRegisterContext(~inMemoryStore),
 }
 
 let getLoaderArgs = (contextEnv, ~inMemoryStore, ~loadLayer) => {
-  Types.Handlers.event: contextEnv.event,
+  Types.HandlerTypes.event: contextEnv.event,
   context: contextEnv->getLoaderContext(~inMemoryStore, ~loadLayer),
 }
 
 let getHandlerArgs = (contextEnv, ~inMemoryStore, ~loaderReturn, ~loadLayer) => {
-  Types.Handlers.event: contextEnv.event,
+  Types.HandlerTypes.event: contextEnv.event,
   context: contextEnv->getHandlerContext(~inMemoryStore, ~loadLayer),
   loaderReturn,
 }

--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
@@ -93,7 +93,7 @@ module EventFunctions = {
       //steps
       let mockDbClone = mockDb->TestHelpers_MockDb.cloneMockDb
 
-      if !(Event.handlerRegister->Types.Handlers.Register.hasRegistration) {
+      if !(Event.handlerRegister->Types.HandlerTypes.Register.hasRegistration) {
         Not_found->ErrorHandling.mkLogAndRaise(
           ~logger,
           ~msg=`No registered handler found for "${Event.name}" on contract "${Event.contractName}"`,
@@ -111,7 +111,7 @@ module EventFunctions = {
       //The only purpose is to test the registerContract function and to
       //add the entity to the in memory store for asserting registrations
 
-      switch Event.handlerRegister->Types.Handlers.Register.getContractRegister {
+      switch Event.handlerRegister->Types.HandlerTypes.Register.getContractRegister {
       | Some(contractRegister) =>
         switch contractRegister->EventProcessing.runEventContractRegister(
           ~logger,
@@ -137,7 +137,7 @@ module EventFunctions = {
 
       let latestProcessedBlocks = EventProcessing.EventsProcessed.makeEmpty(~config)
 
-      switch Event.handlerRegister->Types.Handlers.Register.getLoaderHandler {
+      switch Event.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler {
       | Some(loaderHandler) =>
         switch await event->EventProcessing.runEventHandler(
           ~inMemoryStore,

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -203,7 +203,7 @@ type eventLog<'a> = {
 }
 
 @genType
-module Handlers = {
+module HandlerTypes = {
   type args<'eventArgs, 'context> = {
     event: eventLog<'eventArgs>,
     context: 'context,
@@ -382,7 +382,7 @@ module type Event = {
   let eventArgsSchema: S.schema<eventArgs>
   let convertHyperSyncEventArgs: HyperSyncClient.Decoder.decodedEvent => eventArgs
   let decodeHyperFuelData: string => eventArgs
-  let handlerRegister: Handlers.Register.t<eventArgs>
+  let handlerRegister: HandlerTypes.Register.t<eventArgs>
 }
 module type InternalEvent = Event with type eventArgs = internalEventArgs
 
@@ -392,7 +392,7 @@ external eventModWithoutArgTypeToInternal: module(Event) => module(InternalEvent
 
 module MakeRegister = (Event: Event) => {
   let handler = handler =>
-    Event.handlerRegister->Handlers.Register.setLoaderHandler(
+    Event.handlerRegister->HandlerTypes.Register.setLoaderHandler(
       {
         loader: _ => Promise.resolve(),
         handler,
@@ -400,14 +400,14 @@ module MakeRegister = (Event: Event) => {
       ~eventOptions=None,
     )
 
-  let contractRegister: Handlers.contractRegister<Event.eventArgs> => unit = contractRegister =>
-    Event.handlerRegister->Handlers.Register.setContractRegister(
+  let contractRegister: HandlerTypes.contractRegister<Event.eventArgs> => unit = contractRegister =>
+    Event.handlerRegister->HandlerTypes.Register.setContractRegister(
       contractRegister,
       ~eventOptions=None,
     )
 
-  let handlerWithLoader: Handlers.loaderHandler<Event.eventArgs, 'loaderReturn> => unit = args =>
-    Event.handlerRegister->Handlers.Register.setLoaderHandler(args, ~eventOptions=None)
+  let handlerWithLoader: HandlerTypes.loaderHandler<Event.eventArgs, 'loaderReturn> => unit = args =>
+    Event.handlerRegister->HandlerTypes.Register.setLoaderHandler(args, ~eventOptions=None)
 }
 
 {{#each codegen_contracts as | contract |}}
@@ -431,7 +431,7 @@ module {{contract.name.capitalized}} = {
     let convertHyperSyncEventArgs = {{convert_hyper_sync_event_args_code}}
     let decodeHyperFuelData = {{decode_hyper_fuel_data_code}}
 
-    let handlerRegister: Handlers.Register.t<eventArgs> = Handlers.Register.make(
+    let handlerRegister: HandlerTypes.Register.t<eventArgs> = HandlerTypes.Register.make(
       ~topic0=sighash,
       ~contractName,
       ~eventName=name,

--- a/codegenerator/cli/templates/static/codegen/src/EventModLookup.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventModLookup.res
@@ -16,7 +16,7 @@ module ContractEventMods = {
 
   let isWildcard = (eventMod: eventMod) => {
     let module(Event) = eventMod
-    Event.handlerRegister->Types.Handlers.Register.getEventOptions->(v => v.Types.Handlers.wildcard)
+    Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions->(v => v.Types.HandlerTypes.wildcard)
   }
 
   let hasWildcardCollision = (eventModA, eventModB) => {

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -79,7 +79,7 @@ let addToDynamicContractRegistrations = (
 }
 
 let runEventContractRegister = (
-  contractRegister: Types.Handlers.args<_> => unit,
+  contractRegister: Types.HandlerTypes.args<_> => unit,
   ~event,
   ~eventBatchQueueItem: Types.eventBatchQueueItem,
   ~logger,
@@ -134,7 +134,7 @@ let runEventContractRegister = (
 
 let runEventLoader = async (
   ~contextEnv,
-  ~loader: Types.Handlers.loader<_>,
+  ~loader: Types.HandlerTypes.loader<_>,
   ~inMemoryStore,
   ~loadLayer,
 ) => {
@@ -205,7 +205,7 @@ let updateEventSyncState = (
 let runEventHandler = (
   event,
   ~eventMod: module(Types.InternalEvent),
-  ~loaderHandler: Types.Handlers.loaderHandler<_>,
+  ~loaderHandler: Types.HandlerTypes.loaderHandler<_>,
   ~inMemoryStore,
   ~logger,
   ~chain,
@@ -263,7 +263,7 @@ let runHandler = (
 ) => {
   switch eventMod
   ->getHandlerRegistration
-  ->Types.Handlers.Register.getLoaderHandler {
+  ->Types.HandlerTypes.Register.getLoaderHandler {
   | Some(loaderHandler) =>
     event->runEventHandler(
       ~loaderHandler,
@@ -314,7 +314,7 @@ let rec registerDynamicContracts = (
     } else {
       let {eventMod, event} = eventBatchQueueItem
 
-      switch eventMod->getHandlerRegistration->Types.Handlers.Register.getContractRegister {
+      switch eventMod->getHandlerRegistration->Types.HandlerTypes.Register.getContractRegister {
       | Some(handler) =>
         handler->runEventContractRegister(
           ~event,
@@ -369,7 +369,7 @@ let runLoaders = (
       ->Array.keepMap(({chain, eventMod, event}) => {
         eventMod
         ->getHandlerRegistration
-        ->Types.Handlers.Register.getLoaderHandler
+        ->Types.HandlerTypes.Register.getLoaderHandler
         ->Option.map(
           ({loader}) => {
             let contextEnv = ContextEnv.make(~chain, ~eventMod, ~event, ~logger)

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -60,7 +60,7 @@ module type S = {
       block: Block.t,
     }
 
-    module Handlers: {
+    module HandlerTypes: {
       module Register: {
         type t<'eventArgs>
       }
@@ -75,7 +75,7 @@ module type S = {
       let eventArgsSchema: RescriptSchema.S.schema<eventArgs>
       let convertHyperSyncEventArgs: HyperSyncClient.Decoder.decodedEvent => eventArgs
       let decodeHyperFuelData: string => eventArgs
-      let handlerRegister: Handlers.Register.t<eventArgs>
+      let handlerRegister: HandlerTypes.Register.t<eventArgs>
     }
     module type InternalEvent = Event with type eventArgs = internalEventArgs
 

--- a/scenarios/test_codegen/test/Mock_test.res
+++ b/scenarios/test_codegen/test/Mock_test.res
@@ -18,7 +18,7 @@ describe("E2E Mock Event Batch", () => {
     ) => {
       let eventMod = eventMod->Types.eventModToInternal
       let module(Event) = eventMod
-      switch Event.handlerRegister->Types.Handlers.Register.getLoaderHandler {
+      switch Event.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler {
       | Some(loaderHandler) =>
         await event->EventProcessing.runEventHandler(
           ~loaderHandler,


### PR DESCRIPTION
Avoids collisions with  "Handlers" file module when opening "Types" in global scope of handlers

Only affects rescript indexers. Lots of our examples open Types at the top.