### PR TITLE
Respect suggested block interval for RPC queries

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/ChainWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/ChainWorker.res
@@ -25,7 +25,7 @@ type blockRangeFetchResponse = {
   reorgGuard: reorgGuard,
   parsedQueueItems: array<Internal.eventItem>,
   fromBlockQueried: int,
-  heighestQueriedBlockNumber: int,
+  latestFetchedBlockNumber: int,
   latestFetchedBlockTimestamp: int,
   stats: blockRangeFetchStats,
   fetchStateRegisterId: FetchState.id,
@@ -64,7 +64,6 @@ let waitForNewBlock = (
       "currentBlockHeight": currentBlockHeight,
     },
   )
-  
   logger->Logging.childTrace("Waiting for new blocks")
   ChainWorker.waitForBlockGreaterThanCurrentHeight(
     ~currentBlockHeight,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -536,7 +536,7 @@ module Make = (
       {
         latestFetchedBlockTimestamp: lastBlockScannedData.blockTimestamp,
         parsedQueueItems,
-        heighestQueriedBlockNumber: lastBlockScannedData.blockNumber,
+        latestFetchedBlockNumber: lastBlockScannedData.blockNumber,
         stats,
         currentBlockHeight,
         reorgGuard,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -521,7 +521,7 @@ module Make = (
       {
         latestFetchedBlockTimestamp: lastBlockScannedData.blockTimestamp,
         parsedQueueItems,
-        heighestQueriedBlockNumber: lastBlockScannedData.blockNumber,
+        latestFetchedBlockNumber: lastBlockScannedData.blockNumber,
         stats,
         currentBlockHeight,
         reorgGuard,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -339,7 +339,7 @@ module Make = (
 
       {
         latestFetchedBlockTimestamp: latestFetchedBlock.timestamp,
-        heighestQueriedBlockNumber: latestFetchedBlock.number,
+        latestFetchedBlockNumber: latestFetchedBlock.number,
         parsedQueueItems,
         stats: {
           totalTimeElapsed: totalTimeElapsed,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -43,6 +43,7 @@ let makeThrowingGetEventTransaction = (~getTransactionFields) => {
           }
 
           let fn = switch transactionFieldItems {
+          | [] => _ => %raw(`{}`)->Promise.resolve
           | [{location: "transactionIndex"}] =>
             log => log->parseOrThrowReadableError->Promise.resolve
           | [{location: "hash"}]

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -115,7 +115,7 @@ module Make = (
   let chain = T.chain
   let eventRouter = T.eventRouter
 
-  let blockIntervals = Js.Dict.empty()
+  let suggestedBlockIntervals = Js.Dict.empty()
 
   let transactionLoader = LazyLoader.make(
     ~loaderFn=transactionHash =>
@@ -205,15 +205,10 @@ module Make = (
       | None => currentBlockHeight
       }
 
-      let currentBlockInterval =
-        blockIntervals
+      let suggestedBlockInterval =
+        suggestedBlockIntervals
         ->Utils.Dict.dangerouslyGetNonOption(partitionId->Belt.Int.toString)
         ->Belt.Option.getWithDefault(T.syncConfig.initialBlockInterval)
-
-      let targetBlock =
-        Pervasives.min(toBlock, fromBlock + currentBlockInterval - 1)->Pervasives.max(fromBlock) //Defensively ensure we never query a target block below fromBlock
-
-      let toBlockPromise = blockLoader->LazyLoader.get(targetBlock)
 
       let firstBlockParentPromise =
         fromBlock > 0
@@ -226,16 +221,20 @@ module Make = (
         ~contractAddressMapping,
       )
 
-      let {logs, finalExecutedBlockInterval} = await EventFetching.getNextPage(
+      let {logs, nextSuggestedBlockInterval, latestFetchedBlock} = await EventFetching.getNextPage(
         ~contractInterfaceManager,
         ~fromBlock,
-        ~toBlock=targetBlock,
-        ~initialBlockInterval=currentBlockInterval,
+        ~toBlock,
+        ~loadBlock=blockNumber => blockLoader->LazyLoader.get(blockNumber),
+        ~suggestedBlockInterval,
         ~syncConfig=T.syncConfig,
         ~provider=T.provider,
         ~logger,
       )
-      blockIntervals->Js.Dict.set(partitionId->Belt.Int.toString, finalExecutedBlockInterval)
+      suggestedBlockIntervals->Js.Dict.set(
+        partitionId->Belt.Int.toString,
+        nextSuggestedBlockInterval,
+      )
 
       let parsedQueueItems =
         await logs
@@ -320,9 +319,7 @@ module Make = (
         })
         ->Promise.all
 
-      let (optFirstBlockParent, toBlock) = (await firstBlockParentPromise, await toBlockPromise)
-
-      let heighestQueriedBlockNumber = targetBlock
+      let optFirstBlockParent = await firstBlockParentPromise
 
       let totalTimeElapsed =
         startFetchingBatchTimeRef->Hrtime.timeSince->Hrtime.toMillis->Hrtime.intFromMillis
@@ -333,16 +330,16 @@ module Make = (
           blockHash: b.hash,
         }),
         lastBlockScannedData: {
-          blockNumber: toBlock.number,
-          blockTimestamp: toBlock.timestamp,
-          blockHash: toBlock.hash,
+          blockNumber: latestFetchedBlock.number,
+          blockTimestamp: latestFetchedBlock.timestamp,
+          blockHash: latestFetchedBlock.hash,
         },
       }
 
       {
-        latestFetchedBlockTimestamp: toBlock.timestamp,
+        latestFetchedBlockTimestamp: latestFetchedBlock.timestamp,
+        heighestQueriedBlockNumber: latestFetchedBlock.number,
         parsedQueueItems,
-        heighestQueriedBlockNumber,
         stats: {
           totalTimeElapsed: totalTimeElapsed,
         },

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -305,7 +305,7 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
   let chainFetcher = state.chainManager.chainFetchers->ChainMap.get(chain)
   let {
     parsedQueueItems,
-    heighestQueriedBlockNumber,
+    latestFetchedBlockNumber,
     stats,
     currentBlockHeight,
     reorgGuard,
@@ -322,7 +322,7 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
       ~pageFetchTime=stats.pageFetchTime->Belt.Option.getWithDefault(0),
       ~chainId=chainFetcher.chainConfig.chain->ChainMap.Chain.toChainId,
       ~fromBlock=fromBlockQueried,
-      ~toBlock=heighestQueriedBlockNumber,
+      ~toBlock=latestFetchedBlockNumber,
       ~fetchStateRegisterId,
       ~numEvents=parsedQueueItems->Array.length,
       ~partitionId,
@@ -332,7 +332,7 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
   chainFetcher.logger->Logging.childTrace({
     "message": "Finished page range",
     "fromBlock": fromBlockQueried,
-    "toBlock": heighestQueriedBlockNumber,
+    "toBlock": latestFetchedBlockNumber,
     "number of logs": parsedQueueItems->Array.length,
     "stats": stats,
   })
@@ -357,7 +357,7 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
       ->ChainFetcher.updateFetchState(
         ~currentBlockHeight,
         ~latestFetchedBlockTimestamp,
-        ~latestFetchedBlockNumber=heighestQueriedBlockNumber,
+        ~latestFetchedBlockNumber=latestFetchedBlockNumber,
         ~fetchedEvents=parsedQueueItems,
         ~id={fetchStateId: fetchStateRegisterId, partitionId},
       )
@@ -424,7 +424,7 @@ let handleBlockRangeResponse = (state, ~chain, ~response: ChainWorker.blockRange
       chainManager,
     }
 
-    Prometheus.setFetchedEventsUntilHeight(~blockNumber=response.heighestQueriedBlockNumber, ~chain)
+    Prometheus.setFetchedEventsUntilHeight(~blockNumber=response.latestFetchedBlockNumber, ~chain)
 
     let processAction =
       updatedChainFetcher->ChainFetcher.isPreRegisteringDynamicContracts

--- a/scenarios/helpers/src/ChainMocking.res
+++ b/scenarios/helpers/src/ChainMocking.res
@@ -289,7 +289,7 @@ module Make = (Indexer: Indexer.S) => {
       },
       parsedQueueItems,
       fromBlockQueried: query.fromBlock,
-      heighestQueriedBlockNumber: heighstBlock.blockNumber,
+      latestFetchedBlockNumber: heighstBlock.blockNumber,
       latestFetchedBlockTimestamp: heighstBlock.blockTimestamp,
       stats: "NO_STATS"->Obj.magic,
       fetchStateRegisterId: query.fetchStateRegisterId,

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -89,7 +89,7 @@ module type S = {
       reorgGuard: reorgGuard,
       parsedQueueItems: array<Internal.eventItem>,
       fromBlockQueried: int,
-      heighestQueriedBlockNumber: int,
+      latestFetchedBlockNumber: int,
       latestFetchedBlockTimestamp: int,
       stats: blockRangeFetchStats,
       fetchStateRegisterId: FetchState.id,

--- a/scenarios/test_codegen/pnpm-lock.yaml
+++ b/scenarios/test_codegen/pnpm-lock.yaml
@@ -134,8 +134,8 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       '@envio-dev/hypersync-client':
-        specifier: 0.6.2
-        version: 0.6.2
+        specifier: 0.6.3
+        version: 0.6.3
       '@glennsl/rescript-fetch':
         specifier: 0.2.0
         version: 0.2.0
@@ -390,44 +390,44 @@ packages:
     resolution: {integrity: sha512-eCSBUTgl8KbPyxky8cecDRLCYu2C1oFV4AZ72bEsI+TxXEvaljaL2kgttfzfu7gW+M89eCz55s49uF2t+YMTWA==}
     engines: {node: '>=10'}
 
-  '@envio-dev/hypersync-client-darwin-arm64@0.6.2':
-    resolution: {integrity: sha512-dDIuQqEgARR1JYodbGkmck1i9qbYEidc4Kw4DOrRKQ0uZFwflI4o8wm3P+G/ofc1iXwp4pm7jqNUGzZDpK9pqA==}
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.3':
+    resolution: {integrity: sha512-w4OLJaq3lD03iXPJxLnPpoxOduvzCfEe2nYtamvIRLPB2SlbxnB5EF5dSyFs6WKh1x4PMsksQOUKeCcOtQPZow==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@envio-dev/hypersync-client-darwin-x64@0.6.2':
-    resolution: {integrity: sha512-NGlgkmosAzlZ1EuQ5/djkg6sQI/dgVX+XGOLI6Zden0ca2zr/ByBRA7yCKxpwZHYynFN2FoMsMGSRY8jj6XQWw==}
+  '@envio-dev/hypersync-client-darwin-x64@0.6.3':
+    resolution: {integrity: sha512-zh98zCbm2cse/iIzyMs1YCcA1iI1U/j4Yex1xBVaEa1ogzQSK9peS6M+NygzdmlwPqr7K9rUQ/U56ICRl67fWw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.2':
-    resolution: {integrity: sha512-p2LQSaOSgjVvvFHOGHnPHTnsDHCWNEG78J29guZyqWojmaxTaR4eGyFEknla7eO0w58EIUGEBTF0+EJ7duMimg==}
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.3':
+    resolution: {integrity: sha512-5pI0N6W7W0L7LpgN76BAWRsC+NPOvrlvBEq8IjlBUS47vqZALvcJj3gYNkm466tUBQ4q4tF1x48k7MFKtoO8aw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.2':
-    resolution: {integrity: sha512-/kIL9Q0e5hM0g6cvdCHL93LMu+OCnwQAGKQHCj2TKKUjVpWFNb0Ki5PMgJhQ8mimEBFsJAnErVK+HrugLTlaVQ==}
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.3':
+    resolution: {integrity: sha512-jL3sxWVyTJuKdO5y/0tu1EtWSox+nJdpmr7rdVW1w0gLk4ewzWORp9cl5pXkpqM4MUsjJz+NkcQKsUquGYBkKg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-linux-x64-musl@0.6.2':
-    resolution: {integrity: sha512-4r5hA/zyxUjWBDYYeXLCl5pBfSI9njEIPuLMFXajjVcAvSXRtBhmgVwa3JrjjCxZ8aLfqk9vvPkb/KgYfrbXXw==}
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.3':
+    resolution: {integrity: sha512-4rAh9x3PEWIweih731lWVEUGm+qrIHouElqZgXfTcZS6KkPeDnSYKVw10K5EyDuDtZla/NccEr0pJmcvpui5Ew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.2':
-    resolution: {integrity: sha512-VgsSwmDAgvpgo9QsIiwIp9IN+h3g0U/7zrCrvNAMj+lsMHJPZ7L0cfN58dQUr84wL8domJGJrnMKUtu/Yf49ow==}
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.3':
+    resolution: {integrity: sha512-AINzLdjqU+y6ZiHnxorjFlrGNIw/AAJ80YXABYzokvGhDTF9qupjR1gdZo4sQEumgrRyg7fiG8QnsZVEm6V/zA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@envio-dev/hypersync-client@0.6.2':
-    resolution: {integrity: sha512-wgp0UmblW8yn/q5NMkVYPFDvOmgHWPTibl/QJYyYK2KXqAMHssUjP07ayduiZCexQOZ94Agpv4SvmYxQNjGBIA==}
+  '@envio-dev/hypersync-client@0.6.3':
+    resolution: {integrity: sha512-Lr5WyMZBK1cI++kAQLM/zd62NfUM60A3KWTKgeNew4NOghfoY5YZr99C7vo+CMYePXskYBR+ul+5iNPoHqkFrw==}
     engines: {node: '>= 10'}
 
   '@ethersproject/abi@5.7.0':
@@ -2495,80 +2495,6 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  npm@10.8.3:
-    resolution: {integrity: sha512-0IQlyAYvVtQ7uOhDFYZCGK8kkut2nh8cpAdA9E6FvRSJaTgtZRZgNjlC5ZCct//L73ygrpY93CxXpRJDtNqPVg==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-    hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/config'
-      - '@npmcli/fs'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/package-json'
-      - '@npmcli/promise-spawn'
-      - '@npmcli/redact'
-      - '@npmcli/run-script'
-      - '@sigstore/tuf'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - ci-info
-      - cli-columns
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmhook
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - ms
-      - node-gyp
-      - nopt
-      - normalize-package-data
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - semver
-      - spdx-expression-parse
-      - ssri
-      - supports-color
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
-      - write-file-atomic
-
   nwsapi@2.2.12:
     resolution: {integrity: sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==}
 
@@ -3518,11 +3444,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yarn@1.22.22:
-    resolution: {integrity: sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==}
-    engines: {node: '>=4.0.0'}
-    hasBin: true
-
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -3758,35 +3679,32 @@ snapshots:
     dependencies:
       '@elastic/ecs-helpers': 1.1.0
 
-  '@envio-dev/hypersync-client-darwin-arm64@0.6.2':
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.3':
     optional: true
 
-  '@envio-dev/hypersync-client-darwin-x64@0.6.2':
+  '@envio-dev/hypersync-client-darwin-x64@0.6.3':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.2':
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.3':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.2':
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.3':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-x64-musl@0.6.2':
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.3':
     optional: true
 
-  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.2':
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.3':
     optional: true
 
-  '@envio-dev/hypersync-client@0.6.2':
-    dependencies:
-      npm: 10.8.3
-      yarn: 1.22.22
+  '@envio-dev/hypersync-client@0.6.3':
     optionalDependencies:
-      '@envio-dev/hypersync-client-darwin-arm64': 0.6.2
-      '@envio-dev/hypersync-client-darwin-x64': 0.6.2
-      '@envio-dev/hypersync-client-linux-arm64-gnu': 0.6.2
-      '@envio-dev/hypersync-client-linux-x64-gnu': 0.6.2
-      '@envio-dev/hypersync-client-linux-x64-musl': 0.6.2
-      '@envio-dev/hypersync-client-win32-x64-msvc': 0.6.2
+      '@envio-dev/hypersync-client-darwin-arm64': 0.6.3
+      '@envio-dev/hypersync-client-darwin-x64': 0.6.3
+      '@envio-dev/hypersync-client-linux-arm64-gnu': 0.6.3
+      '@envio-dev/hypersync-client-linux-x64-gnu': 0.6.3
+      '@envio-dev/hypersync-client-linux-x64-musl': 0.6.3
+      '@envio-dev/hypersync-client-win32-x64-msvc': 0.6.3
 
   '@ethersproject/abi@5.7.0':
     dependencies:
@@ -5200,7 +5118,7 @@ snapshots:
 
   envio@file:../../codegenerator/cli/npm/envio(typescript@5.5.4):
     dependencies:
-      '@envio-dev/hypersync-client': 0.6.2
+      '@envio-dev/hypersync-client': 0.6.3
       rescript: 11.1.3
       rescript-schema: 8.1.0(rescript@11.1.3)
       viem: 2.21.0(typescript@5.5.4)
@@ -6593,8 +6511,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  npm@10.8.3: {}
-
   nwsapi@2.2.12: {}
 
   nyc@15.1.0:
@@ -7557,8 +7473,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yarn@1.22.22: {}
 
   yn@3.1.1: {}
 

--- a/scenarios/test_codegen/test/RpcWorker_test.res
+++ b/scenarios/test_codegen/test/RpcWorker_test.res
@@ -38,6 +38,19 @@ describe("RpcSyncWorker - getEventTransactionOrThrow", () => {
     )
   })
 
+  Async.it(
+    "Returns empty object when empty field selection. Doesn't make a transaction request",
+    async () => {
+      let getEventTransactionOrThrow = RpcWorker.makeThrowingGetEventTransaction(
+        ~getTransactionFields=neverGetTransactionFields,
+      )
+      Assert.deepEqual(
+        await mockEthersLog()->getEventTransactionOrThrow(~transactionSchema=S.object(_ => ())),
+        %raw(`{}`),
+      )
+    },
+  )
+
   Async.it("Works with a single transactionIndex field", async () => {
     let getEventTransactionOrThrow = RpcWorker.makeThrowingGetEventTransaction(
       ~getTransactionFields=neverGetTransactionFields,


### PR DESCRIPTION
Initially, I started the PR to remove the `while shouldContinueProcess() {` logic, because it lead to some performance regressions, and I needed this code in another place for parallel queries/wildcard support for rpc.

Removing the `while shouldContinueProcess() {` lead to:
- Prevented a possibility for a short block range query to catch up to the end of initially suggested interval (saving an RPC call once in a while)
- Started sending events for processing much earlier. For example, during my tests with an rpc provider which has a max limit for 1000 blocks, the latest envio version started processing events only after calling `get_logs` for 43 times, while this version provided the first 1000 blocks after 12 calls. There are still huge improvements can be made for the case when an RPC provider errors with a max interval error, but this is for another time.
- The suggested interval is not reduced to a very short interval, when we are fetching to a hard endBlock

Also, while testing the PR, I've found another bug I recently created. Quite critical I'd say. Without fieldSelection for transaction, it'll still make transaction requests on every log. Hopefully there are not many RPC users on latest versions.