### PR TITLE
Add Indexer Benchmarking System

### DIFF
--- a/codegenerator/cli/CommandLineHelp.md
+++ b/codegenerator/cli/CommandLineHelp.md
@@ -17,6 +17,7 @@ This document contains the help content for the `envio` command-line program.
 * [`envio dev`↴](#envio-dev)
 * [`envio stop`↴](#envio-stop)
 * [`envio codegen`↴](#envio-codegen)
+* [`envio benchmark-summary`↴](#envio-benchmark-summary)
 * [`envio local`↴](#envio-local)
 * [`envio local docker`↴](#envio-local-docker)
 * [`envio local docker up`↴](#envio-local-docker-up)
@@ -37,6 +38,7 @@ This document contains the help content for the `envio` command-line program.
 * `dev` — Development commands for starting, stopping, and restarting the indexer with automatic codegen for any changed files
 * `stop` — Stop the local environment - delete the database and stop all processes (including Docker) for the current directory
 * `codegen` — Generate indexing code from user-defined configuration & schema files
+* `benchmark-summary` — Prints a summary of the benchmark data after running the indexer with envio start --bench flag or setting 'ENVIO_SAVE_BENCHMARK_DATA=true'
 * `local` — Prepare local environment for envio testing
 * `start` — Start the indexer without any automatic codegen
 
@@ -222,6 +224,14 @@ Generate indexing code from user-defined configuration & schema files
 
 
 
+## `envio benchmark-summary`
+
+Prints a summary of the benchmark data after running the indexer with envio start --bench flag or setting 'ENVIO_SAVE_BENCHMARK_DATA=true'
+
+**Usage:** `envio benchmark-summary`
+
+
+
 ## `envio local`
 
 Prepare local environment for envio testing
@@ -311,6 +321,7 @@ Start the indexer without any automatic codegen
 ###### **Options:**
 
 * `-r`, `--restart` — Clear your database and restart indexing from scratch
+* `--bench` — Saves benchmark data to a file during indexing
 
 
 

--- a/codegenerator/cli/CommandLineHelp.md
+++ b/codegenerator/cli/CommandLineHelp.md
@@ -321,7 +321,7 @@ Start the indexer without any automatic codegen
 ###### **Options:**
 
 * `-r`, `--restart` — Clear your database and restart indexing from scratch
-* `--bench` — Saves benchmark data to a file during indexing
+* `-b`, `--bench` — Saves benchmark data to a file during indexing
 
 
 

--- a/codegenerator/cli/src/cli_args/clap_definitions.rs
+++ b/codegenerator/cli/src/cli_args/clap_definitions.rs
@@ -94,7 +94,7 @@ pub struct StartArgs {
     #[arg(short = 'r', long, action)]
     pub restart: bool,
     ///Saves benchmark data to a file during indexing
-    #[arg(long, action)]
+    #[arg(short = 'b', long, action)]
     pub bench: bool,
 }
 

--- a/codegenerator/cli/src/cli_args/clap_definitions.rs
+++ b/codegenerator/cli/src/cli_args/clap_definitions.rs
@@ -54,6 +54,10 @@ pub enum CommandType {
     ///Generate indexing code from user-defined configuration & schema files
     Codegen,
 
+    ///Prints a summary of the benchmark data after running the indexer
+    ///with envio start --bench flag or setting 'ENVIO_SAVE_BENCHMARK_DATA=true'
+    BenchmarkSummary,
+
     ///Prepare local environment for envio testing
     // #[clap(hide = true)]
     #[command(subcommand)]
@@ -89,6 +93,9 @@ pub struct StartArgs {
     ///Clear your database and restart indexing from scratch
     #[arg(short = 'r', long, action)]
     pub restart: bool,
+    ///Saves benchmark data to a file during indexing
+    #[arg(long, action)]
+    pub bench: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/codegenerator/cli/src/commands.rs
+++ b/codegenerator/cli/src/commands.rs
@@ -302,3 +302,21 @@ pub mod db_migrate {
         Ok(())
     }
 }
+
+pub mod benchmark {
+    use super::execute_command;
+    use crate::project_paths::ParsedProjectPaths;
+    use anyhow::{anyhow, Result};
+
+    pub async fn print_summary(project_paths: &ParsedProjectPaths) -> Result<()> {
+        let args = vec!["print-benchmark-summary"];
+        let current_dir = &project_paths.generated;
+        let exit = execute_command("pnpm", args, current_dir).await?;
+
+        if !exit.success() {
+            return Err(anyhow!("Failed printing benchmark summary"));
+        }
+
+        Ok(())
+    }
+}

--- a/codegenerator/cli/src/executor/mod.rs
+++ b/codegenerator/cli/src/executor/mod.rs
@@ -61,6 +61,10 @@ pub async fn execute(command_line_args: CommandLineArgs) -> Result<()> {
                 PersistedStateExists::Exists(_) => (),
             };
 
+            if start_args.bench {
+                std::env::set_var("ENVIO_SAVE_BENCHMARK_DATA", "true");
+            }
+
             if start_args.restart {
                 let config = SystemConfig::parse_from_project_files(&parsed_project_paths)
                     .context("Failed parsing config")?;
@@ -89,6 +93,10 @@ pub async fn execute(command_line_args: CommandLineArgs) -> Result<()> {
 
         CommandType::Local(local_commands) => {
             local::run_local(&local_commands, &parsed_project_paths).await?;
+        }
+
+        CommandType::BenchmarkSummary => {
+            commands::benchmark::print_summary(&parsed_project_paths).await?
         }
 
         CommandType::Script(Script::PrintCliHelpMd) => {

--- a/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
@@ -12,6 +12,7 @@
     "db-down": "node -e 'require(`./src/db/Migrations.bs.js`).runDownMigrations(true)'",
     "db-setup": "node -e 'require(`./src/db/Migrations.bs.js`).setupDb()'",
     "db-track-tables": "node -e 'require(`./db/src/Migrations.bs.js`).trackAllTables()'",
+    "print-benchmark-summary": "node -e 'require(`./src/Benchmark.bs.js`).Summary.printSummary()'",
     "start": "node src/Index.bs.js"
   },
   "keywords": [

--- a/codegenerator/cli/templates/static/codegen/.gitignore
+++ b/codegenerator/cli/templates/static/codegen/.gitignore
@@ -30,4 +30,4 @@
 *.bs.mjs
 *.gen.ts
 logs/*
-# *.BenchmarkCache.json
+*.BenchmarkCache.json

--- a/codegenerator/cli/templates/static/codegen/.gitignore
+++ b/codegenerator/cli/templates/static/codegen/.gitignore
@@ -30,3 +30,4 @@
 *.bs.mjs
 *.gen.ts
 logs/*
+# *.BenchmarkCache.json

--- a/codegenerator/cli/templates/static/codegen/src/Benchmark.res
+++ b/codegenerator/cli/templates/static/codegen/src/Benchmark.res
@@ -1,0 +1,72 @@
+module Data = {
+  module BlockRangeFetched = {
+    type t = {
+      stats: ChainWorker.blockRangeFetchStats,
+      chainId: int,
+      fromBlock: int,
+      toBlock: int,
+      fetchStateRegisterId: FetchState.id,
+      partitionId: int,
+    }
+
+    let make = (~stats, ~chainId, ~fromBlock, ~toBlock, ~fetchStateRegisterId, ~partitionId) => {
+      stats,
+      chainId,
+      fromBlock,
+      toBlock,
+      fetchStateRegisterId,
+      partitionId,
+    }
+
+    let schema = S.object(s => {
+      stats: s.field("stats", ChainWorker.blockRangeFetchStatsSchema),
+      chainId: s.field("chainId", S.int),
+      fromBlock: s.field("fromBlock", S.int),
+      toBlock: s.field("toBlock", S.int),
+      fetchStateRegisterId: s.field("fetchStateRegisterId", FetchState.idSchema),
+      partitionId: s.field("partitionId", S.int),
+    })
+  }
+
+  type t = {requestStats: array<BlockRangeFetched.t>}
+  let schema = S.object(s => {
+    requestStats: s.field("requestStats", S.array(BlockRangeFetched.schema)),
+  })
+
+  let make = () => {requestStats: []}
+
+  let addBlockRangeFetched = (self, blockRangeFetched: BlockRangeFetched.t) => {
+    self.requestStats->Js.Array2.push(blockRangeFetched)->ignore
+  }
+}
+
+let data = Data.make()
+let cacheFileName = "BenchmarkCache.json"
+let cacheFilePath = NodeJsLocal.Path.join(NodeJsLocal.Path.__dirname, cacheFileName)
+
+let saveToCacheFile = data => {
+  let json = data->S.serializeToJsonStringOrRaiseWith(Data.schema)
+  NodeJsLocal.Fs.Promises.writeFile(~filepath=cacheFilePath, ~content=json)->ignore
+}
+
+let addBlockRangeFetched = (
+  ~stats,
+  ~chainId,
+  ~fromBlock,
+  ~toBlock,
+  ~fetchStateRegisterId,
+  ~partitionId,
+) => {
+  data->Data.addBlockRangeFetched(
+    Data.BlockRangeFetched.make(
+      ~stats,
+      ~chainId,
+      ~fromBlock,
+      ~toBlock,
+      ~fetchStateRegisterId,
+      ~partitionId,
+    ),
+  )
+
+  data->saveToCacheFile
+}

--- a/codegenerator/cli/templates/static/codegen/src/Benchmark.res
+++ b/codegenerator/cli/templates/static/codegen/src/Benchmark.res
@@ -320,7 +320,7 @@ module Summary = {
     switch data {
     | None =>
       Logging.error(
-        "No benchmark cache file found, please use 'ENVIO_SAVE_BENCHMARK_DATA=true' and rerun the benchmark",
+        "No benchmark cache file found, please run `envio start --bench` or use 'ENVIO_SAVE_BENCHMARK_DATA=true' and rerun the indexer",
       )
     | Some(data) =>
       let config = RegisterHandlers.getConfig()

--- a/codegenerator/cli/templates/static/codegen/src/Benchmark.res
+++ b/codegenerator/cli/templates/static/codegen/src/Benchmark.res
@@ -7,15 +7,25 @@ module Data = {
       toBlock: int,
       fetchStateRegisterId: FetchState.id,
       partitionId: int,
+      numEvents: int,
     }
 
-    let make = (~stats, ~chainId, ~fromBlock, ~toBlock, ~fetchStateRegisterId, ~partitionId) => {
+    let make = (
+      ~stats,
+      ~chainId,
+      ~fromBlock,
+      ~toBlock,
+      ~fetchStateRegisterId,
+      ~partitionId,
+      ~numEvents,
+    ) => {
       stats,
       chainId,
       fromBlock,
       toBlock,
       fetchStateRegisterId,
       partitionId,
+      numEvents,
     }
 
     let schema = S.object(s => {
@@ -25,6 +35,7 @@ module Data = {
       toBlock: s.field("toBlock", S.int),
       fetchStateRegisterId: s.field("fetchStateRegisterId", FetchState.idSchema),
       partitionId: s.field("partitionId", S.int),
+      numEvents: s.field("numEvents", S.int),
     })
   }
 
@@ -49,6 +60,21 @@ let saveToCacheFile = data => {
   NodeJsLocal.Fs.Promises.writeFile(~filepath=cacheFilePath, ~content=json)->ignore
 }
 
+let readFromCacheFile = async () => {
+  switch await NodeJsLocal.Fs.Promises.readFile(~filepath=cacheFilePath, ~encoding=Utf8) {
+  | exception _ => None
+  | content =>
+    switch content->S.parseJsonStringWith(Data.schema) {
+    | Ok(data) => Some(data)
+    | Error(e) =>
+      Logging.error(
+        "Failed to parse benchmark cache file, please delete it and rerun the benchmark",
+      )
+      e->S.Error.raise
+    }
+  }
+}
+
 let addBlockRangeFetched = (
   ~stats,
   ~chainId,
@@ -56,6 +82,7 @@ let addBlockRangeFetched = (
   ~toBlock,
   ~fetchStateRegisterId,
   ~partitionId,
+  ~numEvents,
 ) => {
   data->Data.addBlockRangeFetched(
     Data.BlockRangeFetched.make(
@@ -65,8 +92,116 @@ let addBlockRangeFetched = (
       ~toBlock,
       ~fetchStateRegisterId,
       ~partitionId,
+      ~numEvents,
     ),
   )
 
   data->saveToCacheFile
+}
+
+module Summary = {
+  open Belt
+  type t = {
+    n: int,
+    mean: float,
+    stdDev: float,
+    min: float,
+    max: float,
+  }
+
+  type summaryTable = dict<t>
+
+  external logSummaryTable: summaryTable => unit = "console.table"
+
+  external arrayIntToFloat: array<int> => array<float> = "%identity"
+
+  let make = (arr: array<float>) => {
+    let div = (floatA, floatB) => floatA /. floatB
+    let n = Array.length(arr)
+    if n == 0 {
+      {n, mean: 0., stdDev: 0., min: 0., max: 0.}
+    } else {
+      let nFloat = n->Int.toFloat
+      let mean = arr->Array.reduce(0., (acc, time) => acc +. time)->div(nFloat)
+      let stdDev = {
+        let variance =
+          arr
+          ->Array.reduce(0., (acc, val) => {
+            let diff = val -. mean
+            acc +. Js.Math.pow_float(~base=diff, ~exp=2.)
+          })
+          ->div(nFloat)
+
+        variance->Js.Math.sqrt
+      }
+
+      let min =
+        arr
+        ->Array.reduce(None, (acc, val) =>
+          switch acc {
+          | None => Some(val)
+          | Some(acc) => Some(Pervasives.min(acc, val))
+          }
+        )
+        ->Option.getWithDefault(0.)
+      let max =
+        arr
+        ->Array.reduce(None, (acc, val) =>
+          switch acc {
+          | None => Some(val)
+          | Some(acc) => Some(Pervasives.max(acc, val))
+          }
+        )
+        ->Option.getWithDefault(0.)
+      {n, mean, stdDev, min, max}
+    }
+  }
+
+  let getChainBlockRangeFetchedSummary = (data: Data.t, ~chainId): summaryTable => {
+    let numBlocksFetchedSamples = []
+    let blockRangeSizeSamples = []
+    let totalTimeElapsedSamples = []
+    let parsingTimeElapsedSamples = []
+    let pageFetchTimeSamples = []
+
+    data.requestStats->Array.forEach(request =>
+      if request.chainId == chainId {
+        numBlocksFetchedSamples->Array.push(request.numEvents->Int.toFloat)
+        blockRangeSizeSamples->Array.push(Int.toFloat(request.toBlock - request.fromBlock))
+        totalTimeElapsedSamples->Array.push(request.stats.totalTimeElapsed->Int.toFloat)
+        parsingTimeElapsedSamples->Array.push(
+          request.stats.parsingTimeElapsed->Option.mapWithDefault(0., Int.toFloat),
+        )
+        pageFetchTimeSamples->Array.push(
+          request.stats.pageFetchTime->Option.mapWithDefault(0., Int.toFloat),
+        )
+      }
+    )
+    [
+      ("totalTimeElapsed (ms)", totalTimeElapsedSamples->make),
+      ("parsingTimeElapsed (ms)", parsingTimeElapsedSamples->make),
+      ("pageFetchTime (ms)", pageFetchTimeSamples->make),
+      ("numBlocksFetched", numBlocksFetchedSamples->make),
+      ("blockRangeSize", blockRangeSizeSamples->make),
+    ]->Js.Dict.fromArray
+  }
+  let printSummary = async () => {
+    let data = await readFromCacheFile()
+    switch data {
+    | None =>
+      Logging.error(
+        "No benchmark cache file found, please use 'ENVIO_SAVE_BENCHMARK_DATA=true' and rerun the benchmark",
+      )
+    | Some(data) =>
+      let config = RegisterHandlers.getConfig()
+      config.chainMap
+      ->ChainMap.keys
+      ->Array.forEach(chain => {
+        Js.log2("BlockRangeFetched Summary for Chain", chain)
+        let chainBlockRangeFetchedSummary =
+          data->getChainBlockRangeFetchedSummary(~chainId=chain->ChainMap.Chain.toChainId)
+        chainBlockRangeFetchedSummary->logSummaryTable
+      })
+    }
+  }
 }

--- a/codegenerator/cli/templates/static/codegen/src/Env.res
+++ b/codegenerator/cli/templates/static/codegen/src/Env.res
@@ -27,6 +27,7 @@ let defaultFileLogLevel = getLogLevelConfig("FILE_LOG_LEVEL", ~default=#trace)
 let envioApiToken = envSafe->EnvSafe.get("ENVIO_API_TOKEN", S.option(S.string))
 let hyperSyncClientTimeoutMillis =
   envSafe->EnvSafe.get("ENVIO_HYPERSYNC_CLIENT_TIMEOUT_MILLIS", S.option(S.int))
+let saveBenchmarkData = envSafe->EnvSafe.get("ENVIO_SAVE_BENCHMARK_DATA", S.bool, ~fallback=false)
 
 type logStrategyType =
   | @as("ecs-file") EcsFile

--- a/codegenerator/cli/templates/static/codegen/src/EventUtils.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventUtils.res
@@ -28,6 +28,11 @@ type eventIndex = {
   logIndex: int,
 }
 
+let eventIndexSchema = S.object(s => {
+  blockNumber: s.field("blockNumber", S.int),
+  logIndex: s.field("logIndex", S.int),
+})
+
 // takes blockNumber, logIndex and packs them into a number with
 //32 bits, 16 bits and 16 bits respectively
 let packEventIndex = (~blockNumber, ~logIndex) => {
@@ -99,7 +104,7 @@ let waitForNextBlock = async (provider: Ethers.JsonRpcProvider.t) => {
   await Promise.make((resolve, _reject) => {
     provider->Ethers.JsonRpcProvider.onBlock(blockNumber => {
       provider->Ethers.JsonRpcProvider.removeOnBlockEventListener
-      resolve(. blockNumber)
+      resolve(blockNumber)
     })
   })
 }

--- a/codegenerator/cli/templates/static/codegen/src/bindings/NodeJsLocal.res
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/NodeJsLocal.res
@@ -50,12 +50,5 @@ module Fs = {
 
     @module("fs") @scope("promises")
     external readFile: (~filepath: Path.t, ~encoding: encoding) => promise<string> = "readFile"
-
-    let readFileIfExists = async (~filepath, ~encoding=Utf8) => {
-      switch await readFile(~filepath, ~encoding) {
-      | exception _exn => None
-      | content => Some(content)
-      }
-    }
   }
 }

--- a/codegenerator/cli/templates/static/codegen/src/bindings/NodeJsLocal.res
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/NodeJsLocal.res
@@ -34,3 +34,28 @@ module Util = {
 
   let inspectObj = a => inspect(a, {showHidden: false, depth: Null, colors: true})
 }
+
+module Path = {
+  type t
+  @module("path") external join: (t, string) => t = "join"
+  external toString: t => string = "%identity"
+  external __dirname: t = "__dirname"
+}
+module Fs = {
+  module Promises = {
+    @module("fs") @scope("promises")
+    external writeFile: (~filepath: Path.t, ~content: string) => promise<unit> = "writeFile"
+
+    type encoding = | @as("utf-8") Utf8
+
+    @module("fs") @scope("promises")
+    external readFile: (~filepath: Path.t, ~encoding: encoding) => promise<string> = "readFile"
+
+    let readFileIfExists = async (~filepath, ~encoding=Utf8) => {
+      switch await readFile(~filepath, ~encoding) {
+      | exception _exn => None
+      | content => Some(content)
+      }
+    }
+  }
+}

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -256,6 +256,11 @@ with a dynamicContractId
 */
 type id = Root | DynamicContract(dynamicContractId)
 
+let idSchema = S.union([
+  S.literal(Root),
+  S.schema(s => DynamicContract(s.matches(EventUtils.eventIndexSchema))),
+])
+
 /**
 Constructs id from a register
 */

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/ChainWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/ChainWorker.res
@@ -1,4 +1,3 @@
-
 /**
 The args required for calling block range fetch
 */
@@ -13,6 +12,13 @@ type blockRangeFetchStats = {
   @as("page fetch time (ms)") pageFetchTime?: int,
   @as("average parse time per log (ms)") averageParseTimePerLog?: float,
 }
+
+let blockRangeFetchStatsSchema: S.t<blockRangeFetchStats> = S.object(s => {
+  totalTimeElapsed: s.field("totalTimeElapsed", S.int),
+  parsingTimeElapsed: ?s.field("parsingTimeElapsed", S.option(S.int)),
+  pageFetchTime: ?s.field("pageFetchTime", S.option(S.int)),
+  averageParseTimePerLog: ?s.field("averageParseTimePerLog", S.option(S.float)),
+})
 
 type reorgGuard = {
   lastBlockScannedData: ReorgDetection.blockData,
@@ -52,4 +58,3 @@ module type S = {
     ~setCurrentBlockHeight: int => unit,
   ) => promise<result<blockRangeFetchResponse, ErrorHandling.t>>
 }
-

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -268,6 +268,17 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
     latestFetchedBlockTimestamp,
   } = response
 
+  if Env.saveBenchmarkData {
+    Benchmark.addBlockRangeFetched(
+      ~stats,
+      ~chainId=chainFetcher.chainConfig.chain->ChainMap.Chain.toChainId,
+      ~fromBlock=fromBlockQueried,
+      ~toBlock=heighestQueriedBlockNumber,
+      ~fetchStateRegisterId,
+      ~partitionId,
+    )
+  }
+
   chainFetcher.logger->Logging.childTrace({
     "message": "Finished page range",
     "fromBlock": fromBlockQueried,

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -276,6 +276,7 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
       ~toBlock=heighestQueriedBlockNumber,
       ~fetchStateRegisterId,
       ~partitionId,
+      ~numEvents=parsedQueueItems->Array.length,
     )
   }
 

--- a/codegenerator/cli/templates/static/codegen/src/ink/bindings/DateFns.res
+++ b/codegenerator/cli/templates/static/codegen/src/ink/bindings/DateFns.res
@@ -64,4 +64,8 @@ type interval = {start: Js_date.t, end: Js_date.t}
 @module("date-fns")
 external intervalToDuration: interval => durationTimeFormat = "intervalToDuration"
 
+//helper to convert millis elapsed to duration object
+let durationFromMillis = (millis: int) =>
+  intervalToDuration({start: 0->Utils.magic, end: millis->Utils.magic})
+
 @module("date-fns") external fromUnixTime: float => Js.Date.t = "fromUnixTime"


### PR DESCRIPTION
This is a simple system to get started with summarising benchmarks on an indexer.

I've added datapoints for hypersync fetching stats.

I will add values for everything from event processing, to various individual postgres functions etc.

It will simply print out these types of summary tables when you run the print-benchmark-summary script like in the screenshot below.
![Screenshot 2024-09-18 at 18 44 32](https://github.com/user-attachments/assets/2a51dcae-33f0-4d30-9ce2-631f6f226e84)

I have made it simply opt in via env var for now and we can make it more sophisticated as we go. It currently will just provide a way to save benchmark related data into file with a schema to deserialize it and it should then be easy enough to write any scripts needed for analysing the benchmarks.
