### PR TITLE
Fix reorg threshold bugs

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -83,6 +83,10 @@ let isQueueItemEarlierUnorderedBelowReorgThreshold = (
       ).heighestBlockBelowThreshold,
     )
   }
+  // The idea here is if we are in undordered multichain mode, always prioritize queue
+  // items that are below the reorg threshold. That way we can register contracts all
+  // the way up to the threshold on all chains before starting. 
+  // Similarly we wait till all chains are at their threshold before saving entity history.
   switch (a->isItemBelowReorgThreshold, b->isItemBelowReorgThreshold) {
   | (false, true) => true
   | (true, false) => false

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -522,7 +522,12 @@ let getNextQuery = (~eventFilters=?, ~currentBlockHeight, ~partitionId, self: t)
 type itemWithPopFn = {item: Types.eventBatchQueueItem, popItemOffQueue: unit => unit}
 
 let itemIsInReorgThreshold = (item: itemWithPopFn, ~heighestBlockBelowThreshold) => {
-  item.item.blockNumber > heighestBlockBelowThreshold
+  //Only consider it in reorg threshold when the current block number has advanced beyond 0
+  if heighestBlockBelowThreshold > 0 {
+    item.item.blockNumber > heighestBlockBelowThreshold
+  } else {
+    false
+  }
 }
 
 /**

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -172,7 +172,11 @@ describe("ChainManager", () => {
         let numberOfMockEventsReadFromQueues = ref(0)
         let allEventsRead = []
         let rec testThatCreatedEventsAreOrderedCorrectly = (chainManager, lastEvent) => {
-          let eventsInBlock = ChainManager.createBatch(chainManager, ~maxBatchSize=10000)
+          let eventsInBlock = ChainManager.createBatch(
+            chainManager,
+            ~maxBatchSize=10000,
+            ~onlyBelowReorgThreshold=false,
+          )
 
           // ensure that the events are ordered correctly
           switch eventsInBlock.val {
@@ -283,10 +287,12 @@ describe("determineNextEvent", () => {
     let determineNextEvent_unordered = ChainManager.ExposedForTesting_Hidden.createDetermineNextEventFunction(
       ~isUnorderedMultichainMode=true,
       _,
+      ~onlyBelowReorgThreshold=false,
     )
     let determineNextEvent_ordered = ChainManager.ExposedForTesting_Hidden.createDetermineNextEventFunction(
       ~isUnorderedMultichainMode=false,
       _,
+      ~onlyBelowReorgThreshold=false,
     )
 
     let makeNoItem = timestamp => FetchState.NoItem({blockTimestamp: timestamp, blockNumber: 0})


### PR DESCRIPTION
There were a few bugs with calculating that we were hitting reorg threshold multichain.

This had some knock on effects for when it would start saving entity history and also for when it would end contract pre registration