### PR TITLE
Fix reorg threshold state with start block

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -701,15 +701,15 @@ let queueItemBlockNumber = (queueItem: queueItem) => {
 }
 
 let queueItemIsInReorgThreshold = (queueItem: queueItem, ~heighestBlockBelowThreshold) => {
-  switch queueItem {
-  | Item(_) =>
-    //Only consider it in reorg threshold when the current block number has advanced beyond 0
-    if heighestBlockBelowThreshold > 0 {
+  //Only consider it in reorg threshold when the current block number has advanced beyond 0
+  if heighestBlockBelowThreshold > 0 {
+    switch queueItem {
+    | Item(_) =>
       queueItem->queueItemBlockNumber > heighestBlockBelowThreshold
-    } else {
-      false
+    | NoItem(_) => queueItem->queueItemBlockNumber > heighestBlockBelowThreshold
     }
-  | NoItem(_) => queueItem->queueItemBlockNumber > heighestBlockBelowThreshold
+  } else {
+    false
   }
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/FetchState.res
@@ -700,16 +700,15 @@ let queueItemBlockNumber = (queueItem: queueItem) => {
   }
 }
 
-let queueItemIsInReorgThreshold = (queueItem: queueItem, ~heighestBlockBelowThreshold) => {
-  //Only consider it in reorg threshold when the current block number has advanced beyond 0
-  if heighestBlockBelowThreshold > 0 {
+let queueItemIsInReorgThreshold = (queueItem: queueItem, ~currentBlockHeight, ~heighestBlockBelowThreshold) => {
+  if currentBlockHeight === 0 {
+    false
+  } else {
     switch queueItem {
     | Item(_) =>
-      queueItem->queueItemBlockNumber > heighestBlockBelowThreshold
+        queueItem->queueItemBlockNumber > heighestBlockBelowThreshold
     | NoItem(_) => queueItem->queueItemBlockNumber > heighestBlockBelowThreshold
     }
-  } else {
-    false
   }
 }
 

--- a/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
@@ -320,8 +320,7 @@ describe("Dynamic contract rollback test", () => {
     Assert.deepEqual(
       stubDataInitial->Stubs.getTasks,
       [
-        GlobalState.NextQuery(CheckAllChains),
-        ProcessEventBatch,
+        NextQuery(CheckAllChains),
         Mock.getUpdateEndofBlockRangeScannedData(
           Mock.mockChainDataMap,
           ~chain=Mock.Chain1.chain,

--- a/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
@@ -415,9 +415,9 @@ describe("Multichain rollback test", () => {
       ~chain2User2Balance=Some(100),
     )
     Assert.deepEqual(
+      stubDataInitial->Stubs.getTasks,
       [
-        GlobalState.NextQuery(CheckAllChains),
-        ProcessEventBatch,
+        NextQuery(CheckAllChains),
         Mock.getUpdateEndofBlockRangeScannedData(
           Mock.mockChainDataMapInitial,
           ~chain=Mock.Chain1.chain,
@@ -440,7 +440,6 @@ describe("Multichain rollback test", () => {
         ProcessEventBatch,
         PruneStaleEntityHistory,
       ],
-      stubDataInitial->Stubs.getTasks,
       ~message="Should have processed a batch and run next queries on all chains",
     )
 

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -394,6 +394,7 @@ describe("determineNextEvent", () => {
     ): ChainManager.fetchStateWithData => {
       {
         fetchState: makeMockFetchState(~latestFetchedBlockTimestamp, ~item),
+        currentBlockHeight: 700,
         heighestBlockBelowThreshold: 500,
       }
     }

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -68,7 +68,7 @@ let mockEvent = (~blockNumber, ~logIndex=0, ~chainId=1): Internal.eventItem => {
   event: Utils.magic("Mock event in fetchstate test"),
 }
 
-let makeInitial = () => {
+let makeInitial = (~startBlock=0) => {
   FetchState.make(
     ~eventConfigs=[
       {
@@ -79,7 +79,7 @@ let makeInitial = () => {
     ],
     ~staticContracts=Js.Dict.fromArray([("Gravatar", [mockAddress0])]),
     ~dynamicContracts=[],
-    ~startBlock=0,
+    ~startBlock,
     ~endBlock=None,
     ~maxAddrInPartition=3,
   )
@@ -2481,4 +2481,29 @@ describe("Test queue item", () => {
       ~message=`5. Above reversed`,
     )
   })
+})
+
+describe("FetchState.queueItemIsInReorgThreshold", () => {
+  it("Returns false when we just started the indexer and it has currentBlockHeight=0", () => {
+    let fetchState = makeInitial()
+    Assert.equal(
+      fetchState
+      ->FetchState.getEarliestEvent
+      ->FetchState.queueItemIsInReorgThreshold(~heighestBlockBelowThreshold=0),
+      false,
+    )
+  })
+
+  it(
+    "Returns false when we just started the indexer and it has currentBlockHeight=0, while start block is more than 0 + reorg threshold",
+    () => {
+      let fetchState = makeInitial(~startBlock=6000)
+      Assert.equal(
+        fetchState
+        ->FetchState.getEarliestEvent
+        ->FetchState.queueItemIsInReorgThreshold(~heighestBlockBelowThreshold=0),
+        false,
+      )
+    },
+  )
 })

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -2489,7 +2489,10 @@ describe("FetchState.queueItemIsInReorgThreshold", () => {
     Assert.equal(
       fetchState
       ->FetchState.getEarliestEvent
-      ->FetchState.queueItemIsInReorgThreshold(~heighestBlockBelowThreshold=0),
+      ->FetchState.queueItemIsInReorgThreshold(
+        ~currentBlockHeight=0,
+        ~heighestBlockBelowThreshold=0,
+      ),
       false,
     )
   })
@@ -2501,7 +2504,10 @@ describe("FetchState.queueItemIsInReorgThreshold", () => {
       Assert.equal(
         fetchState
         ->FetchState.getEarliestEvent
-        ->FetchState.queueItemIsInReorgThreshold(~heighestBlockBelowThreshold=0),
+        ->FetchState.queueItemIsInReorgThreshold(
+          ~currentBlockHeight=0,
+          ~heighestBlockBelowThreshold=0,
+        ),
         false,
       )
     },


### PR DESCRIPTION
It caused `Reorg threshold reached` happening earlier than it should have been.