### PR TITLE
Discard invalid tasks

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -784,6 +784,7 @@ let invalidatedActionReducer = (state: t, action: action) =>
   | ({rollbackState: RollingBack(_)}, EventBatchProcessed(_)) =>
     Logging.warn("Finished processing batch before rollback, actioning rollback")
     ({...state, currentlyProcessingBatch: false}, [Rollback])
+  | (_, ErrorExit(_)) => actionReducer(state, action)
   | _ =>
     Logging.warn("Invalidated action discarded")
     (state, [])

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalStateManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalStateManager.res
@@ -40,9 +40,13 @@ module MakeManager = (S: State) => {
   and dispatchTask = (self, task: S.task) => {
     let stateId = self.state->S.getId
     Js.Global.setTimeout(() => {
-      S.taskReducer(self.state, task, ~dispatchAction=action =>
-        dispatchAction(~stateId, self, action)
-      )->ignore
+      if stateId !== self.state->S.getId {
+        Logging.warn("Invalidated task discarded")
+      } else {
+        S.taskReducer(self.state, task, ~dispatchAction=action =>
+          dispatchAction(~stateId, self, action)
+        )->ignore
+      }
     }, 0)->ignore
   }
 


### PR DESCRIPTION
Currently it causes indexer freeze after preRegistration is done on the `2.11.3` pre-release.

I can explain in detail the problems with the old behavior on a call.

It's safe to discard all tasks with unmatching stateId.

Also, I've added support for `ErrorExit` action in the invalidatedActionReducer. Without it, the indexer couldn't gracefully crash during the rollback or when preRegistration is done.