### PR TITLE
Add validation for endblock on finite chains

### DIFF
--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -117,7 +117,12 @@ pub mod evm {
                                 NetworkKind::Supported(network) => {
                                     chain_helpers::Network::from(network).get_finite_end_block()
                                 }
-                                NetworkKind::Unsupported(_, _) => None,
+                                NetworkKind::Unsupported(network_id, _) => {
+                                    chain_helpers::Network::from_network_id(network_id)
+                                        .ok()
+                                        .map(|network| network.get_finite_end_block())
+                                        .flatten()
+                                }
                             };
 
                             Network {

--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -13,6 +13,7 @@ pub mod evm {
 
     use crate::{
         config_parsing::{
+            chain_helpers,
             contract_import::converters::{NetworkKind, SelectedContract},
             human_config::{
                 evm::{ContractConfig, EventConfig, HumanConfig, Network, RpcConfig},
@@ -112,12 +113,19 @@ pub mod evm {
                                 }),
                             };
 
+                            let end_block = match selected_network.network {
+                                NetworkKind::Supported(network) => {
+                                    chain_helpers::Network::from(network).get_finite_end_block()
+                                }
+                                NetworkKind::Unsupported(_, _) => None,
+                            };
+
                             Network {
                                 id: selected_network.network.get_network_id(),
                                 hypersync_config: None,
                                 rpc_config,
                                 start_block: 0,
-                                end_block: None,
+                                end_block,
                                 confirmed_block_threshold: None,
                                 contracts: Vec::new(),
                             }

--- a/codegenerator/cli/src/config_parsing/chain_helpers.rs
+++ b/codegenerator/cli/src/config_parsing/chain_helpers.rs
@@ -342,6 +342,15 @@ impl Network {
             .ok_or_else(|| anyhow!("Failed converting network_id {} to network name", id))
     }
 
+    /// Returns the end block for this network if it is finite
+    pub fn get_finite_end_block(&self) -> Option<i32> {
+        match self {
+            Self::Goerli => Some(10_387_962),
+            Self::Mumbai => Some(47_002_303),
+            _ => None,
+        }
+    }
+
     //TODO: research a sufficient threshold for all chain (some should be 0)
     pub fn get_confirmed_block_threshold(&self) -> i32 {
         match self {

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -931,8 +931,6 @@ impl ProjectTemplate {
 
 #[cfg(test)]
 mod test {
-    use std::vec;
-
     use super::*;
     use crate::{
         config_parsing::system_config::{RpcConfig, SystemConfig},
@@ -940,6 +938,7 @@ mod test {
         utils::text::Capitalize,
     };
     use pretty_assertions::assert_eq;
+    use std::vec;
 
     fn get_per_contract_events_vec_helper(
         event_names: Vec<&str>,
@@ -969,6 +968,20 @@ mod test {
         project_template
     }
 
+    impl Default for NetworkTemplate {
+        fn default() -> Self {
+            Self {
+                id: 0,
+                rpc_config: None,
+                hypersync_config: None,
+                hyperfuel_config: None,
+                confirmed_block_threshold: 200,
+                start_block: 0,
+                end_block: None,
+            }
+        }
+    }
+
     #[test]
     fn chain_configs_parsed_case_1() {
         let address1 = String::from("0x2E645469f354BB4F5c8a05B3b30A929361cf77eC");
@@ -978,14 +991,10 @@ mod test {
             sync_config: system_config::SyncConfig::default(),
         };
 
-        let network1 = super::NetworkTemplate {
+        let network1 = NetworkTemplate {
             id: 1,
             rpc_config: Some(rpc_config1),
-            hypersync_config: None,
-            hyperfuel_config: None,
-            start_block: 0,
-            end_block: None,
-            confirmed_block_threshold: 200,
+            ..NetworkTemplate::default()
         };
 
         let events = get_per_contract_events_vec_helper(vec!["NewGravatar", "UpdatedGravatar"]);
@@ -1025,14 +1034,10 @@ mod test {
             urls: vec!["https://eth.com".to_string()],
             sync_config: system_config::SyncConfig::default(),
         };
-        let network1 = super::NetworkTemplate {
+        let network1 = NetworkTemplate {
             id: 1,
             rpc_config: Some(rpc_config1.clone()),
-            hypersync_config: None,
-            hyperfuel_config: None,
-            start_block: 0,
-            end_block: None,
-            confirmed_block_threshold: 200,
+            ..NetworkTemplate::default()
         };
 
         let rpc_config2 = RpcConfig {
@@ -1043,14 +1048,11 @@ mod test {
             ],
             sync_config: system_config::SyncConfig::default(),
         };
-        let network2 = super::NetworkTemplate {
+
+        let network2 = NetworkTemplate {
             id: 2,
             rpc_config: Some(rpc_config2),
-            hypersync_config: None,
-            hyperfuel_config: None,
-            start_block: 0,
-            end_block: None,
-            confirmed_block_threshold: 200,
+            ..NetworkTemplate::default()
         };
 
         let events = get_per_contract_events_vec_helper(vec!["NewGravatar", "UpdatedGravatar"]);
@@ -1087,17 +1089,13 @@ mod test {
     fn convert_to_chain_configs_case_3() {
         let address1 = String::from("0x2E645469f354BB4F5c8a05B3b30A929361cf77eC");
 
-        let network1 = super::NetworkTemplate {
+        let network1 = NetworkTemplate {
             id: 1,
-            rpc_config: None,
             hypersync_config: Some(HypersyncConfig {
                 endpoint_url: "https://1.hypersync.xyz".to_string(),
                 is_client_decoder: true,
             }),
-            hyperfuel_config: None,
-            start_block: 0,
-            end_block: None,
-            confirmed_block_threshold: 200,
+            ..NetworkTemplate::default()
         };
 
         let events = get_per_contract_events_vec_helper(vec!["NewGravatar", "UpdatedGravatar"]);
@@ -1122,30 +1120,22 @@ mod test {
 
     #[test]
     fn convert_to_chain_configs_case_4() {
-        let network1 = super::NetworkTemplate {
+        let network1 = NetworkTemplate {
             id: 1,
-            rpc_config: None,
             hypersync_config: Some(HypersyncConfig {
                 endpoint_url: "https://myskar.com".to_string(),
                 is_client_decoder: true,
             }),
-            hyperfuel_config: None,
-            start_block: 0,
-            end_block: None,
-            confirmed_block_threshold: 200,
+            ..NetworkTemplate::default()
         };
 
-        let network2 = super::NetworkTemplate {
+        let network2 = NetworkTemplate {
             id: 137,
-            rpc_config: None,
             hypersync_config: Some(HypersyncConfig {
                 endpoint_url: "https://137.hypersync.xyz".to_string(),
                 is_client_decoder: true,
             }),
-            hyperfuel_config: None,
-            start_block: 0,
-            end_block: None,
-            confirmed_block_threshold: 200,
+            ..NetworkTemplate::default()
         };
 
         let chain_config_1 = super::NetworkConfigTemplate {

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -1136,10 +1136,10 @@ mod test {
         };
 
         let network2 = super::NetworkTemplate {
-            id: 5,
+            id: 137,
             rpc_config: None,
             hypersync_config: Some(HypersyncConfig {
-                endpoint_url: "https://5.hypersync.xyz".to_string(),
+                endpoint_url: "https://137.hypersync.xyz".to_string(),
                 is_client_decoder: true,
             }),
             hyperfuel_config: None,

--- a/codegenerator/cli/test/configs/config4.yaml
+++ b/codegenerator/cli/test/configs/config4.yaml
@@ -7,6 +7,6 @@ networks:
       url: https://myskar.com # RPC URL that will be used to subscribe to blockchain data on this network
     start_block: 0
     contracts: []
-  - id: 5 #Goerli will use skar
+  - id: 137 #Polygon will use skar
     start_block: 0
     contracts: []


### PR DESCRIPTION
Closes #183 

- Adds validation for chains that have a known finite end_block (currently only goerli and mumbai). This prevents a user from running a multichain indexer without unordered_multichain_mode or an end_block for this chain.
- Automatically adds the end_block for contract import generated indexers