### PR TITLE
Fix stale action invalidation in global state manager

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalStateManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalStateManager.res
@@ -35,11 +35,14 @@ module MakeManager = (S: State) => {
       NodeJsLocal.process->NodeJsLocal.exitWithCode(Failure)
     }
   }
-  and dispatchTask = (self, task: S.task) => Js.Global.setTimeout(() => {
+  and dispatchTask = (self, task: S.task) => {
+    let stateId = self.state->S.getId
+    Js.Global.setTimeout(() => {
       S.taskReducer(self.state, task, ~dispatchAction=action =>
-        dispatchAction(~stateId=self.state->S.getId, self, action)
+        dispatchAction(~stateId, self, action)
       )->ignore
     }, 0)->ignore
+  }
 
   let getState = self => self.state
   let setState = (self: t, state: S.t) => self.state = state


### PR DESCRIPTION
Closes #311 

The bug was being caused by a stale action being dispatched (from before the restart after pre registration)

This PR:

1. Fixes the state id invalidator that is also used in rollbacks
2. Uses state id to invalidate stale actions after the indexer starts with