### PR TITLE
Fix restart bug with dynamic contracts

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsImplementation.js
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsImplementation.js
@@ -417,16 +417,14 @@ module.exports.deleteStaleEndOfBlockRangeScannedDataForChain = (
     ;`;
 };
 
-module.exports.readDynamicContractsOnChainIdAtOrBeforeBlock = (
+module.exports.readDynamicContractsOnChainIdBeforeEventId = (
   sql,
   chainId,
-  block_number,
+  eventId,
 ) => sql`
-  SELECT c.contract_address, c.contract_type, c.event_id, c.chain_id, c.block_timestamp
-  FROM "public"."dynamic_contract_registry" as c
-  JOIN raw_events e ON c.chain_id = e.chain_id
-  AND c.event_id = e.event_id
-  WHERE e.block_number <= ${block_number} AND e.chain_id = ${chainId};`;
+  SELECT *
+  FROM "public"."dynamic_contract_registry"
+  WHERE event_id < ${eventId} AND chain_id = ${chainId};`;
 
 //Start db operations dynamic_contract_registry
 module.exports.readDynamicContractRegistryEntities = (


### PR DESCRIPTION
Dynamic contract restart resistance has been broken since we removed `raw_events` being required.

- Fixes the query that gets dynamic contract registrations on restart
- Adds test to assert the behaviour of a restart