### PR TITLE
Retry on wrong hypersync instance response

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/Time.res
+++ b/codegenerator/cli/templates/static/codegen/src/Time.res
@@ -1,8 +1,8 @@
 let resolvePromiseAfterDelay = (~delayMilliseconds) => Utils.delay(delayMilliseconds)
 
 let rec retryAsyncWithExponentialBackOff = async (
-  ~backOffMillis=1000,
-  ~multiplicative=2,
+  ~backOffMillis=100,
+  ~multiplicative=4,
   ~retryCount=0,
   ~maxRetries=5,
   ~logger: option<Pino.t>=None,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.res
@@ -206,7 +206,7 @@ module LogsQuery = {
       if res.nextBlock <= fromBlock {
         // Might happen when /height response was from another instance of HyperSync
         Js.Exn.raiseError(
-          "Received page response from another instance of HyperSync. Should work after a retry.",
+          "Received page response from another instance of HyperFuel. Should work after a retry.",
         )
       }
       res
@@ -271,8 +271,8 @@ module BlockData = {
     if res.nextBlock <= blockNumber {
       let logger = Logging.createChild(~params={"url": serverUrl})
       let delayMilliseconds = 100
-      logger->Logging.childWarn(
-        `Block #${blockNumber->Int.toString} not found in HyperSync. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${delayMilliseconds->Int.toString}ms.`,
+      logger->Logging.childInfo(
+        `Block #${blockNumber->Int.toString} not found in HyperFuel. HyperFuel has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${delayMilliseconds->Int.toString}ms.`,
       )
       await Time.resolvePromiseAfterDelay(~delayMilliseconds)
       await queryBlockData(~serverUrl, ~blockNumber, ~logger)

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hypersync/HyperSync.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hypersync/HyperSync.res
@@ -315,7 +315,7 @@ module BlockData = {
     | None => {
         let logger = Logging.createChild(~params={"url": serverUrl})
         let delayMilliseconds = 100
-        logger->Logging.childWarn(
+        logger->Logging.childInfo(
           `Block #${blockNumber->Int.toString} not found in HyperSync. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${delayMilliseconds->Int.toString}ms.`,
         )
         await Time.resolvePromiseAfterDelay(~delayMilliseconds)


### PR DESCRIPTION
Example from the debugging log. You can notice that we receive a page response with `archiveHeight` lower than request `fromBlock`.

```
FETCH BATCH
ACTION { TAG: 'SetUpdatedPartitions', _0: 100, _1: {} }
Fetching queries [
  {
    fetchStateRegisterId: 'Root',
    partitionId: 0,
    fromBlock: 37574315,
    toBlock: undefined,
    contractAddressMapping: { nameByAddress: [Object], addressesByName: [Object] }
  }
]
PAGE {
  items: [],
  nextBlock: 37574315,
  archiveHeight: 37574314,
  rollbackGuard: undefined,
  events: []
}
[19:34:16.620] TRACE (88546):
    chainId: 100
    logType: "Block Range Query"
    workerType: "HyperSync"
    fromBlock: 37574315
    addresses: [
      "0xd4AC1d556fF07D6b3F99a891F2875295F734b994",
      "0xD6CF99F14586BcD7B6c75474dfFBC945c961a819",
      "0xC556C2b335B19a201E4c03A5E0Da6251555EB9d2",
      "... and 17 more"
    ]
    fetchStateRegister: "root"
    message: "Retrieved event page from server"
    toBlock: 37574314
```