### PR TITLE
Dynamic Contract Pre Registration

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
@@ -133,7 +133,6 @@ module EventFunctions = {
             false,
           ~dynamicContractRegistrations=None,
           ~inMemoryStore,
-          ~isPreRegisteringDynamicContracts=false,
         ) {
         | Ok(_) => ()
         | Error(e) => e->ErrorHandling.logAndRaise

--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
@@ -133,6 +133,7 @@ module EventFunctions = {
             false,
           ~dynamicContractRegistrations=None,
           ~inMemoryStore,
+          ~isPreRegisteringDynamicContracts=false,
         ) {
         | Ok(_) => ()
         | Error(e) => e->ErrorHandling.logAndRaise

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -228,26 +228,34 @@ module HandlerTypes = {
     handler: handler<'eventArgs, 'loaderReturn>,
     wildcard?: bool,
     eventFilters?: SingleOrMultiple.t<'eventFilter>,
+    preRegister?: bool,
   }
 
   @genType
   type eventConfig<'eventFilter> = {
     wildcard?: bool,
     eventFilters?: SingleOrMultiple.t<'eventFilter>,
+    preRegister?: bool,
   }
 
   module EventOptions = {
     type t = {
       isWildcard: bool,
       topicSelections: array<LogSelection.topicSelection>,
+      shouldPreRegisterDynamicContracts: bool,
     }
 
     let getDefault = (~topic0) => {
       isWildcard: false,
       topicSelections: [LogSelection.makeTopicSelection(~topic0=[topic0])->Utils.unwrapResultExn],
+      shouldPreRegisterDynamicContracts: false,
     }
 
-    let make = (~isWildcard, ~topicSelections: array<LogSelection.topicSelection>) => {
+    let make = (
+      ~isWildcard,
+      ~topicSelections: array<LogSelection.topicSelection>,
+      ~shouldPreRegisterDynamicContracts,
+    ) => {
       let topic0sGrouped = []
       let topicSelectionWithFilters = []
       topicSelections->Belt.Array.forEach(ts =>
@@ -270,6 +278,7 @@ module HandlerTypes = {
       {
         isWildcard,
         topicSelections,
+        shouldPreRegisterDynamicContracts,
       }
     }
   }
@@ -443,7 +452,7 @@ let makeEventOptions = (
 ) => {
   let module(Event) = eventMod
   open Belt
-  eventConfig->Option.map(({?wildcard, ?eventFilters}) =>
+  eventConfig->Option.map(({?wildcard, ?eventFilters, ?preRegister}) =>
     HandlerTypes.EventOptions.make(
       ~isWildcard=wildcard->Option.getWithDefault(false),
       ~topicSelections=eventFilters->Option.mapWithDefault(
@@ -454,6 +463,7 @@ let makeEventOptions = (
         ],
         v => v->Event.getTopicSelection,
       ),
+      ~shouldPreRegisterDynamicContracts=preRegister->Option.getWithDefault(false),
     )
   )
 }
@@ -466,8 +476,8 @@ let makeGetEventOptions = (
   let module(Event) = eventMod
   (loaderHandler: HandlerTypes.loaderHandler<Event.eventArgs, 'loaderReturn, Event.eventFilter>) =>
     switch loaderHandler {
-    | {wildcard: ?None, eventFilters: ?None} => None
-    | {?wildcard, ?eventFilters} =>
+    | {wildcard: ?None, eventFilters: ?None, preRegister: ?None} => None
+    | {?wildcard, ?eventFilters, ?preRegister} =>
       let topicSelections =
         eventFilters->Option.mapWithDefault(
           [
@@ -480,6 +490,7 @@ let makeGetEventOptions = (
       HandlerTypes.EventOptions.make(
         ~isWildcard=wildcard->Option.getWithDefault(false),
         ~topicSelections,
+        ~shouldPreRegisterDynamicContracts=preRegister->Option.getWithDefault(false),
       )->Some
     }
 }

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -228,14 +228,14 @@ module HandlerTypes = {
     handler: handler<'eventArgs, 'loaderReturn>,
     wildcard?: bool,
     eventFilters?: SingleOrMultiple.t<'eventFilter>,
-    preRegister?: bool,
+    preRegisterDynamicContracts?: bool,
   }
 
   @genType
   type eventConfig<'eventFilter> = {
     wildcard?: bool,
     eventFilters?: SingleOrMultiple.t<'eventFilter>,
-    preRegister?: bool,
+    preRegisterDynamicContracts?: bool,
   }
 
   module EventOptions = {
@@ -452,7 +452,7 @@ let makeEventOptions = (
 ) => {
   let module(Event) = eventMod
   open Belt
-  eventConfig->Option.map(({?wildcard, ?eventFilters, ?preRegister}) =>
+  eventConfig->Option.map(({?wildcard, ?eventFilters, ?preRegisterDynamicContracts}) =>
     HandlerTypes.EventOptions.make(
       ~isWildcard=wildcard->Option.getWithDefault(false),
       ~topicSelections=eventFilters->Option.mapWithDefault(
@@ -463,7 +463,7 @@ let makeEventOptions = (
         ],
         v => v->Event.getTopicSelection,
       ),
-      ~shouldPreRegisterDynamicContracts=preRegister->Option.getWithDefault(false),
+      ~shouldPreRegisterDynamicContracts=preRegisterDynamicContracts->Option.getWithDefault(false),
     )
   )
 }
@@ -476,8 +476,8 @@ let makeGetEventOptions = (
   let module(Event) = eventMod
   (loaderHandler: HandlerTypes.loaderHandler<Event.eventArgs, 'loaderReturn, Event.eventFilter>) =>
     switch loaderHandler {
-    | {wildcard: ?None, eventFilters: ?None, preRegister: ?None} => None
-    | {?wildcard, ?eventFilters, ?preRegister} =>
+    | {wildcard: ?None, eventFilters: ?None, preRegisterDynamicContracts: ?None} => None
+    | {?wildcard, ?eventFilters, ?preRegisterDynamicContracts} =>
       let topicSelections =
         eventFilters->Option.mapWithDefault(
           [
@@ -490,7 +490,7 @@ let makeGetEventOptions = (
       HandlerTypes.EventOptions.make(
         ~isWildcard=wildcard->Option.getWithDefault(false),
         ~topicSelections,
-        ~shouldPreRegisterDynamicContracts=preRegister->Option.getWithDefault(false),
+        ~shouldPreRegisterDynamicContracts=preRegisterDynamicContracts->Option.getWithDefault(false),
       )->Some
     }
 }
@@ -521,6 +521,9 @@ module MakeRegister = (Event: Event) => {
         handler,
         wildcard: ?eventConfig->Belt.Option.flatMap(c => c.wildcard),
         eventFilters: ?eventConfig->Belt.Option.flatMap(c => c.eventFilters),
+        preRegisterDynamicContracts: ?eventConfig->Belt.Option.flatMap(c =>
+          c.preRegisterDynamicContracts
+        ),
       },
       ~getEventOptions=makeGetEventOptions(module(Event)),
     )

--- a/codegenerator/cli/templates/static/codegen/src/Config.res
+++ b/codegenerator/cli/templates/static/codegen/src/Config.res
@@ -42,19 +42,16 @@ type chainConfig = {
 }
 
 let shouldPreRegisterDynamicContracts = (chainConfig: chainConfig) => {
-  let accum = ref(false)
-  chainConfig.contracts->Belt.Array.forEach(contract => {
-    contract.events->Belt.Array.forEach(event => {
-      if !accum.contents {
-        let module(Event) = event
-        let {shouldPreRegisterDynamicContracts} =
-          Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
-        accum := shouldPreRegisterDynamicContracts
-      }
+  chainConfig.contracts->Array.some(contract => {
+    contract.events->Array.some(event => {
+      let module(Event) = event
+
+      let {shouldPreRegisterDynamicContracts} =
+        Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
+
+      shouldPreRegisterDynamicContracts
     })
   })
-
-  accum.contents
 }
 
 type historyFlag = FullHistory | MinHistory

--- a/codegenerator/cli/templates/static/codegen/src/Config.res
+++ b/codegenerator/cli/templates/static/codegen/src/Config.res
@@ -41,21 +41,20 @@ type chainConfig = {
   chainWorker: module(ChainWorker.S),
 }
 
-// TODO: it should be possible to opt out of pre-registering dynamic contracts
 let shouldPreRegisterDynamicContracts = (chainConfig: chainConfig) => {
-  let shouldPreRegisterDynamicContracts = ref(false)
-
+  let accum = ref(false)
   chainConfig.contracts->Belt.Array.forEach(contract => {
     contract.events->Belt.Array.forEach(event => {
-      if !shouldPreRegisterDynamicContracts.contents {
+      if !accum.contents {
         let module(Event) = event
-        shouldPreRegisterDynamicContracts :=
-          Event.handlerRegister->Types.HandlerTypes.Register.getContractRegister->Option.isSome
+        let {shouldPreRegisterDynamicContracts} =
+          Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
+        accum := shouldPreRegisterDynamicContracts
       }
     })
   })
 
-  shouldPreRegisterDynamicContracts.contents
+  accum.contents
 }
 
 type historyFlag = FullHistory | MinHistory

--- a/codegenerator/cli/templates/static/codegen/src/Config.res
+++ b/codegenerator/cli/templates/static/codegen/src/Config.res
@@ -41,6 +41,23 @@ type chainConfig = {
   chainWorker: module(ChainWorker.S),
 }
 
+// TODO: it should be possible to opt out of pre-registering dynamic contracts
+let shouldPreRegisterDynamicContracts = (chainConfig: chainConfig) => {
+  let shouldPreRegisterDynamicContracts = ref(false)
+
+  chainConfig.contracts->Belt.Array.forEach(contract => {
+    contract.events->Belt.Array.forEach(event => {
+      if !shouldPreRegisterDynamicContracts.contents {
+        let module(Event) = event
+        shouldPreRegisterDynamicContracts :=
+          Event.handlerRegister->Types.HandlerTypes.Register.getContractRegister->Option.isSome
+      }
+    })
+  })
+
+  shouldPreRegisterDynamicContracts.contents
+}
+
 type historyFlag = FullHistory | MinHistory
 type rollbackFlag = RollbackOnReorg | NoRollback
 type historyConfig = {rollbackFlag: rollbackFlag, historyFlag: historyFlag}

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -473,7 +473,6 @@ let getDynamicContractRegistrations = (
   ~latestProcessedBlocks: EventsProcessed.t,
   ~checkContractIsRegistered,
 ) => {
-  Js.log("pre-registering dynamic contracts")
   let logger = Logging.createChild(
     ~params={
       "context": "pre-registration",

--- a/codegenerator/cli/templates/static/codegen/src/Index.res
+++ b/codegenerator/cli/templates/static/codegen/src/Index.res
@@ -66,10 +66,8 @@ type mainArgs = Yargs.parsedArgs<args>
 
 let makeAppState = (globalState: GlobalState.t): EnvioInkApp.appState => {
   open Belt
-  {
-    config: globalState.config,
-    indexerStartTime: globalState.indexerStartTime,
-    chains: globalState.chainManager.chainFetchers
+  let chains =
+    globalState.chainManager.chainFetchers
     ->ChainMap.values
     ->Array.map(cf => {
       let {numEventsProcessed, fetchState, numBatchesFetched} = cf
@@ -146,7 +144,12 @@ let makeAppState = (globalState: GlobalState.t): EnvioInkApp.appState => {
           },
         }: EnvioInkApp.chainData
       )
-    }),
+    })
+  {
+    config: globalState.config,
+    indexerStartTime: globalState.indexerStartTime,
+    chains,
+    isPreRegisteringDynamicContracts: globalState.chainManager->ChainManager.isPreRegisteringDynamicContracts,
   }
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/Utils.res
+++ b/codegenerator/cli/templates/static/codegen/src/Utils.res
@@ -42,6 +42,17 @@ module Dict = {
     It's the same as `Js.Dict.get` but it doesn't have runtime overhead to check if the key exists.
    */
   external dangerouslyGetNonOption: (dict<'a>, string) => option<'a> = ""
+
+  let merge = (a: dict<'a>, b: dict<'a>) => {
+    let result = Js.Dict.empty()
+    Js.Dict.entries(a)->Js.Array2.forEach(((key, value)) => {
+      result->Js.Dict.set(key, value)
+    })
+    Js.Dict.entries(b)->Js.Array2.forEach(((key, value)) => {
+      result->Js.Dict.set(key, value)
+    })
+    result
+  }
 }
 
 module Math = {
@@ -220,8 +231,8 @@ module Schema = {
     schema->S.preprocess(s => {
       switch s.schema->S.classify {
       | Literal(Null(_))
-      // This is a workaround for Fuel Bytes type
-      | Unknown => {serializer: _ => %raw(`"null"`)}
+      | // This is a workaround for Fuel Bytes type
+      Unknown => {serializer: _ => %raw(`"null"`)}
       | Null(_)
       | Bool => {
           serializer: unknown => {

--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsImplementation.js
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsImplementation.js
@@ -16,8 +16,9 @@ const chunkBatchQuery = async (sql, entityDataArray, queryToExecute) => {
 const commaSeparateDynamicMapQuery = (sql, dynQueryConstructors) =>
   sql`${dynQueryConstructors.map(
     (constrQuery, i) =>
-      sql`${constrQuery(sql)}${i === dynQueryConstructors.length - 1 ? sql`` : sql`, `
-        }`,
+      sql`${constrQuery(sql)}${
+        i === dynQueryConstructors.length - 1 ? sql`` : sql`, `
+      }`,
   )}`;
 
 const batchSetItemsInTableCore = (table, sql, rowDataArray) => {
@@ -101,13 +102,15 @@ module.exports.batchSetEventSyncState = (sql, entityDataArray) => {
     "block_number",
     "log_index",
     "block_timestamp",
+    "is_pre_registering_dynamic_contracts",
   )}
     ON CONFLICT(chain_id) DO UPDATE
     SET
     "chain_id" = EXCLUDED."chain_id",
     "block_number" = EXCLUDED."block_number",
     "log_index" = EXCLUDED."log_index",
-    "block_timestamp" = EXCLUDED."block_timestamp";
+    "block_timestamp" = EXCLUDED."block_timestamp",
+    "is_pre_registering_dynamic_contracts" = EXCLUDED."is_pre_registering_dynamic_contracts";
     `;
 };
 
@@ -143,7 +146,7 @@ module.exports.batchSetChainMetadata = (sql, entityDataArray) => {
   "latest_fetched_block_number" = EXCLUDED."latest_fetched_block_number",
   "timestamp_caught_up_to_head_or_endblock" = EXCLUDED."timestamp_caught_up_to_head_or_endblock",
   "block_height" = EXCLUDED."block_height";`
-    .then((res) => { })
+    .then((res) => {})
     .catch((err) => {
       console.log("errored", err);
     });
@@ -163,7 +166,7 @@ module.exports.setChainMetadataBlockHeight = (sql, entityDataArray) => {
   SET
   "chain_id" = EXCLUDED."chain_id",
   "block_height" = EXCLUDED."block_height";`
-    .then((res) => { })
+    .then((res) => {})
     .catch((err) => {
       console.log("errored", err);
     });

--- a/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
@@ -13,6 +13,7 @@ module EventSyncState = {
     @as("block_number") blockNumber: int,
     @as("log_index") logIndex: int,
     @as("block_timestamp") blockTimestamp: int,
+    @as("is_pre_registering_dynamic_contracts") isPreRegisteringDynamicContracts: bool,
   }
 
   let table = mkTable(
@@ -22,6 +23,7 @@ module EventSyncState = {
       mkField("block_number", Integer),
       mkField("log_index", Integer),
       mkField("block_timestamp", Integer),
+      mkField("is_pre_registering_dynamic_contracts", Boolean),
     ],
   )
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -78,14 +78,6 @@ let getStaticContracts = (chainConfig: Config.chainConfig) => {
   })
 }
 
-module Stub = {
-  let getShouldPreRegisterDynamicContracts = (
-    handlerRegister: Types.HandlerTypes.Register.t<'eventArgs>,
-  ) => {
-    handlerRegister->Types.HandlerTypes.Register.getContractRegister->Option.isSome
-  }
-}
-
 let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition) => {
   let logger = Logging.createChild(~params={"chainId": chainConfig.chain->ChainMap.Chain.toChainId})
   let staticContracts = chainConfig->getStaticContracts

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -1,5 +1,6 @@
 open Belt
 
+type addressToDynContractLookup = dict<TablesStatic.DynamicContractRegistry.t>
 type t = {
   logger: Pino.t,
   fetchState: PartitionedFetchState.t,
@@ -19,7 +20,7 @@ type t = {
   //Currently this state applies to all chains simultaneously but it may be possible to,
   //in the future, have a per chain state and allow individual chains to start indexing as
   //soon as the pre registration is done
-  isPreRegisteringDynamicContracts: bool,
+  dynamicContractPreRegistration: option<addressToDynContractLookup>,
 }
 
 //CONSTRUCTION
@@ -38,7 +39,7 @@ let make = (
   ~numBatchesFetched,
   ~eventFilters,
   ~maxAddrInPartition,
-  ~isPreRegisteringDynamicContracts,
+  ~dynamicContractPreRegistration,
 ): t => {
   let module(ChainWorker) = chainConfig.chainWorker
   logger->Logging.childInfo("Initializing ChainFetcher with " ++ ChainWorker.name ++ " worker")
@@ -65,7 +66,7 @@ let make = (
     numBatchesFetched,
     eventFilters,
     partitionsCurrentlyFetching: Belt.Set.Int.empty,
-    isPreRegisteringDynamicContracts,
+    dynamicContractPreRegistration,
   }
 }
 
@@ -92,6 +93,9 @@ let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition) => {
     ~confirmedBlockThreshold=chainConfig.confirmedBlockThreshold,
   )
 
+  let dynamicContractPreRegistration =
+    chainConfig->Config.shouldPreRegisterDynamicContracts ? Some(Js.Dict.empty()) : None
+
   make(
     ~staticContracts,
     ~chainConfig,
@@ -107,7 +111,7 @@ let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition) => {
     ~eventFilters=None,
     ~dynamicContractRegistrations=[],
     ~maxAddrInPartition,
-    ~isPreRegisteringDynamicContracts=chainConfig->Config.shouldPreRegisterDynamicContracts,
+    ~dynamicContractPreRegistration,
   )
 }
 
@@ -122,34 +126,53 @@ let makeFromDbState = async (chainConfig: Config.chainConfig, ~maxAddrInPartitio
 
   let chainMetadata = await DbFunctions.ChainMetadata.getLatestChainMetadataState(~chainId)
 
-  let (startBlock, isPreRegisteringDynamicContracts) = latestProcessedEvent->Option.mapWithDefault(
-    (chainConfig.startBlock, chainConfig->Config.shouldPreRegisterDynamicContracts),
-    event => //start from the same block but filter out any events already processed
-    (event.blockNumber, event.isPreRegisteringDynamicContracts),
-  )
-
-  let eventFilters: option<
-    FetchState.eventFilters,
-  > = latestProcessedEvent->Option.map(event => list{
-    {
-      FetchState.filter: qItem => {
-        //Only keep events greater than the last processed event
-        (qItem.chain->ChainMap.Chain.toChainId, qItem.blockNumber, qItem.logIndex) >
-        (event.chainId, event.blockNumber, event.logIndex)
+  let (
+    startBlock: int,
+    isPreRegisteringDynamicContracts: bool,
+    eventFilters: option<FetchState.eventFilters>,
+  ) = switch latestProcessedEvent {
+  | Some(event) =>
+    //start from the same block but filter out any events already processed
+    let eventFilters = list{
+      {
+        FetchState.filter: qItem => {
+          //Only keep events greater than the last processed event
+          (qItem.chain->ChainMap.Chain.toChainId, qItem.blockNumber, qItem.logIndex) >
+          (event.chainId, event.blockNumber, event.logIndex)
+        },
+        isValid: (~fetchState, ~chain as _) => {
+          //the filter can be cleaned up as soon as the fetch state block is ahead of the latestProcessedEvent blockNumber
+          FetchState.getLatestFullyFetchedBlock(fetchState).blockNumber <= event.blockNumber
+        },
       },
-      isValid: (~fetchState, ~chain as _) => {
-        //the filter can be cleaned up as soon as the fetch state block is ahead of the latestProcessedEvent blockNumber
-        FetchState.getLatestFullyFetchedBlock(fetchState).blockNumber <= event.blockNumber
-      },
-    },
-  })
+    }
 
-  //Add all dynamic contracts from DB
-  let dynamicContractRegistrations =
+    (event.blockNumber, event.isPreRegisteringDynamicContracts, Some(eventFilters))
+  | None => (chainConfig.startBlock, chainConfig->Config.shouldPreRegisterDynamicContracts, None)
+  }
+
+  //Get all dynamic contracts already registered on the chain
+  let dbDynamicContractRegistrations =
     await DbFunctions.sql->DbFunctions.DynamicContractRegistry.readDynamicContractsOnChainIdAtOrBeforeBlock(
       ~chainId,
       ~startBlock,
     )
+
+  let (
+    dynamicContractPreRegistration: option<addressToDynContractLookup>,
+    dynamicContractRegistrations: array<TablesStatic.DynamicContractRegistry.t>,
+  ) = if isPreRegisteringDynamicContracts {
+    let dynamicContractPreRegistration: addressToDynContractLookup = Js.Dict.empty()
+    dbDynamicContractRegistrations->Array.forEach(contract => {
+      dynamicContractPreRegistration->Js.Dict.set(
+        contract.contractAddress->Address.toString,
+        contract,
+      )
+    })
+    (Some(dynamicContractPreRegistration), [])
+  } else {
+    (None, dbDynamicContractRegistrations)
+  }
 
   let (
     firstEventBlockNumber,
@@ -202,7 +225,7 @@ let makeFromDbState = async (chainConfig: Config.chainConfig, ~maxAddrInPartitio
     ~logger,
     ~eventFilters,
     ~maxAddrInPartition,
-    ~isPreRegisteringDynamicContracts,
+    ~dynamicContractPreRegistration,
   )
 }
 
@@ -376,3 +399,6 @@ let getFirstEventBlockNumber = (chainFetcher: t) =>
     chainFetcher.dbFirstEventBlockNumber,
     chainFetcher.fetchState->PartitionedFetchState.getFirstEventBlockNumber,
   )
+
+let isPreRegisteringDynamicContracts = (chainFetcher: t) =>
+  chainFetcher.dynamicContractPreRegistration->Option.isSome

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -419,7 +419,7 @@ let isFetchingAtHead = self =>
 let isPreRegisteringDynamicContracts = self =>
   self.chainFetchers
   ->ChainMap.values
-  ->Array.reduce(false, (accum, cf) => accum || cf.isPreRegisteringDynamicContracts)
+  ->Array.reduce(false, (accum, cf) => accum || cf->ChainFetcher.isPreRegisteringDynamicContracts)
 
 module ExposedForTesting_Hidden = {
   let priorityQueueComparitor = priorityQueueComparitor

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -411,6 +411,16 @@ let createBatch = (self: t, ~maxBatchSize: int) => {
   {val, isInReorgThreshold}
 }
 
+let isFetchingAtHead = self =>
+  self.chainFetchers
+  ->ChainMap.values
+  ->Array.reduce(true, (accum, cf) => accum && cf->ChainFetcher.isFetchingAtHead)
+
+let isPreRegisteringDynamicContracts = self =>
+  self.chainFetchers
+  ->ChainMap.values
+  ->Array.reduce(false, (accum, cf) => accum || cf.isPreRegisteringDynamicContracts)
+
 module ExposedForTesting_Hidden = {
   let priorityQueueComparitor = priorityQueueComparitor
   let getComparitorFromItem = getComparitorFromItem

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/ChainWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/ChainWorker.res
@@ -56,5 +56,6 @@ module type S = {
     ~logger: Pino.t,
     ~currentBlockHeight: int,
     ~setCurrentBlockHeight: int => unit,
+    ~isPreRegisteringDynamicContracts: bool,
   ) => promise<result<blockRangeFetchResponse, ErrorHandling.t>>
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -338,6 +338,7 @@ module Make = (
     ~logger,
     ~currentBlockHeight,
     ~setCurrentBlockHeight,
+    ~isPreRegisteringDynamicContracts,
   ) => {
     let mkLogAndRaise = ErrorHandling.mkLogAndRaise(~logger, ...)
     try {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -303,6 +303,7 @@ module Make = (
     ~setCurrentBlockHeight,
     ~contractAddressMapping,
     ~shouldApplyWildcards,
+    ~isPreRegisteringDynamicContracts,
   ) => {
     //Wait for a valid range to query
     //This should never have to wait since we check that the from block is below the toBlock
@@ -316,7 +317,12 @@ module Make = (
     )
 
     //Instantiate each time to add new registered contract addresses
-    let recieptsSelection = getRecieptsSelection(~contractAddressMapping, ~shouldApplyWildcards)
+    let recieptsSelection = if isPreRegisteringDynamicContracts {
+      //TODO: create receipt selections for dynamic contract preregistration
+      Js.Exn.raiseError("HyperFuel does not support pre registering dynamic contracts yet")
+    } else {
+      getRecieptsSelection(~contractAddressMapping, ~shouldApplyWildcards)
+    }
 
     let startFetchingBatchTimeRef = Hrtime.makeTimer()
 
@@ -355,6 +361,7 @@ module Make = (
         //Only apply wildcards on the first partition and root register
         //to avoid duplicate wildcard queries
         ~shouldApplyWildcards=fetchStateRegisterId == Root && partitionId == 0,
+        ~isPreRegisteringDynamicContracts,
       )
 
       //set height and next from block

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -194,7 +194,6 @@ let makeGetNextPage = (
 
     let logSelections = try {
       if isPreRegisteringDynamicContracts {
-        Js.log("pre-registering dynamic contracts hs query")
         getContractPreRegistrationLogSelection(~contractAddressMapping)
       } else {
         getLogSelectionOrThrow(~contractAddressMapping, ~shouldApplyWildcards)

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -99,12 +99,10 @@ let makeGetNextPage = (
   let contractPreregistrationEventOptions = contracts->Belt.Array.keepMap(contract => {
     let eventsOptions = contract.events->Belt.Array.keepMap(event => {
       let module(Event) = event
-      //TODO: This should be configurable via API
-      let isPreRegistration =
-        Event.handlerRegister->Types.HandlerTypes.Register.getContractRegister->Option.isSome
+      let eventOptions = Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
 
-      if isPreRegistration {
-        Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions->Some
+      if eventOptions.shouldPreRegisterDynamicContracts {
+        Some(eventOptions)
       } else {
         None
       }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -103,6 +103,7 @@ module Make = (
     ~logger,
     ~currentBlockHeight,
     ~setCurrentBlockHeight,
+    ~isPreRegisteringDynamicContracts,
   ) => {
     try {
       let {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -106,6 +106,9 @@ module Make = (
     ~isPreRegisteringDynamicContracts,
   ) => {
     try {
+      if isPreRegisteringDynamicContracts {
+        Js.Exn.raiseError("HyperIndex RPC does not support pre registering dynamic contracts yet")
+      }
       let {
         fromBlock,
         toBlock,

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -18,7 +18,6 @@ type t = {
   id: int,
 }
 
-//TODO: remove the optional bool
 let make = (~config, ~chainManager, ~loadLayer) => {
   config,
   currentlyProcessingBatch: false,
@@ -975,7 +974,6 @@ let injectedTaskReducer = (
           //On the first time we enter the reorg threshold, copy all entities to entity history
           //And set the isInReorgThreshold isInReorgThreshold state to true
           dispatchAction(SetIsInReorgThreshold(true))
-          //TODO: persist the isInReorgThreshold state to the db in a transaction with copy
           await DbFunctions.sql->DbFunctions.EntityHistory.copyAllEntitiesToEntityHistory
         }
 

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -603,9 +603,6 @@ let actionReducer = (state: t, action: action) => {
     )
   | ResetRollbackState => ({...state, rollbackState: NoRollback}, [])
   | DynamicContractPreRegisterProcessed({latestProcessedBlocks, dynamicContractRegistrations}) =>
-    Js.log("dynamic contract pre-register processed")
-    Js.log2("latest", latestProcessedBlocks->ChainMap.values)
-    Js.log2("dyn", dynamicContractRegistrations->Option.map(v => v.registrations->Array.length))
     let state = updateLatestProcessedBlocks(~state, ~latestProcessedBlocks)
 
     let state = switch dynamicContractRegistrations {
@@ -661,7 +658,7 @@ let actionReducer = (state: t, action: action) => {
       ],
     )
   | StartIndexingAfterPreRegister =>
-    Js.log("starting indexing after pre-register")
+    Logging.info("Starting indexing after pre-registration")
     let {config, chainManager, loadLayer} = state
     let chainFetchers = chainManager.chainFetchers->ChainMap.map(cf => {
       let {
@@ -914,9 +911,7 @@ let injectedTaskReducer = (
         ->Promise.all
     }
   | PreRegisterDynamicContracts =>
-    Js.log("PreRegisterDynamicContracts task")
     if !state.currentlyProcessingBatch && !isRollingBack(state) {
-      Js.log("PreRegisterDynamicContracts task if check passed")
       switch state.chainManager->ChainManager.createBatch(~maxBatchSize=state.maxBatchSize) {
       | {isInReorgThreshold: false, val: Some({batch, fetchStatesMap, arbitraryEventQueue})} =>
         dispatchAction(SetCurrentlyProcessing(true))

--- a/codegenerator/cli/templates/static/codegen/src/ink/EnvioInkApp.res
+++ b/codegenerator/cli/templates/static/codegen/src/ink/EnvioInkApp.res
@@ -6,6 +6,7 @@ type appState = {
   chains: array<ChainData.chainData>,
   indexerStartTime: Js.Date.t,
   config: Config.t,
+  isPreRegisteringDynamicContracts: bool,
 }
 
 let getTotalNumEventsProcessed = (~chains: array<ChainData.chainData>) => {
@@ -16,9 +17,12 @@ let getTotalNumEventsProcessed = (~chains: array<ChainData.chainData>) => {
 
 module TotalEventsProcessed = {
   @react.component
-  let make = (~totalEventsProcessed) => {
+  let make = (~totalEventsProcessed, ~isPreRegisteringDynamicContracts) => {
+    let label = isPreRegisteringDynamicContracts
+      ? "Total Contracts Registered: "
+      : "Total Events Processed: "
     <Text>
-      <Text bold=true> {"Total events processed: "->React.string} </Text>
+      <Text bold=true> {label->React.string} </Text>
       <Text color={Secondary}>
         {`${totalEventsProcessed->ChainData.formatLocaleString}`->React.string}
       </Text>
@@ -28,7 +32,7 @@ module TotalEventsProcessed = {
 module App = {
   @react.component
   let make = (~appState: appState) => {
-    let {chains, indexerStartTime, config} = appState
+    let {chains, indexerStartTime, config, isPreRegisteringDynamicContracts} = appState
     let hasuraPort = "8080"
     let hasuraLink = `http://localhost:${hasuraPort}`
     let totalEventsProcessed = getTotalNumEventsProcessed(~chains)
@@ -36,11 +40,11 @@ module App = {
       <BigText text="envio" colors=[Secondary, Primary] font={Block} />
       {chains
       ->Array.mapWithIndex((i, chainData) => {
-        <ChainData key={i->Int.toString} chainData />
+        <ChainData key={i->Int.toString} chainData isPreRegisteringDynamicContracts />
       })
       ->React.array}
-      <TotalEventsProcessed totalEventsProcessed />
-      <SyncETA chains indexerStartTime />
+      <TotalEventsProcessed totalEventsProcessed isPreRegisteringDynamicContracts />
+      <SyncETA chains indexerStartTime isPreRegisteringDynamicContracts />
       <Newline />
       <Box flexDirection={Column}>
         <Text bold=true> {"GraphQL:"->React.string} </Text>

--- a/codegenerator/cli/templates/static/codegen/src/ink/components/ChainData.res
+++ b/codegenerator/cli/templates/static/codegen/src/ink/components/ChainData.res
@@ -87,7 +87,7 @@ module SyncBar = {
 }
 
 @react.component
-let make = (~chainData: chainData) => {
+let make = (~chainData: chainData, ~isPreRegisteringDynamicContracts) => {
   let {
     chainId,
     progress,
@@ -120,7 +120,11 @@ let make = (~chainData: chainData) => {
     <Box flexDirection={Column}>
       <Box flexDirection={Row} justifyContent={SpaceBetween} width=Num(57)>
         <Box>
-          <Text> {"Events Processed: "->React.string} </Text>
+          <Text>
+            {isPreRegisteringDynamicContracts
+              ? "Contracts Registered: "->React.string
+              : "Events Processed: "->React.string}
+          </Text>
           <Text bold=true> {numEventsProcessed->formatLocaleString->React.string} </Text>
         </Box>
         <BlocksDisplay latestProcessedBlock currentBlockHeight=toBlock />
@@ -130,7 +134,7 @@ let make = (~chainData: chainData) => {
         loaded={latestProcessedBlock - firstEventBlockNumber}
         buffered={latestFetchedBlockNumber - firstEventBlockNumber}
         outOf={toBlock - firstEventBlockNumber}
-        loadingColor=Secondary
+        loadingColor={isPreRegisteringDynamicContracts ? Primary : Secondary}
         poweredByHyperSync
       />
       <Newline />

--- a/codegenerator/cli/templates/static/codegen/src/ink/components/SyncETA.res
+++ b/codegenerator/cli/templates/static/codegen/src/ink/components/SyncETA.res
@@ -138,9 +138,13 @@ let useEta = (~chains, ~indexerStartTime) => {
 
 module Syncing = {
   @react.component
-  let make = (~etaStr) => {
+  let make = (~etaStr, ~isPreRegisteringDynamicContracts) => {
     <Text bold=true>
-      <Text> {"Sync Time ETA: "->React.string} </Text>
+      <Text>
+        {isPreRegisteringDynamicContracts
+          ? "Start Time ETA: "->React.string
+          : "Sync Time ETA: "->React.string}
+      </Text>
       <Text> {etaStr->React.string} </Text>
       <Text> {" ("->React.string} </Text>
       <Text color=Primary>
@@ -178,14 +182,14 @@ module Calculating = {
 }
 
 @react.component
-let make = (~chains, ~indexerStartTime) => {
+let make = (~chains, ~indexerStartTime, ~isPreRegisteringDynamicContracts) => {
   let optEta = useEta(~chains, ~indexerStartTime)
   if isIndexerFullySynced(chains) {
     let latestTimeCaughtUpToHeadStr = getLatestTimeCaughtUpToHead(chains, indexerStartTime)
     <Synced latestTimeCaughtUpToHeadStr /> //TODO add real time
   } else {
     switch optEta {
-    | Some(etaStr) => <Syncing etaStr />
+    | Some(etaStr) => <Syncing etaStr isPreRegisteringDynamicContracts />
     | None => <Calculating />
     }
   }

--- a/scenarios/erc20_multichain_factory/test/ChainDataHelpers.res
+++ b/scenarios/erc20_multichain_factory/test/ChainDataHelpers.res
@@ -90,8 +90,15 @@ module Stubs = {
     ~chain,
     ~query,
     ~dispatchAction,
+    ~isPreRegisteringDynamicContracts,
   ) => {
-    (logger, currentBlockHeight, setCurrentBlockHeight, chainWorker)->ignore
+    (
+      logger,
+      currentBlockHeight,
+      setCurrentBlockHeight,
+      chainWorker,
+      isPreRegisteringDynamicContracts,
+    )->ignore
 
     let response = stubData->getMockChainData(chain)->MockChainData.executeQuery(query)
     dispatchAction(GlobalState.BlockRangeResponse(chain, response))

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -176,6 +176,7 @@ module type S = {
         ~logger: Pino.t,
         ~currentBlockHeight: int,
         ~setCurrentBlockHeight: int => unit,
+        ~isPreRegisteringDynamicContracts: bool,
       ) => promise<result<blockRangeFetchResponse, ErrorHandling.t>>
     }
   }

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -127,6 +127,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       partitionsCurrentlyFetching: Belt.Set.Int.empty,
       currentBlockHeight: 0,
       eventFilters: None,
+      dynamicContractPreRegistration: None,
     }
 
     mockChainFetcher

--- a/scenarios/test_codegen/test/HyperSyncWorker_test.res
+++ b/scenarios/test_codegen/test/HyperSyncWorker_test.res
@@ -77,6 +77,7 @@ describe("HyperSyncWorker - getNextPage", () => {
         ~setCurrentBlockHeight=_blockNumber => (),
         ~contractAddressMapping=ContractAddressingMap.make(),
         ~shouldApplyWildcards=true,
+        ~isPreRegisteringDynamicContracts=false,
       )
 
       Assert.deepEqual(
@@ -128,6 +129,7 @@ describe("HyperSyncWorker - getNextPage", () => {
         ~setCurrentBlockHeight=_blockNumber => (),
         ~contractAddressMapping=ContractAddressingMap.make(),
         ~shouldApplyWildcards=true,
+        ~isPreRegisteringDynamicContracts=false,
       )
 
       Assert.deepEqual(

--- a/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
@@ -144,33 +144,4 @@ describe("PartitionedFetchState getMostBehindPartitions", () => {
       ~message="Should have skipped partitions that are at max queue size and returned less than maxNumQueries",
     )
   })
-
-  it_only("benchmark fn", () => {
-    let maxNumQueries = 10
-    let numPartitions = 100
-
-    let partitions = Array.makeByAndShuffle(
-      numPartitions,
-      i => {
-        mockFetchState(~latestFetchedBlockNumber=i)
-      },
-    )->List.fromArray
-
-    let partitionedFetchState = mockPartitionedFetchState(~partitions)
-
-    let timeRef = Hrtime.makeTimer()
-    let _mostBehindPartitions =
-      partitionedFetchState->PartitionedFetchState.getMostBehindPartitions(
-        ~maxNumQueries,
-        ~maxPerChainQueueSize=10,
-        ~partitionsCurrentlyFetching=Set.Int.empty,
-      )
-
-    //144750
-    //169209
-    //236334
-    //257334
-    let elapsed = timeRef->Hrtime.timeSince
-    Js.log2("elapsed", elapsed)
-  })
 })

--- a/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
@@ -144,4 +144,33 @@ describe("PartitionedFetchState getMostBehindPartitions", () => {
       ~message="Should have skipped partitions that are at max queue size and returned less than maxNumQueries",
     )
   })
+
+  it_only("benchmark fn", () => {
+    let maxNumQueries = 10
+    let numPartitions = 100
+
+    let partitions = Array.makeByAndShuffle(
+      numPartitions,
+      i => {
+        mockFetchState(~latestFetchedBlockNumber=i)
+      },
+    )->List.fromArray
+
+    let partitionedFetchState = mockPartitionedFetchState(~partitions)
+
+    let timeRef = Hrtime.makeTimer()
+    let _mostBehindPartitions =
+      partitionedFetchState->PartitionedFetchState.getMostBehindPartitions(
+        ~maxNumQueries,
+        ~maxPerChainQueueSize=10,
+        ~partitionsCurrentlyFetching=Set.Int.empty,
+      )
+
+    //144750
+    //169209
+    //236334
+    //257334
+    let elapsed = timeRef->Hrtime.timeSince
+    Js.log2("elapsed", elapsed)
+  })
 })

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -69,8 +69,15 @@ module Stubs = {
     ~chain,
     ~query,
     ~dispatchAction,
+    ~isPreRegisteringDynamicContracts,
   ) => {
-    (logger, currentBlockHeight, setCurrentBlockHeight, chainWorker)->ignore
+    (
+      logger,
+      currentBlockHeight,
+      setCurrentBlockHeight,
+      chainWorker,
+      isPreRegisteringDynamicContracts,
+    )->ignore
 
     let response = mockChainData->MockChainData.executeQuery(query)
     dispatchAction(GlobalState.BlockRangeResponse(chain, response))


### PR DESCRIPTION
Implements Dynamic Contract Preregistration

- Adds separate start up process for only fetching events from contractRegister functions configured for pre registration
- Adds indexer restart resistance
- Implemented ONLY for HyperSync indexers currently (should not be much work to implement for fuel and RPC)
- Adds a TUI representation for pre registration

Before this gets merged for a release, we need to validate how the change affects the hosted service UI since events sync state table has been updated