### PR TITLE
Add postgres copy fn for entity history

### DIFF
--- a/codegenerator/cli/src/config_parsing/entity_parsing.rs
+++ b/codegenerator/cli/src/config_parsing/entity_parsing.rs
@@ -878,7 +878,16 @@ impl UserDefinedFieldType {
                              methods for referencing entities outlined in the docs. The entity \
                              being referenced in the array is '{}'.",
                             name
-                        ))?
+                        ))
+                    }
+                    //TODO: add support for these types
+                    //currently we would need to use explicid casts in the queries to make these
+                    //work https://github.com/porsager/postgres/pull/392
+                    Self::Single(GqlScalar::Boolean) => {
+                        Err(anyhow!("Arrays of booleans are not yet supported."))
+                    }
+                    Self::Single(GqlScalar::Timestamp) => {
+                        Err(anyhow!("Arrays of timestamps are not yet supported."))
                     }
                     _ => field_type.validate_type(schema),
                 },
@@ -886,11 +895,11 @@ impl UserDefinedFieldType {
                     "EE208: Nullable scalars inside lists are unsupported. Please include a '!' \
                      after your '{}' scalar",
                     gql_scalar
-                ))?,
+                )),
                 Self::ListType(_) => Err(anyhow!(
                     "EE209: Nullable multidimensional lists types are unsupported,please include \
                      a '!' for your inner list type eg. [[Int!]!]"
-                ))?,
+                )),
             },
             Self::NonNullType(field_type) => match field_type.as_ref() {
                 Self::NonNullType(_) => Err(anyhow!(

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -529,12 +529,15 @@ pub mod fuel {
         pub name: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
-            description = "An identifier of a logged type from ABI. Used for indexing LogData receipts. The option can be omitted when the event name matches the logged struct/enum name."
+            description = "An identifier of a logged type from ABI. Used for indexing LogData \
+                           receipts. The option can be omitted when the event name matches the \
+                           logged struct/enum name."
         )]
         pub log_id: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
-            description = "Index Mint receipts. The option can be omitted when the event name is Mint."
+            description = "Index Mint receipts. The option can be omitted when the event name is \
+                           Mint."
         )]
         pub mint: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -477,9 +477,10 @@ impl SystemConfig {
             Ecosystem::Fuel => {
                 let fuel_config: FuelConfig =
                     serde_yaml::from_str(&human_config_string).context(format!(
-                    "EE105: Failed to deserialize config. Visit the docs for more information {}",
-                    links::DOC_CONFIGURATION_FILE
-                ))?;
+                        "EE105: Failed to deserialize config. Visit the docs for more information \
+                         {}",
+                        links::DOC_CONFIGURATION_FILE
+                    ))?;
                 let schema = Schema::parse_from_file(&project_paths, &fuel_config.schema)
                     .context("Parsing schema file for config")?;
                 Self::from_fuel_config(fuel_config, schema, project_paths)

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -424,9 +424,8 @@ impl EventTemplate {
          fromStringUnsafe])->Utils.unwrapResultExn]";
 
     const EVENT_FILTER_TYPE_STUB: &'static str = "{}";
-    const CONVERT_HYPER_SYNC_EVENT_ARGS_NOOP: &'static str = "(Utils.magic: \
-    HyperSyncClient.Decoder.decodedEvent => \
-    eventArgs)";
+    const CONVERT_HYPER_SYNC_EVENT_ARGS_NOOP: &'static str =
+        "(Utils.magic: HyperSyncClient.Decoder.decodedEvent => eventArgs)";
 
     pub fn generate_event_filter_type(params: &Vec<EventParam>) -> String {
         let field_rows = params

--- a/codegenerator/cli/src/hbs_templating/contract_import_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/contract_import_templates.rs
@@ -287,7 +287,8 @@ impl Event {
         };
 
         format!(
-            "`${{{event_var_name}.chainId}}_${{{event_var_name}.block.{block_number_field}}}_${{{event_var_name}.logIndex{}}}`",
+            "`${{{event_var_name}.chainId}}_${{{event_var_name}.block.\
+             {block_number_field}}}_${{{event_var_name}.logIndex{}}}`",
             to_string_code
         )
     }

--- a/codegenerator/cli/src/rescript_types.rs
+++ b/codegenerator/cli/src/rescript_types.rs
@@ -683,7 +683,7 @@ mod tests {
         assert_eq!(
             RescriptTypeExpr::Identifier(RescriptTypeIdent::Int)
                 .to_rescript_schema(&"eventArgs".to_string()),
-            "S.int".to_string()
+            "GqlDbCustomTypes.Int.schema".to_string()
         );
         assert_eq!(
             RescriptTypeExpr::Identifier(RescriptTypeIdent::Float)
@@ -723,12 +723,12 @@ mod tests {
         assert_eq!(
             RescriptTypeExpr::Identifier(RescriptTypeIdent::array(RescriptTypeIdent::Int))
                 .to_rescript_schema(&"eventArgs".to_string()),
-            "S.array(S.int)".to_string()
+            "S.array(GqlDbCustomTypes.Int.schema)".to_string()
         );
         assert_eq!(
             RescriptTypeExpr::Identifier(RescriptTypeIdent::option(RescriptTypeIdent::Int))
                 .to_rescript_schema(&"eventArgs".to_string()),
-            "S.null(S.int)".to_string()
+            "S.null(GqlDbCustomTypes.Int.schema)".to_string()
         );
         assert_eq!(
             RescriptTypeExpr::Identifier(RescriptTypeIdent::Tuple(vec![
@@ -736,7 +736,7 @@ mod tests {
                 RescriptTypeIdent::Bool
             ]))
             .to_rescript_schema(&"eventArgs".to_string()),
-            "S.tuple(s => (s.item(0, S.int), s.item(1, S.bool)))".to_string()
+            "S.tuple(s => (s.item(0, GqlDbCustomTypes.Int.schema), s.item(1, S.bool)))".to_string()
         );
         assert_eq!(
             RescriptTypeExpr::Variant(vec![
@@ -747,7 +747,7 @@ mod tests {
             r#"S.union([S.object((s): eventArgs =>
 {
   s.tag("case", "ConstrA")
-  ConstrA({payload: s.field("payload", S.int)})
+  ConstrA({payload: s.field("payload", GqlDbCustomTypes.Int.schema)})
 }), S.object((s): eventArgs =>
 {
   s.tag("case", "ConstrB")
@@ -761,7 +761,7 @@ mod tests {
                 RescriptRecordField::new("fieldB".to_string(), RescriptTypeIdent::Bool),
             ])
             .to_rescript_schema(&"eventArgs".to_string()),
-            "S.object((s): eventArgs => {fieldA: s.field(\"fieldA\", S.int), fieldB: s.field(\"fieldB\", \
+            "S.object((s): eventArgs => {fieldA: s.field(\"fieldA\", GqlDbCustomTypes.Int.schema), fieldB: s.field(\"fieldB\", \
              S.bool)})"
                 .to_string()
         );

--- a/codegenerator/cli/src/rescript_types.rs
+++ b/codegenerator/cli/src/rescript_types.rs
@@ -761,8 +761,8 @@ mod tests {
                 RescriptRecordField::new("fieldB".to_string(), RescriptTypeIdent::Bool),
             ])
             .to_rescript_schema(&"eventArgs".to_string()),
-            "S.object((s): eventArgs => {fieldA: s.field(\"fieldA\", GqlDbCustomTypes.Int.schema), fieldB: s.field(\"fieldB\", \
-             S.bool)})"
+            "S.object((s): eventArgs => {fieldA: s.field(\"fieldA\", \
+             GqlDbCustomTypes.Int.schema), fieldB: s.field(\"fieldB\", S.bool)})"
                 .to_string()
         );
         assert_eq!(

--- a/codegenerator/cli/src/rescript_types.rs
+++ b/codegenerator/cli/src/rescript_types.rs
@@ -426,7 +426,7 @@ impl RescriptTypeIdent {
     pub fn to_rescript_schema(&self) -> String {
         match self {
             Self::Unit => "S.literal(%raw(`null`))->S.variant(_ => ())".to_string(),
-            Self::Int => "S.int".to_string(),
+            Self::Int => "GqlDbCustomTypes.Int.schema".to_string(),
             Self::Unknown => "S.unknown".to_string(),
             Self::Float => "GqlDbCustomTypes.Float.schema".to_string(),
             Self::BigInt => "BigInt.schema".to_string(),

--- a/codegenerator/cli/templates/static/codegen/src/GqlDbCustomTypes.res
+++ b/codegenerator/cli/templates/static/codegen/src/GqlDbCustomTypes.res
@@ -7,12 +7,29 @@ module Float = {
     S.string
     ->S.setName("GqlDbCustomTypes.Float")
     ->S.transform(s => {
-      parser: (. string) => {
+      parser: string => {
         switch string->Belt.Float.fromString {
         | Some(db) => db
-        | None => s.fail(. "The string is not valid GqlDbCustomTypes.Float")
+        | None => s.fail("The string is not valid GqlDbCustomTypes.Float")
         }
       },
-      serializer: (. float) => float->Js.Float.toString,
+      serializer: float => float->Js.Float.toString,
     })
+}
+
+// Schema allows parsing strings or numbers to ints
+// this is needed for entity_history field where we on the first copy we encode all numbers as strings
+// to avoid loss of precision. Otherwise we always serialize to int
+module Int = {
+  @genType
+  type t = int
+
+  external number: unknown => Js.Json.t = "Number"
+
+  let schema = S.custom("GqlDbCustomTypes.Int", _ => {
+    parser: unknown => {
+      unknown->number->S.parseOrRaiseWith(S.int)
+    },
+    serializer: int => int,
+  })
 }

--- a/codegenerator/cli/templates/static/codegen/src/GqlDbCustomTypes.res
+++ b/codegenerator/cli/templates/static/codegen/src/GqlDbCustomTypes.res
@@ -24,12 +24,11 @@ module Int = {
   @genType
   type t = int
 
-  external number: unknown => Js.Json.t = "Number"
+  external fromStringUnsafe: string => int = "Number"
 
-  let schema = S.custom("GqlDbCustomTypes.Int", _ => {
-    parser: unknown => {
-      unknown->number->S.parseOrRaiseWith(S.int)
-    },
-    serializer: int => int,
-  })
+  let schema =
+    S.union([
+      S.int,
+      S.string->S.transform(_s => {parser: string => string->fromStringUnsafe}),
+    ])->S.setName("GqlDbCustomTypes.Int")
 }

--- a/codegenerator/cli/templates/static/codegen/src/bindings/Postgres.res
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/Postgres.res
@@ -94,3 +94,5 @@ external makeSql: (~config: poolConfig) => sql = "postgres"
 // TODO: can explore this approach (https://forum.rescript-lang.org/t/rfc-support-for-tagged-template-literals/3744)
 // @send @variadic
 // external sql:  array<string>  => (sql, array<string>) => int = "sql"
+
+@send external unsafe: (sql, string) => promise<'a> = "unsafe"

--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
@@ -359,38 +359,14 @@ module EntityHistory = {
       rollbackDiffResponseArr_decode,
     )
 
-  let copyTableToEntityHistory = (
-    sql,
-    ~sourceTableName: Enums.EntityType.t,
-    ~blockTimestamp: int,
-    ~chainId: int,
-    ~blockNumber: int,
-    ~logIndex: int,
-  ): promise<unit> => {
-    let toStr = Belt.Int.toString
-    sql->Postgres.unsafe(
-      `
-      SELECT copy_table_to_entity_history(
-        '${(sourceTableName :> string)}',
-        ${blockTimestamp->toStr},
-        ${chainId->toStr},
-        ${blockNumber->toStr},
-        ${logIndex->toStr}
-      );
-    `,
-    )
+  let copyTableToEntityHistory = (sql, ~sourceTableName: Enums.EntityType.t): promise<unit> => {
+    sql->Postgres.unsafe(`SELECT copy_table_to_entity_history('${(sourceTableName :> string)}');`)
   }
 
-  let copyAllEntitiesToEntityHistory = (sql, ~chainId: int, ~blockNumber: int, ~logIndex: int) => {
+  let copyAllEntitiesToEntityHistory = sql => {
     sql->Postgres.beginSql(sql => {
       Enums.EntityType.variants->Belt.Array.map(entityType => {
-        sql->copyTableToEntityHistory(
-          ~sourceTableName=entityType,
-          ~blockTimestamp=blockNumber,
-          ~chainId,
-          ~blockNumber,
-          ~logIndex,
-        )
+        sql->copyTableToEntityHistory(~sourceTableName=entityType)
       })
     })
   }

--- a/codegenerator/cli/templates/static/codegen/src/db/Migrations.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/Migrations.res
@@ -1,5 +1,5 @@
 let sql = DbFunctions.sql
-@send external unsafe: (Postgres.sql, string) => promise<'a> = "unsafe"
+let unsafe = Postgres.unsafe
 
 let creatTableIfNotExists = (sql, table) => {
   open Belt
@@ -82,6 +82,50 @@ let createEnumIfNotExists = (sql, enum: Enums.enumType<_>) => {
 
 module EntityHistory = {
   let createEntityHistoryTableFunctions: unit => promise<unit> = async () => {
+    // Creates a function for copying all entities in a table into the entity_history table
+    // when near the head of the chain
+    let _ = await sql->unsafe(`
+      CREATE OR REPLACE FUNCTION copy_table_to_entity_history(
+          source_table_name TEXT,
+          block_timestamp INTEGER,
+          chain_id INTEGER,
+          block_number INTEGER,
+          log_index INTEGER
+      )
+      RETURNS VOID AS $$
+      DECLARE
+          row RECORD;
+          sql_query TEXT;
+      BEGIN
+          -- Dynamically construct the query to select all rows from the given source table
+          sql_query := 'SELECT * FROM ' || quote_ident(source_table_name);
+          
+          -- Loop through each row in the dynamically selected table
+          FOR row IN EXECUTE sql_query LOOP
+              -- Insert the serialized JSON and other provided values into the entity_history table
+              INSERT INTO entity_history (
+                entity_id,
+                block_timestamp,
+                chain_id,
+                block_number,
+                log_index,
+                entity_type,
+                params
+              )
+              VALUES (
+                row.id,
+                block_timestamp,
+                chain_id,
+                block_number,
+                log_index,
+                source_table_name::entity_type,
+                row_to_json(row)
+              );
+          END LOOP;
+      END;
+      $$ LANGUAGE plpgsql;
+    `)
+
     // Create a function for inserting entities into the db.
     let _ = await sql->unsafe(`
       CREATE OR REPLACE FUNCTION insert_entity_history(
@@ -423,8 +467,8 @@ let runDownMigrations = async (~shouldExit) => {
   await deleteAllTables()->Promise.catch(err => {
     exitCode := Failure
     err
-      ->ErrorHandling.make(~msg="EE804: Error dropping entity tables")
-      ->ErrorHandling.log
+    ->ErrorHandling.make(~msg="EE804: Error dropping entity tables")
+    ->ErrorHandling.log
     Promise.resolve()
   })
   if shouldExit {

--- a/codegenerator/cli/templates/static/codegen/src/db/Table.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/Table.res
@@ -9,7 +9,7 @@ type fieldType =
   | @as("NUMERIC") Numeric
   | @as("TEXT") Text
   | @as("SERIAL") Serial
-  | @as("JSON") Json
+  | @as("JSONB") JsonB
   | @as("TIMESTAMP WITH TIME ZONE") Timestamp
   | @as("TIMESTAMP") TimestampWithoutTimezone
   | @as("TIMESTAMP WITH TIME ZONE NULL") TimestampWithNullTimezone

--- a/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
@@ -134,9 +134,9 @@ module RawEvents = {
       mkField("src_address", Text),
       mkField("block_hash", Text),
       mkField("block_timestamp", Integer),
-      mkField("block_fields", Json),
-      mkField("transaction_fields", Json),
-      mkField("params", Json),
+      mkField("block_fields", JsonB),
+      mkField("transaction_fields", JsonB),
+      mkField("params", JsonB),
       mkField("db_write_timestamp", TimestampWithoutTimezone, ~default="CURRENT_TIMESTAMP"),
     ],
   )
@@ -152,7 +152,7 @@ module DynamicContractRegistry = {
     @as("contract_type") contractType: Enums.ContractType.t,
   }
 
-  let schema = S.object((. s) => {
+  let schema = S.object(s => {
     chainId: s.field("chain_id", S.int),
     eventId: s.field("event_id", BigInt.schema),
     blockTimestamp: s.field("block_timestamp", S.int),
@@ -197,7 +197,7 @@ module EntityHistory = {
       mkField("block_number", Integer, ~isPrimaryKey),
       mkField("log_index", Integer, ~isPrimaryKey),
       mkField("entity_type", Enum(EntityType.enum.name), ~isPrimaryKey),
-      mkField("params", Json, ~isNullable),
+      mkField("params", JsonB, ~isNullable),
       mkField("previous_block_timestamp", Integer, ~isNullable),
       mkField("previous_chain_id", Integer, ~isNullable),
       mkField("previous_block_number", Integer, ~isNullable),
@@ -229,8 +229,8 @@ module EntityHistoryFilter = {
       // NULL for an `entity_id` means that the entity was deleted.
       mkField("entity_id", Text, ~isPrimaryKey),
       mkField("chain_id", Integer, ~isPrimaryKey),
-      mkField("old_val", Json, ~isNullable),
-      mkField("new_val", Json, ~isNullable),
+      mkField("old_val", JsonB, ~isNullable),
+      mkField("new_val", JsonB, ~isNullable),
       mkField("block_number", Integer, ~isPrimaryKey),
       mkField("block_timestamp", Integer, ~isPrimaryKey),
       mkField("previous_block_number", Integer, ~isNullable),

--- a/scenarios/test_codegen/schema.graphql
+++ b/scenarios/test_codegen/schema.graphql
@@ -92,14 +92,18 @@ type EntityWithAllTypes {
   arrayOfFloats: [Float!]!
   bool: Boolean!
   optBool: Boolean
-  arrayOfBool: [Boolean!]!
+  # NOTE: array of boolean is currently broken since queries would require special type casting.
+  # see https://github.com/porsager/postgres/pull/392
+  # arrayOfBool: [Boolean!]!
   bigInt: BigInt!
   optBigInt: BigInt
   arrayOfBigInts: [BigInt!]!
   bigDecimal: BigDecimal!
   optBigDecimal: BigDecimal
   arrayOfBigDecimals: [BigDecimal!]!
+  # NOTE: Timestamp serialization is currently just a type cast and so testing is non deterministic
   # timestamp: Timestamp!
   # optTimestamp: Timestamp
+  # NOTE: array of timestamps has the same problem as array of booleans described above
   # arrayOfTimestamps: [Timestamp!]!
 }

--- a/scenarios/test_codegen/schema.graphql
+++ b/scenarios/test_codegen/schema.graphql
@@ -73,7 +73,33 @@ type C {
   stringThatIsMirroredToA: String!
   d: [D!]! @derivedFrom(field: "c")
 }
+
 type D {
   id: ID!
   c: ID! @index
+}
+
+type EntityWithAllTypes {
+  id: ID!
+  string: String!
+  optString: String
+  arrayOfStrings: [String!]!
+  int_: Int!
+  optInt: Int
+  arrayOfInts: [Int!]!
+  float_: Float!
+  optFloat: Float
+  arrayOfFloats: [Float!]!
+  bool: Boolean!
+  optBool: Boolean
+  arrayOfBool: [Boolean!]!
+  bigInt: BigInt!
+  optBigInt: BigInt
+  arrayOfBigInts: [BigInt!]!
+  bigDecimal: BigDecimal!
+  optBigDecimal: BigDecimal
+  arrayOfBigDecimals: [BigDecimal!]!
+  # timestamp: Timestamp!
+  # optTimestamp: Timestamp
+  # arrayOfTimestamps: [Timestamp!]!
 }

--- a/scenarios/test_codegen/test/SerDe_Test.res
+++ b/scenarios/test_codegen/test/SerDe_Test.res
@@ -1,0 +1,67 @@
+open RescriptMocha
+
+@send external padStart: (string, ~padCount: int, ~padChar: string) => string = "padStart"
+
+let mockDate = (~year=2024, ~month=1, ~day=1) => {
+  let padInt = i => i->Belt.Int.toString->padStart(~padCount=2, ~padChar="0")
+  Js.Date.fromString(`${year->padInt}-${month->padInt}-${day->padInt}T00:00:00Z`)
+}
+
+describe("SerDe Test", () => {
+  Async.before(async () => {
+    await DbHelpers.runUpDownMigration()
+  })
+
+  Async.it("All type entity", async () => {
+    let entity: Entities.EntityWithAllTypes.t = {
+      id: "1",
+      string: "string",
+      optString: Some("optString"),
+      arrayOfStrings: ["arrayOfStrings1", "arrayOfStrings2"],
+      int_: 1,
+      optInt: Some(2),
+      arrayOfInts: [3, 4],
+      float_: 1.1,
+      optFloat: Some(2.2),
+      arrayOfFloats: [3.3, 4.4],
+      bool: true,
+      optBool: Some(false),
+      //TODO: get array of bools working
+      // arrayOfBool: [true, false],
+      arrayOfBool: [],
+      bigInt: BigInt.fromInt(1),
+      optBigInt: Some(BigInt.fromInt(2)),
+      arrayOfBigInts: [BigInt.fromInt(3), BigInt.fromInt(4)],
+      bigDecimal: BigDecimal.fromStringUnsafe("1.1"),
+      optBigDecimal: Some(BigDecimal.fromStringUnsafe("2.2")),
+      arrayOfBigDecimals: [BigDecimal.fromStringUnsafe("3.3"), BigDecimal.fromStringUnsafe("4.4")],
+      //TODO: get timestamp working
+      // timestamp: mockDate(~day=1),
+      // optTimestamp: Some(mockDate(~day=2)),
+      // arrayOfTimestamps: [Js.Date.fromFloat(3.3), Js.Date.fromFloat(4.4)],
+      // arrayOfTimestamps: [],
+    }
+
+    let set = DbFunctionsEntities.batchSet(~entityMod=module(Entities.EntityWithAllTypes))
+
+    //set the entity
+    await DbFunctions.sql->set([entity])
+
+    //The copy function will do it's custom postgres serialization of the entity
+    await DbFunctions.sql->DbFunctions.EntityHistory.copyAllEntitiesToEntityHistory
+
+    let res = await DbFunctions.sql->Postgres.unsafe(`SELECT * FROM public.entity_history;`)
+
+    switch res {
+    | [row] =>
+      let json = row["params"]
+      let parsed = json->S.parseOrRaiseWith(Entities.EntityWithAllTypes.schema)
+      Assert.deepEqual(
+        parsed,
+        entity,
+        ~message="Postgres json serialization should be compatable with our schema",
+      )
+    | _ => Assert.fail("Should have returned a row")
+    }
+  })
+})

--- a/scenarios/test_codegen/test/SerDe_Test.res
+++ b/scenarios/test_codegen/test/SerDe_Test.res
@@ -28,7 +28,6 @@ describe("SerDe Test", () => {
       optBool: Some(false),
       //TODO: get array of bools working
       // arrayOfBool: [true, false],
-      arrayOfBool: [],
       bigInt: BigInt.fromInt(1),
       optBigInt: Some(BigInt.fromInt(2)),
       arrayOfBigInts: [BigInt.fromInt(3), BigInt.fromInt(4)],

--- a/scenarios/test_codegen/test/raw-events-table-migration-test.ts
+++ b/scenarios/test_codegen/test/raw-events-table-migration-test.ts
@@ -29,10 +29,10 @@ describe("Raw Events Table Migrations", () => {
       { column_name: "block_number", data_type: "integer" },
       { column_name: "log_index", data_type: "integer" },
       { column_name: "block_timestamp", data_type: "integer" },
-      { column_name: "params", data_type: "json" },
+      { column_name: "params", data_type: "jsonb" },
       { column_name: "block_hash", data_type: "text" },
-      { column_name: "block_fields", data_type: "json" },
-      { column_name: "transaction_fields", data_type: "json" },
+      { column_name: "block_fields", data_type: "jsonb" },
+      { column_name: "transaction_fields", data_type: "jsonb" },
       { column_name: "src_address", data_type: "text" },
     ];
 


### PR DESCRIPTION
This adds a method to make a transactional copy of all entity tables into the entity history table.

The goal will be call this function before processing in the confirmed block threshold and then omit writes to this table during historical sync.