### PR TITLE
Query Wildcard events concurrently with static events

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -81,7 +81,11 @@ let make = (
         Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
 
       if isWildcard {
-        hasWildcard := true
+        hasWildcard := (
+            isPreRegisteringDynamicContracts
+              ? hasWildcard.contents || preRegisterDynamicContracts
+              : true
+          )
       } else {
         let _ = contractNamesWithNonWildcard->Utils.Set.add(contractName)
       }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -35,8 +35,7 @@ type t = {
 let make = (
   ~chainConfig: Config.chainConfig,
   ~lastBlockScannedHashes,
-  ~staticContracts,
-  ~dynamicContracts,
+  ~dynamicContracts: array<TablesStatic.DynamicContractRegistry.t>,
   ~startBlock,
   ~endBlock,
   ~dbFirstEventBlockNumber,
@@ -52,13 +51,61 @@ let make = (
   let module(ChainWorker) = chainConfig.chainWorker
   logger->Logging.childInfo("Initializing ChainFetcher with " ++ ChainWorker.name ++ " worker")
 
+  let hasWildcard = ref(false)
+  let contractNamesWithNonWildcard = Utils.Set.make()
+  let contractNamesWithPreRegistration = Utils.Set.make()
+
+  let isPreRegisteringDynamicContracts = dynamicContractPreRegistration->Option.isSome
+  let shouldIncludeContractAddress = (~contractName) => {
+    // Check that there are events without wildcard
+    // Otherwise the events will be queried in the Wildcard partition
+    // and shouldn't be included in the Normal partition
+    contractNamesWithNonWildcard->Utils.Set.has(contractName) &&
+      // Include only addresses having preRegistration,
+      // so we don't end up with partition having an empty ContractAddressMapping
+      // for preregistration
+      isPreRegisteringDynamicContracts
+      ? contractNamesWithPreRegistration->Utils.Set.has(contractName)
+      : true
+  }
+
+  let staticContracts = []
+
+  chainConfig.contracts->Array.forEach(contract => {
+    let contractName = contract.name
+
+    contract.events->Array.forEach(event => {
+      let module(Event) = event
+
+      let {isWildcard, preRegisterDynamicContracts} =
+        Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
+
+      if isWildcard {
+        hasWildcard := true
+      } else {
+        let _ = contractNamesWithNonWildcard->Utils.Set.add(contractName)
+      }
+      if preRegisterDynamicContracts {
+        let _ = contractNamesWithPreRegistration->Utils.Set.add(contractName)
+      }
+    })
+
+    if shouldIncludeContractAddress(~contractName) {
+      contract.addresses->Array.forEach(a => {
+        staticContracts->Array.push((contractName, a))
+      })
+    }
+  })
+
   let fetchState = FetchState.make(
     ~maxAddrInPartition,
     ~staticContracts,
-    ~dynamicContracts,
+    ~dynamicContracts=dynamicContracts->Array.keep(dc =>
+      shouldIncludeContractAddress(~contractName=(dc.contractType :> string))
+    ),
     ~startBlock,
     ~endBlock,
-    ~isFetchingAtHead=false,
+    ~hasWildcard=hasWildcard.contents,
   )
 
   {
@@ -82,17 +129,8 @@ let make = (
   }
 }
 
-let getStaticContracts = (chainConfig: Config.chainConfig) => {
-  chainConfig.contracts->Belt.Array.flatMap(contract => {
-    contract.addresses->Belt.Array.map(address => {
-      (contract.name, address)
-    })
-  })
-}
-
 let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition) => {
   let logger = Logging.createChild(~params={"chainId": chainConfig.chain->ChainMap.Chain.toChainId})
-  let staticContracts = chainConfig->getStaticContracts
   let lastBlockScannedHashes = ReorgDetection.LastBlockScannedHashes.empty(
     ~confirmedBlockThreshold=chainConfig.confirmedBlockThreshold,
   )
@@ -101,7 +139,6 @@ let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition) => {
     chainConfig->Config.shouldPreRegisterDynamicContracts ? Some(Js.Dict.empty()) : None
 
   make(
-    ~staticContracts,
     ~chainConfig,
     ~startBlock=chainConfig.startBlock,
     ~endBlock=chainConfig.endBlock,
@@ -124,7 +161,6 @@ let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition) => {
  */
 let makeFromDbState = async (chainConfig: Config.chainConfig, ~maxAddrInPartition) => {
   let logger = Logging.createChild(~params={"chainId": chainConfig.chain->ChainMap.Chain.toChainId})
-  let staticContracts = chainConfig->getStaticContracts
   let chainId = chainConfig.chain->ChainMap.Chain.toChainId
   let latestProcessedEvent =
     await Db.sql->DbFunctions.EventSyncState.getLatestProcessedEvent(~chainId)
@@ -232,7 +268,6 @@ let makeFromDbState = async (chainConfig: Config.chainConfig, ~maxAddrInPartitio
     )
 
   make(
-    ~staticContracts,
     ~dynamicContracts,
     ~chainConfig,
     ~startBlock,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -15,6 +15,15 @@ type blockNumberAndLogIndex = {blockNumber: int, logIndex: int}
 
 type status = {mutable fetchingStateId: option<int>}
 
+type partitionKind =
+  | Wildcard
+  | Normal({
+      contractAddressMapping: ContractAddressingMap.mapping,
+      //Used to prune dynamic contract registrations in the event
+      //of a rollback.
+      dynamicContracts: array<TablesStatic.DynamicContractRegistry.t>,
+    })
+
 /**
 A state that holds a queue of events and data regarding what to fetch next
 for specific contract events with a given contract address.
@@ -25,12 +34,9 @@ type partition = {
   id: string,
   status: status,
   latestFetchedBlock: blockNumberAndTimestamp,
-  contractAddressMapping: ContractAddressingMap.mapping,
+  kind: partitionKind,
   //Events ordered from latest to earliest
   fetchedEventQueue: array<Internal.eventItem>,
-  //Used to prune dynamic contract registrations in the event
-  //of a rollback.
-  dynamicContracts: array<TablesStatic.DynamicContractRegistry.t>,
 }
 
 type t = {
@@ -88,74 +94,97 @@ Pass the shorter list into A for better performance
 let mergeSortedEventList = (a, b) => Utils.Array.mergeSorted(eventItemGt, a, b)
 
 let mergeIntoPartition = (p: partition, ~target: partition, ~maxAddrInPartition) => {
-  let latestFetchedBlock = target.latestFetchedBlock
+  switch (p, target) {
+  | ({kind: Wildcard}, _)
+  | (_, {kind: Wildcard}) => (p, Some(target))
+  | (
+      {
+        kind: Normal({
+          contractAddressMapping: mergingContractAddressMapping,
+          dynamicContracts: mergingDynamicContracts,
+        }),
+      },
+      {
+        kind: Normal({
+          contractAddressMapping: targetContractAddressMapping,
+          dynamicContracts: targetDynamicContracts,
+        }),
+      },
+    ) => {
+      let latestFetchedBlock = target.latestFetchedBlock
 
-  let mergedContractAddressMapping = target.contractAddressMapping->ContractAddressingMap.copy
-  let mergedDynamicContracts = target.dynamicContracts->Js.Array2.copy
+      let mergedContractAddressMapping = targetContractAddressMapping->ContractAddressingMap.copy
+      let mergedDynamicContracts = targetDynamicContracts->Js.Array2.copy
 
-  let restDcsCount =
-    target.contractAddressMapping->ContractAddressingMap.addressCount +
-    p.contractAddressMapping->ContractAddressingMap.addressCount -
-    maxAddrInPartition
+      let restDcsCount =
+        targetContractAddressMapping->ContractAddressingMap.addressCount +
+        mergingContractAddressMapping->ContractAddressingMap.addressCount -
+        maxAddrInPartition
 
-  let rest = if restDcsCount > 0 {
-    let restAddresses = Utils.Set.make()
+      let rest = if restDcsCount > 0 {
+        let restAddresses = Utils.Set.make()
 
-    let restDcs = p.dynamicContracts->Js.Array2.slice(~start=0, ~end_=restDcsCount)
-    restDcs->Array.forEach(dc => {
-      let _ = restAddresses->Utils.Set.add(dc.contractAddress)
-    })
+        let restDcs = mergingDynamicContracts->Js.Array2.slice(~start=0, ~end_=restDcsCount)
+        restDcs->Array.forEach(dc => {
+          let _ = restAddresses->Utils.Set.add(dc.contractAddress)
+        })
 
-    let restContractAddressMapping = ContractAddressingMap.make()
+        let restContractAddressMapping = ContractAddressingMap.make()
 
-    p.contractAddressMapping.nameByAddress
-    ->Js.Dict.keys
-    ->Belt.Array.forEach(key => {
-      let name = p.contractAddressMapping.nameByAddress->Js.Dict.unsafeGet(key)
-      let address = key->Address.unsafeFromString
-      let map =
-        restAddresses->Utils.Set.has(address)
-          ? restContractAddressMapping
-          : mergedContractAddressMapping
-      map->ContractAddressingMap.addAddress(~address, ~name)
-    })
+        mergingContractAddressMapping.nameByAddress
+        ->Js.Dict.keys
+        ->Belt.Array.forEach(key => {
+          let name = mergingContractAddressMapping.nameByAddress->Js.Dict.unsafeGet(key)
+          let address = key->Address.unsafeFromString
+          let map =
+            restAddresses->Utils.Set.has(address)
+              ? restContractAddressMapping
+              : mergedContractAddressMapping
+          map->ContractAddressingMap.addAddress(~address, ~name)
+        })
 
-    let _ =
-      mergedDynamicContracts->Js.Array2.pushMany(
-        p.dynamicContracts->Js.Array2.sliceFrom(restDcsCount),
+        let _ =
+          mergedDynamicContracts->Js.Array2.pushMany(
+            mergingDynamicContracts->Js.Array2.sliceFrom(restDcsCount),
+          )
+
+        Some({
+          id: p.id,
+          status: {
+            fetchingStateId: None,
+          },
+          fetchedEventQueue: [],
+          kind: Normal({
+            contractAddressMapping: restContractAddressMapping,
+            dynamicContracts: restDcs,
+          }),
+          latestFetchedBlock,
+        })
+      } else {
+        mergingContractAddressMapping->ContractAddressingMap.mergeInPlace(
+          ~target=mergedContractAddressMapping,
+        )
+        let _ = mergedDynamicContracts->Js.Array2.pushMany(mergingDynamicContracts)
+        None
+      }
+
+      (
+        {
+          id: target.id,
+          status: {
+            fetchingStateId: None,
+          },
+          kind: Normal({
+            contractAddressMapping: mergedContractAddressMapping,
+            dynamicContracts: mergedDynamicContracts,
+          }),
+          fetchedEventQueue: mergeSortedEventList(p.fetchedEventQueue, target.fetchedEventQueue),
+          latestFetchedBlock,
+        },
+        rest,
       )
-
-    Some({
-      id: p.id,
-      status: {
-        fetchingStateId: None,
-      },
-      fetchedEventQueue: [],
-      contractAddressMapping: restContractAddressMapping,
-      dynamicContracts: restDcs,
-      latestFetchedBlock,
-    })
-  } else {
-    p.contractAddressMapping->ContractAddressingMap.mergeInPlace(
-      ~target=mergedContractAddressMapping,
-    )
-    let _ = mergedDynamicContracts->Js.Array2.pushMany(p.dynamicContracts)
-    None
+    }
   }
-
-  (
-    {
-      id: target.id,
-      status: {
-        fetchingStateId: None,
-      },
-      fetchedEventQueue: mergeSortedEventList(p.fetchedEventQueue, target.fetchedEventQueue),
-      contractAddressMapping: mergedContractAddressMapping,
-      dynamicContracts: mergedDynamicContracts,
-      latestFetchedBlock,
-    },
-    rest,
-  )
 }
 
 /**
@@ -279,7 +308,7 @@ let updateInternal = (
   }
 }
 
-let makePartition = (
+let makeNormalPartition = (
   ~partitionIndex,
   ~latestFetchedBlock,
   ~dynamicContracts: array<TablesStatic.DynamicContractRegistry.t>=[],
@@ -304,8 +333,10 @@ let makePartition = (
       fetchingStateId: None,
     },
     latestFetchedBlock,
-    contractAddressMapping,
-    dynamicContracts,
+    kind: Normal({
+      contractAddressMapping,
+      dynamicContracts,
+    }),
     fetchedEventQueue: [],
   }
 }
@@ -334,7 +365,7 @@ let registerDynamicContracts = (
     dcsByStartBlock
     ->Js.Dict.entries
     ->Array.mapWithIndex((index, (startBlockKey, dcs)) => {
-      makePartition(
+      makeNormalPartition(
         ~partitionIndex=fetchState.nextPartitionIndex + index,
         ~dynamicContracts=dcs,
         ~latestFetchedBlock={
@@ -351,43 +382,27 @@ let registerDynamicContracts = (
   )
 }
 
-type partitionQuery = {
+type queryTarget =
+  | Head
+  | EndBlock({toBlock: int})
+  | Merge({
+      // The partition we are going to merge into
+      // It shouldn't be fetching during the query
+      intoPartitionId: string,
+      toBlock: int,
+    })
+
+// Strip internal fields from partition kind like dynamicContracts
+type querySelection =
+  | Wildcard
+  | Normal({contractAddressMapping: ContractAddressingMap.mapping})
+
+type query = {
   partitionId: string,
   fromBlock: int,
-  toBlock: option<int>,
-  contractAddressMapping: ContractAddressingMap.mapping,
+  selection: querySelection,
+  target: queryTarget,
 }
-
-type mergeQuery = {
-  // The catching up partition
-  partitionId: string,
-  // The partition we are going to merge into
-  // It shouldn't be fetching during the query
-  intoPartitionId: string,
-  fromBlock: int,
-  toBlock: int,
-  contractAddressMapping: ContractAddressingMap.mapping,
-}
-
-type query =
-  | PartitionQuery(partitionQuery)
-  | MergeQuery(mergeQuery)
-
-let queryFromBlock = query => {
-  switch query {
-  | PartitionQuery({fromBlock}) => fromBlock
-  | MergeQuery({fromBlock}) => fromBlock
-  }
-}
-
-let queryPartitionId = query => {
-  switch query {
-  | PartitionQuery({partitionId}) => partitionId
-  | MergeQuery({partitionId}) => partitionId
-  }
-}
-
-let shouldApplyWildcards = (~partitionId) => partitionId === "0"
 
 exception UnexpectedPartitionNotFound({partitionId: string})
 exception UnexpectedMergeQueryResponse({message: string})
@@ -405,19 +420,21 @@ let setQueryResponse = (
   ~latestFetchedBlock: blockNumberAndTimestamp,
   ~newItems,
   ~currentBlockHeight,
-): result<t, exn> => {
-  switch query {
-  | PartitionQuery({partitionId})
-  | MergeQuery({partitionId}) =>
+): result<t, exn> =>
+  {
+    let partitionId = query.partitionId
+
     switch partitions->Array.getIndexBy(p => p.id === partitionId) {
     | Some(pIndex) =>
       let p = partitions->Js.Array2.unsafe_get(pIndex)
       let updatedPartition =
         p->addItemsToPartition(~latestFetchedBlock, ~reversedNewItems=newItems->Array.reverse)
 
-      switch query {
-      | PartitionQuery(_) => Ok(partitions->Utils.Array.setIndexImmutable(pIndex, updatedPartition))
-      | MergeQuery({intoPartitionId}) =>
+      switch query.target {
+      | Head
+      | EndBlock(_) =>
+        Ok(partitions->Utils.Array.setIndexImmutable(pIndex, updatedPartition))
+      | Merge({intoPartitionId}) =>
         switch partitions->Array.getIndexBy(p => p.id === intoPartitionId) {
         | Some(targetIndex)
           if (partitions->Js.Array2.unsafe_get(targetIndex)).latestFetchedBlock.blockNumber ===
@@ -460,7 +477,6 @@ let setQueryResponse = (
       },
     )
   })
-}
 
 let makePartitionQuery = (p: partition, ~endBlock) => {
   let fromBlock = switch p.latestFetchedBlock.blockNumber {
@@ -469,14 +485,19 @@ let makePartitionQuery = (p: partition, ~endBlock) => {
   }
   switch endBlock {
   | Some(endBlock) if fromBlock > endBlock => None
-  | _ =>
-    Some({
+  | Some(endBlock) => Some(EndBlock({toBlock: endBlock}))
+  | None => Some(Head)
+  }->Option.map(target => {
+    {
       partitionId: p.id,
       fromBlock,
-      toBlock: endBlock,
-      contractAddressMapping: p.contractAddressMapping,
-    })
-  }
+      target,
+      selection: switch p.kind {
+      | Wildcard => Wildcard
+      | Normal({contractAddressMapping}) => Normal({contractAddressMapping: contractAddressMapping})
+      },
+    }
+  })
 }
 
 type nextQuery =
@@ -487,13 +508,22 @@ type nextQuery =
 
 let startFetchingQueries = ({partitions}: t, ~queries: array<query>, ~stateId) => {
   queries->Array.forEach(q => {
-    switch partitions->Js.Array2.find(p => p.id === q->queryPartitionId) {
+    switch partitions->Js.Array2.find(p => p.id === q.partitionId) {
     // Shouldn't be mutated to None anymore
     // The status will be immutably set to the initial one when we handle response
     | Some(p) => p.status.fetchingStateId = Some(stateId)
     | None => Js.Exn.raiseError("Unexpected case: Couldn't find partition for the fetching query")
     }
   })
+}
+
+@inline
+let isFullPartition = (p, ~maxAddrInPartition) => {
+  switch p.kind {
+  | Wildcard => true
+  | Normal({contractAddressMapping}) =>
+    contractAddressMapping->ContractAddressingMap.addressCount >= maxAddrInPartition
+  }
 }
 
 let getNextQuery = (
@@ -531,7 +561,7 @@ let getNextQuery = (
         hasFetchingPartition := true
       }
 
-      if p.contractAddressMapping->ContractAddressingMap.addressCount >= maxAddrInPartition {
+      if p->isFullPartition(~maxAddrInPartition) {
         fullPartitions->Array.push(p)
       } else {
         mergingPartitions->Array.push(p)
@@ -588,17 +618,14 @@ let getNextQuery = (
           } else {
             queries->Array.push(
               switch mergeTarget {
-              | Some(mergeTarget)
-                if // This is to prevent breaking the current check for shouldApplyWildcards
-                !shouldApplyWildcards(~partitionId=q.partitionId) =>
-                MergeQuery({
-                  partitionId: q.partitionId,
-                  contractAddressMapping: q.contractAddressMapping,
-                  fromBlock: q.fromBlock,
-                  toBlock: mergeTarget.latestFetchedBlock.blockNumber,
-                  intoPartitionId: mergeTarget.id,
-                })
-              | _ => PartitionQuery(q)
+              | Some(mergeTarget) => {
+                  ...q,
+                  target: Merge({
+                    toBlock: mergeTarget.latestFetchedBlock.blockNumber,
+                    intoPartitionId: mergeTarget.id,
+                  }),
+                }
+              | None => q
               },
             )
           }
@@ -643,7 +670,7 @@ let getNextQuery = (
       Ready(
         if queries->Array.length > concurrencyLimit {
           queries
-          ->Js.Array2.sortInPlaceWith((a, b) => a->queryFromBlock - b->queryFromBlock)
+          ->Js.Array2.sortInPlaceWith((a, b) => a.fromBlock - b.fromBlock)
           ->Js.Array2.slice(~start=0, ~end_=concurrencyLimit)
         } else {
           queries
@@ -767,7 +794,7 @@ let make = (
 
   let addPartition = (~staticContracts=?, ~dynamicContracts=?, ~latestFetchedBlock) => {
     partitions->Array.push(
-      makePartition(
+      makeNormalPartition(
         ~partitionIndex=partitions->Array.length,
         ~staticContracts?,
         ~dynamicContracts?,
@@ -865,21 +892,25 @@ let checkContainsRegisteredContractAddress = (
   ~contractAddress,
   ~chainId,
 ) => {
-  self.partitions->Array.some(r => {
-    switch r.contractAddressMapping->ContractAddressingMap.getContractNameFromAddress(
-      ~contractAddress,
-    ) {
-    | Some(existingContractName) =>
-      if existingContractName != contractName {
-        warnIfAttemptedAddressRegisterOnDifferentContracts(
-          ~contractAddress,
-          ~contractName,
-          ~existingContractName,
-          ~chainId,
-        )
+  self.partitions->Array.some(p => {
+    switch p.kind {
+    | Wildcard => false
+    | Normal({contractAddressMapping}) =>
+      switch contractAddressMapping->ContractAddressingMap.getContractNameFromAddress(
+        ~contractAddress,
+      ) {
+      | Some(existingContractName) =>
+        if existingContractName != contractName {
+          warnIfAttemptedAddressRegisterOnDifferentContracts(
+            ~contractAddress,
+            ~contractName,
+            ~existingContractName,
+            ~chainId,
+          )
+        }
+        true
+      | None => false
       }
-      true
-    | None => false
     }
   })
 }
@@ -906,59 +937,71 @@ let rollbackPartition = (
   ~lastScannedBlock,
   ~firstChangeEvent: blockNumberAndLogIndex,
 ) => {
-  //get all dynamic contract addresses past valid blockNumber to remove along with
-  //updated dynamicContracts map
-  let addressesToRemove = []
-  let dynamicContracts = p.dynamicContracts->Array.keep(dc => {
-    if (
-      (dc.registeringEventBlockNumber, dc.registeringEventLogIndex) >=
-      (firstChangeEvent.blockNumber, firstChangeEvent.logIndex)
-    ) {
-      //If the registration block is later than the first change event,
-      //Do not keep it and add to the removed addresses
-      addressesToRemove->Array.push(dc.contractAddress)
-      false
-    } else {
-      true
-    }
-  })
-
-  if (
-    addressesToRemove->Array.length ===
-      p.contractAddressMapping->ContractAddressingMap.addressCount &&
-      !shouldApplyWildcards(~partitionId=p.id)
-  ) {
-    None
-  } else {
-    //remove them from the contract address mapping and dynamic contract addresses mapping
-    let contractAddressMapping =
-      p.contractAddressMapping->ContractAddressingMap.removeAddresses(~addressesToRemove)
-
-    let shouldRollbackFetched = p.latestFetchedBlock.blockNumber >= firstChangeEvent.blockNumber
-
-    let fetchedEventQueue = if shouldRollbackFetched {
-      p.fetchedEventQueue->pruneQueueFromFirstChangeEvent(~firstChangeEvent)
-    } else {
-      p.fetchedEventQueue
-    }
-
+  switch p.kind {
+  | Wildcard =>
     Some({
-      id: p.id,
-      dynamicContracts,
-      contractAddressMapping,
+      ...p,
       status: {
         fetchingStateId: None,
       },
-      fetchedEventQueue,
-      latestFetchedBlock: shouldRollbackFetched ? lastScannedBlock : p.latestFetchedBlock,
     })
+  | Normal({contractAddressMapping, dynamicContracts}) => {
+      //get all dynamic contract addresses past valid blockNumber to remove along with
+      //updated dynamicContracts map
+      let addressesToRemove = []
+      let dynamicContracts = dynamicContracts->Array.keep(dc => {
+        if (
+          (dc.registeringEventBlockNumber, dc.registeringEventLogIndex) >=
+          (firstChangeEvent.blockNumber, firstChangeEvent.logIndex)
+        ) {
+          //If the registration block is later than the first change event,
+          //Do not keep it and add to the removed addresses
+          addressesToRemove->Array.push(dc.contractAddress)
+          false
+        } else {
+          true
+        }
+      })
+
+      if (
+        addressesToRemove->Array.length ===
+          contractAddressMapping->ContractAddressingMap.addressCount
+      ) {
+        None
+      } else {
+        //remove them from the contract address mapping and dynamic contract addresses mapping
+        let contractAddressMapping =
+          contractAddressMapping->ContractAddressingMap.removeAddresses(~addressesToRemove)
+
+        let shouldRollbackFetched = p.latestFetchedBlock.blockNumber >= firstChangeEvent.blockNumber
+
+        let fetchedEventQueue = if shouldRollbackFetched {
+          p.fetchedEventQueue->pruneQueueFromFirstChangeEvent(~firstChangeEvent)
+        } else {
+          p.fetchedEventQueue
+        }
+
+        Some({
+          id: p.id,
+          kind: Normal({
+            dynamicContracts,
+            contractAddressMapping,
+          }),
+          status: {
+            fetchingStateId: None,
+          },
+          fetchedEventQueue,
+          latestFetchedBlock: shouldRollbackFetched ? lastScannedBlock : p.latestFetchedBlock,
+        })
+      }
+    }
   }
 }
 
 let rollback = (fetchState: t, ~lastScannedBlock, ~firstChangeEvent) => {
   let partitions =
-    fetchState.partitions->Array.keepMap(r =>
-      r->rollbackPartition(~lastScannedBlock, ~firstChangeEvent)
+    fetchState.partitions->Array.keepMap(p =>
+      p->rollbackPartition(~lastScannedBlock, ~firstChangeEvent)
     )
 
   fetchState->updateInternal(~partitions)

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -847,7 +847,7 @@ let make = (
   }
 
   if partitions->Array.length === 0 {
-    Js.Exn.raiseError("Invalid configuration. Nothing to fetch")
+    Js.Exn.raiseError("Invalid configuration: Nothing to fetch. Make sure that you provided at least one contract address to index, or have events with Wildcard mode enabled.")
   }
 
   if Env.Benchmark.shouldSaveData {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/ChainWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/ChainWorker.res
@@ -39,7 +39,7 @@ module type S = {
     ~contractAddressMapping: ContractAddressingMap.mapping,
     ~currentBlockHeight: int,
     ~partitionId: string,
-    ~shouldApplyWildcards: bool,
+    ~forceWildcardEvents: bool,
     ~isPreRegisteringDynamicContracts: bool,
     ~logger: Pino.t,
   ) => promise<result<blockRangeFetchResponse, ErrorHandling.t>>
@@ -66,7 +66,7 @@ let fetchBlockRange = async (
   ~partitionId,
   ~chain,
   ~currentBlockHeight,
-  ~shouldApplyWildcards,
+  ~forceWildcardEvents,
   ~isPreRegisteringDynamicContracts,
   ~logger,
 ) => {
@@ -98,7 +98,7 @@ let fetchBlockRange = async (
     ~contractAddressMapping,
     ~partitionId,
     ~logger,
-    ~shouldApplyWildcards,
+    ~forceWildcardEvents,
     ~currentBlockHeight,
     ~isPreRegisteringDynamicContracts,
   ))->Utils.Result.forEach(response => {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -137,7 +137,7 @@ let makeGetRecieptsSelection = (
     )
   }
 
-  (~contractAddressMapping, ~shouldApplyWildcards) => {
+  (~contractAddressMapping, ~forceWildcardEvents) => {
     let selection: array<HyperFuelClient.QueryTypes.receiptSelection> = []
 
     //Instantiate each time to add new registered contract addresses
@@ -179,7 +179,7 @@ let makeGetRecieptsSelection = (
       }
     })
 
-    if shouldApplyWildcards {
+    if forceWildcardEvents {
       switch maybeWildcardNonLogDataSelection {
       | None => ()
       | Some(wildcardNonLogDataSelection) =>
@@ -277,7 +277,7 @@ module Make = (
     ~toBlock,
     ~logger,
     ~contractAddressMapping,
-    ~shouldApplyWildcards,
+    ~forceWildcardEvents,
     ~isPreRegisteringDynamicContracts,
   ) => {
     //Instantiate each time to add new registered contract addresses
@@ -285,7 +285,7 @@ module Make = (
       //TODO: create receipt selections for dynamic contract preregistration
       Js.Exn.raiseError("HyperFuel does not support pre registering dynamic contracts yet")
     } else {
-      getRecieptsSelection(~contractAddressMapping, ~shouldApplyWildcards)
+      getRecieptsSelection(~contractAddressMapping, ~forceWildcardEvents)
     }
 
     let startFetchingBatchTimeRef = Hrtime.makeTimer()
@@ -309,7 +309,7 @@ module Make = (
     ~contractAddressMapping,
     ~currentBlockHeight as _,
     ~partitionId as _,
-    ~shouldApplyWildcards,
+    ~forceWildcardEvents,
     ~isPreRegisteringDynamicContracts,
     ~logger,
   ) => {
@@ -322,7 +322,7 @@ module Make = (
         ~toBlock,
         ~contractAddressMapping,
         ~logger,
-        ~shouldApplyWildcards,
+        ~forceWildcardEvents,
         ~isPreRegisteringDynamicContracts,
       )
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -121,7 +121,7 @@ let makeGetNextPage = (
     })
   })
 
-  let getLogSelectionOrThrow = (~contractAddressMapping, ~shouldApplyWildcards): array<
+  let getLogSelectionOrThrow = (~contractAddressMapping, ~forceWildcardEvents): array<
     LogSelection.t,
   > => {
     let nonWildcardLogSelection = contracts->Belt.Array.keepMap((contract): option<
@@ -145,7 +145,7 @@ let makeGetNextPage = (
       }
     })
 
-    shouldApplyWildcards
+    forceWildcardEvents
       ? nonWildcardLogSelection->Array.concat(wildcardLogSelection)
       : nonWildcardLogSelection
   }
@@ -155,7 +155,7 @@ let makeGetNextPage = (
     ~toBlock,
     ~logger,
     ~contractAddressMapping,
-    ~shouldApplyWildcards,
+    ~forceWildcardEvents,
     ~isPreRegisteringDynamicContracts,
   ) => {
     //Instantiate each time to add new registered contract addresses
@@ -168,7 +168,7 @@ let makeGetNextPage = (
       if isPreRegisteringDynamicContracts {
         getContractPreRegistrationLogSelection(~contractAddressMapping)
       } else {
-        getLogSelectionOrThrow(~contractAddressMapping, ~shouldApplyWildcards)
+        getLogSelectionOrThrow(~contractAddressMapping, ~forceWildcardEvents)
       }
     } catch {
     | exn =>
@@ -293,7 +293,7 @@ module Make = (
     ~contractAddressMapping,
     ~currentBlockHeight as _,
     ~partitionId as _,
-    ~shouldApplyWildcards,
+    ~forceWildcardEvents,
     ~isPreRegisteringDynamicContracts,
     ~logger,
   ) => {
@@ -306,7 +306,7 @@ module Make = (
         ~toBlock,
         ~contractAddressMapping,
         ~logger,
-        ~shouldApplyWildcards,
+        ~forceWildcardEvents,
         ~isPreRegisteringDynamicContracts,
       )
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -192,13 +192,16 @@ module Make = (
     ~contractAddressMapping,
     ~currentBlockHeight,
     ~partitionId,
-    ~forceWildcardEvents as _,
+    ~forceWildcardEvents,
     ~isPreRegisteringDynamicContracts,
     ~logger,
   ) => {
     try {
       if isPreRegisteringDynamicContracts {
         Js.Exn.raiseError("HyperIndex RPC does not support pre registering dynamic contracts yet")
+      }
+      if forceWildcardEvents {
+        Js.Exn.raiseError("RPC worker does not yet support wildcard events")
       }
 
       let startFetchingBatchTimeRef = Hrtime.makeTimer()

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -192,7 +192,7 @@ module Make = (
     ~contractAddressMapping,
     ~currentBlockHeight,
     ~partitionId,
-    ~shouldApplyWildcards as _,
+    ~forceWildcardEvents as _,
     ~isPreRegisteringDynamicContracts,
     ~logger,
   ) => {

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -336,14 +336,17 @@ let handlePartitionQueryResponse = (
       ~fromBlock=fromBlockQueried,
       ~toBlock=latestFetchedBlockNumber,
       ~numEvents=parsedQueueItems->Array.length,
-      ~numAddresses=switch query {
-      | PartitionQuery({contractAddressMapping})
-      | MergeQuery({contractAddressMapping}) => contractAddressMapping
-      }->ContractAddressingMap.addressCount,
-      ~queryName=switch query {
-      | PartitionQuery({partitionId}) => `Partition ${partitionId}`
+      ~numAddresses=switch query.selection {
+      | Normal({contractAddressMapping}) =>
+        contractAddressMapping->ContractAddressingMap.addressCount
+      | Wildcard => 0
+      },
+      ~queryName=switch query.target {
+      | Head
+      | EndBlock(_) =>
+        `Partition ${query.partitionId}`
       // Group all merge queries into a single summary
-      | MergeQuery(_) => `Merge Query`
+      | Merge(_) => `Merge Query`
       },
     )
   }
@@ -749,43 +752,35 @@ let invalidatedActionReducer = (state: t, action: action) =>
   }
 
 let executeQuery = (
-  query: FetchState.query,
+  q: FetchState.query,
   ~logger,
   ~chainWorker,
   ~currentBlockHeight,
   ~chain,
   ~isPreRegisteringDynamicContracts,
 ) => {
-  switch query {
-  | PartitionQuery({partitionId, fromBlock, toBlock, contractAddressMapping}) =>
-    chainWorker->ChainWorker.fetchBlockRange(
-      ~fromBlock,
-      ~toBlock,
-      ~contractAddressMapping,
-      ~partitionId,
-      ~chain,
-      ~currentBlockHeight,
-      ~isPreRegisteringDynamicContracts,
-      ~logger,
-      //Only apply wildcards on the first partition
-      //to avoid duplicate wildcard queries
-      ~shouldApplyWildcards=partitionId === "0",
-    )
-  | MergeQuery({partitionId, fromBlock, toBlock, contractAddressMapping}) =>
-    chainWorker->ChainWorker.fetchBlockRange(
-      ~fromBlock,
-      ~toBlock=Some(toBlock),
-      ~contractAddressMapping,
-      ~partitionId,
-      ~chain,
-      ~currentBlockHeight,
-      ~isPreRegisteringDynamicContracts,
-      ~logger,
-      //Only apply wildcards on the first partition
-      //to avoid duplicate wildcard queries
-      ~shouldApplyWildcards=partitionId === "0",
-    )
-  }
+  chainWorker->ChainWorker.fetchBlockRange(
+    ~fromBlock=q.fromBlock,
+    ~toBlock=switch q.target {
+    | Head => None
+    | EndBlock({toBlock})
+    | Merge({toBlock}) =>
+      Some(toBlock)
+    },
+    ~contractAddressMapping=switch q.selection {
+    | Normal({contractAddressMapping}) => contractAddressMapping
+    | Wildcard => ContractAddressingMap.make()
+    },
+    ~partitionId=q.partitionId,
+    ~chain,
+    ~currentBlockHeight,
+    ~isPreRegisteringDynamicContracts,
+    ~logger,
+    ~forceWildcardEvents=switch q.selection {
+    | Normal(_) => false
+    | Wildcard => true
+    },
+  )
 }
 
 let checkAndFetchForChain = (

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -325,7 +325,7 @@ let handlePartitionQueryResponse = (
   if Env.Benchmark.shouldSaveData {
     Prometheus.PartitionBlockFetched.set(
       ~blockNumber=latestFetchedBlockNumber,
-      ~partitionId=query->FetchState.queryPartitionId,
+      ~partitionId=query.partitionId,
       ~chainId=chain->ChainMap.Chain.toChainId,
     )
     Benchmark.addBlockRangeFetched(

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -341,12 +341,10 @@ let handlePartitionQueryResponse = (
         contractAddressMapping->ContractAddressingMap.addressCount
       | Wildcard => 0
       },
-      ~queryName=switch query.target {
-      | Head
-      | EndBlock(_) =>
-        `Partition ${query.partitionId}`
-      // Group all merge queries into a single summary
-      | Merge(_) => `Merge Query`
+      ~queryName=switch query {
+      | {target: Merge(_)} => `Merge Query`
+      | {selection: Wildcard} => `Wildcard Query`
+      | {selection: Normal(_)} => `Normal Query`
       },
     )
   }

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -703,7 +703,6 @@ let actionReducer = (state: t, action: action) => {
         ~lastBlockScannedHashes=ReorgDetection.LastBlockScannedHashes.empty(
           ~confirmedBlockThreshold=chainConfig.confirmedBlockThreshold,
         ),
-        ~staticContracts=chainConfig->ChainFetcher.getStaticContracts,
         ~startBlock,
         ~endBlock=chainConfig.endBlock,
         ~dbFirstEventBlockNumber=None,

--- a/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
@@ -134,10 +134,12 @@ describe("Dynamic contract restart resistance test", () => {
       ~maxAddrInPartition=Env.maxAddrInPartition,
     )
 
-    let dcs =
-      chainFetcher.fetchState.partitions->Array.flatMap(p =>
-        p.dynamicContracts->Array.map(dc => dc.contractAddress)
-      )
+    let dcs = chainFetcher.fetchState.partitions->Array.flatMap(p =>
+      switch p.kind {
+      | Normal({dynamicContracts}) => dynamicContracts->Array.map(dc => dc.contractAddress)
+      | Wildcard => []
+      }
+    )
 
     dcs
   }

--- a/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
@@ -418,7 +418,10 @@ describe("Dynamic contract rollback test", () => {
       ~message=`Should get a root partition`,
     )
     Assert.deepEqual(
-      dcPartition.dynamicContracts->Js.Array2.length,
+      switch dcPartition.kind {
+      | Normal({dynamicContracts}) => dynamicContracts->Array.length
+      | Wildcard => 0
+      },
       1,
       ~message=`Should have a single dc`,
     )

--- a/scenarios/fuel_test/test/HyperFuelWorker_test.res
+++ b/scenarios/fuel_test/test/HyperFuelWorker_test.res
@@ -32,7 +32,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [],
     )
@@ -50,7 +50,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [],
     )
@@ -81,7 +81,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -132,7 +132,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       Assert.deepEqual(
         getRecieptsSelection(
           ~contractAddressMapping=mockContractAddressMapping(),
-          ~shouldApplyWildcards=true,
+          ~forceWildcardEvents=true,
         ),
         [
           {
@@ -186,7 +186,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -239,7 +239,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -278,7 +278,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -311,7 +311,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -376,7 +376,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -487,7 +487,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -737,7 +737,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -788,7 +788,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -840,7 +840,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -891,7 +891,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -907,7 +907,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     )
   })
 
-  it("Removes wildcard selection with shouldApplyWildcards (needed for partitioning)", () => {
+  it("Removes wildcard selection with forceWildcardEvents (needed for partitioning)", () => {
     let getRecieptsSelection = mock(
       ~contracts=[
         {
@@ -962,7 +962,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
       ),
       [
         {
@@ -985,7 +985,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     Assert.deepEqual(
       getRecieptsSelection(
         ~contractAddressMapping=mockContractAddressMapping(),
-        ~shouldApplyWildcards=false,
+        ~forceWildcardEvents=false,
       ),
       [
         {

--- a/scenarios/fuel_test/test/HyperFuelWorker_test.res
+++ b/scenarios/fuel_test/test/HyperFuelWorker_test.res
@@ -1,6 +1,6 @@
 open RescriptMocha
 
-describe("HyperFuelWorker - getRecieptsSelection", () => {
+describe("HyperFuelWorker - getNormalRecieptsSelection", () => {
   let contractName1 = "TestContract"
   let contractName2 = "TestContract2"
   let chain = ChainMap.Chain.makeUnsafe(~chainId=0)
@@ -10,11 +10,9 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
 
   let mock = (~contracts) => {
     let workerConfig = HyperFuelWorker.makeWorkerConfigOrThrow(~contracts, ~chain)
-    HyperFuelWorker.makeGetRecieptsSelection(
-      ~wildcardLogDataRbs=workerConfig.wildcardLogDataRbs,
+    HyperFuelWorker.makeGetNormalRecieptsSelection(
       ~nonWildcardLogDataRbsByContract=workerConfig.nonWildcardLogDataRbsByContract,
       ~nonLogDataReceiptTypesByContract=workerConfig.nonLogDataReceiptTypesByContract,
-      ~nonLogDataWildcardReceiptTypes=workerConfig.nonLogDataWildcardReceiptTypes,
       ~contracts,
     )
   }
@@ -28,18 +26,15 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
   }
 
   it("Receipts Selection with no contracts", () => {
-    let getRecieptsSelection = mock(~contracts=[])
+    let getNormalRecieptsSelection = mock(~contracts=[])
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
       [],
     )
   })
 
   it("Receipts Selection with no events", () => {
-    let getRecieptsSelection = mock(
+    let getNormalRecieptsSelection = mock(
       ~contracts=[
         {
           name: "TestContract",
@@ -48,16 +43,13 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ],
     )
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
       [],
     )
   })
 
   it("Receipts Selection with single non-wildcard log event", () => {
-    let getRecieptsSelection = mock(
+    let getNormalRecieptsSelection = mock(
       ~contracts=[
         {
           name: "TestContract",
@@ -79,10 +71,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ],
     )
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
       [
         {
           rb: [1n],
@@ -97,7 +86,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
   it(
     "Receipts Selection with non-wildcard transfer event - catches both TRANSFER and TRANSFER_OUT receipts",
     () => {
-      let getRecieptsSelection = mock(
+      let getNormalRecieptsSelection = mock(
         ~contracts=[
           {
             name: "TestContract",
@@ -130,10 +119,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
         ],
       )
       Assert.deepEqual(
-        getRecieptsSelection(
-          ~contractAddressMapping=mockContractAddressMapping(),
-          ~forceWildcardEvents=true,
-        ),
+        getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
         [
           {
             receiptType: [Transfer, TransferOut],
@@ -151,7 +137,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
   )
 
   it("Receipts Selection with non-wildcard mint event", () => {
-    let getRecieptsSelection = mock(
+    let getNormalRecieptsSelection = mock(
       ~contracts=[
         {
           name: "TestContract",
@@ -184,10 +170,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ],
     )
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
       [
         {
           receiptType: [Mint],
@@ -204,7 +187,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
   })
 
   it("Receipts Selection with non-wildcard burn event", () => {
-    let getRecieptsSelection = mock(
+    let getNormalRecieptsSelection = mock(
       ~contracts=[
         {
           name: "TestContract",
@@ -237,10 +220,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ],
     )
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
       [
         {
           receiptType: [Burn],
@@ -256,140 +236,8 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
     )
   })
 
-  it("Receipts Selection with wildcard mint event", () => {
-    let getRecieptsSelection = mock(
-      ~contracts=[
-        {
-          name: "TestContract",
-          events: [
-            {
-              name: "Mint",
-              kind: Mint,
-              isWildcard: true,
-              handler: None,
-              loader: None,
-              contractRegister: None,
-              paramsRawEventSchema: %raw(`"Not relevat"`),
-            },
-          ],
-        },
-      ],
-    )
-    Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
-      [
-        {
-          receiptType: [Mint],
-          txStatus: [1],
-        },
-      ],
-    )
-  })
-
-  it("Receipts Selection with wildcard burn event", () => {
-    let getRecieptsSelection = mock(
-      ~contracts=[
-        {
-          name: "TestContract",
-          events: [
-            {
-              name: "Burn",
-              kind: Burn,
-              isWildcard: true,
-              handler: None,
-              loader: None,
-              contractRegister: None,
-              paramsRawEventSchema: %raw(`"Not relevat"`),
-            },
-          ],
-        },
-      ],
-    )
-    Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
-      [
-        {
-          receiptType: [Burn],
-          txStatus: [1],
-        },
-      ],
-    )
-  })
-
-  it("Receipts Selection with multiple wildcard log event", () => {
-    let getRecieptsSelection = mock(
-      ~contracts=[
-        {
-          name: "TestContract",
-          events: [
-            {
-              name: "StrLog",
-              kind: LogData({
-                logId: "1",
-                decode: _ => %raw(`null`),
-              }),
-              isWildcard: true,
-              handler: None,
-              loader: None,
-              contractRegister: None,
-              paramsRawEventSchema: %raw(`"Not relevat"`),
-            },
-            {
-              name: "BoolLog",
-              kind: LogData({
-                logId: "2",
-                decode: _ => %raw(`null`),
-              }),
-              isWildcard: true,
-              handler: None,
-              loader: None,
-              contractRegister: None,
-              paramsRawEventSchema: %raw(`"Not relevat"`),
-            },
-          ],
-        },
-        {
-          name: "TestContract2",
-          events: [
-            {
-              name: "UnitLog",
-              kind: LogData({
-                logId: "3",
-                decode: _ => %raw(`null`),
-              }),
-              isWildcard: true,
-              handler: None,
-              loader: None,
-              contractRegister: None,
-              paramsRawEventSchema: %raw(`"Not relevat"`),
-            },
-          ],
-        },
-      ],
-    )
-    Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
-      [
-        {
-          rb: [1n, 2n, 3n],
-          receiptType: [LogData],
-          txStatus: [1],
-        },
-      ],
-    )
-  })
-
   it("Receipts Selection with all possible events together", () => {
-    let getRecieptsSelection = mock(
+    let getNormalRecieptsSelection = mock(
       ~contracts=[
         {
           name: "TestContract",
@@ -485,10 +333,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ],
     )
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
       [
         {
           receiptType: [Mint, Burn, Transfer, TransferOut],
@@ -512,16 +357,8 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
           rootContractId: [address3],
           txStatus: [1],
         },
-        {
-          receiptType: [Call],
-          txStatus: [1],
-        },
-        {
-          rb: [2n],
-          receiptType: [LogData],
-          txStatus: [1],
-        },
       ],
+      ~message=`Note that non-wildcard events should be skipped`,
     )
   })
 
@@ -702,7 +539,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
   })
 
   it("Works with wildcard mint and non-wildcard mint together in different contract", () => {
-    let getRecieptsSelection = mock(
+    let getNormalRecieptsSelection = mock(
       ~contracts=[
         {
           name: "TestContract2",
@@ -735,25 +572,18 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ],
     )
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
       [
         {
           receiptType: [Mint],
           rootContractId: [address3],
-          txStatus: [1],
-        },
-        {
-          receiptType: [Mint],
           txStatus: [1],
         },
       ],
     )
 
     // The same but with different event registration order
-    let getRecieptsSelection = mock(
+    let getNormalRecieptsSelection = mock(
       ~contracts=[
         {
           name: "TestContract",
@@ -786,18 +616,11 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ],
     )
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
       [
         {
           receiptType: [Mint],
           rootContractId: [address3],
-          txStatus: [1],
-        },
-        {
-          receiptType: [Mint],
           txStatus: [1],
         },
       ],
@@ -805,7 +628,7 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
   })
 
   it("Works with wildcard burn and non-wildcard burn together in different contract", () => {
-    let getRecieptsSelection = mock(
+    let getNormalRecieptsSelection = mock(
       ~contracts=[
         {
           name: "TestContract2",
@@ -838,25 +661,18 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ],
     )
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
       [
         {
           receiptType: [Burn],
           rootContractId: [address3],
-          txStatus: [1],
-        },
-        {
-          receiptType: [Burn],
           txStatus: [1],
         },
       ],
     )
 
     // The same but with different event registration order
-    let getRecieptsSelection = mock(
+    let getNormalRecieptsSelection = mock(
       ~contracts=[
         {
           name: "TestContract",
@@ -889,26 +705,213 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ],
     )
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      getNormalRecieptsSelection(~contractAddressMapping=mockContractAddressMapping()),
       [
         {
           receiptType: [Burn],
           rootContractId: [address3],
           txStatus: [1],
         },
+      ],
+    )
+  })
+})
+
+describe("HyperFuelWorker - makeWildcardRecieptsSelection", () => {
+  let chain = ChainMap.Chain.makeUnsafe(~chainId=0)
+
+  let mock = (~contracts) => {
+    let workerConfig = HyperFuelWorker.makeWorkerConfigOrThrow(~contracts, ~chain)
+    HyperFuelWorker.makeWildcardRecieptsSelection(
+      ~wildcardLogDataRbs=workerConfig.wildcardLogDataRbs,
+      ~nonLogDataWildcardReceiptTypes=workerConfig.nonLogDataWildcardReceiptTypes,
+    )
+  }
+
+  it("Receipts Selection with no contracts", () => {
+    let wildcardReceiptsSelection = mock(~contracts=[])
+    Assert.deepEqual(
+      wildcardReceiptsSelection,
+      [],
+      ~message=`It should never happen, since the partition like this wouldn't exist`,
+    )
+  })
+
+  it("Receipts Selection with no events", () => {
+    let wildcardReceiptsSelection = mock(
+      ~contracts=[
         {
-          receiptType: [Burn],
+          name: "TestContract",
+          events: [],
+        },
+      ],
+    )
+    Assert.deepEqual(
+      wildcardReceiptsSelection,
+      [],
+      ~message=`It should never happen, since the partition like this wouldn't exist`,
+    )
+  })
+
+  it("Receipts Selection with all possible events together", () => {
+    let wildcardReceiptsSelection = mock(
+      ~contracts=[
+        {
+          name: "TestContract",
+          events: [
+            {
+              name: "StrLog",
+              kind: LogData({
+                logId: "1",
+                decode: _ => %raw(`null`),
+              }),
+              isWildcard: false,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+            {
+              name: "BoolLog",
+              kind: LogData({
+                logId: "2",
+                decode: _ => %raw(`null`),
+              }),
+              isWildcard: true,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+            {
+              name: "Mint",
+              kind: Mint,
+              isWildcard: false,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+            {
+              name: "Burn",
+              kind: Burn,
+              isWildcard: false,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+            {
+              name: "Transfer",
+              kind: Transfer,
+              isWildcard: false,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+            {
+              name: "Call",
+              kind: Call,
+              isWildcard: true,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+          ],
+        },
+        {
+          name: "TestContract2",
+          events: [
+            {
+              name: "UnitLog",
+              kind: LogData({
+                logId: "3",
+                decode: _ => %raw(`null`),
+              }),
+              isWildcard: false,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+            {
+              name: "Burn",
+              kind: Burn,
+              isWildcard: false,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+          ],
+        },
+      ],
+    )
+    Assert.deepEqual(
+      wildcardReceiptsSelection,
+      [
+        {
+          receiptType: [Call],
+          txStatus: [1],
+        },
+        {
+          rb: [2n],
+          receiptType: [LogData],
+          txStatus: [1],
+        },
+      ],
+      ~message=`Note that wildcard events should be skipped`,
+    )
+  })
+
+  it("Works with wildcard mint and non-wildcard mint together in different contract", () => {
+    let wildcardReceiptsSelection = mock(
+      ~contracts=[
+        {
+          name: "TestContract2",
+          events: [
+            {
+              name: "Mint",
+              kind: Mint,
+              isWildcard: false,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+          ],
+        },
+        {
+          name: "TestContract",
+          events: [
+            {
+              name: "Mint",
+              kind: Mint,
+              isWildcard: true,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+          ],
+        },
+      ],
+    )
+    Assert.deepEqual(
+      wildcardReceiptsSelection,
+      [
+        {
+          receiptType: [Mint],
           txStatus: [1],
         },
       ],
     )
   })
 
-  it("Removes wildcard selection with forceWildcardEvents (needed for partitioning)", () => {
-    let getRecieptsSelection = mock(
+  it("Receipts Selection with wildcard mint event", () => {
+    let wildcardReceiptsSelection = mock(
       ~contracts=[
         {
           name: "TestContract",
@@ -922,6 +925,27 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
               contractRegister: None,
               paramsRawEventSchema: %raw(`"Not relevat"`),
             },
+          ],
+        },
+      ],
+    )
+    Assert.deepEqual(
+      wildcardReceiptsSelection,
+      [
+        {
+          receiptType: [Mint],
+          txStatus: [1],
+        },
+      ],
+    )
+  })
+
+  it("Receipts Selection with wildcard burn event", () => {
+    let wildcardReceiptsSelection = mock(
+      ~contracts=[
+        {
+          name: "TestContract",
+          events: [
             {
               name: "Burn",
               kind: Burn,
@@ -931,8 +955,29 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
               contractRegister: None,
               paramsRawEventSchema: %raw(`"Not relevat"`),
             },
+          ],
+        },
+      ],
+    )
+    Assert.deepEqual(
+      wildcardReceiptsSelection,
+      [
+        {
+          receiptType: [Burn],
+          txStatus: [1],
+        },
+      ],
+    )
+  })
+
+  it("Receipts Selection with multiple wildcard log event", () => {
+    let wildcardReceiptsSelection = mock(
+      ~contracts=[
+        {
+          name: "TestContract",
+          events: [
             {
-              name: "WildcardLog",
+              name: "StrLog",
               kind: LogData({
                 logId: "1",
                 decode: _ => %raw(`null`),
@@ -944,12 +989,29 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
               paramsRawEventSchema: %raw(`"Not relevat"`),
             },
             {
-              name: "NonWildcardLog",
+              name: "BoolLog",
               kind: LogData({
                 logId: "2",
                 decode: _ => %raw(`null`),
               }),
-              isWildcard: false,
+              isWildcard: true,
+              handler: None,
+              loader: None,
+              contractRegister: None,
+              paramsRawEventSchema: %raw(`"Not relevat"`),
+            },
+          ],
+        },
+        {
+          name: "TestContract2",
+          events: [
+            {
+              name: "UnitLog",
+              kind: LogData({
+                logId: "3",
+                decode: _ => %raw(`null`),
+              }),
+              isWildcard: true,
               handler: None,
               loader: None,
               contractRegister: None,
@@ -960,38 +1022,11 @@ describe("HyperFuelWorker - getRecieptsSelection", () => {
       ],
     )
     Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=true,
-      ),
+      wildcardReceiptsSelection,
       [
         {
-          rb: [2n],
+          rb: [1n, 2n, 3n],
           receiptType: [LogData],
-          rootContractId: [address1, address2],
-          txStatus: [1],
-        },
-        {
-          receiptType: [Mint, Burn],
-          txStatus: [1],
-        },
-        {
-          rb: [1n],
-          receiptType: [LogData],
-          txStatus: [1],
-        },
-      ],
-    )
-    Assert.deepEqual(
-      getRecieptsSelection(
-        ~contractAddressMapping=mockContractAddressMapping(),
-        ~forceWildcardEvents=false,
-      ),
-      [
-        {
-          rb: [2n],
-          receiptType: [LogData],
-          rootContractId: [address1, address2],
           txStatus: [1],
         },
       ],

--- a/scenarios/helpers/src/ChainMocking.res
+++ b/scenarios/helpers/src/ChainMocking.res
@@ -251,9 +251,16 @@ module Make = (Indexer: Indexer.S) => {
   }
 
   let executeQuery = (self: t, query: FetchState.query): ChainWorker.blockRangeFetchResponse => {
-    let (fromBlock, toBlock, contractAddressMapping) = switch query {
-    | PartitionQuery(query) => (query.fromBlock, query.toBlock, query.contractAddressMapping)
-    | MergeQuery(query) => (query.fromBlock, Some(query.toBlock), query.contractAddressMapping)
+    let {fromBlock} = query
+    let toBlock = switch query.target {
+    | Head => None
+    | EndBlock({toBlock})
+    | Merge({toBlock}) =>
+      Some(toBlock)
+    }
+    let contractAddressMapping = switch query.selection {
+    | Normal({contractAddressMapping}) => contractAddressMapping
+    | Wildcard => ContractAddressingMap.make()
     }
 
     let unfilteredBlocks = self->getBlocks(~fromBlock, ~toBlock)

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -62,29 +62,33 @@ module type S = {
 
   module ContractAddressingMap: {
     type mapping
+    let make: unit => mapping
     let getAllAddresses: mapping => array<Address.t>
     let getAddressesFromContractName: (mapping, ~contractName: string) => array<Address.t>
   }
 
   module FetchState: {
-    type partitionQuery = {
+    type queryTarget =
+      | Head
+      | EndBlock({toBlock: int})
+      | Merge({
+          // The partition we are going to merge into
+          // It shouldn't be fetching during the query
+          intoPartitionId: string,
+          toBlock: int,
+        })
+
+    // Strip internal fields from partition kind like dynamicContracts
+    type querySelection =
+      | Wildcard
+      | Normal({contractAddressMapping: ContractAddressingMap.mapping})
+
+    type query = {
       partitionId: string,
       fromBlock: int,
-      toBlock: option<int>,
-      contractAddressMapping: ContractAddressingMap.mapping,
+      selection: querySelection,
+      target: queryTarget,
     }
-
-    type mergeQuery = {
-      partitionId: string,
-      intoPartitionId: string,
-      fromBlock: int,
-      toBlock: int,
-      contractAddressMapping: ContractAddressingMap.mapping,
-    }
-
-    type query =
-      | PartitionQuery(partitionQuery)
-      | MergeQuery(mergeQuery)
   }
 
   module ChainWorker: {

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -116,7 +116,7 @@ module type S = {
         ~contractAddressMapping: ContractAddressingMap.mapping,
         ~currentBlockHeight: int,
         ~partitionId: string,
-        ~shouldApplyWildcards: bool,
+        ~forceWildcardEvents: bool,
         ~isPreRegisteringDynamicContracts: bool,
         ~logger: Pino.t,
       ) => promise<result<blockRangeFetchResponse, ErrorHandling.t>>

--- a/scenarios/test_codegen/config.yaml
+++ b/scenarios/test_codegen/config.yaml
@@ -7,6 +7,11 @@ field_selection:
   transaction_fields:
     - transactionIndex
     - hash
+contracts:
+  - name: Noop
+    handler: ./src/EventHandlers.bs.js
+    events:
+      - event: "EmptyEvent()"
 networks:
   - id: 1337
     rpc_config:
@@ -73,8 +78,12 @@ networks:
           - event: "IndexedStructWithArray"
   - id: 1
     start_block: 1
-    contracts: []
+    contracts:
+      - name: Noop
+        address: "0x0B2f78c5BF6D9C12Ee1225D5F374aa91204580c3" # -> use this if you want to deploy to local ganache
   - id: 137
     start_block: 1
-    contracts: []
+    contracts:
+      - name: Noop
+        address: "0x0B2f78c5BF6D9C12Ee1225D5F374aa91204580c3" # -> use this if you want to deploy to local ganache
 raw_events: true

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -26,7 +26,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       ~staticContracts=[],
       ~dynamicContracts=[],
       ~startBlock=0,
-      ~isFetchingAtHead=false,
+      ~hasWildcard=true,
     )
 
     let fetchState = ref(fetcherStateInit)
@@ -77,12 +77,12 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
           fetchState :=
             fetchState.contents
             ->FetchState.setQueryResponse(
-              ~query=PartitionQuery({
+              ~query={
                 partitionId: "0",
                 fromBlock: 0,
-                toBlock: None,
-                contractAddressMapping: ContractAddressingMap.make(),
-              }),
+                target: Head,
+                selection: Wildcard,
+              },
               ~latestFetchedBlock={
                 blockNumber: batchItem.blockNumber,
                 blockTimestamp: batchItem.timestamp,
@@ -100,12 +100,12 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
             fetchState :=
               fetchState.contents
               ->FetchState.setQueryResponse(
-                ~query=PartitionQuery({
+                ~query={
                   partitionId: "0",
                   fromBlock: 0,
-                  toBlock: None,
-                  contractAddressMapping: ContractAddressingMap.make(),
-                }),
+                  target: Head,
+                  selection: Wildcard,
+                },
                 ~latestFetchedBlock={
                   blockNumber: batchItem.blockNumber,
                   blockTimestamp: batchItem.timestamp,
@@ -342,13 +342,14 @@ describe("determineNextEvent", () => {
         status: {
           fetchingStateId: None,
         },
-        contractAddressMapping: ContractAddressingMap.make(),
+        kind: Normal({
+          contractAddressMapping: ContractAddressingMap.make(),
+          dynamicContracts: [],
+        }),
         fetchedEventQueue: item->Option.mapWithDefault([], v => [v]),
-        dynamicContracts: [],
       }
       {
         partitions: [partition],
-        batchSize: 5,
         maxAddrInPartition: 5,
         nextPartitionIndex: 1,
         queueSize: 10,

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -9,7 +9,22 @@ describe("getGeneratedByChainId Test", () => {
         syncSource: HyperSync({endpointUrl: "https://1.hypersync.xyz"}),
         startBlock: 1,
         confirmedBlockThreshold: 200,
-        contracts: Js.Dict.empty(),
+        contracts: Js.Dict.fromArray([
+          (
+            "Noop",
+            {
+              ConfigYAML.name: "Noop",
+              abi: %raw(`[{
+                anonymous: false,
+                inputs: [],
+                name: "EmptyEvent",
+                type: "event"
+              }]`),
+              addresses: ["0x0B2f78c5BF6D9C12Ee1225D5F374aa91204580c3"],
+              events: ["EmptyEvent"],
+            },
+          ),
+        ]),
       },
     )
   })

--- a/scenarios/test_codegen/test/HyperSyncWorker_test.res
+++ b/scenarios/test_codegen/test/HyperSyncWorker_test.res
@@ -71,7 +71,7 @@ describe("HyperSyncWorker - getNextPage", () => {
         ~toBlock=2,
         ~logger=Logging.logger,
         ~contractAddressMapping=ContractAddressingMap.make(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
         ~isPreRegisteringDynamicContracts=false,
       )
 
@@ -120,7 +120,7 @@ describe("HyperSyncWorker - getNextPage", () => {
         ~toBlock=2,
         ~logger=Logging.logger,
         ~contractAddressMapping=ContractAddressingMap.make(),
-        ~shouldApplyWildcards=true,
+        ~forceWildcardEvents=true,
         ~isPreRegisteringDynamicContracts=false,
       )
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -921,7 +921,7 @@ describe("FetchState.getNextQuery & integration", () => {
     )
   })
 
-  it("Root partition never merges to another one (because of shouldApplyWildcards check)", () => {
+  it("Root partition never merges to another one (because of forceWildcardEvents check)", () => {
     let fetchState =
       FetchState.make(
         ~staticContracts=[("ContractA", mockAddress1)],


### PR DESCRIPTION
- This is a final preparation step for Wildcard RPC indexing support
- As an additional benefit, this will add concurrency to the HyperSync fetching as well, making it a little bit faster
- Unrelated change: The Indexer started failing with a user-readable error that there's nothing to fetch when there are no static contracts in the config or wildcard events are registered.

Even though the change looks scary, these are mostly test updates. What's going on:

- To have better control and be able to build a query for Wildcard events on RPC we've decided to use an already existing partitioning mechanism
- It used to use it before as well, but was implemented as a workaround by mixing in wildcard events to the first partition.
- Now, there's always a separate partition for wildcard events, allowing us to build a wildcard get_logs rpc query

Besides the partitions refactoring done in the previous release, the mane challenge of the PR is to make sure, that we always create partitions with the correct initial addresses (you can see it in the ChainFetcher logic). Now, a normal partition without addresses shouldn't be possible, so we throw an error on FetchState creation.