### PR TITLE
Support for Fuel Transfer Out and Call (wildcard-only) events

### DIFF
--- a/codegenerator/cli/npm/envio/fuel.schema.json
+++ b/codegenerator/cli/npm/envio/fuel.schema.json
@@ -98,6 +98,17 @@
     "EventConfig": {
       "type": "object",
       "properties": {
+        "type": {
+          "description": "Explicitly set the event type you want to index. It's derived from the event name and fallbacks to LogData.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EventType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "name": {
           "description": "Name of the event in the HyperIndex generated code",
           "type": "string"
@@ -108,39 +119,21 @@
             "string",
             "null"
           ]
-        },
-        "mint": {
-          "description": "Index Mint receipts. The option can be omitted when the event name is Mint.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "burn": {
-          "description": "Index Burn receipts. The option can be omitted when the event name is Burn.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "call": {
-          "description": "Index Call receipts. The option can be omitted when the event name is Call.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "transferOut": {
-          "description": "Index TransferOut receipts. The option can be omitted when the event name is TransferOut.",
-          "type": [
-            "boolean",
-            "null"
-          ]
         }
       },
       "additionalProperties": false,
       "required": [
         "name"
+      ]
+    },
+    "EventType": {
+      "type": "string",
+      "enum": [
+        "LOG_DATA",
+        "MINT",
+        "BURN",
+        "TRANSFER_OUT",
+        "CALL"
       ]
     },
     "Network": {

--- a/codegenerator/cli/npm/envio/fuel.schema.json
+++ b/codegenerator/cli/npm/envio/fuel.schema.json
@@ -122,6 +122,13 @@
             "boolean",
             "null"
           ]
+        },
+        "transferOut": {
+          "description": "Index TransferOut receipts. The option can be omitted when the event name is TransferOut.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false,

--- a/codegenerator/cli/npm/envio/fuel.schema.json
+++ b/codegenerator/cli/npm/envio/fuel.schema.json
@@ -123,6 +123,13 @@
             "null"
           ]
         },
+        "call": {
+          "description": "Index Call receipts. The option can be omitted when the event name is Call.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "transferOut": {
           "description": "Index TransferOut receipts. The option can be omitted when the event name is TransferOut.",
           "type": [

--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -278,6 +278,7 @@ pub mod fuel {
                                         mint: None,
                                         burn: None,
                                         transfer_out: None,
+                                        call: None,
                                     })
                                     .collect(),
                             }),

--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -277,6 +277,7 @@ pub mod fuel {
                                         log_id: selected_log.id.clone().into(),
                                         mint: None,
                                         burn: None,
+                                        transfer_out: None,
                                     })
                                     .collect(),
                             }),

--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -275,10 +275,7 @@ pub mod fuel {
                                     .map(|selected_log| EventConfig {
                                         name: selected_log.event_name.clone(),
                                         log_id: selected_log.id.clone().into(),
-                                        mint: None,
-                                        burn: None,
-                                        transfer_out: None,
-                                        call: None,
+                                        type_: None,
                                     })
                                     .collect(),
                             }),

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -545,6 +545,11 @@ pub mod fuel {
             description = "Index Burn receipts. The option can be omitted when the event name is Burn."
         )]
         pub burn: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[schemars(
+            description = "Index TransferOut receipts. The option can be omitted when the event name is TransferOut."
+        )]
+        pub transfer_out: Option<bool>,
     }
 }
 
@@ -764,18 +769,21 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
                                 log_id: None.into(),
                                 mint: None,
                                 burn: None,
+                                transfer_out: None,
                             },
                             fuel::EventConfig {
                                 name: "MarketCreateEvent".to_string(),
                                 log_id: None.into(),
                                 mint: None,
                                 burn: None,
+                                transfer_out: None,
                             },
                             fuel::EventConfig {
                                 name: "TradeEvent".to_string(),
                                 log_id: None.into(),
                                 mint: None,
                                 burn: None,
+                                transfer_out: None,
                             },
                         ],
                     }),

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -547,6 +547,11 @@ pub mod fuel {
         pub burn: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
+            description = "Index Call receipts. The option can be omitted when the event name is Call."
+        )]
+        pub call: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[schemars(
             description = "Index TransferOut receipts. The option can be omitted when the event name is TransferOut."
         )]
         pub transfer_out: Option<bool>,
@@ -770,6 +775,7 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
                                 mint: None,
                                 burn: None,
                                 transfer_out: None,
+                                call: None,
                             },
                             fuel::EventConfig {
                                 name: "MarketCreateEvent".to_string(),
@@ -777,6 +783,7 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
                                 mint: None,
                                 burn: None,
                                 transfer_out: None,
+                                call: None,
                             },
                             fuel::EventConfig {
                                 name: "TradeEvent".to_string(),
@@ -784,6 +791,7 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
                                 mint: None,
                                 burn: None,
                                 transfer_out: None,
+                                call: None,
                             },
                         ],
                     }),

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -424,6 +424,7 @@ pub mod fuel {
     use super::{GlobalContract, NetworkContract, NetworkId};
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
+    use strum::Display;
 
     #[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
     #[schemars(
@@ -522,11 +523,27 @@ pub mod fuel {
         pub events: Vec<EventConfig>,
     }
 
+    #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, JsonSchema, Display)]
+    #[serde(rename_all = "SCREAMING_SNAKE_CASE", deny_unknown_fields)]
+    pub enum EventType {
+        LogData,
+        Mint,
+        Burn,
+        TransferOut,
+        Call,
+    }
+
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct EventConfig {
         #[schemars(description = "Name of the event in the HyperIndex generated code")]
         pub name: String,
+        #[serde(rename = "type")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[schemars(
+            description = "Explicitly set the event type you want to index. It's derived from the event name and fallbacks to LogData."
+        )]
+        pub type_: Option<EventType>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
             description = "An identifier of a logged type from ABI. Used for indexing LogData \
@@ -534,27 +551,6 @@ pub mod fuel {
                            logged struct/enum name."
         )]
         pub log_id: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[schemars(
-            description = "Index Mint receipts. The option can be omitted when the event name is \
-                           Mint."
-        )]
-        pub mint: Option<bool>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[schemars(
-            description = "Index Burn receipts. The option can be omitted when the event name is Burn."
-        )]
-        pub burn: Option<bool>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[schemars(
-            description = "Index Call receipts. The option can be omitted when the event name is Call."
-        )]
-        pub call: Option<bool>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[schemars(
-            description = "Index TransferOut receipts. The option can be omitted when the event name is TransferOut."
-        )]
-        pub transfer_out: Option<bool>,
     }
 }
 
@@ -772,26 +768,17 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
                             fuel::EventConfig {
                                 name: "OrderChangeEvent".to_string(),
                                 log_id: None.into(),
-                                mint: None,
-                                burn: None,
-                                transfer_out: None,
-                                call: None,
+                                type_: None,
                             },
                             fuel::EventConfig {
                                 name: "MarketCreateEvent".to_string(),
                                 log_id: None.into(),
-                                mint: None,
-                                burn: None,
-                                transfer_out: None,
-                                call: None,
+                                type_: None,
                             },
                             fuel::EventConfig {
                                 name: "TradeEvent".to_string(),
                                 log_id: None.into(),
-                                mint: None,
-                                burn: None,
-                                transfer_out: None,
-                                call: None,
+                                type_: None,
                             },
                         ],
                     }),

--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -999,25 +999,26 @@ impl Event {
                     selectors[1]
                 ));
             }
+            let should_derive_from_name = selectors.len() == 0;
             let event = match event_config {
                 FuelEventConfig {
                     mint: Some(true), ..
                 } => mint_event,
                 FuelEventConfig {
                     mint: None, name, ..
-                } if selectors.len() == 0 && name == "Mint" => mint_event,
+                } if should_derive_from_name && name == "Mint" => mint_event,
                 FuelEventConfig {
                     burn: Some(true), ..
                 } => burn_event,
                 FuelEventConfig {
                     burn: None, name, ..
-                } if selectors.len() == 0 && name == "Burn" => burn_event,
+                } if should_derive_from_name && name == "Burn" => burn_event,
                 FuelEventConfig {
                     call: Some(true), ..
                 } => call_event,
                 FuelEventConfig {
                     call: None, name, ..
-                } if selectors.len() == 0 && name == "Call" => call_event,
+                } if should_derive_from_name && name == "Call" => call_event,
                 FuelEventConfig {
                     transfer_out: Some(true),
                     ..
@@ -1026,7 +1027,7 @@ impl Event {
                     transfer_out: None,
                     name,
                     ..
-                } if selectors.len() == 0 && name == "TransferOut" => transfer_out_event,
+                } if should_derive_from_name && name == "TransferOut" => transfer_out_event,
                 FuelEventConfig {
                     mint: None | Some(false),
                     burn: None | Some(false),

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -7,8 +7,8 @@ use crate::{
         event_parsing::{abi_to_rescript_type, EthereumEventParam},
         postgres_types,
         system_config::{
-            self, Abi, Ecosystem, EventPayload, HyperfuelConfig, HypersyncConfig, RpcConfig,
-            SelectedField, SystemConfig,
+            self, Abi, Ecosystem, EventKind, FuelEventKind, HyperfuelConfig, HypersyncConfig,
+            RpcConfig, SelectedField, SystemConfig,
         },
     },
     persisted_state::{PersistedState, PersistedStateJsonString},
@@ -328,14 +328,6 @@ impl EntityRecordTypeTemplate {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum FuelEventKind {
-    LogData,
-    Mint,
-    Burn,
-    TransferOut,
-}
-
-#[derive(Debug, PartialEq, Clone)]
 pub struct EventMod {
     pub sighash: String,
     pub topic_count: usize,
@@ -359,12 +351,13 @@ impl EventMod {
         let event_filter_type = &self.event_filter_type;
         let get_topic_selection_code = &self.get_topic_selection_code;
 
-        let fuel_event_kind_code = match &self.fuel_event_kind {
+        let fuel_event_kind_code = match self.fuel_event_kind {
             None => None,
             Some(FuelEventKind::Mint) => Some("Mint".to_string()),
             Some(FuelEventKind::Burn) => Some("Burn".to_string()),
+            Some(FuelEventKind::Call) => Some("Call".to_string()),
             Some(FuelEventKind::TransferOut) => Some("TransferOut".to_string()),
-            Some(FuelEventKind::LogData) => Some(format!(
+            Some(FuelEventKind::LogData(_)) => Some(format!(
                 r#"LogData({{
   logId: sighash,
   decode: Fuel.Receipt.getLogDataDecoder(~abi, ~logId=sighash),
@@ -376,7 +369,7 @@ impl EventMod {
             None => "".to_string(),
             Some(fuel_event_kind_code) => format!(
                 r#"
-let config: fuelEventConfig = {{
+let register = (): fuelEventConfig => {{
   name,
   kind: {fuel_event_kind_code},
   isWildcard: (handlerRegister->HandlerTypes.Register.getEventOptions).isWildcard,
@@ -574,8 +567,8 @@ impl EventTemplate {
 
     pub fn from_config_event(config_event: &system_config::Event) -> Result<Self> {
         let event_name = config_event.name.capitalize();
-        match &config_event.payload {
-            EventPayload::Params(params) => {
+        match &config_event.kind {
+            EventKind::Params(params) => {
                 let template_params = params
                     .iter()
                     .map(|input| {
@@ -630,41 +623,41 @@ impl EventTemplate {
                     params: template_params,
                 })
             }
-            EventPayload::FuelLogData(type_indent) => {
-                let event_mod = EventMod {
-                    sighash: config_event.sighash.to_string(),
-                    topic_count: 0, //Default to 0 for fuel,
-                    event_name: event_name.clone(),
-                    data_type: type_indent.to_string(),
-                    params_raw_event_schema: format!(
-                        "{}->Utils.Schema.coerceToJsonPgType",
-                        type_indent.to_rescript_schema()
-                    ),
-                    convert_hyper_sync_event_args_code: Self::CONVERT_HYPER_SYNC_EVENT_ARGS_NOOP
-                        .to_string(),
-                    event_filter_type: Self::EVENT_FILTER_TYPE_STUB.to_string(),
-                    get_topic_selection_code: Self::GET_TOPIC_SELECTION_CODE_STUB.to_string(),
-                    fuel_event_kind: Some(FuelEventKind::LogData),
-                };
+            EventKind::Fuel(fuel_event_kind) => {
+                let fuel_event_kind = fuel_event_kind.clone();
+                match &fuel_event_kind {
+                    FuelEventKind::LogData(type_indent) => {
+                        let event_mod = EventMod {
+                            sighash: config_event.sighash.to_string(),
+                            topic_count: 0, //Default to 0 for fuel,
+                            event_name: event_name.clone(),
+                            data_type: type_indent.to_string(),
+                            params_raw_event_schema: format!(
+                                "{}->Utils.Schema.coerceToJsonPgType",
+                                type_indent.to_rescript_schema()
+                            ),
+                            convert_hyper_sync_event_args_code:
+                                Self::CONVERT_HYPER_SYNC_EVENT_ARGS_NOOP.to_string(),
+                            event_filter_type: Self::EVENT_FILTER_TYPE_STUB.to_string(),
+                            get_topic_selection_code: Self::GET_TOPIC_SELECTION_CODE_STUB
+                                .to_string(),
+                            fuel_event_kind: Some(fuel_event_kind),
+                        };
 
-                Ok(EventTemplate {
-                    name: event_name,
-                    module_code: event_mod.to_string(),
-                    params: vec![],
-                })
+                        Ok(EventTemplate {
+                            name: event_name,
+                            module_code: event_mod.to_string(),
+                            params: vec![],
+                        })
+                    }
+                    FuelEventKind::Mint | FuelEventKind::Burn => {
+                        Ok(Self::from_fuel_supply_event(config_event, fuel_event_kind))
+                    }
+                    FuelEventKind::Call | FuelEventKind::TransferOut => Ok(
+                        Self::from_fuel_transfer_event(config_event, fuel_event_kind),
+                    ),
+                }
             }
-            EventPayload::FuelMint => Ok(Self::from_fuel_supply_event(
-                config_event,
-                FuelEventKind::Mint,
-            )),
-            EventPayload::FuelBurn => Ok(Self::from_fuel_supply_event(
-                config_event,
-                FuelEventKind::Burn,
-            )),
-            EventPayload::FuelTransferOut => Ok(Self::from_fuel_transfer_event(
-                config_event,
-                FuelEventKind::TransferOut,
-            )),
         }
     }
 }
@@ -1350,7 +1343,7 @@ let getTopicSelection = (eventFilters) => eventFilters->SingleOrMultiple.normali
     fn event_template_with_empty_params() {
         let event_template = EventTemplate::from_config_event(&system_config::Event {
             name: "NewGravatar".to_string(),
-            payload: system_config::EventPayload::Params(vec![]),
+            kind: system_config::EventKind::Params(vec![]),
             sighash: "0x50f7d27e90d1a5a38aeed4ceced2e8ec1ff185737aca96d15791b470d3f17363"
                 .to_string(),
         })

--- a/codegenerator/cli/src/hbs_templating/contract_import_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/contract_import_templates.rs
@@ -328,9 +328,10 @@ impl Event {
         let empty_params = vec![];
         let params = match &event.payload {
             EventPayload::Params(params) => params,
-            EventPayload::FuelLogData(_) | EventPayload::FuelMint | EventPayload::FuelBurn => {
-                &empty_params
-            }
+            EventPayload::FuelLogData(_)
+            | EventPayload::FuelMint
+            | EventPayload::FuelBurn
+            | EventPayload::FuelTransferOut => &empty_params,
         };
         let params = flatten_event_inputs(params.clone())
             .into_iter()

--- a/codegenerator/cli/src/hbs_templating/contract_import_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/contract_import_templates.rs
@@ -192,7 +192,7 @@ use crate::{
     cli_args::init_config::Language,
     config_parsing::{
         entity_parsing::{Entity, Field, FieldType, Schema},
-        system_config::{self, Ecosystem, EventPayload, SystemConfig},
+        system_config::{self, Ecosystem, EventKind, SystemConfig},
     },
     rescript_types::RescriptRecordField,
     template_dirs::TemplateDirs,
@@ -326,12 +326,9 @@ impl Event {
         language: &Language,
     ) -> Result<Self> {
         let empty_params = vec![];
-        let params = match &event.payload {
-            EventPayload::Params(params) => params,
-            EventPayload::FuelLogData(_)
-            | EventPayload::FuelMint
-            | EventPayload::FuelBurn
-            | EventPayload::FuelTransferOut => &empty_params,
+        let params = match &event.kind {
+            EventKind::Params(params) => params,
+            EventKind::Fuel(_) => &empty_params,
         };
         let params = flatten_event_inputs(params.clone())
             .into_iter()

--- a/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
@@ -143,7 +143,7 @@ let registerContractHandlers = (
                   name: "{{contract.name.capitalized}}",
                   events: [
                     {{#each contract.events as | event |}}
-                    Types.{{contract.name.capitalized}}.{{event.name}}.config,
+                    Types.{{contract.name.capitalized}}.{{event.name}}.register(),
                     {{/each}}
                   ]
                 },

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -538,6 +538,7 @@ type fuelEventKind =
   })
   | Mint
   | Burn
+  | TransferOut
 
 type fuelEventConfig = {
   name: string,
@@ -559,6 +560,18 @@ type fuelSupplyParams = {
 
 let fuelSupplyParamsSchema = S.object(s => {
   subId: s.field("subId", S.string),
+  amount: s.field("amount", BigInt.schema),
+})
+
+type fuelTransferParams = {
+  to: string,
+  assetId: string,
+  amount: bigint,
+}
+
+let fuelTransferParamsSchema = S.object(s => {
+  to: s.field("to", S.string),
+  assetId: s.field("assetId", S.string),
   amount: s.field("amount", BigInt.schema),
 })
 

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -539,6 +539,7 @@ type fuelEventKind =
   | Mint
   | Burn
   | TransferOut
+  | Call
 
 type fuelEventConfig = {
   name: string,
@@ -564,13 +565,13 @@ let fuelSupplyParamsSchema = S.object(s => {
 })
 
 type fuelTransferParams = {
-  to: string,
+  to: Address.t,
   assetId: string,
   amount: bigint,
 }
 
 let fuelTransferParamsSchema = S.object(s => {
-  to: s.field("to", S.string),
+  to: s.field("to", Address.schema),
   assetId: s.field("assetId", S.string),
   amount: s.field("amount", BigInt.schema),
 })

--- a/codegenerator/cli/templates/static/codegen/src/bindings/Fuel.res
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/Fuel.res
@@ -11,7 +11,7 @@
 // 10 = MessageOut,
 // 11 = Mint,
 // 12 = Burn,
-type receiptType = | @as(6) LogData | @as(8) TransferOut | @as(11) Mint | @as(12) Burn
+type receiptType = | @as(0) Call | @as(6) LogData | @as(8) TransferOut | @as(11) Mint | @as(12) Burn
 
 @module("./vendored-fuel-abi-coder.js")
 external transpileAbi: Js.Json.t => Ethers.abi = "transpileAbi"
@@ -23,6 +23,7 @@ external getLogDecoder: (~abi: Ethers.abi, ~logId: string) => (. string) => unkn
 module Receipt = {
   @tag("receiptType")
   type t =
+    | @as(0) Call({assetId: string, amount: bigint})
     | @as(6) LogData({data: string, rb: bigint})
     | @as(8) TransferOut({amount: bigint, assetId: string, toAddress: string})
     | @as(11) Mint({val: bigint, subId: string})

--- a/codegenerator/cli/templates/static/codegen/src/bindings/Fuel.res
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/Fuel.res
@@ -11,7 +11,7 @@
 // 10 = MessageOut,
 // 11 = Mint,
 // 12 = Burn,
-type receiptType = | @as(6) LogData | @as(11) Mint | @as(12) Burn
+type receiptType = | @as(6) LogData | @as(8) TransferOut | @as(11) Mint | @as(12) Burn
 
 @module("./vendored-fuel-abi-coder.js")
 external transpileAbi: Js.Json.t => Ethers.abi = "transpileAbi"
@@ -24,6 +24,7 @@ module Receipt = {
   @tag("receiptType")
   type t =
     | @as(6) LogData({data: string, rb: bigint})
+    | @as(8) TransferOut({amount: bigint, assetId: string, toAddress: string})
     | @as(11) Mint({val: bigint, subId: string})
     | @as(12) Burn({val: bigint, subId: string})
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -67,7 +67,7 @@ let makeWorkerConfigOrThrow = (~contracts: array<Types.fuelContractConfig>, ~cha
       | {kind: TransferOut, isWildcard: true} => addNonLogDataWildcardReceiptTypes(TransferOut)
       | {kind: TransferOut} => addNonLogDataReceiptType(contract.name, TransferOut)
       | {kind: Call, isWildcard: true} => addNonLogDataWildcardReceiptTypes(Call)
-      | {kind: Call} => addNonLogDataReceiptType(contract.name, Call)
+      | {kind: Call} => Js.Exn.raiseError("Call receipt indexing currently supported only in wildcard mode")
       | {kind: LogData({logId}), isWildcard} => {
           let rb = logId->BigInt.fromStringUnsafe
           if isWildcard {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.res
@@ -233,8 +233,10 @@ module BlockData = {
     let query: HyperFuelClient.QueryTypes.query = {
       fromBlock: blockNumber,
       toBlockExclusive: blockNumber + 1,
-      // TODO: Theoretically it should work without the outputs filter, but it doesn't for some reason
+      // FIXME: Theoretically it should work without the outputs filter, but it doesn't for some reason
       outputs: [%raw(`{}`)],
+      // FIXME: Had to add inputs {} as well, since it failed on block 1211599 during wildcard Call indexing
+      inputs: [%raw(`{}`)],
       fieldSelection: {
         block: [Height, Id, Time],
       },

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.res
@@ -25,9 +25,9 @@ type hyperSyncPage<'item> = {
 }
 
 type block = {
-  hash: string,
-  timestamp: int,
-  blockNumber: int,
+  id: string,
+  time: int,
+  height: int,
 }
 
 type item = {
@@ -68,7 +68,6 @@ let queryErrorToMsq = (e: queryError): string => {
     switch e {
     | FailedToFetch(e) =>
       let msg = e->getMsgFromExn
-
       `Failed during fetch query: ${msg}`
     | FailedToParseJson(e) =>
       let msg = e->getMsgFromExn
@@ -97,14 +96,16 @@ module LogsQuery = {
           TxId,
           BlockHeight,
           RootContractId,
-          // ContractId,
           Data,
           ReceiptIndex,
           ReceiptType,
           Rb,
-          // TODO: Include them only when there's a mint/burn receipt selection 
+          // TODO: Include them only when there's a mint/burn/transferOut receipt selection
           SubId,
-          Val
+          Val,
+          Amount,
+          ToAddress,
+          AssetId,
         ],
         block: [Id, Height, Time],
       },
@@ -151,9 +152,9 @@ module LogsQuery = {
           ->Array.push({
             transactionId: receipt.txId,
             block: {
-              blockNumber: block.height,
-              hash: block.id,
-              timestamp: block.time,
+              height: block.height,
+              id: block.id,
+              time: block.time,
             },
             contractId,
             receipt: receipt->(Utils.magic: HyperFuelClient.FuelTypes.receipt => Fuel.Receipt.t),

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.resi
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.resi
@@ -5,9 +5,9 @@ type hyperSyncPage<'item> = {
 }
 
 type block = {
-  hash: string,
-  timestamp: int,
-  blockNumber: int,
+  id: string,
+  time: int,
+  height: int,
 }
 
 type item = {

--- a/scenarios/fuel_test/config.yaml
+++ b/scenarios/fuel_test/config.yaml
@@ -59,3 +59,4 @@ networks:
             logId: "14832741149864513620"
           - name: Mint
           - name: Burn
+          - name: TransferOut

--- a/scenarios/fuel_test/config.yaml
+++ b/scenarios/fuel_test/config.yaml
@@ -59,5 +59,6 @@ networks:
             logId: "14832741149864513620"
           - name: Mint
           - name: Burn
-          - name: TransferOut
+          - name: Transfer
+            type: TRANSFER_OUT
           - name: Call

--- a/scenarios/fuel_test/config.yaml
+++ b/scenarios/fuel_test/config.yaml
@@ -60,3 +60,4 @@ networks:
           - name: Mint
           - name: Burn
           - name: TransferOut
+          - name: Call

--- a/scenarios/fuel_test/src/AllEventsHandlers.ts
+++ b/scenarios/fuel_test/src/AllEventsHandlers.ts
@@ -228,3 +228,15 @@ AllEvents.Burn.handler(async ({ event }) => {
   burnSchema.assert(event.params)!;
   expectType<AssertSchemaType<typeof event.params, typeof burnSchema>>(true);
 });
+
+const transferOutSchema = S.object({
+  assetId: S.string,
+  to: S.string,
+  amount: SExtra.bigint,
+});
+AllEvents.TransferOut.handler(async ({ event }) => {
+  transferOutSchema.assert(event.params)!;
+  expectType<AssertSchemaType<typeof event.params, typeof transferOutSchema>>(
+    true
+  );
+});

--- a/scenarios/fuel_test/src/AllEventsHandlers.ts
+++ b/scenarios/fuel_test/src/AllEventsHandlers.ts
@@ -240,3 +240,13 @@ AllEvents.TransferOut.handler(async ({ event }) => {
     true
   );
 });
+
+const callSchema = S.object({
+  assetId: S.string,
+  to: S.string,
+  amount: SExtra.bigint,
+});
+AllEvents.Call.handler(async ({ event }) => {
+  callSchema.assert(event.params)!;
+  expectType<AssertSchemaType<typeof event.params, typeof callSchema>>(true);
+});

--- a/scenarios/fuel_test/src/AllEventsHandlers.ts
+++ b/scenarios/fuel_test/src/AllEventsHandlers.ts
@@ -246,7 +246,10 @@ const callSchema = S.object({
   to: S.string,
   amount: SExtra.bigint,
 });
-AllEvents.Call.handler(async ({ event }) => {
-  callSchema.assert(event.params)!;
-  expectType<AssertSchemaType<typeof event.params, typeof callSchema>>(true);
-});
+AllEvents.Call.handler(
+  async ({ event }) => {
+    callSchema.assert(event.params)!;
+    expectType<AssertSchemaType<typeof event.params, typeof callSchema>>(true);
+  },
+  { wildcard: true }
+);

--- a/scenarios/fuel_test/src/AllEventsHandlers.ts
+++ b/scenarios/fuel_test/src/AllEventsHandlers.ts
@@ -234,7 +234,7 @@ const transferOutSchema = S.object({
   to: S.string,
   amount: SExtra.bigint,
 });
-AllEvents.TransferOut.handler(async ({ event }) => {
+AllEvents.Transfer.handler(async ({ event }) => {
   transferOutSchema.assert(event.params)!;
   expectType<AssertSchemaType<typeof event.params, typeof transferOutSchema>>(
     true

--- a/scenarios/fuel_test/test/HyperFuelWorker_test.res
+++ b/scenarios/fuel_test/test/HyperFuelWorker_test.res
@@ -359,6 +359,13 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
               handlerRegister: %raw(`"Not relevat"`),
               paramsRawEventSchema: %raw(`"Not relevat"`),
             },
+            {
+              name: "Call",
+              kind: Call,
+              isWildcard: true,
+              handlerRegister: %raw(`"Not relevat"`),
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
           ],
         },
         {
@@ -414,13 +421,47 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
           txStatus: [1],
         },
         {
+          receiptType: [Call],
+          txStatus: [1],
+        },
+        {
           rb: [2n],
           receiptType: [LogData],
           txStatus: [1],
         },
+        
       ],
     )
   })
+
+
+  it("Fails with non-wildcard Call event", () => {
+    Assert.throws(
+      () => {
+        mock(
+          ~contracts=[
+            {
+              name: "TestContract",
+              events: [
+                {
+                  name: "Call",
+                  kind: Call,
+                  isWildcard: false,
+                  handlerRegister: %raw(`"Not relevat"`),
+                  paramsRawEventSchema: %raw(`"Not relevat"`),
+                },
+               
+              ],
+            },
+          ],
+        )
+      },
+      ~error={
+        "message": "Call receipt indexing currently supported only in wildcard mode",
+      },
+    )
+  })
+
 
   it("Fails when contract has multiple mint events", () => {
     Assert.throws(

--- a/scenarios/fuel_test/test/HyperFuelWorker_test.res
+++ b/scenarios/fuel_test/test/HyperFuelWorker_test.res
@@ -352,6 +352,13 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
               handlerRegister: %raw(`"Not relevat"`),
               paramsRawEventSchema: %raw(`"Not relevat"`),
             },
+            {
+              name: "TransferOut",
+              kind: TransferOut,
+              isWildcard: false,
+              handlerRegister: %raw(`"Not relevat"`),
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
           ],
         },
         {
@@ -385,7 +392,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ),
       [
         {
-          receiptType: [Mint, Burn],
+          receiptType: [Mint, Burn, TransferOut],
           rootContractId: [address1, address2],
           txStatus: [1],
         },


### PR DESCRIPTION
The PR adds support for indexing TRANSFER_OUT on Fuel. And partial support for CALL receipts - currently, they work only in wildcard mode. 