### PR TITLE
Use Fallback RPC when the primary Sync data-source stalled

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/Index.res
+++ b/codegenerator/cli/templates/static/codegen/src/Index.res
@@ -136,7 +136,7 @@ let makeAppState = (globalState: GlobalState.t): EnvioInkApp.appState => {
           numBatchesFetched,
           chainId: cf.chainConfig.chain->ChainMap.Chain.toChainId,
           endBlock: cf.chainConfig.endBlock,
-          poweredByHyperSync: cf.sourceManager.activeSource.poweredByHyperSync,
+          poweredByHyperSync: (cf.sourceManager->SourceManager.getActiveSource).poweredByHyperSync,
         }: EnvioInkApp.chainData
       )
     })

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -421,7 +421,7 @@ If not found, returns the higehest block below threshold
 let getLastKnownValidBlock = async (
   chainFetcher: t,
   //Parameter used for dependency injecting in tests
-  ~getBlockHashes=chainFetcher.sourceManager.activeSource.getBlockHashes,
+  ~getBlockHashes=(chainFetcher.sourceManager->SourceManager.getActiveSource).getBlockHashes,
 ) => {
   let scannedBlockNumbers =
     chainFetcher.lastBlockScannedHashes->ReorgDetection.LastBlockScannedHashes.getThresholdBlockNumbers(

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -128,7 +128,6 @@ let make = (
     sourceManager: SourceManager.make(
       ~sources=chainConfig.sources,
       ~maxPartitionConcurrency=Env.maxPartitionConcurrency,
-      ~logger,
     ),
     lastBlockScannedHashes,
     currentBlockHeight: 0,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/Source.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/Source.res
@@ -73,10 +73,10 @@ let getHeightWithRetry = async (~source, ~logger) => {
 
 //Poll for a height greater or equal to the given blocknumber.
 //Used for waiting until there is a new block to index
-let waitForNewBlock = async (~source, ~currentBlockHeight, ~logger) => {
-  let logger = Logging.createChildFrom(
-    ~logger,
+let waitForNewBlock = async (~source, ~currentBlockHeight) => {
+  let logger = Logging.createChild(
     ~params={
+      "chainId": source.chain->ChainMap.Chain.toChainId,
       "logType": "Poll for block greater than current height",
       "currentBlockHeight": currentBlockHeight,
     },
@@ -99,10 +99,8 @@ let fetchBlockRange = async (
   ~toBlock,
   ~contractAddressMapping,
   ~partitionId,
-  ~chain,
   ~currentBlockHeight,
   ~selection,
-  ~logger,
 ) => {
   let logger = {
     let allAddresses = contractAddressMapping->ContractAddressingMap.getAllAddresses
@@ -112,10 +110,9 @@ let fetchBlockRange = async (
     if restCount > 0 {
       addresses->Js.Array2.push(`... and ${restCount->Int.toString} more`)->ignore
     }
-    Logging.createChildFrom(
-      ~logger,
+    Logging.createChild(
       ~params={
-        "chainId": chain->ChainMap.Chain.toChainId,
+        "chainId": source.chain->ChainMap.Chain.toChainId,
         "logType": "Block Range Query",
         "partitionId": partitionId,
         "source": source.name,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.res
@@ -7,7 +7,10 @@ open Belt
 // with a mutable state for easier reasoning and testing.
 type t = {
   sources: array<Source.t>,
+  syncSources: array<Source.t>,
   maxPartitionConcurrency: int,
+  newBlockFallbackStallTimeout: int,
+  stalledPollingInterval: int,
   mutable activeSource: Source.t,
   mutable waitingForNewBlockStateId: option<int>,
   // Should take into consideration partitions fetching for previous states (before rollback)
@@ -16,17 +19,26 @@ type t = {
 
 let getActiveSource = sourceManager => sourceManager.activeSource
 
-let make = (~sources: array<Source.t>, ~maxPartitionConcurrency) => {
-  let activeSource = switch sources->Js.Array2.find(source => source.sourceFor === Sync) {
+let make = (
+  ~sources: array<Source.t>,
+  ~maxPartitionConcurrency,
+  ~newBlockFallbackStallTimeout=20_000,
+  ~stalledPollingInterval=5_000,
+) => {
+  let syncSources = sources->Js.Array2.filter(source => source.sourceFor === Sync)
+  let initialActiveSource = switch syncSources->Array.get(0) {
   | None => Js.Exn.raiseError("Invalid configuration, no data-source for historical sync provided")
   | Some(source) => source
   }
   {
     maxPartitionConcurrency,
     sources,
-    activeSource,
+    syncSources,
+    activeSource: initialActiveSource,
     waitingForNewBlockStateId: None,
     fetchingPartitionsCount: 0,
+    newBlockFallbackStallTimeout,
+    stalledPollingInterval,
   }
 }
 
@@ -58,7 +70,7 @@ let fetchNext = async (
     | Some(_) // Case for the prev state before a rollback
     | None =>
       sourceManager.waitingForNewBlockStateId = Some(stateId)
-      let currentBlockHeight = await waitForNewBlock(~source=activeSource, ~currentBlockHeight)
+      let currentBlockHeight = await waitForNewBlock(~currentBlockHeight)
       switch sourceManager.waitingForNewBlockStateId {
       | Some(waitingStateId) if waitingStateId === stateId => {
           sourceManager.waitingForNewBlockStateId = None
@@ -84,4 +96,150 @@ let fetchNext = async (
         ->Promise.all
     }
   }
+}
+
+type status = Active | Stalled | Done
+
+let getSourceNewHeight = async (
+  ~source: Source.t,
+  ~currentBlockHeight,
+  ~stalledPollingInterval,
+  ~status: ref<status>,
+  ~logger,
+) => {
+  let newHeight = ref(0)
+  //Amount the retry interval is multiplied between each retry
+  let backOffMultiplicative = 2
+  let initalRetryIntervalMillis = 1000
+  //Interval after which to retry request (multiplied by backOffMultiplicative between each retry)
+  let retryIntervalMillis = ref(initalRetryIntervalMillis)
+
+  while newHeight.contents <= currentBlockHeight && status.contents !== Done {
+    try {
+      let height = await source.getHeightOrThrow()
+      newHeight := height
+      if height <= currentBlockHeight {
+        // Slowdown polling when the chain isn't progressing
+        let delayMilliseconds = if status.contents === Stalled {
+          retryIntervalMillis := stalledPollingInterval // Reset possible backOff
+          stalledPollingInterval
+        } else {
+          retryIntervalMillis := initalRetryIntervalMillis // Reset possible backOff
+          source.pollingInterval
+        }
+        await Time.resolvePromiseAfterDelay(~delayMilliseconds)
+      }
+    } catch {
+    | exn =>
+      logger->Logging.childTrace({
+        "msg": `Height retrieval from ${source.name} source failed. Retrying in ${retryIntervalMillis.contents->Int.toString}ms.`,
+        "source": source.name,
+        "error": exn->ErrorHandling.prettifyExn,
+      })
+      await Time.resolvePromiseAfterDelay(
+        ~delayMilliseconds=Pervasives.max(
+          retryIntervalMillis.contents * backOffMultiplicative,
+          60_000,
+        ),
+      )
+    }
+  }
+  newHeight.contents
+}
+
+// Polls for a block height greater than the given block number to ensure a new block is available for indexing.
+let waitForNewBlock = async (sourceManager: t, ~currentBlockHeight) => {
+  let {stalledPollingInterval, sources} = sourceManager
+
+  let logger = Logging.createChild(
+    ~params={
+      "chainId": sourceManager.activeSource.chain->ChainMap.Chain.toChainId,
+      "currentBlockHeight": currentBlockHeight,
+    },
+  )
+  logger->Logging.childTrace("Initiating check for new blocks.")
+
+  let syncSources = []
+  let fallbackSources = []
+  sources->Array.forEach(source => {
+    if (
+      source.sourceFor === Sync ||
+        // Even if the active source is a fallback, still include
+        // it to the list. So we don't wait for a timeout again
+        // if all main sync sources are still not valid
+        source === sourceManager.activeSource
+    ) {
+      syncSources->Array.push(source)
+    } else {
+      fallbackSources->Array.push(source)
+    }
+  })
+
+  let status = ref(Active)
+
+  let (source, newBlockHeight) = await Promise.race(
+    syncSources
+    ->Array.map(async source => {
+      (
+        source,
+        await getSourceNewHeight(
+          ~source,
+          ~currentBlockHeight,
+          ~status,
+          ~logger,
+          ~stalledPollingInterval,
+        ),
+      )
+    })
+    ->Array.concat([
+      Utils.delay(sourceManager.newBlockFallbackStallTimeout)->Promise.then(() => {
+        if status.contents !== Done {
+          status := Stalled
+
+          switch fallbackSources {
+          | [] =>
+            logger->Logging.childError(
+              `No new blocks detected within ${(sourceManager.newBlockFallbackStallTimeout / 1000)
+                  ->Int.toString}s. Polling will continue at a reduced rate. For better reliability, refer to our RPC fallback guide: https://docs.envio.dev/docs/HyperIndex/rpc-sync`,
+            )
+          | _ =>
+            logger->Logging.childWarn(
+              `No new blocks detected within ${(sourceManager.newBlockFallbackStallTimeout / 1000)
+                  ->Int.toString}s. Continuing polling with fallback RPC sources from the configuration.`,
+            )
+          }
+        }
+        // Promise.race will be forever pending if fallbackSources is empty
+        // which is good for this use case
+        Promise.race(
+          fallbackSources->Array.map(async source => {
+            (
+              source,
+              await getSourceNewHeight(
+                ~source,
+                ~currentBlockHeight,
+                ~status,
+                ~logger,
+                ~stalledPollingInterval,
+              ),
+            )
+          }),
+        )
+      }),
+    ]),
+  )
+
+  sourceManager.activeSource = source
+
+  // Show a higher level log if we displayed a warning/error after newBlockFallbackStallTimeout
+  let log = status.contents === Stalled ? Logging.childInfo : Logging.childTrace
+  logger->log({
+    "msg": `New blocks successfully found.`,
+    "source": source.name,
+    "newBlockHeight": newBlockHeight,
+  })
+
+  status := Done
+
+  newBlockHeight
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.res
@@ -7,7 +7,6 @@ open Belt
 // with a mutable state for easier reasoning and testing.
 type t = {
   sources: array<Source.t>,
-  syncSources: array<Source.t>,
   maxPartitionConcurrency: int,
   newBlockFallbackStallTimeout: int,
   stalledPollingInterval: int,
@@ -25,15 +24,13 @@ let make = (
   ~newBlockFallbackStallTimeout=20_000,
   ~stalledPollingInterval=5_000,
 ) => {
-  let syncSources = sources->Js.Array2.filter(source => source.sourceFor === Sync)
-  let initialActiveSource = switch syncSources->Array.get(0) {
+  let initialActiveSource = switch sources->Js.Array2.find(source => source.sourceFor === Sync) {
   | None => Js.Exn.raiseError("Invalid configuration, no data-source for historical sync provided")
   | Some(source) => source
   }
   {
     maxPartitionConcurrency,
     sources,
-    syncSources,
     activeSource: initialActiveSource,
     waitingForNewBlockStateId: None,
     fetchingPartitionsCount: 0,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.res
@@ -15,6 +15,8 @@ type t = {
   mutable fetchingPartitionsCount: int,
 }
 
+let getActiveSource = sourceManager => sourceManager.activeSource
+
 let make = (~sources, ~maxPartitionConcurrency, ~logger) => {
   let activeSource = switch sources->Array.get(0) {
   | Some(source) => source

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.resi
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.resi
@@ -1,6 +1,11 @@
 type t
 
-let make: (~sources: array<Source.t>, ~maxPartitionConcurrency: int) => t
+let make: (
+  ~sources: array<Source.t>,
+  ~maxPartitionConcurrency: int,
+  ~newBlockFallbackStallTimeout: int=?,
+  ~stalledPollingInterval: int=?,
+) => t
 
 let getActiveSource: t => Source.t
 
@@ -9,8 +14,10 @@ let fetchNext: (
   ~fetchState: FetchState.t,
   ~currentBlockHeight: int,
   ~executeQuery: (FetchState.query, ~source: Source.t) => promise<unit>,
-  ~waitForNewBlock: (~source: Source.t, ~currentBlockHeight: int) => promise<int>,
+  ~waitForNewBlock: (~currentBlockHeight: int) => promise<int>,
   ~onNewBlock: (~currentBlockHeight: int) => unit,
   ~maxPerChainQueueSize: int,
   ~stateId: int,
 ) => promise<unit>
+
+let waitForNewBlock: (t, ~currentBlockHeight: int) => promise<int>

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.resi
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.resi
@@ -1,6 +1,6 @@
 type t
 
-let make: (~sources: array<Source.t>, ~maxPartitionConcurrency: int, ~logger: Pino.t) => t
+let make: (~sources: array<Source.t>, ~maxPartitionConcurrency: int) => t
 
 let getActiveSource: t => Source.t
 
@@ -9,7 +9,7 @@ let fetchNext: (
   ~fetchState: FetchState.t,
   ~currentBlockHeight: int,
   ~executeQuery: (FetchState.query, ~source: Source.t) => promise<unit>,
-  ~waitForNewBlock: (~source: Source.t, ~currentBlockHeight: int, ~logger: Pino.t) => promise<int>,
+  ~waitForNewBlock: (~source: Source.t, ~currentBlockHeight: int) => promise<int>,
   ~onNewBlock: (~currentBlockHeight: int) => unit,
   ~maxPerChainQueueSize: int,
   ~stateId: int,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.resi
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.resi
@@ -1,0 +1,16 @@
+type t
+
+let make: (~sources: array<Source.t>, ~maxPartitionConcurrency: int, ~logger: Pino.t) => t
+
+let getActiveSource: t => Source.t
+
+let fetchNext: (
+  t,
+  ~fetchState: FetchState.t,
+  ~currentBlockHeight: int,
+  ~executeQuery: (FetchState.query, ~source: Source.t) => promise<unit>,
+  ~waitForNewBlock: (~source: Source.t, ~currentBlockHeight: int, ~logger: Pino.t) => promise<int>,
+  ~onNewBlock: (~currentBlockHeight: int) => unit,
+  ~maxPerChainQueueSize: int,
+  ~stateId: int,
+) => promise<unit>

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -156,7 +156,7 @@ let updateChainMetadataTable = async (cm: ChainManager.t, ~throttler: Throttler.
         firstEventBlockNumber: cf->ChainFetcher.getFirstEventBlockNumber,
         latestProcessedBlock: cf.latestProcessedBlock, // this is already optional
         numEventsProcessed: Some(cf.numEventsProcessed),
-        poweredByHyperSync: cf.sourceManager.activeSource.poweredByHyperSync,
+        poweredByHyperSync: (cf.sourceManager->SourceManager.getActiveSource).poweredByHyperSync,
         numBatchesFetched: cf.numBatchesFetched,
         latestFetchedBlockNumber: latestFetchedBlock.blockNumber,
         timestampCaughtUpToHeadOrEndblock: cf.timestampCaughtUpToHeadOrEndblock->Js.Nullable.fromOption,

--- a/scenarios/erc20_multichain_factory/test/ChainDataHelpers.res
+++ b/scenarios/erc20_multichain_factory/test/ChainDataHelpers.res
@@ -87,13 +87,11 @@ module Stubs = {
   //Stub executePartitionQuery with mock data
   let makeExecutePartitionQuery = (stubData: t) => async (
     query,
-    ~logger,
-    ~source,
+    ~source: Source.t,
     ~currentBlockHeight,
-    ~chain,
   ) => {
-    (logger, currentBlockHeight, source)->ignore
-    stubData->getMockChainData(chain)->MockChainData.executeQuery(query)->Ok
+    (currentBlockHeight, source)->ignore
+    stubData->getMockChainData(source.chain)->MockChainData.executeQuery(query)->Ok
   }
 
   //Stub for getting block hashes instead of the worker
@@ -115,13 +113,11 @@ module Stubs = {
   }
 
   //Stub wait for new block
-  let makeWaitForNewBlock = (stubData: t) => async (
-    ~source: Source.t,
-    ~currentBlockHeight,
-    ~logger,
-  ) => {
-    (logger, currentBlockHeight)->ignore
-    stubData->getMockChainData(source.chain)->MockChainData.getHeight
+  let makeWaitForNewBlock = (stubData: t) => async (sourceManager, ~currentBlockHeight) => {
+    currentBlockHeight->ignore
+    stubData
+    ->getMockChainData((sourceManager->SourceManager.getActiveSource).chain)
+    ->MockChainData.getHeight
   }
   //Stub dispatch action to set state and not dispatch task but store in
   //the tasks ref
@@ -142,7 +138,7 @@ module Stubs = {
         chainFetcher->ChainFetcher.getLastKnownValidBlock(
           ~getBlockHashes=makeGetBlockHashes(
             ~stubData,
-            ~source=chainFetcher->SourceManager.getActiveSource,
+            ~source=chainFetcher.sourceManager->SourceManager.getActiveSource,
           ),
         ),
     )(

--- a/scenarios/erc20_multichain_factory/test/ChainDataHelpers.res
+++ b/scenarios/erc20_multichain_factory/test/ChainDataHelpers.res
@@ -142,7 +142,7 @@ module Stubs = {
         chainFetcher->ChainFetcher.getLastKnownValidBlock(
           ~getBlockHashes=makeGetBlockHashes(
             ~stubData,
-            ~source=chainFetcher.sourceManager.activeSource,
+            ~source=chainFetcher->SourceManager.getActiveSource,
           ),
         ),
     )(

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -150,7 +150,6 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       sourceManager: SourceManager.make(
         ~sources=chainConfig.sources,
         ~maxPartitionConcurrency=Env.maxPartitionConcurrency,
-        ~logger=Logging.logger,
       ),
       chainConfig,
       // This is quite a hack - but it works!

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -49,20 +49,18 @@ module Mock = {
 
 module Stubs = {
   //Stub wait for new block
-  let waitForNewBlock = async (~source, ~currentBlockHeight, ~logger) => {
-    (logger, currentBlockHeight, source)->ignore
+  let waitForNewBlock = async (~source, ~currentBlockHeight) => {
+    (currentBlockHeight, source)->ignore
     Mock.mockChainData->MockChainData.getHeight
   }
 
   //Stub executePartitionQuery with mock data
   let executePartitionQueryWithMockChainData = mockChainData => async (
     query,
-    ~logger,
     ~source,
     ~currentBlockHeight,
-    ~chain,
   ) => {
-    (logger, chain, currentBlockHeight, source)->ignore
+    (currentBlockHeight, source)->ignore
 
     Ok(mockChainData->MockChainData.executeQuery(query))
   }

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -49,8 +49,8 @@ module Mock = {
 
 module Stubs = {
   //Stub wait for new block
-  let waitForNewBlock = async (~source, ~currentBlockHeight) => {
-    (currentBlockHeight, source)->ignore
+  let waitForNewBlock = async (_sourceManager, ~currentBlockHeight) => {
+    currentBlockHeight->ignore
     Mock.mockChainData->MockChainData.getHeight
   }
 


### PR DESCRIPTION
- Better tested
- Multiple sync sources support
- Improved logs
- Fallback support
- Increase polling interval for stalled chain

What's left:
- Fix broken existing rpc fallback logic (when you provide multiple URLs)
- Add wait for new block tests when the request throws
- Include sanitized RPC URL to the source name to be able to distinguish sources in the logs