### PR TITLE
Add ignore from tests to mev commit

### DIFF
--- a/codegenerator/cli/src/config_parsing/chain_helpers.rs
+++ b/codegenerator/cli/src/config_parsing/chain_helpers.rs
@@ -9,7 +9,7 @@ use subenum::subenum;
 
 use crate::constants::DEFAULT_CONFIRMED_BLOCK_THRESHOLD;
 
-#[subenum(NetworkWithExplorer, HypersyncNetwork, GraphNetwork)]
+#[subenum(NetworkWithExplorer, HypersyncNetwork, GraphNetwork, IgnoreFromTests)]
 #[derive(
     Clone,
     Debug,
@@ -207,7 +207,7 @@ pub enum Network {
     #[subenum(HypersyncNetwork, NetworkWithExplorer)]
     Metis = 1088,
 
-    #[subenum(HypersyncNetwork)]
+    #[subenum(IgnoreFromTests)]
     MevCommit = 17864,
 
     #[subenum(HypersyncNetwork, NetworkWithExplorer)]


### PR DESCRIPTION
Fixes integration tests and adds a way to ignore chains we don't need tests for.