### PR TITLE
Fixes contract import with `0.0.0-main-...` versions

### DIFF
--- a/codegenerator/cli/src/executor/init.rs
+++ b/codegenerator/cli/src/executor/init.rs
@@ -27,7 +27,7 @@ use std::{env, path::PathBuf};
 fn is_valid_release_version_number(version: &str) -> bool {
     let re_version_pattern = Regex::new(r"^\d+\.\d+\.\d+(-rc\.\d+)?$")
         .expect("version regex pattern should be valid regex");
-    re_version_pattern.is_match(version)
+    re_version_pattern.is_match(version) || version.starts_with("0.0.0-main-")
 }
 
 pub async fn run_init_args(init_args: InitArgs, project_paths: &ProjectPaths) -> Result<()> {
@@ -303,7 +303,14 @@ mod test {
 
     #[test]
     fn test_valid_version_numbers() {
-        let valid_version_numbers = vec!["0.0.0", "999.999.999", "0.0.1", "10.2.3", "2.0.0-rc.1"];
+        let valid_version_numbers = vec![
+            "0.0.0",
+            "999.999.999",
+            "0.0.1",
+            "10.2.3",
+            "2.0.0-rc.1",
+            "0.0.0-main-20241001144237-a236a894",
+        ];
 
         for vn in valid_version_numbers {
             assert!(super::is_valid_release_version_number(vn));


### PR DESCRIPTION
The path to envio is broken when installing the `0.0.0-main-...` package from npm. It adds a lousy fix for it:

```
"envio": "/Users/dzakh/.npm/_npx/ee52c6fd71a620c9/node_modules/envio-darwin-arm64/bin/envio/../../../cli/npm/envio"
```