### PR TITLE
[1] Field selection per handler - Introduce non-codegen internal types

### DIFF
--- a/codegenerator/cli/npm/envio/src/Internal.gen.ts
+++ b/codegenerator/cli/npm/envio/src/Internal.gen.ts
@@ -1,0 +1,15 @@
+/* TypeScript file generated from Internal.res by genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+import type {t as Address_t} from './Address.gen';
+
+export type genericEvent<params,transaction,block> = {
+  readonly params: params; 
+  readonly chainId: number; 
+  readonly srcAddress: Address_t; 
+  readonly logIndex: number; 
+  readonly transaction: transaction; 
+  readonly block: block
+};

--- a/codegenerator/cli/npm/envio/src/Internal.res
+++ b/codegenerator/cli/npm/envio/src/Internal.res
@@ -1,1 +1,18 @@
 type eventParams
+type eventBlock
+type eventTransaction
+
+@genType
+type genericEvent<'params, 'transaction, 'block> = {
+  params: 'params,
+  chainId: int,
+  srcAddress: Address.t,
+  logIndex: int,
+  transaction: 'transaction,
+  block: 'block,
+}
+
+type event = genericEvent<eventParams, eventTransaction, eventBlock>
+
+external fromGenericEvent: genericEvent<'a, 'b, 'c> => event = "%identity"
+external toGenericEvent: event => genericEvent<'a, 'b, 'c> = "%identity"

--- a/codegenerator/cli/npm/envio/src/Internal.res
+++ b/codegenerator/cli/npm/envio/src/Internal.res
@@ -16,3 +16,5 @@ type event = genericEvent<eventParams, eventTransaction, eventBlock>
 
 external fromGenericEvent: genericEvent<'a, 'b, 'c> => event = "%identity"
 external toGenericEvent: event => genericEvent<'a, 'b, 'c> = "%identity"
+
+type loaderReturn

--- a/codegenerator/cli/npm/envio/src/Internal.res
+++ b/codegenerator/cli/npm/envio/src/Internal.res
@@ -1,0 +1,1 @@
+type eventParams

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -375,8 +375,8 @@ let register = (): fuelEventConfig => {{
   name,
   kind: {fuel_event_kind_code},
   isWildcard: (handlerRegister->HandlerTypes.Register.getEventOptions).isWildcard,
-  handlerRegister: handlerRegister->(Utils.magic: HandlerTypes.Register.t<eventArgs> => HandlerTypes.Register.t<internalEventArgs>),
-  paramsRawEventSchema: paramsRawEventSchema->(Utils.magic: S.t<eventArgs> => S.t<internalEventArgs>),
+  handlerRegister: handlerRegister->(Utils.magic: HandlerTypes.Register.t<eventArgs> => HandlerTypes.Register.t<Internal.eventParams>),
+  paramsRawEventSchema: paramsRawEventSchema->(Utils.magic: S.t<eventArgs> => S.t<Internal.eventParams>),
 }}"#
             ),
         };

--- a/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
@@ -5,7 +5,7 @@ The context holds all the state for a given events loader and handler.
 */
 type t = {
   logger: Pino.t,
-  eventBatchQueueItem: Types.eventBatchQueueItem,
+  eventItem: Types.eventItem,
   addedDynamicContractRegistrations: array<TablesStatic.DynamicContractRegistry.t>,
 }
 
@@ -19,9 +19,9 @@ let getUserLogger = (logger): Logs.userLogger => {
 }
 
 let makeEventIdentifier = (
-  eventBatchQueueItem: Types.eventBatchQueueItem,
+  eventItem: Types.eventItem,
 ): Types.eventIdentifier => {
-  let {event, blockNumber, timestamp} = eventBatchQueueItem
+  let {event, blockNumber, timestamp} = eventItem
   {
     chainId: event.chainId,
     blockTimestamp: timestamp,
@@ -30,15 +30,15 @@ let makeEventIdentifier = (
   }
 }
 
-let getEventId = (eventBatchQueueItem: Types.eventBatchQueueItem) => {
+let getEventId = (eventItem: Types.eventItem) => {
   EventUtils.packEventIndex(
-    ~blockNumber=eventBatchQueueItem.blockNumber,
-    ~logIndex=eventBatchQueueItem.event.logIndex,
+    ~blockNumber=eventItem.blockNumber,
+    ~logIndex=eventItem.event.logIndex,
   )
 }
 
-let make = (~eventBatchQueueItem: Types.eventBatchQueueItem, ~logger) => {
-  let {event, chain, eventName, contractName, blockNumber} = eventBatchQueueItem
+let make = (~eventItem: Types.eventItem, ~logger) => {
+  let {event, chain, eventName, contractName, blockNumber} = eventItem
   let logger = logger->(
     Logging.createChildFrom(
       ~logger=_,
@@ -53,7 +53,7 @@ let make = (~eventBatchQueueItem: Types.eventBatchQueueItem, ~logger) => {
 
   {
     logger,
-    eventBatchQueueItem,
+    eventItem,
     addedDynamicContractRegistrations: [],
   }
 }
@@ -76,8 +76,8 @@ let makeDynamicContractRegisterFn = (
   let contractAddress = contractAddress->Address.Evm.fromAddressOrThrow
   {{/if}}
 
-  let {eventBatchQueueItem, addedDynamicContractRegistrations} = contextEnv
-  let {chain, timestamp, blockNumber, logIndex} = eventBatchQueueItem
+  let {eventItem, addedDynamicContractRegistrations} = contextEnv
+  let {chain, timestamp, blockNumber, logIndex} = eventItem
 
   let chainId = chain->ChainMap.Chain.toChainId
   let dynamicContractRegistration: TablesStatic.DynamicContractRegistry.t = {
@@ -85,9 +85,9 @@ let makeDynamicContractRegisterFn = (
     chainId,
     registeringEventBlockNumber: blockNumber,
     registeringEventLogIndex: logIndex,
-    registeringEventName: eventBatchQueueItem.eventName,
-    registeringEventContractName: eventBatchQueueItem.contractName,
-    registeringEventSrcAddress: eventBatchQueueItem.event.srcAddress,
+    registeringEventName: eventItem.eventName,
+    registeringEventContractName: eventItem.contractName,
+    registeringEventSrcAddress: eventItem.event.srcAddress,
     registeringEventBlockTimestamp: timestamp,
     contractAddress,
     contractType: contractName,
@@ -198,9 +198,9 @@ let getHandlerContext = (
   ~loadLayer,
   ~shouldSaveHistory,
 ) => {
-  let {eventBatchQueueItem, logger} = context
+  let {eventItem, logger} = context
 
-  let eventIdentifier = eventBatchQueueItem->makeEventIdentifier
+  let eventIdentifier = eventItem->makeEventIdentifier
   {
     log: logger->getUserLogger,
     {{#each entities as | entity |}}
@@ -218,12 +218,12 @@ let getHandlerContext = (
 }
 
 let getContractRegisterArgs = (contextEnv, ~inMemoryStore, ~shouldSaveHistory) => {
-  Types.HandlerTypes.event: contextEnv.eventBatchQueueItem.event->Internal.toGenericEvent,
+  Types.HandlerTypes.event: contextEnv.eventItem.event->Internal.toGenericEvent,
   context: contextEnv->getContractRegisterContext(~inMemoryStore, ~shouldSaveHistory),
 }
 
 let getLoaderArgs = (contextEnv, ~inMemoryStore, ~loadLayer) => {
-  Types.HandlerTypes.event: contextEnv.eventBatchQueueItem.event->Internal.toGenericEvent,
+  Types.HandlerTypes.event: contextEnv.eventItem.event->Internal.toGenericEvent,
   context: contextEnv->getLoaderContext(~inMemoryStore, ~loadLayer),
 }
 
@@ -234,7 +234,7 @@ let getHandlerArgs = (
   ~loadLayer,
   ~shouldSaveHistory,
 ) => {
-  Types.HandlerTypes.event: contextEnv.eventBatchQueueItem.event->Internal.toGenericEvent,
+  Types.HandlerTypes.event: contextEnv.eventItem.event->Internal.toGenericEvent,
   context: contextEnv->getHandlerContext(~inMemoryStore, ~loadLayer, ~shouldSaveHistory),
   loaderReturn,
 }

--- a/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
@@ -218,12 +218,12 @@ let getHandlerContext = (
 }
 
 let getContractRegisterArgs = (contextEnv, ~inMemoryStore, ~shouldSaveHistory) => {
-  Types.HandlerTypes.event: contextEnv.eventBatchQueueItem.event,
+  Types.HandlerTypes.event: contextEnv.eventBatchQueueItem.event->Internal.toGenericEvent,
   context: contextEnv->getContractRegisterContext(~inMemoryStore, ~shouldSaveHistory),
 }
 
 let getLoaderArgs = (contextEnv, ~inMemoryStore, ~loadLayer) => {
-  Types.HandlerTypes.event: contextEnv.eventBatchQueueItem.event,
+  Types.HandlerTypes.event: contextEnv.eventBatchQueueItem.event->Internal.toGenericEvent,
   context: contextEnv->getLoaderContext(~inMemoryStore, ~loadLayer),
 }
 
@@ -234,7 +234,7 @@ let getHandlerArgs = (
   ~loadLayer,
   ~shouldSaveHistory,
 ) => {
-  Types.HandlerTypes.event: contextEnv.eventBatchQueueItem.event,
+  Types.HandlerTypes.event: contextEnv.eventBatchQueueItem.event->Internal.toGenericEvent,
   context: contextEnv->getHandlerContext(~inMemoryStore, ~loadLayer, ~shouldSaveHistory),
   loaderReturn,
 }

--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
@@ -110,10 +110,8 @@ module EventFunctions = {
       //The only purpose is to test the registerContract function and to
       //add the entity to the in memory store for asserting registrations
 
-      let loaderHandler =
-        handlerRegister->Types.HandlerTypes.Register.getLoaderHandler
-      let loader = loaderHandler->Belt.Option.map(lh => lh.loader)
-      let handler = loaderHandler->Belt.Option.map(lh => lh.handler)
+      let loader = handlerRegister->Types.HandlerTypes.Register.getLoader
+      let handler = handlerRegister->Types.HandlerTypes.Register.getHandler
       let eventItem: Types.eventItem = {
         event,
         eventName,

--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
@@ -110,11 +110,17 @@ module EventFunctions = {
       //The only purpose is to test the registerContract function and to
       //add the entity to the in memory store for asserting registrations
 
+      let loaderHandler =
+        handlerRegister->Types.HandlerTypes.Register.getLoaderHandler
+      let loader = loaderHandler->Belt.Option.map(lh => lh.loader)
+      let handler = loaderHandler->Belt.Option.map(lh => lh.handler)
       let eventItem: Types.eventItem = {
         event,
         eventName,
         contractName,
-        handlerRegister,
+        loader,
+        handler,
+        contractRegister: handlerRegister->Types.HandlerTypes.Register.getContractRegister,
         paramsRawEventSchema,
         chain,
         logIndex: event.logIndex,
@@ -139,12 +145,13 @@ module EventFunctions = {
       | None => () //No need to run contract registration
       }
 
-      switch handlerRegister->Types.HandlerTypes.Register.getLoaderHandler {
-      | Some(loaderHandler) =>
+      switch handler {
+      | Some(handler) =>
         switch await eventItem->EventProcessing.runEventHandler(
           ~inMemoryStore,
+          ~loader,
+          ~handler,
           ~loadLayer,
-          ~loaderHandler,
           ~logger,
           ~shouldSaveHistory=false,
         ) {

--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
@@ -59,10 +59,10 @@ module EventFunctions = {
     async args => {
       let {event, mockDb, ?chainId} =
         args->(
-          Utils.magic: eventProcessorArgs<'eventArgs> => eventProcessorArgs<Types.internalEventArgs>
+          Utils.magic: eventProcessorArgs<'eventArgs> => eventProcessorArgs<Internal.eventParams>
         )
-      let handlerRegister = handlerRegister->(Utils.magic: Types.HandlerTypes.Register.t<'eventArgs> => Types.HandlerTypes.Register.t<Types.internalEventArgs>)
-      let paramsRawEventSchema = paramsRawEventSchema->(Utils.magic: S.t<'eventArgs> => S.t<Types.internalEventArgs>)
+      let handlerRegister = handlerRegister->(Utils.magic: Types.HandlerTypes.Register.t<'eventArgs> => Types.HandlerTypes.Register.t<Internal.eventParams>)
+      let paramsRawEventSchema = paramsRawEventSchema->(Utils.magic: S.t<'eventArgs> => S.t<Internal.eventParams>)
 
       let config = RegisterHandlers.getConfig()
 

--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
@@ -57,10 +57,8 @@ module EventFunctions = {
   */
   let makeEventProcessor = (~contractName, ~eventName, ~handlerRegister, ~paramsRawEventSchema) => {
     async args => {
-      let {event, mockDb, ?chainId} =
-        args->(
-          Utils.magic: eventProcessorArgs<'eventArgs> => eventProcessorArgs<Internal.eventParams>
-        )
+      let {event, mockDb, ?chainId} = args
+      let event = event->(Utils.magic: Types.eventLog<'eventArgs> => Internal.event)
       let handlerRegister = handlerRegister->(Utils.magic: Types.HandlerTypes.Register.t<'eventArgs> => Types.HandlerTypes.Register.t<Internal.eventParams>)
       let paramsRawEventSchema = paramsRawEventSchema->(Utils.magic: S.t<'eventArgs> => S.t<Internal.eventParams>)
 
@@ -120,8 +118,8 @@ module EventFunctions = {
         paramsRawEventSchema,
         chain,
         logIndex: event.logIndex,
-        timestamp: event.block->Types.Block.getTimestamp,
-        blockNumber: event.block->Types.Block.getNumber,
+        timestamp: event.block->Types.Block.getInternalTimestamp,
+        blockNumber: event.block->Types.Block.getInternalNumber,
       }
 
       switch handlerRegister->Types.HandlerTypes.Register.getContractRegister {

--- a/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/TestHelpers.res.hbs
@@ -110,7 +110,7 @@ module EventFunctions = {
       //The only purpose is to test the registerContract function and to
       //add the entity to the in memory store for asserting registrations
 
-      let eventBatchQueueItem: Types.eventBatchQueueItem = {
+      let eventItem: Types.eventItem = {
         event,
         eventName,
         contractName,
@@ -126,7 +126,7 @@ module EventFunctions = {
       | Some(contractRegister) =>
         switch contractRegister->EventProcessing.runEventContractRegister(
           ~logger,
-          ~eventBatchQueueItem,
+          ~eventItem,
           ~checkContractIsRegistered=(~chain as _, ~contractAddress as _, ~contractName as _) =>
             false,
           ~dynamicContractRegistrations=None,
@@ -141,7 +141,7 @@ module EventFunctions = {
 
       switch handlerRegister->Types.HandlerTypes.Register.getLoaderHandler {
       | Some(loaderHandler) =>
-        switch await eventBatchQueueItem->EventProcessing.runEventHandler(
+        switch await eventItem->EventProcessing.runEventHandler(
           ~inMemoryStore,
           ~loadLayer,
           ~loaderHandler,

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -312,36 +312,48 @@ module HandlerTypes = {
       ~eventOptions: option<EventOptions.t>,
       ~logger: Pino.t=?,
     ) => unit
-    let getLoaderHandler: t<'eventArgs> => option<
-      loaderHandler<'eventArgs, 'loaderReturn, 'eventFilter>,
+    let noopLoader: loader<'eventArgs, ()>
+    let getLoader: t<'eventArgs> => option<
+      loader<Internal.eventParams, Internal.loaderReturn>,
     >
-    let getContractRegister: t<'eventArgs> => option<contractRegister<'eventArgs>>
+    let getHandler: t<'eventArgs> => option<
+      handler<Internal.eventParams, Internal.loaderReturn>,
+    >
+    let getContractRegister: t<'eventArgs> => option<contractRegister<Internal.eventParams>>
     let getEventOptions: t<'eventArgs> => EventOptions.t
     let hasRegistration: t<'eventArgs> => bool
   } = {
-    type loaderReturn
     type eventFilter
 
     type t<'eventArgs> = {
       contractName: string,
       eventName: string,
       topic0: EvmTypes.Hex.t,
-      mutable loaderHandler: option<loaderHandler<'eventArgs, loaderReturn, eventFilter>>,
+      mutable loaderHandler: option<loaderHandler<'eventArgs, Internal.loaderReturn, eventFilter>>,
       mutable contractRegister: option<contractRegister<'eventArgs>>,
       mutable eventOptions: option<EventOptions.t>,
     }
 
-    let getLoaderHandler = (t: t<'eventArgs>): option<
-      loaderHandler<'eventArgs, 'loaderReturn, 'eventFilter>,
-    > =>
+    let noopLoader = _ => Promise.resolve()
+
+    let getLoaderHandler = (t: t<'eventArgs>) =>
       t.loaderHandler->(
-        Utils.magic: option<loaderHandler<'eventArgs, loaderReturn, eventFilter>> => option<
-          loaderHandler<'eventArgs, 'loaderReturn, 'eventFilter>,
+        Utils.magic: option<loaderHandler<'eventArgs, Internal.loaderReturn, eventFilter>> => option<
+          loaderHandler<Internal.eventParams, Internal.loaderReturn, 'eventFilter>,
         >
       )
 
-    let getContractRegister = (t: t<'eventArgs>): option<contractRegister<'eventArgs>> =>
-      t.contractRegister
+    let getLoader = (t: t<'eventArgs>) => t->getLoaderHandler->Belt.Option.flatMap(lh => 
+      if lh.loader === noopLoader->(Utils.magic: loader<'eventArgs, ()> => loader<Internal.eventParams, Internal.loaderReturn>) {
+        None
+      } else {
+        Some(lh.loader)
+      }
+    )
+
+    let getHandler = (t: t<'eventArgs>) => t->getLoaderHandler->Belt.Option.map(lh => lh.handler)
+
+    let getContractRegister = (t: t<'eventArgs>) => t.contractRegister->(Utils.magic: option<contractRegister<'eventArgs>> => option<contractRegister<Internal.eventParams>>)
 
     let getEventOptions = ({eventOptions, topic0}: t<'eventArgs>): EventOptions.t =>
       switch eventOptions {
@@ -388,7 +400,7 @@ module HandlerTypes = {
           value
           ->(Utils.magic: loaderHandler<'eventArgs, 'loaderReturn, 'eventFilter> => loaderHandler<
             'eventArgs,
-            loaderReturn,
+            Internal.loaderReturn,
             eventFilter,
           >)
           ->Some
@@ -520,7 +532,7 @@ module MakeRegister = (Event: Event) => {
   ) => {
     Event.handlerRegister->HandlerTypes.Register.setLoaderHandler(
       {
-        loader: _ => Promise.resolve(),
+        loader: HandlerTypes.Register.noopLoader,
         handler,
         wildcard: ?eventConfig->Belt.Option.flatMap(c => c.wildcard),
         eventFilters: ?eventConfig->Belt.Option.flatMap(c => c.eventFilters),

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -612,7 +612,9 @@ type chainId = int
 type eventItem = {
   eventName: string,
   contractName: string,
-  handlerRegister: HandlerTypes.Register.t<Internal.eventParams>,
+  loader: option<HandlerTypes.loader<Internal.eventParams, Internal.loaderReturn>>,
+  handler: option<HandlerTypes.handler<Internal.eventParams, Internal.loaderReturn>>,
+  contractRegister: option<HandlerTypes.contractRegister<Internal.eventParams>>,
   timestamp: int,
   chain: ChainMap.Chain.t,
   blockNumber: int,

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -417,8 +417,6 @@ module HandlerTypes = {
   }
 }
 
-type internalEventArgs
-
 module type Event = {
   let sighash: string // topic0 for Evm and rb for Fuel receipts
   let topicCount: int // Number of topics for evm, always 0 for fuel
@@ -433,9 +431,9 @@ module type Event = {
   type eventFilter
   let getTopicSelection: SingleOrMultiple.t<eventFilter> => array<LogSelection.topicSelection>
 }
-module type InternalEvent = Event with type eventArgs = internalEventArgs
+module type InternalEvent = Event with type eventArgs = Internal.eventParams
 
-external eventToInternal: eventLog<'a> => eventLog<internalEventArgs> = "%identity"
+external eventToInternal: eventLog<'a> => eventLog<Internal.eventParams> = "%identity"
 external eventModToInternal: module(Event with type eventArgs = 'a) => module(InternalEvent) = "%identity"
 external eventModWithoutArgTypeToInternal: module(Event) => module(InternalEvent) = "%identity"
 
@@ -542,7 +540,7 @@ module MakeRegister = (Event: Event) => {
 type fuelEventKind = 
   | LogData({
     logId: string,
-    decode: string => internalEventArgs,
+    decode: string => Internal.eventParams,
   })
   | Mint
   | Burn
@@ -553,8 +551,8 @@ type fuelEventConfig = {
   name: string,
   kind: fuelEventKind,
   isWildcard: bool,
-  handlerRegister: HandlerTypes.Register.t<internalEventArgs>,
-  paramsRawEventSchema: S.schema<internalEventArgs>,
+  handlerRegister: HandlerTypes.Register.t<Internal.eventParams>,
+  paramsRawEventSchema: S.schema<Internal.eventParams>,
 }
 
 type fuelContractConfig = {
@@ -603,13 +601,13 @@ type chainId = int
 type eventBatchQueueItem = {
   eventName: string,
   contractName: string,
-  handlerRegister: HandlerTypes.Register.t<internalEventArgs>,
+  handlerRegister: HandlerTypes.Register.t<Internal.eventParams>,
   timestamp: int,
   chain: ChainMap.Chain.t,
   blockNumber: int,
   logIndex: int,
-  event: eventLog<internalEventArgs>,
-  paramsRawEventSchema: S.schema<internalEventArgs>,
+  event: eventLog<Internal.eventParams>,
+  paramsRawEventSchema: S.schema<Internal.eventParams>,
   //Default to false, if an event needs to
   //be reprocessed after it has loaded dynamic contracts
   //This gets set to true and does not try and reload events

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -609,7 +609,7 @@ module {{event.name}} = {
 @genType
 type chainId = int
 
-type eventBatchQueueItem = {
+type eventItem = {
   eventName: string,
   contractName: string,
   handlerRegister: HandlerTypes.Register.t<Internal.eventParams>,

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -124,10 +124,20 @@ module Block = {
   external getNumber: t => int = "number"
 
   @get
+  external getInternalNumber: Internal.eventBlock => int = "number"
+
+  @get
   external getTimestamp: t => int = "timestamp"
+
+  @get
+  external getInternalTimestamp: Internal.eventBlock => int = "timestamp"
  
   @get
   external getId: t => string = "hash"
+
+  {{!-- TODO: Remove this by moving block hash to eventItem --}}
+  @get
+  external getInternalId: Internal.eventBlock => string = "hash"
   {{/if}}
 
   {{#if is_fuel_ecosystem}}
@@ -135,22 +145,24 @@ module Block = {
   external getNumber: t => int = "height"
 
   @get
+  external getInternalNumber: Internal.eventBlock => int = "height"
+
+  @get
   external getTimestamp: t => int = "time"
+
+  @get
+  external getInternalTimestamp: Internal.eventBlock => int = "time"
  
   @get
   external getId: t => string = "id"
+
+  @get
+  external getInternalId: Internal.eventBlock => string = "id"
   {{/if}}
 }
 
 @genType.as("EventLog")
-type eventLog<'a> = {
-  params: 'a,
-  chainId: int,
-  srcAddress: Address.t,
-  logIndex: int,
-  transaction: Transaction.t,
-  block: Block.t,
-}
+type eventLog<'params> = Internal.genericEvent<'params, Transaction.t, Block.t>
 
 module SingleOrMultiple: {
   @genType.import(("./bindings/OpaqueTypes", "SingleOrMultiple"))
@@ -433,7 +445,6 @@ module type Event = {
 }
 module type InternalEvent = Event with type eventArgs = Internal.eventParams
 
-external eventToInternal: eventLog<'a> => eventLog<Internal.eventParams> = "%identity"
 external eventModToInternal: module(Event with type eventArgs = 'a) => module(InternalEvent) = "%identity"
 external eventModWithoutArgTypeToInternal: module(Event) => module(InternalEvent) = "%identity"
 
@@ -606,7 +617,7 @@ type eventBatchQueueItem = {
   chain: ChainMap.Chain.t,
   blockNumber: int,
   logIndex: int,
-  event: eventLog<Internal.eventParams>,
+  event: Internal.event,
   paramsRawEventSchema: S.schema<Internal.eventParams>,
   //Default to false, if an event needs to
   //be reprocessed after it has loaded dynamic contracts

--- a/codegenerator/cli/templates/static/codegen/src/EventFetching.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventFetching.res
@@ -70,7 +70,7 @@ let makeCombinedEventFilterQuery = (
   })
 }
 
-type eventBatchPromise = promise<Types.eventBatchQueueItem>
+type eventBatchPromise = promise<Types.eventItem>
 
 let applyConditionalFunction = (value: 'a, condition: bool, callback: 'a => 'b) => {
   condition ? callback(value) : value

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -225,8 +225,8 @@ let addEventToRawEvents = (
   let chainId = chain->ChainMap.Chain.toChainId
   let eventId = EventUtils.packEventIndex(~logIndex, ~blockNumber)
   let blockFields =
-    (block :> Types.Block.rawEventFields)->S.serializeOrRaiseWith(Types.Block.rawEventSchema)
-  let transactionFields = transaction->S.serializeOrRaiseWith(Types.Transaction.rawEventSchema)
+    block->(Utils.magic: Internal.eventBlock => Types.Block.rawEventFields)->S.serializeOrRaiseWith(Types.Block.rawEventSchema)
+  let transactionFields = transaction->(Utils.magic: Internal.eventTransaction => Types.Transaction.t)->S.serializeOrRaiseWith(Types.Transaction.rawEventSchema)
   // Serialize to unknown, because serializing to Js.Json.t fails for Bytes Fuel type, since it has unknown schema
   let params =
     params
@@ -241,7 +241,7 @@ let addEventToRawEvents = (
     blockNumber,
     logIndex,
     srcAddress,
-    blockHash: block->Types.Block.getId,
+    blockHash: block->Types.Block.getInternalId,
     blockTimestamp,
     blockFields,
     transactionFields,

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -316,12 +316,11 @@ let runHandler = async (
   ~config: Config.t,
   ~isInReorgThreshold,
 ) => {
-  let result = switch eventItem {
-  | {loader: None, handler: None}
-  | {loader: Some(_), handler: None} => Ok()
-  | {loader, handler: Some(handler)} =>
+  let result = switch eventItem.handler {
+  | None => Ok()
+  | Some(handler) =>
     await eventItem->runEventHandler(
-      ~loader,
+      ~loader=eventItem.loader,
       ~handler,
       ~inMemoryStore,
       ~logger,

--- a/codegenerator/cli/templates/static/codegen/src/EventUtils.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventUtils.res
@@ -12,7 +12,7 @@ let getEventComparator = (multiChainEventIndex: multiChainEventIndex) => {
 }
 
 let getEventComparatorFromQueueItem = (
-  {chain, timestamp, blockNumber, logIndex}: Types.eventBatchQueueItem,
+  {chain, timestamp, blockNumber, logIndex}: Types.eventItem,
 ) => {
   let chainId = chain->ChainMap.Chain.toChainId
   (timestamp, chainId, blockNumber, logIndex)

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainEventQueue.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainEventQueue.res
@@ -2,7 +2,7 @@ type t = {
   pushBacklogCallbacks: SDSL.Queue.t<unit => unit>,
   popBacklogCallbacks: SDSL.Queue.t<unit => unit>,
   maxQueueSize: int,
-  queue: SDSL.Queue.t<Types.eventBatchQueueItem>,
+  queue: SDSL.Queue.t<Types.eventItem>,
 }
 
 let make = (~maxQueueSize): t => {
@@ -37,12 +37,12 @@ let isQueueAtMax = self => self.queue->SDSL.Queue.size >= self.maxQueueSize
 /**
 Pushes Item Regardless of max size and returns true if queue is over max size
 */
-let pushItem = (self: t, item: Types.eventBatchQueueItem) => {
+let pushItem = (self: t, item: Types.eventItem) => {
   self.queue->SDSL.Queue.push(item)->ignore
   self->isQueueAtMax
 }
 
-let awaitQueueSpaceAndPushItem = async (self: t, item: Types.eventBatchQueueItem) => {
+let awaitQueueSpaceAndPushItem = async (self: t, item: Types.eventItem) => {
   //Check if the queue is already full and wait for space before
   //pushing next batch
   let currentQueueSize = self.queue->SDSL.Queue.size
@@ -67,7 +67,7 @@ let handlePushBackLogCallbacks = (self: t) => {
   }
 }
 
-let popSingleAndAwaitItem = async (self: t): Types.eventBatchQueueItem => {
+let popSingleAndAwaitItem = async (self: t): Types.eventItem => {
   let optItem = self.queue->SDSL.Queue.pop
 
   let item = switch optItem {
@@ -86,7 +86,7 @@ let popSingleAndAwaitItem = async (self: t): Types.eventBatchQueueItem => {
   item
 }
 
-let popSingle = (self: t): option<Types.eventBatchQueueItem> => {
+let popSingle = (self: t): option<Types.eventItem> => {
   let optItem = self.queue->SDSL.Queue.pop
 
   self->handlePushBackLogCallbacks
@@ -94,6 +94,6 @@ let popSingle = (self: t): option<Types.eventBatchQueueItem> => {
   optItem
 }
 
-let peekFront = (self: t): option<Types.eventBatchQueueItem> => {
+let peekFront = (self: t): option<Types.eventItem> => {
   self.queue->SDSL.Queue.front
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainEventQueue.resi
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainEventQueue.resi
@@ -2,12 +2,12 @@ type t = {
   pushBacklogCallbacks: SDSL.Queue.t<unit => unit>,
   popBacklogCallbacks: SDSL.Queue.t<unit => unit>,
   maxQueueSize: int,
-  queue: SDSL.Queue.t<Types.eventBatchQueueItem>,
+  queue: SDSL.Queue.t<Types.eventItem>,
 }
 let make: (~maxQueueSize: int) => t
 let insertCallbackAwaitPromise: SDSL.Queue.t<unit => unit> => promise<unit>
-let awaitQueueSpaceAndPushItem: (t, Types.eventBatchQueueItem) => promise<unit>
-let popSingleAndAwaitItem: t => promise<Types.eventBatchQueueItem>
-let popSingle: t => option<Types.eventBatchQueueItem>
-let peekFront: t => option<Types.eventBatchQueueItem>
-let pushItem: (t, Types.eventBatchQueueItem) => bool
+let awaitQueueSpaceAndPushItem: (t, Types.eventItem) => promise<unit>
+let popSingleAndAwaitItem: t => promise<Types.eventItem>
+let popSingle: t => option<Types.eventItem>
+let peekFront: t => option<Types.eventItem>
+let pushItem: (t, Types.eventItem) => bool

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -3,7 +3,7 @@ open Belt
 //A filter should return true if the event should be kept and isValid should return
 //false when the filter should be removed/cleaned up
 type processingFilter = {
-  filter: Types.eventBatchQueueItem => bool,
+  filter: Types.eventItem => bool,
   isValid: (~fetchState: FetchState.t) => bool,
 }
 
@@ -293,7 +293,7 @@ let addProcessingFilter = (self: t, ~filter, ~isValid) => {
 }
 
 let applyProcessingFilters = (
-  items: array<Types.eventBatchQueueItem>,
+  items: array<Types.eventItem>,
   ~processingFilters: array<processingFilter>,
 ) =>
   items->Array.keep(item => {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -3,12 +3,12 @@ type t = {
   chainFetchers: ChainMap.t<ChainFetcher.t>,
   //Holds arbitrary events that were added when a batch ended processing early
   //due to contract registration. Ordered from latest to earliest
-  arbitraryEventQueue: array<Types.eventBatchQueueItem>,
+  arbitraryEventQueue: array<Types.eventItem>,
   isUnorderedMultichainMode: bool,
   isInReorgThreshold: bool,
 }
 
-let getComparitorFromItem = (queueItem: Types.eventBatchQueueItem) => {
+let getComparitorFromItem = (queueItem: Types.eventItem) => {
   let {timestamp, chain, blockNumber, logIndex} = queueItem
   EventUtils.getEventComparator({
     timestamp,
@@ -35,7 +35,7 @@ let getQueueItemComparitor = (earliestQueueItem: FetchState.queueItem, ~chain) =
   }
 }
 
-let priorityQueueComparitor = (a: Types.eventBatchQueueItem, b: Types.eventBatchQueueItem) => {
+let priorityQueueComparitor = (a: Types.eventItem, b: Types.eventItem) => {
   if a->getComparitorFromItem < b->getComparitorFromItem {
     -1
   } else {
@@ -241,12 +241,12 @@ let setChainFetcher = (self: t, chainFetcher: ChainFetcher.t) => {
 }
 
 let getFirstArbitraryEventsItemForChain = (
-  queue: array<Types.eventBatchQueueItem>,
+  queue: array<Types.eventItem>,
   ~chain,
   ~fetchStatesMap: ChainMap.t<fetchStateWithData>,
 ): option<isInReorgThresholdRes<FetchState.itemWithPopFn>> =>
   queue
-  ->Utils.Array.findReverseWithIndex((item: Types.eventBatchQueueItem) => {
+  ->Utils.Array.findReverseWithIndex((item: Types.eventItem) => {
     item.chain == chain
   })
   ->Option.map(((item, index)) => {
@@ -262,7 +262,7 @@ let getFirstArbitraryEventsItemForChain = (
   })
 
 let getFirstArbitraryEventsItem = (
-  queue: array<Types.eventBatchQueueItem>,
+  queue: array<Types.eventItem>,
   ~fetchStatesMap: ChainMap.t<fetchStateWithData>,
 ): option<isInReorgThresholdRes<FetchState.itemWithPopFn>> =>
   queue
@@ -278,7 +278,7 @@ let getFirstArbitraryEventsItem = (
 
 let popBatchItem = (
   ~fetchStatesMap: ChainMap.t<fetchStateWithData>,
-  ~arbitraryEventQueue: array<Types.eventBatchQueueItem>,
+  ~arbitraryEventQueue: array<Types.eventItem>,
   ~isUnorderedMultichainMode,
   ~onlyBelowReorgThreshold,
 ): isInReorgThresholdRes<option<FetchState.itemWithPopFn>> => {
@@ -387,9 +387,9 @@ let createBatchInternal = (
 }
 
 type batchRes = {
-  batch: array<Types.eventBatchQueueItem>,
+  batch: array<Types.eventItem>,
   fetchStatesMap: ChainMap.t<fetchStateWithData>,
-  arbitraryEventQueue: array<Types.eventBatchQueueItem>,
+  arbitraryEventQueue: array<Types.eventItem>,
 }
 
 let createBatch = (self: t, ~maxBatchSize: int, ~onlyBelowReorgThreshold: bool) => {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -98,7 +98,7 @@ type registerData = {
   latestFetchedBlock: blockNumberAndTimestamp,
   contractAddressMapping: ContractAddressingMap.mapping,
   //Events ordered from latest to earliest
-  fetchedEventQueue: array<Types.eventBatchQueueItem>,
+  fetchedEventQueue: array<Types.eventItem>,
   //Used to prune dynamic contract registrations in the event
   //of a rollback.
   dynamicContracts: DynamicContractsMap.t,
@@ -212,7 +212,7 @@ let copy = (self: t) => {
 /**
 Comapritor for two events from the same chain. No need for chain id or timestamp
 */
-let getEventCmp = (event: Types.eventBatchQueueItem) => {
+let getEventCmp = (event: Types.eventItem) => {
   (event.blockNumber, event.logIndex)
 }
 
@@ -303,7 +303,7 @@ let updateRegister = (
   register: register,
   ~latestFetchedBlock,
   //Events ordered latest to earliest
-  ~reversedNewItems: array<Types.eventBatchQueueItem>,
+  ~reversedNewItems: array<Types.eventItem>,
 ) => {
   let firstEventBlockNumber = switch register.firstEventBlockNumber {
   | Some(n) => Some(n)
@@ -646,7 +646,7 @@ let getNextQuery = ({baseRegister}: t, ~partitionId) => {
   }
 }
 
-type itemWithPopFn = {item: Types.eventBatchQueueItem, popItemOffQueue: unit => unit}
+type itemWithPopFn = {item: Types.eventItem, popItemOffQueue: unit => unit}
 
 let itemIsInReorgThreshold = (item: itemWithPopFn, ~heighestBlockBelowThreshold) => {
   //Only consider it in reorg threshold when the current block number has advanced beyond 0
@@ -933,7 +933,7 @@ let getLatestFullyFetchedBlock = (self: t) => {
 }
 
 let pruneQueueFromFirstChangeEvent = (
-  queue: array<Types.eventBatchQueueItem>,
+  queue: array<Types.eventItem>,
   ~firstChangeEvent: blockNumberAndLogIndex,
 ) => {
   queue->Array.keep(item =>

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/ChainWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/ChainWorker.res
@@ -23,7 +23,7 @@ Thes response returned from a block range fetch
 type blockRangeFetchResponse = {
   currentBlockHeight: int,
   reorgGuard: reorgGuard,
-  parsedQueueItems: array<Types.eventBatchQueueItem>,
+  parsedQueueItems: array<Types.eventItem>,
   fromBlockQueried: int,
   heighestQueriedBlockNumber: int,
   latestFetchedBlockTimestamp: int,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -485,15 +485,12 @@ module Make = (
         | _ => Js.Exn.raiseError("Unexpected bug in the event routing logic")
         }
 
-        let loaderHandler =
-          eventConfig.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler
-
         (
           {
             eventName: eventConfig.name,
             contractName: contractConfig.name,
-            loader: loaderHandler->Option.map(lh => lh.loader),
-            handler: loaderHandler->Option.map(lh => lh.handler),
+            loader: eventConfig.handlerRegister->Types.HandlerTypes.Register.getLoader,
+            handler: eventConfig.handlerRegister->Types.HandlerTypes.Register.getHandler,
             contractRegister: eventConfig.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
             paramsRawEventSchema: eventConfig.paramsRawEventSchema,
             timestamp: block.time,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -485,11 +485,16 @@ module Make = (
         | _ => Js.Exn.raiseError("Unexpected bug in the event routing logic")
         }
 
+        let loaderHandler =
+          eventConfig.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler
+
         (
           {
             eventName: eventConfig.name,
             contractName: contractConfig.name,
-            handlerRegister: eventConfig.handlerRegister,
+            loader: loaderHandler->Option.map(lh => lh.loader),
+            handler: loaderHandler->Option.map(lh => lh.handler),
+            contractRegister: eventConfig.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
             paramsRawEventSchema: eventConfig.paramsRawEventSchema,
             timestamp: block.time,
             chain,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -505,7 +505,7 @@ module Make = (
               srcAddress: contractAddress,
               logIndex: receiptIndex,
             },
-          }: Types.eventBatchQueueItem
+          }: Types.eventItem
         )
       })
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -240,7 +240,7 @@ module Make = (
 
   let makeEventBatchQueueItem = (
     item: HyperSync.logsQueryPageItem,
-    ~params: Types.internalEventArgs,
+    ~params: Internal.eventParams,
     ~eventMod: module(Types.InternalEvent),
   ): Types.eventBatchQueueItem => {
     let module(Event) = eventMod

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -247,14 +247,11 @@ module Make = (
     let {block, log, transaction} = item
     let chainId = chain->ChainMap.Chain.toChainId
 
-    let loaderHandler =
-      Event.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler
-
     {
       eventName: Event.name,
       contractName: Event.contractName,
-      loader: loaderHandler->Option.map(lh => lh.loader),
-      handler: loaderHandler->Option.map(lh => lh.handler),
+      loader: Event.handlerRegister->Types.HandlerTypes.Register.getLoader,
+      handler: Event.handlerRegister->Types.HandlerTypes.Register.getHandler,
       contractRegister: Event.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
       paramsRawEventSchema: Event.paramsRawEventSchema,
       timestamp: block->Types.Block.getTimestamp,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -242,7 +242,7 @@ module Make = (
     item: HyperSync.logsQueryPageItem,
     ~params: Internal.eventParams,
     ~eventMod: module(Types.InternalEvent),
-  ): Types.eventBatchQueueItem => {
+  ): Types.eventItem => {
     let module(Event) = eventMod
     let {block, log, transaction} = item
     let chainId = chain->ChainMap.Chain.toChainId

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -262,7 +262,7 @@ module Make = (
         block,
         srcAddress: log.address,
         logIndex: log.logIndex,
-      },
+      }->Internal.fromGenericEvent,
     }
   }
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -246,10 +246,16 @@ module Make = (
     let module(Event) = eventMod
     let {block, log, transaction} = item
     let chainId = chain->ChainMap.Chain.toChainId
+
+    let loaderHandler =
+      Event.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler
+
     {
       eventName: Event.name,
       contractName: Event.contractName,
-      handlerRegister: Event.handlerRegister,
+      loader: loaderHandler->Option.map(lh => lh.loader),
+      handler: loaderHandler->Option.map(lh => lh.handler),
+      contractRegister: Event.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
       paramsRawEventSchema: Event.paramsRawEventSchema,
       timestamp: block->Types.Block.getTimestamp,
       chain,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -291,11 +291,16 @@ module Make = (
                     )
                   }
 
+                  let loaderHandler =
+                    Event.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler
+
                   (
                     {
                       eventName: Event.name,
                       contractName: Event.contractName,
-                      handlerRegister: Event.handlerRegister,
+                      loader: loaderHandler->Option.map(lh => lh.loader),
+                      handler: loaderHandler->Option.map(lh => lh.handler),
+                      contractRegister: Event.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
                       paramsRawEventSchema: Event.paramsRawEventSchema,
                       timestamp: block->Types.Block.getTimestamp,
                       chain,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -309,7 +309,7 @@ module Make = (
                         srcAddress: log.address,
                         logIndex: log.logIndex,
                       }->Internal.fromGenericEvent,
-                    }: Types.eventBatchQueueItem
+                    }: Types.eventItem
                   )
                 }
               )(),

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -308,7 +308,7 @@ module Make = (
                         block,
                         srcAddress: log.address,
                         logIndex: log.logIndex,
-                      },
+                      }->Internal.fromGenericEvent,
                     }: Types.eventBatchQueueItem
                   )
                 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -291,15 +291,12 @@ module Make = (
                     )
                   }
 
-                  let loaderHandler =
-                    Event.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler
-
                   (
                     {
                       eventName: Event.name,
                       contractName: Event.contractName,
-                      loader: loaderHandler->Option.map(lh => lh.loader),
-                      handler: loaderHandler->Option.map(lh => lh.handler),
+                      loader: Event.handlerRegister->Types.HandlerTypes.Register.getLoader,
+                      handler: Event.handlerRegister->Types.HandlerTypes.Register.getHandler,
                       contractRegister: Event.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
                       paramsRawEventSchema: Event.paramsRawEventSchema,
                       timestamp: block->Types.Block.getTimestamp,

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -93,7 +93,7 @@ let isRollingBack = state =>
   | _ => false
   }
 
-type arbitraryEventQueue = array<Types.eventBatchQueueItem>
+type arbitraryEventQueue = array<Types.eventItem>
 
 type shouldExit = ExitWithSuccess | NoExit
 type action =
@@ -1252,10 +1252,10 @@ let injectedTaskReducer = (
             }
             //On other chains, filter out evennts based on the first change present on the chain after the reorg
             rolledBackCf->ChainFetcher.addProcessingFilter(
-              ~filter=eventBatchQueueItem => {
+              ~filter=eventItem => {
                 //Filter out events that occur passed the block where the query starts but
                 //are lower than the timestamp where we rolled back to
-                (eventBatchQueueItem.blockNumber, eventBatchQueueItem.logIndex) >=
+                (eventItem.blockNumber, eventItem.logIndex) >=
                 (firstChangeEvent.blockNumber, firstChangeEvent.logIndex)
               },
               ~isValid=(~fetchState) => {

--- a/internal_docs/EventFetchers.md
+++ b/internal_docs/EventFetchers.md
@@ -8,12 +8,12 @@ Here are [the original diagrams](https://www.figma.com/file/YC7rKkGC65Out0QlQ2jx
 classDiagram
   class ChainManager {
     chainFetchers: dictionary(ChainFetcher.t)
-    arbitraryEventPriorityQueue: PriorityQueue(eventBatchQueueItem)
+    arbitraryEventPriorityQueue: PriorityQueue(eventItem)
 
     startFetchers(): void
     getChainFetcher(chainId: int): ChainFetcher.t
     createBatch(minBatchSize: int, maxBatchSize: int): promise(eventType[])
-    addItemToArbitraryEvents(eventItem: EventFetching.eventBatchQueueItem): void
+    addItemToArbitraryEvents(eventItem: EventFetching.eventItem): void
   }
 ```
 

--- a/scenarios/erc20_multichain_factory/pnpm-lock.yaml
+++ b/scenarios/erc20_multichain_factory/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
 
   ../helpers:
     dependencies:
+      envio:
+        specifier: file:../../codegenerator/cli/npm/envio
+        version: file:../../codegenerator/cli/npm/envio
       rescript:
         specifier: 11.1.3
         version: 11.1.3

--- a/scenarios/erc20_multichain_factory/test/ChainDataHelpers.res
+++ b/scenarios/erc20_multichain_factory/test/ChainDataHelpers.res
@@ -8,16 +8,20 @@ let getDefaultAddress = (chain, contractName) => {
 }
 
 let gAS_USED_DEFAULT = BigInt.zero
-let makeBlock = (~blockNumber, ~blockTimestamp, ~blockHash): Types.Block.t => {
-  number: blockNumber,
-  hash: blockHash,
-  timestamp: blockTimestamp,
-  gasUsed: gAS_USED_DEFAULT,
-}
-let makeTransaction = (~transactionIndex, ~transactionHash): Types.Transaction.t => {
-  transactionIndex,
-  hash: transactionHash,
-}
+let makeBlock = (~blockNumber, ~blockTimestamp, ~blockHash) =>
+  {
+    number: blockNumber,
+    hash: blockHash,
+    timestamp: blockTimestamp,
+    gasUsed: gAS_USED_DEFAULT,
+  }->(Utils.magic: Types.Block.t => Internal.eventBlock)
+
+let makeTransaction = (~transactionIndex, ~transactionHash) =>
+  {
+    transactionIndex,
+    hash: transactionHash,
+  }->(Utils.magic: Types.Transaction.t => Internal.eventTransaction)
+
 module ERC20 = {
   let contractName = "ERC20"
   let getDefaultAddress = getDefaultAddress(_, contractName)

--- a/scenarios/erc20_multichain_factory/test/DynamicContractEventProcessin_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractEventProcessin_test.res
@@ -77,7 +77,7 @@ describe("dynamic contract event processing test", () => {
   })
   Async.it("One registration event + non registration event", async () => {
     let block0 = Mock.mockChainData.blocks->Js.Array2.unsafe_get(0)
-    let block0Events = block0.logs->Array.map(l => l.eventBatchQueueItem)
+    let block0Events = block0.logs->Array.map(l => l.eventItem)
     let res = await EventProcessing.processEventBatch(
       ~eventBatch=block0Events,
       ~config,
@@ -106,7 +106,7 @@ describe("dynamic contract event processing test", () => {
 
   Async.it("One registration event with dynamicContracts, one without", async () => {
     let block1 = Mock.mockChainData.blocks->Js.Array2.unsafe_get(1)
-    let block1Events = block1.logs->Array.map(l => l.eventBatchQueueItem)
+    let block1Events = block1.logs->Array.map(l => l.eventItem)
     let res = await EventProcessing.processEventBatch(
       ~eventBatch=block1Events,
       ~config,
@@ -136,7 +136,7 @@ describe("dynamic contract event processing test", () => {
   })
   Async.it("One event without dynamicContracts, one with", async () => {
     let block2 = Mock.mockChainData.blocks->Js.Array2.unsafe_get(2)
-    let block2Events = block2.logs->Array.map(l => l.eventBatchQueueItem)
+    let block2Events = block2.logs->Array.map(l => l.eventItem)
     let res = await EventProcessing.processEventBatch(
       ~eventBatch=block2Events,
       ~config,

--- a/scenarios/erc20_multichain_factory/test/MockChainData.res
+++ b/scenarios/erc20_multichain_factory/test/MockChainData.res
@@ -1,17 +1,12 @@
 module Indexer = {
-  module Pino = Pino
   module ErrorHandling = ErrorHandling
-  module Address = Address
+  module Enums = Enums
   module Types = Types
   module Config = Config
-  module Ethers = Ethers
-  module Viem = Viem
   module HyperSyncClient = HyperSyncClient
   module ChainWorker = ChainWorker
   module ReorgDetection = ReorgDetection
   module FetchState = FetchState
-  module ChainMap = ChainMap
-  module Enums = Enums
   module ContractAddressingMap = ContractAddressingMap
   module LogSelection = LogSelection
 }

--- a/scenarios/helpers/package.json
+++ b/scenarios/helpers/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "rescript": "11.1.3",
-    "rescript-schema": "8.1.0"
+    "rescript-schema": "8.1.0",
+    "envio": "file:../../codegenerator/cli/npm/envio"
   }
 }

--- a/scenarios/helpers/rescript.json
+++ b/scenarios/helpers/rescript.json
@@ -10,6 +10,6 @@
     "in-source": true
   },
   "suffix": ".res.js",
-  "bs-dependencies": ["rescript-schema"],
+  "bs-dependencies": ["rescript-schema", "envio"],
   "bsc-flags": ["-open Belt"]
 }

--- a/scenarios/helpers/src/ChainMocking.res
+++ b/scenarios/helpers/src/ChainMocking.res
@@ -43,7 +43,7 @@ module Make = (Indexer: Indexer.S) => {
     eventMod: module(Types.InternalEvent),
   }
 
-  type makeEvent = (~blockHash: string) => Types.eventLog<Types.internalEventArgs>
+  type makeEvent = (~blockHash: string) => Types.eventLog<Internal.eventParams>
 
   type logConstructor = {
     transactionHash: string,
@@ -93,7 +93,7 @@ module Make = (Indexer: Indexer.S) => {
     let makeEvent: makeEvent = (~blockHash) => {
       let block = makeBlock(~blockHash, ~blockNumber, ~blockTimestamp)
       {
-        params: params->(Utils.magic: eventArgs => Types.internalEventArgs),
+        params: params->(Utils.magic: eventArgs => Internal.eventParams),
         srcAddress,
         chainId,
         block,
@@ -109,7 +109,7 @@ module Make = (Indexer: Indexer.S) => {
       srcAddress,
       eventMod: eventMod->(
         Utils.magic: module(Types.Event with type eventArgs = eventArgs) => module(Types.Event with
-          type eventArgs = Types.internalEventArgs
+          type eventArgs = Internal.eventParams
         )
       ),
     }

--- a/scenarios/helpers/src/ChainMocking.res
+++ b/scenarios/helpers/src/ChainMocking.res
@@ -37,7 +37,7 @@ module Crypto = {
 module Make = (Indexer: Indexer.S) => {
   open Indexer
   type log = {
-    eventBatchQueueItem: Types.eventBatchQueueItem,
+    eventItem: Types.eventItem,
     srcAddress: Address.t,
     transactionHash: string,
     eventMod: module(Types.InternalEvent),
@@ -175,7 +175,7 @@ module Make = (Indexer: Indexer.S) => {
       eventMod,
     }): log => {
       let module(Event) = eventMod
-      let log: Types.eventBatchQueueItem = {
+      let log: Types.eventItem = {
         eventName: Event.name,
         contractName: Event.contractName,
         handlerRegister: Event.handlerRegister,
@@ -186,7 +186,7 @@ module Make = (Indexer: Indexer.S) => {
         blockNumber,
         logIndex,
       }
-      {eventBatchQueueItem: log, srcAddress, transactionHash, eventMod}
+      {eventItem: log, srcAddress, transactionHash, eventMod}
     })
 
     let block = {blockNumber, blockTimestamp, blockHash, logs}
@@ -240,7 +240,7 @@ module Make = (Indexer: Indexer.S) => {
           },
         )
         if isLogInConfig {
-          Some(l.eventBatchQueueItem)
+          Some(l.eventItem)
         } else {
           None
         }

--- a/scenarios/helpers/src/ChainMocking.res
+++ b/scenarios/helpers/src/ChainMocking.res
@@ -178,7 +178,9 @@ module Make = (Indexer: Indexer.S) => {
       let log: Types.eventItem = {
         eventName: Event.name,
         contractName: Event.contractName,
-        handlerRegister: Event.handlerRegister,
+        handler: Event.handlerRegister->Types.HandlerTypes.Register.getHandler,
+        loader: Event.handlerRegister->Types.HandlerTypes.Register.getLoader,
+        contractRegister: Event.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
         paramsRawEventSchema: Event.paramsRawEventSchema,
         event: makeEvent(~blockHash),
         chain: self.chainConfig.chain,

--- a/scenarios/helpers/src/ChainMocking.res
+++ b/scenarios/helpers/src/ChainMocking.res
@@ -43,7 +43,7 @@ module Make = (Indexer: Indexer.S) => {
     eventMod: module(Types.InternalEvent),
   }
 
-  type makeEvent = (~blockHash: string) => Types.eventLog<Internal.eventParams>
+  type makeEvent = (~blockHash: string) => Internal.event
 
   type logConstructor = {
     transactionHash: string,
@@ -70,11 +70,11 @@ module Make = (Indexer: Indexer.S) => {
       ~blockNumber: int,
       ~blockTimestamp: int,
       ~blockHash: string,
-    ) => Indexer.Types.Block.t,
+    ) => Internal.eventBlock,
     ~makeTransaction: (
       ~transactionIndex: int,
       ~transactionHash: string,
-    ) => Indexer.Types.Transaction.t,
+    ) => Internal.eventTransaction,
     ~chainId,
     ~blockTimestamp: int,
     ~blockNumber: int,

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -1,25 +1,6 @@
 module type S = {
-  module Pino: {
-    type t
-  }
-
   module ErrorHandling: {
     type t
-  }
-
-  module Address: {
-    type t
-  }
-
-  module Viem: {
-    type decodedEvent<'a>
-  }
-
-  module Ethers: {
-    type abi
-    module JsonRpcProvider: {
-      type t
-    }
   }
 
   module HyperSyncClient: {
@@ -28,39 +9,14 @@ module type S = {
     }
   }
 
-  module ChainMap: {
-    module Chain: {
-      type t
-      let toChainId: t => int
-    }
-    type t<'a>
-  }
-
   module LogSelection: {
     type t
     type topicSelection
   }
 
   module Types: {
-    module Transaction: {
-      type t
-    }
-
-    module Block: {
-      type t
-    }
-
     module Log: {
       type t
-    }
-
-    type eventLog<'a> = {
-      params: 'a,
-      chainId: int,
-      srcAddress: Address.t,
-      logIndex: int,
-      transaction: Transaction.t,
-      block: Block.t,
     }
 
     module HandlerTypes: {
@@ -95,7 +51,7 @@ module type S = {
       chain: ChainMap.Chain.t,
       blockNumber: int,
       logIndex: int,
-      event: eventLog<Internal.eventParams>,
+      event: Internal.event,
       paramsRawEventSchema: RescriptSchema.S.schema<Internal.eventParams>,
       //Default to false, if an event needs to
       //be reprocessed after it has loaded dynamic contracts

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -42,8 +42,6 @@ module type S = {
   }
 
   module Types: {
-    type internalEventArgs
-
     module Transaction: {
       type t
     }
@@ -87,18 +85,18 @@ module type S = {
       type eventFilter
       let getTopicSelection: SingleOrMultiple.t<eventFilter> => array<LogSelection.topicSelection>
     }
-    module type InternalEvent = Event with type eventArgs = internalEventArgs
+    module type InternalEvent = Event with type eventArgs = Internal.eventParams
 
     type eventBatchQueueItem = {
       eventName: string,
       contractName: string,
-      handlerRegister: HandlerTypes.Register.t<internalEventArgs>,
+      handlerRegister: HandlerTypes.Register.t<Internal.eventParams>,
       timestamp: int,
       chain: ChainMap.Chain.t,
       blockNumber: int,
       logIndex: int,
-      event: eventLog<internalEventArgs>,
-      paramsRawEventSchema: RescriptSchema.S.schema<internalEventArgs>,
+      event: eventLog<Internal.eventParams>,
+      paramsRawEventSchema: RescriptSchema.S.schema<Internal.eventParams>,
       //Default to false, if an event needs to
       //be reprocessed after it has loaded dynamic contracts
       //This gets set to true and does not try and reload events

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -43,7 +43,7 @@ module type S = {
     }
     module type InternalEvent = Event with type eventArgs = Internal.eventParams
 
-    type eventBatchQueueItem = {
+    type eventItem = {
       eventName: string,
       contractName: string,
       handlerRegister: HandlerTypes.Register.t<Internal.eventParams>,
@@ -102,7 +102,7 @@ module type S = {
     type blockRangeFetchResponse = {
       currentBlockHeight: int,
       reorgGuard: reorgGuard,
-      parsedQueueItems: array<Types.eventBatchQueueItem>,
+      parsedQueueItems: array<Types.eventItem>,
       fromBlockQueried: int,
       heighestQueriedBlockNumber: int,
       latestFetchedBlockTimestamp: int,

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -20,8 +20,20 @@ module type S = {
     }
 
     module HandlerTypes: {
+      type contractRegister<'eventArgs>
+
+      type loader<'eventArgs, 'loaderReturn>
+
+      type handler<'eventArgs, 'loaderReturn>
+
       module Register: {
         type t<'eventArgs>
+
+        let getLoader: t<'eventArgs> => option<loader<Internal.eventParams, Internal.loaderReturn>>
+        let getHandler: t<'eventArgs> => option<
+          handler<Internal.eventParams, Internal.loaderReturn>,
+        >
+        let getContractRegister: t<'eventArgs> => option<contractRegister<Internal.eventParams>>
       }
     }
 
@@ -46,7 +58,9 @@ module type S = {
     type eventItem = {
       eventName: string,
       contractName: string,
-      handlerRegister: HandlerTypes.Register.t<Internal.eventParams>,
+      loader: option<HandlerTypes.loader<Internal.eventParams, Internal.loaderReturn>>,
+      handler: option<HandlerTypes.handler<Internal.eventParams, Internal.loaderReturn>>,
+      contractRegister: option<HandlerTypes.contractRegister<Internal.eventParams>>,
       timestamp: int,
       chain: ChainMap.Chain.t,
       blockNumber: int,

--- a/scenarios/test_codegen/pnpm-lock.yaml
+++ b/scenarios/test_codegen/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
 
   ../helpers:
     dependencies:
+      envio:
+        specifier: file:../../codegenerator/cli/npm/envio
+        version: file:../../codegenerator/cli/npm/envio(typescript@5.5.4)
       rescript:
         specifier: 11.1.3
         version: 11.1.3

--- a/scenarios/test_codegen/test/ChainEventQueue_test.res
+++ b/scenarios/test_codegen/test/ChainEventQueue_test.res
@@ -10,7 +10,7 @@ let tx1: Types.Transaction.t = {
   hash: "0xaaa",
   transactionIndex: 1,
 }
-let eventMock1: Types.eventLog<Types.internalEventArgs> = {
+let eventMock1: Types.eventLog<Internal.eventParams> = {
   block: {
     number: 1,
     hash: "0xdef",
@@ -34,11 +34,17 @@ let qItemMock1: Types.eventBatchQueueItem = {
   event: eventMock1,
   eventName: "NewGravatar",
   contractName: "Gravatar",
-  handlerRegister: Types.Gravatar.NewGravatar.handlerRegister->(Utils.magic: Types.HandlerTypes.Register.t<Types.Gravatar.NewGravatar.eventArgs> => Types.HandlerTypes.Register.t<Types.internalEventArgs>),
-  paramsRawEventSchema: Types.Gravatar.NewGravatar.paramsRawEventSchema->(Utils.magic: S.t<Types.Gravatar.NewGravatar.eventArgs> => S.t<Types.internalEventArgs>),
+  handlerRegister: Types.Gravatar.NewGravatar.handlerRegister->(
+    Utils.magic: Types.HandlerTypes.Register.t<
+      Types.Gravatar.NewGravatar.eventArgs,
+    > => Types.HandlerTypes.Register.t<Internal.eventParams>
+  ),
+  paramsRawEventSchema: Types.Gravatar.NewGravatar.paramsRawEventSchema->(
+    Utils.magic: S.t<Types.Gravatar.NewGravatar.eventArgs> => S.t<Internal.eventParams>
+  ),
 }
 
-let eventMock2: Types.eventLog<Types.internalEventArgs> = {
+let eventMock2: Types.eventLog<Internal.eventParams> = {
   block: {
     number: 2,
     hash: "0xabc",
@@ -62,8 +68,14 @@ let qItemMock2: Types.eventBatchQueueItem = {
   event: eventMock1,
   eventName: "NewGravatar",
   contractName: "Gravatar",
-  handlerRegister: Types.Gravatar.NewGravatar.handlerRegister->(Utils.magic: Types.HandlerTypes.Register.t<Types.Gravatar.NewGravatar.eventArgs> => Types.HandlerTypes.Register.t<Types.internalEventArgs>),
-  paramsRawEventSchema: Types.Gravatar.NewGravatar.paramsRawEventSchema->(Utils.magic: S.t<Types.Gravatar.NewGravatar.eventArgs> => S.t<Types.internalEventArgs>),
+  handlerRegister: Types.Gravatar.NewGravatar.handlerRegister->(
+    Utils.magic: Types.HandlerTypes.Register.t<
+      Types.Gravatar.NewGravatar.eventArgs,
+    > => Types.HandlerTypes.Register.t<Internal.eventParams>
+  ),
+  paramsRawEventSchema: Types.Gravatar.NewGravatar.paramsRawEventSchema->(
+    Utils.magic: S.t<Types.Gravatar.NewGravatar.eventArgs> => S.t<Internal.eventParams>
+  ),
 }
 
 describe("Chain Event Queue", () => {

--- a/scenarios/test_codegen/test/ChainEventQueue_test.res
+++ b/scenarios/test_codegen/test/ChainEventQueue_test.res
@@ -34,11 +34,9 @@ let qItemMock1: Types.eventItem = {
   event: eventMock1,
   eventName: "NewGravatar",
   contractName: "Gravatar",
-  handlerRegister: Types.Gravatar.NewGravatar.handlerRegister->(
-    Utils.magic: Types.HandlerTypes.Register.t<
-      Types.Gravatar.NewGravatar.eventArgs,
-    > => Types.HandlerTypes.Register.t<Internal.eventParams>
-  ),
+  handler: Types.Gravatar.NewGravatar.handlerRegister->Types.HandlerTypes.Register.getHandler,
+  loader: Types.Gravatar.NewGravatar.handlerRegister->Types.HandlerTypes.Register.getLoader,
+  contractRegister: Types.Gravatar.NewGravatar.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
   paramsRawEventSchema: Types.Gravatar.NewGravatar.paramsRawEventSchema->(
     Utils.magic: S.t<Types.Gravatar.NewGravatar.eventArgs> => S.t<Internal.eventParams>
   ),
@@ -68,11 +66,9 @@ let qItemMock2: Types.eventItem = {
   event: eventMock1,
   eventName: "NewGravatar",
   contractName: "Gravatar",
-  handlerRegister: Types.Gravatar.NewGravatar.handlerRegister->(
-    Utils.magic: Types.HandlerTypes.Register.t<
-      Types.Gravatar.NewGravatar.eventArgs,
-    > => Types.HandlerTypes.Register.t<Internal.eventParams>
-  ),
+  handler: Types.Gravatar.NewGravatar.handlerRegister->Types.HandlerTypes.Register.getHandler,
+  loader: Types.Gravatar.NewGravatar.handlerRegister->Types.HandlerTypes.Register.getLoader,
+  contractRegister: Types.Gravatar.NewGravatar.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
   paramsRawEventSchema: Types.Gravatar.NewGravatar.paramsRawEventSchema->(
     Utils.magic: S.t<Types.Gravatar.NewGravatar.eventArgs> => S.t<Internal.eventParams>
   ),

--- a/scenarios/test_codegen/test/ChainEventQueue_test.res
+++ b/scenarios/test_codegen/test/ChainEventQueue_test.res
@@ -10,21 +10,21 @@ let tx1: Types.Transaction.t = {
   hash: "0xaaa",
   transactionIndex: 1,
 }
-let eventMock1: Types.eventLog<Internal.eventParams> = {
+let eventMock1: Internal.event = {
   block: {
-    number: 1,
-    hash: "0xdef",
-    timestamp: 1900000,
+    "number": 1,
+    "hash": "0xdef",
+    "timestamp": 1900000,
   },
   chainId: 54321,
   logIndex: 0,
   params: MockEvents.newGravatar1,
   srcAddress: "0x1234512345123451234512345123451234512345"->Address.Evm.fromStringOrThrow,
   transaction: {
-    hash: "0xabc",
-    transactionIndex: 987,
+    "hash": "0xabc",
+    "transactionIndex": 987,
   },
-}->Types.eventToInternal
+}->Internal.fromGenericEvent
 
 let qItemMock1: Types.eventBatchQueueItem = {
   timestamp: 0,
@@ -44,21 +44,21 @@ let qItemMock1: Types.eventBatchQueueItem = {
   ),
 }
 
-let eventMock2: Types.eventLog<Internal.eventParams> = {
+let eventMock2: Internal.event = {
   block: {
-    number: 2,
-    hash: "0xabc",
-    timestamp: 1900001,
+    "number": 2,
+    "hash": "0xabc",
+    "timestamp": 1900001,
   },
   chainId: 54321,
   logIndex: 1,
   params: MockEvents.newGravatar2,
   srcAddress: "0x1234512345123451234512345123451234512346"->Address.Evm.fromStringOrThrow,
   transaction: {
-    hash: "0xdef",
-    transactionIndex: 988,
+    "hash": "0xdef",
+    "transactionIndex": 988,
   },
-}->Types.eventToInternal
+}->Internal.fromGenericEvent
 
 let qItemMock2: Types.eventBatchQueueItem = {
   timestamp: 1,

--- a/scenarios/test_codegen/test/ChainEventQueue_test.res
+++ b/scenarios/test_codegen/test/ChainEventQueue_test.res
@@ -26,7 +26,7 @@ let eventMock1: Internal.event = {
   },
 }->Internal.fromGenericEvent
 
-let qItemMock1: Types.eventBatchQueueItem = {
+let qItemMock1: Types.eventItem = {
   timestamp: 0,
   chain: MockConfig.chain1337,
   blockNumber: 1,
@@ -60,7 +60,7 @@ let eventMock2: Internal.event = {
   },
 }->Internal.fromGenericEvent
 
-let qItemMock2: Types.eventBatchQueueItem = {
+let qItemMock2: Types.eventItem = {
   timestamp: 1,
   chain: MockConfig.chain1337,
   blockNumber: 2,

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -60,7 +60,9 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
           logIndex,
           eventName: "MockEvent",
           contractName: "MockContract",
-          handlerRegister: Utils.magic("Mock event handlerRegister in fetchstate test"),
+          handler: None,
+          loader: None,
+          contractRegister: None,
           paramsRawEventSchema: Utils.magic("Mock event paramsRawEventSchema in fetchstate test"),
           event: `mock event (chainId)${chain->ChainMap.Chain.toString} - (blockNumber)${currentBlockNumber.contents->string_of_int} - (logIndex)${logIndex->string_of_int} - (timestamp)${currentTime.contents->string_of_int}`->Utils.magic,
         }
@@ -165,7 +167,9 @@ describe("ChainManager", () => {
           logIndex: 0,
           eventName: "MockEvent",
           contractName: "MockContract",
-          handlerRegister: Utils.magic("Mock event handlerRegister in fetchstate test"),
+          handler: None,
+          loader: None,
+          contractRegister: None,
           paramsRawEventSchema: Utils.magic("Mock event paramsRawEventSchema in fetchstate test"),
           event: `mock initial event`->Utils.magic,
         }
@@ -305,7 +309,9 @@ describe("determineNextEvent", () => {
         logIndex: 123456,
         eventName: "MockEvent",
         contractName: "MockContract",
-        handlerRegister: Utils.magic("Mock event handlerRegister"),
+        handler: None,
+        loader: None,
+        contractRegister: None,
         paramsRawEventSchema: Utils.magic("Mock event paramsRawEventSchema"),
         event: "SINGLE TEST EVENT"->Utils.magic,
       }

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -53,7 +53,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       let numberOfEventsInBatch = getRandomInt(0, 2 * averageEventsPerBlock)
 
       for logIndex in 0 to numberOfEventsInBatch {
-        let batchItem: Types.eventBatchQueueItem = {
+        let batchItem: Types.eventItem = {
           timestamp: currentTime.contents,
           chain,
           blockNumber: currentBlockNumber.contents,
@@ -158,7 +158,7 @@ describe("ChainManager", () => {
           _allEvents,
         ) = populateChainQueuesWithRandomEvents()
 
-        let defaultFirstEvent: Types.eventBatchQueueItem = {
+        let defaultFirstEvent: Types.eventItem = {
           timestamp: 0,
           chain: MockConfig.chain1,
           blockNumber: 0,
@@ -297,7 +297,7 @@ describe("determineNextEvent", () => {
     )
 
     let makeNoItem = timestamp => FetchState.NoItem({blockTimestamp: timestamp, blockNumber: 0})
-    let makeMockQItem = (timestamp, chain): Types.eventBatchQueueItem => {
+    let makeMockQItem = (timestamp, chain): Types.eventItem => {
       {
         timestamp,
         chain,

--- a/scenarios/test_codegen/test/Mock_test.res
+++ b/scenarios/test_codegen/test/Mock_test.res
@@ -11,10 +11,10 @@ describe("E2E Mock Event Batch", () => {
 
     let loadLayer = LoadLayer.makeWithDbConnection()
 
-    let runEventHandler = async (eventBatchQueueItem: Types.eventBatchQueueItem) => {
-      switch eventBatchQueueItem.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler {
+    let runEventHandler = async (eventItem: Types.eventItem) => {
+      switch eventItem.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler {
       | Some(loaderHandler) =>
-        await eventBatchQueueItem->EventProcessing.runEventHandler(
+        await eventItem->EventProcessing.runEventHandler(
           ~loaderHandler,
           ~inMemoryStore,
           ~logger=Logging.logger,

--- a/scenarios/test_codegen/test/Mock_test.res
+++ b/scenarios/test_codegen/test/Mock_test.res
@@ -12,16 +12,17 @@ describe("E2E Mock Event Batch", () => {
     let loadLayer = LoadLayer.makeWithDbConnection()
 
     let runEventHandler = async (eventItem: Types.eventItem) => {
-      switch eventItem.handlerRegister->Types.HandlerTypes.Register.getLoaderHandler {
-      | Some(loaderHandler) =>
+      switch eventItem.handler {
+      | None => Ok()
+      | Some(handler) =>
         await eventItem->EventProcessing.runEventHandler(
-          ~loaderHandler,
+          ~loader=eventItem.loader,
+          ~handler,
           ~inMemoryStore,
           ~logger=Logging.logger,
           ~loadLayer,
           ~shouldSaveHistory=false,
         )
-      | None => Ok()
       }
     }
 

--- a/scenarios/test_codegen/test/__mocks__/MockEvents.res
+++ b/scenarios/test_codegen/test/__mocks__/MockEvents.res
@@ -138,7 +138,7 @@ let setGravatarLog4: Types.eventLog<Types.Gravatar.UpdatedGravatar.eventArgs> = 
 
 let newGravatarEventToBatchItem = (
   event: Types.eventLog<Types.Gravatar.NewGravatar.eventArgs>,
-): Types.eventBatchQueueItem => {
+): Types.eventItem => {
   {
     timestamp: event.block.timestamp,
     chain: MockConfig.chain1337,
@@ -160,7 +160,7 @@ let newGravatarEventToBatchItem = (
 
 let updatedGravatarEventToBatchItem = (
   event: Types.eventLog<Types.Gravatar.UpdatedGravatar.eventArgs>,
-): Types.eventBatchQueueItem => {
+): Types.eventItem => {
   {
     timestamp: event.block.timestamp,
     chain: MockConfig.chain1337,

--- a/scenarios/test_codegen/test/__mocks__/MockEvents.res
+++ b/scenarios/test_codegen/test/__mocks__/MockEvents.res
@@ -146,11 +146,9 @@ let newGravatarEventToBatchItem = (
     logIndex: event.logIndex,
     eventName: "NewGravatar",
     contractName: "Gravatar",
-    handlerRegister: Types.Gravatar.NewGravatar.handlerRegister->(
-      Utils.magic: Types.HandlerTypes.Register.t<
-        Types.Gravatar.NewGravatar.eventArgs,
-      > => Types.HandlerTypes.Register.t<Internal.eventParams>
-    ),
+    handler: Types.Gravatar.NewGravatar.handlerRegister->Types.HandlerTypes.Register.getHandler,
+    loader: Types.Gravatar.NewGravatar.handlerRegister->Types.HandlerTypes.Register.getLoader,
+    contractRegister: Types.Gravatar.NewGravatar.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
     paramsRawEventSchema: Types.Gravatar.NewGravatar.paramsRawEventSchema->(
       Utils.magic: S.t<Types.Gravatar.NewGravatar.eventArgs> => S.t<Internal.eventParams>
     ),
@@ -168,11 +166,9 @@ let updatedGravatarEventToBatchItem = (
     logIndex: event.logIndex,
     eventName: "UpdatedGravatar",
     contractName: "Gravatar",
-    handlerRegister: Types.Gravatar.UpdatedGravatar.handlerRegister->(
-      Utils.magic: Types.HandlerTypes.Register.t<
-        Types.Gravatar.UpdatedGravatar.eventArgs,
-      > => Types.HandlerTypes.Register.t<Internal.eventParams>
-    ),
+    handler: Types.Gravatar.UpdatedGravatar.handlerRegister->Types.HandlerTypes.Register.getHandler,
+    loader: Types.Gravatar.UpdatedGravatar.handlerRegister->Types.HandlerTypes.Register.getLoader,
+    contractRegister: Types.Gravatar.UpdatedGravatar.handlerRegister->Types.HandlerTypes.Register.getContractRegister,
     paramsRawEventSchema: Types.Gravatar.UpdatedGravatar.paramsRawEventSchema->(
       Utils.magic: S.t<Types.Gravatar.UpdatedGravatar.eventArgs> => S.t<Internal.eventParams>
     ),

--- a/scenarios/test_codegen/test/__mocks__/MockEvents.res
+++ b/scenarios/test_codegen/test/__mocks__/MockEvents.res
@@ -154,7 +154,7 @@ let newGravatarEventToBatchItem = (
     paramsRawEventSchema: Types.Gravatar.NewGravatar.paramsRawEventSchema->(
       Utils.magic: S.t<Types.Gravatar.NewGravatar.eventArgs> => S.t<Internal.eventParams>
     ),
-    event: event->Types.eventToInternal,
+    event: event->Internal.fromGenericEvent,
   }
 }
 
@@ -176,7 +176,7 @@ let updatedGravatarEventToBatchItem = (
     paramsRawEventSchema: Types.Gravatar.UpdatedGravatar.paramsRawEventSchema->(
       Utils.magic: S.t<Types.Gravatar.UpdatedGravatar.eventArgs> => S.t<Internal.eventParams>
     ),
-    event: event->Types.eventToInternal,
+    event: event->Internal.fromGenericEvent,
   }
 }
 

--- a/scenarios/test_codegen/test/__mocks__/MockEvents.res
+++ b/scenarios/test_codegen/test/__mocks__/MockEvents.res
@@ -136,7 +136,9 @@ let setGravatarLog4: Types.eventLog<Types.Gravatar.UpdatedGravatar.eventArgs> = 
   block: block1,
 }
 
-let newGravatarEventToBatchItem = (event: Types.eventLog<Types.Gravatar.NewGravatar.eventArgs>): Types.eventBatchQueueItem => {
+let newGravatarEventToBatchItem = (
+  event: Types.eventLog<Types.Gravatar.NewGravatar.eventArgs>,
+): Types.eventBatchQueueItem => {
   {
     timestamp: event.block.timestamp,
     chain: MockConfig.chain1337,
@@ -144,14 +146,21 @@ let newGravatarEventToBatchItem = (event: Types.eventLog<Types.Gravatar.NewGrava
     logIndex: event.logIndex,
     eventName: "NewGravatar",
     contractName: "Gravatar",
-    handlerRegister: Types.Gravatar.NewGravatar.handlerRegister->(Utils.magic: Types.HandlerTypes.Register.t<Types.Gravatar.NewGravatar.eventArgs> => Types.HandlerTypes.Register.t<Types.internalEventArgs>),
-    paramsRawEventSchema: Types.Gravatar.NewGravatar.paramsRawEventSchema->(Utils.magic: S.t<Types.Gravatar.NewGravatar.eventArgs> => S.t<Types.internalEventArgs>),
+    handlerRegister: Types.Gravatar.NewGravatar.handlerRegister->(
+      Utils.magic: Types.HandlerTypes.Register.t<
+        Types.Gravatar.NewGravatar.eventArgs,
+      > => Types.HandlerTypes.Register.t<Internal.eventParams>
+    ),
+    paramsRawEventSchema: Types.Gravatar.NewGravatar.paramsRawEventSchema->(
+      Utils.magic: S.t<Types.Gravatar.NewGravatar.eventArgs> => S.t<Internal.eventParams>
+    ),
     event: event->Types.eventToInternal,
   }
 }
 
-
-let updatedGravatarEventToBatchItem = (event: Types.eventLog<Types.Gravatar.UpdatedGravatar.eventArgs>): Types.eventBatchQueueItem => {
+let updatedGravatarEventToBatchItem = (
+  event: Types.eventLog<Types.Gravatar.UpdatedGravatar.eventArgs>,
+): Types.eventBatchQueueItem => {
   {
     timestamp: event.block.timestamp,
     chain: MockConfig.chain1337,
@@ -159,8 +168,14 @@ let updatedGravatarEventToBatchItem = (event: Types.eventLog<Types.Gravatar.Upda
     logIndex: event.logIndex,
     eventName: "UpdatedGravatar",
     contractName: "Gravatar",
-    handlerRegister: Types.Gravatar.UpdatedGravatar.handlerRegister->(Utils.magic: Types.HandlerTypes.Register.t<Types.Gravatar.UpdatedGravatar.eventArgs> => Types.HandlerTypes.Register.t<Types.internalEventArgs>),
-    paramsRawEventSchema: Types.Gravatar.UpdatedGravatar.paramsRawEventSchema->(Utils.magic: S.t<Types.Gravatar.UpdatedGravatar.eventArgs> => S.t<Types.internalEventArgs>),
+    handlerRegister: Types.Gravatar.UpdatedGravatar.handlerRegister->(
+      Utils.magic: Types.HandlerTypes.Register.t<
+        Types.Gravatar.UpdatedGravatar.eventArgs,
+      > => Types.HandlerTypes.Register.t<Internal.eventParams>
+    ),
+    paramsRawEventSchema: Types.Gravatar.UpdatedGravatar.paramsRawEventSchema->(
+      Utils.magic: S.t<Types.Gravatar.UpdatedGravatar.eventArgs> => S.t<Internal.eventParams>
+    ),
     event: event->Types.eventToInternal,
   }
 }

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -189,7 +189,7 @@ describe("FetchState.fetchState", () => {
     Assert.deepEqual(updatedState3, expected3, ~message="3rd registration")
   })
 
-  let mockEvent = (~blockNumber, ~logIndex=0, ~chainId=1): Types.eventBatchQueueItem => {
+  let mockEvent = (~blockNumber, ~logIndex=0, ~chainId=1): Types.eventItem => {
     timestamp: blockNumber * 15,
     chain: ChainMap.Chain.makeUnsafe(~chainId),
     blockNumber,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -196,7 +196,9 @@ describe("FetchState.fetchState", () => {
     logIndex,
     eventName: "MockEvent",
     contractName: "MockContract",
-    handlerRegister: Utils.magic("Mock event handlerRegister in fetchstate test"),
+    handler: None,
+    loader: None,
+    contractRegister: None,
     paramsRawEventSchema: Utils.magic("Mock event paramsRawEventSchema in fetchstate test"),
     event: Utils.magic("Mock event in fetchstate test"),
   }

--- a/scenarios/test_codegen/test/rollback/ChainDataHelpers.res
+++ b/scenarios/test_codegen/test/rollback/ChainDataHelpers.res
@@ -1,13 +1,17 @@
 open Belt
-let makeBlock = (~blockNumber, ~blockTimestamp, ~blockHash): Types.Block.t => {
-  number: blockNumber,
-  hash: blockHash,
-  timestamp: blockTimestamp,
-}
-let makeTransaction = (~transactionIndex, ~transactionHash): Types.Transaction.t => {
-  transactionIndex,
-  hash: transactionHash,
-}
+let makeBlock = (~blockNumber, ~blockTimestamp, ~blockHash) =>
+  {
+    number: blockNumber,
+    hash: blockHash,
+    timestamp: blockTimestamp,
+  }->(Utils.magic: Types.Block.t => Internal.eventBlock)
+
+let makeTransaction = (~transactionIndex, ~transactionHash) =>
+  {
+    transactionIndex,
+    hash: transactionHash,
+  }->(Utils.magic: Types.Transaction.t => Internal.eventTransaction)
+
 module Gravatar = {
   let contractName = "Gravatar"
   let chainConfig =

--- a/scenarios/test_codegen/test/rollback/MockChainData.res
+++ b/scenarios/test_codegen/test/rollback/MockChainData.res
@@ -1,17 +1,12 @@
 module Indexer = {
-  module Pino = Pino
-  module Address = Address
   module ErrorHandling = ErrorHandling
   module Enums = Enums
   module Types = Types
   module Config = Config
-  module Ethers = Ethers
-  module Viem = Viem
   module HyperSyncClient = HyperSyncClient
   module ChainWorker = ChainWorker
   module ReorgDetection = ReorgDetection
   module FetchState = FetchState
-  module ChainMap = ChainMap
   module ContractAddressingMap = ContractAddressingMap
   module LogSelection = LogSelection
 }

--- a/scenarios/test_codegen/test/rollback/MockChainData_test.res
+++ b/scenarios/test_codegen/test/rollback/MockChainData_test.res
@@ -77,11 +77,11 @@ describe("Check that MockChainData works as expected", () => {
           -1,
           (accum, next) => {
             Assert.equal(
-              next.eventBatchQueueItem.logIndex,
+              next.eventItem.logIndex,
               accum + 1,
               ~message="Log indexes should increment in each block",
             )
-            next.eventBatchQueueItem.logIndex
+            next.eventItem.logIndex
           },
         )
         ->ignore

--- a/scenarios/test_codegen/test/schema_types/BigDecimal_test.res
+++ b/scenarios/test_codegen/test/schema_types/BigDecimal_test.res
@@ -33,7 +33,7 @@ describe("Load and save an entity with a BigDecimal from DB", () => {
     let loadLayer = LoadLayer.makeWithDbConnection()
 
     let contextEnv = ContextEnv.make(
-      ~eventBatchQueueItem=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
+      ~eventItem=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
       ~logger=Logging.logger,
     )
 

--- a/scenarios/test_codegen/test/schema_types/Timestamp_test.res
+++ b/scenarios/test_codegen/test/schema_types/Timestamp_test.res
@@ -28,7 +28,7 @@ describe("Load and save an entity with a Timestamp from DB", () => {
     let loadLayer = LoadLayer.makeWithDbConnection()
 
     let contextEnv = ContextEnv.make(
-      ~eventBatchQueueItem=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
+      ~eventItem=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
       ~logger=Logging.logger,
     )
 


### PR DESCRIPTION
- Start moving internal types from Types.res.hsb to envio/src/Internal.res. There are two goals:
   1. To remove dependency on `Types.res.hsb` module, specifically on `Types.Block.t` and `Types.Transaction.t`. So we can move more code to npm package and use more generic types different per each handler.
   2. To be able to configure HyperSyncWorker/RpcWorker with a `evmEventConfig` instead of the `Event` module. This is how it's already done for HyperFuel and will allow more flexibility in terms of testing + more convenient way of getting the event configuration like block or transaction schema
- I renamed `eventBatchQueueItem` to `eventItem` because it's shorter.
- Removed dependency on the `Register` for `eventItem`. I also included a micro-optimization to skip the loader path completely when it's not provided. Previously we still ran it with a noop function.

Next I will:
- Completely remove dependency on `Types.Block.t` and `Types.Transaction.t` from workers (this will also clean up the messy Block.getInternalId` fns).
- Generate the `block`, `transaction`, `blockSchema`, `transactionSchema` for each Event
- Start using the `blockSchema`, `transactionSchema` in workers per event instead of the global one
- Generalize handlers type to support different `block` and `transation` args
- Codegen mock helpers per event

Decided to split the PRs, since there are already quite many changes.