### PR TITLE
Fix polling at the head until all partitions finished historical sync

### DIFF
--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -582,6 +582,15 @@ describe("FetchState.getNextQuery & integration", () => {
     Assert.deepEqual(updatedFetchState->getNextQuery(~concurrencyLimit=0), ReachedMaxConcurrency)
     Assert.deepEqual(updatedFetchState->getNextQuery(~endBlock=Some(10)), NothingToQuery)
     Assert.deepEqual(updatedFetchState->getNextQuery(~maxQueueSize=2), NothingToQuery)
+
+    updatedFetchState->FetchState.startFetchingQueries(~queries=[query], ~stateId=0)
+    Assert.deepEqual(
+      updatedFetchState->getNextQuery,
+      NothingToQuery,
+      ~message=`Test that even if all partitions reached the current block height,
+      we won't wait for new block while even one partition is fetching.
+      It might return an updated currentBlockHeight in response and we won't need to poll for new block`,
+    )
   })
 
   it("Emulate dynamic contract registration", () => {

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -580,8 +580,34 @@ describe("FetchState.getNextQuery & integration", () => {
 
     Assert.deepEqual(updatedFetchState->getNextQuery, WaitingForNewBlock)
     Assert.deepEqual(updatedFetchState->getNextQuery(~concurrencyLimit=0), ReachedMaxConcurrency)
-    Assert.deepEqual(updatedFetchState->getNextQuery(~endBlock=Some(10)), NothingToQuery)
-    Assert.deepEqual(updatedFetchState->getNextQuery(~maxQueueSize=2), NothingToQuery)
+    Assert.deepEqual(
+      updatedFetchState->getNextQuery(~endBlock=Some(11)),
+      WaitingForNewBlock,
+      ~message=`Should wait for new block
+      when block height didn't reach the end block`,
+    )
+    Assert.deepEqual(
+      updatedFetchState->getNextQuery(~endBlock=Some(10)),
+      NothingToQuery,
+      ~message=`Shouldn't wait for new block
+      when block height reached the end block`,
+    )
+    Assert.deepEqual(
+      updatedFetchState->getNextQuery(~endBlock=Some(9)),
+      NothingToQuery,
+      ~message=`Shouldn't wait for new block
+      when block height exceeded the end block`,
+    )
+    Assert.deepEqual(
+      updatedFetchState->getNextQuery(~maxQueueSize=2),
+      WaitingForNewBlock,
+      ~message=`Should wait for new block even if partitions have nothing to query`,
+    )
+    Assert.deepEqual(
+      updatedFetchState->getNextQuery(~maxQueueSize=2, ~currentBlockHeight=11),
+      NothingToQuery,
+      ~message=`Should do nothing if the case above is not waiting for new block`,
+    )
 
     updatedFetchState->FetchState.startFetchingQueries(~queries=[query], ~stateId=0)
     Assert.deepEqual(


### PR DESCRIPTION
Two fixes:
- Don't wait for new block until all partitions reached the head
- Don't query for partitions in sync range, until all partitions reached sync range