### PR TITLE
Trace log on the first HyperSync retry

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/Time.res
+++ b/codegenerator/cli/templates/static/codegen/src/Time.res
@@ -14,7 +14,8 @@ let rec retryAsyncWithExponentialBackOff = async (
   | exn =>
     if retryCount < maxRetries {
       let nextRetryCount = retryCount + 1
-      logger->Logging.childWarn({
+      let log = retryCount === 0 ? Logging.childTrace : Logging.childWarn
+      logger->log({
         "msg": `Retrying query ${nextRetryCount->Belt.Int.toString}/${maxRetries->Belt.Int.toString} in ${backOffMillis->Belt.Int.toString}ms - waiting for correct result.`,
         "error": exn->ErrorHandling.prettifyExn,
       })


### PR DESCRIPTION
This scared a few users, but it's nothing dangerous.
<img width="679" alt="image" src="https://github.com/user-attachments/assets/849f208d-98d4-4bab-a24b-05c216732b99" />
