### PR TITLE
Fix panic on null exn passed to error handling

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/ErrorHandling.res
+++ b/codegenerator/cli/templates/static/codegen/src/ErrorHandling.res
@@ -3,11 +3,16 @@ type exnType = Js(Js.Exn.t) | Other(exn)
 type t = {logger: Pino.t, exn: exnType, msg: option<string>}
 
 let makeExnType = (exn): exnType => {
-  switch exn {
-  | Js.Exn.Error(e)
-  | Promise.JsError(e) =>
-    Js(e)
-  | exn => Other(exn)
+  // exn might be not an object which will break the pattern match by RE_EXN_ID
+  if exn->Obj.magic {
+    switch exn {
+    | Js.Exn.Error(e)
+    | Promise.JsError(e) =>
+      Js(e)
+    | exn => Other(exn)
+    }
+  } else {
+    Other(exn)
   }
 }
 


### PR DESCRIPTION
Solves https://github.com/enviodev/hyperindex/issues/201

Before:
![image](https://github.com/user-attachments/assets/0b849430-595d-4437-b7d5-d2a9f6923349)

After:
<img width="876" alt="image" src="https://github.com/user-attachments/assets/96a819a7-09fd-431b-80f2-fa3835c34aec">
