### PR TITLE
Deduplicate wildcard queries on multiple registers and partitions

### DIFF
--- a/scenarios/test_codegen/test/HyperSyncWorker_test.res
+++ b/scenarios/test_codegen/test/HyperSyncWorker_test.res
@@ -76,6 +76,7 @@ describe("HyperSyncWorker - getNextPage", () => {
         ~logger=Logging.logger,
         ~setCurrentBlockHeight=_blockNumber => (),
         ~contractAddressMapping=ContractAddressingMap.make(),
+        ~shouldApplyWildcards=true,
       )
 
       Assert.deepEqual(
@@ -126,6 +127,7 @@ describe("HyperSyncWorker - getNextPage", () => {
         ~logger=Logging.logger,
         ~setCurrentBlockHeight=_blockNumber => (),
         ~contractAddressMapping=ContractAddressingMap.make(),
+        ~shouldApplyWildcards=true,
       )
 
       Assert.deepEqual(


### PR DESCRIPTION
Close #205 

Currently for multiple partitions and dynamic contract registers, wild card queries are always applied. This results in duplicate queries being run and double processing of events.

The solution is to always only apply wildcard queries on the first partition and on Root queries.