### PR TITLE
Update sync state and raw events regardless of handler registration

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
@@ -140,8 +140,6 @@ module EventFunctions = {
       | None => () //No need to run contract registration
       }
 
-      let latestProcessedBlocks = EventProcessing.EventsProcessed.makeEmpty(~config)
-
       switch handlerRegister->Types.HandlerTypes.Register.getLoaderHandler {
       | Some(loaderHandler) =>
         switch await eventBatchQueueItem->EventProcessing.runEventHandler(
@@ -149,8 +147,6 @@ module EventFunctions = {
           ~loadLayer,
           ~loaderHandler,
           ~logger,
-          ~latestProcessedBlocks,
-          ~config,
           ~isInReorgThreshold=false,
         ) {
         | Ok(_) => ()

--- a/scenarios/test_codegen/test/Mock_test.res
+++ b/scenarios/test_codegen/test/Mock_test.res
@@ -5,7 +5,6 @@ let inMemoryStore = InMemoryStore.make()
 
 describe("E2E Mock Event Batch", () => {
   Async.before(async () => {
-    let config = RegisterHandlers.registerAllHandlers()
     DbStub.setGravatarDb(~gravatar=MockEntities.gravatarEntity1)
     DbStub.setGravatarDb(~gravatar=MockEntities.gravatarEntity2)
     // EventProcessing.processEventBatch(MockEvents.eventBatch)
@@ -17,14 +16,12 @@ describe("E2E Mock Event Batch", () => {
       | Some(loaderHandler) =>
         await eventBatchQueueItem->EventProcessing.runEventHandler(
           ~loaderHandler,
-          ~latestProcessedBlocks=EventProcessing.EventsProcessed.makeEmpty(~config),
           ~inMemoryStore,
           ~logger=Logging.logger,
           ~loadLayer,
-          ~config,
           ~isInReorgThreshold=false,
         )
-      | None => Ok(EventProcessing.EventsProcessed.makeEmpty(~config))
+      | None => Ok()
       }
     }
 


### PR DESCRIPTION
A quick one to close #282 

This actually is a small bug for restarts in an edgecase described below, also I think it's an improvement.

Before this change, an event that doesn't have a handler registered (even if it has a contractRegister instead) 

1. does not count towards number of events processed on UI
2. does not increment event sync state table (this should be atomic and it's what gets read on restarts)
3. does not add the event to raw_events table (when it's configured to)

The edgecase bug this can cause is if the last event processed had only a contractRegister function. The event sync state will not increase and on a restart it would then include the event that had already been processed. There should be no crash or double processing though since it would only have a contractRegister function and this is already protected against double registrations.