### PR TITLE
Support Event Filtering for RPC data-source applied to a single wildcard event

### DIFF
--- a/codegenerator/cli/npm/envio/src/LogSelection.res
+++ b/codegenerator/cli/npm/envio/src/LogSelection.res
@@ -26,7 +26,7 @@ let hasFilters = ({topic1, topic2, topic3}: topicSelection) => {
 For a group of topic selections, if multiple only use topic0, then they can be compressed into one
 selection combining the topic0s
 */
-let compressTopicSelectionsOrThrow = (topicSelections: array<topicSelection>) => {
+let compressTopicSelections = (topicSelections: array<topicSelection>) => {
   let topic0sOfSelectionsWithoutFilters = []
 
   let selectionsWithFilters = []
@@ -44,7 +44,12 @@ let compressTopicSelectionsOrThrow = (topicSelections: array<topicSelection>) =>
   switch topic0sOfSelectionsWithoutFilters {
   | [] => selectionsWithFilters
   | topic0 =>
-    let selectionWithoutFilters = makeTopicSelection(~topic0)->Utils.unwrapResultExn
+    let selectionWithoutFilters = {
+      topic0,
+      topic1: [],
+      topic2: [],
+      topic3: [],
+    }
     Belt.Array.concat([selectionWithoutFilters], selectionsWithFilters)
   }
 }
@@ -54,7 +59,7 @@ type t = {
   topicSelections: array<topicSelection>,
 }
 
-let makeOrThrow = (~addresses, ~topicSelections) => {
-  let topicSelections = compressTopicSelectionsOrThrow(topicSelections)
+let make = (~addresses, ~topicSelections) => {
+  let topicSelections = compressTopicSelections(topicSelections)
   {addresses, topicSelections}
 }

--- a/codegenerator/cli/npm/envio/src/bindings/Ethers.res
+++ b/codegenerator/cli/npm/envio/src/bindings/Ethers.res
@@ -47,10 +47,6 @@ module Addresses = {
     mockAddresses[0]
 }
 
-module EventFilter = {
-  type topic = EvmTypes.Hex.t
-}
-
 module Filter = {
   type t
 }
@@ -59,7 +55,7 @@ module CombinedFilter = {
   type combinedFilterRecord = {
     address?: array<Address.t>,
     //The second element of the tuple is the
-    topics: array<array<EventFilter.topic>>,
+    topics: array<array<EvmTypes.Hex.t>>,
     fromBlock: int,
     toBlock: int,
   }
@@ -74,7 +70,7 @@ type log = {
   //Note: this is the index of the log in the transaction and should be used whenever we use "logIndex"
   address: Address.t,
   data: string,
-  topics: array<EventFilter.topic>,
+  topics: array<EvmTypes.Hex.t>,
   transactionHash: txHash,
   transactionIndex: int,
   //Note: this logIndex is the index of the log in the block, not the transaction
@@ -83,7 +79,7 @@ type log = {
 
 type transaction
 
-type minimumParseableLogData = {topics: array<EventFilter.topic>, data: string}
+type minimumParseableLogData = {topics: array<EvmTypes.Hex.t>, data: string}
 
 //Can safely convert from log to minimumParseableLogData since it contains
 //both data points required

--- a/codegenerator/cli/npm/envio/src/sources/HyperSyncJsonApi.res
+++ b/codegenerator/cli/npm/envio/src/sources/HyperSyncJsonApi.res
@@ -156,7 +156,7 @@ module QueryTypes = {
 
   type logParams = {
     address?: array<Address.t>,
-    topics: array<array<Ethers.EventFilter.topic>>,
+    topics: array<array<EvmTypes.Hex.t>>,
   }
 
   let logParamsSchema = S.object(s => {
@@ -309,10 +309,10 @@ module ResponseTypes = {
     blockNumber?: int,
     address?: unchecksummedEthAddress,
     data?: string,
-    topic0?: option<Ethers.EventFilter.topic>,
-    topic1?: option<Ethers.EventFilter.topic>,
-    topic2?: option<Ethers.EventFilter.topic>,
-    topic3?: option<Ethers.EventFilter.topic>,
+    topic0?: option<EvmTypes.Hex.t>,
+    topic1?: option<EvmTypes.Hex.t>,
+    topic2?: option<EvmTypes.Hex.t>,
+    topic3?: option<EvmTypes.Hex.t>,
   }
 
   let logDataSchema = S.object(s => {
@@ -361,16 +361,12 @@ let queryRoute = Rest.route(() => {
   path: "/query",
   method: Post,
   variables: s => s.body(QueryTypes.postQueryBodySchema),
-  responses: [
-    s => s.data(ResponseTypes.queryResponseSchema),
-  ]
+  responses: [s => s.data(ResponseTypes.queryResponseSchema)],
 })
 
 let heightRoute = Rest.route(() => {
   path: "/height",
   method: Get,
   variables: _ => (),
-  responses: [
-    s => s.field("height", S.int),
-  ]
+  responses: [s => s.field("height", S.int)],
 })

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -368,6 +368,15 @@ impl EventMod {
             )),
         };
 
+        let event_id = match self.fuel_event_kind {
+            None => format!("{sighash}_{topic_count}"),
+            Some(FuelEventKind::Mint) => "mint".to_string(),
+            Some(FuelEventKind::Burn) => "burn".to_string(),
+            Some(FuelEventKind::Call) => "call".to_string(),
+            Some(FuelEventKind::Transfer) => "transfer".to_string(),
+            Some(FuelEventKind::LogData(_)) => sighash.to_string(),
+        };
+
         let (block_type, block_schema, transaction_type, transaction_schema) =
             match self.custom_field_selection {
                 Some(ref field_selection) => {
@@ -410,8 +419,8 @@ let register = (): Internal.fuelEventConfig => {{
 
         format!(
             r#"
+let id = "{event_id}"
 let sighash = "{sighash}"
-let topicCount = {topic_count}
 let name = "{event_name}"
 let contractName = contractName
 
@@ -1410,8 +1419,8 @@ mod test {
             params,
             module_code: format!(
                 r#"
+let id = "{sighash}_1"
 let sighash = "{sighash}"
-let topicCount = 1
 let name = "NewGravatar"
 let contractName = contractName
 
@@ -1477,8 +1486,8 @@ let getTopicSelection = (eventFilters) => eventFilters->SingleOrMultiple.normali
                 params: vec![],
                 module_code: format!(
                     r#"
+let id = "0x50f7d27e90d1a5a38aeed4ceced2e8ec1ff185737aca96d15791b470d3f17363_1"
 let sighash = "0x50f7d27e90d1a5a38aeed4ceced2e8ec1ff185737aca96d15791b470d3f17363"
-let topicCount = 1
 let name = "NewGravatar"
 let contractName = contractName
 
@@ -1544,8 +1553,8 @@ let getTopicSelection = (eventFilters) => eventFilters->SingleOrMultiple.normali
                 params: vec![],
                 module_code: format!(
                     r#"
+let id = "0x50f7d27e90d1a5a38aeed4ceced2e8ec1ff185737aca96d15791b470d3f17363_1"
 let sighash = "0x50f7d27e90d1a5a38aeed4ceced2e8ec1ff185737aca96d15791b470d3f17363"
-let topicCount = 1
 let name = "NewGravatar"
 let contractName = contractName
 

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -411,8 +411,8 @@ module HandlerTypes = {
 }
 
 module type Event = {
+  let id: string // The unique identifier for the event
   let sighash: string // topic0 for Evm and rb for Fuel receipts
-  let topicCount: int // Number of topics for evm, always 0 for fuel
   let name: string
   let contractName: string
 

--- a/codegenerator/cli/templates/static/codegen/src/EventFetching.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventFetching.res
@@ -67,7 +67,7 @@ let getNextPage = (
       ->Ethers.JsonRpcProvider.getLogs(
         ~filter={
           address: ?addresses,
-          topics: [topics],
+          topics,
           fromBlock,
           toBlock: queryToBlock,
         }->Ethers.CombinedFilter.toFilter,
@@ -93,6 +93,9 @@ let getNextPage = (
     [queryTimoutPromise, logsPromise]
     ->Promise.race
     ->Promise.catch(err => {
+      // Might fail with message "query exceeds max results 20000, retry with the range 6000438-6000934"
+      // Ideally to handle it and respect
+
       logger->Logging.childWarn({
         "msg": "Error getting events. Will retry after backoff time",
         "backOffMilliseconds": sc.backoffMillis,

--- a/codegenerator/cli/templates/static/codegen/src/EventRouter.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventRouter.res
@@ -52,17 +52,17 @@ let empty = () => Js.Dict.empty()
 
 let addOrThrow = (
   router: t<'a>,
-  eventTag,
+  eventId,
   event,
   ~contractName,
   ~isWildcard,
   ~eventName,
   ~chain,
 ) => {
-  let group = switch router->Utils.Dict.dangerouslyGetNonOption(eventTag) {
+  let group = switch router->Utils.Dict.dangerouslyGetNonOption(eventId) {
   | None =>
     let group = Group.empty()
-    router->Js.Dict.set(eventTag, group)
+    router->Js.Dict.set(eventId, group)
     group
   | Some(group) => group
   }
@@ -85,7 +85,7 @@ let get = (router: t<'a>, ~tag, ~contractAddress, ~contractAddressMapping) => {
   }
 }
 
-let getEvmEventTag = (~sighash, ~topicCount) => {
+let getEvmEventId = (~sighash, ~topicCount) => {
   sighash ++ "_" ++ topicCount->Belt.Int.toString
 }
 
@@ -97,7 +97,7 @@ let fromEvmEventModsOrThrow = (eventMods: array<module(Types.Event)>, ~chain): t
     let eventMod = eventMod->(Utils.magic: module(Types.Event) => module(Types.InternalEvent))
     let module(Event) = eventMod
     router->addOrThrow(
-      getEvmEventTag(~sighash=Event.sighash, ~topicCount=Event.topicCount),
+      Event.id,
       eventMod,
       ~contractName=Event.contractName,
       ~eventName=Event.name,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -69,8 +69,7 @@ let make = (
       if isPreRegisteringDynamicContracts ? preRegisterDynamicContracts : true {
         eventConfigs->Array.push({
           contractName,
-          // FIXME: For fuel it doesn't need topicCount
-          eventTag: Event.sighash ++ "_" ++ Event.topicCount->Int.toString,
+          eventId: Event.id,
           isWildcard,
         })
       }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -51,26 +51,10 @@ let make = (
   let module(ChainWorker) = chainConfig.chainWorker
   logger->Logging.childInfo("Initializing ChainFetcher with " ++ ChainWorker.name ++ " worker")
 
-  let hasWildcard = ref(false)
-  let contractNamesWithNonWildcard = Utils.Set.make()
-  let contractNamesWithPreRegistration = Utils.Set.make()
-
   let isPreRegisteringDynamicContracts = dynamicContractPreRegistration->Option.isSome
-  let shouldIncludeContractAddress = (~contractName) => {
-    // Check that there are events without wildcard
-    // Otherwise the events will be queried in the Wildcard partition
-    // and shouldn't be included in the Normal partition
-    contractNamesWithNonWildcard->Utils.Set.has(contractName) &&
-      // Include only addresses having preRegistration,
-      // so we don't end up with partition having an empty ContractAddressMapping
-      // for preregistration
-      isPreRegisteringDynamicContracts
-      ? contractNamesWithPreRegistration->Utils.Set.has(contractName)
-      : true
-  }
 
-  let staticContracts = []
-
+  let staticContracts = Js.Dict.empty()
+  let eventConfigs: array<FetchState.eventConfig> = []
   chainConfig.contracts->Array.forEach(contract => {
     let contractName = contract.name
 
@@ -80,36 +64,28 @@ let make = (
       let {isWildcard, preRegisterDynamicContracts} =
         Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
 
-      if isWildcard {
-        hasWildcard := (
-            isPreRegisteringDynamicContracts
-              ? hasWildcard.contents || preRegisterDynamicContracts
-              : true
-          )
-      } else {
-        let _ = contractNamesWithNonWildcard->Utils.Set.add(contractName)
-      }
-      if preRegisterDynamicContracts {
-        let _ = contractNamesWithPreRegistration->Utils.Set.add(contractName)
+      // Filter out non-preRegistration events on preRegistration phase
+      // so we don't care about it in fetch state and workers anymore
+      if isPreRegisteringDynamicContracts ? preRegisterDynamicContracts : true {
+        eventConfigs->Array.push({
+          contractName,
+          // FIXME: For fuel it doesn't need topicCount
+          eventTag: Event.sighash ++ "_" ++ Event.topicCount->Int.toString,
+          isWildcard,
+        })
       }
     })
 
-    if shouldIncludeContractAddress(~contractName) {
-      contract.addresses->Array.forEach(a => {
-        staticContracts->Array.push((contractName, a))
-      })
-    }
+    staticContracts->Js.Dict.set(contractName, contract.addresses)
   })
 
   let fetchState = FetchState.make(
     ~maxAddrInPartition,
     ~staticContracts,
-    ~dynamicContracts=dynamicContracts->Array.keep(dc =>
-      shouldIncludeContractAddress(~contractName=(dc.contractType :> string))
-    ),
+    ~dynamicContracts,
     ~startBlock,
     ~endBlock,
-    ~hasWildcard=hasWildcard.contents,
+    ~eventConfigs,
   )
 
   {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -15,7 +15,7 @@ type blockNumberAndLogIndex = {blockNumber: int, logIndex: int}
 
 type eventConfig = {
   contractName: string,
-  eventTag: string,
+  eventId: string,
   isWildcard: bool,
 }
 
@@ -79,6 +79,21 @@ let copy = (fetchState: t) => {
     firstEventBlockNumber: fetchState.firstEventBlockNumber,
   }
 }
+
+let checkIsInSelection = (~selection, ~contractName, ~eventId, ~isWildcard) => {
+  switch selection {
+  | Normal({}) => !isWildcard
+  | Wildcard({eventConfigs}) =>
+    if isWildcard {
+      eventConfigs->Array.some(c => {
+        c.contractName === contractName && c.eventId === eventId
+      })
+    } else {
+      false
+    }
+  }
+}
+
 
 /*
 Comapritor for two events from the same chain. No need for chain id or timestamp

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperFuelWorker.res
@@ -389,7 +389,7 @@ module Make = (
         let {contractId: contractAddress, receipt, block, receiptIndex} = item
 
         let chainId = chain->ChainMap.Chain.toChainId
-        let eventTag = switch receipt {
+        let eventId = switch receipt {
         | LogData({rb}) => BigInt.toString(rb)
         | Mint(_) => mintEventTag
         | Burn(_) => burnEventTag
@@ -399,7 +399,7 @@ module Make = (
         }
 
         let eventConfig = switch workerConfig.eventRouter->EventRouter.get(
-          ~tag=eventTag,
+          ~tag=eventId,
           ~contractAddressMapping,
           ~contractAddress,
         ) {
@@ -411,7 +411,7 @@ module Make = (
                 "blockNumber": block.height,
                 "logIndex": receiptIndex,
                 "contractAddress": contractAddress,
-                "eventTag": eventTag,
+                "eventId": eventId,
               },
             )
             EventRoutingFailed->ErrorHandling.mkLogAndRaise(

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -54,16 +54,22 @@ let getSelectionConfig = (selection: FetchState.selection, ~contracts: array<Con
   let nonOptionalTransactionFieldNames = Utils.Set.make()
   let capitalizedBlockFields = Utils.Set.make()
   let capitalizedTransactionFields = Utils.Set.make()
+  let wildcardLogSelection = []
 
   contracts->Array.forEach(contract => {
     contract.events->Array.forEach(event => {
       let module(Event) = event
-      let {isWildcard} = Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
-      let isIncluded = switch selection {
-      | Wildcard({}) => isWildcard
-      | Normal({}) => !isWildcard
-      }
-      if isIncluded {
+      let {isWildcard, topicSelections} =
+        Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
+
+      if (
+        FetchState.checkIsInSelection(
+          ~selection,
+          ~contractName=contract.name,
+          ~eventId=Event.id,
+          ~isWildcard,
+        )
+      ) {
         nonOptionalBlockFieldNames->Utils.Set.addMany(
           Event.blockSchema->Utils.Schema.getNonOptionalFieldNames,
         )
@@ -76,6 +82,11 @@ let getSelectionConfig = (selection: FetchState.selection, ~contracts: array<Con
         capitalizedTransactionFields->Utils.Set.addMany(
           Event.transactionSchema->Utils.Schema.getCapitalizedFieldNames,
         )
+        if isWildcard {
+          wildcardLogSelection->Array.push(
+            LogSelection.makeOrThrow(~addresses=[], ~topicSelections),
+          )
+        }
       }
     })
   })
@@ -121,34 +132,9 @@ let getSelectionConfig = (selection: FetchState.selection, ~contracts: array<Con
   }
 
   let getLogSelectionOrThrow = switch selection {
-  | Wildcard({}) => {
-      let wildcardLogSelection = contracts->Belt.Array.flatMap(contract => {
-        contract.events->Belt.Array.keepMap(event => {
-          let module(Event) = event
-          let {isWildcard, topicSelections} =
-            Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
-          isWildcard ? Some(LogSelection.makeOrThrow(~addresses=[], ~topicSelections)) : None
-        })
-      })
-
-      let preRegWildcardLogSelection = contracts->Belt.Array.flatMap(contract => {
-        contract.events->Belt.Array.keepMap(event => {
-          let module(Event) = event
-          let {isWildcard, preRegisterDynamicContracts, topicSelections} =
-            Event.handlerRegister->Types.HandlerTypes.Register.getEventOptions
-          isWildcard && preRegisterDynamicContracts
-            ? Some(LogSelection.makeOrThrow(~addresses=[], ~topicSelections))
-            : None
-        })
-      })
-
-      (~contractAddressMapping as _, ~isPreRegisteringDynamicContracts) => {
-        if isPreRegisteringDynamicContracts {
-          preRegWildcardLogSelection
-        } else {
-          wildcardLogSelection
-        }
-      }
+  | Wildcard({}) =>
+    (~contractAddressMapping as _, ~isPreRegisteringDynamicContracts as _) => {
+      wildcardLogSelection
     }
   | Normal({}) => getNormalLogSelectionOrThrow
   }
@@ -281,10 +267,7 @@ module Make = (
         ~isPreRegisteringDynamicContracts,
       ) catch {
       | exn =>
-        exn->ErrorHandling.mkLogAndRaise(
-          ~logger,
-          ~msg="Failed getting log selection for the query",
-        )
+        exn->ErrorHandling.mkLogAndRaise(~logger, ~msg="Failed getting log selection for the query")
       }
 
       let startFetchingBatchTimeRef = Hrtime.makeTimer()
@@ -422,7 +405,7 @@ module Make = (
           let topic0 = log.topics->Js.Array2.unsafe_get(0)
           let maybeEventMod =
             eventRouter->EventRouter.get(
-              ~tag=EventRouter.getEvmEventTag(
+              ~tag=EventRouter.getEvmEventId(
                 ~sighash=topic0->EvmTypes.Hex.toString,
                 ~topicCount=log.topics->Array.length,
               ),
@@ -463,7 +446,7 @@ module Make = (
           let topic0 = log.topics->Js.Array2.unsafe_get(0)
 
           switch eventRouter->EventRouter.get(
-            ~tag=EventRouter.getEvmEventTag(
+            ~tag=EventRouter.getEvmEventId(
               ~sighash=topic0->EvmTypes.Hex.toString,
               ~topicCount=log.topics->Array.length,
             ),

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/HyperSyncWorker.res
@@ -84,7 +84,7 @@ let getSelectionConfig = (selection: FetchState.selection, ~contracts: array<Con
         )
         if isWildcard {
           wildcardLogSelection->Array.push(
-            LogSelection.makeOrThrow(~addresses=[], ~topicSelections),
+            LogSelection.make(~addresses=[], ~topicSelections),
           )
         }
       }
@@ -125,7 +125,7 @@ let getSelectionConfig = (selection: FetchState.selection, ~contracts: array<Con
             : []
         }) {
         | [] => None
-        | topicSelections => Some(LogSelection.makeOrThrow(~addresses, ~topicSelections))
+        | topicSelections => Some(LogSelection.make(~addresses, ~topicSelections))
         }
       }
     })

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/chainWorkers/RpcWorker.res
@@ -252,7 +252,7 @@ module Make = (
         ->Belt.Array.keepMap(log => {
           let topic0 = log.topics->Js.Array2.unsafe_get(0)
           switch eventRouter->EventRouter.get(
-            ~tag=EventRouter.getEvmEventTag(
+            ~tag=EventRouter.getEvmEventId(
               ~sighash=topic0->EvmTypes.Hex.toString,
               ~topicCount=log.topics->Array.length,
             ),

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -68,8 +68,14 @@ module type S = {
   }
 
   module FetchState: {
+    type eventConfig = {
+      contractName: string,
+      eventTag: string,
+      isWildcard: bool,
+    }
+
     type selection =
-      | Wildcard({})
+      | Wildcard({eventConfigs: array<eventConfig>})
       | Normal({})
 
     type queryTarget =

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -23,8 +23,8 @@ module type S = {
     }
 
     module type Event = {
+      let id: string
       let sighash: string // topic0 for Evm and rb for Fuel receipts
-      let topicCount: int // Number of topics for evm, always 0 for fuel
       let name: string
       let contractName: string
 
@@ -70,7 +70,7 @@ module type S = {
   module FetchState: {
     type eventConfig = {
       contractName: string,
-      eventTag: string,
+      eventId: string,
       isWildcard: bool,
     }
 

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -23,7 +23,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
     let eventConfigs = [
       {
         FetchState.contractName: "Gravatar",
-        eventTag: "0",
+        eventId: "0",
         isWildcard: true,
       },
     ]

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -20,13 +20,20 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       Belt.Int.fromFloat(Js.Math.random() *. float_of_int(max - min + 1) +. float_of_int(min))
     }
 
+    let eventConfigs = [
+      {
+        FetchState.contractName: "Gravatar",
+        eventTag: "0",
+        isWildcard: true,
+      },
+    ]
     let fetcherStateInit: FetchState.t = FetchState.make(
       ~maxAddrInPartition=Env.maxAddrInPartition,
       ~endBlock=None,
-      ~staticContracts=[],
+      ~staticContracts=Js.Dict.empty(),
+      ~eventConfigs,
       ~dynamicContracts=[],
       ~startBlock=0,
-      ~hasWildcard=true,
     )
 
     let fetchState = ref(fetcherStateInit)
@@ -81,7 +88,9 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
                 partitionId: "0",
                 fromBlock: 0,
                 target: Head,
-                selection: Wildcard({}),
+                selection: Wildcard({
+                  eventConfigs: eventConfigs,
+                }),
                 contractAddressMapping: ContractAddressingMap.make(),
               },
               ~latestFetchedBlock={
@@ -105,7 +114,9 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
                   partitionId: "0",
                   fromBlock: 0,
                   target: Head,
-                  selection: Wildcard({}),
+                  selection: Wildcard({
+                    eventConfigs: eventConfigs,
+                  }),
                   contractAddressMapping: ContractAddressingMap.make(),
                 },
                 ~latestFetchedBlock={

--- a/scenarios/test_codegen/test/HyperSyncWorker_test.res
+++ b/scenarios/test_codegen/test/HyperSyncWorker_test.res
@@ -64,6 +64,10 @@ module MockEvent = (
     )
 }
 
+// TODO: Add tests for RpcWorker
+// TODO: Split changes into smaller PRs
+// TODO: Handle rpc error to adjust suggested block range
+
 let withConfig = (
   eventMod: module(Types.Event),
   eventConfig: Types.HandlerTypes.eventConfig<'a>,

--- a/scenarios/test_codegen/test/HyperSyncWorker_test.res
+++ b/scenarios/test_codegen/test/HyperSyncWorker_test.res
@@ -64,10 +64,6 @@ module MockEvent = (
     )
 }
 
-// TODO: Add tests for RpcWorker
-// TODO: Split changes into smaller PRs
-// TODO: Handle rpc error to adjust suggested block range
-
 let withConfig = (
   eventMod: module(Types.Event),
   eventConfig: Types.HandlerTypes.eventConfig<'a>,
@@ -90,6 +86,14 @@ let withConfig = (
       ),
     ),
   )
+  eventMod
+}
+
+let withOverride = (eventMod: module(Types.Event), ~sighash=?) => {
+  switch sighash {
+  | Some(sighash) => (eventMod->Obj.magic)["sighash"] = sighash
+  | None => ()
+  }
   eventMod
 }
 

--- a/scenarios/test_codegen/test/HyperSyncWorker_test.res
+++ b/scenarios/test_codegen/test/HyperSyncWorker_test.res
@@ -11,8 +11,8 @@ module MockEvent = (
     let transactionSchema: S.t<transaction>
   },
 ): Types.Event => {
+  let id = "0xcf16a92280c1bbb43f72d31126b724d508df2877835849e8744017ab36a9b47f_1"
   let sighash = "0xcf16a92280c1bbb43f72d31126b724d508df2877835849e8744017ab36a9b47f"
-  let topicCount = 1
   let name = "EventWithoutFields"
   let contractName = "Foo"
 
@@ -351,6 +351,34 @@ describe("HyperSyncWorker - getSelectionConfig", () => {
             )->withConfig({wildcard: true}),
           ],
         },
+        {
+          name: "Baz",
+          abi: %raw(`[]`),
+          addresses: [],
+          events: [
+            module(
+              MockEvent({
+                type transaction = {}
+                type block = {}
+                let blockSchema = S.object(
+                  (s): block => {
+                    let _ = s.field("uncles", S.null(BigInt.schema))
+                    {}
+                  },
+                )
+                let transactionSchema = S.object(
+                  (s): transaction => {
+                    let _ = s.field("gasPrice", S.null(S.string))
+                    {}
+                  },
+                )
+              })
+              // Eventhough this is a second wildcard event
+              // it shouldn't be included in the field selection,
+              // since it's not specified in the FetchState.selection
+            )->withConfig({wildcard: true}),
+          ],
+        },
       ]
 
       let normalSelectionConfig = Normal({})->HyperSyncWorker.getSelectionConfig(~contracts)
@@ -358,7 +386,7 @@ describe("HyperSyncWorker - getSelectionConfig", () => {
         eventConfigs: [
           {
             contractName: "Bar",
-            eventTag: "0", // FIXME: Should be failing
+            eventId: "0xcf16a92280c1bbb43f72d31126b724d508df2877835849e8744017ab36a9b47f_1",
             isWildcard: true,
           },
         ],

--- a/scenarios/test_codegen/test/HyperSyncWorker_test.res
+++ b/scenarios/test_codegen/test/HyperSyncWorker_test.res
@@ -354,7 +354,15 @@ describe("HyperSyncWorker - getSelectionConfig", () => {
       ]
 
       let normalSelectionConfig = Normal({})->HyperSyncWorker.getSelectionConfig(~contracts)
-      let wildcardSelectionConfig = Wildcard({})->HyperSyncWorker.getSelectionConfig(~contracts)
+      let wildcardSelectionConfig = Wildcard({
+        eventConfigs: [
+          {
+            contractName: "Bar",
+            eventTag: "0", // FIXME: Should be failing
+            isWildcard: true,
+          },
+        ],
+      })->HyperSyncWorker.getSelectionConfig(~contracts)
 
       Assert.deepEqual(
         normalSelectionConfig,

--- a/scenarios/test_codegen/test/integration-raw-events-test.ts
+++ b/scenarios/test_codegen/test/integration-raw-events-test.ts
@@ -13,7 +13,7 @@ import {
 } from "./helpers/node-and-contracts";
 import { deployContracts } from "./helpers/setupNodeAndContracts";
 
-import { runMigrationsNoLogs, createSql, EventVariants } from "./helpers/utils";
+import { runMigrationsNoLogs, createSql } from "./helpers/utils";
 
 import {
   getLocalChainConfig,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -73,7 +73,7 @@ let makeInitial = () => {
     ~eventConfigs=[
       {
         contractName: "Gravatar",
-        eventTag: "0",
+        eventId: "0",
         isWildcard: false,
       },
     ],
@@ -127,7 +127,7 @@ describe("FetchState.make", () => {
           ~eventConfigs=[
             {
               contractName: "Gravatar",
-              eventTag: "0",
+              eventId: "0",
               isWildcard: false,
             },
           ],
@@ -153,7 +153,7 @@ describe("FetchState.make", () => {
         ~eventConfigs=[
           {
             contractName: "Gravatar",
-            eventTag: "0",
+            eventId: "0",
             isWildcard: false,
           },
         ],
@@ -208,12 +208,12 @@ describe("FetchState.make", () => {
         ~eventConfigs=[
           {
             contractName: "ContractA",
-            eventTag: "0",
+            eventId: "0",
             isWildcard: false,
           },
           {
             contractName: "Gravatar",
-            eventTag: "0",
+            eventId: "0",
             isWildcard: false,
           },
         ],
@@ -286,12 +286,12 @@ describe("FetchState.make", () => {
         ~eventConfigs=[
           {
             contractName: "ContractA",
-            eventTag: "0",
+            eventId: "0",
             isWildcard: false,
           },
           {
             contractName: "Gravatar",
-            eventTag: "0",
+            eventId: "0",
             isWildcard: false,
           },
         ],
@@ -445,17 +445,17 @@ describe("FetchState.registerDynamicContracts", () => {
       let fetchState = FetchState.make(
         ~eventConfigs=[
           {
-            eventTag: "wildcard1",
+            eventId: "wildcard1",
             contractName: "Gravatar",
             isWildcard: true,
           },
           {
-            eventTag: "wildcard2",
+            eventId: "wildcard2",
             contractName: "Gravatar",
             isWildcard: true,
           },
           {
-            eventTag: "normal1",
+            eventId: "normal1",
             contractName: "NftFactory",
             isWildcard: false,
           },
@@ -495,12 +495,12 @@ describe("FetchState.registerDynamicContracts", () => {
               selection: Wildcard({
                 eventConfigs: [
                   {
-                    eventTag: "wildcard1",
+                    eventId: "wildcard1",
                     contractName: "Gravatar",
                     isWildcard: true,
                   },
                   {
-                    eventTag: "wildcard2",
+                    eventId: "wildcard2",
                     contractName: "Gravatar",
                     isWildcard: true,
                   },
@@ -1173,12 +1173,12 @@ describe("FetchState.getNextQuery & integration", () => {
       ~eventConfigs=[
         {
           contractName: "ContractA",
-          eventTag: "0",
+          eventId: "0",
           isWildcard: false,
         },
         {
           contractName: "ContractA",
-          eventTag: "wildcard",
+          eventId: "wildcard",
           isWildcard: true,
         },
       ],
@@ -1212,7 +1212,7 @@ describe("FetchState.getNextQuery & integration", () => {
             eventConfigs: [
               {
                 contractName: "ContractA",
-                eventTag: "wildcard",
+                eventId: "wildcard",
                 isWildcard: true,
               },
             ],
@@ -1321,7 +1321,7 @@ describe("FetchState.getNextQuery & integration", () => {
     let eventConfigs = [
       {
         FetchState.contractName: "ContractA",
-        eventTag: "wildcard",
+        eventId: "wildcard",
         isWildcard: true,
       },
     ]
@@ -1503,12 +1503,12 @@ describe("FetchState unit tests for specific cases", () => {
         ~eventConfigs=[
           {
             contractName: "ContractA",
-            eventTag: "0",
+            eventId: "0",
             isWildcard: false,
           },
           {
             contractName: "ContractA",
-            eventTag: "wildcard",
+            eventId: "wildcard",
             isWildcard: true,
           },
         ],
@@ -1526,7 +1526,7 @@ describe("FetchState unit tests for specific cases", () => {
             eventConfigs: [
               {
                 contractName: "ContractA",
-                eventTag: "wildcard",
+                eventId: "wildcard",
                 isWildcard: true,
               },
             ],
@@ -1568,7 +1568,7 @@ describe("FetchState unit tests for specific cases", () => {
             eventConfigs: [
               {
                 contractName: "ContractA",
-                eventTag: "wildcard",
+                eventId: "wildcard",
                 isWildcard: true,
               },
             ],
@@ -1608,7 +1608,7 @@ describe("FetchState unit tests for specific cases", () => {
         ~eventConfigs=[
           {
             contractName: "ContractA",
-            eventTag: "0",
+            eventId: "0",
             isWildcard: false,
           },
         ],
@@ -1785,7 +1785,7 @@ describe("FetchState unit tests for specific cases", () => {
       ~eventConfigs=[
         {
           contractName: "ContractA",
-          eventTag: "0",
+          eventId: "0",
           isWildcard: false,
         },
       ],
@@ -1901,12 +1901,12 @@ describe("FetchState unit tests for specific cases", () => {
       ~eventConfigs=[
         {
           contractName: "ContractA",
-          eventTag: "0",
+          eventId: "0",
           isWildcard: false,
         },
         {
           contractName: "Gravatar",
-          eventTag: "0",
+          eventId: "0",
           isWildcard: false,
         },
       ],
@@ -1968,12 +1968,12 @@ describe("FetchState unit tests for specific cases", () => {
       ~eventConfigs=[
         {
           contractName: "ContractA",
-          eventTag: "0",
+          eventId: "0",
           isWildcard: false,
         },
         {
           contractName: "ContractB",
-          eventTag: "0",
+          eventId: "0",
           isWildcard: false,
         },
       ],
@@ -2186,7 +2186,7 @@ describe("FetchState unit tests for specific cases", () => {
           ~eventConfigs=[
             {
               contractName: "Gravatar",
-              eventTag: "0",
+              eventId: "0",
               isWildcard: false,
             },
           ],

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -72,31 +72,33 @@ let onNewBlockMock = () => {
 }
 
 describe("SourceManager fetchNext", () => {
+  let normalSelection = FetchState.Normal({})
+
   let mockFullPartition = (
     ~partitionIndex,
     ~latestFetchedBlockNumber,
     ~numContracts=2,
     ~fetchedEventQueue=[],
-  ) => {
-    let staticContracts = []
+  ): FetchState.partition => {
+    let contractAddressMapping = ContractAddressingMap.make()
 
     for i in 0 to numContracts - 1 {
       let address = TestHelpers.Addresses.mockAddresses[i]->Option.getExn
-      staticContracts->Array.push(("MockContract", address))
+      contractAddressMapping->ContractAddressingMap.addAddress(~name="MockContract", ~address)
     }
 
-    let latestFetchedBlock: FetchState.blockNumberAndTimestamp = {
-      blockNumber: latestFetchedBlockNumber,
-      blockTimestamp: latestFetchedBlockNumber * 15,
-    }
-
-    let partition = FetchState.makeNormalPartition(
-      ~partitionIndex,
-      ~staticContracts,
-      ~latestFetchedBlock,
-    )
     {
-      ...partition,
+      id: partitionIndex->Int.toString,
+      status: {
+        fetchingStateId: None,
+      },
+      latestFetchedBlock: {
+        blockNumber: latestFetchedBlockNumber,
+        blockTimestamp: latestFetchedBlockNumber * 15,
+      },
+      selection: normalSelection,
+      contractAddressMapping,
+      dynamicContracts: [],
       fetchedEventQueue,
     }
   }


### PR DESCRIPTION
After I do the same for normal queries, it will automatically add support for preRegistration with RPC and HyperFuel data-sources.