### PR TITLE
Remove validation for indexer name

### DIFF
--- a/codegenerator/cli/src/cli_args/interactive_init/mod.rs
+++ b/codegenerator/cli/src/cli_args/interactive_init/mod.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 use strum;
 use strum::{Display, EnumIter, IntoEnumIterator};
 use validation::{
-    contains_no_whitespace_validator, is_directory_new_validator, is_not_empty_string_validator,
+    contains_no_whitespace_validator, is_directory_new_validator,
     is_valid_foldername_inquire_validator,
 };
 
@@ -113,17 +113,6 @@ pub async fn prompt_missing_init_args(
     init_args: InitArgs,
     project_paths: &ProjectPaths,
 ) -> Result<InitConfig> {
-    let name: String = match init_args.name {
-        Some(args_name) => args_name,
-        None => {
-            // TODO: input validation for name
-            Text::new("Name your indexer:")
-                .with_default("envio-indexer")
-                .with_validator(is_not_empty_string_validator)
-                .prompt()?
-        }
-    };
-
     let directory: String = match &project_paths.directory {
         Some(args_directory) => args_directory.clone(),
         None => {
@@ -135,6 +124,17 @@ pub async fn prompt_missing_init_args(
                 .with_validator(is_directory_new_validator)
                 .with_validator(contains_no_whitespace_validator)
                 .prompt()?
+        }
+    };
+
+    let name: String = match init_args.name {
+        Some(args_name) => args_name,
+        None => {
+            if directory == DEFAULT_PROJECT_ROOT_PATH {
+                "envio-indexer".to_string()
+            } else {
+                directory.to_string()
+            }
         }
     };
 

--- a/codegenerator/cli/src/cli_args/interactive_init/mod.rs
+++ b/codegenerator/cli/src/cli_args/interactive_init/mod.rs
@@ -118,7 +118,7 @@ pub async fn prompt_missing_init_args(
         None => {
             // TODO: input validation for name
             Text::new("Name your indexer:")
-                .with_default("My Envio Indexer")
+                .with_default("envio-indexer")
                 .with_validator(is_not_empty_string_validator)
                 .prompt()?
         }

--- a/codegenerator/cli/src/cli_args/interactive_init/validation.rs
+++ b/codegenerator/cli/src/cli_args/interactive_init/validation.rs
@@ -75,14 +75,6 @@ impl<T> UniqueValueValidator<T> {
     }
 }
 
-pub fn is_not_empty_string_validator(s: &str) -> Result<Validation, CustomUserError> {
-    if s.trim().is_empty() {
-        Ok(Validation::Invalid("Invalid empty string input".into()))
-    } else {
-        Ok(Validation::Valid)
-    }
-}
-
 pub fn contains_no_whitespace_validator(s: &str) -> Result<Validation, CustomUserError> {
     if s.contains(char::is_whitespace) {
         Ok(Validation::Invalid(

--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -39,16 +39,6 @@ type ContractMap = HashMap<ContractNameKey, Contract>;
 pub type EntityMap = HashMap<EntityKey, Entity>;
 pub type GraphQlEnumMap = HashMap<GraphqlEnumKey, GraphQLEnum>;
 
-fn strip_to_letters(string: &str) -> String {
-    let mut pg_friendly_name = String::new();
-    for c in string.chars() {
-        if c.is_alphabetic() {
-            pg_friendly_name.push(c);
-        }
-    }
-    pg_friendly_name
-}
-
 #[derive(Debug, PartialEq)]
 pub enum Ecosystem {
     Evm,
@@ -468,13 +458,12 @@ impl SystemConfig {
 
         match ecosystem {
             Ecosystem::Evm => {
-                let mut evm_config: EvmConfig = serde_yaml::from_str(&human_config_string)
-                    .context(format!(
+                let evm_config: EvmConfig =
+                    serde_yaml::from_str(&human_config_string).context(format!(
                         "EE105: Failed to deserialize config. Visit the docs for more information \
                          {}",
                         links::DOC_CONFIGURATION_FILE
                     ))?;
-                evm_config.name = strip_to_letters(&evm_config.name);
                 let schema = Schema::parse_from_file(&project_paths, &evm_config.schema)
                     .context("Parsing schema file for config")?;
                 Self::from_evm_config(evm_config, schema, project_paths)
@@ -484,12 +473,11 @@ impl SystemConfig {
                     "EE105: Failed to deserialize config. It's not supported with the main envio \
                      package yet, please install the envio@fuel version."
                 ));
-                // let mut fuel_config: FuelConfig = serde_yaml::from_str(&human_config_string)
+                // let fuel_config: FuelConfig = serde_yaml::from_str(&human_config_string)
                 //     .context(format!(
                 //     "EE105: Failed to deserialize config. Visit the docs for more information {}",
                 //     links::DOC_CONFIGURATION_FILE
                 // ))?;
-                // fuel_config.name = strip_to_letters(&fuel_config.name);
                 // let schema = Schema::parse_from_file(&project_paths, &fuel_config.schema)
                 //     .context("Parsing schema file for config")?;
                 // Self::from_fuel_config(fuel_config, schema, project_paths)
@@ -1308,19 +1296,6 @@ mod test {
             .unwrap_err();
 
         assert_eq!(error.to_string(), "EE106: Cannot define both rpc_config and hypersync_config for the same network, please choose only one of them, read more in our docs https://docs.envio.dev/docs/configuration-file");
-    }
-
-    #[test]
-    fn valid_name_conversion() {
-        let name_with_space = super::strip_to_letters("My too lit to quit indexer");
-        let expected_name_with_space = "Mytoolittoquitindexer";
-        let name_with_special_chars = super::strip_to_letters("Myto@littoq$itindexer");
-        let expected_name_with_special_chars = "Mytolittoqitindexer";
-        let name_with_numbers = super::strip_to_letters("yes0123456789okay");
-        let expected_name_with_numbers = "yesokay";
-        assert_eq!(name_with_space, expected_name_with_space);
-        assert_eq!(name_with_special_chars, expected_name_with_special_chars);
-        assert_eq!(name_with_numbers, expected_name_with_numbers);
     }
 
     #[test]

--- a/codegenerator/cli/src/config_parsing/validation.rs
+++ b/codegenerator/cli/src/config_parsing/validation.rs
@@ -126,15 +126,6 @@ pub fn validate_names_valid_rescript(
 }
 
 pub fn validate_deserialized_config_yaml(evm_config: &HumanConfig) -> anyhow::Result<()> {
-    if !is_valid_postgres_db_name(&evm_config.name) {
-        return Err(anyhow!(
-            "EE108: The 'name' field in your config file must have the following pattern: It must \
-             start with a letter or underscore. It can contain letters, numbers, and underscores \
-             (no spaces). It must have a maximum length of 63 characters",
-        )
-        .into());
-    }
-
     let mut contract_names = Vec::new();
 
     if let Some(global_contracts) = &evm_config.contracts {


### PR DESCRIPTION
We use it only for package.json which is not used for anything, so I just removed all validation and transformation logic for now.