### PR TITLE
Fix indexer stopping fetching nested dynamic contract registrations on restart when a preRegistration is used

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
@@ -6,7 +6,6 @@ The context holds all the state for a given events loader and handler.
 type t = {
   logger: Pino.t,
   eventItem: Internal.eventItem,
-  addedDynamicContractRegistrations: array<TablesStatic.DynamicContractRegistry.t>,
 }
 
 let getUserLogger = (logger): Logs.userLogger => {
@@ -54,12 +53,8 @@ let make = (~eventItem: Internal.eventItem, ~logger) => {
   {
     logger,
     eventItem,
-    addedDynamicContractRegistrations: [],
   }
 }
-
-let getAddedDynamicContractRegistrations = (contextEnv: t) =>
-  contextEnv.addedDynamicContractRegistrations
 
 let makeDynamicContractId = (~chainId, ~contractAddress) => {
   chainId->Belt.Int.toString ++ "-" ++ contractAddress->Address.toString

--- a/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/ContextEnv.res.hbs
@@ -64,11 +64,10 @@ let getAddedDynamicContractRegistrations = (contextEnv: t) =>
 let makeDynamicContractId = (~chainId, ~contractAddress) => {
   chainId->Belt.Int.toString ++ "-" ++ contractAddress->Address.toString
 }
+
 let makeDynamicContractRegisterFn = (
-  ~contextEnv: t,
-  ~contractName,
-  ~inMemoryStore,
-  ~shouldSaveHistory,
+  ~contractName: Enums.ContractType.t,
+  ~onRegister,
 ) => (contractAddress: Address.t) => {
   {{#if is_evm_ecosystem}} {{!-- TODO: Add validation for Fuel --}}
   // Even though it's the Address.t type on ReScript side, for TS side it's a string.
@@ -76,41 +75,7 @@ let makeDynamicContractRegisterFn = (
   let contractAddress = contractAddress->Address.Evm.fromAddressOrThrow
   {{/if}}
 
-  let {eventItem, addedDynamicContractRegistrations} = contextEnv
-  let {chain, timestamp, blockNumber, logIndex} = eventItem
-
-  let chainId = chain->ChainMap.Chain.toChainId
-  let dynamicContractRegistration: TablesStatic.DynamicContractRegistry.t = {
-    id: makeDynamicContractId(~chainId, ~contractAddress),
-    chainId,
-    registeringEventBlockNumber: blockNumber,
-    registeringEventLogIndex: logIndex,
-    registeringEventName: eventItem.eventName,
-    registeringEventContractName: eventItem.contractName,
-    registeringEventSrcAddress: eventItem.event.srcAddress,
-    registeringEventBlockTimestamp: timestamp,
-    contractAddress,
-    contractType: contractName,
-  }
-
-  addedDynamicContractRegistrations->Js.Array2.push(dynamicContractRegistration)->ignore
-
-  let eventIdentifier: Types.eventIdentifier = {
-    chainId,
-    blockTimestamp: timestamp,
-    blockNumber,
-    logIndex,
-  }
-
-  inMemoryStore.InMemoryStore.entities
-  ->InMemoryStore.EntityTables.get(module(TablesStatic.DynamicContractRegistry))
-  ->InMemoryTable.Entity.set(
-    Set(dynamicContractRegistration)->Types.mkEntityUpdate(
-      ~eventIdentifier,
-      ~entityId=dynamicContractRegistration.id,
-    ),
-    ~shouldSaveHistory,
-  )
+  onRegister(~contractAddress, ~contractName)
 }
 
 let makeWhereLoader = (
@@ -158,10 +123,10 @@ let makeEntityHandlerContext = (
   }
 }
 
-let getContractRegisterContext = (contextEnv, ~inMemoryStore, ~shouldSaveHistory) => {
+let getContractRegisterContext = (~onRegister) => {
   //TODO only add contracts we've registered for the event in the config
   {{#each codegen_contracts as |contract| }}
-  add{{contract.name.capitalized}}:  makeDynamicContractRegisterFn(~contextEnv, ~inMemoryStore, ~contractName={{contract.name.capitalized}}, ~shouldSaveHistory),
+  add{{contract.name.capitalized}}:  makeDynamicContractRegisterFn(~contractName={{contract.name.capitalized}}, ~onRegister),
   {{/each}}
 }->(Utils.magic: Types.contractRegistrations => Internal.contractRegisterContext)
 
@@ -217,9 +182,9 @@ let getHandlerContext = (
   }->(Utils.magic: Types.handlerContext => Internal.handlerContext)
 }
 
-let getContractRegisterArgs = (contextEnv, ~inMemoryStore, ~shouldSaveHistory): Internal.contractRegisterArgs => {
+let getContractRegisterArgs = (contextEnv, ~onRegister): Internal.contractRegisterArgs => {
   event: contextEnv.eventItem.event,
-  context: contextEnv->getContractRegisterContext(~inMemoryStore, ~shouldSaveHistory),
+  context: getContractRegisterContext(~onRegister),
 }
 
 let getLoaderArgs = (contextEnv, ~inMemoryStore, ~loadLayer): Internal.loaderArgs => {

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -125,10 +125,9 @@ let runEventContractRegister = (
 ) => {
   let {chain} = eventItem
 
-  let contextEnv = ContextEnv.make(~eventItem, ~logger)
+  let addedDynamicContractRegistrations = []
 
   let onRegister = (~contractAddress, ~contractName) => {
-    let {eventItem, addedDynamicContractRegistrations} = contextEnv
     let {chain, timestamp, blockNumber, logIndex} = eventItem
 
     let chainId = chain->ChainMap.Chain.toChainId
@@ -166,6 +165,7 @@ let runEventContractRegister = (
     )
   }
 
+  let contextEnv = ContextEnv.make(~eventItem, ~logger)
   switch contractRegister(contextEnv->ContextEnv.getContractRegisterArgs(~onRegister)) {
   | exception exn =>
     exn
@@ -176,8 +176,7 @@ let runEventContractRegister = (
     ->Error
   | () =>
     let dynamicContracts =
-      contextEnv
-      ->ContextEnv.getAddedDynamicContractRegistrations
+      addedDynamicContractRegistrations
       ->Array.keep(({contractAddress, contractType}) =>
         !checkContractIsRegistered(~chain, ~contractAddress, ~contractName=contractType) &&
         !checkContractIsInCurrentRegistrations(

--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsImplementation.js
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsImplementation.js
@@ -231,7 +231,7 @@ module.exports.deleteStaleEndOfBlockRangeScannedDataForChain = (
     ;`;
 };
 
-module.exports.readDynamicContractsOnChainIdAtOrBeforeBlockNumber = (
+module.exports.recoverRegisteredDynamicContracts = (
   sql,
   chainId,
   blockNumber
@@ -241,20 +241,16 @@ module.exports.readDynamicContractsOnChainIdAtOrBeforeBlockNumber = (
   WHERE registering_event_block_number <= ${blockNumber} 
   AND chain_id = ${chainId};`;
 
-module.exports.readDynamicContractsOnChainIdMatchingEvents = (
+module.exports.recoverPreRegisteredAndRegisteredDynamicContracts = (
   sql,
   chainId,
-  preRegisterEvents // array<{registering_event_contract_name, registering_event_name, registering_event_src_address}>
-) => {
-  return sql`
-    SELECT *
-    FROM "public"."dynamic_contract_registry"
-    WHERE chain_id = ${chainId}
-    AND (registering_event_contract_name, registering_event_name, registering_event_src_address) IN ${sql(
-      preRegisterEvents.map((item) => sql(item))
-    )};
-  `;
-};
+  blockNumber
+) => sql`
+  SELECT *
+  FROM "public"."dynamic_contract_registry"
+  WHERE registering_event_block_number <= ${blockNumber} 
+  OR is_pre_registered
+  AND chain_id = ${chainId};`;
 
 const makeHistoryTableName = (entityName) => entityName + "_history";
 

--- a/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
@@ -159,6 +159,7 @@ module DynamicContractRegistry = {
     @as("registering_event_block_timestamp") registeringEventBlockTimestamp: int,
     @as("contract_address") contractAddress: Address.t,
     @as("contract_type") contractType: Enums.ContractType.t,
+    @as("is_pre_registered") isPreRegistered: bool,
   }
 
   let schema = S.schema(s => {
@@ -172,6 +173,7 @@ module DynamicContractRegistry = {
     registeringEventBlockTimestamp: s.matches(S.int),
     contractAddress: s.matches(Address.schema),
     contractType: s.matches(Enums.ContractType.enum.schema),
+    isPreRegistered: s.matches(S.bool),
   })
 
   let rowsSchema = S.array(schema)
@@ -189,6 +191,7 @@ module DynamicContractRegistry = {
       mkField("registering_event_src_address", Text),
       mkField("contract_address", Text),
       mkField("contract_type", Custom(Enums.ContractType.enum.name)),
+      mkField("is_pre_registered", Boolean),
     ],
   )
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -36,7 +36,7 @@ let make = (
   ~chainConfig: Config.chainConfig,
   ~lastBlockScannedHashes,
   ~staticContracts,
-  ~dynamicContractRegistrations,
+  ~dynamicContracts,
   ~startBlock,
   ~endBlock,
   ~dbFirstEventBlockNumber,
@@ -55,7 +55,7 @@ let make = (
   let fetchState = FetchState.make(
     ~maxAddrInPartition,
     ~staticContracts,
-    ~dynamicContracts=dynamicContractRegistrations,
+    ~dynamicContracts,
     ~startBlock,
     ~endBlock,
     ~isFetchingAtHead=false,
@@ -113,7 +113,7 @@ let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition) => {
     ~numBatchesFetched=0,
     ~logger,
     ~processingFilters=None,
-    ~dynamicContractRegistrations=[],
+    ~dynamicContracts=[],
     ~maxAddrInPartition,
     ~dynamicContractPreRegistration,
   )
@@ -201,7 +201,7 @@ let makeFromDbState = async (chainConfig: Config.chainConfig, ~maxAddrInPartitio
 
   let (
     dynamicContractPreRegistration: option<addressToDynContractLookup>,
-    dynamicContractRegistrations: array<TablesStatic.DynamicContractRegistry.t>,
+    dynamicContracts: array<TablesStatic.DynamicContractRegistry.t>,
   ) = if isPreRegisteringDynamicContracts {
     let dynamicContractPreRegistration: addressToDynContractLookup = Js.Dict.empty()
     dbDynamicContractRegistrations->Array.forEach(contract => {
@@ -263,7 +263,7 @@ let makeFromDbState = async (chainConfig: Config.chainConfig, ~maxAddrInPartitio
 
   make(
     ~staticContracts,
-    ~dynamicContractRegistrations,
+    ~dynamicContracts,
     ~chainConfig,
     ~startBlock,
     ~endBlock=chainConfig.endBlock,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -159,52 +159,22 @@ let makeFromDbState = async (chainConfig: Config.chainConfig, ~maxAddrInPartitio
   }
 
   //Get all dynamic contracts already registered on the chain
-  let dbDynamicContractRegistrations = if preRegisterDynamicContracts {
-    //An array of records containing srcAddress, eventName, contractName for each contract
-    //address & event that should be pre registered
-    let preRegisteringEvents = chainConfig.contracts->Array.flatMap(contract =>
-      contract.events->Array.flatMap(eventMod => {
-        let module(Event) = eventMod
-        let {preRegisterDynamicContracts} =
-          Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
-
-        if preRegisterDynamicContracts {
-          contract.addresses->Belt.Array.map(
-            address => {
-              {
-                DbFunctions.DynamicContractRegistry.registeringEventContractName: contract.name,
-                registeringEventName: Event.name,
-                registeringEventSrcAddress: address,
-              }
-            },
-          )
-        } else {
-          []
-        }
-      })
-    )
-
-    //If preregistration is done, but the indexer stops and restarts during indexing. We still get all the dynamic
-    //contracts that were registered during preregistration. We need to match on registering event name, contract name and src address
-    //to ensure we only get the dynamic contracts that were registered during preregistration
-    await Db.sql->DbFunctions.DynamicContractRegistry.readDynamicContractsOnChainIdMatchingEvents(
-      ~chainId,
-      ~preRegisteringEvents,
-    )
-  } else {
-    //If no preregistration should be done, only get dynamic contracts up to the the block that the indexing starts from
-    await Db.sql->DbFunctions.DynamicContractRegistry.readDynamicContractsOnChainIdAtOrBeforeBlock(
+  let dbRecoveredDynamicContracts =
+    //Get dynamic contracts up to the the block that the indexing starts from
+    //With preregistration also include all preregistered events.
+    //For preregistration need to do both, for the case of nested dynamic registrations
+    await Db.sql->DbFunctions.DynamicContractRegistry.recoverRegisteredDynamicContracts(
       ~chainId,
       ~startBlock,
+      ~hasPreRegistration=preRegisterDynamicContracts,
     )
-  }
 
   let (
     dynamicContractPreRegistration: option<addressToDynContractLookup>,
     dynamicContracts: array<TablesStatic.DynamicContractRegistry.t>,
   ) = if isPreRegisteringDynamicContracts {
     let dynamicContractPreRegistration: addressToDynContractLookup = Js.Dict.empty()
-    dbDynamicContractRegistrations->Array.forEach(contract => {
+    dbRecoveredDynamicContracts->Array.forEach(contract => {
       dynamicContractPreRegistration->Js.Dict.set(
         contract.contractAddress->Address.toString,
         contract,
@@ -212,7 +182,7 @@ let makeFromDbState = async (chainConfig: Config.chainConfig, ~maxAddrInPartitio
     })
     (Some(dynamicContractPreRegistration), [])
   } else {
-    (None, dbDynamicContractRegistrations)
+    (None, dbRecoveredDynamicContracts)
   }
 
   let (

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -690,10 +690,7 @@ let actionReducer = (state: t, action: action) => {
       } = cf
 
       ChainFetcher.make(
-        ~dynamicContractRegistrations=dynamicContractPreRegistration->Option.mapWithDefault(
-          [],
-          Js.Dict.values,
-        ),
+        ~dynamicContracts=dynamicContractPreRegistration->Option.mapWithDefault([], Js.Dict.values),
         ~chainConfig,
         ~lastBlockScannedHashes=ReorgDetection.LastBlockScannedHashes.empty(
           ~confirmedBlockThreshold=chainConfig.confirmedBlockThreshold,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -41,6 +41,7 @@ let makeDynContractRegistration = (
     contractAddress,
     contractType,
     registeringEventContractName,
+    isPreRegistered: false,
   }
 }
 


### PR DESCRIPTION
Bug reproduction:
1. Have an indexer with a preRegistering dynamic contract
2. The preRegistering one should register a contract which registers another contract
3. If we stop the indexer and start it again, the nested registered contract won't be indexing

Terminology:
- dc - dynamic contract

The issue was caused by incorrect dc recovering logic when we have an event with preRegistration.
Without preRegistration we recover all dcs registered before or equal to the start block, while with preRegistration event this logic is changed to get all events with preRegistration and extract them from the db. Even though it sounds broken, but this worked in 95% of the usecases, besides when we got new dc registrations after preRegistration. It caused two bugs:
1. If a dc contract is registered after preRegistration and NONE of its events have preRegistration enabled, it won't be loaded from db on the restart recovery
2. If a dc contract is registered after preRegistration and SOME of its events have preRegistration enabled, in some cases it will be loaded from db even after the restart start block

To solve the problem:
1. I've added the `is_pre_registered` flag to the dc entity in the db, so it's possible to correctly get all preRegistered dcs from db correctly for both 1 and 2 cases mentioned above.
2. Fixed overwriting the dc in db when it's already registered. Wasn't really an issue before, besides wasted resources, but now it caused overwriting the `is_pre_registered` flag

Unrelated issue I solved:
If a single event registers multiple dcs with the same addresses, the duplicate wasn't detected correctly.