### PR TITLE
Fix db saves as false

### DIFF
--- a/codegenerator/cli/npm/envio/src/db/Table.res
+++ b/codegenerator/cli/npm/envio/src/db/Table.res
@@ -214,8 +214,8 @@ let toSqlParams = (table: table, ~schema) => {
           | Bool =>
             // Workaround for https://github.com/porsager/postgres/issues/471
             S.union([
-              S.literal("t")->S.to(_ => true),
-              S.literal("f")->S.to(_ => false),
+              S.literal(1)->S.to(_ => true),
+              S.literal(0)->S.to(_ => false),
             ])->S.toUnknown
           | _ => schema
           }
@@ -242,6 +242,7 @@ let toSqlParams = (table: table, ~schema) => {
           | Field(f) =>
             switch f.fieldType {
             | Custom(fieldType) => `${(Text :> string)}[]::${(fieldType :> string)}`
+            | Boolean => `${(Integer :> string)}[]::${(f.fieldType :> string)}`
             | fieldType => (fieldType :> string)
             }
           | DerivedFrom(_) => (Text :> string)

--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
@@ -66,7 +66,7 @@ SELECT * FROM unnest(${arrayFieldTypes
     }
   } else {
     let convertOrThrow = S.compile(
-      S.array(dbSchema),
+      S.array(schema),
       ~input=Value,
       ~output=Unknown,
       ~mode=Sync,

--- a/scenarios/test_codegen/README.md
+++ b/scenarios/test_codegen/README.md
@@ -9,6 +9,8 @@
 
     - `pnpm docker-up`
 
+- Make sure to gen ts types in contracts dir `(cd contracts && npx hardhat compile)`
+
 - Then run the tests and confirm all pass: 
     - `pnpm test`
 

--- a/scenarios/test_codegen/test/SerDe_Test.res
+++ b/scenarios/test_codegen/test/SerDe_Test.res
@@ -7,7 +7,7 @@ let mockDate = (~year=2024, ~month=1, ~day=1) => {
   Js.Date.fromString(`${year->padInt}-${month->padInt}-${day->padInt}T00:00:00Z`)
 }
 
-describe("SerDe Test", () => {
+describe_only("SerDe Test", () => {
   Async.before(async () => {
     await DbHelpers.runUpDownMigration()
   })
@@ -25,7 +25,7 @@ describe("SerDe Test", () => {
       optFloat: Some(2.2),
       arrayOfFloats: [3.3, 4.4],
       bool: true,
-      optBool: Some(false),
+      optBool: Some(true),
       //TODO: get array of bools working
       // arrayOfBool: [true, false],
       bigInt: BigInt.fromInt(1),
@@ -81,7 +81,7 @@ describe("SerDe Test", () => {
     | exception exn =>
       Js.log(exn)
       Assert.fail("Failed to read entity from table")
-    | [_entity] => ()
+    | [_entity] => Assert.deepEqual(_entity, entity)      
     | _ => Assert.fail("Should have returned a row on batch read fn")
     }
 
@@ -112,7 +112,7 @@ describe("SerDe Test", () => {
       float_: 1.1,
       optFloat: Some(2.2),
       bool: true,
-      optBool: Some(false),
+      optBool: Some(true),
       bigInt: BigInt.fromInt(1),
       optBigInt: Some(BigInt.fromInt(2)),
       bigDecimal: BigDecimal.fromStringUnsafe("1.1"),
@@ -159,7 +159,7 @@ describe("SerDe Test", () => {
     | exception exn =>
       Js.log(exn)
       Assert.fail("Failed to read entity from table")
-    | [_entity] => ()
+    | [_entity] => Assert.deepEqual(_entity, entity)      
     | _ => Assert.fail("Should have returned a row on batch read fn")
     }
 

--- a/scenarios/test_codegen/test/SerDe_Test.res
+++ b/scenarios/test_codegen/test/SerDe_Test.res
@@ -7,7 +7,7 @@ let mockDate = (~year=2024, ~month=1, ~day=1) => {
   Js.Date.fromString(`${year->padInt}-${month->padInt}-${day->padInt}T00:00:00Z`)
 }
 
-describe_only("SerDe Test", () => {
+describe("SerDe Test", () => {
   Async.before(async () => {
     await DbHelpers.runUpDownMigration()
   })
@@ -25,7 +25,7 @@ describe_only("SerDe Test", () => {
       optFloat: Some(2.2),
       arrayOfFloats: [3.3, 4.4],
       bool: true,
-      optBool: Some(true),
+      optBool: Some(false),
       //TODO: get array of bools working
       // arrayOfBool: [true, false],
       bigInt: BigInt.fromInt(1),
@@ -112,7 +112,7 @@ describe_only("SerDe Test", () => {
       float_: 1.1,
       optFloat: Some(2.2),
       bool: true,
-      optBool: Some(true),
+      optBool: Some(false),
       bigInt: BigInt.fromInt(1),
       optBigInt: Some(BigInt.fromInt(2)),
       bigDecimal: BigDecimal.fromStringUnsafe("1.1"),


### PR DESCRIPTION
Was missed as test wasn't asserting that what was written was equal to what was read back from the db.

Effected v2.12.1 & v2.12.2, I suggest we deprecate those two versions on npm

- fix: assert write & read equivalence in test
- fix: bool type sql conversion
