### PR TITLE
Feat: Add support for Foundry output ABI format

### DIFF
--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -1760,6 +1760,93 @@ mod test {
     }
 
     #[test]
+    fn test_get_nested_contract_abi() {
+        let test_dir = format!("{}/test", env!("CARGO_MANIFEST_DIR"));
+        let project_root = test_dir.as_str();
+        let config_dir = "configs/nested-abi.yaml";
+        let generated = "generated/";
+        let project_paths = ParsedProjectPaths::new(project_root, generated, config_dir)
+            .expect("Failed creating parsed_paths");
+
+        let config =
+            SystemConfig::parse_from_project_files(&project_paths).expect("Failed parsing config");
+
+        let contract_name = "Contract3".to_string();
+
+        let contract_abi = match &config
+            .get_contract(&contract_name)
+            .expect("Failed getting contract")
+            .abi
+        {
+            super::Abi::Evm(abi) => abi.typed.clone(),
+            super::Abi::Fuel(_) => panic!("Fuel abi should not be parsed"),
+        };
+
+        let expected_abi_string = r#"
+                [
+                {
+                    "anonymous": false,
+                    "inputs": [
+                    {
+                        "indexed": false,
+                        "name": "id",
+                        "type": "uint256"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "owner",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "displayName",
+                        "type": "string"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "imageUrl",
+                        "type": "string"
+                    }
+                    ],
+                    "name": "NewGravatar",
+                    "type": "event"
+                },
+                {
+                    "anonymous": false,
+                    "inputs": [
+                    {
+                        "indexed": false,
+                        "name": "id",
+                        "type": "uint256"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "owner",
+                        "type": "address"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "displayName",
+                        "type": "string"
+                    },
+                    {
+                        "indexed": false,
+                        "name": "imageUrl",
+                        "type": "string"
+                    }
+                    ],
+                    "name": "UpdatedGravatar",
+                    "type": "event"
+                }
+                ]
+    "#;
+
+        let expected_abi: ethers::abi::Abi = serde_json::from_str(expected_abi_string).unwrap();
+
+        assert_eq!(expected_abi, contract_abi);
+    }
+
+    #[test]
     fn parse_event_sig_with_event_prefix() {
         let event_string = "event MyEvent(uint256 myArg)".to_string();
 

--- a/codegenerator/cli/test/abis/Contract3.json
+++ b/codegenerator/cli/test/abis/Contract3.json
@@ -1,0 +1,58 @@
+{
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "id",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "displayName",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "name": "imageUrl",
+          "type": "string"
+        }
+      ],
+      "name": "NewGravatar",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "id",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "displayName",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "name": "imageUrl",
+          "type": "string"
+        }
+      ],
+      "name": "UpdatedGravatar",
+      "type": "event"
+    }
+  ]
+} 

--- a/codegenerator/cli/test/configs/nested-abi.yaml
+++ b/codegenerator/cli/test/configs/nested-abi.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=../../npm/envio/evm.schema.json
+name: config3
+schema: ../schemas/schema.graphql
+description: Gravatar for Ethereum with nested ABI
+networks:
+  - id: 1
+    rpc_config:
+      url: https://eth-mainnet.g.alchemy.com/v2/demo
+      initial_block_interval: 10000
+      backoff_multiplicative: 0.8
+      acceleration_additive: 2000
+      interval_ceiling: 10000
+      backoff_millis: 5000
+      query_timeout_millis: 20000
+    start_block: 0
+    contracts:
+      - name: Contract3
+        abi_file_path: ../abis/Contract3.json
+        handler: ./src/EventHandler.js
+        address: "0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"
+        events:
+          - event: "NewGravatar"
+          - event: "UpdatedGravatar"
+field_selection:
+  transaction_fields:
+    - !from
+    - !value
+  block_fields:
+    - !difficulty


### PR DESCRIPTION
This PR adds support for Foundry output ABI format, which places the ABI definition in an "abi" child field within the JSON file. Previously, the code would fail early when trying to parse these files, as it expected the ABI to be at the root level of the JSON.

## Changes

- Enhanced the ABI parsing logic in `LocalImportArgs::parse_contract_abi` to handle nested ABI structures
- Added a two-step parsing approach:
  1. First attempt to parse the JSON directly as an ABI
  2. If that fails, try to parse it as a JSON object that might contain an "abi" field
- Added comprehensive error messages to help users troubleshoot ABI parsing issues
- Added test cases to verify both direct and nested ABI parsing works correctly

## Test Coverage

Added two test cases to verify the functionality:
- `test_parse_contract_abi_direct`: Tests parsing a standard ABI file
- `test_parse_contract_abi_nested`: Tests parsing an ABI file with the "abi" field at the root level (Foundry format)

Also added test fixtures:
- Added a sample Foundry-style ABI file (`Contract3.json`) with the ABI in an "abi" child field
- Added a corresponding test configuration (`nested-abi.yaml`) to test the system config parsing