### PR TITLE
Fix second part of Fuel id on contract import

### DIFF
--- a/codegenerator/cli/src/hbs_templating/contract_import_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/contract_import_templates.rs
@@ -273,7 +273,7 @@ pub struct Event {
 }
 
 impl Event {
-    fn get_entity_id_code(event_var_name: String, language: &Language) -> String {
+    fn get_entity_id_code(event_var_name: String, is_fuel: bool, language: &Language) -> String {
         let to_string_code = match language {
             Language::ReScript => "->Belt.Int.toString",
             Language::TypeScript => "",
@@ -281,9 +281,13 @@ impl Event {
         }
         .to_string();
 
+        let second_part = match is_fuel {
+            true => format!("${{{event_var_name}.transaction.id}}"),
+            false => format!("${{{event_var_name}.block.number}}"),
+        };
+
         format!(
-            "`${{{event_var_name}.chainId}}_${{{event_var_name}.block.\
-           number}}_${{{event_var_name}.logIndex{}}}`",
+            "`${{{event_var_name}.chainId}}_{second_part}_${{{event_var_name}.logIndex{}}}`",
             to_string_code
         )
     }
@@ -333,7 +337,11 @@ impl Event {
 
         Ok(Event {
             name: event.name.to_capitalized_options(),
-            entity_id_from_event_code: Event::get_entity_id_code("event".to_string(), &language),
+            entity_id_from_event_code: Event::get_entity_id_code(
+                "event".to_string(),
+                is_fuel,
+                &language,
+            ),
             create_mock_code: Event::get_create_mock_code(&event, &contract, is_fuel, &language),
             params,
         })


### PR DESCRIPTION
I've decided to keep it as before, since I'm not sure how logIndex behaves for Fuel. Can change it later to block number , but it should be `block.height` instead anyways.