### PR TITLE
Improve Batch Set error lil bit

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/GqlDbCustomTypes.res
+++ b/codegenerator/cli/templates/static/codegen/src/GqlDbCustomTypes.res
@@ -26,9 +26,11 @@ module Int = {
 
   external fromStringUnsafe: string => int = "Number"
 
-  let schema =
-    S.union([
-      S.int,
-      S.string->S.transform(_s => {parser: string => string->fromStringUnsafe}),
-    ])->S.setName("GqlDbCustomTypes.Int")
+  let schema = S.union([
+    S.int,
+    S.string->S.transform(_s => {
+      parser: string => string->fromStringUnsafe,
+      serializer: Utils.magic,
+    }),
+  ])->S.setName("GqlDbCustomTypes.Int")
 }

--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsEntities.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsEntities.res
@@ -53,7 +53,7 @@ let makeBatchSet = (~table: Table.table, ~rowsSchema: S.schema<array<'entityRow>
     | exception exn =>
       exn->ErrorHandling.mkLogAndRaise(
         ~logger?,
-        ~msg=`Failed during batch read of entity ${table.tableName}`,
+        ~msg=`Failed during batch set of entity ${table.tableName}`,
       )
     | res => res
     }


### PR DESCRIPTION
It became:
<img width="1411" alt="image" src="https://github.com/user-attachments/assets/6fe37280-214e-4757-aa7c-36665825728a">

Instead of:
![image](https://github.com/user-attachments/assets/a265a55e-3195-47b8-a588-3a1905cd9b9d)

Still not perfect, but much better than before.

I think after the rescript-schema v9 release, we'll be able to improve it even more. It'll allow run serializing with type validation, so if we catch this null constraint error from pg, we can run the serializing with type validation and get the index of the entity where it fails. If we include it in the error, it should definitely help with debugging. Unfortunately adding the event id is difficult here.

