### PR TITLE
More robust reorg detection logic

### DIFF
--- a/codegenerator/cli/npm/envio/src/ReorgDetection.res
+++ b/codegenerator/cli/npm/envio/src/ReorgDetection.res
@@ -151,6 +151,14 @@ module LastBlockScannedHashes: {
           lastBlockScannedData.blockNumber->Int.toString,
           lastBlockScannedData,
         )
+        switch firstBlockParentNumberAndHash {
+        | None => ()
+        | Some(firstBlockParentNumberAndHash) =>
+          dataByBlockNumberCopyInThreshold->Js.Dict.set(
+            firstBlockParentNumberAndHash.blockNumber->Int.toString,
+            firstBlockParentNumberAndHash,
+          )
+        }
 
         Ok({
           confirmedBlockThreshold,

--- a/codegenerator/cli/npm/envio/src/ReorgDetection.res
+++ b/codegenerator/cli/npm/envio/src/ReorgDetection.res
@@ -53,11 +53,7 @@ module LastBlockScannedHashes: {
 
   let getThresholdBlockNumbers: (t, ~currentBlockHeight: int) => array<int>
 
-  /**
-  Return a BlockNumbersAndHashes.t rolled back to where blockData is less
-  than the provided blockNumber
-  */
-  let rollBackToBlockNumberLt: (t, ~blockNumber: int) => t
+  let rollbackToValidBlockNumber: (t, ~blockNumber: int) => t
 } = {
   type t = {
     // Number of blocks behind head, we want to keep track
@@ -209,20 +205,20 @@ module LastBlockScannedHashes: {
   Return a BlockNumbersAndHashes.t rolled back to where blockData is less
   than the provided blockNumber
   */
-  let rollBackToBlockNumberLt = (
+  let rollbackToValidBlockNumber = (
     {dataByBlockNumber, confirmedBlockThreshold}: t,
     ~blockNumber: int,
   ) => {
     // Js engine automatically orders numeric object keys
     let ascBlockNumberKeys = dataByBlockNumber->Js.Dict.keys
 
-    let newDataByBlockNumber = dataByBlockNumber->Utils.Dict.shallowCopy
+    let newDataByBlockNumber = Js.Dict.empty()
 
     let rec loop = idx => {
       switch ascBlockNumberKeys->Belt.Array.get(idx) {
       | Some(blockNumberKey) => {
           let scannedBlock = dataByBlockNumber->Js.Dict.unsafeGet(blockNumberKey)
-          let shouldKeep = scannedBlock.blockNumber < blockNumber
+          let shouldKeep = scannedBlock.blockNumber <= blockNumber
           if shouldKeep {
             newDataByBlockNumber->Js.Dict.set(blockNumberKey, scannedBlock)
             loop(idx + 1)

--- a/codegenerator/cli/npm/envio/src/ReorgDetection.res
+++ b/codegenerator/cli/npm/envio/src/ReorgDetection.res
@@ -1,21 +1,22 @@
 open Belt
 
-type blockNumberAndHash = {
-  //Block hash is used for actual comparison to test for reorg
+type blockDataWithTimestamp = {
+  blockHash: string,
+  blockNumber: int,
+  blockTimestamp: int,
+}
+
+type blockData = {
+  // Block hash is used for actual comparison to test for reorg
   blockHash: string,
   blockNumber: int,
 }
 
-type blockData = {
-  ...blockNumberAndHash,
-  //Timestamp is needed for multichain to action reorgs across chains from given blocks to
-  //ensure ordering is kept constant
-  blockTimestamp: int,
-}
+external generalizeBlockDataWithTimestamp: blockDataWithTimestamp => blockData = "%identity"
 
 type reorgGuard = {
   lastBlockScannedData: blockData,
-  firstBlockParentNumberAndHash: option<blockNumberAndHash>,
+  firstBlockParentNumberAndHash: option<blockData>,
 }
 
 type reorgDetected = {
@@ -31,26 +32,14 @@ module LastBlockScannedHashes: {
   /**Instantiat empty t with no block data*/
   let empty: (~confirmedBlockThreshold: int) => t
 
-  /**Add the latest scanned block data to t*/
-  let registerReorgGuard: (t, ~reorgGuard: reorgGuard) => result<t, reorgDetected>
-
-  /** Given the head block number, find the earliest timestamp from the data where the data
-      is still within the given block threshold from the head
+  /** Registers a new reorg guard, prunes unnened data and returns the updated data 
+   or an error if a reorg has occured 
   */
-  let getEarlistTimestampInThreshold: (t, ~currentHeight: int) => option<int>
-
-  /**
-  Prunes the back of the unneeded data on the queue.
-
-  In the case of a multichain indexer, pass in the earliest needed timestamp that
-  occurs within the chains threshold. Ensure that we keep track of one range before that
-  as this is that could be the target range block for a reorg
-  */
-  let pruneStaleBlockData: (
+  let registerReorgGuard: (
     t,
-    ~currentHeight: int,
-    ~earliestMultiChainTimestampInThreshold: option<int>,
-  ) => t
+    ~reorgGuard: reorgGuard,
+    ~currentBlockHeight: int,
+  ) => result<t, reorgDetected>
 
   /**
   Returns the latest block data which matches block number and hashes in the provided array
@@ -58,28 +47,9 @@ module LastBlockScannedHashes: {
   */
   let getLatestValidScannedBlock: (
     t,
-    ~blockNumbersAndHashes: array<blockData>,
-    ~currentHeight: int,
-  ) => option<blockData>
-
-  /**
-  A record that holds the current height of a chain and the lastBlockScannedHashes,
-  used for passing into getEarliestMultiChainTimestampInThreshold where these values 
-  need to be zipped
-  */
-  type currentHeightAndLastBlockHashes = {
-    lastBlockScannedHashes: t,
-    currentHeight: int,
-  }
-
-  /**
-  Finds the earliest timestamp that is withtin the confirmedBlockThreshold of
-  each chain in a multi chain indexer. Returns None if its a single chain or if
-  the list is empty
-  */
-  let getEarliestMultiChainTimestampInThreshold: array<currentHeightAndLastBlockHashes> => option<
-    int,
-  >
+    ~blockNumbersAndHashes: array<blockDataWithTimestamp>,
+    ~currentBlockHeight: int,
+  ) => option<blockDataWithTimestamp>
 
   let getThresholdBlockNumbers: (t, ~currentBlockHeight: int) => array<int>
 
@@ -118,167 +88,116 @@ module LastBlockScannedHashes: {
     dataByBlockNumber: Js.Dict.empty(),
   }
 
-  let getEarliestBlockDataInThreshold = (
+  let getDataByBlockNumberCopyInThreshold = (
     {dataByBlockNumber, confirmedBlockThreshold}: t,
-    ~currentHeight,
+    ~currentBlockHeight,
   ) => {
     // Js engine automatically orders numeric object keys
     let ascBlockNumberKeys = dataByBlockNumber->Js.Dict.keys
-    let thresholdBlockNumber = currentHeight - confirmedBlockThreshold
-    let rec loop = idx => {
-      switch ascBlockNumberKeys->Belt.Array.get(idx) {
-      | Some(blockNumberKey) =>
-        let scannedBlock = dataByBlockNumber->Js.Dict.unsafeGet(blockNumberKey)
-        if scannedBlock.blockNumber >= thresholdBlockNumber {
-          scannedBlock->Some
-        } else {
-          loop(idx + 1)
-        }
-      | None => None
+    let thresholdBlockNumber = currentBlockHeight - confirmedBlockThreshold
+
+    let copy = Js.Dict.empty()
+
+    for idx in 0 to ascBlockNumberKeys->Array.length - 1 {
+      let blockNumberKey = ascBlockNumberKeys->Js.Array2.unsafe_get(idx)
+      let scannedBlock = dataByBlockNumber->Js.Dict.unsafeGet(blockNumberKey)
+      let isInReorgThreshold = scannedBlock.blockNumber >= thresholdBlockNumber
+      if isInReorgThreshold {
+        copy->Js.Dict.set(blockNumberKey, scannedBlock)
       }
     }
-    loop(0)
+
+    copy
   }
 
-  /** Given the head block number, find the earliest timestamp from the data where the data
-      is still within the given block threshold from the head
-  */
-  let getEarlistTimestampInThreshold = (self: t, ~currentHeight) =>
-    self->getEarliestBlockDataInThreshold(~currentHeight)->Option.map(d => d.blockTimestamp)
-
-  // Adds the latest blockData to the head of the list
   let registerReorgGuard = (
-    {confirmedBlockThreshold, dataByBlockNumber} as self: t,
+    {confirmedBlockThreshold} as self: t,
     ~reorgGuard: reorgGuard,
+    ~currentBlockHeight,
   ) => {
+    let dataByBlockNumberCopyInThreshold =
+      self->getDataByBlockNumberCopyInThreshold(~currentBlockHeight)
+
     let {lastBlockScannedData, firstBlockParentNumberAndHash} = reorgGuard
 
-    switch dataByBlockNumber->Utils.Dict.dangerouslyGetNonOption(
+    let maybeReorgDetected = switch dataByBlockNumberCopyInThreshold->Utils.Dict.dangerouslyGetNonOption(
       lastBlockScannedData.blockNumber->Int.toString,
     ) {
     | Some(scannedBlock) if scannedBlock.blockHash !== lastBlockScannedData.blockHash =>
-      Error({
+      Some({
         reorgGuard,
         scannedBlock,
       })
-    | _ as maybeScannedData =>
-      let updatedSelf = if maybeScannedData === None {
-        {
-          confirmedBlockThreshold,
-          dataByBlockNumber: dataByBlockNumber->Utils.Dict.updateImmutable(
-            lastBlockScannedData.blockNumber->Int.toString,
-            lastBlockScannedData,
-          ),
-        }
-      } else {
-        self
-      }
-
+    | _ =>
       switch firstBlockParentNumberAndHash {
       //If parentHash is None, either it's the genesis block (no reorg)
       //Or its already confirmed so no Reorg
-      | None => Ok(updatedSelf)
+      | None => None
       | Some(firstBlockParentNumberAndHash) =>
-        switch dataByBlockNumber->Utils.Dict.dangerouslyGetNonOption(
+        switch dataByBlockNumberCopyInThreshold->Utils.Dict.dangerouslyGetNonOption(
           firstBlockParentNumberAndHash.blockNumber->Int.toString,
         ) {
         | Some(scannedBlock)
           if scannedBlock.blockHash !== firstBlockParentNumberAndHash.blockHash =>
-          Error({
+          Some({
             reorgGuard,
             scannedBlock,
           })
-        | _ => Ok(updatedSelf)
+        | _ => None
         }
       }
     }
-  }
 
-  //Prunes the back of the unneeded data on the queue
-  let pruneStaleBlockData = (
-    {confirmedBlockThreshold, dataByBlockNumber}: t,
-    ~currentHeight,
-    ~earliestMultiChainTimestampInThreshold,
-  ) => {
-    // Js engine automatically orders numeric object keys
-    let ascBlockNumberKeys = dataByBlockNumber->Js.Dict.keys
-    let thresholdBlockNumber = currentHeight - confirmedBlockThreshold
+    switch maybeReorgDetected {
+    | Some(reorgDetected) => Error(reorgDetected)
+    | None => {
+        dataByBlockNumberCopyInThreshold->Js.Dict.set(
+          lastBlockScannedData.blockNumber->Int.toString,
+          lastBlockScannedData,
+        )
 
-    let dataByBlockNumberCopy = dataByBlockNumber->Utils.Dict.shallowCopy
-
-    let rec loop = idx => {
-      switch ascBlockNumberKeys->Belt.Array.get(idx) {
-      | Some(blockNumberKey) => {
-          let scannedBlock = dataByBlockNumber->Js.Dict.unsafeGet(blockNumberKey)
-          let isInReorgThreshold = scannedBlock.blockNumber >= thresholdBlockNumber
-          let shouldPrune = switch earliestMultiChainTimestampInThreshold {
-          | None => !isInReorgThreshold
-          | Some(timestampThresholdNeeded) =>
-            switch ascBlockNumberKeys
-            ->Belt.Array.get(idx + 1)
-            ->Option.map(blockNumberKey => dataByBlockNumber->Js.Dict.unsafeGet(blockNumberKey)) {
-            // Ony prune in the case where the second lastBlockScannedData from the back
-            // Has an earlier timestamp than the timestampThresholdNeeded (this is
-            // the earliest timestamp across all chains where the lastBlockScannedData is
-            // still within the confirmedBlockThreshold)
-            | Some(nextScannedBlock) => nextScannedBlock.blockTimestamp < timestampThresholdNeeded
-            | None => false
-            }
-          }
-          if shouldPrune {
-            dataByBlockNumberCopy->Utils.Dict.deleteInPlace(blockNumberKey)
-            loop(idx + 1)
-          } else {
-            ()
-          }
-        }
-      | None => ()
+        Ok({
+          confirmedBlockThreshold,
+          dataByBlockNumber: dataByBlockNumberCopyInThreshold,
+        })
       }
-    }
-    loop(0)
-
-    {
-      confirmedBlockThreshold,
-      dataByBlockNumber: dataByBlockNumberCopy,
     }
   }
 
   let getLatestValidScannedBlock = (
-    {confirmedBlockThreshold, dataByBlockNumber}: t,
-    ~blockNumbersAndHashes: array<blockData>,
-    ~currentHeight,
+    self: t,
+    ~blockNumbersAndHashes: array<blockDataWithTimestamp>,
+    ~currentBlockHeight,
   ) => {
     let verifiedDataByBlockNumber = Js.Dict.empty()
     blockNumbersAndHashes->Array.forEach(blockData => {
       verifiedDataByBlockNumber->Js.Dict.set(blockData.blockNumber->Int.toString, blockData)
     })
 
+    let dataByBlockNumber = self->getDataByBlockNumberCopyInThreshold(~currentBlockHeight)
     // Js engine automatically orders numeric object keys
     let ascBlockNumberKeys = dataByBlockNumber->Js.Dict.keys
-    let thresholdBlockNumber = currentHeight - confirmedBlockThreshold
 
     let getPrevScannedBlock = idx =>
       ascBlockNumberKeys
       ->Belt.Array.get(idx - 1)
-      ->Option.flatMap(key => dataByBlockNumber->Utils.Dict.dangerouslyGetNonOption(key))
+      ->Option.flatMap(key => {
+        // We should already validate that the block number is verified at the point
+        verifiedDataByBlockNumber->Utils.Dict.dangerouslyGetNonOption(key)
+      })
 
     let rec loop = idx => {
       switch ascBlockNumberKeys->Belt.Array.get(idx) {
       | Some(blockNumberKey) =>
         let scannedBlock = dataByBlockNumber->Js.Dict.unsafeGet(blockNumberKey)
-        let isInReorgThreshold = scannedBlock.blockNumber >= thresholdBlockNumber
-        if isInReorgThreshold {
-          switch verifiedDataByBlockNumber->Utils.Dict.dangerouslyGetNonOption(blockNumberKey) {
-          | None =>
-            Js.Exn.raiseError(
-              `Unexpected case. Couldn't find verified hash for block number ${blockNumberKey}`,
-            )
-          | Some(verifiedBlockData) if verifiedBlockData.blockHash === scannedBlock.blockHash =>
-            loop(idx + 1)
-          | Some(_) => getPrevScannedBlock(idx)
-          }
-        } else {
+        switch verifiedDataByBlockNumber->Utils.Dict.dangerouslyGetNonOption(blockNumberKey) {
+        | None =>
+          Js.Exn.raiseError(
+            `Unexpected case. Couldn't find verified hash for block number ${blockNumberKey}`,
+          )
+        | Some(verifiedBlockData) if verifiedBlockData.blockHash === scannedBlock.blockHash =>
           loop(idx + 1)
+        | Some(_) => getPrevScannedBlock(idx)
         }
       | None => getPrevScannedBlock(idx)
       }
@@ -322,68 +241,10 @@ module LastBlockScannedHashes: {
     }
   }
 
-  type currentHeightAndLastBlockHashes = {
-    lastBlockScannedHashes: t,
-    currentHeight: int,
-  }
+  let getThresholdBlockNumbers = (self: t, ~currentBlockHeight) => {
+    let dataByBlockNumberCopyInThreshold =
+      self->getDataByBlockNumberCopyInThreshold(~currentBlockHeight)
 
-  let min = (arrInt: array<int>) => {
-    arrInt->Belt.Array.reduce(None, (current, val) => {
-      switch current {
-      | None => Some(val)
-      | Some(current) => Js.Math.min_int(current, val)->Some
-      }
-    })
-  }
-
-  /**
-  Find the the earliest block time across multiple instances of self where the block timestamp
-  falls within its own confirmed block threshold
-
-  Return None if there is only one chain (since we don't want to take this val into account for a
-  single chain indexer) or if there are no chains (should never be the case)
-  */
-  let getEarliestMultiChainTimestampInThreshold = (
-    multiSelf: array<currentHeightAndLastBlockHashes>,
-  ) => {
-    switch multiSelf {
-    | [_singleVal] =>
-      //In the case where there is only one chain, return none as there would be no need to aggregate
-      //or keep track of the lowest timestamp. The chain can purge as far back as its confirmed block range
-      None
-    | multiSelf =>
-      multiSelf
-      ->Belt.Array.keepMap(({currentHeight, lastBlockScannedHashes}) => {
-        lastBlockScannedHashes->getEarlistTimestampInThreshold(~currentHeight)
-      })
-      ->min
-    }
-  }
-
-  let getThresholdBlockNumbers = (
-    {dataByBlockNumber, confirmedBlockThreshold}: t,
-    ~currentBlockHeight,
-  ) => {
-    let blockNumbers = []
-
-    // Js engine automatically orders numeric object keys
-    let ascBlockNumberKeys = dataByBlockNumber->Js.Dict.keys
-    let thresholdBlockNumber = currentBlockHeight - confirmedBlockThreshold
-
-    let rec loop = idx => {
-      switch ascBlockNumberKeys->Belt.Array.get(idx) {
-      | Some(blockNumberKey) => {
-          let scannedBlock = dataByBlockNumber->Js.Dict.unsafeGet(blockNumberKey)
-          if scannedBlock.blockNumber >= thresholdBlockNumber {
-            blockNumbers->Array.push(scannedBlock.blockNumber)
-          }
-          loop(idx + 1)
-        }
-      | None => ()
-      }
-    }
-    loop(0)
-
-    blockNumbers
+    dataByBlockNumberCopyInThreshold->Js.Dict.values->Js.Array2.map(v => v.blockNumber)
   }
 }

--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctions.res
@@ -132,7 +132,6 @@ module ChainMetadata = {
 module EndOfBlockRangeScannedData = {
   type endOfBlockRangeScannedData = {
     @as("chain_id") chainId: int,
-    @as("block_timestamp") blockTimestamp: int,
     @as("block_number") blockNumber: int,
     @as("block_hash") blockHash: string,
   }
@@ -156,9 +155,6 @@ module EndOfBlockRangeScannedData = {
     ~chainId: int,
     //minimum blockNumber that should be kept in db
     ~blockNumberThreshold: int,
-    //minimum blockTimestamp that should be kept in db
-    //(timestamp could be lower/higher than blockTimestampThreshold depending on multichain configuration)
-    ~blockTimestampThreshold: option<int>,
   ) => promise<unit> = "deleteStaleEndOfBlockRangeScannedDataForChain"
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsImplementation.js
+++ b/codegenerator/cli/templates/static/codegen/src/db/DbFunctionsImplementation.js
@@ -167,17 +167,10 @@ ${sql`${commaSeparateDynamicMapQuery(sql, fieldQueryConstructors)}`};`;
 const batchSetEndOfBlockRangeScannedDataCore = (sql, rowDataArray) => {
   return sql`
     INSERT INTO "public"."end_of_block_range_scanned_data"
-  ${sql(
-    rowDataArray,
-    "chain_id",
-    "block_timestamp",
-    "block_number",
-    "block_hash"
-  )}
+  ${sql(rowDataArray, "chain_id", "block_number", "block_hash")}
     ON CONFLICT(chain_id, block_number) DO UPDATE
     SET
     "chain_id" = EXCLUDED."chain_id",
-    "block_timestamp" = EXCLUDED."block_timestamp",
     "block_number" = EXCLUDED."block_number",
     "block_hash" = EXCLUDED."block_hash";`;
 };
@@ -197,20 +190,13 @@ module.exports.readEndOfBlockRangeScannedDataForChain = (sql, chainId) => {
 module.exports.deleteStaleEndOfBlockRangeScannedDataForChain = (
   sql,
   chainId,
-  blockNumberThreshold,
-  blockTimestampThreshold
+  blockNumberThreshold
 ) => {
   return sql`
     DELETE
     FROM "public"."end_of_block_range_scanned_data"
     WHERE chain_id = ${chainId}
-    AND block_number < ${blockNumberThreshold}
-    ${
-      blockTimestampThreshold
-        ? sql`AND block_timestamp < ${blockTimestampThreshold}`
-        : sql``
-    }
-    ;`;
+    AND block_number < ${blockNumberThreshold};`;
 };
 
 module.exports.deleteInvalidDynamicContractsOnRestart = (

--- a/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
@@ -90,7 +90,6 @@ module EndOfBlockRangeScannedData = {
   @genType
   type t = {
     chain_id: int,
-    block_timestamp: int,
     block_number: int,
     block_hash: string,
   }
@@ -99,7 +98,6 @@ module EndOfBlockRangeScannedData = {
     "end_of_block_range_scanned_data",
     ~fields=[
       mkField("chain_id", Integer, ~isPrimaryKey),
-      mkField("block_timestamp", Integer),
       mkField("block_number", Integer, ~isPrimaryKey),
       mkField("block_hash", Text),
     ],

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -290,10 +290,9 @@ let makeFromDbState = async (
 
   let lastBlockScannedHashes =
     endOfBlockRangeScannedData
-    ->Array.map(({blockNumber, blockHash, blockTimestamp}) => {
+    ->Array.map(({blockNumber, blockHash}) => {
       ReorgDetection.blockNumber,
       blockHash,
-      blockTimestamp,
     })
     ->ReorgDetection.LastBlockScannedHashes.makeWithData(
       ~confirmedBlockThreshold=chainConfig.confirmedBlockThreshold,
@@ -457,7 +456,7 @@ let getLastKnownValidBlock = async (
 
       switch chainFetcher.lastBlockScannedHashes->ReorgDetection.LastBlockScannedHashes.getLatestValidScannedBlock(
         ~blockNumbersAndHashes,
-        ~currentHeight=chainFetcher.currentBlockHeight,
+        ~currentBlockHeight=chainFetcher.currentBlockHeight,
       ) {
       | Some(block) => block
       | None => await fallback()

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -1047,7 +1047,7 @@ let rollbackPartition = (p: partition, ~firstChangeEvent: blockNumberAndLogIndex
           fetchedEventQueue,
           latestFetchedBlock: shouldRollbackFetched
             ? {
-                blockNumber: firstChangeEvent.blockNumber - 1,
+                blockNumber: Pervasives.max(firstChangeEvent.blockNumber - 1, 0),
                 blockTimestamp: 0,
               }
             : p.latestFetchedBlock,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/Source.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/Source.res
@@ -30,7 +30,7 @@ type t = {
   getBlockHashes: (
     ~blockNumbers: array<int>,
     ~logger: Pino.t,
-  ) => promise<result<array<ReorgDetection.blockData>, exn>>,
+  ) => promise<result<array<ReorgDetection.blockDataWithTimestamp>, exn>>,
   getHeightOrThrow: unit => promise<int>,
   fetchBlockRange: (
     ~fromBlock: int,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.res
@@ -203,7 +203,7 @@ module LogsQuery = {
 
 module BlockData = {
   let convertResponse = (res: HyperFuelClient.queryResponseTyped): option<
-    ReorgDetection.blockData,
+    ReorgDetection.blockDataWithTimestamp,
   > => {
     res.data.blocks->Option.flatMap(blocks => {
       blocks
@@ -216,7 +216,7 @@ module BlockData = {
               blockTimestamp: timestamp,
               blockNumber,
               blockHash,
-            }: ReorgDetection.blockData
+            }: ReorgDetection.blockDataWithTimestamp
           )
         }
       })
@@ -224,7 +224,7 @@ module BlockData = {
   }
 
   let rec queryBlockData = async (~serverUrl, ~blockNumber, ~logger): option<
-    ReorgDetection.blockData,
+    ReorgDetection.blockDataWithTimestamp,
   > => {
     let query: HyperFuelClient.QueryTypes.query = {
       fromBlock: blockNumber,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.resi
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.resi
@@ -48,6 +48,6 @@ let queryBlockData: (
   ~serverUrl: string,
   ~blockNumber: int,
   ~logger: Pino.t,
-) => promise<option<ReorgDetection.blockData>>
+) => promise<option<ReorgDetection.blockDataWithTimestamp>>
 
 let heightRoute: Rest.route<(), int>

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hypersync/HyperSync.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hypersync/HyperSync.res
@@ -209,7 +209,7 @@ module BlockData = {
   }
 
   let convertResponse = (res: HyperSyncJsonApi.ResponseTypes.queryResponse): queryResponse<
-    array<ReorgDetection.blockData>,
+    array<ReorgDetection.blockDataWithTimestamp>,
   > => {
     res.data
     ->Array.flatMap(item => {
@@ -225,7 +225,7 @@ module BlockData = {
                     blockTimestamp,
                     blockNumber,
                     blockHash,
-                  }: ReorgDetection.blockData
+                  }: ReorgDetection.blockDataWithTimestamp
                 ),
               )
             | _ =>
@@ -251,7 +251,7 @@ module BlockData = {
   }
 
   let rec queryBlockData = async (~serverUrl, ~fromBlock, ~toBlock, ~logger): queryResponse<
-    array<ReorgDetection.blockData>,
+    array<ReorgDetection.blockDataWithTimestamp>,
   > => {
     let body = makeRequestBody(~fromBlock, ~toBlock)
 
@@ -334,9 +334,9 @@ module BlockData = {
         })
         if set->Utils.Set.size > 0 {
           Js.Exn.raiseError(
-            `Invalid response. Failed to get block data for block numbers: ${set->Utils.Set.toArray->Js.Array2.joinWith(
-              ", ",
-            )}`,
+            `Invalid response. Failed to get block data for block numbers: ${set
+              ->Utils.Set.toArray
+              ->Js.Array2.joinWith(", ")}`,
           )
         }
         filtered

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hypersync/HyperSync.resi
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hypersync/HyperSync.resi
@@ -43,20 +43,20 @@ let queryLogsPage: (
   ~fieldSelection: HyperSyncClient.QueryTypes.fieldSelection,
   ~nonOptionalBlockFieldNames: array<string>,
   ~nonOptionalTransactionFieldNames: array<string>,
-  ~logger: Pino.t
+  ~logger: Pino.t,
 ) => promise<queryResponse<logsQueryPage>>
 
 let queryBlockData: (
   ~serverUrl: string,
   ~blockNumber: int,
   ~logger: Pino.t,
-) => promise<queryResponse<option<ReorgDetection.blockData>>>
+) => promise<queryResponse<option<ReorgDetection.blockDataWithTimestamp>>>
 
 let queryBlockDataMulti: (
   ~serverUrl: string,
   ~blockNumbers: array<int>,
   ~logger: Pino.t,
-) => promise<queryResponse<array<ReorgDetection.blockData>>>
+) => promise<queryResponse<array<ReorgDetection.blockDataWithTimestamp>>>
 
 let mapExn: queryResponse<'a> => result<'a, exn>
 let getExn: queryResponse<'a> => 'a

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/rpc/RpcSource.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/rpc/RpcSource.res
@@ -341,7 +341,6 @@ let make = ({syncConfig, provider, chain, contracts, eventRouter}: options): t =
         }),
         lastBlockScannedData: {
           blockNumber: latestFetchedBlock.number,
-          blockTimestamp: latestFetchedBlock.timestamp,
           blockHash: latestFetchedBlock.hash,
         },
       }
@@ -368,8 +367,8 @@ let make = ({syncConfig, provider, chain, contracts, eventRouter}: options): t =
     ->Promise.all
     ->Promise.thenResolve(blocks => {
       blocks
-      ->Array.map(b => {
-        ReorgDetection.blockNumber: b.number,
+      ->Array.map((b): ReorgDetection.blockDataWithTimestamp => {
+        blockNumber: b.number,
         blockHash: b.hash,
         blockTimestamp: b.timestamp,
       })

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -358,104 +358,106 @@ let handlePartitionQueryResponse = (
     "stats": stats,
   })
 
-  let hasReorgOccurred =
-    chainFetcher.lastBlockScannedHashes->ReorgDetection.LastBlockScannedHashes.hasReorgOccurred(
-      ~reorgGuard,
-    )
-
-  if !hasReorgOccurred || !(state.config->Config.shouldRollbackOnReorg) {
-    if hasReorgOccurred {
-      chainFetcher.logger->Logging.childInfo(
-        "Reorg detected, not rolling back due to configuration",
-      )
+  switch chainFetcher.lastBlockScannedHashes->ReorgDetection.LastBlockScannedHashes.registerReorgGuard(
+    ~reorgGuard,
+  ) {
+  | Error(_) if state.config->Config.shouldRollbackOnReorg => {
+      chainFetcher.logger->Logging.childInfo("Reorg detected, rolling back")
       Prometheus.incrementReorgsDetected(~chain)
+      (state->incrementId->setRollingBack(chain), [Rollback])
     }
+  | reorgResult => {
+      let lastBlockScannedHashes = switch reorgResult {
+      | Ok(lastBlockScannedHashes) => lastBlockScannedHashes
+      | Error(_) => {
+          chainFetcher.logger->Logging.childInfo(
+            "Reorg detected, not rolling back due to configuration",
+          )
+          Prometheus.incrementReorgsDetected(~chain)
+          chainFetcher.lastBlockScannedHashes
+        }
+      }
+      let updatedChainFetcher =
+        chainFetcher
+        ->ChainFetcher.setQueryResponse(
+          ~query,
+          ~currentBlockHeight,
+          ~latestFetchedBlockTimestamp,
+          ~latestFetchedBlockNumber,
+          ~fetchedEvents=parsedQueueItems,
+        )
+        ->Utils.unwrapResultExn
+        ->updateChainFetcherCurrentBlockHeight(~currentBlockHeight)
 
-    let updatedChainFetcher =
-      chainFetcher
-      ->ChainFetcher.setQueryResponse(
-        ~query,
-        ~currentBlockHeight,
-        ~latestFetchedBlockTimestamp,
-        ~latestFetchedBlockNumber,
-        ~fetchedEvents=parsedQueueItems,
+      let hasArbQueueEvents = state.chainManager->ChainManager.hasChainItemsOnArbQueue(~chain)
+      let hasNoMoreEventsToProcess =
+        updatedChainFetcher->ChainFetcher.hasNoMoreEventsToProcess(~hasArbQueueEvents)
+
+      let latestProcessedBlock = if hasNoMoreEventsToProcess {
+        FetchState.getLatestFullyFetchedBlock(updatedChainFetcher.fetchState).blockNumber->Some
+      } else {
+        updatedChainFetcher.latestProcessedBlock
+      }
+
+      let updatedChainFetcher = {
+        ...updatedChainFetcher,
+        latestProcessedBlock,
+        numBatchesFetched: updatedChainFetcher.numBatchesFetched + 1,
+      }
+
+      let wasFetchingAtHead = ChainFetcher.isFetchingAtHead(chainFetcher)
+      let isCurrentlyFetchingAtHead = ChainFetcher.isFetchingAtHead(updatedChainFetcher)
+
+      if !wasFetchingAtHead && isCurrentlyFetchingAtHead {
+        updatedChainFetcher.logger->Logging.childInfo("All events have been fetched")
+      }
+
+      let chainManager = {
+        ...state.chainManager,
+        chainFetchers: state.chainManager.chainFetchers->ChainMap.set(chain, updatedChainFetcher),
+      }->ChainManager.updateLastBlockScannedHashes(
+        ~chain,
+        ~lastBlockScannedHashes,
+        ~currentHeight=currentBlockHeight,
       )
-      ->Utils.unwrapResultExn
-      ->updateChainFetcherCurrentBlockHeight(~currentBlockHeight)
 
-    let hasArbQueueEvents = state.chainManager->ChainManager.hasChainItemsOnArbQueue(~chain)
-    let hasNoMoreEventsToProcess =
-      updatedChainFetcher->ChainFetcher.hasNoMoreEventsToProcess(~hasArbQueueEvents)
+      let updateEndOfBlockRangeScannedDataArr =
+        //Only update endOfBlockRangeScannedData if rollbacks are enabled
+        state.config->Config.shouldRollbackOnReorg
+          ? [
+              UpdateEndOfBlockRangeScannedData({
+                chain,
+                blockNumberThreshold: lastBlockScannedData.blockNumber -
+                updatedChainFetcher.chainConfig.confirmedBlockThreshold,
+                blockTimestampThreshold: chainManager->ChainManager.getEarliestMultiChainTimestampInThreshold,
+                nextEndOfBlockRangeScannedData: {
+                  chainId: chain->ChainMap.Chain.toChainId,
+                  blockNumber: lastBlockScannedData.blockNumber,
+                  blockTimestamp: lastBlockScannedData.blockTimestamp,
+                  blockHash: lastBlockScannedData.blockHash,
+                },
+              }),
+            ]
+          : []
 
-    let latestProcessedBlock = if hasNoMoreEventsToProcess {
-      FetchState.getLatestFullyFetchedBlock(updatedChainFetcher.fetchState).blockNumber->Some
-    } else {
-      updatedChainFetcher.latestProcessedBlock
+      let nextState = {
+        ...state,
+        chainManager,
+      }
+
+      let processAction =
+        updatedChainFetcher->ChainFetcher.isPreRegisteringDynamicContracts
+          ? PreRegisterDynamicContracts
+          : ProcessEventBatch
+
+      (
+        nextState,
+        Array.concat(
+          updateEndOfBlockRangeScannedDataArr,
+          [UpdateChainMetaDataAndCheckForExit(NoExit), processAction, NextQuery(Chain(chain))],
+        ),
+      )
     }
-
-    let updatedChainFetcher = {
-      ...updatedChainFetcher,
-      latestProcessedBlock,
-      numBatchesFetched: updatedChainFetcher.numBatchesFetched + 1,
-    }
-
-    let wasFetchingAtHead = ChainFetcher.isFetchingAtHead(chainFetcher)
-    let isCurrentlyFetchingAtHead = ChainFetcher.isFetchingAtHead(updatedChainFetcher)
-
-    if !wasFetchingAtHead && isCurrentlyFetchingAtHead {
-      updatedChainFetcher.logger->Logging.childInfo("All events have been fetched")
-    }
-
-    let chainManager = {
-      ...state.chainManager,
-      chainFetchers: state.chainManager.chainFetchers->ChainMap.set(chain, updatedChainFetcher),
-    }->ChainManager.addLastBlockScannedData(
-      ~chain,
-      ~lastBlockScannedData,
-      ~currentHeight=currentBlockHeight,
-    )
-
-    let updateEndOfBlockRangeScannedDataArr =
-      //Only update endOfBlockRangeScannedData if rollbacks are enabled
-      state.config->Config.shouldRollbackOnReorg
-        ? [
-            UpdateEndOfBlockRangeScannedData({
-              chain,
-              blockNumberThreshold: lastBlockScannedData.blockNumber -
-              updatedChainFetcher.chainConfig.confirmedBlockThreshold,
-              blockTimestampThreshold: chainManager
-              ->ChainManager.getEarliestMultiChainTimestampInThreshold,
-              nextEndOfBlockRangeScannedData: {
-                chainId: chain->ChainMap.Chain.toChainId,
-                blockNumber: lastBlockScannedData.blockNumber,
-                blockTimestamp: lastBlockScannedData.blockTimestamp,
-                blockHash: lastBlockScannedData.blockHash,
-              },
-            }),
-          ]
-        : []
-
-    let nextState = {
-      ...state,
-      chainManager,
-    }
-
-    let processAction =
-      updatedChainFetcher->ChainFetcher.isPreRegisteringDynamicContracts
-        ? PreRegisterDynamicContracts
-        : ProcessEventBatch
-
-    (
-      nextState,
-      Array.concat(
-        updateEndOfBlockRangeScannedDataArr,
-        [UpdateChainMetaDataAndCheckForExit(NoExit), processAction, NextQuery(Chain(chain))],
-      ),
-    )
-  } else {
-    chainFetcher.logger->Logging.childInfo("Reorg detected, rolling back")
-    Prometheus.incrementReorgsDetected(~chain)
-    (state->incrementId->setRollingBack(chain), [Rollback])
   }
 }
 
@@ -802,7 +804,7 @@ let injectedTaskReducer = (
   //Used for dependency injection for tests
   ~waitForNewBlock,
   ~executeQuery,
-  ~rollbackLastBlockHashesToReorgLocation,
+  ~getLastKnownValidBlock,
 ) => async (
   //required args
   state: t,
@@ -1089,13 +1091,11 @@ let injectedTaskReducer = (
 
       let chainFetcher = state.chainManager.chainFetchers->ChainMap.get(reorgChain)
 
-      //Rollback the lastBlockScannedHashes to a point before blockhashes diverged
-      let reorgChainRolledBackLastBlockData =
-        await chainFetcher->rollbackLastBlockHashesToReorgLocation
-
-      //Get the last known valid block that was scanned on the reorg chain
-      let {blockNumber: lastKnownValidBlockNumber, blockTimestamp: lastKnownValidBlockTimestamp} =
-        reorgChainRolledBackLastBlockData->ChainFetcher.getLastScannedBlockData
+      let {
+        blockNumber: lastKnownValidBlockNumber,
+        blockTimestamp: lastKnownValidBlockTimestamp,
+      }: ReorgDetection.blockData =
+        await chainFetcher->getLastKnownValidBlock
 
       let isUnorderedMultichainMode = state.config.isUnorderedMultichainMode
 
@@ -1137,11 +1137,7 @@ let injectedTaskReducer = (
               ~blockNumber=firstChangeEvent.blockNumber,
             )
 
-          let fetchState =
-            cf.fetchState->FetchState.rollback(
-              ~lastScannedBlock=rolledBackLastBlockData->ChainFetcher.getLastScannedBlockData,
-              ~firstChangeEvent,
-            )
+          let fetchState = cf.fetchState->FetchState.rollback(~firstChangeEvent)
 
           let rolledBackCf = {
             ...cf,
@@ -1168,16 +1164,11 @@ let injectedTaskReducer = (
         }
       })
 
-      let reorgChainLastBlockScannedData = {
-        let reorgChainFetcher = chainFetchers->ChainMap.get(reorgChain)
-        reorgChainFetcher.lastBlockScannedHashes->ChainFetcher.getLastScannedBlockData
-      }
-
       //Construct a rolledback in Memory store
       let inMemoryStore = await IO.RollBack.rollBack(
         ~chainId=reorgChain->ChainMap.Chain.toChainId,
-        ~blockTimestamp=reorgChainLastBlockScannedData.blockTimestamp,
-        ~blockNumber=reorgChainLastBlockScannedData.blockNumber,
+        ~blockTimestamp=lastKnownValidBlockTimestamp,
+        ~blockNumber=lastKnownValidBlockNumber,
         ~logIndex=0,
         ~isUnorderedMultichainMode,
       )
@@ -1197,5 +1188,5 @@ let injectedTaskReducer = (
 let taskReducer = injectedTaskReducer(
   ~waitForNewBlock=Source.waitForNewBlock,
   ~executeQuery,
-  ~rollbackLastBlockHashesToReorgLocation=ChainFetcher.rollbackLastBlockHashesToReorgLocation(_),
+  ~getLastKnownValidBlock=ChainFetcher.getLastKnownValidBlock(_),
 )

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -374,7 +374,7 @@ let handlePartitionQueryResponse = (
             "Reorg detected, not rolling back due to configuration",
           )
           Prometheus.incrementReorgsDetected(~chain)
-          chainFetcher.lastBlockScannedHashes
+          ReorgDetection.LastBlockScannedHashes.empty(~confirmedBlockThreshold=chainFetcher.chainConfig.confirmedBlockThreshold)
         }
       }
       let updatedChainFetcher =

--- a/scenarios/erc20_multichain_factory/test/ChainDataHelpers.res
+++ b/scenarios/erc20_multichain_factory/test/ChainDataHelpers.res
@@ -138,8 +138,8 @@ module Stubs = {
     GlobalState.injectedTaskReducer(
       ~executeQuery=makeExecutePartitionQuery(stubData),
       ~waitForNewBlock=makeWaitForNewBlock(stubData),
-      ~rollbackLastBlockHashesToReorgLocation=chainFetcher =>
-        chainFetcher->ChainFetcher.rollbackLastBlockHashesToReorgLocation(
+      ~getLastKnownValidBlock=chainFetcher =>
+        chainFetcher->ChainFetcher.getLastKnownValidBlock(
           ~getBlockHashes=makeGetBlockHashes(~stubData, ~source=chainFetcher.chainConfig.source),
         ),
     )(

--- a/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
@@ -94,7 +94,6 @@ module Mock = {
     ~chain,
     ~blockNumber,
     ~blockNumberThreshold,
-    ~blockTimestampThreshold,
   ) => {
     let (blockNumber, blockTimestamp, blockHash) =
       mcdMap
@@ -108,7 +107,6 @@ module Mock = {
 
     GlobalState.UpdateEndOfBlockRangeScannedData({
       blockNumberThreshold,
-      blockTimestampThreshold,
       chain,
       nextEndOfBlockRangeScannedData: {
         blockNumber,
@@ -205,7 +203,6 @@ describe("Dynamic contract restart resistance test", () => {
             Mock.mockChainDataMap,
             ~chain=Mock.Chain1.chain,
             ~blockNumberThreshold=-199,
-            ~blockTimestampThreshold=Some(25),
             ~blockNumber=1,
           ),
           UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -417,7 +414,6 @@ describe("Dynamic contract restart resistance test", () => {
             Mock.mockChainDataMap,
             ~chain=Mock.Chain1.chain,
             ~blockNumberThreshold=-197,
-            ~blockTimestampThreshold=Some(25),
             ~blockNumber=3,
           ),
           UpdateChainMetaDataAndCheckForExit(NoExit),

--- a/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
@@ -95,15 +95,11 @@ module Mock = {
     ~blockNumber,
     ~blockNumberThreshold,
   ) => {
-    let (blockNumber, blockTimestamp, blockHash) =
+    let (blockNumber, blockHash) =
       mcdMap
       ->ChainMap.get(chain)
       ->MockChainData.getBlock(~blockNumber)
-      ->Option.mapWithDefault((0, 0, "0xstub"), ({blockNumber, blockTimestamp, blockHash}) => (
-        blockNumber,
-        blockTimestamp,
-        blockHash,
-      ))
+      ->Option.mapWithDefault((0, "0xstub"), ({blockNumber, blockHash}) => (blockNumber, blockHash))
 
     GlobalState.UpdateEndOfBlockRangeScannedData({
       blockNumberThreshold,
@@ -111,7 +107,6 @@ module Mock = {
       nextEndOfBlockRangeScannedData: {
         blockNumber,
         blockHash,
-        blockTimestamp,
         chainId: chain->ChainMap.Chain.toChainId,
       },
     })

--- a/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
@@ -103,7 +103,7 @@ ensure that this doesn't trigger a reorg
     ~blockNumber,
     ~blockNumberThreshold,
   ) => {
-    let {blockNumber, blockTimestamp, blockHash} =
+    let {blockNumber, blockHash} =
       mcdMap->ChainMap.get(chain)->MockChainData.getBlock(~blockNumber)->Option.getUnsafe
 
     GlobalState.UpdateEndOfBlockRangeScannedData({
@@ -112,7 +112,6 @@ ensure that this doesn't trigger a reorg
       nextEndOfBlockRangeScannedData: {
         blockNumber,
         blockHash,
-        blockTimestamp,
         chainId: chain->ChainMap.Chain.toChainId,
       },
     })

--- a/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
@@ -102,14 +102,12 @@ ensure that this doesn't trigger a reorg
     ~chain,
     ~blockNumber,
     ~blockNumberThreshold,
-    ~blockTimestampThreshold,
   ) => {
     let {blockNumber, blockTimestamp, blockHash} =
       mcdMap->ChainMap.get(chain)->MockChainData.getBlock(~blockNumber)->Option.getUnsafe
 
     GlobalState.UpdateEndOfBlockRangeScannedData({
       blockNumberThreshold,
-      blockTimestampThreshold,
       chain,
       nextEndOfBlockRangeScannedData: {
         blockNumber,
@@ -276,7 +274,6 @@ describe("Dynamic contract rollback test", () => {
           Mock.mockChainDataMap,
           ~chain=Mock.Chain1.chain,
           ~blockNumberThreshold=-199,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=1,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -286,7 +283,6 @@ describe("Dynamic contract rollback test", () => {
           Mock.mockChainDataMap,
           ~chain=Mock.Chain2.chain,
           ~blockNumberThreshold=-198,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=2,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -331,7 +327,6 @@ describe("Dynamic contract rollback test", () => {
           Mock.mockChainDataMap,
           ~chain=Mock.Chain1.chain,
           ~blockNumberThreshold=-197,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=3,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -341,7 +336,6 @@ describe("Dynamic contract rollback test", () => {
           Mock.mockChainDataMap,
           ~chain=Mock.Chain2.chain,
           ~blockNumberThreshold=-195,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=5,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -379,7 +373,6 @@ describe("Dynamic contract rollback test", () => {
           Mock.mockChainDataMap,
           ~chain=Mock.Chain1.chain,
           ~blockNumberThreshold=-195,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=5,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -389,7 +382,6 @@ describe("Dynamic contract rollback test", () => {
           Mock.mockChainDataMap,
           ~chain=Mock.Chain2.chain,
           ~blockNumberThreshold=-192,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=8,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -451,7 +443,6 @@ describe("Dynamic contract rollback test", () => {
           Mock.mockChainDataMap,
           ~chain=Mock.Chain1.chain,
           ~blockNumberThreshold=-196,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=4,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -461,7 +452,6 @@ describe("Dynamic contract rollback test", () => {
           Mock.mockChainDataMap,
           ~chain=Mock.Chain2.chain,
           ~blockNumberThreshold=-191,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=9,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),

--- a/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
@@ -172,14 +172,12 @@ module Mock = {
     ~chain,
     ~blockNumber,
     ~blockNumberThreshold,
-    ~blockTimestampThreshold,
   ) => {
     let {blockNumber, blockTimestamp, blockHash} =
       mcdMap->ChainMap.get(chain)->MockChainData.getBlock(~blockNumber)->Option.getUnsafe
 
     GlobalState.UpdateEndOfBlockRangeScannedData({
       blockNumberThreshold,
-      blockTimestampThreshold,
       chain,
       nextEndOfBlockRangeScannedData: {
         blockNumber,
@@ -373,7 +371,6 @@ describe("Multichain rollback test", () => {
           Mock.mockChainDataMapInitial,
           ~chain=Mock.Chain1.chain,
           ~blockNumberThreshold=-199,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=1,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -383,7 +380,6 @@ describe("Multichain rollback test", () => {
           Mock.mockChainDataMapInitial,
           ~chain=Mock.Chain2.chain,
           ~blockNumberThreshold=-198,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=2,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -428,7 +424,6 @@ describe("Multichain rollback test", () => {
           Mock.mockChainDataMapInitial,
           ~chain=Mock.Chain1.chain,
           ~blockNumberThreshold=-197,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=3,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -438,7 +433,6 @@ describe("Multichain rollback test", () => {
           Mock.mockChainDataMapInitial,
           ~chain=Mock.Chain2.chain,
           ~blockNumberThreshold=-195,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=5,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -469,7 +463,6 @@ describe("Multichain rollback test", () => {
           Mock.mockChainDataMapInitial,
           ~chain=Mock.Chain1.chain,
           ~blockNumberThreshold=-195,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=5,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -479,7 +472,6 @@ describe("Multichain rollback test", () => {
           Mock.mockChainDataMapInitial,
           ~chain=Mock.Chain2.chain,
           ~blockNumberThreshold=-192,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=8,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),
@@ -525,7 +517,6 @@ describe("Multichain rollback test", () => {
           Mock.mockChainDataMapInitial,
           ~chain=Mock.Chain2.chain,
           ~blockNumberThreshold=-191,
-          ~blockTimestampThreshold=Some(25),
           ~blockNumber=9,
         ),
         UpdateChainMetaDataAndCheckForExit(NoExit),

--- a/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
@@ -173,7 +173,7 @@ module Mock = {
     ~blockNumber,
     ~blockNumberThreshold,
   ) => {
-    let {blockNumber, blockTimestamp, blockHash} =
+    let {blockNumber, blockHash} =
       mcdMap->ChainMap.get(chain)->MockChainData.getBlock(~blockNumber)->Option.getUnsafe
 
     GlobalState.UpdateEndOfBlockRangeScannedData({
@@ -182,7 +182,6 @@ module Mock = {
       nextEndOfBlockRangeScannedData: {
         blockNumber,
         blockHash,
-        blockTimestamp,
         chainId: chain->ChainMap.Chain.toChainId,
       },
     })

--- a/scenarios/erc20_multichain_factory/test/TestDeleteEntity.res
+++ b/scenarios/erc20_multichain_factory/test/TestDeleteEntity.res
@@ -79,14 +79,12 @@ module Mock = {
     ~chain,
     ~blockNumber,
     ~blockNumberThreshold,
-    ~blockTimestampThreshold,
   ) => {
     let {blockNumber, blockTimestamp, blockHash} =
       mcdMap->ChainMap.get(chain)->MockChainData.getBlock(~blockNumber)->Option.getUnsafe
 
     GlobalState.UpdateEndOfBlockRangeScannedData({
       blockNumberThreshold,
-      blockTimestampThreshold,
       chain,
       nextEndOfBlockRangeScannedData: {
         blockNumber,

--- a/scenarios/erc20_multichain_factory/test/TestDeleteEntity.res
+++ b/scenarios/erc20_multichain_factory/test/TestDeleteEntity.res
@@ -80,7 +80,7 @@ module Mock = {
     ~blockNumber,
     ~blockNumberThreshold,
   ) => {
-    let {blockNumber, blockTimestamp, blockHash} =
+    let {blockNumber, blockHash} =
       mcdMap->ChainMap.get(chain)->MockChainData.getBlock(~blockNumber)->Option.getUnsafe
 
     GlobalState.UpdateEndOfBlockRangeScannedData({
@@ -89,7 +89,6 @@ module Mock = {
       nextEndOfBlockRangeScannedData: {
         blockNumber,
         blockHash,
-        blockTimestamp,
         chainId: chain->ChainMap.Chain.toChainId,
       },
     })

--- a/scenarios/erc20_multichain_factory/test/TestWhereQuery.res
+++ b/scenarios/erc20_multichain_factory/test/TestWhereQuery.res
@@ -81,14 +81,12 @@ module Mock = {
     ~chain,
     ~blockNumber,
     ~blockNumberThreshold,
-    ~blockTimestampThreshold,
   ) => {
     let {blockNumber, blockTimestamp, blockHash} =
       mcdMap->ChainMap.get(chain)->MockChainData.getBlock(~blockNumber)->Option.getUnsafe
 
     GlobalState.UpdateEndOfBlockRangeScannedData({
       blockNumberThreshold,
-      blockTimestampThreshold,
       chain,
       nextEndOfBlockRangeScannedData: {
         blockNumber,

--- a/scenarios/erc20_multichain_factory/test/TestWhereQuery.res
+++ b/scenarios/erc20_multichain_factory/test/TestWhereQuery.res
@@ -82,7 +82,7 @@ module Mock = {
     ~blockNumber,
     ~blockNumberThreshold,
   ) => {
-    let {blockNumber, blockTimestamp, blockHash} =
+    let {blockNumber, blockHash} =
       mcdMap->ChainMap.get(chain)->MockChainData.getBlock(~blockNumber)->Option.getUnsafe
 
     GlobalState.UpdateEndOfBlockRangeScannedData({
@@ -91,7 +91,6 @@ module Mock = {
       nextEndOfBlockRangeScannedData: {
         blockNumber,
         blockHash,
-        blockTimestamp,
         chainId: chain->ChainMap.Chain.toChainId,
       },
     })

--- a/scenarios/helpers/src/ChainMocking.res
+++ b/scenarios/helpers/src/ChainMocking.res
@@ -288,7 +288,6 @@ module Make = (Indexer: Indexer.S) => {
         lastBlockScannedData: {
           blockHash: heighstBlock.blockHash,
           blockNumber: heighstBlock.blockNumber,
-          blockTimestamp: heighstBlock.blockTimestamp,
         },
         firstBlockParentNumberAndHash,
       },

--- a/scenarios/helpers/src/ChainMocking.res
+++ b/scenarios/helpers/src/ChainMocking.res
@@ -304,8 +304,12 @@ module Make = (Indexer: Indexer.S) => {
     blockNumbers->Array.keepMap(blockNumber =>
       self
       ->getBlock(~blockNumber)
-      ->Option.map(({blockTimestamp, blockHash, blockNumber}) => {
-        ReorgDetection.blockTimestamp,
+      ->Option.map(({
+        blockTimestamp,
+        blockHash,
+        blockNumber,
+      }): ReorgDetection.blockDataWithTimestamp => {
+        blockTimestamp,
         blockHash,
         blockNumber,
       })

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -118,7 +118,7 @@ module type S = {
       getBlockHashes: (
         ~blockNumbers: array<int>,
         ~logger: Pino.t,
-      ) => promise<result<array<ReorgDetection.blockData>, exn>>,
+      ) => promise<result<array<ReorgDetection.blockDataWithTimestamp>, exn>>,
       getHeightOrThrow: unit => promise<int>,
       fetchBlockRange: (
         ~fromBlock: int,

--- a/scenarios/test_codegen/test/ReorgDetection_test.res
+++ b/scenarios/test_codegen/test/ReorgDetection_test.res
@@ -4,19 +4,13 @@ open Belt
 open ReorgDetection
 
 describe("Validate reorg detection functions", () => {
-  let lastBlockScannedHashesArr = [
-    (1, "0x123", 123),
-    (50, "0x456", 456),
-    (300, "0x789", 789),
-    (500, "0x5432", 5432),
-  ]
+  let lastBlockScannedHashesArr = [(1, "0x123"), (50, "0x456"), (300, "0x789"), (500, "0x5432")]
 
   let intoLastBlockScannedHashesHelper = arr =>
     arr
-    ->Array.map(((blockNumber, blockHash, blockTimestamp)) => {
+    ->Array.map(((blockNumber, blockHash)) => {
       blockNumber,
       blockHash,
-      blockTimestamp,
     })
     ->LastBlockScannedHashes.makeWithData(~confirmedBlockThreshold=200)
 

--- a/scenarios/test_codegen/test/ReorgDetection_test.res
+++ b/scenarios/test_codegen/test/ReorgDetection_test.res
@@ -3,73 +3,299 @@ open RescriptMocha
 open Belt
 open ReorgDetection
 
-describe("Validate reorg detection functions", () => {
-  let lastBlockScannedHashesArr = [(1, "0x123"), (50, "0x456"), (300, "0x789"), (500, "0x5432")]
+describe_only("Validate reorg detection functions", () => {
+  let scannedHashesFixture = [(1, "0x123"), (50, "0x456"), (300, "0x789"), (500, "0x5432")]
 
-  let intoLastBlockScannedHashesHelper = arr =>
+  let mock = (arr, ~confirmedBlockThreshold=200) => {
     arr
     ->Array.map(((blockNumber, blockHash)) => {
       blockNumber,
       blockHash,
     })
-    ->LastBlockScannedHashes.makeWithData(~confirmedBlockThreshold=200)
+    ->LastBlockScannedHashes.makeWithData(~confirmedBlockThreshold)
+  }
 
-  let lastBlockScannedHashes = lastBlockScannedHashesArr->intoLastBlockScannedHashesHelper
+  it("getThresholdBlockNumbers works as expected", () => {
+    Assert.deepEqual(
+      mock(
+        scannedHashesFixture,
+        ~confirmedBlockThreshold=200,
+      )->ReorgDetection.LastBlockScannedHashes.getThresholdBlockNumbers(~currentBlockHeight=500),
+      [300, 500],
+      ~message="Both 300 and 500 should be included in the threshold",
+    )
+    Assert.deepEqual(
+      mock(
+        scannedHashesFixture,
+        ~confirmedBlockThreshold=200,
+      )->ReorgDetection.LastBlockScannedHashes.getThresholdBlockNumbers(~currentBlockHeight=501),
+      [500],
+      ~message="If chain progresses one more block, 300 is not included in the threshold anymore",
+    )
+    Assert.deepEqual(
+      mock(
+        scannedHashesFixture,
+        ~confirmedBlockThreshold=200,
+      )->ReorgDetection.LastBlockScannedHashes.getThresholdBlockNumbers(~currentBlockHeight=499),
+      [300, 500],
+      ~message="We don't prevent blocks higher than currentBlockHeight from being included in the threshold, since the case is not possible",
+    )
+    Assert.deepEqual(
+      mock(
+        [(300, "0x789"), (50, "0x456"), (500, "0x5432"), (1, "0x123")],
+        ~confirmedBlockThreshold=200,
+      )->ReorgDetection.LastBlockScannedHashes.getThresholdBlockNumbers(~currentBlockHeight=500),
+      [300, 500],
+      ~message="The order of blocks doesn't matter when we create reorg detection object",
+    )
+    Assert.deepEqual(
+      mock(
+        scannedHashesFixture,
+        ~confirmedBlockThreshold=199,
+      )->ReorgDetection.LastBlockScannedHashes.getThresholdBlockNumbers(~currentBlockHeight=500),
+      [500],
+      ~message="Possible to shrink confirmedBlockThreshold",
+    )
+    Assert.deepEqual(
+      mock(
+        scannedHashesFixture,
+        ~confirmedBlockThreshold=450,
+      )->ReorgDetection.LastBlockScannedHashes.getThresholdBlockNumbers(~currentBlockHeight=500),
+      [50, 300, 500],
+      ~message="Possible to increase confirmedBlockThreshold",
+    )
+  })
 
-  // it("Get Latest and Add Latest Work", () => {
-  //   Assert.deepEqual(
-  //     Some({blockNumber: 500, blockHash: "0x5432", blockTimestamp: 5432}),
-  //     lastBlockScannedHashes->LastBlockScannedHashes.getLatestLastBlockData,
-  //   )
+  it("The registerReorgGuard should correctly add scanned data", () => {
+    let currentBlockHeight = 500
 
-  //   let nextLastBlockScanned = {
-  //     blockNumber: 700,
-  //     blockHash: "0x7654",
-  //     blockTimestamp: 7654,
-  //   }
+    let reorgDetection =
+      ReorgDetection.LastBlockScannedHashes.empty(~confirmedBlockThreshold=500)
+      ->ReorgDetection.LastBlockScannedHashes.registerReorgGuard(
+        ~reorgGuard={
+          lastBlockScannedData: {
+            blockNumber: 1,
+            blockHash: "0x123",
+          },
+          firstBlockParentNumberAndHash: None,
+        },
+        ~currentBlockHeight,
+      )
+      ->Result.getExn
+      ->ReorgDetection.LastBlockScannedHashes.registerReorgGuard(
+        ~reorgGuard={
+          lastBlockScannedData: {
+            blockNumber: 50,
+            blockHash: "0x456",
+          },
+          firstBlockParentNumberAndHash: Some({
+            blockNumber: 1,
+            blockHash: "0x123",
+          }),
+        },
+        ~currentBlockHeight,
+      )
+      ->Result.getExn
+      ->ReorgDetection.LastBlockScannedHashes.registerReorgGuard(
+        ~reorgGuard={
+          lastBlockScannedData: {
+            blockNumber: 300,
+            blockHash: "0x789",
+          },
+          firstBlockParentNumberAndHash: Some({
+            blockNumber: 50,
+            blockHash: "0x456",
+          }),
+        },
+        ~currentBlockHeight,
+      )
+      ->Result.getExn
+      ->ReorgDetection.LastBlockScannedHashes.registerReorgGuard(
+        ~reorgGuard={
+          lastBlockScannedData: {
+            blockNumber: 500,
+            blockHash: "0x5432",
+          },
+          firstBlockParentNumberAndHash: Some({
+            blockNumber: 300,
+            blockHash: "0x789",
+          }),
+        },
+        ~currentBlockHeight,
+      )
+      ->Result.getExn
 
-  //   let lastBlockScannedHashes =
-  //     lastBlockScannedHashes->LastBlockScannedHashes.registerReorgGuard(
-  //       ~lastBlockScannedData=nextLastBlockScanned,
-  //     )
+    Assert.deepEqual(
+      reorgDetection,
+      mock(scannedHashesFixture, ~confirmedBlockThreshold=500),
+      ~message="Should have the same data as the mock",
+    )
+  })
 
-  //   Assert.deepEqual(
-  //     Some(nextLastBlockScanned),
-  //     lastBlockScannedHashes->LastBlockScannedHashes.getLatestLastBlockData,
-  //   )
-  // })
+  it(
+    "The firstBlockParentNumberAndHash in reorg guard should add a scanned block data to reorg detection",
+    () => {
+      let currentBlockHeight = 500
+      let reorgDetection =
+        ReorgDetection.LastBlockScannedHashes.empty(~confirmedBlockThreshold=200)
+        ->ReorgDetection.LastBlockScannedHashes.registerReorgGuard(
+          ~reorgGuard={
+            lastBlockScannedData: {
+              blockNumber: 50,
+              blockHash: "0x456",
+            },
+            firstBlockParentNumberAndHash: Some({
+              blockNumber: 1,
+              blockHash: "0x123",
+            }),
+          },
+          ~currentBlockHeight,
+        )
+        ->Result.getExn
 
-  // it("Pruning works as expected", () => {
-  //   let pruned =
-  //     lastBlockScannedHashes->LastBlockScannedHashes.pruneStaleBlockData(
-  //       ~currentHeight=500,
-  //       ~earliestMultiChainTimestampInThreshold=None,
-  //     )
+      Assert.deepEqual(
+        reorgDetection,
+        mock([(1, "0x123"), (50, "0x456")], ~confirmedBlockThreshold=200),
+        ~message="Should add two records. One for lastBlockScannedData and one for firstBlockParentNumberAndHash",
+      )
+    },
+  )
 
-  //   let expected = [(300, "0x789", 789), (500, "0x5432", 5432)]->intoLastBlockScannedHashesHelper
+  it("Should prune records outside of the reorg threshold on registering new data", () => {
+    let reorgDetection =
+      mock([(1, "0x1"), (2, "0x2"), (3, "0x3")], ~confirmedBlockThreshold=2)
+      ->ReorgDetection.LastBlockScannedHashes.registerReorgGuard(
+        ~reorgGuard={
+          lastBlockScannedData: {
+            blockNumber: 4,
+            blockHash: "0x4",
+          },
+          firstBlockParentNumberAndHash: Some({
+            blockNumber: 3,
+            blockHash: "0x3",
+          }),
+        },
+        ~currentBlockHeight=4,
+      )
+      ->Result.getExn
 
-  //   Assert.deepEqual(expected, pruned, ~message="Should prune up to the block threshold")
+    Assert.deepEqual(
+      reorgDetection,
+      mock([(2, "0x2"), (3, "0x3"), (4, "0x4")], ~confirmedBlockThreshold=2),
+      ~message="Should prune 1 since it's outside of reorg threshold", // Keeping block n 2 is questionable
+    )
+  })
 
-  //   let prunedWithMinTimestamp =
-  //     lastBlockScannedHashes->LastBlockScannedHashes.pruneStaleBlockData(
-  //       ~currentHeight=500,
-  //       ~earliestMultiChainTimestampInThreshold=Some(470),
-  //     )
-  //   let expected =
-  //     [
-  //       (50, "0x456", 456),
-  //       (300, "0x789", 789),
-  //       (500, "0x5432", 5432),
-  //     ]->intoLastBlockScannedHashesHelper
+  it("Shouldn't validate reorg detection if it's outside of the reorg threshold", () => {
+    let reorgDetection =
+      mock(scannedHashesFixture, ~confirmedBlockThreshold=200)
+      ->ReorgDetection.LastBlockScannedHashes.registerReorgGuard(
+        ~reorgGuard={
+          lastBlockScannedData: {
+            blockNumber: 50,
+            blockHash: "0x50-invalid",
+          },
+          firstBlockParentNumberAndHash: Some({
+            blockNumber: 20,
+            blockHash: "0x20-invalid",
+          }),
+        },
+        ~currentBlockHeight=500,
+      )
+      ->Result.getExn
 
-  //   Assert.deepEqual(
-  //     expected,
-  //     prunedWithMinTimestamp,
-  //     ~message="Should keep one range end before the earliestMultiChainTimestampInThreshold",
-  //   )
-  // })
+    Assert.deepEqual(
+      reorgDetection,
+      mock(
+        [(20, "0x20-invalid"), (50, "0x50-invalid"), (300, "0x789"), (500, "0x5432")],
+        ~confirmedBlockThreshold=200,
+      ),
+      ~message="Prunes original blocks at 1 and 50. It writes invalid data for block 20 and 50, but they are outside of the reorg thershold, so we don't care",
+    )
+  })
 
-  it("Rolling back to matching hashes works as expected", () => {
+  it("Should detect reorg when lastBlockScannedData hash doesn't match the scanned block", () => {
+    let reorgGuard = {
+      lastBlockScannedData: {
+        blockNumber: 10,
+        blockHash: "0x10-invalid",
+      },
+      firstBlockParentNumberAndHash: None,
+    }
+
+    let reorgDetectionResult =
+      mock(
+        [(10, "0x10")],
+        ~confirmedBlockThreshold=2,
+      )->ReorgDetection.LastBlockScannedHashes.registerReorgGuard(
+        ~reorgGuard,
+        ~currentBlockHeight=10,
+      )
+
+    Assert.deepEqual(
+      reorgDetectionResult,
+      Error({
+        scannedBlock: {
+          blockNumber: 10,
+          blockHash: "0x10",
+        },
+        reorgGuard,
+      }),
+    )
+  })
+
+  it(
+    "Should detect reorg when firstBlockParentNumberAndHash hash doesn't match the scanned block",
+    () => {
+      let reorgGuard = {
+        lastBlockScannedData: {
+          blockNumber: 11,
+          blockHash: "0x11",
+        },
+        firstBlockParentNumberAndHash: Some({
+          blockNumber: 10,
+          blockHash: "0x10-invalid",
+        }),
+      }
+
+      let reorgDetectionResult =
+        mock(
+          [(10, "0x10")],
+          ~confirmedBlockThreshold=2,
+        )->ReorgDetection.LastBlockScannedHashes.registerReorgGuard(
+          ~reorgGuard,
+          ~currentBlockHeight=11,
+        )
+
+      Assert.deepEqual(
+        reorgDetectionResult,
+        Error({
+          scannedBlock: {
+            blockNumber: 10,
+            blockHash: "0x10",
+          },
+          reorgGuard,
+        }),
+      )
+    },
+  )
+
+  it("rollbackToValidBlockNumber works as expected", () => {
+    let reorgDetection = mock(scannedHashesFixture, ~confirmedBlockThreshold=200)
+
+    Assert.deepEqual(
+      reorgDetection->LastBlockScannedHashes.rollbackToValidBlockNumber(~blockNumber=500),
+      reorgDetection,
+      ~message="Shouldn't prune anything when the latest block number is the valid one",
+    )
+    Assert.deepEqual(
+      reorgDetection->LastBlockScannedHashes.rollbackToValidBlockNumber(~blockNumber=499),
+      mock([(1, "0x123"), (50, "0x456"), (300, "0x789")], ~confirmedBlockThreshold=200),
+      ~message="Shouldn't prune blocks outside of the threshold. Would be nice, but it doesn't matter",
+    )
+  })
+
+  it("Correctly finds the latest valid scanned block", () => {
     let unusedBlockTimestamp = -1
     let blockNumbersAndHashes = [
       (1, "0x123", unusedBlockTimestamp),
@@ -84,12 +310,85 @@ describe("Validate reorg detection functions", () => {
       },
     )
 
-    let validScannedBlock =
-      lastBlockScannedHashes->LastBlockScannedHashes.getLatestValidScannedBlock(
+    Assert.deepEqual(
+      mock(
+        scannedHashesFixture,
+        ~confirmedBlockThreshold=500,
+      )->LastBlockScannedHashes.getLatestValidScannedBlock(
         ~blockNumbersAndHashes,
         ~currentBlockHeight=500,
-      )
+      ),
+      Some({
+        blockNumber: 50,
+        blockHash: "0x456",
+        blockTimestamp: unusedBlockTimestamp,
+      }),
+      ~message="Should return the latest non-different block if we assume that all blocks are in the threshold",
+    )
+    Assert.deepEqual(
+      mock(
+        scannedHashesFixture,
+        ~confirmedBlockThreshold=200,
+      )->LastBlockScannedHashes.getLatestValidScannedBlock(
+        ~blockNumbersAndHashes,
+        ~currentBlockHeight=500,
+      ),
+      None,
+      ~message="Returns None if there's no valid block in threshold",
+    )
 
-    Assert.deepEqual(validScannedBlock, None, ~message="Should prune up to the block threshold")
+    let blockNumbersAndHashes = [
+      (1, "0x123", unusedBlockTimestamp),
+      (50, "0x456", unusedBlockTimestamp),
+      (300, "0x789differnt", unusedBlockTimestamp),
+      (500, "0x5432", unusedBlockTimestamp),
+    ]->Array.map(
+      ((blockNumber, blockHash, blockTimestamp)): ReorgDetection.blockDataWithTimestamp => {
+        blockNumber,
+        blockHash,
+        blockTimestamp,
+      },
+    )
+    Assert.deepEqual(
+      mock(
+        scannedHashesFixture,
+        ~confirmedBlockThreshold=500,
+      )->LastBlockScannedHashes.getLatestValidScannedBlock(
+        ~blockNumbersAndHashes,
+        ~currentBlockHeight=500,
+      ),
+      Some({
+        blockNumber: 50,
+        blockHash: "0x456",
+        blockTimestamp: unusedBlockTimestamp,
+      }),
+      ~message="Case when the different block is in between of valid ones",
+    )
+    Assert.deepEqual(
+      mock(
+        scannedHashesFixture,
+        ~confirmedBlockThreshold=200,
+      )->LastBlockScannedHashes.getLatestValidScannedBlock(
+        ~blockNumbersAndHashes,
+        ~currentBlockHeight=500,
+      ),
+      None,
+      ~message="Returns None if the different block is the last one in the threshold",
+    )
+    Assert.deepEqual(
+      mock(
+        scannedHashesFixture,
+        ~confirmedBlockThreshold=200,
+      )->LastBlockScannedHashes.getLatestValidScannedBlock(
+        ~blockNumbersAndHashes,
+        ~currentBlockHeight=501,
+      ),
+      Some({
+        blockNumber: 500,
+        blockHash: "0x5432",
+        blockTimestamp: unusedBlockTimestamp,
+      }),
+      ~message="Ignores invalid blocks outside of the threshold",
+    )
   })
 })

--- a/scenarios/test_codegen/test/ReorgDetection_test.res
+++ b/scenarios/test_codegen/test/ReorgDetection_test.res
@@ -45,44 +45,35 @@ describe("Validate reorg detection functions", () => {
   //   )
   // })
 
-  it("Earliest timestamp in threshold works as expected", () => {
-    Assert.deepEqual(
-      Some(789),
-      lastBlockScannedHashes->LastBlockScannedHashes.getEarlistTimestampInThreshold(
-        ~currentHeight=500,
-      ),
-    )
-  })
+  // it("Pruning works as expected", () => {
+  //   let pruned =
+  //     lastBlockScannedHashes->LastBlockScannedHashes.pruneStaleBlockData(
+  //       ~currentHeight=500,
+  //       ~earliestMultiChainTimestampInThreshold=None,
+  //     )
 
-  it("Pruning works as expected", () => {
-    let pruned =
-      lastBlockScannedHashes->LastBlockScannedHashes.pruneStaleBlockData(
-        ~currentHeight=500,
-        ~earliestMultiChainTimestampInThreshold=None,
-      )
+  //   let expected = [(300, "0x789", 789), (500, "0x5432", 5432)]->intoLastBlockScannedHashesHelper
 
-    let expected = [(300, "0x789", 789), (500, "0x5432", 5432)]->intoLastBlockScannedHashesHelper
+  //   Assert.deepEqual(expected, pruned, ~message="Should prune up to the block threshold")
 
-    Assert.deepEqual(expected, pruned, ~message="Should prune up to the block threshold")
+  //   let prunedWithMinTimestamp =
+  //     lastBlockScannedHashes->LastBlockScannedHashes.pruneStaleBlockData(
+  //       ~currentHeight=500,
+  //       ~earliestMultiChainTimestampInThreshold=Some(470),
+  //     )
+  //   let expected =
+  //     [
+  //       (50, "0x456", 456),
+  //       (300, "0x789", 789),
+  //       (500, "0x5432", 5432),
+  //     ]->intoLastBlockScannedHashesHelper
 
-    let prunedWithMinTimestamp =
-      lastBlockScannedHashes->LastBlockScannedHashes.pruneStaleBlockData(
-        ~currentHeight=500,
-        ~earliestMultiChainTimestampInThreshold=Some(470),
-      )
-    let expected =
-      [
-        (50, "0x456", 456),
-        (300, "0x789", 789),
-        (500, "0x5432", 5432),
-      ]->intoLastBlockScannedHashesHelper
-
-    Assert.deepEqual(
-      expected,
-      prunedWithMinTimestamp,
-      ~message="Should keep one range end before the earliestMultiChainTimestampInThreshold",
-    )
-  })
+  //   Assert.deepEqual(
+  //     expected,
+  //     prunedWithMinTimestamp,
+  //     ~message="Should keep one range end before the earliestMultiChainTimestampInThreshold",
+  //   )
+  // })
 
   it("Rolling back to matching hashes works as expected", () => {
     let unusedBlockTimestamp = -1
@@ -92,7 +83,7 @@ describe("Validate reorg detection functions", () => {
       (300, "0x789differnt", unusedBlockTimestamp),
       (500, "0x5432differnt", unusedBlockTimestamp),
     ]->Array.map(
-      ((blockNumber, blockHash, blockTimestamp)): ReorgDetection.blockData => {
+      ((blockNumber, blockHash, blockTimestamp)): ReorgDetection.blockDataWithTimestamp => {
         blockNumber,
         blockHash,
         blockTimestamp,
@@ -102,7 +93,7 @@ describe("Validate reorg detection functions", () => {
     let validScannedBlock =
       lastBlockScannedHashes->LastBlockScannedHashes.getLatestValidScannedBlock(
         ~blockNumbersAndHashes,
-        ~currentHeight=500,
+        ~currentBlockHeight=500,
       )
 
     Assert.deepEqual(validScannedBlock, None, ~message="Should prune up to the block threshold")

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1279,8 +1279,8 @@ describe("FetchState.getNextQuery & integration", () => {
             id: "0",
             status: {fetchingStateId: None},
             latestFetchedBlock: {
-              blockNumber: 2,
-              blockTimestamp: 2,
+              blockNumber: 1,
+              blockTimestamp: 0,
             },
             selection: fetchState.normalSelection,
             contractAddressMapping: ContractAddressingMap.fromArray([(mockAddress0, "Gravatar")]),

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1268,10 +1268,7 @@ describe("FetchState.getNextQuery & integration", () => {
     let fetchState = makeIntermidiateDcMerge()
 
     let fetchStateAfterRollback1 =
-      fetchState->FetchState.rollback(
-        ~lastScannedBlock={blockNumber: 2, blockTimestamp: 2},
-        ~firstChangeEvent={blockNumber: 2, logIndex: 0},
-      )
+      fetchState->FetchState.rollback(~firstChangeEvent={blockNumber: 2, logIndex: 0})
 
     Assert.deepEqual(
       fetchStateAfterRollback1,
@@ -1313,10 +1310,7 @@ describe("FetchState.getNextQuery & integration", () => {
 
     // Rollback even more to see the removal of partition "2"
     let fetchStateAfterRollback2 =
-      fetchStateAfterRollback1->FetchState.rollback(
-        ~lastScannedBlock={blockNumber: 0, blockTimestamp: 0},
-        ~firstChangeEvent={blockNumber: 0, logIndex: 0},
-      )
+      fetchStateAfterRollback1->FetchState.rollback(~firstChangeEvent={blockNumber: 0, logIndex: 0})
 
     Assert.deepEqual(
       fetchStateAfterRollback2,
@@ -1399,10 +1393,7 @@ describe("FetchState.getNextQuery & integration", () => {
     )
 
     let fetchStateAfterRollback =
-      fetchState->FetchState.rollback(
-        ~lastScannedBlock={blockNumber: 2, blockTimestamp: 2},
-        ~firstChangeEvent={blockNumber: 2, logIndex: 0},
-      )
+      fetchState->FetchState.rollback(~firstChangeEvent={blockNumber: 2, logIndex: 0})
 
     Assert.deepEqual(
       fetchStateAfterRollback,

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -173,12 +173,10 @@ describe("Single Chain Simple Rollback", () => {
       [
         UpdateEndOfBlockRangeScannedData({
           blockNumberThreshold: -198,
-          blockTimestampThreshold: Some(50),
           chain: MockConfig.chain1337,
           nextEndOfBlockRangeScannedData: {
             blockHash: block2.blockHash,
             blockNumber: block2.blockNumber,
-            blockTimestamp: block2.blockTimestamp,
             chainId: 1337,
           },
         }),
@@ -236,12 +234,10 @@ describe("Single Chain Simple Rollback", () => {
       [
         UpdateEndOfBlockRangeScannedData({
           blockNumberThreshold: -198,
-          blockTimestampThreshold: Some(50),
           chain: MockConfig.chain1337,
           nextEndOfBlockRangeScannedData: {
             blockHash: block2.blockHash,
             blockNumber: block2.blockNumber,
-            blockTimestamp: block2.blockTimestamp,
             chainId: 1337,
           },
         }),
@@ -331,12 +327,10 @@ describe("Single Chain Simple Rollback", () => {
         UpdateChainMetaDataAndCheckForExit(NoExit),
         GlobalState.UpdateEndOfBlockRangeScannedData({
           blockNumberThreshold: -198,
-          blockTimestampThreshold: Some(50),
           chain: MockConfig.chain1337,
           nextEndOfBlockRangeScannedData: {
             blockHash: block2.blockHash,
             blockNumber: block2.blockNumber,
-            blockTimestamp: block2.blockTimestamp,
             chainId: 1337,
           },
         }),
@@ -359,12 +353,10 @@ describe("Single Chain Simple Rollback", () => {
         NextQuery(CheckAllChains),
         GlobalState.UpdateEndOfBlockRangeScannedData({
           blockNumberThreshold: -196,
-          blockTimestampThreshold: Some(50),
           chain: MockConfig.chain1337,
           nextEndOfBlockRangeScannedData: {
             blockHash: block4.blockHash,
             blockNumber: block4.blockNumber,
-            blockTimestamp: block4.blockTimestamp,
             chainId: 1337,
           },
         }),

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -99,8 +99,8 @@ module Stubs = {
     GlobalState.injectedTaskReducer(
       ~executeQuery=executePartitionQueryWithMockChainData(mockChainData),
       ~waitForNewBlock,
-      ~rollbackLastBlockHashesToReorgLocation=chainFetcher =>
-        chainFetcher->ChainFetcher.rollbackLastBlockHashesToReorgLocation(
+      ~getLastKnownValidBlock=chainFetcher =>
+        chainFetcher->ChainFetcher.getLastKnownValidBlock(
           ~getBlockHashes=getBlockHashes(mockChainData),
         ),
     )(


### PR DESCRIPTION
1. Better data structure for scanned block data, to prevent duplications
2. Remove timestamps from the reorg detection logic, to simplify it
3. Don't clean up scanned block data for chains which didn't have a rollback
4. Store `firstBlockParentNumberAndHash` in the scanned block data, so it's possible to use it to detect a rollback
5. Removed complicated logic to handle multichain, since it's already done by the entity history
6. If we, for some reason, couldn't find a valid block in the reorg threshold - fallback to the `heighestBlockBelowThreshold` instead of start of the chain or some other weird place.
7. Improve latest fetch block after a rollback