### PR TITLE
Fix queries becoming too large

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -101,7 +101,7 @@ let makeGetNextPage = (
       let module(Event) = event
       let {isWildcard, topicSelections} =
         Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
-      isWildcard ? Some(LogSelection.make(~addresses=[], ~topicSelections)) : None
+      isWildcard ? Some(LogSelection.makeOrThrow(~addresses=[], ~topicSelections)) : None
     })
   })
 
@@ -124,7 +124,7 @@ let makeGetNextPage = (
           isWildcard ? [] : topicSelections
         }) {
         | [] => None
-        | topicSelections => Some(LogSelection.make(~addresses, ~topicSelections))
+        | topicSelections => Some(LogSelection.makeOrThrow(~addresses, ~topicSelections))
         }
       }
     })
@@ -460,10 +460,7 @@ module Make = (
           let topic0 = log.topics->Js.Array2.unsafe_get(0)
 
           switch eventRouter->EventRouter.get(
-            ~tag=EventRouter.getEvmEventTag(
-              ~sighash=topic0,
-              ~topicCount=log.topics->Array.length,
-            ),
+            ~tag=EventRouter.getEvmEventTag(~sighash=topic0, ~topicCount=log.topics->Array.length),
             ~contractAddressMapping,
             ~contractAddress=log.address,
           ) {


### PR DESCRIPTION
We are getting a lot of problems with queries being too large. Unfortunately it has not been combining topic0s into 1 query param:

So queries would be:

```json
[
  "logs": [
    {
      "address": [...manyAddresses],
      "topics": [
        [
          "0x2150ada912bf189ed721c44211199e270903fc88008c2a1e1e889ef30fe67c5f"
        ],
        [],
        [],
        []
      ]
    },
    {
      "address": [...the same addresses],
      "topics": [
        [
          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
        ],
        [],
        [],
        []
      ]
    },
]
```

Now it will be:
```json
[
  "logs": [
    {
      "address": [...manyAddresses],
      "topics": [
        [
          "0x2150ada912bf189ed721c44211199e270903fc88008c2a1e1e889ef30fe67c5f",
          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
        ],
        [],
        [],
        []
      ]
    }
]
```

Which compresses the query a lot!
