### PR TITLE
Improve benchmarking for long running metrics

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/Benchmark.res
+++ b/codegenerator/cli/templates/static/codegen/src/Benchmark.res
@@ -24,7 +24,7 @@ module MillisAccum = {
 module SummaryData = {
   module DataSet = {
     type t = {
-      count: int,
+      count: float,
       min: float,
       max: float,
       sum: BigDecimal.t,
@@ -33,7 +33,7 @@ module SummaryData = {
     }
 
     let schema = S.schema(s => {
-      count: s.matches(S.int),
+      count: s.matches(S.float),
       min: s.matches(S.float),
       max: s.matches(S.float),
       sum: s.matches(BigDecimal.schema),
@@ -44,7 +44,7 @@ module SummaryData = {
     let make = (val: float, ~decimalPlaces=2) => {
       let bigDecimal = val->BigDecimal.fromFloat
       {
-        count: 1,
+        count: 1.,
         min: val,
         max: val,
         sum: bigDecimal,
@@ -58,7 +58,7 @@ module SummaryData = {
     let add = (self: t, val: float) => {
       let bigDecimal = val->BigDecimal.fromFloat
       {
-        count: self.count + 1,
+        count: self.count +. 1.,
         min: Pervasives.min(self.min, val),
         max: Pervasives.max(self.max, val),
         sum: self.sum->BigDecimal.plus(bigDecimal),
@@ -113,7 +113,7 @@ module SummaryData = {
 module Stats = {
   open Belt
   type t = {
-    n: int,
+    n: float,
     mean: float,
     @as("std-dev") stdDev: option<float>,
     min: float,
@@ -128,7 +128,7 @@ module Stats = {
 
   let makeFromDataSet = (dataSet: SummaryData.DataSet.t) => {
     let n = dataSet.count
-    let countBigDecimal = n->BigDecimal.fromInt
+    let countBigDecimal = n->BigDecimal.fromFloat
     let mean = dataSet.sum->BigDecimal.div(countBigDecimal)
 
     let roundBigDecimal = bd =>

--- a/codegenerator/cli/templates/static/codegen/src/Env.res
+++ b/codegenerator/cli/templates/static/codegen/src/Env.res
@@ -78,6 +78,14 @@ module Benchmark = {
     )
 
   let shouldSaveData = saveDataStrategy->SaveDataStrategy.shouldSaveData
+
+  /**
+  StdDev involves saving sum of squares of data points, which could get very large.
+
+  Currently only do this for local runs on json-file and not prometheus.
+  */
+  let shouldSaveStdDev =
+    saveDataStrategy->SaveDataStrategy.shouldSaveJsonFile
 }
 
 let maxPartitionConcurrency =

--- a/codegenerator/cli/templates/static/codegen/src/Prometheus.res
+++ b/codegenerator/cli/templates/static/codegen/src/Prometheus.res
@@ -49,7 +49,7 @@ let benchmarkSummaryData = PromClient.Gauge.makeGauge({
 let setBenchmarkSummaryData = (
   ~group: string,
   ~label: string,
-  ~n: int,
+  ~n: float,
   ~mean: float,
   ~stdDev: option<float>,
   ~min: float,
@@ -58,7 +58,7 @@ let setBenchmarkSummaryData = (
 ) => {
   benchmarkSummaryData
   ->PromClient.Gauge.labels({"group": group, "label": label, "stat": "n"})
-  ->PromClient.Gauge.set(n)
+  ->PromClient.Gauge.setFloat(n)
 
   benchmarkSummaryData
   ->PromClient.Gauge.labels({"group": group, "label": label, "stat": "mean"})

--- a/codegenerator/cli/templates/static/codegen/src/Prometheus.res
+++ b/codegenerator/cli/templates/static/codegen/src/Prometheus.res
@@ -51,7 +51,7 @@ let setBenchmarkSummaryData = (
   ~label: string,
   ~n: int,
   ~mean: float,
-  ~stdDev: float,
+  ~stdDev: option<float>,
   ~min: float,
   ~max: float,
   ~sum: float,
@@ -64,9 +64,13 @@ let setBenchmarkSummaryData = (
   ->PromClient.Gauge.labels({"group": group, "label": label, "stat": "mean"})
   ->PromClient.Gauge.setFloat(mean)
 
-  benchmarkSummaryData
-  ->PromClient.Gauge.labels({"group": group, "label": label, "stat": "stdDev"})
-  ->PromClient.Gauge.setFloat(stdDev)
+  switch stdDev {
+  | Some(stdDev) =>
+    benchmarkSummaryData
+    ->PromClient.Gauge.labels({"group": group, "label": label, "stat": "stdDev"})
+    ->PromClient.Gauge.setFloat(stdDev)
+  | None => ()
+  }
 
   benchmarkSummaryData
   ->PromClient.Gauge.labels({"group": group, "label": label, "stat": "min"})


### PR DESCRIPTION
- Make std dev optional and currently only when using benchmarks locally. Storing sum of squares continuously could get quite large. I'm sure the BigNumber js lib handles it well but I think it's not really needed especially for long running benchmarks.
- Uses float instead of int for sample size to avoid the rescript 32 bit limit