### PR TITLE
Handle HyperSync logs query errors

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/ErrorHandling.res
+++ b/codegenerator/cli/templates/static/codegen/src/ErrorHandling.res
@@ -1,7 +1,7 @@
 type t = {logger: Pino.t, exn: exn, msg: option<string>}
 
 let prettifyExn = exn => {
-  switch exn {
+  switch exn->Js.Exn.anyToExnInternal {
   | Js.Exn.Error(e) => e->(Utils.magic: Js.Exn.t => exn)
   | exn => exn
   }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/Source.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/Source.res
@@ -22,7 +22,7 @@ type blockRangeFetchResponse = {
 
 type getItemsRetry =
   | WithSuggestedToBlock({toBlock: int})
-  | WithBackoff({backoffMillis: int})
+  | WithBackoff({message: string, backoffMillis: int})
 
 type getItemsError =
   | UnsupportedSelection({message: string})
@@ -52,6 +52,7 @@ type t = {
     ~currentBlockHeight: int,
     ~partitionId: string,
     ~selection: FetchState.selection,
+    ~retry: int,
     ~logger: Pino.t,
   ) => promise<blockRangeFetchResponse>,
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.resi
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hyperfuel/HyperFuel.resi
@@ -29,20 +29,26 @@ type missingParams = {
   queryName: string,
   missingParams: array<string>,
 }
-type queryError =
-  UnexpectedMissingParams(missingParams)
-
-exception UnexpectedMissingParamsExn(missingParams)
+type queryError = UnexpectedMissingParams(missingParams)
 
 let queryErrorToMsq: queryError => string
 
 type queryResponse<'a> = result<'a, queryError>
-let queryLogsPage: (
-  ~serverUrl: string,
-  ~fromBlock: int,
-  ~toBlock: option<int>,
-  ~recieptsSelection: array<HyperFuelClient.QueryTypes.receiptSelection>,
-) => promise<queryResponse<logsQueryPage>>
+
+module GetLogs: {
+  type error =
+    | UnexpectedMissingParams({missingParams: array<string>})
+    | WrongInstance
+
+  exception Error(error)
+
+  let query: (
+    ~serverUrl: string,
+    ~fromBlock: int,
+    ~toBlock: option<int>,
+    ~recieptsSelection: array<HyperFuelClient.QueryTypes.receiptSelection>,
+  ) => promise<logsQueryPage>
+}
 
 let queryBlockData: (
   ~serverUrl: string,
@@ -50,4 +56,4 @@ let queryBlockData: (
   ~logger: Pino.t,
 ) => promise<option<ReorgDetection.blockDataWithTimestamp>>
 
-let heightRoute: Rest.route<(), int>
+let heightRoute: Rest.route<unit, int>

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/hypersync/HyperSync.resi
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/hypersync/HyperSync.resi
@@ -30,21 +30,27 @@ type missingParams = {
 
 type queryError = UnexpectedMissingParams(missingParams)
 
-exception UnexpectedMissingParamsExn(missingParams)
-
 let queryErrorToMsq: queryError => string
 
 type queryResponse<'a> = result<'a, queryError>
-let queryLogsPage: (
-  ~client: HyperSyncClient.t,
-  ~fromBlock: int,
-  ~toBlock: option<int>,
-  ~logSelections: array<LogSelection.t>,
-  ~fieldSelection: HyperSyncClient.QueryTypes.fieldSelection,
-  ~nonOptionalBlockFieldNames: array<string>,
-  ~nonOptionalTransactionFieldNames: array<string>,
-  ~logger: Pino.t,
-) => promise<queryResponse<logsQueryPage>>
+
+module GetLogs: {
+  type error =
+    | UnexpectedMissingParams({missingParams: array<string>})
+    | WrongInstance
+
+  exception Error(error)
+
+  let query: (
+    ~client: HyperSyncClient.t,
+    ~fromBlock: int,
+    ~toBlock: option<int>,
+    ~logSelections: array<LogSelection.t>,
+    ~fieldSelection: HyperSyncClient.QueryTypes.fieldSelection,
+    ~nonOptionalBlockFieldNames: array<string>,
+    ~nonOptionalTransactionFieldNames: array<string>,
+  ) => promise<logsQueryPage>
+}
 
 let queryBlockData: (
   ~serverUrl: string,
@@ -61,4 +67,3 @@ let queryBlockDataMulti: (
 ) => promise<queryResponse<array<ReorgDetection.blockDataWithTimestamp>>>
 
 let mapExn: queryResponse<'a> => result<'a, exn>
-let getExn: queryResponse<'a> => 'a

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/rpc/RpcSource.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/rpc/RpcSource.res
@@ -150,6 +150,7 @@ let getNextPage = (
             exn: err,
             attemptedToBlock: toBlock,
             retry: WithBackoff({
+              message: `Failed getting data for the block range. Will try smaller block range for the next attempt.`,
               backoffMillis: sc.backoffMillis,
             }),
           }),
@@ -416,6 +417,7 @@ let make = ({sourceFor, syncConfig, url, chain, contracts, eventRouter}: options
     ~currentBlockHeight,
     ~partitionId,
     ~selection: FetchState.selection,
+    ~retry as _,
     ~logger as _,
   ) => {
     let startFetchingBatchTimeRef = Hrtime.makeTimer()

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -66,6 +66,7 @@ module type S = {
         ~currentBlockHeight: int,
         ~partitionId: string,
         ~selection: FetchState.selection,
+        ~retry: int,
         ~logger: Pino.t,
       ) => promise<blockRangeFetchResponse>,
     }

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -1315,7 +1315,7 @@ describe("SourceManager wait for new blocks", () => {
   )
 })
 
-describe_only("SourceManager.executeQuery", () => {
+describe("SourceManager.executeQuery", () => {
   let selection = {FetchState.dependsOnAddresses: false, eventConfigs: []}
   let contractAddressMapping = ContractAddressingMap.make()
   let items = []

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -8,7 +8,7 @@ type sourceMock = {
   getHeightOrThrowCalls: array<bool>,
   resolveGetHeightOrThrow: int => unit,
   rejectGetHeightOrThrow: 'exn. 'exn => unit,
-  getItemsOrThrowCalls: array<{"toBlock": option<int>}>,
+  getItemsOrThrowCalls: array<{"toBlock": option<int>, "retry": int}>,
   resolveGetItemsOrThrow: array<Internal.eventItem> => unit,
   rejectGetItemsOrThrow: 'exn. 'exn => unit,
 }
@@ -67,12 +67,14 @@ let sourceMock = (
           ~currentBlockHeight,
           ~partitionId as _,
           ~selection as _,
+          ~retry,
           ~logger as _,
         ) =>
           if mockGetItemsOrThrow {
             getItemsOrThrowCalls
             ->Js.Array2.push({
               "toBlock": toBlock,
+              "retry": retry,
             })
             ->ignore
             Promise.make((resolve, reject) => {
@@ -1313,7 +1315,7 @@ describe("SourceManager wait for new blocks", () => {
   )
 })
 
-describe("SourceManager.executeQuery", () => {
+describe_only("SourceManager.executeQuery", () => {
   let selection = {FetchState.dependsOnAddresses: false, eventConfigs: []}
   let contractAddressMapping = ContractAddressingMap.make()
   let items = []
@@ -1332,7 +1334,7 @@ describe("SourceManager.executeQuery", () => {
     )
     let sourceManager = SourceManager.make(~sources=[source], ~maxPartitionConcurrency=10)
     let p = sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~currentBlockHeight=100)
-    Assert.deepEqual(getItemsOrThrowCalls, [{"toBlock": None}])
+    Assert.deepEqual(getItemsOrThrowCalls, [{"toBlock": None, "retry": 0}])
     resolveGetItemsOrThrow(items)
     Assert.equal((await p).parsedQueueItems, items)
   })
@@ -1377,209 +1379,119 @@ describe("SourceManager.executeQuery", () => {
       ~message="Only one call before the microtask",
     )
     await Promise.resolve() // Wait for microtask, so the rejection is caught
-    Assert.deepEqual(getItemsOrThrowCalls, [{"toBlock": None}, {"toBlock": Some(10)}])
+    Assert.deepEqual(
+      getItemsOrThrowCalls,
+      [{"toBlock": None, "retry": 0}, {"toBlock": Some(10), "retry": 0}],
+      ~message="Should reset retry count on WithSuggestedToBlock error",
+    )
 
     resolveGetItemsOrThrow(items)
     Assert.equal((await p).parsedQueueItems, items)
   })
 
   Async.it(
-    "When there are multiple sync sources, it immediately retries with another source without waiting for backoff",
+    "When there are multiple sync sources, it retries 2 times and then immediately switches to another source without waiting for backoff. After that it switches every second retry",
     async () => {
-      let mock0 = sourceMock(~mockGetItemsOrThrow=true)
-      let mock1 = sourceMock(~mockGetItemsOrThrow=true)
+      let mock0 = sourceMock(~mockGetHeightOrThrow=true, ~mockGetItemsOrThrow=true)
+      let mock1 = sourceMock(
+        ~sourceFor=Fallback,
+        ~mockGetHeightOrThrow=true,
+        ~mockGetItemsOrThrow=true,
+      )
+      let newBlockFallbackStallTimeout = 0
       let sourceManager = SourceManager.make(
-        ~sources=[mock0.source, mock1.source],
+        ~newBlockFallbackStallTimeout,
+        ~sources=[
+          mock0.source,
+          // Should be skipped until the 10th retry,
+          // but we won't test it here
+          sourceMock(~sourceFor=Fallback).source,
+          mock1.source,
+        ],
         ~maxPartitionConcurrency=10,
       )
+
+      {
+        // Switch the initial active source to fallback,
+        // to test that it's included to the rotation
+        let p = sourceManager->SourceManager.waitForNewBlock(~currentBlockHeight=100)
+        await Utils.delay(newBlockFallbackStallTimeout)
+        mock1.resolveGetHeightOrThrow(101)
+        Assert.equal(await p, 101)
+        Assert.equal(
+          sourceManager->SourceManager.getActiveSource,
+          mock1.source,
+          ~message="Should switch to the fallback source",
+        )
+      }
+
       let p = sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~currentBlockHeight=100)
+
+      for idx in 0 to 2 {
+        mock1.rejectGetItemsOrThrow(
+          Source.GetItemsError(
+            FailedGettingItems({
+              exn: %raw(`null`),
+              attemptedToBlock: 100,
+              retry: WithBackoff({message: "test", backoffMillis: 0}),
+            }),
+          ),
+        )
+        // Wait for microtask, so the rejection is caught
+        await Promise.resolve()
+        if idx !== 2 {
+          // Don't need to wait for backoff on switch
+          await Utils.delay(0)
+        }
+      }
+
       mock0.rejectGetItemsOrThrow(
         Source.GetItemsError(
           FailedGettingItems({
             exn: %raw(`null`),
             attemptedToBlock: 100,
-            retry: WithBackoff({backoffMillis: 1000}),
+            retry: WithBackoff({message: "test", backoffMillis: 0}),
           }),
         ),
       )
       await Promise.resolve() // Wait for microtask, so the rejection is caught
-      Assert.deepEqual(mock0.getItemsOrThrowCalls->Array.length, 1)
-      Assert.deepEqual(
-        mock1.getItemsOrThrowCalls->Array.length,
-        1,
-        ~message="Calls source 1 after a microtask",
-      )
+      await Utils.delay(0)
 
-      mock1.rejectGetItemsOrThrow(
+      mock0.rejectGetItemsOrThrow(
         Source.GetItemsError(
           FailedGettingItems({
             exn: %raw(`null`),
             attemptedToBlock: 100,
-            retry: WithBackoff({backoffMillis: 1000}),
+            retry: WithBackoff({message: "test", backoffMillis: 0}),
           }),
         ),
       )
-      await Promise.resolve() // Wait for microtask, so the rejection is caught
-      Assert.deepEqual(
-        mock0.getItemsOrThrowCalls->Array.length,
-        2,
-        ~message="Switches back to the first source",
-      )
-      Assert.deepEqual(mock1.getItemsOrThrowCalls->Array.length, 1, ~message="Isn't called anymore")
+      await Promise.resolve()
+      // Doesn't wait for backoff on switch
 
-      mock0.resolveGetItemsOrThrow(items)
+      Assert.deepEqual(
+        (mock0.getItemsOrThrowCalls, mock1.getItemsOrThrowCalls),
+        (
+          [{"toBlock": None, "retry": 3}, {"toBlock": None, "retry": 4}],
+          [
+            {"toBlock": None, "retry": 0},
+            {"toBlock": None, "retry": 1},
+            {"toBlock": None, "retry": 2},
+            {"toBlock": None, "retry": 5},
+          ],
+        ),
+        ~message=`Should start with the initial active source and perform 3 tries.
+        After that it switches to another sync source.
+        The fallback source is skipped.
+        Then sources start switching every second retry.
+        The fallback sources not included in the rotation until the 10th retry,
+        but we still attempt the fallback source if it was the initial active source.
+        `,
+      )
+
+      mock1.resolveGetItemsOrThrow(items)
+
       Assert.equal((await p).parsedQueueItems, items)
     },
   )
-
-  Async.it("Backoff error doesn't switch the source to the fallback one", async () => {
-    let backoffMillis = 2
-    let mock0 = sourceMock(~mockGetItemsOrThrow=true)
-    let mock1 = sourceMock(~sourceFor=Fallback)
-    let sourceManager = SourceManager.make(
-      ~sources=[mock0.source, mock1.source],
-      ~maxPartitionConcurrency=10,
-    )
-    let p = sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~currentBlockHeight=100)
-    mock0.rejectGetItemsOrThrow(
-      Source.GetItemsError(
-        FailedGettingItems({
-          exn: %raw(`null`),
-          attemptedToBlock: 100,
-          retry: WithBackoff({backoffMillis: backoffMillis}),
-        }),
-      ),
-    )
-
-    await Utils.delay(backoffMillis)
-    Assert.deepEqual(
-      mock0.getItemsOrThrowCalls->Array.length,
-      1,
-      ~message="Should still have only initial call",
-    )
-    await Utils.delay(0)
-    Assert.deepEqual(
-      mock0.getItemsOrThrowCalls->Array.length,
-      2,
-      ~message="Calls the second time after a backoff",
-    )
-
-    mock0.resolveGetItemsOrThrow(items)
-    Assert.equal((await p).parsedQueueItems, items)
-  })
-
-  Async.it("Executes the query on the active source even if it's a fallback", async () => {
-    let backoffMillis = 2
-    let mock0 = sourceMock(~mockGetHeightOrThrow=true, ~mockGetItemsOrThrow=true)
-    let mock1 = sourceMock(
-      ~mockGetHeightOrThrow=true,
-      ~mockGetItemsOrThrow=true,
-      ~sourceFor=Fallback,
-    )
-    let newBlockFallbackStallTimeout = 0
-    let sourceManager = SourceManager.make(
-      ~sources=[mock0.source, mock1.source],
-      ~maxPartitionConcurrency=10,
-      ~newBlockFallbackStallTimeout,
-    )
-
-    let p = sourceManager->SourceManager.waitForNewBlock(~currentBlockHeight=100)
-    await Utils.delay(newBlockFallbackStallTimeout)
-    mock1.resolveGetHeightOrThrow(101)
-    Assert.equal(await p, 101)
-    Assert.equal(
-      sourceManager->SourceManager.getActiveSource,
-      mock1.source,
-      ~message="Should switch to the fallback source",
-    )
-
-    let p = sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~currentBlockHeight=101)
-    Assert.deepEqual(
-      mock0.getItemsOrThrowCalls->Array.length,
-      0,
-      ~message="The sync source should not be called",
-    )
-    Assert.deepEqual(
-      mock1.getItemsOrThrowCalls->Array.length,
-      1,
-      ~message="Should call the fallback source for items",
-    )
-
-    mock1.rejectGetItemsOrThrow(
-      Source.GetItemsError(
-        FailedGettingItems({
-          exn: %raw(`null`),
-          attemptedToBlock: 100,
-          retry: WithBackoff({backoffMillis: backoffMillis}),
-        }),
-      ),
-    )
-
-    await Promise.resolve() // Wait for microtask, so the rejection is caught
-    Assert.deepEqual(
-      (mock0.getItemsOrThrowCalls->Array.length, mock1.getItemsOrThrowCalls->Array.length),
-      (1, 1),
-      ~message="Backoff error should immediately retry with the sync source",
-    )
-
-    mock0.rejectGetItemsOrThrow(
-      Source.GetItemsError(
-        FailedGettingItems({
-          exn: %raw(`null`),
-          attemptedToBlock: 100,
-          retry: WithBackoff({backoffMillis: backoffMillis}),
-        }),
-      ),
-    )
-
-    await Promise.resolve() // Wait for microtask, so the rejection is caught
-    Assert.deepEqual(
-      (mock0.getItemsOrThrowCalls->Array.length, mock1.getItemsOrThrowCalls->Array.length),
-      (1, 2),
-      ~message=`Backoff error of the sync source should immediately retry with the fallback source.
-      This is only for the initial fallback source. Other fallback sources are not in the retry rotation.`,
-    )
-
-    // Might happen in the case when we switched from HyperSync to RPC fallback
-    // and it has some not-supported features
-    mock1.rejectGetItemsOrThrow(
-      Source.GetItemsError(
-        UnsupportedSelection({
-          message: "RPC data-source currently supports event filters only when there's a single wildcard event.",
-        }),
-      ),
-    )
-
-    await Promise.resolve() // Wait for microtask, so the rejection is caught
-    Assert.deepEqual(
-      (mock0.getItemsOrThrowCalls->Array.length, mock1.getItemsOrThrowCalls->Array.length),
-      (2, 2),
-      ~message=`Immediately switches back to the sync source.`,
-    )
-
-    mock0.rejectGetItemsOrThrow(
-      Source.GetItemsError(
-        FailedGettingItems({
-          exn: %raw(`null`),
-          attemptedToBlock: 100,
-          retry: WithBackoff({backoffMillis: backoffMillis}),
-        }),
-      ),
-    )
-    await Utils.delay(backoffMillis)
-    Assert.deepEqual(
-      (mock0.getItemsOrThrowCalls->Array.length, mock1.getItemsOrThrowCalls->Array.length),
-      (2, 2),
-      ~message=`No changes before backoff.`,
-    )
-    await Utils.delay(0)
-    Assert.deepEqual(
-      (mock0.getItemsOrThrowCalls->Array.length, mock1.getItemsOrThrowCalls->Array.length),
-      (3, 2),
-      ~message=`Doesn't try to switch to the fallback source anymore, since we know that it's not valid.`,
-    )
-
-    mock0.resolveGetItemsOrThrow(items)
-    Assert.equal((await p).parsedQueueItems, items)
-  })
 })


### PR DESCRIPTION
Don't crash the indexer on HyperSync logs request query error. Infinitely retry with the support of a fallback data source.