### PR TITLE
Fix missing nested dependencies in fuel types gen causing incorrect ordering of code generation

### DIFF
--- a/codegenerator/cli/src/rescript_types.rs
+++ b/codegenerator/cli/src/rescript_types.rs
@@ -998,4 +998,29 @@ mod tests {
 
         assert_eq!(type_decl_multi.to_string(), expected);
     }
+
+    #[test]
+    fn test_recursive_type_application_dependencies() {
+        let type19 = RescriptTypeIdent::TypeApplication {
+            name: "type19".to_string(),
+            type_params: vec![RescriptTypeIdent::TypeApplication {
+                name: "type18".to_string(),
+                type_params: vec![RescriptTypeIdent::TypeApplication {
+                    name: "type17".to_string(),
+                    type_params: vec![],
+                }],
+            }],
+        };
+
+        let deps = type19.dependencies();
+
+        assert_eq!(
+            deps,
+            vec![
+                "type19".to_string(),
+                "type18".to_string(),
+                "type17".to_string()
+            ]
+        );
+    }
 }

--- a/codegenerator/cli/src/rescript_types.rs
+++ b/codegenerator/cli/src/rescript_types.rs
@@ -493,7 +493,15 @@ impl RescriptTypeIdent {
             | Self::Timestamp
             | Self::SchemaEnum(_)
             | Self::GenericParam(_) => vec![],
-            Self::TypeApplication { name, .. } => vec![name.clone()],
+            Self::TypeApplication {
+                name, type_params, ..
+            } => {
+                let mut deps = vec![name.clone()];
+                for param in type_params {
+                    deps.extend(param.dependencies());
+                }
+                deps
+            }
             Self::Array(inner_type) | Self::Option(inner_type) => inner_type.dependencies(),
             Self::Tuple(inner_types) => inner_types
                 .iter()

--- a/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
@@ -25,12 +25,12 @@
     "@envio-dev/hypersync-client": "0.6.2",
     {{/if}}
     {{#if is_fuel_ecosystem}}
-    "@fuel-ts/crypto": "0.94.6",
-    "@fuel-ts/errors": "0.94.6",
-    "@fuel-ts/hasher": "0.94.6",
-    "@fuel-ts/math": "0.94.6",
-    "@fuel-ts/utils": "0.94.6",
-    "@fuel-ts/address": "0.94.6",
+    "@fuel-ts/crypto": "0.94.9",
+    "@fuel-ts/errors": "0.94.9",
+    "@fuel-ts/hasher": "0.94.9",
+    "@fuel-ts/math": "0.94.9",
+    "@fuel-ts/utils": "0.94.9",
+    "@fuel-ts/address": "0.94.9",
     "@envio-dev/hyperfuel-client": "1.2.2",
     {{/if}}
     "@elastic/ecs-pino-format": "1.4.0",


### PR DESCRIPTION
The following type from the spark abi was resulting in the 

```json
 {
      "type": "(_, _, _, _, _, _, _)",
      "metadataTypeId": 4,
      "components": [
        {
          "name": "__tuple_element",
          "typeId": 40
        },
        {
          "name": "__tuple_element",
          "typeId": "d7649d428b9ff33d188ecbf38a7e4d8fd167fa01b2e10fe9a8f9308e52f1d7cc"
        },
        {
          "name": "__tuple_element",
          "typeId": 40
        },
        {
          "name": "__tuple_element",
          "typeId": "d7649d428b9ff33d188ecbf38a7e4d8fd167fa01b2e10fe9a8f9308e52f1d7cc"
        },
        {
          "name": "__tuple_element",
          "typeId": 19,
          "typeArguments": [
            {
              "name": "",
              "typeId": 18
            }
          ]
        },
        {
          "name": "__tuple_element",
          "typeId": "d7649d428b9ff33d188ecbf38a7e4d8fd167fa01b2e10fe9a8f9308e52f1d7cc"
        },
        {
          "name": "__tuple_element",
          "typeId": "d7649d428b9ff33d188ecbf38a7e4d8fd167fa01b2e10fe9a8f9308e52f1d7cc"
        }
      ]
    },
```

Was giving a [dependencies](https://github.com/enviodev/hyperindex/blob/615a0d694eea9fcece9cfb6cd0405b6bc1a1e5e9/codegenerator/cli/src/rescript_types.rs#L30-L31) of 
["type40", "type47", "type40", "type47", "type19", "type47", "type47"] - missing the type18

This was causing the [codegen of the rescript schema](https://github.com/enviodev/hyperindex/blob/615a0d694eea9fcece9cfb6cd0405b6bc1a1e5e9/codegenerator/cli/src/hbs_templating/codegen_templates.rs#L717-L718) to generate in the wrong order where the above type4Schema was generated before the type18Schema yet it was referencing the type18Schema in type4Schema.

The solution was to account for nested dependency types. 


