### PR TITLE
Support indexing multiple events with same sighash and different topics

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -418,6 +418,7 @@ type internalEventArgs
 
 module type Event = {
   let sighash: string // topic0 for Evm and rb for Fuel receipts
+  let topicCount: int // Number of topics for evm, always 0 for fuel
   let name: string
   let contractName: string
 
@@ -538,6 +539,7 @@ module {{contract.name.capitalized}} = {
 {{#each contract.codegen_events as | event |}}
   module {{event.name.capitalized}} = {
     let sighash = "{{event.sighash}}"
+    let topicCount = {{event.topic_count}}
     let name = "{{event.name.capitalized}}"
     let contractName = contractName
 

--- a/codegenerator/cli/templates/static/codegen/src/EventFetching.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventFetching.res
@@ -88,7 +88,8 @@ let getTxFieldFromEthersLog = (log: Ethers.log, txField: string, ~logger): txFie
     )
   }
 
-let nonOptionalTransactionFieldNames = Types.Transaction.schema->Utils.Schema.getNonOptionalFieldNames
+let nonOptionalTransactionFieldNames =
+  Types.Transaction.schema->Utils.Schema.getNonOptionalFieldNames
 
 let transactionFieldsFromLog = (log, ~logger): Types.Transaction.t => {
   let dict = Js.Dict.empty()
@@ -97,7 +98,7 @@ let transactionFieldsFromLog = (log, ~logger): Types.Transaction.t => {
   nonOptionalTransactionFieldNames->Belt.Array.forEach(name => {
     dict->Js.Dict.set(name, getTxFieldFromEthersLog(log, name, ~logger))
   })
-  dict->(Utils.magic: Js.Dict.t<txFieldVal> => Types.Transaction.t)  
+  dict->(Utils.magic: Js.Dict.t<txFieldVal> => Types.Transaction.t)
 }
 
 //Types.blockFields is a subset of  Ethers.JsonRpcProvider.block so we can safely cast
@@ -125,7 +126,7 @@ let convertLogs = (
   })
 
   logs->Belt.Array.map(async (log): Types.eventBatchQueueItem => {
-    let block = (await blockLoader->LazyLoader.get(log.blockNumber))
+    let block = await blockLoader->LazyLoader.get(log.blockNumber)
     let transaction = log->transactionFieldsFromLog(~logger)
     let log = log->ethersLogToLog
     let chainId = chain->ChainMap.Chain.toChainId
@@ -133,6 +134,7 @@ let convertLogs = (
     let topic0 = log.topics->Js.Array2.unsafe_get(0)
     let eventMod = switch eventModLookup->EventModLookup.get(
       ~sighash=topic0,
+      ~topicCount=log.topics->Array.length,
       ~contractAddressMapping=contractInterfaceManager.contractAddressMapping,
       ~contractAddress=log.address,
     ) {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -266,6 +266,7 @@ module Make = (
 
         let eventMod = switch eventModLookup->EventModLookup.get(
           ~sighash,
+          ~topicCount=0,
           ~contractAddressMapping,
           ~contractAddress,
         ) {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -50,7 +50,14 @@ type nextPageFetchRes = {
   pageFetchTime: int,
 }
 
-let makeGetNextPage = (~endpointUrl, ~contracts: array<Config.contract>, ~queryLogsPage, ~pollForHeightGtOrEq, ~blockSchema, ~transactionSchema) => {
+let makeGetNextPage = (
+  ~endpointUrl,
+  ~contracts: array<Config.contract>,
+  ~queryLogsPage,
+  ~pollForHeightGtOrEq,
+  ~blockSchema,
+  ~transactionSchema,
+) => {
   let nonOptionalBlockFieldNames = blockSchema->Utils.Schema.getNonOptionalFieldNames
   let blockFieldSelection =
     blockSchema
@@ -90,7 +97,7 @@ let makeGetNextPage = (~endpointUrl, ~contracts: array<Config.contract>, ~queryL
       setCurrentBlockHeight(currentBlockHeight)
     }
   }
-  
+
   let wildcardLogSelection = contracts->Belt.Array.flatMap(contract => {
     contract.events->Belt.Array.keepMap(event => {
       let module(Event) = event
@@ -248,7 +255,14 @@ module Make = (
     }
   }
 
-  let getNextPage = makeGetNextPage(~endpointUrl=T.endpointUrl, ~contracts=T.contracts, ~queryLogsPage=HyperSync.queryLogsPage, ~pollForHeightGtOrEq=HyperSync.pollForHeightGtOrEq, ~blockSchema=T.blockSchema, ~transactionSchema=T.transactionSchema)
+  let getNextPage = makeGetNextPage(
+    ~endpointUrl=T.endpointUrl,
+    ~contracts=T.contracts,
+    ~queryLogsPage=HyperSync.queryLogsPage,
+    ~pollForHeightGtOrEq=HyperSync.pollForHeightGtOrEq,
+    ~blockSchema=T.blockSchema,
+    ~transactionSchema=T.transactionSchema,
+  )
 
   let fetchBlockRange = async (
     ~query: blockRangeFetchArgs,
@@ -394,6 +408,7 @@ module Make = (
 
           let eventMod = switch eventModLookup->EventModLookup.get(
             ~sighash=topic0,
+            ~topicCount=log.topics->Array.length,
             ~contractAddressMapping,
             ~contractAddress=log.address,
           ) {
@@ -449,6 +464,7 @@ module Make = (
 
           let eventMod = switch eventModLookup->EventModLookup.get(
             ~sighash=topic0,
+            ~topicCount=log.topics->Array.length,
             ~contractAddressMapping,
             ~contractAddress=log.address,
           ) {

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -77,6 +77,7 @@ module type S = {
 
     module type Event = {
       let sighash: string
+      let topicCount: int
       let name: string
       let contractName: string
       type eventArgs

--- a/scenarios/test_codegen/test/lib_tests/EventModLookup_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EventModLookup_test.res
@@ -13,6 +13,8 @@ let toInternal: module(Types.Event) => module(Types.InternalEvent) = Utils.magic
 let mockAddress1 = TestHelpers.Addresses.mockAddresses[0]
 let mockAddress2 = TestHelpers.Addresses.mockAddresses[1]
 
+let mockTopicCount = 1
+
 module MakeEventMock = (
   E: {
     let sighash: string
@@ -22,6 +24,7 @@ module MakeEventMock = (
   },
 ): Types.Event => {
   let sighash = E.sighash
+  let topicCount = mockTopicCount
   let name = E.name
   let contractName = E.contractName
 
@@ -135,7 +138,11 @@ describe("EventModLookup", () => {
     ->EventModLookup.unwrapAddEventResponse(~chain=mockChain)
 
     Assert.deepEqual(
-      lookup->EventModLookup.getByKey(~sighash=mockSighash, ~contractName="TestContract"),
+      lookup->EventModLookup.getByKey(
+        ~sighash=mockSighash,
+        ~topicCount=mockTopicCount,
+        ~contractName="TestContract",
+      ),
       Some(mockEventMod->toInternal),
     )
   })
@@ -156,6 +163,7 @@ describe("EventModLookup", () => {
     Assert.deepEqual(
       lookup->EventModLookup.get(
         ~sighash=mockSighash,
+        ~topicCount=mockTopicCount,
         ~contractAddress=mockAddress1,
         ~contractAddressMapping=ContractAddressingMap.make(),
       ),
@@ -190,7 +198,6 @@ describe("EventModLookup", () => {
       lookup
       ->EventModLookup.set(mockNonWildcardEventMod)
       ->EventModLookup.unwrapAddEventResponse(~chain=mockChain)
-      Js.log(lookup)
 
       let contractAddressMapping = ContractAddressingMap.make()
       contractAddressMapping->ContractAddressingMap.addAddress(
@@ -201,6 +208,7 @@ describe("EventModLookup", () => {
       Assert.deepEqual(
         lookup->EventModLookup.get(
           ~sighash=mockSighash,
+          ~topicCount=mockTopicCount,
           ~contractAddress=nonWildcardContractAddress,
           ~contractAddressMapping,
         ),
@@ -211,6 +219,7 @@ describe("EventModLookup", () => {
       Assert.deepEqual(
         lookup->EventModLookup.get(
           ~sighash=mockSighash,
+          ~topicCount=mockTopicCount,
           ~contractAddress=wildcardContractAddress,
           ~contractAddressMapping,
         ),


### PR DESCRIPTION
Closes #195 

This should allow defining multiple events with the same sighash (and aliasing with a different name). The client decoder already supports this.