### PR TITLE
Improve contract import

### DIFF
--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -209,10 +209,7 @@ pub mod fuel {
             fuel::{ContractConfig, EcosystemTag, EventConfig, HumanConfig, Network},
             NetworkContract,
         },
-        fuel::{
-            abi::{FuelAbi, FuelLog},
-            address::Address,
-        },
+        fuel::{abi::FuelAbi, address::Address},
     };
 
     use super::InitConfig;
@@ -227,7 +224,7 @@ pub mod fuel {
         pub name: String,
         pub addresses: Vec<Address>,
         pub abi: FuelAbi,
-        pub selected_logs: Vec<FuelLog>,
+        pub selected_events: Vec<EventConfig>,
     }
 
     impl SelectedContract {
@@ -269,15 +266,7 @@ pub mod fuel {
                             config: Some(ContractConfig {
                                 abi_file_path: selected_contract.get_vendored_abi_file_path(),
                                 handler: init_config.language.get_event_handler_directory(),
-                                events: selected_contract
-                                    .selected_logs
-                                    .iter()
-                                    .map(|selected_log| EventConfig {
-                                        name: selected_log.event_name.clone(),
-                                        log_id: selected_log.id.clone().into(),
-                                        type_: None,
-                                    })
-                                    .collect(),
+                                events: selected_contract.selected_events.clone(),
                             }),
                         })
                         .collect(),

--- a/codegenerator/cli/src/cli_args/interactive_init/fuel_prompts.rs
+++ b/codegenerator/cli/src/cli_args/interactive_init/fuel_prompts.rs
@@ -122,35 +122,28 @@ async fn get_contract_import_selection(args: ContractImportArgs) -> Result<Selec
         get_abi_path_string(&local_import_args).context("Failed getting Fuel ABI path")?;
     let abi = FuelAbi::parse(PathBuf::from(&abi_path_string)).context("Failed parsing Fuel ABI")?;
 
-    let mut selected_events: Vec<EventConfig> = abi
-        .get_logs()
-        .iter()
-        .map(|log| EventConfig {
-            name: log.event_name.clone(),
-            log_id: Some(log.id.clone()),
-            type_: None,
-        })
-        .collect();
-    selected_events.push(EventConfig {
-        name: TRANSFER_EVENT_NAME.to_string(),
-        log_id: None,
-        type_: None,
-    });
-    selected_events.push(EventConfig {
-        name: MINT_EVENT_NAME.to_string(),
-        log_id: None,
-        type_: None,
-    });
-    selected_events.push(EventConfig {
-        name: BURN_EVENT_NAME.to_string(),
-        log_id: None,
-        type_: None,
-    });
-    selected_events.push(EventConfig {
-        name: CALL_EVENT_NAME.to_string(),
-        log_id: None,
-        type_: None,
-    });
+  let mut selected_events: Vec<EventConfig> = abi
+      .get_logs()
+      .iter()
+      .map(|log| EventConfig {
+          name: log.event_name.clone(),
+          log_id: Some(log.id.clone()),
+          type_: None,
+      })
+      .collect();
+  
+  let event_names = [
+      TRANSFER_EVENT_NAME,
+      MINT_EVENT_NAME,
+      BURN_EVENT_NAME,
+      CALL_EVENT_NAME,
+  ];
+  
+  selected_events.extend(event_names.iter().map(|&name| EventConfig {
+      name: name.to_string(),
+      log_id: None,
+      type_: None,
+  }));
     if !args.all_events {
         selected_events = prompt_event_selection(selected_events)?;
     }

--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     config_parsing::human_config::evm::{RpcBlockField, RpcTransactionField},
     constants::{links, project_paths::DEFAULT_SCHEMA_PATH},
-    fuel::abi::FuelAbi,
+    fuel::abi::{FuelAbi, BURN_EVENT_NAME, CALL_EVENT_NAME, MINT_EVENT_NAME, TRANSFER_EVENT_NAME},
     project_paths::{path_utils, ParsedProjectPaths},
     rescript_types::RescriptTypeIdent,
     utils::unique_hashmap,
@@ -969,10 +969,10 @@ impl Event {
                         EventType::LogData
                     } else {
                         match event_config.name.as_str() {
-                            "Mint" => EventType::Mint,
-                            "Burn" => EventType::Burn,
-                            "Transfer" => EventType::Transfer,
-                            "Call" => EventType::Call,
+                            MINT_EVENT_NAME => EventType::Mint,
+                            BURN_EVENT_NAME => EventType::Burn,
+                            TRANSFER_EVENT_NAME => EventType::Transfer,
+                            CALL_EVENT_NAME => EventType::Call,
                             _ => EventType::LogData,
                         }
                     }

--- a/codegenerator/cli/src/fuel/abi.rs
+++ b/codegenerator/cli/src/fuel/abi.rs
@@ -11,6 +11,11 @@ use crate::{
     utils::text::Capitalize,
 };
 
+pub const TRANSFER_EVENT_NAME: &str = "Transfer";
+pub const MINT_EVENT_NAME: &str = "Mint";
+pub const BURN_EVENT_NAME: &str = "Burn";
+pub const CALL_EVENT_NAME: &str = "Call";
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct FuelType {
     pub id: usize,

--- a/codegenerator/cli/templates/dynamic/contract_import_templates/typescript/src/EventHandlers.ts.hbs
+++ b/codegenerator/cli/templates/dynamic/contract_import_templates/typescript/src/EventHandlers.ts.hbs
@@ -29,6 +29,5 @@ import {
 
   context.{{contract.name.capitalized}}_{{event.name}}.set(entity);
 });
-
   {{/each}}
 {{/each}}


### PR DESCRIPTION
- Adds `Transfer`, `Mint`, `Burn`, `Call` events in the selection for the Fuel contract import
- Fix broken schema.graphql - wasn't released (this part is not tested, so we'd miss it if I didn't test it manually)
- Remove the second linebreak between handlers in contract import
- Remove unused code for contract import codegen