### PR TITLE
Sets the unordered_multichain_mode in the generated config.yaml to true

### DIFF
--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -163,7 +163,7 @@ pub mod evm {
                 schema: None,
                 contracts,
                 networks: networks_map.into_values().sorted_by_key(|v| v.id).collect(),
-                unordered_multichain_mode: None,
+                unordered_multichain_mode: Some(true),
                 event_decoder: None,
                 rollback_on_reorg: None,
                 save_full_history: None,


### PR DESCRIPTION
Problem: a developer footgun is that indexer dev's forget to turn multichain mode to true 

Solution: make it true by default in the config.yaml file when using contract import