### PR TITLE
Add a trace log if a polling request hangs

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/SourceManager.res
@@ -131,7 +131,18 @@ let getSourceNewHeight = async (
 
   while newHeight.contents <= currentBlockHeight && status.contents !== Done {
     try {
+      //Set a timer to warn if the source is taking too long to respond
+      let warningTimeOutMillis = 1_000
+      let timeoutId = Js.Global.setTimeout(() => {
+        logger->Logging.childTrace({
+          "msg": `Height retrieval from the source is taking longer than ${warningTimeOutMillis->Int.toString}ms.`,
+          "source": source.name,
+        })
+      }, warningTimeOutMillis)
+
       let height = await source.getHeightOrThrow()
+      //Clear the timer after the source responds
+      timeoutId->Js.Global.clearTimeout
       newHeight := height
       if height <= currentBlockHeight {
         retry := 0
@@ -437,3 +448,4 @@ let executeQuery = async (sourceManager: t, ~query: FetchState.query, ~currentBl
 
   responseRef.contents->Option.getUnsafe
 }
+


### PR DESCRIPTION
Thought this would be helpful since I have a case where hypersync was not lagging at all but the indexer was reporting that the source height did not increase in > 20s. And there were no failures on the polling.

I wanted a simple way to check if the polling was hanging for some time or if it was successful.