### PR TITLE
Upgrade hasura to latest v2 release

### DIFF
--- a/codegenerator/cli/templates/static/codegen/docker-compose.yaml
+++ b/codegenerator/cli/templates/static/codegen/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     networks:
       - my-proxy-net
   graphql-engine:
-    image: hasura/graphql-engine:v2.23.0
+    image: hasura/graphql-engine:v2.43.0
     ports:
       - "${HASURA_EXTERNAL_PORT:-8080}:8080"
     user: 1001:1001


### PR DESCRIPTION
Versions < 2.29 don't have support for querying postgres built in arrays. See https://github.com/hasura/graphql-engine/issues/7187#issuecomment-1630703199

An example bug reported is:

Schema:
```gql
enum Permissions @enumeration {
  CHANGEOWNER
  ADDCONTROLLER
  EDITPERMISSIONS
  ADDEXTENSIONS
  CHANGEEXTENSIONS
  ADDUNIVERSALRECEIVERDELEGATE
  CHANGEUNIVERSALRECEIVERDELEGATE
  REENTRANCY
  SUPER_TRANSFERVALUE
  TRANSFERVALUE
  SUPER_CALL
  CALL
  SUPER_STATICCALL
  STATICCALL
  SUPER_DELEGATECALL
  DELEGATECALL
  DEPLOY
  SUPER_SETDATA
  SETDATA
  ENCRYPT
  DECRYPT
  SIGN
  EXECUTE_RELAY_CALL
  ISRECOVERY
}

type Controller @entity {
  id: ID!
  address: String
  profile: Profile @has_inverse(field: "controllers")
  permissions: String
  blockNumber: Int!
  tags: [Permissions!]
}
```

query:
```gql
query MyQuery {
  Controller(where: {tags: {_in: "ISRECOVERY"}}, limit: 10) {
    address
    permissions
  }
}
```

response:
```json
{
  "errors": [
    {
      "extensions": {
        "code": "constraint-error",
        "path": "$"
      },
      "message": "type \"_permissions[]\" does not exist"
    }
  ]
}
```