### PR TITLE
Remove debug loggers

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.res
@@ -281,7 +281,6 @@ module HeightQuery = {
     //Retry if the height is 0 (expect height to be greater)
     while height.contents <= 0 {
       let res = await HyperFuelJsonApi.getArchiveHeight(~serverUrl)
-      Logging.debug({"msg": "querying height", "response": res})
       switch res {
       | Ok({height: newHeight}) => height := newHeight
       | Error(e) =>

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuelJsonApi.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuelJsonApi.res
@@ -297,7 +297,6 @@ module Query = {
 let executeHyperSyncQuery = (~serverUrl, ~postQueryBody: QueryTypes.postQueryBody): promise<
   result<ResponseTypes.queryResponse, Query.queryError>,
 > => {
-  Logging.debug({"msg": "Executing HyperSync query", "body": postQueryBody})
   Query.executeFetchRequest(
     ~endpoint=serverUrl ++ "/query",
     ~method=#POST,


### PR DESCRIPTION
Noticed this in the logs:
<img width="729" alt="image" src="https://github.com/user-attachments/assets/bf2b16c3-9caa-4c87-9160-c92323d4b999">

It is also worth investigating why it's called so many times.