### PR TITLE
Use double precision for float representation

### DIFF
--- a/codegenerator/cli/src/config_parsing/entity_parsing.rs
+++ b/codegenerator/cli/src/config_parsing/entity_parsing.rs
@@ -1394,7 +1394,7 @@ impl GqlScalar {
             }
             "Timestamp" => GqlScalar::Timestamp,
             "Bytes" => GqlScalar::Bytes,
-            _name => GqlScalar::Custom(name.to_string()),
+            name => GqlScalar::Custom(name.to_string()),
         }
     }
 
@@ -1403,7 +1403,7 @@ impl GqlScalar {
             GqlScalar::ID => PGPrimitive::Text,
             GqlScalar::String => PGPrimitive::Text,
             GqlScalar::Int => PGPrimitive::Integer,
-            GqlScalar::Float => PGPrimitive::Numeric(None), // Should we allow this type? Rounding issues will abound.
+            GqlScalar::Float => PGPrimitive::DoublePrecision, // Should we allow this type? Rounding issues will abound.
             GqlScalar::Boolean => PGPrimitive::Boolean,
             GqlScalar::Bytes => PGPrimitive::Text,
             GqlScalar::BigInt(None) => PGPrimitive::Numeric(None),

--- a/codegenerator/cli/src/config_parsing/postgres_types.rs
+++ b/codegenerator/cli/src/config_parsing/postgres_types.rs
@@ -8,6 +8,7 @@ pub enum Primitive {
     Text,
     Integer,
     Numeric(Option<(u32, u32)>), // (precision, scale)
+    DoublePrecision,
     Serial,
     Json,
     Timestamp,
@@ -27,6 +28,7 @@ impl Primitive {
             Self::Serial => "Serial".to_string(),
             Self::Json => "Json".to_string(),
             Self::Timestamp => "Timestamp".to_string(),
+            Self::DoublePrecision => "DoublePrecision".to_string(),
             Self::Enum(enum_name) => format!("Custom(Enums.{enum_name}.enum.name)"),
         }
     }

--- a/codegenerator/cli/templates/static/codegen/src/db/Table.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/Table.res
@@ -7,6 +7,7 @@ type fieldType =
   | @as("INTEGER") Integer
   | @as("BOOLEAN") Boolean
   | @as("NUMERIC") Numeric
+  | @as("DOUBLE PRECISION") DoublePrecision
   | @as("TEXT") Text
   | @as("SERIAL") Serial
   | @as("JSONB") JsonB


### PR DESCRIPTION
Closes #187 

- We do now have BigDecimal type that uses numeric so if "Double Precision" is not enough they can just use that.
- Double Precision maps to a  "Float" scalar in Hasura so it solves the given problem.
- There is already a test in test_codegen on the entity `EntityWithAllTypes` that validates de/serialising and writing to the db.
- Double Precision is also handled by the `HASURA_GRAPHQL_STRINGIFY_NUMERIC_TYPES` variable we already set for hasura.

This should probably at least go into a minor release since it could break an indexer that already uses the "Float" type.