### PR TITLE
Fixes for contract registration registers and partitions

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -55,12 +55,7 @@ let updateEventSyncState = (
   )
 }
 
-type dynamicContractRegistration = {
-  registeringEventBlockNumber: int,
-  registeringEventLogIndex: int,
-  registeringEventChain: ChainMap.Chain.t,
-  dynamicContracts: array<TablesStatic.DynamicContractRegistry.t>,
-}
+type dynamicContractRegistration = FetchState.dynamicContractRegistration
 
 type dynamicContractRegistrations = {
   registrations: array<dynamicContractRegistration>,
@@ -87,7 +82,7 @@ let addToDynamicContractRegistrations = (
   ]
 
   let dynamicContractRegistration = {
-    dynamicContracts,
+    FetchState.dynamicContracts,
     registeringEventBlockNumber,
     registeringEventLogIndex,
     registeringEventChain: eventBatchQueueItem.chain,

--- a/codegenerator/cli/templates/static/codegen/src/Utils.res
+++ b/codegenerator/cli/templates/static/codegen/src/Utils.res
@@ -43,16 +43,13 @@ module Dict = {
    */
   external dangerouslyGetNonOption: (dict<'a>, string) => option<'a> = ""
 
-  let merge = (a: dict<'a>, b: dict<'a>) => {
-    let result = Js.Dict.empty()
-    Js.Dict.entries(a)->Js.Array2.forEach(((key, value)) => {
-      result->Js.Dict.set(key, value)
-    })
-    Js.Dict.entries(b)->Js.Array2.forEach(((key, value)) => {
-      result->Js.Dict.set(key, value)
-    })
-    result
-  }
+  let merge: (dict<'a>, dict<'a>) => dict<'a> = %raw(`(dictA, dictB) => ({...dictA, ...dictB})`)
+
+  let updateImmutable: (
+    dict<'a>,
+    string,
+    'a,
+  ) => dict<'a> = %raw(`(dict, key, value) => ({...dict, [key]: value})`)
 }
 
 module Math = {

--- a/codegenerator/cli/templates/static/codegen/src/Utils.res
+++ b/codegenerator/cli/templates/static/codegen/src/Utils.res
@@ -97,6 +97,15 @@ module Array = {
     }
   }
 
+  /**
+  Creates a shallow copy of the array and sets the value at the given index
+  */
+  let setIndexImmutable = (arr: array<'a>, index: int, value: 'a): array<'a> => {
+    let shallowCopy = arr->Belt.Array.copy
+    shallowCopy->Js.Array2.unsafe_set(index, value)
+    shallowCopy
+  }
+
   let transposeResults = (results: array<result<'a, 'b>>): result<array<'a>, 'b> => {
     let rec loop = (index: int, output: array<'a>): result<array<'a>, 'b> => {
       if index >= Array.length(results) {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -295,9 +295,7 @@ let cleanUpProcessingFilters = (
   ~fetchState as {partitions}: PartitionedFetchState.t,
 ) => {
   switch processingFilters->Array.keep(processingFilter =>
-    partitions
-    ->Js.Dict.values
-    ->Array.reduce(false, (accum, partition) => {
+    partitions->Array.reduce(false, (accum, partition) => {
       accum || processingFilter.isValid(~fetchState=partition)
     })
   ) {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -295,7 +295,9 @@ let cleanUpProcessingFilters = (
   ~fetchState as {partitions}: PartitionedFetchState.t,
 ) => {
   switch processingFilters->Array.keep(processingFilter =>
-    partitions->List.reduce(false, (accum, partition) => {
+    partitions
+    ->Js.Dict.values
+    ->Array.reduce(false, (accum, partition) => {
       accum || processingFilter.isValid(~fetchState=partition)
     })
   ) {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -1025,9 +1025,14 @@ let rec rollbackRegisterList = (
 
 let rollback = (self: t, ~lastKnownValidBlock) => {
   let baseRegister = rollbackRegisterList(self.baseRegister, ~lastKnownValidBlock)
-  //TODO rollback pending dynamic contract registrations
+
+  let pendingDynamicContracts =
+    self.pendingDynamicContracts->Array.keep(({registeringEventBlockNumber}) =>
+      registeringEventBlockNumber <= lastKnownValidBlock.blockNumber
+    )
   {
     ...self,
+    pendingDynamicContracts,
     baseRegister,
   }
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -439,7 +439,7 @@ let registerDynamicContract = (self: t, registration: dynamicContractRegistratio
   isFetchingAtHead: false,
 }
 
-let registerDynamicContracts = (baseRegister, pendingDynamicContracts) => {
+let addDynamicContractRegisters = (baseRegister, pendingDynamicContracts) => {
   pendingDynamicContracts->Array.reduce(baseRegister, (
     baseRegister,
     {registeringEventBlockNumber, registeringEventLogIndex, dynamicContracts},
@@ -475,7 +475,7 @@ let applyPendingDynamicContractRegistrations = (self: t) => {
   | pendingDynamicContracts =>
     Some({
       ...self,
-      baseRegister: self.baseRegister->registerDynamicContracts(pendingDynamicContracts),
+      baseRegister: self.baseRegister->addDynamicContractRegisters(pendingDynamicContracts),
       pendingDynamicContracts: [],
     })
   }
@@ -498,7 +498,8 @@ let update = (
   baseRegister
   ->updateInternal(~id, ~latestFetchedBlock, ~reversedNewItems=newItems->Array.reverse)
   ->Result.map(updatedRegister => {
-    let withNewDynamicContracts = updatedRegister->registerDynamicContracts(pendingDynamicContracts)
+    let withNewDynamicContracts =
+      updatedRegister->addDynamicContractRegisters(pendingDynamicContracts)
     let maybeMerged = withNewDynamicContracts->pruneAndMergeNextRegistered
     {
       baseRegister: maybeMerged->Option.getWithDefault(withNewDynamicContracts),

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -86,7 +86,7 @@ As one dynamic contract register catches up to the fetched blocknumebr of the ne
 merge itself into the next register and combine queries/addresses and queues until fully caught
 up to the root. 
 */
-type fetchStateData = {
+type registerData = {
   latestFetchedBlock: blockNumberAndTimestamp,
   contractAddressMapping: ContractAddressingMap.mapping,
   //Events ordered from latest to earliest
@@ -94,22 +94,35 @@ type fetchStateData = {
   //Used to prune dynamic contract registrations in the event
   //of a rollback.
   dynamicContracts: DynamicContractsMap.t,
-  isFetchingAtHead: bool,
   firstEventBlockNumber: option<int>,
 }
 
-type rec t = {
-  registerType: register,
-  ...fetchStateData,
+type rec register = {
+  registerType: registerType,
+  ...registerData,
 }
-and register = RootRegister({endBlock: option<int>}) | DynamicContractRegister(dynamicContractId, t)
+and registerType =
+  | RootRegister({endBlock: option<int>})
+  | DynamicContractRegister({id: EventUtils.eventIndex, nextRegister: register})
+
+type dynamicContractRegistration = {
+  registeringEventBlockNumber: int,
+  registeringEventLogIndex: int,
+  registeringEventChain: ChainMap.Chain.t,
+  dynamicContracts: array<TablesStatic.DynamicContractRegistry.t>,
+}
+type t = {
+  baseRegister: register,
+  pendingDynamicContracts: array<dynamicContractRegistration>,
+  isFetchingAtHead: bool,
+}
 
 module Parent = {
-  type fetchState = t
+  type fetchState = register
   type rec t = {
     dynamicContractId: dynamicContractId,
     parent: option<t>,
-    ...fetchStateData,
+    ...registerData,
   }
 
   let make = (
@@ -118,7 +131,6 @@ module Parent = {
       contractAddressMapping,
       fetchedEventQueue,
       dynamicContracts,
-      isFetchingAtHead,
       firstEventBlockNumber,
     }: fetchState,
     ~dynamicContractId,
@@ -128,7 +140,6 @@ module Parent = {
     contractAddressMapping,
     fetchedEventQueue,
     dynamicContracts,
-    isFetchingAtHead,
     firstEventBlockNumber,
     dynamicContractId,
     parent,
@@ -140,7 +151,6 @@ module Parent = {
       contractAddressMapping,
       fetchedEventQueue,
       dynamicContracts,
-      isFetchingAtHead,
       firstEventBlockNumber,
       dynamicContractId,
       parent,
@@ -148,12 +158,11 @@ module Parent = {
     child: fetchState,
   ) => {
     let joined: fetchState = {
-      registerType: DynamicContractRegister(dynamicContractId, child),
+      registerType: DynamicContractRegister({id: dynamicContractId, nextRegister: child}),
       latestFetchedBlock,
       contractAddressMapping,
       fetchedEventQueue,
       dynamicContracts,
-      isFetchingAtHead,
       firstEventBlockNumber,
     }
 
@@ -164,27 +173,33 @@ module Parent = {
   }
 }
 
-let shallowCopyRegister = (self: t) => {
-  ...self,
-  fetchedEventQueue: self.fetchedEventQueue->Array.copy,
+let shallowCopyRegister = (register: register) => {
+  ...register,
+  fetchedEventQueue: register.fetchedEventQueue->Array.copy,
 }
 
 let copy = (self: t) => {
-  let rec loop = (self: t, ~parent=?) =>
-    switch self.registerType {
+  let rec loop = (register: register, ~parent=?) =>
+    switch register.registerType {
     | RootRegister(_) =>
-      let copied = self->shallowCopyRegister
+      let copied = register->shallowCopyRegister
       switch parent {
       | Some(parent) => parent->Parent.joinChild(copied)
       | None => copied
       }
-    | DynamicContractRegister(dynamicContractId, nextRegistered) =>
-      nextRegistered->loop(
-        ~parent=self->shallowCopyRegister->Parent.make(~dynamicContractId, ~parent),
+    | DynamicContractRegister({id, nextRegister}) =>
+      nextRegister->loop(
+        ~parent=register->shallowCopyRegister->Parent.make(~dynamicContractId=id, ~parent),
       )
     }
 
-  loop(self)
+  let baseRegister = loop(self.baseRegister)
+  let pendingDynamicContracts = self.pendingDynamicContracts->Array.copy
+  {
+    baseRegister,
+    pendingDynamicContracts,
+    isFetchingAtHead: self.isFetchingAtHead,
+  }
 }
 /**
 Comapritor for two events from the same chain. No need for chain id or timestamp
@@ -208,41 +223,40 @@ let mergeSortedEventList = (a, b) => Utils.Array.mergeSorted(eventCmp, a, b)
 /**
 Merges a node into its next registered branch. Combines contract address mappings and queues
 */
-let mergeIntoNextRegistered = (self: t) => {
+let mergeIntoNextRegistered = (self: register) => {
   switch self.registerType {
-  | DynamicContractRegister(_id, nextRegistered) =>
+  | DynamicContractRegister({nextRegister}) =>
     let fetchedEventQueue = mergeSortedEventList(
       self.fetchedEventQueue,
-      nextRegistered.fetchedEventQueue,
+      nextRegister.fetchedEventQueue,
     )
     let contractAddressMapping = ContractAddressingMap.combine(
       self.contractAddressMapping,
-      nextRegistered.contractAddressMapping,
+      nextRegister.contractAddressMapping,
     )
 
     let dynamicContracts = DynamicContractsMap.merge(
       self.dynamicContracts,
-      nextRegistered.dynamicContracts,
+      nextRegister.dynamicContracts,
     )
 
     {
-      isFetchingAtHead: nextRegistered.isFetchingAtHead,
-      registerType: nextRegistered.registerType,
+      registerType: nextRegister.registerType,
       fetchedEventQueue,
       contractAddressMapping,
       dynamicContracts,
       firstEventBlockNumber: Utils.Math.minOptInt(
         self.firstEventBlockNumber,
-        nextRegistered.firstEventBlockNumber,
+        nextRegister.firstEventBlockNumber,
       ),
       latestFetchedBlock: {
         blockTimestamp: Pervasives.max(
           self.latestFetchedBlock.blockTimestamp,
-          nextRegistered.latestFetchedBlock.blockTimestamp,
+          nextRegister.latestFetchedBlock.blockTimestamp,
         ),
         blockNumber: Pervasives.max(
           self.latestFetchedBlock.blockNumber,
-          nextRegistered.latestFetchedBlock.blockNumber,
+          nextRegister.latestFetchedBlock.blockNumber,
         ),
       },
     }
@@ -264,10 +278,10 @@ let idSchema = S.union([
 /**
 Constructs id from a register
 */
-let getRegisterId = (self: t) => {
+let getRegisterId = (self: register) => {
   switch self.registerType {
   | RootRegister(_) => Root
-  | DynamicContractRegister(id, _) => DynamicContract(id)
+  | DynamicContractRegister({id}) => DynamicContract(id)
   }
 }
 
@@ -278,22 +292,20 @@ Updates a given register with new latest block values and new fetched
 events.
 */
 let updateRegister = (
-  self: t,
+  register: register,
   ~latestFetchedBlock,
   //Events ordered latest to earliest
   ~reversedNewItems: array<Types.eventBatchQueueItem>,
-  ~isFetchingAtHead,
 ) => {
-  let firstEventBlockNumber = switch self.firstEventBlockNumber {
+  let firstEventBlockNumber = switch register.firstEventBlockNumber {
   | Some(n) => Some(n)
   | None => reversedNewItems->Utils.Array.last->Option.map(v => v.blockNumber)
   }
   {
-    ...self,
-    isFetchingAtHead,
+    ...register,
     latestFetchedBlock,
     firstEventBlockNumber,
-    fetchedEventQueue: Array.concat(reversedNewItems, self.fetchedEventQueue),
+    fetchedEventQueue: Array.concat(reversedNewItems, register.fetchedEventQueue),
   }
 }
 
@@ -302,14 +314,13 @@ Updates node at the given id with the values passed.
 Errors if the node can't be found.
 */
 let rec updateInternal = (
-  register: t,
+  register: register,
   ~id,
   ~latestFetchedBlock,
   ~reversedNewItems,
-  ~isFetchingAtHead,
   ~parent: option<Parent.t>=?,
-): result<t, exn> => {
-  let handleParent = (updated: t) => {
+): result<register, exn> => {
+  let handleParent = (updated: register) => {
     switch parent {
     | Some(parent) => parent->Parent.joinChild(updated)->Ok
     | None => updated->Ok
@@ -319,18 +330,17 @@ let rec updateInternal = (
   switch (register.registerType, id) {
   | (RootRegister(_), Root) =>
     register
-    ->updateRegister(~reversedNewItems, ~latestFetchedBlock, ~isFetchingAtHead)
+    ->updateRegister(~reversedNewItems, ~latestFetchedBlock)
     ->handleParent
-  | (DynamicContractRegister(id, _nextRegistered), DynamicContract(targetId)) if id == targetId =>
+  | (DynamicContractRegister({id}), DynamicContract(targetId)) if id == targetId =>
     register
-    ->updateRegister(~reversedNewItems, ~latestFetchedBlock, ~isFetchingAtHead)
+    ->updateRegister(~reversedNewItems, ~latestFetchedBlock)
     ->handleParent
-  | (DynamicContractRegister(dynamicContractId, nextRegistered), id) =>
-    nextRegistered->updateInternal(
+  | (DynamicContractRegister({id: dynamicContractId, nextRegister}), id) =>
+    nextRegister->updateInternal(
       ~id,
       ~latestFetchedBlock,
       ~reversedNewItems,
-      ~isFetchingAtHead,
       ~parent=register->Parent.make(~dynamicContractId, ~parent),
     )
   | (RootRegister(_), DynamicContract(_)) => Error(UnexpectedRegisterDoesNotExist(id))
@@ -341,15 +351,16 @@ let rec updateInternal = (
 If a fetchState register has caught up to its next regisered node. Merge them and recurse.
 If no merging happens, None is returned
 */
-let rec pruneAndMergeNextRegistered = (self: t, ~isMerged=false) => {
-  let merged = isMerged ? Some(self) : None
-  switch self.registerType {
+let rec pruneAndMergeNextRegistered = (register: register, ~isMerged=false) => {
+  let merged = isMerged ? Some(register) : None
+  switch register.registerType {
   | RootRegister(_) => merged
-  | DynamicContractRegister(_, nextRegister)
-    if self.latestFetchedBlock.blockNumber < nextRegister.latestFetchedBlock.blockNumber => merged
+  | DynamicContractRegister({nextRegister})
+    if register.latestFetchedBlock.blockNumber <
+    nextRegister.latestFetchedBlock.blockNumber => merged
   | DynamicContractRegister(_) =>
     // Recursively look for other merges
-    self->mergeIntoNextRegistered->pruneAndMergeNextRegistered(~isMerged=true)
+    register->mergeIntoNextRegistered->pruneAndMergeNextRegistered(~isMerged=true)
   }
 }
 
@@ -359,20 +370,22 @@ Returns Error if the node with given id cannot be found (unexpected)
 
 newItems are ordered earliest to latest (as they are returned from the worker)
 */
-let update = (self: t, ~id, ~latestFetchedBlock, ~newItems, ~currentBlockHeight): result<
-  t,
-  exn,
-> => {
-  let isFetchingAtHead =
-    currentBlockHeight <= latestFetchedBlock.blockNumber ? true : self.isFetchingAtHead
-  self
-  ->updateInternal(
-    ~id,
-    ~latestFetchedBlock,
-    ~reversedNewItems=newItems->Array.reverse,
-    ~isFetchingAtHead,
-  )
-  ->Result.map(result => pruneAndMergeNextRegistered(result)->Option.getWithDefault(result))
+let update = (
+  {baseRegister, pendingDynamicContracts, isFetchingAtHead}: t,
+  ~id,
+  ~latestFetchedBlock,
+  ~newItems,
+  ~currentBlockHeight,
+): result<t, exn> => {
+  let isFetchingAtHead = isFetchingAtHead || currentBlockHeight <= latestFetchedBlock.blockNumber
+
+  baseRegister
+  ->updateInternal(~id, ~latestFetchedBlock, ~reversedNewItems=newItems->Array.reverse)
+  ->Result.map(baseRegister => {
+    baseRegister,
+    pendingDynamicContracts,
+    isFetchingAtHead,
+  })
 }
 
 type nextQuery = {
@@ -430,13 +443,13 @@ let minOfOption: (int, option<int>) => int = (a: int, b: option<int>) => {
 Constructs `nextQuery` from a given node
 */
 let getNextQueryFromNode = (
-  {registerType, latestFetchedBlock, contractAddressMapping}: t,
+  {registerType, latestFetchedBlock, contractAddressMapping}: register,
   ~toBlock,
   ~partitionId,
 ) => {
   let (id, endBlock) = switch registerType {
   | RootRegister({endBlock}) => (Root, endBlock)
-  | DynamicContractRegister(id, _) => (DynamicContract(id), None)
+  | DynamicContractRegister({id}) => (DynamicContract(id), None)
   }
   let fromBlock = switch latestFetchedBlock.blockNumber {
   | 0 => 0
@@ -466,39 +479,10 @@ let isGreaterThanOpt: (int, option<int>) => bool = (a: int, b: option<int>) => {
   }
 }
 
-let rec getEndBlock = (self: t) => {
+let rec getEndBlock = (self: register) => {
   switch self.registerType {
   | RootRegister({endBlock}) => endBlock
-  | DynamicContractRegister(_, nextRegister) => nextRegister->getEndBlock
-  }
-}
-
-/**
-Gets the next query either with a to block of the current height if it is the root node.
-Or with a toBlock of the nextRegistered latestBlockNumber to catch up and merge with the next regisetered.
-
-Errors if nextRegistered dynamic contract has a lower latestFetchedBlock than the current as this would be
-an invalid state.
-*/
-let getNextQuery = (self: t, ~currentBlockHeight, ~partitionId) => {
-  let maybeMerged = self->pruneAndMergeNextRegistered
-  let self = maybeMerged->Option.getWithDefault(self)
-
-  let nextQuery = switch self.registerType {
-  | RootRegister({endBlock}) =>
-    self->getNextQueryFromNode(~toBlock={minOfOption(currentBlockHeight, endBlock)}, ~partitionId)
-  | DynamicContractRegister(_, {latestFetchedBlock}) =>
-    self->getNextQueryFromNode(~toBlock=latestFetchedBlock.blockNumber, ~partitionId)
-  }
-
-  switch nextQuery {
-  | {fromBlock} if fromBlock > currentBlockHeight || currentBlockHeight == 0 =>
-    (WaitForNewBlock, maybeMerged)->Ok
-  | {fromBlock, toBlock} if fromBlock <= toBlock => (NextQuery(nextQuery), maybeMerged)->Ok
-  | {fromBlock} if fromBlock->isGreaterThanOpt(getEndBlock(self)) => (Done, maybeMerged)->Ok
-  //This is an invalid case. We should never arrive at this match arm but it would be
-  //detrimental if it were the case.
-  | {fromBlock, toBlock} => Error(FromBlockIsHigherThanToBlock(fromBlock, toBlock))
+  | DynamicContractRegister({nextRegister}) => nextRegister->getEndBlock
   }
 }
 
@@ -544,7 +528,7 @@ let getCmpVal = qItem =>
 /**
 Simple constructor for no item from register
 */
-let makeNoItem = ({latestFetchedBlock}: t) => NoItem(latestFetchedBlock)
+let makeNoItem = ({latestFetchedBlock}: register) => NoItem(latestFetchedBlock)
 
 let qItemLt = (a, b) => a->getCmpVal < b->getCmpVal
 
@@ -552,7 +536,7 @@ let qItemLt = (a, b) => a->getCmpVal < b->getCmpVal
 Returns queue item WITHOUT the updated fetch state. Used for checking values
 not updating state
 */
-let getEarliestEventInRegister = (self: t) => {
+let getEarliestEventInRegister = (self: register) => {
   switch self.fetchedEventQueue->Utils.Array.last {
   | Some(head) =>
     Item({item: head, popItemOffQueue: () => self.fetchedEventQueue->Js.Array2.pop->ignore})
@@ -564,22 +548,24 @@ let getEarliestEventInRegister = (self: t) => {
 Recurses through all registers and finds the register with the earliest queue item,
 then returns its id.
 */
-let rec findRegisterIdWithEarliestQueueItem = (~currentEarliestRegister=?, self: t) => {
+let rec findRegisterIdWithEarliestQueueItem = (~currentEarliestRegister=?, register: register) => {
   let currentEarliestRegister = switch currentEarliestRegister {
-  | None => self
+  | None => register
   | Some(currentEarliestRegister) =>
     if (
-      self->getEarliestEventInRegister->qItemLt(currentEarliestRegister->getEarliestEventInRegister)
+      register
+      ->getEarliestEventInRegister
+      ->qItemLt(currentEarliestRegister->getEarliestEventInRegister)
     ) {
-      self
+      register
     } else {
       currentEarliestRegister
     }
   }
 
-  switch self.registerType {
+  switch register.registerType {
   | RootRegister(_) => currentEarliestRegister->getRegisterId
-  | DynamicContractRegister(_, nextRegister) =>
+  | DynamicContractRegister({nextRegister}) =>
     nextRegister->findRegisterIdWithEarliestQueueItem(~currentEarliestRegister)
   }
 }
@@ -590,12 +576,12 @@ fetch state with that item.
 
 Recurses through registers and Errors if ID does not exist
 */
-let rec popQItemAtRegisterId = (self: t, ~id) => {
-  switch self.registerType {
+let rec popQItemAtRegisterId = (register: register, ~id) => {
+  switch register.registerType {
   | RootRegister(_)
-  | DynamicContractRegister(_) if id == self->getRegisterId =>
-    self->getEarliestEventInRegister->Ok
-  | DynamicContractRegister(_, nextRegister) => nextRegister->popQItemAtRegisterId(~id)
+  | DynamicContractRegister(_) if id == register->getRegisterId =>
+    register->getEarliestEventInRegister->Ok
+  | DynamicContractRegister({nextRegister}) => nextRegister->popQItemAtRegisterId(~id)
   | RootRegister(_) => Error(UnexpectedRegisterDoesNotExist(id))
   }
 }
@@ -607,9 +593,9 @@ Finds the earliest queue item across all registers and then returns that
 queue item with an update fetch state.
 */
 let getEarliestEvent = (self: t) => {
-  let registerWithEarliestQItem = self->findRegisterIdWithEarliestQueueItem
+  let registerWithEarliestQItem = self.baseRegister->findRegisterIdWithEarliestQueueItem
   //Can safely unwrap here since the id is returned from self and so is guarenteed to exist
-  self->popQItemAtRegisterId(~id=registerWithEarliestQItem)->Utils.unwrapResultExn
+  self.baseRegister->popQItemAtRegisterId(~id=registerWithEarliestQItem)->Utils.unwrapResultExn
 }
 
 let makeInternal = (
@@ -653,8 +639,7 @@ let makeInternal = (
     accum->DynamicContractsMap.addAddress(dynamicContractId, contractAddress)
   })
 
-  {
-    isFetchingAtHead,
+  let baseRegister = {
     registerType,
     latestFetchedBlock: {
       blockTimestamp: 0,
@@ -664,6 +649,12 @@ let makeInternal = (
     dynamicContracts,
     fetchedEventQueue: [],
     firstEventBlockNumber: None,
+  }
+
+  {
+    baseRegister,
+    pendingDynamicContracts: [],
+    isFetchingAtHead,
   }
 }
 
@@ -686,7 +677,7 @@ let addNewRegisterToHead = (
     blockNumber: registeringEventBlockNumber,
     logIndex: registeringEventLogIndex,
   }
-  let registerType = DynamicContractRegister(id, self)
+  let registerType = DynamicContractRegister({id, nextRegister: self})
 
   let dynamicContracts =
     DynamicContractsMap.empty->DynamicContractsMap.add(
@@ -695,7 +686,6 @@ let addNewRegisterToHead = (
     )
 
   {
-    isFetchingAtHead: false,
     registerType,
     latestFetchedBlock: {
       blockNumber: registeringEventBlockNumber - 1,
@@ -714,8 +704,8 @@ chain from earliest registered contract to latest. So if this is being called on
 of registrations its best to do this in order of latest to earliest to reduce recursions
 of this function.
 */
-let rec registerDynamicContract = (
-  self: t,
+let rec addDynamicContractRegister = (
+  self: register,
   ~registeringEventBlockNumber,
   ~registeringEventLogIndex,
   ~dynamicContractRegistrations: array<TablesStatic.DynamicContractRegistry.t>,
@@ -744,8 +734,8 @@ let rec registerDynamicContract = (
   | RootRegister(_) => self->addToHead
   | DynamicContractRegister(_) if latestFetchedBlockNumber <= self.latestFetchedBlock.blockNumber =>
     self->addToHead
-  | DynamicContractRegister(dynamicContractId, nextRegister) =>
-    nextRegister->registerDynamicContract(
+  | DynamicContractRegister({id: dynamicContractId, nextRegister}) =>
+    nextRegister->addDynamicContractRegister(
       ~registeringEventBlockNumber,
       ~registeringEventLogIndex,
       ~dynamicContractRegistrations,
@@ -755,15 +745,105 @@ let rec registerDynamicContract = (
 }
 
 /**
-Calculates the cummulative queue sizes in all registers
+Adds a new dynamic contract registration. It appends the registration to the pending dynamic
+contract registrations. These pending registrations are applied to the base register when next
+query is called.
 */
-let rec queueSize = (self: t, ~accum=0) => {
-  let accum = self.fetchedEventQueue->Array.length + accum
-  switch self.registerType {
-  | RootRegister(_) => accum
-  | DynamicContractRegister(_, nextRegister) => nextRegister->queueSize(~accum)
+let registerDynamicContract = (self: t, registration: dynamicContractRegistration) => {
+  ...self,
+  pendingDynamicContracts: self.pendingDynamicContracts->Array.concat([registration]),
+  isFetchingAtHead: false,
+}
+
+let applyPendingDynamicContractRegistrations = (self: t) => {
+  switch self.pendingDynamicContracts {
+  | [] => None
+  | pendingDynamicContracts =>
+    let baseRegister = pendingDynamicContracts->Array.reduce(self.baseRegister, (
+      baseRegister,
+      {registeringEventBlockNumber, registeringEventLogIndex, dynamicContracts},
+    ) => {
+      baseRegister->addDynamicContractRegister(
+        ~registeringEventBlockNumber,
+        ~registeringEventLogIndex,
+        ~dynamicContractRegistrations=dynamicContracts,
+      )
+    })
+
+    Some({...self, baseRegister, pendingDynamicContracts: []})
   }
 }
+
+/**
+Gets the next query either with a to block of the current height if it is the root node.
+Or with a toBlock of the nextRegistered latestBlockNumber to catch up and merge with the next regisetered.
+
+Errors if nextRegistered dynamic contract has a lower latestFetchedBlock than the current as this would be
+an invalid state.
+*/
+let getNextQuery = (self: t, ~currentBlockHeight, ~partitionId) => {
+  let mapMaybeMerge = (fetchState: t) =>
+    fetchState.baseRegister
+    ->pruneAndMergeNextRegistered
+    ->Option.map(merged => {
+      ...fetchState,
+      baseRegister: merged,
+    })
+
+  //First apply pending dynamic contracts, then try and merge
+  //These steps should only happen on getNextQuery, to avoid in between states where a
+  //query is in flight and the underlying registers are changing
+  let maybeUpdatedFetchState = switch self->applyPendingDynamicContractRegistrations {
+  | Some(updatedWithDynamicContracts) =>
+    //After adding the pending dynamic contracts, try and merge registers
+    switch updatedWithDynamicContracts->mapMaybeMerge {
+    //Pass through the merged value if it updated anything
+    | Some(merged) => Some(merged)
+    //Even if the merge returned none, the pending dynamic contracts should be applied
+    //as an updated
+    | None => Some(updatedWithDynamicContracts)
+    }
+  //If no dynamic contracts were added just try and merge
+  | None => self->mapMaybeMerge
+  }
+
+  let {baseRegister} = maybeUpdatedFetchState->Option.getWithDefault(self)
+
+  let nextQuery = switch baseRegister.registerType {
+  | RootRegister({endBlock}) =>
+    baseRegister->getNextQueryFromNode(
+      ~toBlock={minOfOption(currentBlockHeight, endBlock)},
+      ~partitionId,
+    )
+  | DynamicContractRegister({nextRegister: {latestFetchedBlock}}) =>
+    baseRegister->getNextQueryFromNode(~toBlock=latestFetchedBlock.blockNumber, ~partitionId)
+  }
+
+  switch nextQuery {
+  | {fromBlock} if fromBlock > currentBlockHeight || currentBlockHeight == 0 =>
+    (WaitForNewBlock, maybeUpdatedFetchState)->Ok
+  | {fromBlock, toBlock} if fromBlock <= toBlock =>
+    (NextQuery(nextQuery), maybeUpdatedFetchState)->Ok
+  | {fromBlock} if fromBlock->isGreaterThanOpt(getEndBlock(baseRegister)) =>
+    (Done, maybeUpdatedFetchState)->Ok
+  //This is an invalid case. We should never arrive at this match arm but it would be
+  //detrimental if it were the case.
+  | {fromBlock, toBlock} => Error(FromBlockIsHigherThanToBlock(fromBlock, toBlock))
+  }
+}
+
+/**
+Calculates the cummulative queue sizes in all registers
+*/
+let rec registerQueueSize = (register: register, ~accum=0) => {
+  let accum = register.fetchedEventQueue->Array.length + accum
+  switch register.registerType {
+  | RootRegister(_) => accum
+  | DynamicContractRegister({nextRegister}) => nextRegister->registerQueueSize(~accum)
+  }
+}
+
+let queueSize = (self: t) => self.baseRegister->registerQueueSize
 
 /**
 Check the max queue size of the tip of the tree.
@@ -773,9 +853,13 @@ could be a deadlock. With a very small buffer size of the actively
 fetching registration
 */
 let isReadyForNextQuery = (self: t, ~maxQueueSize) =>
-  self.fetchedEventQueue->Array.length < maxQueueSize
+  self.baseRegister.fetchedEventQueue->Array.length < maxQueueSize
 
-let rec getAllAddressesForContract = (~addresses=Set.String.empty, ~contractName, self: t) => {
+let rec getAllAddressesForContract = (
+  ~addresses=Set.String.empty,
+  ~contractName,
+  self: register,
+) => {
   let addresses =
     self.contractAddressMapping
     ->ContractAddressingMap.getAddresses(contractName)
@@ -785,7 +869,7 @@ let rec getAllAddressesForContract = (~addresses=Set.String.empty, ~contractName
 
   switch self.registerType {
   | RootRegister(_) => addresses
-  | DynamicContractRegister(_, nextRegister) =>
+  | DynamicContractRegister({nextRegister}) =>
     nextRegister->getAllAddressesForContract(~addresses, ~contractName)
   }
 }
@@ -795,14 +879,14 @@ Recurses through registers and determines whether a contract has already been re
 the given name and address
 */
 let checkContainsRegisteredContractAddress = (self: t, ~contractName, ~contractAddress) => {
-  let allAddr = self->getAllAddressesForContract(~contractName)
+  let allAddr = self.baseRegister->getAllAddressesForContract(~contractName)
   allAddr->Set.String.has(contractAddress->Address.toString)
 }
 
 /**
 * Returns the latest block number fetched for the lowest fetcher queue (ie the earliest un-fetched dynamic contract)
 */
-let getLatestFullyFetchedBlock = (self: t) => self.latestFetchedBlock
+let getLatestFullyFetchedBlock = (self: t) => self.baseRegister.latestFetchedBlock
 
 let pruneQueuePastValidBlock = (queue: array<Types.eventBatchQueueItem>, ~lastKnownValidBlock) => {
   let prunedQueue = []
@@ -819,7 +903,7 @@ let pruneQueuePastValidBlock = (queue: array<Types.eventBatchQueueItem>, ~lastKn
   loop(0)
 }
 
-let pruneDynamicContractAddressesPastValidBlock = (~lastKnownValidBlock, register: t) => {
+let pruneDynamicContractAddressesPastValidBlock = (~lastKnownValidBlock, register: register) => {
   //get all dynamic contract addresses past valid blockNumber to remove along with
   //updated dynamicContracts map
   let (dynamicContracts, addressesToRemove) =
@@ -837,8 +921,8 @@ let pruneDynamicContractAddressesPastValidBlock = (~lastKnownValidBlock, registe
 /**
 Rolls back registers to the given valid block
 */
-let rec rollback = (
-  self: t,
+let rec rollbackRegisterList = (
+  self: register,
   ~lastKnownValidBlock: blockNumberAndTimestamp,
   ~parent: option<Parent.t>=?,
 ) => {
@@ -855,9 +939,9 @@ let rec rollback = (
     self->handleParent
   //Case 2 Dynamic register that has only fetched up to a confirmed valid block number
   //Should just return itself, with the next register rolled back recursively
-  | DynamicContractRegister(id, nextRegister)
+  | DynamicContractRegister({id, nextRegister})
     if self.latestFetchedBlock.blockNumber <= lastKnownValidBlock.blockNumber =>
-    nextRegister->rollback(
+    nextRegister->rollbackRegisterList(
       ~lastKnownValidBlock,
       ~parent=self->Parent.make(~dynamicContractId=id, ~parent),
     )
@@ -875,14 +959,14 @@ let rec rollback = (
   //Case 4 DynamicContract register that has fetched further than the confirmed valid block number
   //Should prune its queue, set its latest fetched blockdata + pruned queue
   //And recursivle prune the nextRegister
-  | DynamicContractRegister(id, nextRegister) =>
+  | DynamicContractRegister({id, nextRegister}) =>
     let updatedWithRemovedDynamicContracts =
       self->pruneDynamicContractAddressesPastValidBlock(~lastKnownValidBlock)
 
     if updatedWithRemovedDynamicContracts.contractAddressMapping->ContractAddressingMap.isEmpty {
       //If the contractAddressMapping is empty after pruning dynamic contracts, then this
       //is a dead register. Simly return its next register rolled back
-      nextRegister->rollback(~lastKnownValidBlock, ~parent?)
+      nextRegister->rollbackRegisterList(~lastKnownValidBlock, ~parent?)
     } else {
       //If there are still values in the contractAddressMapping, we should keep the register but
       //prune queues and next register
@@ -891,7 +975,7 @@ let rec rollback = (
         fetchedEventQueue: self.fetchedEventQueue->pruneQueuePastValidBlock(~lastKnownValidBlock),
         latestFetchedBlock: lastKnownValidBlock,
       }
-      nextRegister->rollback(
+      nextRegister->rollbackRegisterList(
         ~lastKnownValidBlock,
         ~parent=updated->Parent.make(~dynamicContractId=id, ~parent),
       )
@@ -899,17 +983,26 @@ let rec rollback = (
   }
 }
 
+let rollback = (self: t, ~lastKnownValidBlock) => {
+  let baseRegister = rollbackRegisterList(self.baseRegister, ~lastKnownValidBlock)
+  //TODO rollback pending dynamic contract registrations
+  {
+    ...self,
+    baseRegister,
+  }
+}
+
 /**
 * Returns a boolean indicating whether the fetch state is actively indexing
 * used for comparing event queues in the chain manager
 */
-let isActivelyIndexing = fetchState => {
+let isActivelyIndexing = ({baseRegister}: t) => {
   // nesting to limit additional unnecessary computation
-  switch fetchState.registerType {
+  switch baseRegister.registerType {
   | RootRegister({endBlock: Some(endBlock)}) =>
-    let isPastEndblock = fetchState.latestFetchedBlock.blockNumber >= endBlock
+    let isPastEndblock = baseRegister.latestFetchedBlock.blockNumber >= endBlock
     if isPastEndblock {
-      fetchState->queueSize > 0
+      baseRegister->registerQueueSize > 0
     } else {
       true
     }
@@ -917,12 +1010,15 @@ let isActivelyIndexing = fetchState => {
   }
 }
 
-let rec getNumContracts = (self: t, ~accum=0) => {
-  let accum = accum + self.contractAddressMapping->ContractAddressingMap.addressCount
-  switch self.registerType {
-  | RootRegister(_) => accum
-  | DynamicContractRegister(_, nextRegister) => nextRegister->getNumContracts(~accum)
+let getNumContracts = (self: t) => {
+  let rec loop = (register: register, ~accum=0) => {
+    let accum = accum + register.contractAddressMapping->ContractAddressingMap.addressCount
+    switch register.registerType {
+    | RootRegister(_) => accum
+    | DynamicContractRegister({nextRegister}) => nextRegister->loop(~accum)
+    }
   }
+  loop(self.baseRegister)
 }
 
 /**
@@ -932,35 +1028,35 @@ module DebugHelpers = {
   let registerToString = register =>
     switch register {
     | RootRegister(_) => "root"
-    | DynamicContractRegister({blockNumber, logIndex}, _) =>
+    | DynamicContractRegister({id: {blockNumber, logIndex}}) =>
       `DC-${blockNumber->Int.toString}-${logIndex->Int.toString}`
     }
 
-  let rec getQueueSizesInternal = (self: t, ~accum) => {
-    let next = (self.registerType->registerToString, self.fetchedEventQueue->Array.length)
+  let rec getQueueSizesInternal = (register: register, ~accum) => {
+    let next = (register.registerType->registerToString, register.fetchedEventQueue->Array.length)
     let accum = list{next, ...accum}
-    switch self.registerType {
+    switch register.registerType {
     | RootRegister(_) => accum
-    | DynamicContractRegister(_, nextRegister) => nextRegister->getQueueSizesInternal(~accum)
+    | DynamicContractRegister({nextRegister}) => nextRegister->getQueueSizesInternal(~accum)
     }
   }
 
   let getQueueSizes = (self: t) =>
-    self->getQueueSizesInternal(~accum=list{})->List.toArray->Js.Dict.fromArray
+    self.baseRegister->getQueueSizesInternal(~accum=list{})->List.toArray->Js.Dict.fromArray
 
-  let rec numberRegistered = (~accum=0, self: t) => {
+  let rec numberRegistered = (~accum=0, self: register) => {
     let accum = accum + 1
     switch self.registerType {
     | RootRegister(_) => accum
-    | DynamicContractRegister(_, nextRegister) => nextRegister->numberRegistered(~accum)
+    | DynamicContractRegister({nextRegister}) => nextRegister->numberRegistered(~accum)
     }
   }
 
-  let rec getRegisterAddressMaps = (self: t, ~accum=[]) => {
+  let rec getRegisterAddressMaps = (self: register, ~accum=[]) => {
     accum->Js.Array2.push(self.contractAddressMapping.nameByAddress)->ignore
     switch self.registerType {
     | RootRegister(_) => accum
-    | DynamicContractRegister(_, nextRegister) => nextRegister->getRegisterAddressMaps(~accum)
+    | DynamicContractRegister({nextRegister}) => nextRegister->getRegisterAddressMaps(~accum)
     }
   }
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
@@ -135,7 +135,11 @@ let registerDynamicContracts = (
   let (partitions, newestPartitionIndex) = if (
     newestPartition->FetchState.getNumContracts < maxAddrInPartition
   ) {
-    let updated = newestPartition->FetchState.registerDynamicContract(dynamicContractRegistration)
+    let updated =
+      newestPartition->FetchState.registerDynamicContract(
+        dynamicContractRegistration,
+        ~isFetchingAtHead,
+      )
     let partitions =
       partitions->Utils.Dict.updateImmutable(newestPartitionIndex->Int.toString, updated)
     (partitions, newestPartitionIndex)

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
@@ -40,7 +40,7 @@ let make = (
   let getNewestPartitionIndex = () => {
     switch newestPartitionIndexRef.contents {
     | Some(newestPartitionIndex) => newestPartitionIndex
-    | None => Js.Exn.raiseError("Unexpected no part")
+    | None => Js.Exn.raiseError("Unexpected no partions added during construction")
     }
   }
 

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -447,12 +447,7 @@ let actionReducer = (state: t, action: action) => {
     ]
 
     let nextState = registrations->Array.reduce(state, (state, registration) => {
-      let {
-        registeringEventBlockNumber,
-        registeringEventLogIndex,
-        registeringEventChain,
-        dynamicContracts,
-      } = registration
+      let {registeringEventChain, dynamicContracts} = registration
 
       let currentChainFetcher =
         state.chainManager.chainFetchers->ChainMap.get(registeringEventChain)
@@ -501,9 +496,7 @@ let actionReducer = (state: t, action: action) => {
 
       let updatedFetchState =
         currentChainFetcher.fetchState->PartitionedFetchState.registerDynamicContracts(
-          ~registeringEventBlockNumber,
-          ~registeringEventLogIndex,
-          ~dynamicContractRegistrations=dynamicContracts,
+          registration,
           ~isFetchingAtHead,
         )
 

--- a/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
@@ -210,7 +210,7 @@ describe("Dynamic contract restart resistance test", () => {
       }
 
       let dynamicContracts =
-        restartedFetchState.dynamicContracts
+        restartedFetchState.baseRegister.dynamicContracts
         ->Belt.Map.valuesToArray
         ->Array.flatMap(set => set->Belt.Set.String.toArray)
 
@@ -248,7 +248,7 @@ describe("Dynamic contract restart resistance test", () => {
         }
 
         let dynamicContracts =
-          restartedFetchState.dynamicContracts
+          restartedFetchState.baseRegister.dynamicContracts
           ->Belt.Map.valuesToArray
           ->Array.flatMap(set => set->Belt.Set.String.toArray)
 
@@ -277,7 +277,7 @@ describe("Dynamic contract restart resistance test", () => {
         restartedChainFetcher.fetchState.partitions->List.head->Option.getExn
 
       let dynamicContracts =
-        restartedFetchState.dynamicContracts
+        restartedFetchState.baseRegister.dynamicContracts
         ->Belt.Map.valuesToArray
         ->Array.flatMap(set => set->Belt.Set.String.toArray)
 

--- a/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
@@ -204,9 +204,9 @@ describe("Dynamic contract restart resistance test", () => {
         ~maxAddrInPartition=Env.maxAddrInPartition,
       )
 
-      let restartedFetchState = switch restartedChainFetcher.fetchState.partitions->List.head {
-      | Some(partition) => partition
-      | None => failwith("No partitions found in restarted chain fetcher")
+      let restartedFetchState = switch restartedChainFetcher.fetchState.partitions->Js.Dict.values {
+      | [partition] => partition
+      | _ => failwith("No partitions found in restarted chain fetcher")
       }
 
       let dynamicContracts =
@@ -242,9 +242,9 @@ describe("Dynamic contract restart resistance test", () => {
           ~maxAddrInPartition=Env.maxAddrInPartition,
         )
 
-        let restartedFetchState = switch restartedChainFetcher.fetchState.partitions->List.head {
-        | Some(partition) => partition
-        | None => failwith("No partitions found in restarted chain fetcher with")
+        let restartedFetchState = switch restartedChainFetcher.fetchState.partitions->Js.Dict.values {
+        | [partition] => partition
+        | _ => failwith("No partitions found in restarted chain fetcher with")
         }
 
         let dynamicContracts =
@@ -274,7 +274,7 @@ describe("Dynamic contract restart resistance test", () => {
       )
 
       let restartedFetchState =
-        restartedChainFetcher.fetchState.partitions->List.head->Option.getExn
+        restartedChainFetcher.fetchState.partitions->Js.Dict.values->Array.get(0)->Option.getExn
 
       let dynamicContracts =
         restartedFetchState.baseRegister.dynamicContracts

--- a/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
@@ -204,7 +204,7 @@ describe("Dynamic contract restart resistance test", () => {
         ~maxAddrInPartition=Env.maxAddrInPartition,
       )
 
-      let restartedFetchState = switch restartedChainFetcher.fetchState.partitions->Js.Dict.values {
+      let restartedFetchState = switch restartedChainFetcher.fetchState.partitions {
       | [partition] => partition
       | _ => failwith("No partitions found in restarted chain fetcher")
       }
@@ -242,7 +242,7 @@ describe("Dynamic contract restart resistance test", () => {
           ~maxAddrInPartition=Env.maxAddrInPartition,
         )
 
-        let restartedFetchState = switch restartedChainFetcher.fetchState.partitions->Js.Dict.values {
+        let restartedFetchState = switch restartedChainFetcher.fetchState.partitions {
         | [partition] => partition
         | _ => failwith("No partitions found in restarted chain fetcher with")
         }
@@ -274,7 +274,7 @@ describe("Dynamic contract restart resistance test", () => {
       )
 
       let restartedFetchState =
-        restartedChainFetcher.fetchState.partitions->Js.Dict.values->Array.get(0)->Option.getExn
+        restartedChainFetcher.fetchState.partitions->Array.get(0)->Option.getExn
 
       let dynamicContracts =
         restartedFetchState.baseRegister.dynamicContracts

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -330,14 +330,25 @@ describe("determineNextEvent", () => {
       ~latestFetchedBlockTimestamp,
       ~item,
     ): ChainManager.fetchStateWithData => {
-      partitionedFetchState: {
-        partitions: list{makeMockFetchState(~latestFetchedBlockTimestamp, ~item)},
-        maxAddrInPartition: Env.maxAddrInPartition,
-        startBlock: 0,
-        endBlock: None,
-        logger: Logging.logger,
-      },
-      heighestBlockBelowThreshold: 500,
+      let newestPartitionIndex = 0
+      let partitions =
+        [
+          (
+            newestPartitionIndex->Int.toString,
+            makeMockFetchState(~latestFetchedBlockTimestamp, ~item),
+          ),
+        ]->Js.Dict.fromArray
+      {
+        partitionedFetchState: {
+          newestPartitionIndex,
+          partitions,
+          maxAddrInPartition: Env.maxAddrInPartition,
+          startBlock: 0,
+          endBlock: None,
+          logger: Logging.logger,
+        },
+        heighestBlockBelowThreshold: 500,
+      }
     }
 
     it(

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -330,17 +330,9 @@ describe("determineNextEvent", () => {
       ~latestFetchedBlockTimestamp,
       ~item,
     ): ChainManager.fetchStateWithData => {
-      let newestPartitionIndex = 0
-      let partitions =
-        [
-          (
-            newestPartitionIndex->Int.toString,
-            makeMockFetchState(~latestFetchedBlockTimestamp, ~item),
-          ),
-        ]->Js.Dict.fromArray
+      let partitions = [makeMockFetchState(~latestFetchedBlockTimestamp, ~item)]
       {
         partitionedFetchState: {
-          newestPartitionIndex,
           partitions,
           maxAddrInPartition: Env.maxAddrInPartition,
           startBlock: 0,

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -311,16 +311,19 @@ describe("determineNextEvent", () => {
     }
 
     let makeMockFetchState = (~latestFetchedBlockTimestamp, ~item): FetchState.t => {
-      isFetchingAtHead: false,
-      registerType: RootRegister({endBlock: None}),
-      latestFetchedBlock: {
-        blockTimestamp: latestFetchedBlockTimestamp,
-        blockNumber: 0,
+      baseRegister: {
+        registerType: RootRegister({endBlock: None}),
+        latestFetchedBlock: {
+          blockTimestamp: latestFetchedBlockTimestamp,
+          blockNumber: 0,
+        },
+        contractAddressMapping: ContractAddressingMap.make(),
+        fetchedEventQueue: item->Option.mapWithDefault([], v => [v]),
+        dynamicContracts: FetchState.DynamicContractsMap.empty,
+        firstEventBlockNumber: item->Option.map(v => v.blockNumber),
       },
-      contractAddressMapping: ContractAddressingMap.make(),
-      fetchedEventQueue: item->Option.mapWithDefault([], v => [v]),
-      dynamicContracts: FetchState.DynamicContractsMap.empty,
-      firstEventBlockNumber: item->Option.map(v => v.blockNumber),
+      pendingDynamicContracts: [],
+      isFetchingAtHead: false,
     }
 
     let makeMockPartitionedFetchState = (

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -51,6 +51,12 @@ let getDynContractId = (
   logIndex: registeringEventLogIndex,
 }
 
+let makeMockFetchState = baseRegister => {
+  baseRegister,
+  pendingDynamicContracts: [],
+  isFetchingAtHead: false,
+}
+
 describe("FetchState.fetchState", () => {
   it("dynamic contract map", () => {
     let makeDcId = (blockNumber, logIndex): dynamicContractId => {
@@ -90,7 +96,7 @@ describe("FetchState.fetchState", () => {
     let dcId1 = getDynContractId(dc1)
 
     let updatedState1 =
-      root->registerDynamicContract(
+      root.baseRegister->addDynamicContractRegister(
         ~registeringEventBlockNumber=dcId1.blockNumber,
         ~registeringEventLogIndex=dcId1.logIndex,
         ~dynamicContractRegistrations=[dc1],
@@ -101,14 +107,13 @@ describe("FetchState.fetchState", () => {
       contractAddressMapping: ContractAddressingMap.fromArray([
         (dc1.contractAddress, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(
         dcId1,
         [dc1.contractAddress],
       ),
       fetchedEventQueue: [],
-      registerType: DynamicContractRegister(dcId1, root),
+      registerType: DynamicContractRegister({id: dcId1, nextRegister: root.baseRegister}),
     }
 
     Assert.deepEqual(updatedState1, expected1, ~message="1st registration")
@@ -117,7 +122,7 @@ describe("FetchState.fetchState", () => {
     let dcId2 = getDynContractId(dc2)
 
     let updatedState2 =
-      updatedState1->registerDynamicContract(
+      updatedState1->addDynamicContractRegister(
         ~registeringEventBlockNumber=dcId2.blockNumber,
         ~registeringEventLogIndex=dcId2.logIndex,
         ~dynamicContractRegistrations=[dc2],
@@ -128,19 +133,18 @@ describe("FetchState.fetchState", () => {
       contractAddressMapping: ContractAddressingMap.fromArray([
         (dc2.contractAddress, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(
         dcId2,
         [dc2.contractAddress],
       ),
       fetchedEventQueue: [],
-      registerType: DynamicContractRegister(dcId2, root),
+      registerType: DynamicContractRegister({id: dcId2, nextRegister: root.baseRegister}),
     }
 
     let expected2 = {
       ...expected1,
-      registerType: DynamicContractRegister(dcId1, expected2ChildRegister),
+      registerType: DynamicContractRegister({id: dcId1, nextRegister: expected2ChildRegister}),
     }
 
     Assert.deepEqual(updatedState2, expected2, ~message="2nd registration")
@@ -149,7 +153,7 @@ describe("FetchState.fetchState", () => {
     let dcId3 = getDynContractId(dc3)
 
     let updatedState3 =
-      updatedState2->registerDynamicContract(
+      updatedState2->addDynamicContractRegister(
         ~registeringEventBlockNumber=dcId3.blockNumber,
         ~registeringEventLogIndex=dcId3.logIndex,
         ~dynamicContractRegistrations=[dc3],
@@ -157,29 +161,28 @@ describe("FetchState.fetchState", () => {
 
     let expected3 = {
       ...expected2,
-      registerType: DynamicContractRegister(
-        dcId1,
-        {
+      registerType: DynamicContractRegister({
+        id: dcId1,
+        nextRegister: {
           ...expected2ChildRegister,
-          registerType: DynamicContractRegister(
-            dcId2,
-            {
+          registerType: DynamicContractRegister({
+            id: dcId2,
+            nextRegister: {
               latestFetchedBlock: {blockNumber: dcId3.blockNumber - 1, blockTimestamp: 0},
               contractAddressMapping: ContractAddressingMap.fromArray([
                 (dc3.contractAddress, (Gravatar :> string)),
               ]),
-              isFetchingAtHead: false,
               firstEventBlockNumber: None,
               dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(
                 dcId3,
                 [dc3.contractAddress],
               ),
               fetchedEventQueue: [],
-              registerType: DynamicContractRegister(dcId3, root),
+              registerType: DynamicContractRegister({id: dcId3, nextRegister: root.baseRegister}),
             },
-          ),
+          }),
         },
-      ),
+      }),
     }
 
     Assert.deepEqual(updatedState3, expected3, ~message="3rd registration")
@@ -206,7 +209,6 @@ describe("FetchState.fetchState", () => {
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress2, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
       fetchedEventQueue: [
@@ -214,14 +216,13 @@ describe("FetchState.fetchState", () => {
         mockEvent(~blockNumber=5),
         mockEvent(~blockNumber=1, ~logIndex=2),
       ],
-      registerType: DynamicContractRegister(
-        dcId,
-        {
+      registerType: DynamicContractRegister({
+        id: dcId,
+        nextRegister: {
           latestFetchedBlock,
           contractAddressMapping: ContractAddressingMap.fromArray([
             (mockAddress1, (Gravatar :> string)),
           ]),
-          isFetchingAtHead: false,
           firstEventBlockNumber: None,
           dynamicContracts: DynamicContractsMap.empty,
           fetchedEventQueue: [
@@ -231,7 +232,7 @@ describe("FetchState.fetchState", () => {
           ],
           registerType: RootRegister({endBlock: None}),
         },
-      ),
+      }),
     }
 
     let expected = {
@@ -240,7 +241,6 @@ describe("FetchState.fetchState", () => {
         (mockAddress2, (Gravatar :> string)),
         (mockAddress1, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
       fetchedEventQueue: [
@@ -268,12 +268,13 @@ describe("FetchState.fetchState", () => {
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress1, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: Some(1),
       dynamicContracts: DynamicContractsMap.empty,
       fetchedEventQueue: currentEvents,
       registerType: RootRegister({endBlock: None}),
     }
+
+    let fetchState = makeMockFetchState(root)
 
     let newItems = [
       mockEvent(~blockNumber=5),
@@ -281,7 +282,7 @@ describe("FetchState.fetchState", () => {
       mockEvent(~blockNumber=6, ~logIndex=2),
     ]
     let updated1 =
-      root
+      fetchState
       ->update(
         ~id=Root,
         ~latestFetchedBlock=getBlockData(~blockNumber=600),
@@ -290,27 +291,29 @@ describe("FetchState.fetchState", () => {
       )
       ->Utils.unwrapResultExn
 
-    let expected1 = {
+    let expectedRegister1 = {
       ...root,
       latestFetchedBlock: getBlockData(~blockNumber=600),
-      isFetchingAtHead: true,
       fetchedEventQueue: Array.concat(newItems->Array.reverse, currentEvents),
     }
+
+    let expected1 = expectedRegister1->makeMockFetchState
 
     Assert.deepEqual(expected1, updated1)
 
     let dcId1: dynamicContractId = {blockNumber: 100, logIndex: 0}
-    let fetchState1 = {
+    let register1 = {
       latestFetchedBlock: getBlockData(~blockNumber=500),
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress2, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId1, [mockAddress2]),
       fetchedEventQueue: [],
-      registerType: DynamicContractRegister(dcId1, root),
+      registerType: DynamicContractRegister({id: dcId1, nextRegister: root}),
     }
+
+    let fetchState1 = register1->makeMockFetchState
 
     let updated2 =
       fetchState1
@@ -322,30 +325,32 @@ describe("FetchState.fetchState", () => {
       )
       ->Utils.unwrapResultExn
 
-    let expected2 = {
-      ...expected1,
-      isFetchingAtHead: false,
+    let register2 = {
+      ...expectedRegister1,
       latestFetchedBlock: getBlockData(~blockNumber=500),
-      dynamicContracts: fetchState1.dynamicContracts,
-      contractAddressMapping: fetchState1.contractAddressMapping->ContractAddressingMap.combine(
+      dynamicContracts: register1.dynamicContracts,
+      contractAddressMapping: register1.contractAddressMapping->ContractAddressingMap.combine(
         root.contractAddressMapping,
       ),
     }
 
+    let expected2 = register2->makeMockFetchState
+
     Assert.deepEqual(expected2, updated2)
 
     let dcId2: dynamicContractId = {blockNumber: 99, logIndex: 0}
-    let fetchState2 = {
+    let register2 = {
       latestFetchedBlock: getBlockData(~blockNumber=300),
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress3, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId2, [mockAddress3]),
       fetchedEventQueue: [],
-      registerType: DynamicContractRegister(dcId2, fetchState1),
+      registerType: DynamicContractRegister({id: dcId2, nextRegister: fetchState1.baseRegister}),
     }
+
+    let fetchState2 = register2->makeMockFetchState
 
     let updated3 =
       fetchState2
@@ -357,18 +362,19 @@ describe("FetchState.fetchState", () => {
       )
       ->Utils.unwrapResultExn
 
-    let expected3 = {
-      ...fetchState2,
-      registerType: DynamicContractRegister(
-        dcId2,
-        {
-          ...fetchState1,
-          fetchedEventQueue: Array.concat(newItems->Array.reverse, fetchState1.fetchedEventQueue),
+    let expectedRegister3 = {
+      ...register2,
+      registerType: DynamicContractRegister({
+        id: dcId2,
+        nextRegister: {
+          ...register1,
+          fetchedEventQueue: Array.concat(newItems->Array.reverse, register1.fetchedEventQueue),
           firstEventBlockNumber: Some(5),
-          registerType: DynamicContractRegister(dcId1, root),
+          registerType: DynamicContractRegister({id: dcId1, nextRegister: root}),
         },
-      ),
+      }),
     }
+    let expected3 = expectedRegister3->makeMockFetchState
 
     Assert.deepEqual(expected3, updated3)
   })
@@ -377,12 +383,11 @@ describe("FetchState.fetchState", () => {
     let dcId: dynamicContractId = {blockNumber: 100, logIndex: 0}
     let latestFetchedBlock = getBlockData(~blockNumber=500)
 
-    let fetchState = {
+    let baseRegister = {
       latestFetchedBlock,
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress2, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
       fetchedEventQueue: [
@@ -390,14 +395,13 @@ describe("FetchState.fetchState", () => {
         mockEvent(~blockNumber=5),
         mockEvent(~blockNumber=1, ~logIndex=2),
       ],
-      registerType: DynamicContractRegister(
-        dcId,
-        {
+      registerType: DynamicContractRegister({
+        id: dcId,
+        nextRegister: {
           latestFetchedBlock,
           contractAddressMapping: ContractAddressingMap.fromArray([
             (mockAddress1, (Gravatar :> string)),
           ]),
-          isFetchingAtHead: false,
           firstEventBlockNumber: None,
           dynamicContracts: DynamicContractsMap.empty,
           fetchedEventQueue: [
@@ -407,8 +411,10 @@ describe("FetchState.fetchState", () => {
           ],
           registerType: RootRegister({endBlock: None}),
         },
-      ),
+      }),
     }
+
+    let fetchState = baseRegister->makeMockFetchState
 
     let earliestQueueItem = fetchState->getEarliestEvent->getItem->Option.getExn
 
@@ -422,7 +428,6 @@ describe("FetchState.fetchState", () => {
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress1, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty,
       fetchedEventQueue: [
@@ -433,10 +438,16 @@ describe("FetchState.fetchState", () => {
       registerType: RootRegister({endBlock: None}),
     }
 
+    let fetchState = {
+      baseRegister: root,
+      pendingDynamicContracts: [],
+      isFetchingAtHead: false,
+    }
+
     let partitionId = 0
     let currentBlockHeight = 600
     let (nextQuery, _optUpdatedRoot) =
-      root->getNextQuery(~partitionId, ~currentBlockHeight)->Utils.unwrapResultExn
+      fetchState->getNextQuery(~partitionId, ~currentBlockHeight)->Utils.unwrapResultExn
 
     Assert.deepEqual(
       nextQuery,
@@ -448,15 +459,19 @@ describe("FetchState.fetchState", () => {
         contractAddressMapping: root.contractAddressMapping,
       }),
     )
+
     let (nextQuery, _optUpdatedRoot) =
-      root->getNextQuery(~partitionId, ~currentBlockHeight=500)->Utils.unwrapResultExn
+      fetchState->getNextQuery(~partitionId, ~currentBlockHeight=500)->Utils.unwrapResultExn
 
     Assert.deepEqual(nextQuery, WaitForNewBlock)
 
     let endblockCase = {
-      ...root,
-      fetchedEventQueue: [],
-      registerType: RootRegister({endBlock: Some(500)}),
+      ...fetchState,
+      baseRegister: {
+        ...root,
+        fetchedEventQueue: [],
+        registerType: RootRegister({endBlock: Some(500)}),
+      },
     }
 
     let (nextQuery, _optUpdatedRoot) =
@@ -469,12 +484,11 @@ describe("FetchState.fetchState", () => {
     let dcId: dynamicContractId = {blockNumber: 100, logIndex: 0}
     let latestFetchedBlock = getBlockData(~blockNumber=500)
 
-    let fetchState = {
+    let baseRegister = {
       latestFetchedBlock,
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress2, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
       fetchedEventQueue: [
@@ -482,14 +496,13 @@ describe("FetchState.fetchState", () => {
         mockEvent(~blockNumber=5),
         mockEvent(~blockNumber=1, ~logIndex=2),
       ],
-      registerType: DynamicContractRegister(
-        dcId,
-        {
+      registerType: DynamicContractRegister({
+        id: dcId,
+        nextRegister: {
           latestFetchedBlock,
           contractAddressMapping: ContractAddressingMap.fromArray([
             (mockAddress1, (Gravatar :> string)),
           ]),
-          isFetchingAtHead: false,
           firstEventBlockNumber: None,
           dynamicContracts: DynamicContractsMap.empty,
           fetchedEventQueue: [
@@ -499,7 +512,13 @@ describe("FetchState.fetchState", () => {
           ],
           registerType: RootRegister({endBlock: None}),
         },
-      ),
+      }),
+    }
+
+    let fetchState = {
+      baseRegister,
+      pendingDynamicContracts: [],
+      isFetchingAtHead: false,
     }
 
     Assert.equal(
@@ -517,14 +536,13 @@ describe("FetchState.fetchState", () => {
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress1, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty,
       fetchedEventQueue: [mockEvent(~blockNumber=140), mockEvent(~blockNumber=99)],
       registerType: RootRegister({endBlock: Some(150)}),
     }
 
-    case1->isActivelyIndexing->Assert.equal(true)
+    case1->makeMockFetchState->isActivelyIndexing->Assert.equal(true)
     case1->getEndBlock->Assert.equal(Some(150))
 
     let case2 = {
@@ -532,14 +550,17 @@ describe("FetchState.fetchState", () => {
       fetchedEventQueue: [],
     }
 
-    case2->isActivelyIndexing->Assert.equal(false)
+    case2->makeMockFetchState->isActivelyIndexing->Assert.equal(false)
 
     let case3 = {
       ...case2,
-      registerType: DynamicContractRegister({blockNumber: 100, logIndex: 0}, case2),
+      registerType: DynamicContractRegister({
+        id: {blockNumber: 100, logIndex: 0},
+        nextRegister: case2,
+      }),
     }
 
-    case3->isActivelyIndexing->Assert.equal(true)
+    case3->makeMockFetchState->isActivelyIndexing->Assert.equal(true)
     case3->getEndBlock->Assert.equal(Some(150))
 
     let case4 = {
@@ -547,7 +568,7 @@ describe("FetchState.fetchState", () => {
       registerType: RootRegister({endBlock: Some(151)}),
     }
 
-    case4->isActivelyIndexing->Assert.equal(true)
+    case4->makeMockFetchState->isActivelyIndexing->Assert.equal(true)
     case4->getEndBlock->Assert.equal(Some(151))
 
     let case5 = {
@@ -555,7 +576,7 @@ describe("FetchState.fetchState", () => {
       registerType: RootRegister({endBlock: None}),
     }
 
-    case5->isActivelyIndexing->Assert.equal(true)
+    case5->makeMockFetchState->isActivelyIndexing->Assert.equal(true)
     case5->getEndBlock->Assert.equal(None)
   })
 
@@ -568,7 +589,6 @@ describe("FetchState.fetchState", () => {
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress1, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty,
       fetchedEventQueue: [mockEvent(~blockNumber=140), mockEvent(~blockNumber=99)],
@@ -580,19 +600,17 @@ describe("FetchState.fetchState", () => {
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress3, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId2, [mockAddress3]),
       fetchedEventQueue: [mockEvent(~blockNumber=110)],
-      registerType: DynamicContractRegister(dcId2, root),
+      registerType: DynamicContractRegister({id: dcId2, nextRegister: root}),
     }
 
-    let fetchState = {
+    let register3 = {
       latestFetchedBlock: getBlockData(~blockNumber=99),
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress2, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId1, [mockAddress2]),
       fetchedEventQueue: [
@@ -600,22 +618,25 @@ describe("FetchState.fetchState", () => {
         mockEvent(~blockNumber=5),
         mockEvent(~blockNumber=1, ~logIndex=2),
       ],
-      registerType: DynamicContractRegister(dcId1, register2),
+      registerType: DynamicContractRegister({id: dcId1, nextRegister: register2}),
     }
+
+    let fetchState = register3->makeMockFetchState
 
     let updated = fetchState->rollback(~lastKnownValidBlock=getBlockData(~blockNumber=100))
 
     let expected = {
-      ...fetchState,
-      registerType: DynamicContractRegister(
-        dcId1,
-        {
+      ...register3,
+      registerType: DynamicContractRegister({
+        id: dcId1,
+        nextRegister: {
           ...root,
           latestFetchedBlock: getBlockData(~blockNumber=100),
           fetchedEventQueue: [mockEvent(~blockNumber=99)],
         },
-      ),
-    }
+      }),
+    }->makeMockFetchState
+
     Assert.deepEqual(
       expected,
       updated,
@@ -627,12 +648,11 @@ describe("FetchState.fetchState", () => {
     let dcId: dynamicContractId = {blockNumber: 100, logIndex: 0}
     let latestFetchedBlock = getBlockData(~blockNumber=500)
 
-    let fetchState = {
+    let baseRegister = {
       latestFetchedBlock,
       contractAddressMapping: ContractAddressingMap.fromArray([
         (mockAddress2, (Gravatar :> string)),
       ]),
-      isFetchingAtHead: false,
       firstEventBlockNumber: None,
       dynamicContracts: DynamicContractsMap.empty->DynamicContractsMap.add(dcId, [mockAddress2]),
       fetchedEventQueue: [
@@ -640,14 +660,13 @@ describe("FetchState.fetchState", () => {
         mockEvent(~blockNumber=5),
         mockEvent(~blockNumber=1, ~logIndex=2),
       ],
-      registerType: DynamicContractRegister(
-        dcId,
-        {
+      registerType: DynamicContractRegister({
+        id: dcId,
+        nextRegister: {
           latestFetchedBlock,
           contractAddressMapping: ContractAddressingMap.fromArray([
             (mockAddress1, (Gravatar :> string)),
           ]),
-          isFetchingAtHead: false,
           firstEventBlockNumber: None,
           dynamicContracts: DynamicContractsMap.empty,
           fetchedEventQueue: [
@@ -657,9 +676,9 @@ describe("FetchState.fetchState", () => {
           ],
           registerType: RootRegister({endBlock: None}),
         },
-      ),
+      }),
     }
 
-    fetchState->getNumContracts->Assert.equal(2)
+    baseRegister->makeMockFetchState->getNumContracts->Assert.equal(2)
   })
 })

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -51,10 +51,10 @@ let getDynContractId = (
   logIndex: registeringEventLogIndex,
 }
 
-let makeMockFetchState = baseRegister => {
+let makeMockFetchState = (baseRegister, ~isFetchingAtHead=false) => {
   baseRegister,
   pendingDynamicContracts: [],
-  isFetchingAtHead: false,
+  isFetchingAtHead,
 }
 
 describe("FetchState.fetchState", () => {
@@ -297,9 +297,9 @@ describe("FetchState.fetchState", () => {
       fetchedEventQueue: Array.concat(newItems->Array.reverse, currentEvents),
     }
 
-    let expected1 = expectedRegister1->makeMockFetchState
+    let expected1 = expectedRegister1->makeMockFetchState(~isFetchingAtHead=true)
 
-    Assert.deepEqual(expected1, updated1)
+    Assert.deepEqual(expected1, updated1, ~message="1st register, should be fetching at head")
 
     let dcId1: dynamicContractId = {blockNumber: 100, logIndex: 0}
     let register1 = {
@@ -334,9 +334,9 @@ describe("FetchState.fetchState", () => {
       ),
     }
 
-    let expected2 = register2->makeMockFetchState
+    let expected2 = register2->makeMockFetchState(~isFetchingAtHead=false)
 
-    Assert.deepEqual(expected2, updated2)
+    Assert.deepEqual(expected2, updated2, ~message="2nd register not fetching at head")
 
     let dcId2: dynamicContractId = {blockNumber: 99, logIndex: 0}
     let register2 = {
@@ -374,9 +374,9 @@ describe("FetchState.fetchState", () => {
         },
       }),
     }
-    let expected3 = expectedRegister3->makeMockFetchState
+    let expected3 = expectedRegister3->makeMockFetchState(~isFetchingAtHead=false)
 
-    Assert.deepEqual(expected3, updated3)
+    Assert.deepEqual(expected3, updated3, ~message="3rd register not fetching at head")
   })
 
   it("getEarliest event", () => {

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -707,12 +707,15 @@ describe("FetchState.fetchState", () => {
       let mockFetchState = rootRegister->makeMockFetchState
 
       //Dynamic contract  A registered at block 100
-      let withRegisteredDynamicContractA = mockFetchState->registerDynamicContract({
-        registeringEventChain: chain,
-        registeringEventBlockNumber: 100,
-        registeringEventLogIndex: 0,
-        dynamicContracts: ["MockDynamicContractA"->Utils.magic],
-      })
+      let withRegisteredDynamicContractA = mockFetchState->registerDynamicContract(
+        {
+          registeringEventChain: chain,
+          registeringEventBlockNumber: 100,
+          registeringEventLogIndex: 0,
+          dynamicContracts: ["MockDynamicContractA"->Utils.magic],
+        },
+        ~isFetchingAtHead=false,
+      )
 
       //Received query
       let (
@@ -743,12 +746,15 @@ describe("FetchState.fetchState", () => {
 
       //Next registration happens at block 200, between the first register and the upperbound of it's query
       let withRegisteredDynamicContractB =
-        withAddedDynamicContractRegisterA->registerDynamicContract({
-          registeringEventChain: chain,
-          registeringEventBlockNumber: 200,
-          registeringEventLogIndex: 0,
-          dynamicContracts: ["MockDynamicContractB"->Utils.magic],
-        })
+        withAddedDynamicContractRegisterA->registerDynamicContract(
+          {
+            registeringEventChain: chain,
+            registeringEventBlockNumber: 200,
+            registeringEventLogIndex: 0,
+            dynamicContracts: ["MockDynamicContractB"->Utils.magic],
+          },
+          ~isFetchingAtHead=false,
+        )
 
       //Response with updated fetch state
       let updatesWithResponseFromQueryA =

--- a/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
@@ -2,30 +2,46 @@ open Belt
 open RescriptMocha
 
 describe("PartitionedFetchState getMostBehindPartitions", () => {
-  let mockFetchState = (~latestFetchedBlockNumber, ~fetchedEventQueue=[]): FetchState.t => {
-    baseRegister: {
-      registerType: RootRegister({endBlock: None}),
-      latestFetchedBlock: {
-        blockNumber: latestFetchedBlockNumber,
-        blockTimestamp: latestFetchedBlockNumber * 15,
+  let mockFetchState = (
+    ~latestFetchedBlockNumber,
+    ~fetchedEventQueue=[],
+    ~numContracts=1,
+  ): FetchState.t => {
+    let contractAddressMapping = ContractAddressingMap.make()
+
+    for i in 0 to numContracts - 1 {
+      let address = TestHelpers.Addresses.mockAddresses[i]->Option.getExn
+      contractAddressMapping->ContractAddressingMap.addAddress(~address, ~name="MockContract")
+    }
+
+    {
+      baseRegister: {
+        registerType: RootRegister({endBlock: None}),
+        latestFetchedBlock: {
+          blockNumber: latestFetchedBlockNumber,
+          blockTimestamp: latestFetchedBlockNumber * 15,
+        },
+        contractAddressMapping,
+        fetchedEventQueue,
+        dynamicContracts: FetchState.DynamicContractsMap.empty,
+        firstEventBlockNumber: None,
       },
-      contractAddressMapping: ContractAddressingMap.make(),
-      fetchedEventQueue,
-      dynamicContracts: FetchState.DynamicContractsMap.empty,
-      firstEventBlockNumber: None,
-    },
-    isFetchingAtHead: false,
-    pendingDynamicContracts: [],
+      isFetchingAtHead: false,
+      pendingDynamicContracts: [],
+    }
   }
 
-  let mockPartitionedFetchState = (~partitions: list<_>): PartitionedFetchState.t => {
+  let mockPartitionedFetchState = (
+    ~partitions: list<_>,
+    ~maxAddrInPartition=1,
+  ): PartitionedFetchState.t => {
     let partitions = partitions->List.mapWithIndex((i, p) => (i->Int.toString, p))->Js.Dict.fromList
     let newestPartitionIndex =
       partitions->Js.Dict.keys->Array.keepMap(Int.fromString)->Js.Math.maxMany_int
     {
       newestPartitionIndex,
       partitions,
-      maxAddrInPartition: 0,
+      maxAddrInPartition,
       startBlock: 0,
       endBlock: None,
       logger: Logging.logger,
@@ -152,5 +168,128 @@ describe("PartitionedFetchState getMostBehindPartitions", () => {
       [0, 1],
       ~message="Should have skipped partitions that are at max queue size and returned less than maxNumQueries",
     )
+  })
+
+  it_only("Partition id never changes when adding new partitions", () => {
+    let rootContractAddressMapping = ContractAddressingMap.make()
+
+    for i in 0 to 3 {
+      let address = TestHelpers.Addresses.mockAddresses[i]->Option.getExn
+      rootContractAddressMapping->ContractAddressingMap.addAddress(~address, ~name="MockContract")
+    }
+
+    let rootRegister: FetchState.register = {
+      registerType: RootRegister({endBlock: None}),
+      latestFetchedBlock: {
+        blockNumber: 100,
+        blockTimestamp: 100 * 15,
+      },
+      contractAddressMapping: rootContractAddressMapping,
+      fetchedEventQueue: [],
+      dynamicContracts: FetchState.DynamicContractsMap.empty,
+      firstEventBlockNumber: None,
+    }
+
+    let dynamicContractId: FetchState.dynamicContractId = {
+      blockNumber: 10,
+      logIndex: 0,
+    }
+
+    let baseRegister: FetchState.register = {
+      registerType: DynamicContractRegister({
+        id: dynamicContractId,
+        nextRegister: rootRegister,
+      }),
+      latestFetchedBlock: {
+        blockNumber: dynamicContractId.blockNumber,
+        blockTimestamp: dynamicContractId.blockNumber * 15,
+      },
+      contractAddressMapping: ContractAddressingMap.make(),
+      fetchedEventQueue: [],
+      dynamicContracts: FetchState.DynamicContractsMap.empty,
+      firstEventBlockNumber: None,
+    }
+
+    let partition0: FetchState.t = {
+      baseRegister,
+      isFetchingAtHead: false,
+      pendingDynamicContracts: [],
+    }
+
+    let maxAddrInPartition = 4
+    let partitions = list{partition0}
+
+    let partitionedFetchState = mockPartitionedFetchState(~partitions, ~maxAddrInPartition)
+    let id = {
+      PartitionedFetchState.partitionId: 0,
+      fetchStateId: DynamicContract(dynamicContractId),
+    }
+
+    //Check the expected query if requsted in this state
+    switch partitionedFetchState->PartitionedFetchState.getNextQueriesOrThrow(
+      ~currentBlockHeight=200,
+      ~maxPerChainQueueSize=10,
+      ~partitionsCurrentlyFetching=Set.Int.empty,
+    ) {
+    | (NextQuery([query]), _) =>
+      Assert.deepEqual(
+        query.fetchStateRegisterId,
+        id.fetchStateId,
+        ~message="Should have returned dynamic contract query",
+      )
+      Assert.equal(query.partitionId, id.partitionId, ~message="Should use first partition")
+    | _ => Assert.fail("Expected a single query from partitioned fetch state")
+    }
+
+    Assert.equal(
+      partitionedFetchState.partitions->Js.Dict.values->Array.length,
+      1,
+      ~message="Should have only one partition",
+    )
+
+    let updatedPartitionedFetchState =
+      partitionedFetchState->PartitionedFetchState.registerDynamicContracts(
+        {
+          registeringEventChain: ChainMap.Chain.makeUnsafe(~chainId=1),
+          registeringEventBlockNumber: 10,
+          registeringEventLogIndex: 0,
+          dynamicContracts: [
+            {
+              chainId: 1,
+              registeringEventBlockTimestamp: 10 * 15,
+              registeringEventBlockNumber: 10,
+              registeringEventLogIndex: 0,
+              registeringEventContractName: "MockFactory",
+              registeringEventName: "MockCreateGravatar",
+              registeringEventSrcAddress: TestHelpers.Addresses.mockAddresses[0]->Option.getExn,
+              contractAddress: TestHelpers.Addresses.mockAddresses[5]->Option.getExn,
+              contractType: Enums.ContractType.Gravatar,
+            },
+          ],
+        },
+        ~isFetchingAtHead=false,
+      )
+
+    Assert.equal(
+      updatedPartitionedFetchState.partitions->Js.Dict.values->Array.length,
+      2,
+      ~message="Should have added a new partition since it's over the maxAddrInPartition threshold",
+    )
+
+    //Check that the original partition is available at it's id
+    //and the new partition has not overwritten it
+    switch updatedPartitionedFetchState->PartitionedFetchState.update(
+      ~id,
+      ~currentBlockHeight=200,
+      ~latestFetchedBlock={blockNumber: 20, blockTimestamp: 20 * 15},
+      ~newItems=[],
+    ) {
+    | Ok(_) => ()
+    | Error(PartitionedFetchState.UnexpectedPartitionDoesNotExist(_)) =>
+      Assert.fail("Partition should exist")
+    | Error(FetchState.UnexpectedRegisterDoesNotExist(_)) =>
+      Assert.fail("Dynamic contract register should exist")
+    | _ => Assert.fail("Unexpected error")
+    }
   })
 })

--- a/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
@@ -18,12 +18,18 @@ describe("PartitionedFetchState getMostBehindPartitions", () => {
     pendingDynamicContracts: [],
   }
 
-  let mockPartitionedFetchState = (~partitions): PartitionedFetchState.t => {
-    partitions,
-    maxAddrInPartition: 0,
-    startBlock: 0,
-    endBlock: None,
-    logger: Logging.logger,
+  let mockPartitionedFetchState = (~partitions: list<_>): PartitionedFetchState.t => {
+    let partitions = partitions->List.mapWithIndex((i, p) => (i->Int.toString, p))->Js.Dict.fromList
+    let newestPartitionIndex =
+      partitions->Js.Dict.keys->Array.keepMap(Int.fromString)->Js.Math.maxMany_int
+    {
+      newestPartitionIndex,
+      partitions,
+      maxAddrInPartition: 0,
+      startBlock: 0,
+      endBlock: None,
+      logger: Logging.logger,
+    }
   }
   let partitions = list{
     mockFetchState(~latestFetchedBlockNumber=4),

--- a/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
@@ -170,7 +170,7 @@ describe("PartitionedFetchState getMostBehindPartitions", () => {
     )
   })
 
-  it_only("Partition id never changes when adding new partitions", () => {
+  it("Partition id never changes when adding new partitions", () => {
     let rootContractAddressMapping = ContractAddressingMap.make()
 
     for i in 0 to 3 {

--- a/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
@@ -3,16 +3,19 @@ open RescriptMocha
 
 describe("PartitionedFetchState getMostBehindPartitions", () => {
   let mockFetchState = (~latestFetchedBlockNumber, ~fetchedEventQueue=[]): FetchState.t => {
-    registerType: RootRegister({endBlock: None}),
-    latestFetchedBlock: {
-      blockNumber: latestFetchedBlockNumber,
-      blockTimestamp: latestFetchedBlockNumber * 15,
+    baseRegister: {
+      registerType: RootRegister({endBlock: None}),
+      latestFetchedBlock: {
+        blockNumber: latestFetchedBlockNumber,
+        blockTimestamp: latestFetchedBlockNumber * 15,
+      },
+      contractAddressMapping: ContractAddressingMap.make(),
+      fetchedEventQueue,
+      dynamicContracts: FetchState.DynamicContractsMap.empty,
+      firstEventBlockNumber: None,
     },
-    contractAddressMapping: ContractAddressingMap.make(),
-    fetchedEventQueue,
-    dynamicContracts: FetchState.DynamicContractsMap.empty,
-    firstEventBlockNumber: None,
     isFetchingAtHead: false,
+    pendingDynamicContracts: [],
   }
 
   let mockPartitionedFetchState = (~partitions): PartitionedFetchState.t => {

--- a/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PartitionedFetchState_test.res
@@ -35,11 +35,8 @@ describe("PartitionedFetchState getMostBehindPartitions", () => {
     ~partitions: list<_>,
     ~maxAddrInPartition=1,
   ): PartitionedFetchState.t => {
-    let partitions = partitions->List.mapWithIndex((i, p) => (i->Int.toString, p))->Js.Dict.fromList
-    let newestPartitionIndex =
-      partitions->Js.Dict.keys->Array.keepMap(Int.fromString)->Js.Math.maxMany_int
+    let partitions = partitions->List.toArray
     {
-      newestPartitionIndex,
       partitions,
       maxAddrInPartition,
       startBlock: 0,
@@ -242,7 +239,7 @@ describe("PartitionedFetchState getMostBehindPartitions", () => {
     }
 
     Assert.equal(
-      partitionedFetchState.partitions->Js.Dict.values->Array.length,
+      partitionedFetchState.partitions->Array.length,
       1,
       ~message="Should have only one partition",
     )
@@ -271,7 +268,7 @@ describe("PartitionedFetchState getMostBehindPartitions", () => {
       )
 
     Assert.equal(
-      updatedPartitionedFetchState.partitions->Js.Dict.values->Array.length,
+      updatedPartitionedFetchState.partitions->Array.length,
       2,
       ~message="Should have added a new partition since it's over the maxAddrInPartition threshold",
     )


### PR DESCRIPTION
Closes #245 

The first bug as linked above was caused by the fact that I used a list to hold partitions. The partition id was it's index in this list. When adding new partitions, since it's a list it gets added to the head. Meaning that the partition ID was not static. The bug occurs when there's an inflight "fetch block range" query for a partition, during this time a new partition gets added (shifting the partition indexes along the list) and the query response gets routed to the wrong partition.

It obviously presents as a crash when there are dynamic contract registers and it can't find the unique register id on the wrong partition. But it can happen silently when they are root register queries. This is not so bad since the events are ordered but it can give us bad "latestFetchedBlock" states between partitions. Causing strange behaviours of which partitions to execute next, or incorrect UI representation of fetch state etc.

I've fixed this by changing the data structure to use a dict to map the partitions.

The second bug is subtle and never actually presented but I added a fix for it anyhow.

It occurs when 
1. A dynamic contract fetchstate register is added upon a contract registration (say at block 100)
2. Next query is actioned and is inflight (say querying block 100-500)
3. A new fetchstate register is added between the first contract and it's upper bound query (say block 200)
4. A response happens from the first register up to the queried block, and merges into the new register before it has queried blocks 2-500. Resulting in a missed block range for that new register.

This has been fixed by adding an array of pending dynamic contract registerations to the fetchState and lazily registering them when the fetch state gets updated or when a "nextQuery" is requested meaning that the actual creation of the fetchState register never occurs when a query is in flight.

It may be worth reviewing this PR one commit at a time.