### PR TITLE
Add more benchmarks and improve framework

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/Benchmark.res
+++ b/codegenerator/cli/templates/static/codegen/src/Benchmark.res
@@ -41,7 +41,7 @@ module SummaryData = {
       decimalPlaces: s.matches(S.int),
     })
 
-    let make = (val: float, ~decimalPlaces=2) => {
+    let make = (val: float, ~decimalPlaces) => {
       count: 1,
       min: val,
       max: val,
@@ -59,15 +59,14 @@ module SummaryData = {
       decimalPlaces: self.decimalPlaces,
     }
   }
-
   module Group = {
     type t = dict<DataSet.t>
     let schema: S.t<t> = S.dict(DataSet.schema)
     let make = () => Js.Dict.empty()
 
-    let add = (self: t, key: string, value: float) => {
+    let add = (self: t, key: string, value: float, ~decimalPlaces=2) => {
       switch self->Utils.Dict.dangerouslyGetNonOption(key) {
-      | None => self->Js.Dict.set(key, DataSet.make(value))
+      | None => self->Js.Dict.set(key, DataSet.make(value, ~decimalPlaces))
       | Some(dataSet) => self->Js.Dict.set(key, dataSet->DataSet.add(value))
       }
     }
@@ -77,7 +76,7 @@ module SummaryData = {
   let schema = S.dict(Group.schema)
   let make = () => Js.Dict.empty()
 
-  let add = (self: t, ~group, ~label, ~value) => {
+  let add = (self: t, ~group, ~label, ~value, ~decimalPlaces=2) => {
     let group = switch self->Utils.Dict.dangerouslyGetNonOption(group) {
     | None =>
       let newGroup = Group.make()
@@ -86,7 +85,7 @@ module SummaryData = {
     | Some(group) => group
     }
 
-    group->Group.add(label, value)
+    group->Group.add(label, value, ~decimalPlaces)
   }
 }
 
@@ -110,8 +109,8 @@ module Data = {
     self.millisAccum->MillisAccum.increment(label, amount)
   }
 
-  let addSummaryData = (self: t, ~group, ~label, ~value) => {
-    self.summaryData->SummaryData.add(~group, ~label, ~value)
+  let addSummaryData = (self: t, ~group, ~label, ~value, ~decimalPlaces=2) => {
+    self.summaryData->SummaryData.add(~group, ~label, ~value, ~decimalPlaces)
   }
 }
 
@@ -179,8 +178,8 @@ let readFromCacheFile = async () => {
   }
 }
 
-let addSummaryData = (~group, ~label, ~value) => {
-  data->Data.addSummaryData(~group, ~label, ~value)
+let addSummaryData = (~group, ~label, ~value, ~decimalPlaces=2) => {
+  data->Data.addSummaryData(~group, ~label, ~value, ~decimalPlaces)
   data->saveToCacheFile
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/Benchmark.res
+++ b/codegenerator/cli/templates/static/codegen/src/Benchmark.res
@@ -126,8 +126,8 @@ module LazyWriter = {
   let lastRunTimeMillis = ref(0.)
 
   let rec start = async () => {
-    switch scheduledWriteFn.contents {
-    | Some(fn) =>
+    switch (scheduledWriteFn.contents, isWriting.contents) {
+    | (Some(fn), false) =>
       isWriting := true
       scheduledWriteFn := None
       lastRunTimeMillis := Js.Date.now()
@@ -138,7 +138,7 @@ module LazyWriter = {
       }
       isWriting := false
       await start()
-    | None => ()
+    | _ => ()
     }
   }
 

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -240,6 +240,9 @@ let runEventHandler = (
     let contextEnv = ContextEnv.make(~eventBatchQueueItem, ~logger)
     let {loader, handler} = loaderHandler
 
+    //Include the load just before handler
+    let timeBeforeHandler = Hrtime.makeTimer()
+
     let loaderReturn =
       (await runEventLoader(~contextEnv, ~loader, ~inMemoryStore, ~loadLayer))->propogate
 
@@ -260,6 +263,15 @@ let runEventHandler = (
       ->Error
       ->propogate
     | () =>
+      if Env.saveBenchmarkData {
+        let timeEnd = timeBeforeHandler->Hrtime.timeSince->Hrtime.toMillis->Hrtime.floatFromMillis
+
+        Benchmark.addSummaryData(
+          ~group="Handlers Per Event",
+          ~label=`${eventBatchQueueItem.contractName} ${eventBatchQueueItem.eventName} Handler (ms)`,
+          ~value=timeEnd,
+        )
+      }
       eventBatchQueueItem->updateEventSyncState(
         ~inMemoryStore,
         ~isPreRegisteringDynamicContracts=false,

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -270,6 +270,7 @@ let runEventHandler = (
           ~group="Handlers Per Event",
           ~label=`${eventBatchQueueItem.contractName} ${eventBatchQueueItem.eventName} Handler (ms)`,
           ~value=timeEnd,
+          ~decimalPlaces=4,
         )
       }
       eventBatchQueueItem->updateEventSyncState(

--- a/codegenerator/cli/templates/static/codegen/src/bindings/BigDecimal.res
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/BigDecimal.res
@@ -1,16 +1,16 @@
 @genType.import(("bignumber.js", "default"))
 type rec t = {
-  toString: (. unit) => string,
-  toFixed: (. int) => string,
-  plus: (. t) => t,
-  minus: (. t) => t,
-  times: (. t) => t,
-  div: (. t) => t,
-  isEqualTo: (. t) => bool,
-  gt: (. t) => bool,
-  gte: (. t) => bool,
-  lt: (. t) => bool,
-  lte: (. t) => bool,
+  toString: unit => string,
+  toFixed: int => string,
+  plus: t => t,
+  minus: t => t,
+  times: t => t,
+  div: t => t,
+  isEqualTo: t => bool,
+  gt: t => bool,
+  gte: t => bool,
+  lt: t => bool,
+  lte: t => bool,
 }
 
 // Constructors
@@ -24,12 +24,14 @@ type rec t = {
 @send external toString: t => string = "toString"
 @send external toFixed: t => string = "toFixed"
 let toInt = (b: t): option<int> => b->toString->Belt.Int.fromString
+@send external toNumber: t => float = "toNumber"
 
 // Arithmetic Operations
 @send external plus: (t, t) => t = "plus"
 @send external minus: (t, t) => t = "minus"
 @send external times: (t, t) => t = "multipliedBy"
 @send external div: (t, t) => t = "dividedBy"
+@send external sqrt: t => t = "sqrt"
 
 // Comparison
 @send external equals: (t, t) => bool = "isEqualTo"
@@ -42,16 +44,17 @@ let notEquals: (t, t) => bool = (a, b) => !equals(a, b)
 // Utilities
 let zero = fromInt(0)
 let one = fromInt(1)
+@send external decimalPlaces: (t, int) => t = "decimalPlaces"
 
 // Serialization
 let schema =
   S.string
   ->S.setName("BigDecimal")
   ->S.transform(s => {
-    parser: (. string) =>
+    parser: string =>
       switch string->fromString {
       | Some(bigDecimal) => bigDecimal
-      | None => s.fail(. "The string is not valid BigDecimal")
+      | None => s.fail("The string is not valid BigDecimal")
       },
-    serializer: (. bigDecimal) => bigDecimal.toString(),
+    serializer: bigDecimal => bigDecimal.toString(),
   })

--- a/codegenerator/cli/templates/static/codegen/src/bindings/Hrtime.res
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/Hrtime.res
@@ -1,6 +1,6 @@
-type seconds = int
-type milliseconds = int
-type nanoseconds = int
+type seconds = float
+type milliseconds = float
+type nanoseconds = float
 
 type timeTuple = (seconds, nanoseconds)
 
@@ -12,13 +12,13 @@ type timeElapsed = timeTuple
 
 @val @scope("process") external timeSince: timeRef => timeElapsed = "hrtime"
 
-let nanoToMilli = (nano: nanoseconds): milliseconds => nano / 1_000_000
-let secToMilli = (sec: seconds): milliseconds => sec * 1_000
+let nanoToMilli = (nano: nanoseconds): milliseconds => nano /. 1_000_000.
+let secToMilli = (sec: seconds): milliseconds => sec *. 1_000.
 
 let nanoToTimeTuple = (nano: nanoseconds): timeTuple => {
-  let factor = 1_000_000_000
-  let seconds = Js.Math.floor(nano->Belt.Float.fromInt /. factor->Belt.Float.fromInt)
-  let nanos = mod(nano, factor)
+  let factor = 1_000_000_000.
+  let seconds = Js.Math.floor_float(nano /. factor)
+  let nanos = mod_float(nano, factor)
   (seconds, nanos)
 }
 
@@ -26,14 +26,16 @@ let timeElapsedToNewRef = (elapsed: timeElapsed, ref: timeRef): timeRef => {
   let (elapsedSeconds, elapsedNano) = elapsed
   let (refSeconds, refNano) = ref
 
-  let (nanoExtraSeconds, remainderNanos) = nanoToTimeTuple(elapsedNano + refNano)
-  (elapsedSeconds + refSeconds + nanoExtraSeconds, remainderNanos)
+  let (nanoExtraSeconds, remainderNanos) = nanoToTimeTuple(elapsedNano +. refNano)
+  (elapsedSeconds +. refSeconds +. nanoExtraSeconds, remainderNanos)
 }
 
 let toMillis = ((sec, nano): timeElapsed): milliseconds => {
-  sec->secToMilli + nano->nanoToMilli
+  sec->secToMilli +. nano->nanoToMilli
 }
 
-let intFromMillis = Utils.magic
-let intFromNanos = Utils.magic
-let intFromSeconds = Utils.magic
+let toInt = float => float->Belt.Int.fromFloat
+let intFromMillis = toInt
+let intFromNanos = toInt
+let intFromSeconds = toInt
+let floatFromMillis = Utils.magic

--- a/codegenerator/cli/templates/static/codegen/src/bindings/Hrtime.resi
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/Hrtime.resi
@@ -21,3 +21,4 @@ let toMillis: timeElapsed => milliseconds
 let intFromMillis: milliseconds => int
 let intFromNanos: nanoseconds => int
 let intFromSeconds: seconds => int
+let floatFromMillis: milliseconds => float


### PR DESCRIPTION
1. Adds a benchmark for every event handler to help identify handler hotspots
2. Improves the framework where SummaryData is not an array of floats as a data point but a rolling accumulation. This helps with not having continuous memory increasing as pushing to these arrays. But it's not yet safe to leave running on an indexer since there's no safety added to the continuous float multiplication/summing. So at some point it could overflow the js number. We could look at converting to bigint but then we loose floating points. 
3. Improve the json file write scheduler to only write every 500ms rather than on every benchmark update. It's helpful so you can fire off many more smaller benchmarks to the data set like the per handler one I added without slowing things down too much.