### PR TITLE
Fix: await fetching partition

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -283,6 +283,12 @@ let hasProcessedToEndblock = (self: t) => {
   }
 }
 
+let hasNoMoreEventsToProcess = (self: t, ~hasArbQueueEvents) => {
+  !hasArbQueueEvents &&
+  !self.isFetchingBatch &&
+  self.fetchState->PartitionedFetchState.queueSize === 0
+}
+
 /**
 Finds the last known block where hashes are valid and returns
 the updated lastBlockScannedHashes rolled back where this occurs

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -194,8 +194,7 @@ let checkAndSetSyncedChains = (~nextQueueItemIsKnownNone=false, chainManager: Ch
           chainManager.arbitraryEventQueue
           ->ChainManager.getFirstArbitraryEventsItemForChain(~chain=cf.chainConfig.chain)
           ->Option.isSome //TODO this is more expensive than it needs to be
-        let queueSize = cf.fetchState->PartitionedFetchState.queueSize
-        let hasNoMoreEventsToProcess = !hasArbQueueEvents && queueSize == 0
+        let hasNoMoreEventsToProcess = cf->ChainFetcher.hasNoMoreEventsToProcess(~hasArbQueueEvents)
 
         if hasNoMoreEventsToProcess {
           {
@@ -233,9 +232,7 @@ let updateLatestProcessedBlocks = (
         state.chainManager.arbitraryEventQueue
         ->ChainManager.getFirstArbitraryEventsItemForChain(~chain)
         ->Option.isSome //TODO this is more expensive than it needs to be
-      let queueSize = fetchState->PartitionedFetchState.queueSize
-
-      let hasNoMoreEventsToProcess = !hasArbQueueEvents && queueSize == 0
+      let hasNoMoreEventsToProcess = cf->ChainFetcher.hasNoMoreEventsToProcess(~hasArbQueueEvents)
 
       let latestProcessedBlock = if hasNoMoreEventsToProcess {
         PartitionedFetchState.getLatestFullyFetchedBlock(fetchState).blockNumber->Some
@@ -310,8 +307,8 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
       state.chainManager.arbitraryEventQueue
       ->ChainManager.getFirstArbitraryEventsItemForChain(~chain)
       ->Option.isSome //TODO this is more expensive than it needs to be
-    let queueSize = chainFetcher.fetchState->PartitionedFetchState.queueSize
-    let hasNoMoreEventsToProcess = !hasArbQueueEvents && queueSize == 0
+    let hasNoMoreEventsToProcess =
+      chainFetcher->ChainFetcher.hasNoMoreEventsToProcess(~hasArbQueueEvents)
 
     let latestProcessedBlock = if hasNoMoreEventsToProcess {
       PartitionedFetchState.getLatestFullyFetchedBlock(chainFetcher.fetchState).blockNumber->Some


### PR DESCRIPTION
During the investigation of lost events, we found, that the indexer stops on the first partition when it returns an empty response and doesn't await pending partitions. This PR fixes it, but it's not guaranteed to fix the lost events issue.