### PR TITLE
Fix inconsistent processed events with many dynamic contracts

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/Benchmark.res
+++ b/codegenerator/cli/templates/static/codegen/src/Benchmark.res
@@ -269,10 +269,7 @@ let addBlockRangeFetched = (
   ~numEvents,
   ~partitionId,
 ) => {
-  let registerName = switch fetchStateRegisterId {
-  | Root => "Root"
-  | DynamicContract(_) => "Dynamic Contract"
-  }
+  let registerName = fetchStateRegisterId->FetchState.registerIdToName
 
   let group = `BlockRangeFetched Summary for Chain ${chainId->Belt.Int.toString} ${registerName} Register`
   let add = (label, value) => data->Data.addSummaryData(~group, ~label, ~value=Utils.magic(value))

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -90,19 +90,13 @@ type id = string
 
 let rootRegisterId = "root"
 
-// Make it unique to prevent the case when there are two registers
-// for the same dynamic contract (even though it's super edge-case)
-let makeDynamicContractRegisterId = {
-  let counter = ref(-1)
-  (dynamicContractId: dynamicContractId) => {
-    counter := counter.contents + 1
-    `dynamic-${dynamicContractId.blockNumber->Int.toString}-${dynamicContractId.logIndex->Int.toString}-${counter.contents->Js.Int.toString}`
-  }
+let makeDynamicContractRegisterId = (dynamicContractId: dynamicContractId) => {
+  `dynamic-${dynamicContractId.blockNumber->Int.toString}-${dynamicContractId.logIndex->Int.toString}`
 }
 
 let isRootRegisterId = id => id === rootRegisterId
 
-let registerIdToName = (id) => {
+let registerIdToName = id => {
   if id->isRootRegisterId {
     "Root"
   } else {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -259,7 +259,7 @@ let makeDynamicContractRegister = (
   {
     id: makeDynamicContractRegisterId(id),
     latestFetchedBlock: {
-      blockNumber: registeringEventBlockNumber - 1,
+      blockNumber: Pervasives.max(registeringEventBlockNumber - 1, 0),
       blockTimestamp: 0,
     },
     contractAddressMapping,
@@ -540,7 +540,7 @@ let getEarliestEvent = (fetchState: t) => {
 
     let earliestItemInPendingDynamicContracts = NoItem({
       blockTimestamp: 0,
-      blockNumber: earliestPendingDynamicContractBlockNumber - 1,
+      blockNumber: Pervasives.max(earliestPendingDynamicContractBlockNumber - 1, 0),
     })
 
     //Compare the earliest item in the pending dynamic contracts with the earliest item in the registers
@@ -709,9 +709,10 @@ let getLatestFullyFetchedBlock = ({mostBehindRegister, pendingDynamicContracts}:
   //the register function is called
   pendingDynamicContracts->Js.Array2.forEach(contract => {
     let {registeringEventBlockNumber} = contract
-    if registeringEventBlockNumber < latestFullyFetchedBlock.contents.blockNumber {
+    let contractLatestFullyFetchedBlockNumber = Pervasives.max(registeringEventBlockNumber - 1, 0)
+    if contractLatestFullyFetchedBlockNumber < latestFullyFetchedBlock.contents.blockNumber {
       latestFullyFetchedBlock := {
-          blockNumber: registeringEventBlockNumber,
+          blockNumber: contractLatestFullyFetchedBlockNumber,
           blockTimestamp: 0,
         }
     }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
@@ -125,13 +125,12 @@ let registerDynamicContracts = (
       newestPartition->FetchState.registerDynamicContract(
         dynamicContractRegistration,
         ~isFetchingAtHead,
-        ~endBlock,
       )
     partitions->Utils.Array.setIndexImmutable(newestPartitionIndex, updated)
   } else {
     let newPartition = FetchState.make(
       ~partitionId=partitions->Array.length,
-      ~startBlock,
+      ~startBlock=dynamicContractRegistration.registeringEventBlockNumber,
       ~logger,
       ~staticContracts=[],
       ~dynamicContractRegistrations=dynamicContractRegistration.dynamicContracts,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/PartitionedFetchState.res
@@ -125,6 +125,7 @@ let registerDynamicContracts = (
       newestPartition->FetchState.registerDynamicContract(
         dynamicContractRegistration,
         ~isFetchingAtHead,
+        ~endBlock,
       )
     partitions->Utils.Array.setIndexImmutable(newestPartitionIndex, updated)
   } else {
@@ -160,7 +161,12 @@ let update = (self: t, ~id: id, ~latestFetchedBlock, ~newItems, ~currentBlockHei
   switch self.partitions[id.partitionId] {
   | Some(partition) =>
     partition
-    ->FetchState.update(~id=id.fetchStateId, ~latestFetchedBlock, ~newItems, ~currentBlockHeight)
+    ->FetchState.setFetchedItems(
+      ~id=id.fetchStateId,
+      ~latestFetchedBlock,
+      ~newItems,
+      ~currentBlockHeight,
+    )
     ->Result.map(updatedPartition => {
       Prometheus.PartitionBlockFetched.set(
         ~blockNumber=latestFetchedBlock.blockNumber,
@@ -188,7 +194,7 @@ let getReadyPartitions = (
   let maxPartitionQueueSize = maxPerChainQueueSize / numPartitions
   allPartitions->Js.Array2.filter(fetchState => {
     !(fetchingPartitions->Utils.Set.has(fetchState.partitionId)) &&
-      fetchState->FetchState.isReadyForNextQuery(~maxQueueSize=maxPartitionQueueSize)
+    fetchState->FetchState.isReadyForNextQuery(~maxQueueSize=maxPartitionQueueSize)
   })
 }
 
@@ -257,7 +263,7 @@ let isFetchingAtHead = ({partitions}: t) => {
 
 let getFirstEventBlockNumber = ({partitions}: t) => {
   partitions->Array.reduce(None, (accum, partition) => {
-    Utils.Math.minOptInt(accum, partition.baseRegister.firstEventBlockNumber)
+    Utils.Math.minOptInt(accum, partition.mostBehindRegister.firstEventBlockNumber)
   })
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.res
@@ -57,7 +57,6 @@ let fetchBatch = async (
   ~waitForNewBlock,
   ~onNewBlock,
   ~maxPerChainQueueSize,
-  ~setMergedPartitions,
   ~stateId,
 ) => {
   if stateId < sourceManager.currentStateId {
@@ -84,14 +83,9 @@ let fetchBatch = async (
         ~fetchingPartitions,
       )
 
-    let mergedPartitions = Js.Dict.empty()
     let hasQueryWaitingForNewBlock = ref(false)
     let queries = readyPartitions->Array.keepMap(fetchState => {
-      let mergedFetchState = fetchState->FetchState.mergeRegistersBeforeNextQuery
-      if mergedFetchState !== fetchState {
-        mergedPartitions->Js.Dict.set(fetchState.partitionId->(Utils.magic: int => string), mergedFetchState)
-      }
-      switch mergedFetchState->FetchState.getNextQuery(~endBlock) {
+      switch fetchState->FetchState.getNextQuery(~endBlock) {
       | Done => None
       | NextQuery(nextQuery) =>
         switch allPartitionsFetchingState->Belt.Array.get(fetchState.partitionId) {
@@ -120,7 +114,6 @@ let fetchBatch = async (
         }
       }
     })
-    setMergedPartitions(mergedPartitions)
 
     switch (queries, currentBlockHeight) {
     | ([], _)

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -321,7 +321,7 @@ module Make = (
         ~logger,
         //Only apply wildcards on the first partition and root register
         //to avoid duplicate wildcard queries
-        ~shouldApplyWildcards=fetchStateRegisterId == Root && partitionId == 0,
+        ~shouldApplyWildcards=fetchStateRegisterId->FetchState.isRootRegisterId && partitionId == 0,
         ~isPreRegisteringDynamicContracts,
       )
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -305,7 +305,7 @@ module Make = (
         ~logger,
         //Only apply wildcards on the first partition and root register
         //to avoid duplicate wildcard queries
-        ~shouldApplyWildcards=fetchStateRegisterId == Root && partitionId == 0, //only
+        ~shouldApplyWildcards=fetchStateRegisterId->FetchState.isRootRegisterId && partitionId == 0, //only
         ~isPreRegisteringDynamicContracts,
       )
 

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -104,6 +104,7 @@ type action =
   | StartIndexingAfterPreRegister
   | SetCurrentlyProcessing(bool)
   | SetIsInReorgThreshold(bool)
+  | SetUpdatedPartitions(chain, dict<FetchState.t>)
   | UpdateQueues(ChainMap.t<ChainManager.fetchStateWithData>, arbitraryEventQueue)
   | SetSyncedChains
   | SuccessExit
@@ -601,6 +602,23 @@ let actionReducer = (state: t, action: action) => {
       Logging.info("Reorg threshold reached")
     }
     ({...state, chainManager: {...state.chainManager, isInReorgThreshold}}, [])
+  | SetUpdatedPartitions(chain, updatedPartitions) =>
+    let updatedPartitionIds = updatedPartitions->Js.Dict.keys
+    if updatedPartitionIds->Utils.Array.isEmpty {
+      (state, [])
+    } else {
+      updateChainFetcher(currentChainFetcher => {
+        let partitionsCopy = currentChainFetcher.partitionedFetchState.partitions->Js.Array2.copy
+        updatedPartitionIds->Js.Array2.forEach(partitionId => {
+          let partition = updatedPartitions->Js.Dict.unsafeGet(partitionId)
+          partitionsCopy->Js.Array2.unsafe_set(partitionId->(Utils.magic: string => int), partition)
+        })
+        {
+          ...currentChainFetcher,
+          partitionedFetchState: {...currentChainFetcher.partitionedFetchState, partitions: partitionsCopy},
+        }
+      }, ~chain, ~state)
+    }
   | SetSyncedChains => {
       let shouldExit = EventProcessing.EventsProcessed.allChainsEventsProcessedToEndblock(
         state.chainManager.chainFetchers,
@@ -831,6 +849,7 @@ let checkAndFetchForChain = (
         ~isPreRegisteringDynamicContracts=state.chainManager->ChainManager.isPreRegisteringDynamicContracts,
       ),
       ~maxPerChainQueueSize=state.maxPerChainQueueSize,
+      ~setMergedPartitions=partitions => dispatchAction(SetUpdatedPartitions(chain, partitions)),
       ~stateId=state.id,
     )
   }

--- a/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
@@ -210,7 +210,7 @@ describe("Dynamic contract restart resistance test", () => {
       }
 
       let dynamicContracts =
-        restartedFetchState.baseRegister.dynamicContracts
+        restartedFetchState.mostBehindRegister.dynamicContracts
         ->Belt.Map.valuesToArray
         ->Array.flatMap(set => set->Belt.Set.String.toArray)
 
@@ -248,7 +248,7 @@ describe("Dynamic contract restart resistance test", () => {
         }
 
         let dynamicContracts =
-          restartedFetchState.baseRegister.dynamicContracts
+          restartedFetchState.mostBehindRegister.dynamicContracts
           ->Belt.Map.valuesToArray
           ->Array.flatMap(set => set->Belt.Set.String.toArray)
 
@@ -309,7 +309,7 @@ describe("Dynamic contract restart resistance test", () => {
         restartedChainFetcher.partitionedFetchState.partitions->Array.get(0)->Option.getExn
 
       let dynamicContracts =
-        restartedFetchState.baseRegister.dynamicContracts
+        restartedFetchState.mostBehindRegister.dynamicContracts
         ->Belt.Map.valuesToArray
         ->Array.flatMap(set => set->Belt.Set.String.toArray)
 

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -77,7 +77,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
           fetchState :=
             fetchState.contents
             ->PartitionedFetchState.update(
-              ~id={fetchStateId: FetchState.Root, partitionId: 0},
+              ~id={fetchStateId: FetchState.rootRegisterId, partitionId: 0},
               ~latestFetchedBlock={
                 blockNumber: batchItem.blockNumber,
                 blockTimestamp: batchItem.timestamp,
@@ -96,7 +96,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
             fetchState :=
               fetchState.contents
               ->PartitionedFetchState.update(
-                ~id={fetchStateId: FetchState.Root, partitionId: 0},
+                ~id={fetchStateId: FetchState.rootRegisterId, partitionId: 0},
                 ~latestFetchedBlock={
                   blockNumber: batchItem.blockNumber,
                   blockTimestamp: batchItem.timestamp,
@@ -323,9 +323,8 @@ describe("determineNextEvent", () => {
     }
 
     let makeMockFetchState = (~latestFetchedBlockTimestamp, ~item): FetchState.t => {
-      partitionId: 0,
-      baseRegister: {
-        registerType: RootRegister,
+      let register: FetchState.register = {
+        id: FetchState.rootRegisterId,
         latestFetchedBlock: {
           blockTimestamp: latestFetchedBlockTimestamp,
           blockNumber: 0,
@@ -334,9 +333,15 @@ describe("determineNextEvent", () => {
         fetchedEventQueue: item->Option.mapWithDefault([], v => [v]),
         dynamicContracts: FetchState.DynamicContractsMap.empty,
         firstEventBlockNumber: item->Option.map(v => v.blockNumber),
-      },
-      pendingDynamicContracts: [],
-      isFetchingAtHead: false,
+      }
+      {
+        partitionId: 0,
+        registers: [register],
+        mostBehindRegister: register,
+        nextMostBehindRegister: None,
+        pendingDynamicContracts: [],
+        isFetchingAtHead: false,
+      }
     }
 
     let makeMockPartitionedFetchState = (

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -79,19 +79,23 @@ describe("SourceManager fetchBatch", () => {
       contractAddressMapping->ContractAddressingMap.addAddress(~address, ~name="MockContract")
     }
 
+    let register: FetchState.register = {
+      id: FetchState.rootRegisterId,
+      latestFetchedBlock: {
+        blockNumber: latestFetchedBlockNumber,
+        blockTimestamp: latestFetchedBlockNumber * 15,
+      },
+      contractAddressMapping,
+      fetchedEventQueue,
+      dynamicContracts: FetchState.DynamicContractsMap.empty,
+      firstEventBlockNumber: None,
+    }
+
     {
       partitionId,
-      baseRegister: {
-        registerType: RootRegister,
-        latestFetchedBlock: {
-          blockNumber: latestFetchedBlockNumber,
-          blockTimestamp: latestFetchedBlockNumber * 15,
-        },
-        contractAddressMapping,
-        fetchedEventQueue,
-        dynamicContracts: FetchState.DynamicContractsMap.empty,
-        firstEventBlockNumber: None,
-      },
+      registers: [register],
+      mostBehindRegister: register,
+      nextMostBehindRegister: None,
       isFetchingAtHead: false,
       pendingDynamicContracts: [],
     }
@@ -143,24 +147,24 @@ describe("SourceManager fetchBatch", () => {
       [
         {
           partitionId: 0,
-          fetchStateRegisterId: fetchState0.baseRegister->FetchState.getRegisterId,
+          fetchStateRegisterId: fetchState0.mostBehindRegister.id,
           fromBlock: 5,
           toBlock: None,
-          contractAddressMapping: fetchState0.baseRegister.contractAddressMapping,
+          contractAddressMapping: fetchState0.mostBehindRegister.contractAddressMapping,
         },
         {
           partitionId: 1,
-          fetchStateRegisterId: fetchState0.baseRegister->FetchState.getRegisterId,
+          fetchStateRegisterId: fetchState0.mostBehindRegister.id,
           fromBlock: 6,
           toBlock: None,
-          contractAddressMapping: fetchState0.baseRegister.contractAddressMapping,
+          contractAddressMapping: fetchState0.mostBehindRegister.contractAddressMapping,
         },
         {
           partitionId: 2,
-          fetchStateRegisterId: fetchState0.baseRegister->FetchState.getRegisterId,
+          fetchStateRegisterId: fetchState0.mostBehindRegister.id,
           fromBlock: 2,
           toBlock: None,
-          contractAddressMapping: fetchState0.baseRegister.contractAddressMapping,
+          contractAddressMapping: fetchState0.mostBehindRegister.contractAddressMapping,
         },
       ],
     )


### PR DESCRIPTION
Terminology:
- FetchState/Partition - This is a chain fetching state split by the max partition contracts limit
- Register - A subset of a FetchState. If there's a dynamic contract, we create a register for it with a specific startBlock. 

We have two fetching modes:
1. When there are registered dynamic contracts, we fetch their contracts up till the latest fetch block
2. When all registers catch up to the latest one, they are merged, and we start fetching all the addresses together without a hard endBlock 

There were two main issues:
- We incorrectly created a new FetchState when the previous one exceeded the limit. The newly created register used to start fetching from the chain startBlock instead of from the dynamic contract registering event block. It caused inconsistently getting events before a dynamic contract registration block.
- When a new FetchState was created, there was another issue, that it could easily go into an incorrect state, when the next dynamic contract would create a register with a latestFetchBlock higher than the Root register. And since we used to store registers in the list-like structure ordered by latestFetchBlock, it was very challenging to operate with.

To fix the second issue, I've change the ordered list-like structure for registers to an independent array, simplifying operations with them, and allowing to addition new dynamic registrations after the latestFetchBlock. Also, this will simplify the further improvement to fetch the dynamic contract registers in parallel. Currently, the fetch requests to catch up to the latest register are done sequentially.