### PR TITLE
Mark MevCommit as HyperSync

### DIFF
--- a/codegenerator/cli/src/config_parsing/chain_helpers.rs
+++ b/codegenerator/cli/src/config_parsing/chain_helpers.rs
@@ -207,6 +207,7 @@ pub enum Network {
     #[subenum(HypersyncNetwork, NetworkWithExplorer)]
     Metis = 1088,
 
+    #[subenum(HypersyncNetwork)]
     MevCommit = 17864,
 
     #[subenum(HypersyncNetwork, NetworkWithExplorer)]


### PR DESCRIPTION
I don't know why it disappears and appears from the list, but it should fix the integration tests. Maybe we should adjust the tests only to complain when we have missing non-experimental chains?