### PR TITLE
Fix typos in test comments

### DIFF
--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -231,7 +231,7 @@ describe("ChainManager", () => {
             )
 
             //Note -> this test was originally for popping all events related to a single block
-            //Now we don't guarentee processing all events in a block so these assertions are no longer needed.
+            //Now we don't guarantee processing all events in a block so these assertions are no longer needed.
             // let lastEvent =
             //   batch
             //   ->List.toArray

--- a/scenarios/test_codegen/test/SerDe_Test.res
+++ b/scenarios/test_codegen/test/SerDe_Test.res
@@ -52,7 +52,7 @@ describe("SerDe Test", () => {
       entityData: Set(entity),
     }
 
-    //Fails if serialziation does not work
+    //Fails if serialization does not work
     let set = DbFunctionsEntities.batchSet(~entityMod=module(Entities.EntityWithAllTypes))
     //Fails if parsing does not work
     let read = DbFunctionsEntities.batchRead(~entityMod=module(Entities.EntityWithAllTypes))
@@ -130,7 +130,7 @@ describe("SerDe Test", () => {
       entityData: Set(entity),
     }
 
-    //Fails if serialziation does not work
+    //Fails if serialization does not work
     let set = DbFunctionsEntities.batchSet(~entityMod=module(Entities.EntityWithAllNonArrayTypes))
     //Fails if parsing does not work
     let read = DbFunctionsEntities.batchRead(~entityMod=module(Entities.EntityWithAllNonArrayTypes))

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -720,7 +720,7 @@ describe("SourceManager fetchNext", () => {
 
     // Partitions 2 and 3 should be ignored.
     // Eventhogh they are not fetching,
-    // but we've alredy called them with the same query
+    // but we've already called them with the same query
     await sourceManager->SourceManager.fetchNext(
       ~fetchState=mockFetchState([
         mockFullPartition(~partitionIndex=0, ~latestFetchedBlockNumber=10),


### PR DESCRIPTION
This PR fixes spelling mistakes in test file comments:

- Corrects "serializiation" to "serialization" in SerDe_Test.res
- Corrects "guarentee" to "guarantee" in ChainManager_test.res

These are simple typo fixes in test file comments with no functional changes.