### PR TITLE
Fix timezone for sync time

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/db/Table.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/Table.res
@@ -12,6 +12,7 @@ type fieldType =
   | @as("JSON") Json
   | @as("TIMESTAMP WITH TIME ZONE") Timestamp
   | @as("TIMESTAMP") TimestampWithoutTimezone
+  | @as("TIMESTAMP WITH TIME ZONE NULL") TimestampWithNullTimezone
   | Enum(string)
 
 type field = {

--- a/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
@@ -55,7 +55,7 @@ module ChainMetadata = {
       mkField("is_hyper_sync", Boolean),
       mkField("num_batches_fetched", Integer),
       mkField("latest_fetched_block_number", Integer),
-      mkField("timestamp_caught_up_to_head_or_endblock", TimestampWithoutTimezone, ~isNullable),
+      mkField("timestamp_caught_up_to_head_or_endblock", TimestampWithNullTimezone, ~isNullable),
     ],
   )
 }
@@ -136,7 +136,7 @@ module RawEvents = {
       mkField("block_fields", Json),
       mkField("transaction_fields", Json),
       mkField("params", Json),
-      mkField("db_write_timestamp", Timestamp, ~default="CURRENT_TIMESTAMP"),
+      mkField("db_write_timestamp", TimestampWithoutTimezone, ~default="CURRENT_TIMESTAMP"),
     ],
   )
 }

--- a/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
@@ -55,6 +55,7 @@ module ChainMetadata = {
       mkField("is_hyper_sync", Boolean),
       mkField("num_batches_fetched", Integer),
       mkField("latest_fetched_block_number", Integer),
+      // Used to show how much time historical sync has taken, so we need a timezone here (TUI and Hosted Service)
       mkField("timestamp_caught_up_to_head_or_endblock", TimestampWithNullTimezone, ~isNullable),
     ],
   )


### PR DESCRIPTION
I've noticed it when trying to reproduce a bug on hosted service 
<img width="798" alt="image" src="https://github.com/user-attachments/assets/423cf5c6-f5db-4670-8396-1ff8177800f1">

The sync took a few minutes, but it shows 4 hours