### PR TITLE
Fix querying a toBlock below fromBlock on RPC

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/EventFetching.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventFetching.res
@@ -258,7 +258,8 @@ let getContractEventsOnFilters = async (
         )
 
       let upperBoundToBlock = fromBlockRef.contents + blockInterval - 1
-      let nextToBlock = Pervasives.min(upperBoundToBlock, toBlock)
+      let nextToBlock =
+        Pervasives.min(upperBoundToBlock, toBlock)->Pervasives.max(fromBlockRef.contents) //Defensively ensure we never query a target block below fromBlock
       let eventsPromise =
         queryEventsWithCombinedFilter(
           ~contractInterfaceManager,


### PR DESCRIPTION
Closes #263 

toBlock and currentBlockHeight should always already be higher than/equal to fromBlock in the query due to this code:
https://github.com/enviodev/hyperindex/blob/25cb56791330fd4e2a7bb98db8c71d274dbf981d/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res#L494-L503

So my guess is that the blockHeight gets set lower on the waitForNextBlock function. I've made a fix here that will ensure this can't happen.

I've also added some defensive checks that the target block should never be lower than the fromBlock on RPC worker