### PR TITLE
 Require Rescript-schema in top-level package.json

### DIFF
--- a/codegenerator/cli/templates/dynamic/init_templates/shared/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/init_templates/shared/package.json.hbs
@@ -33,6 +33,7 @@
     "@glennsl/rescript-fetch": "0.2.0",
     "@ryyppy/rescript-promise": "2.1.0",
     "rescript": "11.1.3",
+    "rescript-schema": "8.2.0",
   {{/if}}
   {{#if is_typescript}}
     "@types/chai": "^4.3.11",    


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/eedf58df-e223-4b1c-9d02-6560f91d47d5)

 I can't explain why I had this issue all of a sudden on the latest version, but I did... (2 weeks ago I didn't have this issue, only had this issue: https://github.com/JasoonS/basic-envio-ens-example/commit/19144a93903d9ebae2575081e290557d5066382f - but that has been fixed :pray: )