### PR TITLE
Add support for `accessList` and `authorizationList` fields in EVM transaction data

### DIFF
--- a/codegenerator/cli/npm/envio/evm.schema.json
+++ b/codegenerator/cli/npm/envio/evm.schema.json
@@ -229,6 +229,7 @@
         "status",
         "yParity",
         "chainId",
+        "accessList",
         "maxFeePerBlobGas",
         "blobVersionedHashes",
         "kind",
@@ -236,7 +237,8 @@
         "l1GasPrice",
         "l1GasUsed",
         "l1FeeScalar",
-        "gasUsedForL1"
+        "gasUsedForL1",
+        "authorizationList"
       ]
     },
     "BlockField": {

--- a/codegenerator/cli/npm/envio/package.json
+++ b/codegenerator/cli/npm/envio/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://envio.dev",
   "dependencies": {
-    "@envio-dev/hypersync-client": "0.6.3",
+    "@envio-dev/hypersync-client": "0.6.4",
     "rescript": "11.1.3",
     "rescript-schema": "9.3.0",
     "viem": "2.21.0"

--- a/codegenerator/cli/npm/envio/package.json
+++ b/codegenerator/cli/npm/envio/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://envio.dev",
   "dependencies": {
-    "@envio-dev/hypersync-client": "0.6.4",
+    "@envio-dev/hypersync-client": "0.6.5",
     "rescript": "11.1.3",
     "rescript-schema": "9.3.0",
     "viem": "2.21.0"

--- a/codegenerator/cli/npm/envio/package.json.tmpl
+++ b/codegenerator/cli/npm/envio/package.json.tmpl
@@ -31,7 +31,7 @@
     "envio-darwin-arm64": "${version}"
   },
   "dependencies": {
-    "@envio-dev/hypersync-client": "0.6.4",
+    "@envio-dev/hypersync-client": "0.6.5",
     "rescript": "11.1.3",
     "rescript-schema": "9.3.0",
     "viem": "2.21.0"

--- a/codegenerator/cli/npm/envio/package.json.tmpl
+++ b/codegenerator/cli/npm/envio/package.json.tmpl
@@ -31,7 +31,7 @@
     "envio-darwin-arm64": "${version}"
   },
   "dependencies": {
-    "@envio-dev/hypersync-client": "0.6.3",
+    "@envio-dev/hypersync-client": "0.6.4",
     "rescript": "11.1.3",
     "rescript-schema": "9.3.0",
     "viem": "2.21.0"

--- a/codegenerator/cli/npm/envio/src/sources/HyperSyncClient.gen.ts
+++ b/codegenerator/cli/npm/envio/src/sources/HyperSyncClient.gen.ts
@@ -1,0 +1,19 @@
+/* TypeScript file generated from HyperSyncClient.res by genType. */
+
+/* eslint-disable */
+/* tslint:disable */
+
+import type {t as Address_t} from '../../src/Address.gen';
+
+export type ResponseTypes_accessList = { readonly address?: Address_t; readonly storageKeys?: string[] };
+
+export type ResponseTypes_authorizationList = {
+  readonly chainId: bigint; 
+  readonly address: Address_t; 
+  readonly nonce: number; 
+  readonly yParity: 
+    1
+  | 0; 
+  readonly r: string; 
+  readonly s: string
+};

--- a/codegenerator/cli/npm/envio/src/sources/HyperSyncClient.res
+++ b/codegenerator/cli/npm/envio/src/sources/HyperSyncClient.res
@@ -75,6 +75,7 @@ module QueryTypes = {
     | L1GasUsed
     | L1FeeScalar
     | GasUsedForL1
+    | AuthorizationList
 
   type logField =
     | Removed
@@ -307,6 +308,30 @@ module ResponseTypes = {
     storageKeys?: array<string>,
   }
 
+  let accessListSchema = S.object(s => {
+    address: ?s.field("address", S.option(Address.schema)),
+    storageKeys: ?s.field("storageKeys", S.option(S.array(S.string))),
+  })
+
+  // TODO: update some of these fields to be integers rather than strings.
+  type authorizationList = {
+    chainId: string,
+    address: Address.t,
+    nonce: string,
+    yParity: string,
+    r: string,
+    s: string,
+  }
+
+  let authorizationListSchema = S.object(s => {
+    chainId: s.field("chainId", S.string),
+    address: s.field("address", Address.schema),
+    nonce: s.field("nonce", S.string),
+    yParity: s.field("yParity", S.string),
+    r: s.field("r", S.string),
+    s: s.field("s", S.string),
+  })
+
   type transaction = {
     blockHash?: string,
     blockNumber?: int,
@@ -342,6 +367,7 @@ module ResponseTypes = {
     l1GasUsed?: bigint,
     l1FeeScalar?: int,
     gasUsedForL1?: bigint,
+    authorizationList?: array<authorizationList>,
   }
 
   type log = {

--- a/codegenerator/cli/npm/envio/src/sources/HyperSyncClient.res
+++ b/codegenerator/cli/npm/envio/src/sources/HyperSyncClient.res
@@ -303,6 +303,7 @@ module ResponseTypes = {
     mixHash?: string,
   }
 
+  @genType
   type accessList = {
     address?: Address.t,
     storageKeys?: array<string>,
@@ -313,21 +314,21 @@ module ResponseTypes = {
     storageKeys: ?s.field("storageKeys", S.option(S.array(S.string))),
   })
 
-  // TODO: update some of these fields to be integers rather than strings.
+  @genType
   type authorizationList = {
-    chainId: string,
+    chainId: bigint,
     address: Address.t,
-    nonce: string,
-    yParity: string,
+    nonce: int,
+    yParity: [#0 | #1],
     r: string,
     s: string,
   }
 
   let authorizationListSchema = S.object(s => {
-    chainId: s.field("chainId", S.string),
+    chainId: s.field("chainId", S.bigint),
     address: s.field("address", Address.schema),
-    nonce: s.field("nonce", S.string),
-    yParity: s.field("yParity", S.string),
+    nonce: s.field("nonce", S.int),
+    yParity: s.field("yParity", S.enum([#0, #1])),
     r: s.field("r", S.string),
     s: s.field("s", S.string),
   })

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -255,7 +255,7 @@ pub mod evm {
         Status,
         YParity,
         ChainId,
-        // AccessList, //TODO this should produce an array of AccessList records
+        AccessList,
         MaxFeePerBlobGas,
         BlobVersionedHashes,
         Kind,
@@ -264,6 +264,7 @@ pub mod evm {
         L1GasUsed,
         L1FeeScalar,
         GasUsedForL1,
+        AuthorizationList,
         //These values are available by default on the block
         //so no need to allow users to configure these values
         // BlockHash,

--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -1571,7 +1571,6 @@ impl FieldSelection {
                 Tx::Status => Res::option(Res::Int),
                 Tx::YParity => Res::option(Res::String),
                 Tx::ChainId => Res::option(Res::Int),
-                // TxField::AccessList => todo!(),
                 Tx::MaxFeePerBlobGas => Res::option(Res::BigInt),
                 Tx::BlobVersionedHashes => Res::option(Res::array(Res::String)),
                 Tx::Kind => Res::option(Res::Int),
@@ -1580,6 +1579,14 @@ impl FieldSelection {
                 Tx::L1GasUsed => Res::option(Res::BigInt),
                 Tx::L1FeeScalar => Res::option(Res::Float),
                 Tx::GasUsedForL1 => Res::option(Res::BigInt),
+                Tx::AccessList => Res::option(Res::Array(Box::new(Res::TypeApplication {
+                    name: "HyperSyncClient.ResponseTypes.accessList".to_string(),
+                    type_params: vec![],
+                }))),
+                Tx::AuthorizationList => Res::option(Res::Array(Box::new(Res::TypeApplication {
+                    name: "HyperSyncClient.ResponseTypes.authorizationList".to_string(),
+                    type_params: vec![],
+                }))),
             };
             selected_transaction_fields.push(SelectedField {
                 name: transaction_field.to_string(),

--- a/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     {{#if is_evm_ecosystem}}
-    "@envio-dev/hypersync-client": "0.6.4",
+    "@envio-dev/hypersync-client": "0.6.5",
     {{/if}}
     {{#if is_fuel_ecosystem}}
     "@fuel-ts/crypto": "0.96.1",

--- a/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     {{#if is_evm_ecosystem}}
-    "@envio-dev/hypersync-client": "0.6.3",
+    "@envio-dev/hypersync-client": "0.6.4",
     {{/if}}
     {{#if is_fuel_ecosystem}}
     "@fuel-ts/crypto": "0.96.1",

--- a/scenarios/test_codegen/pnpm-lock.yaml
+++ b/scenarios/test_codegen/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       '@envio-dev/hypersync-client':
-        specifier: 0.6.3
-        version: 0.6.3
+        specifier: 0.6.4
+        version: 0.6.4
       '@glennsl/rescript-fetch':
         specifier: 0.2.0
         version: 0.2.0
@@ -390,44 +390,44 @@ packages:
     resolution: {integrity: sha512-eCSBUTgl8KbPyxky8cecDRLCYu2C1oFV4AZ72bEsI+TxXEvaljaL2kgttfzfu7gW+M89eCz55s49uF2t+YMTWA==}
     engines: {node: '>=10'}
 
-  '@envio-dev/hypersync-client-darwin-arm64@0.6.3':
-    resolution: {integrity: sha512-w4OLJaq3lD03iXPJxLnPpoxOduvzCfEe2nYtamvIRLPB2SlbxnB5EF5dSyFs6WKh1x4PMsksQOUKeCcOtQPZow==}
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.4':
+    resolution: {integrity: sha512-bdmvkHvWH6UntpUhgWl4kbHjgVZJWSWCAvq++V4eEV/0ZQDAoxLunF5Ux0AY+9v5sHQAC5ckeDLrLnuNBo5KqQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@envio-dev/hypersync-client-darwin-x64@0.6.3':
-    resolution: {integrity: sha512-zh98zCbm2cse/iIzyMs1YCcA1iI1U/j4Yex1xBVaEa1ogzQSK9peS6M+NygzdmlwPqr7K9rUQ/U56ICRl67fWw==}
+  '@envio-dev/hypersync-client-darwin-x64@0.6.4':
+    resolution: {integrity: sha512-KZ3j+0/iq845P1q2/FrQCRhshOIzx850AOhs97mEphI2k2D2nDBnNm3ci9MpIq+llF8/f2Bot6LcM6ih675CGw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.3':
-    resolution: {integrity: sha512-5pI0N6W7W0L7LpgN76BAWRsC+NPOvrlvBEq8IjlBUS47vqZALvcJj3gYNkm466tUBQ4q4tF1x48k7MFKtoO8aw==}
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.4':
+    resolution: {integrity: sha512-QRtPm28Ti7e7mmFLjSNVEiF44doxvH1sh831Nredur2rHx+zneqj3SoyqKWmO06lbwCrd9EjlCTd9n8frn/P1Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.3':
-    resolution: {integrity: sha512-jL3sxWVyTJuKdO5y/0tu1EtWSox+nJdpmr7rdVW1w0gLk4ewzWORp9cl5pXkpqM4MUsjJz+NkcQKsUquGYBkKg==}
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.4':
+    resolution: {integrity: sha512-PCFhnbnQZKZ6DAAEegFRdldxe+mAt6dlX1qdpU6Dz+314gFvOCsE9GOO3EEN55D1u4FmWG1DzBAXWLdqz4rSEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-linux-x64-musl@0.6.3':
-    resolution: {integrity: sha512-4rAh9x3PEWIweih731lWVEUGm+qrIHouElqZgXfTcZS6KkPeDnSYKVw10K5EyDuDtZla/NccEr0pJmcvpui5Ew==}
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.4':
+    resolution: {integrity: sha512-2+e0CjqSRCNC4oAM4vFczcFC97CPyegN2bdsRaArSgWQ5Wm4dBZSJwZybVazdErSNWLLT4X1qcJwLjzpDFIC2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.3':
-    resolution: {integrity: sha512-AINzLdjqU+y6ZiHnxorjFlrGNIw/AAJ80YXABYzokvGhDTF9qupjR1gdZo4sQEumgrRyg7fiG8QnsZVEm6V/zA==}
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.4':
+    resolution: {integrity: sha512-2evLgLH2E1q8IL3hZFOLk7fzPbuvcxmEH9lNP9j87JiatttijTLw87PlgaWLJ31f403dzBZGrPKR0IyOAun+MA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@envio-dev/hypersync-client@0.6.3':
-    resolution: {integrity: sha512-Lr5WyMZBK1cI++kAQLM/zd62NfUM60A3KWTKgeNew4NOghfoY5YZr99C7vo+CMYePXskYBR+ul+5iNPoHqkFrw==}
+  '@envio-dev/hypersync-client@0.6.4':
+    resolution: {integrity: sha512-tFm3L6IelPYUNJhAAtLBn0vROLsDmYAW7a99oKTZldVBhNbUUF0IWcWu5MTnJZEK1uyVrAdSYv7ANxymkTMUag==}
     engines: {node: '>= 10'}
 
   '@ethersproject/abi@5.7.0':
@@ -3665,32 +3665,32 @@ snapshots:
     dependencies:
       '@elastic/ecs-helpers': 1.1.0
 
-  '@envio-dev/hypersync-client-darwin-arm64@0.6.3':
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.4':
     optional: true
 
-  '@envio-dev/hypersync-client-darwin-x64@0.6.3':
+  '@envio-dev/hypersync-client-darwin-x64@0.6.4':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.3':
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.4':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.3':
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.4':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-x64-musl@0.6.3':
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.4':
     optional: true
 
-  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.3':
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.4':
     optional: true
 
-  '@envio-dev/hypersync-client@0.6.3':
+  '@envio-dev/hypersync-client@0.6.4':
     optionalDependencies:
-      '@envio-dev/hypersync-client-darwin-arm64': 0.6.3
-      '@envio-dev/hypersync-client-darwin-x64': 0.6.3
-      '@envio-dev/hypersync-client-linux-arm64-gnu': 0.6.3
-      '@envio-dev/hypersync-client-linux-x64-gnu': 0.6.3
-      '@envio-dev/hypersync-client-linux-x64-musl': 0.6.3
-      '@envio-dev/hypersync-client-win32-x64-msvc': 0.6.3
+      '@envio-dev/hypersync-client-darwin-arm64': 0.6.4
+      '@envio-dev/hypersync-client-darwin-x64': 0.6.4
+      '@envio-dev/hypersync-client-linux-arm64-gnu': 0.6.4
+      '@envio-dev/hypersync-client-linux-x64-gnu': 0.6.4
+      '@envio-dev/hypersync-client-linux-x64-musl': 0.6.4
+      '@envio-dev/hypersync-client-win32-x64-msvc': 0.6.4
 
   '@ethersproject/abi@5.7.0':
     dependencies:
@@ -5104,7 +5104,7 @@ snapshots:
 
   envio@file:../../codegenerator/cli/npm/envio(typescript@5.5.4):
     dependencies:
-      '@envio-dev/hypersync-client': 0.6.3
+      '@envio-dev/hypersync-client': 0.6.4
       rescript: 11.1.3
       rescript-schema: 9.3.0(rescript@11.1.3)
       viem: 2.21.0(typescript@5.5.4)


### PR DESCRIPTION
Here is an example repo showing that this works: https://github.com/enviodev/test-eip7702-selector

Please give me feedback on if there's tests you want to add or anything else I should check since I'm not as familiar with this code base.

I am also keen to change the type that we get from the HyperSync TypeScript client so that chainId and nonce are integers (or even bigInt, will need to read spec about these).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting and handling "accessList" and "authorizationList" fields in EVM transaction data.
  - Enhanced data models to include detailed structures for access and authorization lists in transaction responses.

- **Chores**
  - Updated the "@envio-dev/hypersync-client" dependency to version 0.6.5 in all relevant package configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->