### PR TITLE
Add helper for running and printing benchmarks

### DIFF
--- a/codegenerator/cli/CommandLineHelp.md
+++ b/codegenerator/cli/CommandLineHelp.md
@@ -17,6 +17,7 @@ This document contains the help content for the `envio` command-line program.
 * [`envio dev`↴](#envio-dev)
 * [`envio stop`↴](#envio-stop)
 * [`envio codegen`↴](#envio-codegen)
+* [`envio benchmark-summary`↴](#envio-benchmark-summary)
 * [`envio local`↴](#envio-local)
 * [`envio local docker`↴](#envio-local-docker)
 * [`envio local docker up`↴](#envio-local-docker-up)
@@ -37,6 +38,7 @@ This document contains the help content for the `envio` command-line program.
 * `dev` — Development commands for starting, stopping, and restarting the indexer with automatic codegen for any changed files
 * `stop` — Stop the local environment - delete the database and stop all processes (including Docker) for the current directory
 * `codegen` — Generate indexing code from user-defined configuration & schema files
+* `benchmark-summary` — Prints a summary of the benchmark data after running the indexer with envio start --bench flag or setting 'ENVIO_SAVE_BENCHMARK_DATA=true'
 * `local` — Prepare local environment for envio testing
 * `start` — Start the indexer without any automatic codegen
 
@@ -222,6 +224,14 @@ Generate indexing code from user-defined configuration & schema files
 
 
 
+## `envio benchmark-summary`
+
+Prints a summary of the benchmark data after running the indexer with envio start --bench flag or setting 'ENVIO_SAVE_BENCHMARK_DATA=true'
+
+**Usage:** `envio benchmark-summary`
+
+
+
 ## `envio local`
 
 Prepare local environment for envio testing
@@ -311,6 +321,7 @@ Start the indexer without any automatic codegen
 ###### **Options:**
 
 * `-r`, `--restart` — Clear your database and restart indexing from scratch
+* `--bench` — Saves benchmark data to a file during indexing
 
 
 

--- a/codegenerator/cli/CommandLineHelp.md
+++ b/codegenerator/cli/CommandLineHelp.md
@@ -321,7 +321,7 @@ Start the indexer without any automatic codegen
 ###### **Options:**
 
 * `-r`, `--restart` — Clear your database and restart indexing from scratch
-* `--bench` — Saves benchmark data to a file during indexing
+* `-b`, `--bench` — Saves benchmark data to a file during indexing
 
 
 

--- a/codegenerator/cli/src/cli_args/clap_definitions.rs
+++ b/codegenerator/cli/src/cli_args/clap_definitions.rs
@@ -94,7 +94,7 @@ pub struct StartArgs {
     #[arg(short = 'r', long, action)]
     pub restart: bool,
     ///Saves benchmark data to a file during indexing
-    #[arg(long, action)]
+    #[arg(short = 'b', long, action)]
     pub bench: bool,
 }
 

--- a/codegenerator/cli/src/cli_args/clap_definitions.rs
+++ b/codegenerator/cli/src/cli_args/clap_definitions.rs
@@ -54,6 +54,10 @@ pub enum CommandType {
     ///Generate indexing code from user-defined configuration & schema files
     Codegen,
 
+    ///Prints a summary of the benchmark data after running the indexer
+    ///with envio start --bench flag or setting 'ENVIO_SAVE_BENCHMARK_DATA=true'
+    BenchmarkSummary,
+
     ///Prepare local environment for envio testing
     // #[clap(hide = true)]
     #[command(subcommand)]
@@ -89,6 +93,9 @@ pub struct StartArgs {
     ///Clear your database and restart indexing from scratch
     #[arg(short = 'r', long, action)]
     pub restart: bool,
+    ///Saves benchmark data to a file during indexing
+    #[arg(long, action)]
+    pub bench: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/codegenerator/cli/src/commands.rs
+++ b/codegenerator/cli/src/commands.rs
@@ -302,3 +302,21 @@ pub mod db_migrate {
         Ok(())
     }
 }
+
+pub mod benchmark {
+    use super::execute_command;
+    use crate::project_paths::ParsedProjectPaths;
+    use anyhow::{anyhow, Result};
+
+    pub async fn print_summary(project_paths: &ParsedProjectPaths) -> Result<()> {
+        let args = vec!["print-benchmark-summary"];
+        let current_dir = &project_paths.generated;
+        let exit = execute_command("pnpm", args, current_dir).await?;
+
+        if !exit.success() {
+            return Err(anyhow!("Failed printing benchmark summary"));
+        }
+
+        Ok(())
+    }
+}

--- a/codegenerator/cli/src/executor/mod.rs
+++ b/codegenerator/cli/src/executor/mod.rs
@@ -61,6 +61,10 @@ pub async fn execute(command_line_args: CommandLineArgs) -> Result<()> {
                 PersistedStateExists::Exists(_) => (),
             };
 
+            if start_args.bench {
+                std::env::set_var("ENVIO_SAVE_BENCHMARK_DATA", "true");
+            }
+
             if start_args.restart {
                 let config = SystemConfig::parse_from_project_files(&parsed_project_paths)
                     .context("Failed parsing config")?;
@@ -89,6 +93,10 @@ pub async fn execute(command_line_args: CommandLineArgs) -> Result<()> {
 
         CommandType::Local(local_commands) => {
             local::run_local(&local_commands, &parsed_project_paths).await?;
+        }
+
+        CommandType::BenchmarkSummary => {
+            commands::benchmark::print_summary(&parsed_project_paths).await?
         }
 
         CommandType::Script(Script::PrintCliHelpMd) => {

--- a/codegenerator/cli/templates/static/codegen/src/Benchmark.res
+++ b/codegenerator/cli/templates/static/codegen/src/Benchmark.res
@@ -320,7 +320,7 @@ module Summary = {
     switch data {
     | None =>
       Logging.error(
-        "No benchmark cache file found, please use 'ENVIO_SAVE_BENCHMARK_DATA=true' and rerun the benchmark",
+        "No benchmark cache file found, please run `envio start --bench` or use 'ENVIO_SAVE_BENCHMARK_DATA=true' and rerun the indexer",
       )
     | Some(data) =>
       let config = RegisterHandlers.getConfig()


### PR DESCRIPTION
Now you can run: 

`envio start --bench`

to run the indexer with benchmarks

and 

`envio benchmark-summary`

to get he print out.