### PR TITLE
Fix corrupted Dynamic Contracts table on restart

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
@@ -116,28 +116,27 @@ module RawEvents = {
 
 module DynamicContractRegistry = {
   @module("./DbFunctionsImplementation.js")
-  external recoverRegisteredDynamicContractsRaw: (
+  external deleteInvalidDynamicContractsOnRestart: (
     Postgres.sql,
     ~chainId: chainId,
-    ~blockNumber: int,
-  ) => promise<Js.Json.t> = "recoverRegisteredDynamicContracts"
+    ~restartBlockNumber: int,
+    ~restartLogIndex: int,
+  ) => promise<unit> = "deleteInvalidDynamicContractsOnRestart"
 
   @module("./DbFunctionsImplementation.js")
-  external recoverPreRegisteredAndRegisteredDynamicContractsRaw: (
+  external deleteInvalidDynamicContractsHistoryOnRestart: (
     Postgres.sql,
     ~chainId: chainId,
-    ~blockNumber: int,
-  ) => promise<Js.Json.t> = "recoverPreRegisteredAndRegisteredDynamicContracts"
+    ~restartBlockNumber: int,
+    ~restartLogIndex: int,
+  ) => promise<unit> = "deleteInvalidDynamicContractsHistoryOnRestart"
 
+  @module("./DbFunctionsImplementation.js")
+  external readAllDynamicContractsRaw: (Postgres.sql, ~chainId: chainId) => promise<Js.Json.t> =
+    "readAllDynamicContracts"
 
-  let recoverRegisteredDynamicContracts = async (
-    sql: Postgres.sql,
-    ~chainId: chainId,
-    ~startBlock: int,
-    ~hasPreRegistration: bool,
-  ) => {
-    let raw = hasPreRegistration ? recoverPreRegisteredAndRegisteredDynamicContractsRaw : recoverRegisteredDynamicContractsRaw
-    let json = await sql->raw(~chainId, ~blockNumber=startBlock)
+  let readAllDynamicContracts = async (sql: Postgres.sql, ~chainId: chainId) => {
+    let json = await sql->readAllDynamicContractsRaw(~chainId)
     json->S.parseOrRaiseWith(TablesStatic.DynamicContractRegistry.rowsSchema)
   }
 }

--- a/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
@@ -122,27 +122,45 @@ module Mock = {
 
 module Sql = RollbackMultichain_test.Sql
 
+exception RollbackTransaction
+
 describe("Dynamic contract restart resistance test", () => {
   Async.before(() => {
     //Provision the db
     DbHelpers.runUpDownMigration()
   })
 
-  let getFetchingDcAddressesFromDbState = async (~chainId=1) => {
-    let chainFetcher = await ChainFetcher.makeFromDbState(
-      config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId)),
-      ~maxAddrInPartition=Env.maxAddrInPartition,
-    )
-
-    let dcs = chainFetcher.fetchState.partitions->Array.flatMap(p =>
+  let getChainFetcherDcs = (chainFetcher: ChainFetcher.t) => {
+    chainFetcher.fetchState.partitions->Array.flatMap(p =>
       switch p.kind {
       | Normal({dynamicContracts}) => dynamicContracts->Array.map(dc => dc.contractAddress)
       | Wildcard => []
       }
     )
-
-    dcs
   }
+
+  let getFetchingDcAddressesFromDbState = async (~chainId=1, ~sql=?) => {
+    let chainFetcher = await ChainFetcher.makeFromDbState(
+      config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId)),
+      ~maxAddrInPartition=Env.maxAddrInPartition,
+      ~sql?,
+    )
+
+    chainFetcher->getChainFetcherDcs
+  }
+
+  //Test the preRegistration restart function getting all the dynamic contracts
+  let setRegisterPreRegistration: (
+    Types.HandlerTypes.Register.t,
+    bool,
+  ) => unit => unit = %raw(`(register, bool)=> {
+    const eventOptions = register.eventOptions;
+    if (!eventOptions) {
+      register.eventOptions = {};
+    }
+    register.eventOptions.preRegisterDynamicContracts=bool;
+    return () => register.eventOptions = eventOptions;
+  }`)
 
   Async.it(
     "Indexer should restart with only the dynamic contracts up to the block that was processed",
@@ -152,7 +170,9 @@ describe("Dynamic contract restart resistance test", () => {
       let chainManager = {
         ...ChainManager.makeFromConfig(~config),
         isUnorderedMultichainMode: true,
+        isInReorgThreshold: true,
       }
+      let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId=1))
       let loadLayer = LoadLayer.makeWithDbConnection()
 
       //Setup initial state stub that will be used for both
@@ -204,85 +224,149 @@ describe("Dynamic contract restart resistance test", () => {
       //Only the the first dynamic contract should be registered since we haven't processed
       //up to the second one yet
 
-      let dynamicContractsInTable =
+      let dcsBeforeRestart =
         await Db.sql->Postgres.unsafe(`SELECT * FROM public.dynamic_contract_registry;`)
-
+      let dcsHistoryBeforeRestart =
+        await Db.sql->Postgres.unsafe(`SELECT * FROM public.dynamic_contract_registry_history;`)
       Assert.equal(
-        dynamicContractsInTable->Array.length,
+        dcsBeforeRestart->Array.length,
         2,
-        ~message="Should have 2 dynamic contracts in table",
+        ~message="Should have 2 dynamic contracts in db",
+      )
+      Assert.equal(
+        dcsHistoryBeforeRestart->Array.length,
+        2,
+        ~message="Should have 2 dynamic contract history items in db",
       )
 
-      let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId=1))
+      try await Db.sql->Postgres.beginSql(
+        sql => [
+          (
+            async () => {
+              Assert.deepEqual(
+                await getFetchingDcAddressesFromDbState(~sql),
+                [Mock.mockDynamicToken1],
+                ~message="Should have registered only the dynamic contract up to the block that was processed",
+              )
+
+              Assert.equal(
+                (await sql
+                ->Postgres.unsafe(`SELECT * FROM public.dynamic_contract_registry;`))
+                ->Array.length,
+                1,
+                ~message="Should clean up invalid dc from db on restart",
+              )
+              Assert.equal(
+                (await sql
+                ->Postgres.unsafe(`SELECT * FROM public.dynamic_contract_registry_history;`))
+                ->Array.length,
+                1,
+                ~message=`Should clean up invalid dc history from db on restart.
+            Note: Without it there's a case when the indexer might crash because of a conflict`,
+              )
+
+              raise(RollbackTransaction)
+            }
+          )(),
+        ],
+      ) catch {
+      | RollbackTransaction => ()
+      }
+
+      try await Db.sql->Postgres.beginSql(
+        sql => [
+          (
+            async () => {
+              let resetEventOptionsToOriginal =
+                Types.ERC20Factory.TokenCreated.handlerRegister->setRegisterPreRegistration(true)
+
+              let restartedChainFetcher = await ChainFetcher.makeFromDbState(
+                chainConfig,
+                ~maxAddrInPartition=Env.maxAddrInPartition,
+                ~sql,
+              )
+
+              Assert.deepEqual(
+                restartedChainFetcher.dynamicContractPreRegistration->Option.getExn->Js.Dict.keys,
+                [Mock.mockDynamicToken1->Address.toString],
+                ~message=`Should recover with only dc1 since it was registered at the restart start block.
+                The dc2 wasn't registered during preRegistration phase, so it's not recovered
+                even though the eventOptions says that preRegistration enabled.
+                This might happen when a preRegistered contract, registers itself on the actual indexer run`,
+              )
+
+              Assert.deepEqual(
+                restartedChainFetcher->getChainFetcherDcs,
+                [],
+                ~message="Should have no dynamic contracts yet since this tests the case starting in preregistration",
+              )
+
+              resetEventOptionsToOriginal()
+
+              raise(RollbackTransaction)
+            }
+          )(),
+        ],
+      ) catch {
+      | RollbackTransaction => ()
+      | Js.Exn.Error(e) => raise(e->Obj.magic)
+      }
+
+      try await Db.sql->Postgres.beginSql(
+        sql => [
+          (
+            async () => {
+              let resetEventOptionsToOriginal =
+                Types.ERC20Factory.TokenCreated.handlerRegister->setRegisterPreRegistration(true)
+
+              // Manualy update the second dc in db to make it look as if it was pre registered
+              let () = await sql->Postgres.unsafe(`UPDATE public.dynamic_contract_registry
+                SET is_pre_registered = true
+                WHERE registering_event_block_number = 1;`)
+
+              let restartedChainFetcher = await ChainFetcher.makeFromDbState(
+                chainConfig,
+                ~maxAddrInPartition=Env.maxAddrInPartition,
+                ~sql,
+              )
+
+              Assert.deepEqual(
+                restartedChainFetcher.dynamicContractPreRegistration->Option.getExn->Js.Dict.keys,
+                [
+                  Mock.mockDynamicToken1->Address.toString,
+                  Mock.mockDynamicToken2->Address.toString,
+                ],
+                ~message=`Should include both dc1 which is not pre registered, but registered at the restart start block
+                and dc2 which is after restart start block, but was pre registered`,
+              )
+
+              Assert.deepEqual(
+                restartedChainFetcher->getChainFetcherDcs,
+                [],
+                ~message="Should have no dynamic contracts yet since this tests the case starting in preregistration",
+              )
+
+              resetEventOptionsToOriginal()
+
+              raise(RollbackTransaction)
+            }
+          )(),
+        ],
+      ) catch {
+      | RollbackTransaction => ()
+      | Js.Exn.Error(e) => raise(e->Obj.magic)
+      }
 
       Assert.deepEqual(
-        await getFetchingDcAddressesFromDbState(),
-        [Mock.mockDynamicToken1],
-        ~message="Should have registered only the dynamic contract up to the block that was processed",
+        await Db.sql->Postgres.unsafe(`SELECT * FROM public.dynamic_contract_registry;`),
+        dcsBeforeRestart,
+        ~message="Dcs should rollback after restart tests",
       )
-
-      {
-        //Test the preRegistration restart function getting all the dynamic contracts
-        let setRegisterPreRegistration: (
-          Types.HandlerTypes.Register.t,
-          bool,
-        ) => unit => unit = %raw(`(register, bool)=> {
-          const eventOptions = register.eventOptions;
-          if (!eventOptions) {
-            register.eventOptions = {};
-          } 
-          register.eventOptions.preRegisterDynamicContracts=bool;
-          return () => register.eventOptions = eventOptions;
-        }`)
-
-        let resetEventOptionsToOriginal =
-          Types.ERC20Factory.TokenCreated.handlerRegister->setRegisterPreRegistration(true)
-
-        let restartedChainFetcher = await ChainFetcher.makeFromDbState(
-          chainConfig,
-          ~maxAddrInPartition=Env.maxAddrInPartition,
-        )
-
-        Assert.deepEqual(
-          restartedChainFetcher.dynamicContractPreRegistration->Option.getExn->Js.Dict.keys,
-          [Mock.mockDynamicToken1->Address.toString],
-          ~message=`Should recover with only dc1 since it was registered at the restart start block.
-          The dc2 wasn't registered during preRegistration phase, so it's not recovered
-          even though the eventOptions says that preRegistration enabled.
-          This might happen when a preRegistered contract, registers itself on the actual indexer run`,
-        )
-
-        Assert.deepEqual(
-          await getFetchingDcAddressesFromDbState(),
-          [],
-          ~message="Should have no dynamic contracts yet since this tests the case starting in preregistration",
-        )
-
-        // Manualy update the second dc in db to make it look as if it was pre registered
-        await Db.sql->Postgres.unsafe(`UPDATE public.dynamic_contract_registry
-          SET is_pre_registered = true
-          WHERE registering_event_block_number = 1;`)
-
-        let restartedChainFetcher = await ChainFetcher.makeFromDbState(
-          chainConfig,
-          ~maxAddrInPartition=Env.maxAddrInPartition,
-        )
-
-        Assert.deepEqual(
-          restartedChainFetcher.dynamicContractPreRegistration->Option.getExn->Js.Dict.keys,
-          [Mock.mockDynamicToken1->Address.toString, Mock.mockDynamicToken2->Address.toString],
-          ~message=`Should include both dc1 which is not pre registered, but registered at the restart start block
-          and dc2 which is after restart start block, but was pre registered`,
-        )
-
-        Assert.deepEqual(
-          await getFetchingDcAddressesFromDbState(),
-          [],
-          ~message="Should have no dynamic contracts yet since this tests the case starting in preregistration",
-        )
-
-        resetEventOptionsToOriginal()
-      }
+      Assert.deepEqual(
+        await Db.sql->Postgres.unsafe(`SELECT * FROM public.dynamic_contract_registry_history;`),
+        dcsHistoryBeforeRestart,
+        ~message="Dcs history should rollback after restart tests",
+      )
 
       Assert.deepEqual(
         stubDataInitial->Stubs.getTasks,
@@ -302,26 +386,9 @@ describe("Dynamic contract restart resistance test", () => {
           UpdateChainMetaDataAndCheckForExit(NoExit),
           ProcessEventBatch,
           NextQuery(CheckAllChains),
+          PruneStaleEntityHistory,
         ],
         ~message="This looks wrong, but snapshot to track how it changes with time",
-      )
-      // DynamicContract
-      // fromBlock: 0
-      // toBlock: 0
-      await dispatchAllTasks()
-      // DynamicContract
-      // fromBlock: 0
-      // toBlock: 3
-      await dispatchAllTasks()
-      // DynamicContract
-      // fromBlock: 2
-      // toBlock: 3
-      await dispatchAllTasks()
-
-      Assert.deepEqual(
-        await getFetchingDcAddressesFromDbState(),
-        [Mock.mockDynamicToken1, Mock.mockDynamicToken2],
-        ~message="Should have registered both dynamic contracts up to the block that was processed",
       )
     },
   )

--- a/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
@@ -364,7 +364,18 @@ describe("Dynamic contract restart resistance test", () => {
 
               Assert.deepEqual(
                 await sql->Postgres.unsafe(`SELECT * FROM public.dynamic_contract_registry;`),
-                dcsBeforeRestart,
+                switch dcsBeforeRestart {
+                | [dc1, dc2] => [
+                    dc1,
+                    (
+                      {
+                        ...dc2,
+                        isPreRegistered: true,
+                      }: TablesStatic.DynamicContractRegistry.t
+                    ),
+                  ]
+                | _ => Assert.fail("Should have 2 dcs")
+                },
                 ~message="Should keep both dcs after restart in db",
               )
               Assert.equal(


### PR DESCRIPTION
<img width="1423" alt="image" src="https://github.com/user-attachments/assets/08a47b49-50ef-4281-99d0-2f2271055841" />

Case:
1. Let's say we have a chain with 100_000 blocks and reorg threshold 200
2. We query range 90_000-100_000 and get two contract registrations at 95_000 and 99_900 blocks
3. Indexer will process events between 90_000-95_000 blocks (until the first dc)
4. Also, it'll register two dcs in the fetch state and store them in db, but the second dc is in the reorg threshold, so it saves with an entity history.
5. The batch finishes processing and stores entities in the db
6. For any reason indexer restarts and starts querying, let's say, from the block 99_000
7. Since the dc at block 99_900 wasn't recovered during the restart (which's correct), we register it again and add to the in memory store
8. And if it's still in the reorg threshold, we'll try to add the same dc history entity which will fail with a conflict.

Solution:
Clean up dcs after a restart point from db, two prevent the invalid state.