### PR TITLE
Implement concurrent partitions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,8 @@ jobs:
           else
             timestamp=$(date +'%Y%m%d%H%M%S')
             short_commit=${{ steps.vars.outputs.hash_short }}
-            echo "::set-output name=tag_name::v0.0.0-${GITHUB_REF_NAME}-${timestamp}-${short_commit}"
-            echo "::set-output name=release_name::v0.0.0-${GITHUB_REF_NAME}-${timestamp}-${short_commit}"
+            echo "::set-output name=tag_name::v2.0.0-${GITHUB_REF_NAME}-${timestamp}-${short_commit}"
+            echo "::set-output name=release_name::v2.0.0-${GITHUB_REF_NAME}-${timestamp}-${short_commit}"
             echo "::set-output name=is_tagged::false"
             echo "::set-output name=release_type::dev"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           ]'
           if [[ "${{ steps.release_info.outputs.is_tagged }}" == "false" ]]; then
             # Non-release builds are only for the team, so we don't need to build for windows, or old mac books, or unused arm linux.
-            matrix=$(echo "$matrix" | jq '[.[] | select(.platform != "win32" and .target != "aarch64-unknown-linux-gnu" and .name != "darwin-x64")]')
+            matrix=$(echo "$matrix" | jq '[.[] | select(.platform != "win32" and .name != "darwin-x64")]')
           fi
           matrix=$(echo "$matrix" | jq -c '.') # put it on a single line (compact)
           echo "::set-output name=matrix::${matrix}"

--- a/codegenerator/cli/src/executor/init.rs
+++ b/codegenerator/cli/src/executor/init.rs
@@ -27,7 +27,7 @@ use std::{env, path::PathBuf};
 fn is_valid_release_version_number(version: &str) -> bool {
     let re_version_pattern = Regex::new(r"^\d+\.\d+\.\d+(-rc\.\d+)?$")
         .expect("version regex pattern should be valid regex");
-    re_version_pattern.is_match(version) || version.starts_with("0.0.0-main-")
+    re_version_pattern.is_match(version) || version.contains("-main-")
 }
 
 pub async fn run_init_args(init_args: InitArgs, project_paths: &ProjectPaths) -> Result<()> {

--- a/codegenerator/cli/templates/static/codegen/.gitignore
+++ b/codegenerator/cli/templates/static/codegen/.gitignore
@@ -30,4 +30,4 @@
 *.bs.mjs
 *.gen.ts
 logs/*
-*.BenchmarkCache.json
+*BenchmarkCache.json

--- a/codegenerator/cli/templates/static/codegen/src/Benchmark.res
+++ b/codegenerator/cli/templates/static/codegen/src/Benchmark.res
@@ -129,6 +129,7 @@ let addBlockRangeFetched = (
   ~toBlock,
   ~fetchStateRegisterId: FetchState.id,
   ~numEvents,
+  ~partitionId,
 ) => {
   let registerName = switch fetchStateRegisterId {
   | Root => "Root"
@@ -145,12 +146,15 @@ let addBlockRangeFetched = (
   add("Block Range Size", toBlock - fromBlock)
 
   data->Data.incrementMillis(
-    ~label=`Total Time Fetching Chain ${chainId->Belt.Int.toString}`,
+    ~label=`Total Time Fetching Chain ${chainId->Belt.Int.toString} Partition ${partitionId->Belt.Int.toString}`,
     ~amount=totalTimeElapsed,
   )
 
   data->saveToCacheFile
 }
+
+let eventProcessingGroup = "EventProcessing Summary"
+let batchSizeLabel = "Batch Size"
 
 let addEventProcessing = (
   ~batchSize,
@@ -161,13 +165,9 @@ let addEventProcessing = (
   ~totalTimeElapsed,
 ) => {
   let add = (label, value) =>
-    data->Data.addSummaryData(
-      ~group="EventProcessing Summary",
-      ~label,
-      ~value=value->Belt.Int.toFloat,
-    )
+    data->Data.addSummaryData(~group=eventProcessingGroup, ~label, ~value=value->Belt.Int.toFloat)
 
-  add("Batch Size", batchSize)
+  add(batchSizeLabel, batchSize)
   add("Contract Register Duration (ms)", contractRegisterDuration)
   add("Load Duration (ms)", loadDuration)
   add("Handler Duration (ms)", handlerDuration)
@@ -187,6 +187,7 @@ module Summary = {
     @as("std-dev") stdDev: float,
     min: float,
     max: float,
+    last: float,
     total: float,
   }
 
@@ -208,7 +209,7 @@ module Summary = {
     let div = (floatA, floatB) => floatA /. floatB
     let n = Array.length(arr)
     if n == 0 {
-      {n, mean: 0., stdDev: 0., min: 0., max: 0., total: 0.}
+      {n, mean: 0., stdDev: 0., min: 0., max: 0., last: 0., total: 0.}
     } else {
       let nFloat = n->Int.toFloat
       let mean = arr->Array.reduce(0., (acc, time) => acc +. time)->div(nFloat)->round(~precision=2)
@@ -246,8 +247,12 @@ module Summary = {
           ->Some
         )
         ->Option.getWithDefault(0.)
+      let last =
+        arr
+        ->Utils.Array.last
+        ->Option.getWithDefault(0.)
       let total = arr->Array.reduce(0., (acc, val) => acc +. val)
-      {n, mean, stdDev, min, max, total}
+      {n, mean, stdDev, min, max, last, total}
     }
   }
 
@@ -279,6 +284,27 @@ module Summary = {
       timeBreakdown
       ->Js.Dict.fromArray
       ->logDictTable
+
+      Js.log("General")
+      let batchSizesSum =
+        summaryData
+        ->Js.Dict.get(eventProcessingGroup)
+        ->Option.flatMap(g => g->Js.Dict.get(batchSizeLabel))
+        ->Option.map(data => data->Array.reduce(0., (acc, d) => acc +. d))
+        ->Option.getWithDefault(0.)
+
+      let totalRuntimeMillis =
+        millisAccum.endTime->Js.Date.getTime -. millisAccum.startTime->Js.Date.getTime
+
+      let totalRuntimeSeconds = totalRuntimeMillis /. 1000.
+
+      let eventsPerSecond = (batchSizesSum /. totalRuntimeSeconds)->round(~precision=2)
+
+      logObjTable({
+        "batch sizes sum": batchSizesSum,
+        "total runtime (sec)": totalRuntimeSeconds,
+        "events per second": eventsPerSecond,
+      })
 
       summaryData
       ->Js.Dict.entries

--- a/codegenerator/cli/templates/static/codegen/src/Benchmark.res
+++ b/codegenerator/cli/templates/static/codegen/src/Benchmark.res
@@ -112,7 +112,9 @@ let incrementMillis = (~label, ~amount) => {
 }
 
 let addBlockRangeFetched = (
-  ~stats: ChainWorker.blockRangeFetchStats,
+  ~totalTimeElapsed: int,
+  ~parsingTimeElapsed: int,
+  ~pageFetchTime: int,
   ~chainId,
   ~fromBlock,
   ~toBlock,
@@ -127,15 +129,15 @@ let addBlockRangeFetched = (
   let group = `BlockRangeFetched Summary for Chain ${chainId->Belt.Int.toString} ${registerName} Register`
   let add = (label, value) => data->Data.addSummaryData(~group, ~label, ~value=Utils.magic(value))
 
-  add("Total Time Elapsed (ms)", stats.totalTimeElapsed)
-  add("Parsing Time Elapsed (ms)", stats.parsingTimeElapsed->Belt.Option.getWithDefault(0))
-  add("Page Fetch Time (ms)", stats.pageFetchTime->Belt.Option.getWithDefault(0))
+  add("Total Time Elapsed (ms)", totalTimeElapsed)
+  add("Parsing Time Elapsed (ms)", parsingTimeElapsed)
+  add("Page Fetch Time (ms)", pageFetchTime)
   add("Num Events", numEvents)
   add("Block Range Size", toBlock - fromBlock)
 
   data->Data.incrementMillis(
     ~label=`Total Time Fetching Chain ${chainId->Belt.Int.toString}`,
-    ~amount=stats.totalTimeElapsed,
+    ~amount=totalTimeElapsed,
   )
 
   data->saveToCacheFile

--- a/codegenerator/cli/templates/static/codegen/src/Env.res
+++ b/codegenerator/cli/templates/static/codegen/src/Env.res
@@ -28,6 +28,8 @@ let envioApiToken = envSafe->EnvSafe.get("ENVIO_API_TOKEN", S.option(S.string))
 let hyperSyncClientTimeoutMillis =
   envSafe->EnvSafe.get("ENVIO_HYPERSYNC_CLIENT_TIMEOUT_MILLIS", S.option(S.int))
 let saveBenchmarkData = envSafe->EnvSafe.get("ENVIO_SAVE_BENCHMARK_DATA", S.bool, ~fallback=false)
+let maxPartitionConcurrency =
+  envSafe->EnvSafe.get("ENVIO_MAX_PARTITION_CONCURRENCY", S.int, ~fallback=10)
 
 type logStrategyType =
   | @as("ecs-file") EcsFile

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
@@ -178,6 +178,13 @@ type singlePartition = {
   partitionId: partitionIndex,
 }
 
+/**
+Retrieves an array of partitions that are most behind with a max number based on
+the max number of queries with the context of the partitions currently fetching.
+
+The array could be shorter than the max number of queries if the partitions are
+at the max queue size.
+*/
 let getMostBehindPartitions = (
   {partitions}: t,
   ~maxNumQueries,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
@@ -188,6 +188,7 @@ let getMostBehindPartitions = (
     maxNumQueries - partitionsCurrentlyFetching->Belt.Set.Int.size,
     0,
   )
+  let maxPartitionQueueSize = maxPerChainQueueSize / partitions->List.length
   let accum = []
   partitions->List.forEachWithIndex((partitionIndex, partition) => {
     let val = {fetchState: partition, partitionId: partitionIndex}
@@ -211,7 +212,7 @@ let getMostBehindPartitions = (
     }
     if (
       !(partitionsCurrentlyFetching->Set.Int.has(partitionIndex)) &&
-      partition->FetchState.isReadyForNextQuery(~maxQueueSize=maxPerChainQueueSize)
+      partition->FetchState.isReadyForNextQuery(~maxQueueSize=maxPartitionQueueSize)
     ) {
       loop(0)
     }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
@@ -13,6 +13,8 @@ type id = {
   fetchStateId: FetchState.id,
 }
 
+type partitionIndexSet = Belt.Set.Int.t
+
 let make = (
   ~maxAddrInPartition,
   ~endBlock,
@@ -176,17 +178,46 @@ type singlePartition = {
   partitionId: partitionIndex,
 }
 
-let getMostBehindPartition = ({partitions}: t) =>
-  partitions
-  ->List.reduceWithIndex(None, (accum, partition, partitionIndex) => {
-    switch accum {
-    | Some({fetchState: accumPartition}: singlePartition)
-      if accumPartition.FetchState.latestFetchedBlock.blockNumber <
-      partition.latestFetchedBlock.blockNumber => accum
-    | _ => Some({fetchState: partition, partitionId: partitionIndex})
+let getMostBehindPartitions = (
+  {partitions}: t,
+  ~maxNumQueries,
+  ~maxPerChainQueueSize,
+  ~partitionsCurrentlyFetching,
+) => {
+  let maxNumQueries = Pervasives.max(
+    maxNumQueries - partitionsCurrentlyFetching->Belt.Set.Int.size,
+    0,
+  )
+  let accum = []
+  partitions->List.forEachWithIndex((partitionIndex, partition) => {
+    let val = {fetchState: partition, partitionId: partitionIndex}
+
+    let rec loop = index => {
+      switch accum[index] {
+      | None =>
+        if accum->Array.length < maxNumQueries {
+          accum->Js.Array2.push(val)->ignore
+        }
+      | Some(v) =>
+        if v.fetchState.latestFetchedBlock.blockNumber > partition.latestFetchedBlock.blockNumber {
+          let _ = accum->Js.Array2.spliceInPlace(~pos=index, ~remove=0, ~add=[val])
+          if accum->Array.length > maxNumQueries {
+            accum->Js.Array2.pop->ignore
+          }
+        } else {
+          loop(index + 1)
+        }
+      }
+    }
+    if (
+      !(partitionsCurrentlyFetching->Set.Int.has(partitionIndex)) &&
+      partition->FetchState.isReadyForNextQuery(~maxQueueSize=maxPerChainQueueSize)
+    ) {
+      loop(0)
     }
   })
-  ->Option.getUnsafe
+  accum
+}
 
 let updatePartition = (self: t, ~fetchState: FetchState.t, ~partitionId: partitionIndex) => {
   switch self.partitions->List.splitAt(partitionId) {
@@ -197,20 +228,55 @@ let updatePartition = (self: t, ~fetchState: FetchState.t, ~partitionId: partiti
   }
 }
 
+type nextQueries = WaitForNewBlock | NextQuery(array<FetchState.nextQuery>)
 /**
 Gets the next query from the fetchState with the lowest latestFetchedBlock number.
 */
-let getNextQuery = (self: t, ~eventFilters=?, ~currentBlockHeight) => {
-  let {fetchState, partitionId} = self->getMostBehindPartition
+let getNextQueriesOrThrow = (
+  self: t,
+  ~eventFilters=?,
+  ~currentBlockHeight,
+  ~maxPerChainQueueSize,
+  ~partitionsCurrentlyFetching,
+) => {
+  let optUpdatedPartition = ref(None)
+  let includesWaitForNewBlock = ref(false)
+  let nextQueries = []
+  self
+  ->getMostBehindPartitions(
+    ~maxNumQueries=Env.maxPartitionConcurrency,
+    ~maxPerChainQueueSize,
+    ~partitionsCurrentlyFetching,
+  )
+  ->Array.forEach(({fetchState, partitionId}) => {
+    switch fetchState->FetchState.getNextQuery(~eventFilters?, ~currentBlockHeight, ~partitionId) {
+    | Ok((nextQuery, optUpdatesFetchState)) =>
+      switch nextQuery {
+      | NextQuery(q) => nextQueries->Js.Array2.push(q)->ignore
+      | WaitForNewBlock => includesWaitForNewBlock := true
+      | Done => ()
+      }
+      switch optUpdatesFetchState {
+      | Some(fetchState) =>
+        optUpdatedPartition :=
+          optUpdatedPartition.contents
+          ->Option.getWithDefault(self)
+          ->updatePartition(~fetchState, ~partitionId)
+          ->Utils.unwrapResultExn
+          ->Some
+      | None => ()
+      }
+    | Error(e) =>
+      e->ErrorHandling.mkLogAndRaise(~msg="Unexpected error getting next query in partition")
+    }
+  })
 
-  fetchState
-  ->FetchState.getNextQuery(~eventFilters?, ~currentBlockHeight, ~partitionId)
-  ->Result.map(((nextQuery, optUpdatesFetchState)) => (
-    nextQuery,
-    optUpdatesFetchState->Option.map(fetchState =>
-      self->updatePartition(~fetchState, ~partitionId)->Utils.unwrapResultExn
-    ),
-  ))
+  let nextQueries = switch nextQueries {
+  | [] if includesWaitForNewBlock.contents => WaitForNewBlock
+  | queries => NextQuery(queries)
+  }
+
+  (nextQueries, optUpdatedPartition.contents)
 }
 
 /**
@@ -251,11 +317,6 @@ let getLatestFullyFetchedBlock = ({partitions}: t) =>
     }
   })
   ->Option.getUnsafe
-
-let isReadyForNextQuery = (self: t, ~maxQueueSize) => {
-  let {fetchState} = self->getMostBehindPartition
-  fetchState->FetchState.isReadyForNextQuery(~maxQueueSize)
-}
 
 let checkContainsRegisteredContractAddress = ({partitions}: t, ~contractAddress, ~contractName) => {
   partitions->List.reduce(false, (accum, partition) => {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
@@ -94,6 +94,14 @@ let make = (
     partitions.contents
   }
 
+  if Env.saveBenchmarkData {
+    Benchmark.addSummaryData(
+      ~group="Other",
+      ~label="Num partitions",
+      ~value=partitions->List.size->Int.toFloat,
+    )
+  }
+
   {maxAddrInPartition, partitions, endBlock, startBlock, logger}
 }
 
@@ -124,6 +132,13 @@ let registerDynamicContracts = (
     partitions->List.add(newPartition)
   }
 
+  if Env.saveBenchmarkData {
+    Benchmark.addSummaryData(
+      ~group="Other",
+      ~label="Num partitions",
+      ~value=partitions->List.size->Int.toFloat,
+    )
+  }
   {partitions, maxAddrInPartition, endBlock, startBlock, logger}
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -284,6 +284,7 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
       ~toBlock=heighestQueriedBlockNumber,
       ~fetchStateRegisterId,
       ~numEvents=parsedQueueItems->Array.length,
+      ~partitionId,
     )
   }
 

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -211,12 +211,14 @@ let checkAndSetSyncedChains = (~nextQueueItemIsKnownNone=false, chainManager: Ch
   })
 
   let allChainsSyncedAtHead =
-  chainFetchers
-  ->ChainMap.values
-  ->Array.reduce(true, (accum, cf) => cf.timestampCaughtUpToHeadOrEndblock->Option.isSome && accum)
+    chainFetchers
+    ->ChainMap.values
+    ->Array.reduce(true, (accum, cf) =>
+      cf.timestampCaughtUpToHeadOrEndblock->Option.isSome && accum
+    )
 
   if allChainsSyncedAtHead {
-   Prometheus.setAllChainsSyncedToHead()
+    Prometheus.setAllChainsSyncedToHead()
   }
 
   {
@@ -274,7 +276,9 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
 
   if Env.saveBenchmarkData {
     Benchmark.addBlockRangeFetched(
-      ~stats,
+      ~totalTimeElapsed=stats.totalTimeElapsed,
+      ~parsingTimeElapsed=stats.parsingTimeElapsed->Belt.Option.getWithDefault(0),
+      ~pageFetchTime=stats.pageFetchTime->Belt.Option.getWithDefault(0),
       ~chainId=chainFetcher.chainConfig.chain->ChainMap.Chain.toChainId,
       ~fromBlock=fromBlockQueried,
       ~toBlock=heighestQueriedBlockNumber,

--- a/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
@@ -360,10 +360,12 @@ describe("Dynamic contract rollback test", () => {
       ]
 
     let getFetchStateRegisterId = () =>
-      switch getFetchState(Mock.Chain1.chain)
-      ->PartitionedFetchState.getNextQuery(~currentBlockHeight=6)
-      ->Result.getExn {
-      | (FetchState.NextQuery(q), _) => q.fetchStateRegisterId
+      switch getFetchState(Mock.Chain1.chain)->PartitionedFetchState.getNextQueriesOrThrow(
+        ~currentBlockHeight=6,
+        ~maxPerChainQueueSize=100_000,
+        ~partitionsCurrentlyFetching=Set.Int.empty,
+      ) {
+      | (NextQuery([q]), _) => q.fetchStateRegisterId
       | _ => raise(Not_found)
       }
 

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -124,7 +124,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       lastBlockScannedHashes: ReorgDetection.LastBlockScannedHashes.empty(
         ~confirmedBlockThreshold=200,
       ),
-      isFetchingBatch: false,
+      partitionsCurrentlyFetching: Belt.Set.Int.empty,
       currentBlockHeight: 0,
       eventFilters: None,
     }

--- a/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
@@ -1,0 +1,147 @@
+open Belt
+open RescriptMocha
+
+describe("PartitionedFetchState getMostBehindPartitions", () => {
+  let mockFetchState = (~latestFetchedBlockNumber, ~fetchedEventQueue=[]): FetchState.t => {
+    registerType: RootRegister({endBlock: None}),
+    latestFetchedBlock: {
+      blockNumber: latestFetchedBlockNumber,
+      blockTimestamp: latestFetchedBlockNumber * 15,
+    },
+    contractAddressMapping: ContractAddressingMap.make(),
+    fetchedEventQueue,
+    dynamicContracts: FetchState.DynamicContractsMap.empty,
+    firstEventBlockNumber: None,
+    isFetchingAtHead: false,
+  }
+
+  let mockPartitionedFetchState = (~partitions): PartitionedFetchState.t => {
+    partitions,
+    maxAddrInPartition: 0,
+    startBlock: 0,
+    endBlock: None,
+    logger: Logging.logger,
+  }
+  let partitions = list{
+    mockFetchState(~latestFetchedBlockNumber=4),
+    mockFetchState(~latestFetchedBlockNumber=5),
+    mockFetchState(~latestFetchedBlockNumber=1),
+    mockFetchState(~latestFetchedBlockNumber=2),
+    mockFetchState(~latestFetchedBlockNumber=3),
+  }
+  let partitionedFetchState = mockPartitionedFetchState(~partitions)
+  it(
+    "With multiple partitions always returns the most behind partitions up to the max concurrency level",
+    () => {
+      let maxNumQueries = 3
+      let partitionsCurrentlyFetching = Set.Int.empty
+
+      let mostBehindPartitions =
+        partitionedFetchState->PartitionedFetchState.getMostBehindPartitions(
+          ~maxNumQueries,
+          ~maxPerChainQueueSize=10,
+          ~partitionsCurrentlyFetching,
+        )
+
+      Assert.equal(mostBehindPartitions->Array.length, maxNumQueries)
+
+      let partitionIds = mostBehindPartitions->Array.map(p => p.partitionId)
+      Assert.deepEqual(
+        partitionIds,
+        [2, 3, 4],
+        ~message="Should have returned the partitions with the lowest latestFetchedBlock",
+      )
+    },
+  )
+
+  it("Will not return partitions that are currently fetching", () => {
+    let maxNumQueries = 3
+    let partitionsCurrentlyFetching = Set.Int.fromArray([2, 3])
+
+    let mostBehindPartitions =
+      partitionedFetchState->PartitionedFetchState.getMostBehindPartitions(
+        ~maxNumQueries,
+        ~maxPerChainQueueSize=10,
+        ~partitionsCurrentlyFetching,
+      )
+
+    Assert.equal(
+      mostBehindPartitions->Array.length,
+      maxNumQueries - partitionsCurrentlyFetching->Set.Int.size,
+    )
+
+    let partitionIds = mostBehindPartitions->Array.map(p => p.partitionId)
+    Assert.deepEqual(
+      partitionIds,
+      [4],
+      ~message="Should have returned the partitions with the lowest latestFetchedBlock that are not currently fetching",
+    )
+  })
+
+  it("Should not return partition that is at max partition size", () => {
+    let maxNumQueries = 3
+    let partitions = list{
+      mockFetchState(~latestFetchedBlockNumber=4),
+      mockFetchState(~latestFetchedBlockNumber=5),
+      mockFetchState(
+        ~latestFetchedBlockNumber=1,
+        ~fetchedEventQueue=["mockEvent1", "mockEvent2", "mockEvent3"]->Utils.magic,
+      ),
+      mockFetchState(
+        ~latestFetchedBlockNumber=2,
+        ~fetchedEventQueue=["mockEvent4", "mockEvent5"]->Utils.magic,
+      ),
+      mockFetchState(~latestFetchedBlockNumber=3),
+    }
+    let partitionedFetchState = mockPartitionedFetchState(~partitions)
+
+    let mostBehindPartitions =
+      partitionedFetchState->PartitionedFetchState.getMostBehindPartitions(
+        ~maxNumQueries,
+        ~maxPerChainQueueSize=10, //each partition should therefore have a max of 2 events
+        ~partitionsCurrentlyFetching=Set.Int.empty,
+      )
+
+    let partitionIds = mostBehindPartitions->Array.map(p => p.partitionId)
+    Assert.deepEqual(
+      partitionIds,
+      [4, 0, 1],
+      ~message="Should have skipped partitions that are at max queue size",
+    )
+  })
+
+  it("if need be should return less than maxNum queries if all partitions at their max", () => {
+    let maxNumQueries = 3
+    let partitions = list{
+      mockFetchState(~latestFetchedBlockNumber=4),
+      mockFetchState(~latestFetchedBlockNumber=5),
+      mockFetchState(
+        ~latestFetchedBlockNumber=1,
+        ~fetchedEventQueue=["mockEvent1", "mockEvent2", "mockEvent3"]->Utils.magic,
+      ),
+      mockFetchState(
+        ~latestFetchedBlockNumber=2,
+        ~fetchedEventQueue=["mockEvent4", "mockEvent5"]->Utils.magic,
+      ),
+      mockFetchState(
+        ~latestFetchedBlockNumber=3,
+        ~fetchedEventQueue=["mockEvent6", "mockEvent7"]->Utils.magic,
+      ),
+    }
+    let partitionedFetchState = mockPartitionedFetchState(~partitions)
+
+    let mostBehindPartitions =
+      partitionedFetchState->PartitionedFetchState.getMostBehindPartitions(
+        ~maxNumQueries,
+        ~maxPerChainQueueSize=10, //each partition should therefore have a max of 2 events
+        ~partitionsCurrentlyFetching=Set.Int.empty,
+      )
+
+    let partitionIds = mostBehindPartitions->Array.map(p => p.partitionId)
+    Assert.deepEqual(
+      partitionIds,
+      [0, 1],
+      ~message="Should have skipped partitions that are at max queue size and returned less than maxNumQueries",
+    )
+  })
+})


### PR DESCRIPTION
This to allow indexers with lots of partitions to do concurrent requests to hypersync.

Currently it's experimental and seems like it could contain a memory leak so the idea is to have a side release that I can test a deployment.