### PR TITLE
Implement start saving history the near the head

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
@@ -18,7 +18,9 @@ let getUserLogger = (logger): Logs.userLogger => {
     logger->Logging.uerrorWithExn(exn, message),
 }
 
-let makeEventIdentifier = (eventBatchQueueItem: Types.eventBatchQueueItem): Types.eventIdentifier => {
+let makeEventIdentifier = (
+  eventBatchQueueItem: Types.eventBatchQueueItem,
+): Types.eventIdentifier => {
   let {event, blockNumber, timestamp} = eventBatchQueueItem
   {
     chainId: event.chainId,
@@ -29,7 +31,10 @@ let makeEventIdentifier = (eventBatchQueueItem: Types.eventBatchQueueItem): Type
 }
 
 let getEventId = (eventBatchQueueItem: Types.eventBatchQueueItem) => {
-  EventUtils.packEventIndex(~blockNumber=eventBatchQueueItem.blockNumber, ~logIndex=eventBatchQueueItem.event.logIndex)
+  EventUtils.packEventIndex(
+    ~blockNumber=eventBatchQueueItem.blockNumber,
+    ~logIndex=eventBatchQueueItem.event.logIndex,
+  )
 }
 
 let make = (~eventBatchQueueItem: Types.eventBatchQueueItem, ~logger) => {
@@ -86,8 +91,21 @@ let makeDynamicContractRegisterFn = (~contextEnv: t, ~contractName, ~inMemorySto
   )
 }
 
-let makeWhereLoader = (loadLayer, ~entityMod, ~inMemoryStore, ~fieldName, ~fieldValueSchema, ~logger) => {
-  Entities.eq: loadLayer->LoadLayer.makeWhereEqLoader(~entityMod, ~fieldName, ~fieldValueSchema, ~inMemoryStore, ~logger)
+let makeWhereLoader = (
+  loadLayer,
+  ~entityMod,
+  ~inMemoryStore,
+  ~fieldName,
+  ~fieldValueSchema,
+  ~logger,
+) => {
+  Entities.eq: loadLayer->LoadLayer.makeWhereEqLoader(
+    ~entityMod,
+    ~fieldName,
+    ~fieldValueSchema,
+    ~inMemoryStore,
+    ~logger,
+  ),
 }
 
 let makeEntityHandlerContext = (
@@ -98,20 +116,22 @@ let makeEntityHandlerContext = (
   ~logger,
   ~getKey,
   ~loadLayer,
+  ~isInReorgThreshold,
 ): entityHandlerContext<entity> => {
   let inMemTable = inMemoryStore->InMemoryStore.getInMemTable(~entityMod)
-  let shouldRollbackOnReorg = RegisterHandlers.getConfig()->Config.shouldRollbackOnReorg
+  let shouldSaveHistory =
+    RegisterHandlers.getConfig()->Config.shouldSaveHistory(~isInReorgThreshold)
   {
     set: entity => {
       inMemTable->InMemoryTable.Entity.set(
         Set(entity)->Types.mkEntityUpdate(~eventIdentifier, ~entityId=getKey(entity)),
-        ~shouldRollbackOnReorg,
+        ~shouldSaveHistory,
       )
     },
     deleteUnsafe: entityId => {
       inMemTable->InMemoryTable.Entity.set(
         Delete->Types.mkEntityUpdate(~eventIdentifier, ~entityId),
-        ~shouldRollbackOnReorg,
+        ~shouldSaveHistory,
       )
     },
     get: loadLayer->LoadLayer.makeLoader(~entityMod, ~logger, ~inMemoryStore),
@@ -152,7 +172,12 @@ let getLoaderContext = (contextEnv: t, ~inMemoryStore: InMemoryStore.t, ~loadLay
   }
 }
 
-let getHandlerContext = (context, ~inMemoryStore: InMemoryStore.t, ~loadLayer) => {
+let getHandlerContext = (
+  context,
+  ~inMemoryStore: InMemoryStore.t,
+  ~loadLayer,
+  ~isInReorgThreshold,
+) => {
   let {eventBatchQueueItem, logger} = context
 
   let eventIdentifier = eventBatchQueueItem->makeEventIdentifier
@@ -166,6 +191,7 @@ let getHandlerContext = (context, ~inMemoryStore: InMemoryStore.t, ~loadLayer) =
       ~getKey=entity => entity.id,
       ~logger,
       ~loadLayer,
+      ~isInReorgThreshold,
     ),
     {{/each}}
   }
@@ -181,8 +207,14 @@ let getLoaderArgs = (contextEnv, ~inMemoryStore, ~loadLayer) => {
   context: contextEnv->getLoaderContext(~inMemoryStore, ~loadLayer),
 }
 
-let getHandlerArgs = (contextEnv, ~inMemoryStore, ~loaderReturn, ~loadLayer) => {
+let getHandlerArgs = (
+  contextEnv,
+  ~inMemoryStore,
+  ~loaderReturn,
+  ~loadLayer,
+  ~isInReorgThreshold,
+) => {
   Types.HandlerTypes.event: contextEnv.eventBatchQueueItem.event,
-  context: contextEnv->getHandlerContext(~inMemoryStore, ~loadLayer),
+  context: contextEnv->getHandlerContext(~inMemoryStore, ~loadLayer, ~isInReorgThreshold),
   loaderReturn,
 }

--- a/codegenerator/cli/templates/dynamic/codegen/src/IO.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/IO.res.hbs
@@ -136,9 +136,9 @@ let executeDbFunctionsEntity = (
   promises->Promise.all->Promise.thenResolve(_ => ())
 }
 
-let executeBatch = async (sql, ~inMemoryStore: InMemoryStore.t) => {
+let executeBatch = async (sql, ~inMemoryStore: InMemoryStore.t, ~isInReorgThreshold) => {
   let entityDbExecutionComposer =
-    RegisterHandlers.getConfig()->Config.shouldRollbackOnReorg
+    RegisterHandlers.getConfig()->Config.shouldSaveHistory(~isInReorgThreshold)
       ? executeSetEntityWithHistory
       : executeDbFunctionsEntity
 
@@ -223,7 +223,8 @@ module RollBack = {
 
     let inMemStore = InMemoryStore.makeWithRollBackEventIdentifier(Some(rollBackEventIdentifier))
 
-    let shouldRollbackOnReorg = RegisterHandlers.getConfig()->Config.shouldRollbackOnReorg
+    //Don't save the rollback diffs to history table
+    let shouldSaveHistory = false
 
     reorgData->Belt.Array.forEach(e => {
       switch e {
@@ -232,8 +233,8 @@ module RollBack = {
       {{#each entities as | entity |}}
       | {previousEntity: Some({entity: {{entity.name.capitalized}}(entity), eventIdentifier}), entityId} =>
         inMemStore.{{entity.name.uncapitalized}}->InMemoryTable.Entity.set(
-          Set(entity)->Types.mkEntityUpdate(~eventIdentifier, ~entityId, ~shouldSaveHistory=false),
-          ~shouldRollbackOnReorg,
+          Set(entity)->Types.mkEntityUpdate(~eventIdentifier, ~entityId, ~shouldSaveHistory),
+          ~shouldSaveHistory,
         )
       {{/each}}
       //Where previousEntity is None, 
@@ -241,8 +242,8 @@ module RollBack = {
       {{#each entities as | entity |}}
       | {previousEntity: None, entityType: {{entity.name.capitalized}}, entityId} =>
         inMemStore.{{entity.name.uncapitalized}}->InMemoryTable.Entity.set(
-          Delete->Types.mkEntityUpdate(~eventIdentifier=rollBackEventIdentifier, ~entityId, ~shouldSaveHistory=false),
-          ~shouldRollbackOnReorg,
+          Delete->Types.mkEntityUpdate(~eventIdentifier=rollBackEventIdentifier, ~entityId, ~shouldSaveHistory),
+          ~shouldSaveHistory,
         )
       {{/each}}
       }

--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
@@ -151,6 +151,7 @@ module EventFunctions = {
           ~logger,
           ~latestProcessedBlocks,
           ~config,
+          ~isInReorgThreshold=false,
         ) {
         | Ok(_) => ()
         | Error(e) => e->ErrorHandling.logAndRaise

--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers_MockDb.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers_MockDb.res.hbs
@@ -140,7 +140,7 @@ let makeStoreOperatorEntity = (
         ~entityId,
         ~eventIdentifier={chainId: -1, blockNumber: -1, blockTimestamp: 0, logIndex: -1},
       ),
-      ~shouldRollbackOnReorg=RegisterHandlers.getConfig()->Config.shouldRollbackOnReorg,
+      ~shouldSaveHistory=false,
     )
 
     updateEntityIndicesMockDb(~mockDbTable=table, ~entity, ~entityId)

--- a/codegenerator/cli/templates/static/codegen/src/Config.res
+++ b/codegenerator/cli/templates/static/codegen/src/Config.res
@@ -120,6 +120,13 @@ let shouldRollbackOnReorg = config =>
   | _ => false
   }
 
+let shouldSaveHistory = (config, ~isInReorgThreshold) =>
+  switch config.historyConfig {
+  | {rollbackFlag: RollbackOnReorg} if isInReorgThreshold => true
+  | {historyFlag: FullHistory} => true
+  | _ => false
+  }
+
 let shouldPruneHistory = config =>
   switch config.historyConfig {
   | {historyFlag: MinHistory} => true

--- a/codegenerator/cli/templates/static/codegen/src/InMemoryTable.res
+++ b/codegenerator/cli/templates/static/codegen/src/InMemoryTable.res
@@ -141,7 +141,7 @@ module Entity = {
   let set = (
     inMemTable: t<'entity>,
     entityUpdate: Types.entityUpdate<'entity>,
-    ~shouldRollbackOnReorg,
+    ~shouldSaveHistory,
   ) => {
     let {entityRow, entityIndices} = switch inMemTable.table->get(entityUpdate.entityId) {
     | Some({entityRow: InitialReadFromDb(entity_read), entityIndices}) =>
@@ -152,7 +152,7 @@ module Entity = {
       })
       {entityRow, entityIndices}
     | Some({entityRow: Updated(previous_values), entityIndices})
-      if !shouldRollbackOnReorg ||
+      if !shouldSaveHistory ||
       //Rollback initial state cases should not save history
       !previous_values.latest.shouldSaveHistory ||
       // This prevents two db actions in the same event on the same entity from being recorded to the history table.

--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
@@ -16,6 +16,18 @@ type chainId = int
 type eventId = string
 type blockNumberRow = {@as("block_number") blockNumber: int}
 
+module General = {
+  type existsRes = {exists: bool}
+
+  let hasRows = async (sql, ~table: Table.table) => {
+    let query = `SELECT EXISTS(SELECT 1 FROM public.${table.tableName});`
+    switch await sql->Postgres.unsafe(query) {
+    | [{exists}] => exists
+    | _ => Js.Exn.raiseError("Unexpected result from hasRows query: " ++ query)
+    }
+  }
+}
+
 module ChainMetadata = {
   type chainMetadata = {
     @as("chain_id") chainId: int,
@@ -370,4 +382,6 @@ module EntityHistory = {
       })
     })
   }
+
+  let hasRows = () => General.hasRows(sql, ~table=TablesStatic.EntityHistory.table)
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -284,8 +284,7 @@ let hasProcessedToEndblock = (self: t) => {
 }
 
 let hasNoMoreEventsToProcess = (self: t, ~hasArbQueueEvents) => {
-  !hasArbQueueEvents &&
-  self.fetchState->PartitionedFetchState.queueSize === 0
+  !hasArbQueueEvents && self.fetchState->PartitionedFetchState.queueSize === 0
 }
 
 /**

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -5,6 +5,7 @@ type t = {
   //due to contract registration. Ordered from latest to earliest
   arbitraryEventQueue: array<Types.eventBatchQueueItem>,
   isUnorderedMultichainMode: bool,
+  isInReorgThreshold: bool,
 }
 
 let getComparitorFromItem = (queueItem: Types.eventBatchQueueItem) => {
@@ -126,6 +127,7 @@ let makeFromConfig = (~config: Config.t, ~maxAddrInPartition=Env.maxAddrInPartit
     chainFetchers,
     arbitraryEventQueue: [],
     isUnorderedMultichainMode: config.isUnorderedMultichainMode,
+    isInReorgThreshold: false,
   }
 }
 
@@ -140,10 +142,15 @@ let makeFromDbState = async (~config: Config.t, ~maxAddrInPartition=Env.maxAddrI
 
   let chainFetchers = ChainMap.fromArrayUnsafe(chainFetchersArr)
 
+  let hasStartedSavingHistory = await DbFunctions.EntityHistory.hasRows()
+
   {
     isUnorderedMultichainMode: config.isUnorderedMultichainMode,
     arbitraryEventQueue: [],
     chainFetchers,
+    //If we have started saving history, continue to save history
+    //as regardless of whether we are still in a reorg threshold
+    isInReorgThreshold: hasStartedSavingHistory,
   }
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -61,10 +61,20 @@ let chainFetcherPeekComparitorEarliestEventPrioritizeEvents = (
 
 type noItemsInArray = NoItemsInArray
 
+type isInReorgThresholdRes<'payload> = {
+  isInReorgThreshold: bool,
+  val: 'payload,
+}
+
+type fetchStateWithData = {
+  partitionedFetchState: PartitionedFetchState.t,
+  heighestBlockBelowThreshold: int,
+}
+
 let determineNextEvent = (
-  fetchStatesMap: ChainMap.t<PartitionedFetchState.t>,
+  fetchStatesMap: ChainMap.t<fetchStateWithData>,
   ~isUnorderedMultichainMode: bool,
-): result<multiChainEventComparitor, noItemsInArray> => {
+): result<isInReorgThresholdRes<multiChainEventComparitor>, noItemsInArray> => {
   let comparitorFunction = if isUnorderedMultichainMode {
     chainFetcherPeekComparitorEarliestEventPrioritizeEvents
   } else {
@@ -74,27 +84,38 @@ let determineNextEvent = (
   let nextItem =
     fetchStatesMap
     ->ChainMap.entries
-    ->Array.reduce(None, (accum, (chain, partitionedFetchState)) => {
+    ->Array.reduce({isInReorgThreshold: false, val: None}, (
+      accum,
+      (chain, {partitionedFetchState, heighestBlockBelowThreshold}),
+    ) => {
       // If the fetch state has reached the end block we don't need to consider it
       switch partitionedFetchState->PartitionedFetchState.getEarliestEvent {
       | Some(earliestEvent) =>
+        let {val, isInReorgThreshold} = accum
+        let mk = cmp => {
+          {
+            val: Some(cmp),
+            isInReorgThreshold: isInReorgThreshold ||
+            cmp.earliestEvent->FetchState.queueItemIsInReorgThreshold(~heighestBlockBelowThreshold),
+          }
+        }
         let cmpA: multiChainEventComparitor = {chain, earliestEvent}
-        switch accum {
-        | None => cmpA
+        switch val {
+        | None => mk(cmpA)
         | Some(cmpB) =>
           if comparitorFunction(cmpB, cmpA) {
-            cmpB
+            mk(cmpB)
           } else {
-            cmpA
+            mk(cmpA)
           }
-        }->Some
+        }
       | None => accum
       }
     })
 
   switch nextItem {
-  | None => Error(NoItemsInArray)
-  | Some(item) => Ok(item)
+  | {val: None} => Error(NoItemsInArray)
+  | {val: Some(item), isInReorgThreshold} => Ok({val: item, isInReorgThreshold})
   }
 }
 
@@ -186,49 +207,93 @@ let setChainFetcher = (self: t, chainFetcher: ChainFetcher.t) => {
   }
 }
 
-let getFirstArbitraryEventsItemForChain = (queue: array<Types.eventBatchQueueItem>, ~chain) =>
+let getFirstArbitraryEventsItemForChain = (
+  queue: array<Types.eventBatchQueueItem>,
+  ~chain,
+  ~fetchStatesMap: ChainMap.t<fetchStateWithData>,
+): option<isInReorgThresholdRes<FetchState.itemWithPopFn>> =>
   queue
   ->Utils.Array.findReverseWithIndex((item: Types.eventBatchQueueItem) => {
     item.chain == chain
   })
   ->Option.map(((item, index)) => {
-    FetchState.item,
-    popItemOffQueue: () => queue->Utils.Array.spliceInPlace(~pos=index, ~remove=1)->ignore,
+    let {heighestBlockBelowThreshold} = fetchStatesMap->ChainMap.get(item.chain)
+    let isInReorgThreshold = item.blockNumber > heighestBlockBelowThreshold
+    {
+      val: {
+        FetchState.item,
+        popItemOffQueue: () => queue->Utils.Array.spliceInPlace(~pos=index, ~remove=1)->ignore,
+      },
+      isInReorgThreshold,
+    }
   })
 
-let getFirstArbitraryEventsItem = (queue: array<Types.eventBatchQueueItem>) =>
+let getFirstArbitraryEventsItem = (
+  queue: array<Types.eventBatchQueueItem>,
+  ~fetchStatesMap: ChainMap.t<fetchStateWithData>,
+): option<isInReorgThresholdRes<FetchState.itemWithPopFn>> =>
   queue
   ->Utils.Array.last
-  ->Option.map(item => {FetchState.item, popItemOffQueue: () => queue->Js.Array2.pop->ignore})
+  ->Option.map(item => {
+    let {heighestBlockBelowThreshold} = fetchStatesMap->ChainMap.get(item.chain)
+    let isInReorgThreshold = item.blockNumber > heighestBlockBelowThreshold
+    {
+      val: {FetchState.item, popItemOffQueue: () => queue->Js.Array2.pop->ignore},
+      isInReorgThreshold,
+    }
+  })
 
 let popBatchItem = (
-  ~fetchStatesMap: ChainMap.t<PartitionedFetchState.t>,
+  ~fetchStatesMap: ChainMap.t<fetchStateWithData>,
   ~arbitraryEventQueue: array<Types.eventBatchQueueItem>,
   ~isUnorderedMultichainMode,
-): option<FetchState.itemWithPopFn> => {
+): isInReorgThresholdRes<option<FetchState.itemWithPopFn>> => {
   //Compare the peeked items and determine the next item
   switch fetchStatesMap->determineNextEvent(~isUnorderedMultichainMode) {
-  | Ok({chain, earliestEvent}) =>
+  | Ok({val: {chain, earliestEvent}, isInReorgThreshold}) =>
     let maybeArbItem = if isUnorderedMultichainMode {
-      arbitraryEventQueue->getFirstArbitraryEventsItemForChain(~chain)
+      arbitraryEventQueue->getFirstArbitraryEventsItemForChain(~chain, ~fetchStatesMap)
     } else {
-      arbitraryEventQueue->getFirstArbitraryEventsItem
+      arbitraryEventQueue->getFirstArbitraryEventsItem(~fetchStatesMap)
     }
     switch maybeArbItem {
     //If there is item on the arbitray events queue, and it is earlier than
     //than the earlist event, take the item off from there
-    | Some(itemWithPopFn)
+    | Some({val: itemWithPopFn, isInReorgThreshold})
       if Item(itemWithPopFn)->getQueueItemComparitor(~chain=itemWithPopFn.item.chain) <
-        earliestEvent->getQueueItemComparitor(~chain) =>
-      Some(itemWithPopFn)
+        earliestEvent->getQueueItemComparitor(~chain) => {
+        isInReorgThreshold,
+        val: Some(itemWithPopFn),
+      }
     | _ =>
       switch earliestEvent {
-      | NoItem(_) => None
-      | Item(itemWithPopFn) => Some(itemWithPopFn)
+      | NoItem(_) => {
+          isInReorgThreshold,
+          val: None,
+        }
+      | Item(itemWithPopFn) => {
+          isInReorgThreshold,
+          val: Some(itemWithPopFn),
+        }
       }
     }
-  | Error(NoItemsInArray) => arbitraryEventQueue->getFirstArbitraryEventsItem
+  | Error(NoItemsInArray) =>
+    arbitraryEventQueue
+    ->getFirstArbitraryEventsItem(~fetchStatesMap)
+    ->Option.mapWithDefault({val: None, isInReorgThreshold: false}, ({val, isInReorgThreshold}) => {
+      isInReorgThreshold,
+      val: Some(val),
+    })
   }
+}
+
+let getFetchStateWithData = (self: t, ~shouldDeepCopy=false): ChainMap.t<fetchStateWithData> => {
+  self.chainFetchers->ChainMap.map(cf => {
+    partitionedFetchState: shouldDeepCopy
+      ? cf.fetchState->PartitionedFetchState.copy
+      : cf.fetchState,
+    heighestBlockBelowThreshold: cf.currentBlockHeight - cf.chainConfig.confirmedBlockThreshold,
+  })
 }
 
 /**
@@ -237,31 +302,36 @@ the context of a batch
 */
 let nextItemIsNone = (self: t): bool => {
   popBatchItem(
-    ~fetchStatesMap=self.chainFetchers->ChainMap.map(cf => cf.fetchState),
+    ~fetchStatesMap=self->getFetchStateWithData,
     ~arbitraryEventQueue=self.arbitraryEventQueue,
     ~isUnorderedMultichainMode=self.isUnorderedMultichainMode,
-  )->Option.isNone
+  ).val->Option.isNone
 }
 
-type batchRes = {
-  batch: array<Types.eventBatchQueueItem>,
-  fetchStatesMap: ChainMap.t<PartitionedFetchState.t>,
-  arbitraryEventQueue: array<Types.eventBatchQueueItem>,
+let hasChainItemsOnArbQueue = (self: t, ~chain): bool => {
+  self.arbitraryEventQueue->Js.Array2.find(item => item.chain == chain)->Option.isSome
 }
 
 let createBatchInternal = (
   ~maxBatchSize,
-  ~fetchStatesMap: ChainMap.t<PartitionedFetchState.t>,
+  ~fetchStatesMap: ChainMap.t<fetchStateWithData>,
   ~arbitraryEventQueue,
   ~isUnorderedMultichainMode,
 ) => {
+  let isInReorgThresholdRef = ref(false)
   let batch = []
   let rec loop = () =>
-    if batch->Array.length >= maxBatchSize {
-      batch
-    } else {
-      switch popBatchItem(~fetchStatesMap, ~arbitraryEventQueue, ~isUnorderedMultichainMode) {
-      | None => batch
+    if batch->Array.length < maxBatchSize {
+      let {val, isInReorgThreshold} = popBatchItem(
+        ~fetchStatesMap,
+        ~arbitraryEventQueue,
+        ~isUnorderedMultichainMode,
+      )
+
+      isInReorgThresholdRef := isInReorgThresholdRef.contents || isInReorgThreshold
+
+      switch val {
+      | None => ()
       | Some({item, popItemOffQueue}) =>
         popItemOffQueue()
         batch->Js.Array2.push(item)->ignore
@@ -269,6 +339,14 @@ let createBatchInternal = (
       }
     }
   loop()
+
+  {val: batch, isInReorgThreshold: isInReorgThresholdRef.contents}
+}
+
+type batchRes = {
+  batch: array<Types.eventBatchQueueItem>,
+  fetchStatesMap: ChainMap.t<fetchStateWithData>,
+  arbitraryEventQueue: array<Types.eventBatchQueueItem>,
 }
 
 let createBatch = (self: t, ~maxBatchSize: int) => {
@@ -277,9 +355,9 @@ let createBatch = (self: t, ~maxBatchSize: int) => {
   let {arbitraryEventQueue, chainFetchers} = self
   //Make a copy of the queues and fetch states since we are going to mutate them
   let arbitraryEventQueue = arbitraryEventQueue->Array.copy
-  let fetchStatesMap = chainFetchers->ChainMap.map(cf => cf.fetchState->PartitionedFetchState.copy)
+  let fetchStatesMap = self->getFetchStateWithData(~shouldDeepCopy=true)
 
-  let batch = createBatchInternal(
+  let {val: batch, isInReorgThreshold} = createBatchInternal(
     ~maxBatchSize,
     ~fetchStatesMap,
     ~arbitraryEventQueue,
@@ -288,7 +366,7 @@ let createBatch = (self: t, ~maxBatchSize: int) => {
 
   let batchSize = batch->Array.length
 
-  if batchSize > 0 {
+  let val = if batchSize > 0 {
     let fetchedEventsBuffer =
       chainFetchers
       ->ChainMap.values
@@ -312,6 +390,8 @@ let createBatch = (self: t, ~maxBatchSize: int) => {
   } else {
     None
   }
+
+  {val, isInReorgThreshold}
 }
 
 module ExposedForTesting_Hidden = {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -521,6 +521,10 @@ let getNextQuery = (~eventFilters=?, ~currentBlockHeight, ~partitionId, self: t)
 
 type itemWithPopFn = {item: Types.eventBatchQueueItem, popItemOffQueue: unit => unit}
 
+let itemIsInReorgThreshold = (item: itemWithPopFn, ~heighestBlockBelowThreshold) => {
+  item.item.blockNumber > heighestBlockBelowThreshold
+}
+
 /**
 Represents a fetchState registers head of the  fetchedEventQueue as either
 an existing item, or no item with latest fetched block data
@@ -528,6 +532,13 @@ an existing item, or no item with latest fetched block data
 type queueItem =
   | Item(itemWithPopFn)
   | NoItem(blockNumberAndTimestamp)
+
+let queueItemIsInReorgThreshold = (queueItem: queueItem, ~heighestBlockBelowThreshold) => {
+  switch queueItem {
+  | Item(itemWithPopFn) => itemWithPopFn->itemIsInReorgThreshold(~heighestBlockBelowThreshold)
+  | NoItem({blockNumber}) => blockNumber > heighestBlockBelowThreshold
+  }
+}
 
 /**
 Creates a compareable value for items and no items on register queues.

--- a/scenarios/test_codegen/test/Mock_test.res
+++ b/scenarios/test_codegen/test/Mock_test.res
@@ -22,6 +22,7 @@ describe("E2E Mock Event Batch", () => {
           ~logger=Logging.logger,
           ~loadLayer,
           ~config,
+          ~isInReorgThreshold=false,
         )
       | None => Ok(EventProcessing.EventsProcessed.makeEmpty(~config))
       }
@@ -64,6 +65,7 @@ describe_skip("E2E Db check", () => {
       ~latestProcessedBlocks=EventProcessing.EventsProcessed.makeEmpty(~config),
       ~loadLayer,
       ~config,
+      ~isInReorgThreshold=false,
     )
 
     //// TODO: write code (maybe via dependency injection) to allow us to use the stub rather than the actual database here.

--- a/scenarios/test_codegen/test/helpers/Mock.res
+++ b/scenarios/test_codegen/test/helpers/Mock.res
@@ -13,7 +13,9 @@ module InMemoryStore = {
         },
         ~entityId=entity->Entities.getEntityId,
       ),
-      ~shouldRollbackOnReorg=RegisterHandlers.getConfig()->Config.shouldRollbackOnReorg,
+      ~shouldSaveHistory=RegisterHandlers.getConfig()->Config.shouldSaveHistory(
+        ~isInReorgThreshold=false,
+      ),
     )
   }
 

--- a/scenarios/test_codegen/test/schema_types/BigDecimal_test.res
+++ b/scenarios/test_codegen/test/schema_types/BigDecimal_test.res
@@ -42,7 +42,12 @@ describe("Load and save an entity with a BigDecimal from DB", () => {
     let _ = loaderContext.entityWithBigDecimal.get(testEntity1.id)
     let _ = loaderContext.entityWithBigDecimal.get(testEntity2.id)
 
-    let handlerContext = contextEnv->ContextEnv.getHandlerContext(~inMemoryStore, ~loadLayer)
+    let handlerContext =
+      contextEnv->ContextEnv.getHandlerContext(
+        ~inMemoryStore,
+        ~loadLayer,
+        ~isInReorgThreshold=false,
+      )
 
     switch await handlerContext.entityWithBigDecimal.get(testEntity1.id) {
     | Some(entity) => Assert.equal(entity.bigDecimal.toString(), "123.456")

--- a/scenarios/test_codegen/test/schema_types/Timestamp_test.res
+++ b/scenarios/test_codegen/test/schema_types/Timestamp_test.res
@@ -36,7 +36,12 @@ describe("Load and save an entity with a Timestamp from DB", () => {
 
     let _ = loaderContext.entityWithTimestamp.get(testEntity.id)
 
-    let handlerContext = contextEnv->ContextEnv.getHandlerContext(~inMemoryStore, ~loadLayer)
+    let handlerContext =
+      contextEnv->ContextEnv.getHandlerContext(
+        ~inMemoryStore,
+        ~loadLayer,
+        ~isInReorgThreshold=false,
+      )
 
     switch await handlerContext.entityWithTimestamp.get(testEntity.id) {
     | Some(entity) =>


### PR DESCRIPTION
- Implements a way to only start saving history when we start processing events within the the confirmed block threshold

I have just run a number of manual tests so far to see that it's working as expected. 

I still need to add some tests and thinking about the best way for this.