### PR TITLE
Optimise Indexing Buffer

### DIFF
--- a/codegenerator/cli/npm/envio/src/FetchState.res
+++ b/codegenerator/cli/npm/envio/src/FetchState.res
@@ -948,11 +948,7 @@ queue item with an update fetch state.
 let getEarliestEvent = ({queue, latestFullyFetchedBlock}: t) => {
   switch queue->Utils.Array.last {
   | Some(item) =>
-    if (
-      item.blockNumber <= latestFullyFetchedBlock.blockNumber &&
-        // FIXME: Should make latestFullyFetchedBlock a -1 instead
-        item.blockNumber > 0
-    ) {
+    if item.blockNumber <= latestFullyFetchedBlock.blockNumber {
       Item({item, popItemOffQueue: () => queue->Js.Array2.pop->ignore})
     } else {
       NoItem({
@@ -981,8 +977,7 @@ let make = (
 ): t => {
   let latestFetchedBlock = {
     blockTimestamp: 0,
-    // Here's a bug that startBlock: 1 won't work
-    blockNumber: Pervasives.max(startBlock - 1, 0),
+    blockNumber: startBlock - 1,
   }
 
   let notDependingOnAddresses = []
@@ -1191,7 +1186,7 @@ let rollbackPartition = (
         addressesByContractName: rollbackedAddressesByContractName,
         latestFetchedBlock: shouldRollbackFetched
           ? {
-              blockNumber: Pervasives.max(firstChangeEvent.blockNumber - 1, 0),
+              blockNumber: firstChangeEvent.blockNumber - 1,
               blockTimestamp: 0,
             }
           : p.latestFetchedBlock,

--- a/codegenerator/cli/npm/envio/src/Prometheus.res
+++ b/codegenerator/cli/npm/envio/src/Prometheus.res
@@ -400,15 +400,14 @@ module IndexingBufferSize = {
   }
 }
 
-module IndexingMaxBufferSize = {
-  let gauge = SafeGauge.makeOrThrow(
-    ~name="envio_indexing_max_buffer_size",
-    ~help="The maximum number of items allowed in the indexing buffer for the chain.",
-    ~labelSchema=chainIdLabelsSchema,
-  )
+module IndexingTargetBufferSize = {
+  let gauge = PromClient.Gauge.makeGauge({
+    "name": "envio_indexing_target_buffer_size",
+    "help": "The target buffer size per chain for indexing. The actual number of items in the queue may exceed this value, but the indexer always tries to keep the buffer filled up to this target.",
+  })
 
-  let set = (~maxBufferSize, ~chainId) => {
-    gauge->SafeGauge.handleInt(~labels=chainId, ~value=maxBufferSize)
+  let set = (~targetBufferSize) => {
+    gauge->PromClient.Gauge.set(targetBufferSize)
   }
 }
 
@@ -543,5 +542,16 @@ module RollbackTargetBlockNumber = {
 
   let set = (~blockNumber, ~chain) => {
     gauge->SafeGauge.handleInt(~labels=chain->ChainMap.Chain.toChainId, ~value=blockNumber)
+  }
+}
+
+module ProcessingMaxBatchSize = {
+  let gauge = PromClient.Gauge.makeGauge({
+    "name": "envio_processing_max_batch_size",
+    "help": "The maximum number of items to process in a single batch.",
+  })
+
+  let set = (~maxBatchSize) => {
+    gauge->PromClient.Gauge.set(maxBatchSize)
   }
 }

--- a/codegenerator/cli/npm/envio/src/sources/SourceManager.res
+++ b/codegenerator/cli/npm/envio/src/sources/SourceManager.res
@@ -96,7 +96,7 @@ let fetchNext = async (
   ~executeQuery,
   ~waitForNewBlock,
   ~onNewBlock,
-  ~maxPerChainQueueSize,
+  ~targetBufferSize,
   ~stateId,
 ) => {
   let {maxPartitionConcurrency} = sourceManager
@@ -105,7 +105,7 @@ let fetchNext = async (
     ~concurrencyLimit={
       maxPartitionConcurrency - sourceManager.fetchingPartitionsCount
     },
-    ~maxQueueSize=maxPerChainQueueSize,
+    ~targetBufferSize,
     ~currentBlockHeight,
     ~stateId,
   ) {

--- a/codegenerator/cli/npm/envio/src/sources/SourceManager.resi
+++ b/codegenerator/cli/npm/envio/src/sources/SourceManager.resi
@@ -17,7 +17,7 @@ let fetchNext: (
   ~executeQuery: FetchState.query => promise<unit>,
   ~waitForNewBlock: (~currentBlockHeight: int) => promise<int>,
   ~onNewBlock: (~currentBlockHeight: int) => unit,
-  ~maxPerChainQueueSize: int,
+  ~targetBufferSize: int,
   ~stateId: int,
 ) => promise<unit>
 
@@ -29,4 +29,8 @@ let executeQuery: (
   ~currentBlockHeight: int,
 ) => promise<Source.blockRangeFetchResponse>
 
-let makeGetHeightRetryInterval: (~initialRetryInterval: int, ~backoffMultiplicative: int, ~maxRetryInterval: int) => (~retry: int) => int
+let makeGetHeightRetryInterval: (
+  ~initialRetryInterval: int,
+  ~backoffMultiplicative: int,
+  ~maxRetryInterval: int,
+) => (~retry: int) => int

--- a/codegenerator/cli/templates/static/codegen/src/Env.res
+++ b/codegenerator/cli/templates/static/codegen/src/Env.res
@@ -12,8 +12,8 @@ Dotenv.initialize()
 // resets the timestampCaughtUpToHeadOrEndblock after a restart when true
 let updateSyncTimeOnRestart =
   envSafe->EnvSafe.get("UPDATE_SYNC_TIME_ON_RESTART", S.bool, ~fallback=true)
-let maxEventFetchedQueueSize = envSafe->EnvSafe.get("MAX_QUEUE_SIZE", S.int, ~fallback=100_000)
 let maxProcessBatchSize = envSafe->EnvSafe.get("MAX_BATCH_SIZE", S.int, ~fallback=5_000)
+let targetBufferSize = envSafe->EnvSafe.get("ENVIO_INDEXING_MAX_BUFFER_SIZE", S.int, ~fallback=maxProcessBatchSize * 3)
 let maxAddrInPartition = envSafe->EnvSafe.get("MAX_PARTITION_SIZE", S.int, ~fallback=5_000)
 let maxPartitionConcurrency =
   envSafe->EnvSafe.get("ENVIO_MAX_PARTITION_CONCURRENCY", S.int, ~fallback=10)

--- a/codegenerator/cli/templates/static/codegen/src/Index.res
+++ b/codegenerator/cli/templates/static/codegen/src/Index.res
@@ -181,7 +181,7 @@ let makeAppState = (globalState: GlobalState.t): EnvioInkApp.appState => {
     ->ChainMap.values
     ->Array.map(cf => {
       let {numEventsProcessed, fetchState, numBatchesFetched} = cf
-      let latestFetchedBlockNumber = FetchState.getLatestFullyFetchedBlock(fetchState).blockNumber
+      let latestFetchedBlockNumber = Pervasives.max(FetchState.getLatestFullyFetchedBlock(fetchState).blockNumber, 0)
       let hasProcessedToEndblock = cf->ChainFetcher.hasProcessedToEndblock
       let currentBlockHeight =
         cf->ChainFetcher.hasProcessedToEndblock

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -300,10 +300,11 @@ let updateLatestProcessedBlocks = (
       let {chainConfig: {chain}, fetchState} = cf
       let {numEventsProcessed, latestProcessedBlock} = latestProcessedBlocks->ChainMap.get(chain)
 
-      let hasNoMoreEventsToProcess = cf->ChainFetcher.hasNoMoreEventsToProcess
-
-      let latestProcessedBlock = if hasNoMoreEventsToProcess {
-        FetchState.getLatestFullyFetchedBlock(fetchState).blockNumber->Some
+      let latestProcessedBlock = if cf->ChainFetcher.hasNoMoreEventsToProcess {
+        Pervasives.max(
+          FetchState.getLatestFullyFetchedBlock(fetchState).blockNumber,
+          0,
+        )->Some
       } else {
         latestProcessedBlock
       }

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -54,7 +54,7 @@ type t = {
   currentlyProcessingBatch: bool,
   rollbackState: rollbackState,
   maxBatchSize: int,
-  maxPerChainQueueSize: int,
+  targetBufferSize: int,
   indexerStartTime: Js.Date.t,
   writeThrottlers: WriteThrottlers.t,
   loadLayer: LoadLayer.t,
@@ -70,24 +70,18 @@ let make = (
   ~loadLayer: LoadLayer.t,
   ~shouldUseTui=false,
 ) => {
-  let maxPerChainQueueSize = {
-    let numChains = config.chainMap->ChainMap.size
-    Env.maxEventFetchedQueueSize / numChains
-  }
-  config.chainMap
-  ->ChainMap.keys
-  ->Array.forEach(chain => {
-    Prometheus.IndexingMaxBufferSize.set(
-      ~maxBufferSize=maxPerChainQueueSize,
-      ~chainId=chain->ChainMap.Chain.toChainId,
-    )
-  })
+  Prometheus.ProcessingMaxBatchSize.set(
+    ~maxBatchSize=Env.maxProcessBatchSize,
+  )
+  Prometheus.IndexingTargetBufferSize.set(
+    ~targetBufferSize=Env.targetBufferSize,
+  )
   {
     config,
     currentlyProcessingBatch: false,
     chainManager,
     maxBatchSize: Env.maxProcessBatchSize,
-    maxPerChainQueueSize,
+    targetBufferSize: Env.targetBufferSize,
     indexerStartTime: Js.Date.make(),
     rollbackState: NoRollback,
     writeThrottlers: WriteThrottlers.make(~config),
@@ -726,7 +720,7 @@ let checkAndFetchForChain = (
         | exn => dispatchAction(ErrorExit(exn->ErrorHandling.make))
         }
       },
-      ~maxPerChainQueueSize=state.maxPerChainQueueSize,
+      ~targetBufferSize=state.targetBufferSize,
       ~stateId=state.id,
     )
   }

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -283,35 +283,35 @@ describe("determineNextEvent", () => {
       }
     }
 
-    let makeMockFetchState = (~latestFetchedBlockTimestamp, ~item): FetchState.t => {
+    let makeMockFetchState = (
+      ~latestFetchedBlockTimestamp,
+      ~item: option<Internal.eventItem>,
+    ): FetchState.t => {
       let normalSelection: FetchState.selection = {
         dependsOnAddresses: true,
         eventConfigs: [
           (Mock.evmEventConfig(~id="0", ~contractName="MockContract") :> Internal.eventConfig),
         ],
       }
+      let latestFetchedBlock: FetchState.blockNumberAndTimestamp = {
+        blockTimestamp: latestFetchedBlockTimestamp,
+        blockNumber: item->Option.mapWithDefault(0, v => v.blockNumber),
+      }
       let partition: FetchState.partition = {
         id: "0",
-        latestFetchedBlock: {
-          blockTimestamp: latestFetchedBlockTimestamp,
-          blockNumber: 0,
-        },
+        latestFetchedBlock,
         status: {
           fetchingStateId: None,
         },
         selection: normalSelection,
         addressesByContractName: Js.Dict.empty(),
-        fetchedEventQueue: item->Option.mapWithDefault([], v => [v]),
       }
       {
         partitions: [partition],
         maxAddrInPartition: 5,
         nextPartitionIndex: 1,
-        queueSize: 10,
-        latestFullyFetchedBlock: {
-          blockTimestamp: latestFetchedBlockTimestamp,
-          blockNumber: 0,
-        },
+        queue: item->Option.mapWithDefault([], v => [v]),
+        latestFullyFetchedBlock: latestFetchedBlock,
         endBlock: None,
         isFetchingAtHead: false,
         firstEventBlockNumber: item->Option.map(v => v.blockNumber),

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -122,7 +122,6 @@ describe("FetchState.make", () => {
             },
             selection: fetchState.normalSelection,
             addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress0])]),
-            fetchedEventQueue: [],
           },
         ],
         endBlock: undefined,
@@ -133,7 +132,7 @@ describe("FetchState.make", () => {
           blockNumber: 0,
           blockTimestamp: 0,
         },
-        queueSize: 0,
+        queue: [],
         firstEventBlockNumber: None,
         normalSelection: fetchState.normalSelection,
         chainId: 0,
@@ -194,7 +193,6 @@ describe("FetchState.make", () => {
               addressesByContractName: Js.Dict.fromArray([
                 ("Gravatar", [mockAddress1, mockAddress2]),
               ]),
-              fetchedEventQueue: [],
             },
           ],
           nextPartitionIndex: 1,
@@ -204,7 +202,7 @@ describe("FetchState.make", () => {
             blockNumber: 0,
             blockTimestamp: 0,
           },
-          queueSize: 0,
+          queue: [],
           endBlock: undefined,
           firstEventBlockNumber: None,
           normalSelection: fetchState.normalSelection,
@@ -249,7 +247,6 @@ describe("FetchState.make", () => {
               },
               selection: fetchState.normalSelection,
               addressesByContractName: Js.Dict.fromArray([("ContractA", [mockAddress1])]),
-              fetchedEventQueue: [],
             },
             {
               id: "1",
@@ -260,7 +257,6 @@ describe("FetchState.make", () => {
               },
               selection: fetchState.normalSelection,
               addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress2])]),
-              fetchedEventQueue: [],
             },
           ],
           nextPartitionIndex: 2,
@@ -270,7 +266,7 @@ describe("FetchState.make", () => {
             blockNumber: 0,
             blockTimestamp: 0,
           },
-          queueSize: 0,
+          queue: [],
           endBlock: undefined,
           firstEventBlockNumber: None,
           normalSelection: fetchState.normalSelection,
@@ -322,7 +318,6 @@ describe("FetchState.make", () => {
               },
               selection: fetchState.normalSelection,
               addressesByContractName: Js.Dict.fromArray([("ContractA", [mockAddress1])]),
-              fetchedEventQueue: [],
             },
             {
               id: "1",
@@ -333,7 +328,6 @@ describe("FetchState.make", () => {
               },
               selection: fetchState.normalSelection,
               addressesByContractName: Js.Dict.fromArray([("ContractA", [mockAddress2])]),
-              fetchedEventQueue: [],
             },
             {
               id: "2",
@@ -344,7 +338,6 @@ describe("FetchState.make", () => {
               },
               selection: fetchState.normalSelection,
               addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress3])]),
-              fetchedEventQueue: [],
             },
             {
               id: "3",
@@ -355,7 +348,6 @@ describe("FetchState.make", () => {
               },
               selection: fetchState.normalSelection,
               addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress4])]),
-              fetchedEventQueue: [],
             },
           ],
           nextPartitionIndex: 4,
@@ -365,7 +357,7 @@ describe("FetchState.make", () => {
             blockNumber: 0,
             blockTimestamp: 0,
           },
-          queueSize: 0,
+          queue: [],
           firstEventBlockNumber: None,
           endBlock: undefined,
           normalSelection: fetchState.normalSelection,
@@ -467,7 +459,6 @@ describe("FetchState.registerDynamicContracts", () => {
           addressesByContractName: Js.Dict.fromArray([
             ("Gravatar", [mockAddress1, mockAddress2, mockAddress3]),
           ]),
-          fetchedEventQueue: [],
         },
         {
           id: "2",
@@ -478,7 +469,6 @@ describe("FetchState.registerDynamicContracts", () => {
           },
           selection: fetchState.normalSelection,
           addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress4])]),
-          fetchedEventQueue: [],
         },
       ]),
       ~message=`Should split into two partitions`,
@@ -515,7 +505,6 @@ describe("FetchState.registerDynamicContracts", () => {
             ("NftFactory", [mockAddress1, mockAddress4]),
             ("Gravatar", [mockAddress2]),
           ]),
-          fetchedEventQueue: [],
         },
         {
           id: "2",
@@ -526,7 +515,6 @@ describe("FetchState.registerDynamicContracts", () => {
           },
           selection: fetchState.normalSelection,
           addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress3])]),
-          fetchedEventQueue: [],
         },
       ]),
       ~message=`Still split into two partitions, but try to put addresses from the same contract together as much as possible`,
@@ -616,7 +604,6 @@ describe("FetchState.registerDynamicContracts", () => {
             addressesByContractName: Js.Dict.fromArray([
               ("SimpleNft", [mockAddress2, mockAddress3]),
             ]),
-            fetchedEventQueue: [],
           },
           {
             id: "2",
@@ -627,7 +614,6 @@ describe("FetchState.registerDynamicContracts", () => {
             },
             selection: fetchState.normalSelection,
             addressesByContractName: Js.Dict.fromArray([("SimpleNft", [mockAddress4])]),
-            fetchedEventQueue: [],
           },
           {
             id: "3",
@@ -641,7 +627,6 @@ describe("FetchState.registerDynamicContracts", () => {
               ("NftFactory", [mockAddress5]),
               ("Gravatar", [mockAddress1]),
             ]),
-            fetchedEventQueue: [],
           },
         ]),
         ~message=`All dcs without filterByAddresses should use the original logic and be grouped into a single partition,
@@ -652,7 +637,7 @@ describe("FetchState.registerDynamicContracts", () => {
         updatedFetchState->FetchState.getNextQuery(
           ~currentBlockHeight=10,
           ~concurrencyLimit=10,
-          ~maxQueueSize=10,
+          ~targetBufferSize=10,
           ~stateId=0,
         )
 
@@ -711,7 +696,6 @@ describe("FetchState.registerDynamicContracts", () => {
           },
           selection: fetchState.normalSelection,
           addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress1])]),
-          fetchedEventQueue: [],
         },
       ]),
     )
@@ -760,7 +744,6 @@ describe("FetchState.registerDynamicContracts", () => {
             addressesByContractName: Js.Dict.fromArray([
               ("Gravatar", [mockAddress1, mockAddress3, mockAddress2]),
             ]),
-            fetchedEventQueue: [],
           },
         ]),
       },
@@ -833,7 +816,6 @@ describe("FetchState.registerDynamicContracts", () => {
                 eventConfigs: [wildcard1, wildcard2],
               },
               addressesByContractName: Js.Dict.empty(),
-              fetchedEventQueue: [],
             },
             {
               id: "1",
@@ -849,7 +831,6 @@ describe("FetchState.registerDynamicContracts", () => {
               addressesByContractName: Js.Dict.fromArray([
                 ("NftFactory", [mockAddress0, mockAddress1, mockAddress5]),
               ]),
-              fetchedEventQueue: [],
             },
           ],
           endBlock: undefined,
@@ -860,7 +841,7 @@ describe("FetchState.registerDynamicContracts", () => {
             blockNumber: 0,
             blockTimestamp: 0,
           },
-          queueSize: 0,
+          queue: [],
           firstEventBlockNumber: None,
           normalSelection: fetchState.normalSelection,
           chainId,
@@ -893,7 +874,6 @@ describe("FetchState.getNextQuery & integration", () => {
           },
           selection: normalSelection,
           addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress0])]),
-          fetchedEventQueue: [mockEvent(~blockNumber=2), mockEvent(~blockNumber=1)],
         },
       ],
       nextPartitionIndex: 1,
@@ -903,7 +883,7 @@ describe("FetchState.getNextQuery & integration", () => {
         blockNumber: 10,
         blockTimestamp: 10,
       },
-      queueSize: 2,
+      queue: [mockEvent(~blockNumber=2), mockEvent(~blockNumber=1)],
       firstEventBlockNumber: Some(1),
       endBlock: None,
       dcsToStore: None,
@@ -939,7 +919,6 @@ describe("FetchState.getNextQuery & integration", () => {
           },
           selection: normalSelection,
           addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress0])]),
-          fetchedEventQueue: [mockEvent(~blockNumber=2), mockEvent(~blockNumber=1)],
         },
         {
           id: "2",
@@ -952,7 +931,6 @@ describe("FetchState.getNextQuery & integration", () => {
           addressesByContractName: Js.Dict.fromArray([
             ("Gravatar", [mockAddress3, mockAddress2, mockAddress1]),
           ]),
-          fetchedEventQueue: [],
         },
       ],
       nextPartitionIndex: 3,
@@ -962,7 +940,7 @@ describe("FetchState.getNextQuery & integration", () => {
         blockNumber: 1,
         blockTimestamp: 0,
       },
-      queueSize: 2,
+      queue: [mockEvent(~blockNumber=2), mockEvent(~blockNumber=1)],
       firstEventBlockNumber: Some(1),
       endBlock: undefined,
       normalSelection,
@@ -979,13 +957,18 @@ describe("FetchState.getNextQuery & integration", () => {
       fs,
       ~endBlock=None,
       ~currentBlockHeight=10,
-      ~maxQueueSize=10,
+      ~targetBufferSize=10,
       ~concurrencyLimit=10,
     ) =>
       switch endBlock {
       | Some(_) => {...fs, endBlock}
       | None => fs
-      }->FetchState.getNextQuery(~currentBlockHeight, ~concurrencyLimit, ~maxQueueSize, ~stateId=0)
+      }->FetchState.getNextQuery(
+        ~currentBlockHeight,
+        ~concurrencyLimit,
+        ~targetBufferSize,
+        ~stateId=0,
+      )
 
     let fetchState = makeInitial()
 
@@ -1028,7 +1011,6 @@ describe("FetchState.getNextQuery & integration", () => {
             },
             selection: fetchState.normalSelection,
             addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress0])]),
-            fetchedEventQueue: [],
           },
         ],
       },
@@ -1083,12 +1065,12 @@ describe("FetchState.getNextQuery & integration", () => {
       when block height exceeded the end block`,
     )
     Assert.deepEqual(
-      updatedFetchState->getNextQuery(~maxQueueSize=2),
+      updatedFetchState->getNextQuery(~targetBufferSize=2),
       WaitingForNewBlock,
       ~message=`Should wait for new block even if partitions have nothing to query`,
     )
     Assert.deepEqual(
-      updatedFetchState->getNextQuery(~maxQueueSize=2, ~currentBlockHeight=11),
+      updatedFetchState->getNextQuery(~targetBufferSize=2, ~currentBlockHeight=11),
       NothingToQuery,
       ~message=`Should do nothing if the case above is not waiting for new block`,
     )
@@ -1109,13 +1091,18 @@ describe("FetchState.getNextQuery & integration", () => {
       fs,
       ~endBlock=None,
       ~currentBlockHeight=10,
-      ~maxQueueSize=10,
+      ~targetBufferSize=10,
       ~concurrencyLimit=10,
     ) =>
       switch endBlock {
       | Some(_) => {...fs, endBlock}
       | None => fs
-      }->FetchState.getNextQuery(~currentBlockHeight, ~concurrencyLimit, ~maxQueueSize, ~stateId=0)
+      }->FetchState.getNextQuery(
+        ~currentBlockHeight,
+        ~concurrencyLimit,
+        ~targetBufferSize,
+        ~stateId=0,
+      )
 
     let fetchState = makeInitial(~blockLag=2)
 
@@ -1189,13 +1176,18 @@ describe("FetchState.getNextQuery & integration", () => {
       fs,
       ~endBlock=None,
       ~currentBlockHeight=11,
-      ~maxQueueSize=10,
+      ~targetBufferSize=10,
       ~concurrencyLimit=10,
     ) =>
       switch endBlock {
       | Some(_) => {...fs, endBlock}
       | None => fs
-      }->FetchState.getNextQuery(~currentBlockHeight, ~concurrencyLimit, ~maxQueueSize, ~stateId=0)
+      }->FetchState.getNextQuery(
+        ~currentBlockHeight,
+        ~concurrencyLimit,
+        ~targetBufferSize,
+        ~stateId=0,
+      )
 
     // Continue with the state from previous test
     let fetchState = makeAfterFirstStaticAddressesQuery()
@@ -1232,7 +1224,6 @@ describe("FetchState.getNextQuery & integration", () => {
             addressesByContractName: Js.Dict.fromArray([
               ("Gravatar", [mockAddress2, mockAddress1]),
             ]),
-            fetchedEventQueue: [],
           },
           {
             id: "2",
@@ -1243,7 +1234,6 @@ describe("FetchState.getNextQuery & integration", () => {
             },
             selection: fetchState.normalSelection,
             addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress3])]),
-            fetchedEventQueue: [],
           },
         ]),
       },
@@ -1319,18 +1309,11 @@ describe("FetchState.getNextQuery & integration", () => {
     }
 
     Assert.deepEqual(
-      updatedFetchState->getNextQuery(~maxQueueSize=6),
+      updatedFetchState->getNextQuery(~targetBufferSize=6),
       Ready([expectedPartition2Query, expectedPartition1Query]),
       ~message=`Since the partition "2" reached the maxAddrNumber,
       there's no point to continue merging partitions,
       so we have two queries concurrently`,
-    )
-    Assert.deepEqual(
-      updatedFetchState->getNextQuery(~maxQueueSize=5),
-      Ready([expectedPartition2Query]),
-      ~message=`Partition queue size is adjusted according to
-      the number of fully fetched partitions + 1. In the case it should be 5 / 2 = 2,
-      so the partition "0" is skipped`,
     )
     Assert.deepEqual(
       updatedFetchState->getNextQuery(~concurrencyLimit=1),
@@ -1361,13 +1344,18 @@ describe("FetchState.getNextQuery & integration", () => {
       fs,
       ~endBlock=None,
       ~currentBlockHeight=11,
-      ~maxQueueSize=10,
+      ~targetBufferSize=10,
       ~concurrencyLimit=10,
     ) =>
       switch endBlock {
       | Some(_) => {...fs, endBlock}
       | None => fs
-      }->FetchState.getNextQuery(~currentBlockHeight, ~concurrencyLimit, ~maxQueueSize, ~stateId=0)
+      }->FetchState.getNextQuery(
+        ~currentBlockHeight,
+        ~concurrencyLimit,
+        ~targetBufferSize,
+        ~stateId=0,
+      )
 
     // Continue with the state from previous test
     // But increase the maxAddrInPartition up to 4
@@ -1431,7 +1419,6 @@ describe("FetchState.getNextQuery & integration", () => {
             },
             selection: fetchState.normalSelection,
             addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress0])]),
-            fetchedEventQueue: [mockEvent(~blockNumber=2), mockEvent(~blockNumber=1)],
           },
           {
             id: "2",
@@ -1444,23 +1431,23 @@ describe("FetchState.getNextQuery & integration", () => {
             addressesByContractName: Js.Dict.fromArray([
               ("Gravatar", [mockAddress3, mockAddress2, mockAddress1]),
             ]),
-            // dynamicContracts: [dc2, dc3, dc1],
-            fetchedEventQueue: [
-              mockEvent(~blockNumber=4, ~logIndex=6),
-              mockEvent(~blockNumber=4, ~logIndex=2),
-            ],
           },
         ],
         latestFullyFetchedBlock: {
           blockNumber: 9,
           blockTimestamp: 9,
         },
-        queueSize: 4,
+        queue: [
+          mockEvent(~blockNumber=4, ~logIndex=6),
+          mockEvent(~blockNumber=4, ~logIndex=2),
+          mockEvent(~blockNumber=2),
+          mockEvent(~blockNumber=1),
+        ],
       },
     )
 
     Assert.deepEqual(
-      fetchStateWithResponse1->getNextQuery(~maxQueueSize=0),
+      fetchStateWithResponse1->getNextQuery(~targetBufferSize=0),
       Ready([
         {
           partitionId: "2",
@@ -1476,10 +1463,10 @@ describe("FetchState.getNextQuery & integration", () => {
           indexingContracts: fetchState.indexingContracts,
         },
       ]),
-      ~message="MergeQuery should ignore the maxQueueSize limit",
+      ~message="MergeQuery should ignore the targetBufferSize limit",
     )
 
-    let query = switch fetchState->getNextQuery(~maxQueueSize=0) {
+    let query = switch fetchState->getNextQuery(~targetBufferSize=0) {
     | Ready([q]) => q
     | _ => Assert.fail("Failed to extract query. The getNextQuery should be idempotent")
     }
@@ -1512,19 +1499,18 @@ describe("FetchState.getNextQuery & integration", () => {
             addressesByContractName: Js.Dict.fromArray([
               ("Gravatar", [mockAddress0, mockAddress3, mockAddress2, mockAddress1]),
             ]),
-            // dynamicContracts: [dc2, dc3, dc1],
-            fetchedEventQueue: [
-              mockEvent(~blockNumber=4, ~logIndex=6),
-              mockEvent(~blockNumber=4, ~logIndex=2),
-              mockEvent(~blockNumber=2),
-              mockEvent(~blockNumber=1),
-            ],
           },
         ],
         latestFullyFetchedBlock: {
           blockNumber: 10,
           blockTimestamp: 10,
         },
+        queue: [
+          mockEvent(~blockNumber=4, ~logIndex=6),
+          mockEvent(~blockNumber=4, ~logIndex=2),
+          mockEvent(~blockNumber=2),
+          mockEvent(~blockNumber=1),
+        ],
       },
     )
 
@@ -1562,12 +1548,6 @@ describe("FetchState.getNextQuery & integration", () => {
             addressesByContractName: Js.Dict.fromArray([
               ("Gravatar", [mockAddress0, mockAddress3]),
             ]),
-            fetchedEventQueue: [
-              mockEvent(~blockNumber=4, ~logIndex=6),
-              mockEvent(~blockNumber=4, ~logIndex=2),
-              mockEvent(~blockNumber=2),
-              mockEvent(~blockNumber=1),
-            ],
           },
           {
             id: "2",
@@ -1580,13 +1560,18 @@ describe("FetchState.getNextQuery & integration", () => {
             addressesByContractName: Js.Dict.fromArray([
               ("Gravatar", [mockAddress2, mockAddress1]),
             ]),
-            fetchedEventQueue: [],
           },
         ],
         latestFullyFetchedBlock: {
           blockNumber: 10,
           blockTimestamp: 10,
         },
+        queue: [
+          mockEvent(~blockNumber=4, ~logIndex=6),
+          mockEvent(~blockNumber=4, ~logIndex=2),
+          mockEvent(~blockNumber=2),
+          mockEvent(~blockNumber=1),
+        ],
       },
       ~message=`If on merge the target partition exceeds maxAddrsInPartition,
       then it should keep the rest addresses in the merging partition`,
@@ -1623,7 +1608,7 @@ describe("FetchState.getNextQuery & integration", () => {
       fetchState->FetchState.getNextQuery(
         ~currentBlockHeight=10,
         ~concurrencyLimit=10,
-        ~maxQueueSize=10,
+        ~targetBufferSize=10,
         ~stateId=0,
       )
 
@@ -1679,8 +1664,6 @@ describe("FetchState.getNextQuery & integration", () => {
             },
             selection: fetchState.normalSelection,
             addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress0])]),
-            // Removed an item here, but kept the partition.
-            fetchedEventQueue: [mockEvent(~blockNumber=1)],
           },
           {
             id: "2",
@@ -1691,12 +1674,12 @@ describe("FetchState.getNextQuery & integration", () => {
               blockTimestamp: 0,
             },
             selection: fetchState.normalSelection,
-            addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress1])]),
-            fetchedEventQueue: [],
             // Removed dc2 and dc3, even though the latestFetchedBlock is not exceeding the lastScannedBlock
+            addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress1])]),
           },
         ],
-        queueSize: 1,
+        // Removed an item here, but kept the partition.
+        queue: [mockEvent(~blockNumber=1)],
       },
       ~message=`Should rollback the partition state, but keep them`,
     )
@@ -1721,14 +1704,13 @@ describe("FetchState.getNextQuery & integration", () => {
             },
             selection: fetchState.normalSelection,
             addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress0])]),
-            fetchedEventQueue: [],
           },
         ],
         latestFullyFetchedBlock: {
           blockNumber: 0,
           blockTimestamp: 0,
         },
-        queueSize: 0,
+        queue: [],
       },
       ~message=`Partition "2" should be removed, but the partition "0" should be kept`,
     )
@@ -1806,10 +1788,9 @@ describe("FetchState.getNextQuery & integration", () => {
               eventConfigs: wildcardEventConfigs,
             },
             addressesByContractName: Js.Dict.empty(),
-            fetchedEventQueue: [],
           },
         ],
-        queueSize: 0,
+        queue: [],
       },
       ~message=`Should keep Wildcard partition even if it's empty`,
     )
@@ -1833,11 +1814,6 @@ describe("FetchState unit tests for specific cases", () => {
           },
           selection: normalSelection,
           addressesByContractName: Js.Dict.empty(),
-          fetchedEventQueue: [
-            mockEvent(~blockNumber=4, ~logIndex=2),
-            mockEvent(~blockNumber=4),
-            mockEvent(~blockNumber=2),
-          ],
         },
         {
           id: "1",
@@ -1848,7 +1824,6 @@ describe("FetchState unit tests for specific cases", () => {
           },
           selection: normalSelection,
           addressesByContractName: Js.Dict.empty(),
-          fetchedEventQueue: [mockEvent(~blockNumber=3), mockEvent(~blockNumber=1)],
         },
       ],
       nextPartitionIndex: 2,
@@ -1858,7 +1833,13 @@ describe("FetchState unit tests for specific cases", () => {
         blockNumber: 1,
         blockTimestamp: 0,
       },
-      queueSize: 5,
+      queue: [
+        mockEvent(~blockNumber=4, ~logIndex=2),
+        mockEvent(~blockNumber=4),
+        mockEvent(~blockNumber=3),
+        mockEvent(~blockNumber=2),
+        mockEvent(~blockNumber=1),
+      ],
       firstEventBlockNumber: Some(1),
       endBlock: undefined,
       normalSelection,
@@ -1913,22 +1894,21 @@ describe("FetchState unit tests for specific cases", () => {
             },
             selection: fetchState.normalSelection,
             addressesByContractName: Js.Dict.empty(),
-            fetchedEventQueue: [
-              mockEvent(~blockNumber=4, ~logIndex=2),
-              mockEvent(~blockNumber=4, ~logIndex=1),
-              mockEvent(~blockNumber=4, ~logIndex=1),
-              mockEvent(~blockNumber=4),
-              mockEvent(~blockNumber=3),
-              mockEvent(~blockNumber=2),
-              mockEvent(~blockNumber=1),
-            ],
           },
         ],
         latestFullyFetchedBlock: {
           blockNumber: 10,
           blockTimestamp: 10,
         },
-        queueSize: 7,
+        queue: [
+          mockEvent(~blockNumber=4, ~logIndex=2),
+          mockEvent(~blockNumber=4, ~logIndex=1),
+          mockEvent(~blockNumber=4, ~logIndex=1),
+          mockEvent(~blockNumber=4),
+          mockEvent(~blockNumber=3),
+          mockEvent(~blockNumber=2),
+          mockEvent(~blockNumber=1),
+        ],
       },
       ~message="Should merge events in correct order",
     )
@@ -1993,7 +1973,7 @@ describe("FetchState unit tests for specific cases", () => {
       fetchState->FetchState.getNextQuery(
         ~concurrencyLimit=10,
         ~currentBlockHeight=2,
-        ~maxQueueSize=10,
+        ~targetBufferSize=10,
         ~stateId=0,
       ),
       Ready([
@@ -2016,146 +1996,12 @@ describe("FetchState unit tests for specific cases", () => {
       fetchState->FetchState.getNextQuery(
         ~concurrencyLimit=10,
         ~currentBlockHeight=2,
-        ~maxQueueSize=4,
+        ~targetBufferSize=2,
         ~stateId=0,
       ),
       NothingToQuery,
       ~message=`Should wait until queue is processed, to continue fetching.
       Don't wait for new block, until all partitions reached the head`,
-    )
-  })
-
-  it("Shouldn't query full partitions at the head until all partitions entered sync range", () => {
-    let currentBlockHeight = 1_000_000
-    let syncRange = 1_000 // Should be 1/1000 of block height
-
-    // FetchState with 2 full partitions,
-    // one of them reached the head
-    // For the test we have 1 address per partition,
-    // but in real life it's going to be 5000.
-    // And we don't want to query 5000 addresses every new block,
-    // until all partitions reached the head
-    let fetchState = FetchState.make(
-      ~eventConfigs=[
-        (Mock.evmEventConfig(~id="0", ~contractName="ContractA") :> Internal.eventConfig),
-      ],
-      ~staticContracts=Js.Dict.fromArray([("ContractA", [mockAddress0, mockAddress1])]),
-      ~dynamicContracts=[],
-      ~startBlock=0,
-      ~endBlock=None,
-      ~maxAddrInPartition=1,
-      ~chainId,
-    )
-    let fetchState =
-      fetchState
-      ->FetchState.handleQueryResult(
-        ~query={
-          partitionId: "0",
-          target: Head,
-          selection: fetchState.normalSelection,
-          addressesByContractName: Js.Dict.empty(),
-          fromBlock: 0,
-          indexingContracts: fetchState.indexingContracts,
-        },
-        ~latestFetchedBlock=getBlockData(~blockNumber=currentBlockHeight - syncRange),
-        ~reversedNewItems=[],
-        ~currentBlockHeight,
-      )
-      ->Result.getExn
-
-    Assert.deepEqual(
-      fetchState->FetchState.getNextQuery(
-        ~concurrencyLimit=10,
-        ~currentBlockHeight,
-        ~maxQueueSize=10,
-        ~stateId=0,
-      ),
-      Ready([
-        {
-          partitionId: "1",
-          target: Head,
-          selection: fetchState.normalSelection,
-          addressesByContractName: Js.Dict.fromArray([("ContractA", [mockAddress1])]),
-          fromBlock: 0,
-          indexingContracts: fetchState.indexingContracts,
-        },
-      ]),
-      ~message=`Should only query partition "1", since partition "0" already entered the sync range
-        and it need to wait until all partitions reach it`,
-    )
-
-    Assert.deepEqual(
-      fetchState->FetchState.getNextQuery(
-        ~concurrencyLimit=10,
-        ~currentBlockHeight=currentBlockHeight + 1,
-        ~maxQueueSize=10,
-        ~stateId=0,
-      ),
-      Ready([
-        {
-          partitionId: "0",
-          target: Head,
-          selection: fetchState.normalSelection,
-          addressesByContractName: Js.Dict.fromArray([("ContractA", [mockAddress0])]),
-          fromBlock: 999001,
-          indexingContracts: fetchState.indexingContracts,
-        },
-        {
-          partitionId: "1",
-          target: Head,
-          selection: fetchState.normalSelection,
-          addressesByContractName: Js.Dict.fromArray([("ContractA", [mockAddress1])]),
-          fromBlock: 0,
-          indexingContracts: fetchState.indexingContracts,
-        },
-      ]),
-      ~message=`After partition exists from the sync range, it should be included to the query again.
-        Not a perfect solution, but as a quick fix it's good to query every 1000+ blocks than every block`,
-    )
-
-    let fetchStateWithBothInSyncRange =
-      fetchState
-      ->FetchState.handleQueryResult(
-        ~query={
-          partitionId: "1",
-          target: Head,
-          selection: fetchState.normalSelection,
-          addressesByContractName: Js.Dict.empty(),
-          fromBlock: 0,
-          indexingContracts: fetchState.indexingContracts,
-        },
-        ~latestFetchedBlock=getBlockData(~blockNumber=currentBlockHeight - syncRange),
-        ~reversedNewItems=[],
-        ~currentBlockHeight,
-      )
-      ->Result.getExn
-
-    Assert.deepEqual(
-      fetchStateWithBothInSyncRange->FetchState.getNextQuery(
-        ~concurrencyLimit=10,
-        ~currentBlockHeight,
-        ~maxQueueSize=10,
-        ~stateId=0,
-      ),
-      Ready([
-        {
-          partitionId: "0",
-          target: Head,
-          selection: fetchState.normalSelection,
-          addressesByContractName: Js.Dict.fromArray([("ContractA", [mockAddress0])]),
-          fromBlock: 999001,
-          indexingContracts: fetchState.indexingContracts,
-        },
-        {
-          partitionId: "1",
-          target: Head,
-          selection: fetchState.normalSelection,
-          addressesByContractName: Js.Dict.fromArray([("ContractA", [mockAddress1])]),
-          fromBlock: 999001,
-          indexingContracts: fetchState.indexingContracts,
-        },
-      ]),
-      ~message=`Should query both partitions when both are in the sync range`,
     )
   })
 
@@ -2258,6 +2104,8 @@ describe("FetchState unit tests for specific cases", () => {
       )
       ->Result.getExn
 
+    Js.log(updatedFetchState)
+
     Assert.deepEqual(
       updatedFetchState->FetchState.getEarliestEvent,
       NoItem({
@@ -2287,11 +2135,6 @@ describe("FetchState unit tests for specific cases", () => {
           latestFetchedBlock,
           selection: normalSelection,
           addressesByContractName: Js.Dict.empty(),
-          fetchedEventQueue: [
-            mockEvent(~blockNumber=6, ~logIndex=2),
-            mockEvent(~blockNumber=4),
-            mockEvent(~blockNumber=2, ~logIndex=1),
-          ],
         },
         {
           id: "1",
@@ -2299,18 +2142,17 @@ describe("FetchState unit tests for specific cases", () => {
           latestFetchedBlock,
           selection: normalSelection,
           addressesByContractName: Js.Dict.empty(),
-          fetchedEventQueue: [
-            mockEvent(~blockNumber=6, ~logIndex=1),
-            mockEvent(~blockNumber=5),
-            mockEvent(~blockNumber=2, ~logIndex=2),
-          ],
         },
       ],
       nextPartitionIndex: 2,
       isFetchingAtHead: false,
       maxAddrInPartition: 2,
       latestFullyFetchedBlock: latestFetchedBlock,
-      queueSize: 5,
+      queue: [
+        mockEvent(~blockNumber=6, ~logIndex=1),
+        mockEvent(~blockNumber=5),
+        mockEvent(~blockNumber=2, ~logIndex=1),
+      ],
       firstEventBlockNumber: Some(1),
       endBlock: undefined,
       normalSelection,
@@ -2600,7 +2442,7 @@ describe("FetchState unit tests for specific cases", () => {
       let queryA = switch fetchStateWithDcA->FetchState.getNextQuery(
         ~concurrencyLimit=10,
         ~currentBlockHeight,
-        ~maxQueueSize=10,
+        ~targetBufferSize=10,
         ~stateId=0,
       ) {
       | Ready([q]) => {
@@ -2641,7 +2483,7 @@ describe("FetchState unit tests for specific cases", () => {
         fetchStateWithDcB->FetchState.getNextQuery(
           ~concurrencyLimit=10,
           ~currentBlockHeight,
-          ~maxQueueSize=10,
+          ~targetBufferSize=10,
           ~stateId=0,
         ),
         NothingToQuery,
@@ -2663,7 +2505,7 @@ describe("FetchState unit tests for specific cases", () => {
         fetchStateWithBothDcsAndQueryAResponse->FetchState.getNextQuery(
           ~concurrencyLimit=10,
           ~currentBlockHeight,
-          ~maxQueueSize=10,
+          ~targetBufferSize=10,
           ~stateId=0,
         ),
         Ready([

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -105,7 +105,7 @@ let makeIndexingContractsWithDynamics = (dcs: array<FetchState.indexingContract>
 // instead of setting a value to undefined. It's fixed in v12.
 let undefined = (%raw(`undefined`): option<'a>)
 
-describe_only("FetchState.make", () => {
+describe("FetchState.make", () => {
   it("Creates FetchState with a single static address", () => {
     let fetchState = makeInitial()
 
@@ -372,7 +372,7 @@ describe_only("FetchState.make", () => {
   )
 })
 
-describe_only("FetchState.registerDynamicContracts", () => {
+describe("FetchState.registerDynamicContracts", () => {
   // It shouldn't happen, but just in case
   it("Nothing breaks when provided an empty array", () => {
     let fetchState = makeInitial()
@@ -856,7 +856,7 @@ describe_only("FetchState.registerDynamicContracts", () => {
   )
 })
 
-describe_only("FetchState.getNextQuery & integration", () => {
+describe("FetchState.getNextQuery & integration", () => {
   let dc1 = makeDynContractRegistration(~blockNumber=1, ~contractAddress=mockAddress1)
   let dc2 = makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress2)
   let dc3 = makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress3)
@@ -1797,7 +1797,7 @@ describe_only("FetchState.getNextQuery & integration", () => {
   })
 })
 
-describe_only("FetchState unit tests for specific cases", () => {
+describe("FetchState unit tests for specific cases", () => {
   it("Should merge events in correct order on merging", () => {
     let normalSelection: FetchState.selection = {
       dependsOnAddresses: true,
@@ -2532,7 +2532,7 @@ describe_only("FetchState unit tests for specific cases", () => {
   )
 })
 
-describe_only("Test queue item", () => {
+describe("Test queue item", () => {
   it("Correctly compares queue items", () => {
     Assert.deepEqual(
       FetchState.NoItem({
@@ -2648,7 +2648,7 @@ describe_only("Test queue item", () => {
   })
 })
 
-describe_only("FetchState.queueItemIsInReorgThreshold", () => {
+describe("FetchState.queueItemIsInReorgThreshold", () => {
   it("Returns false when we just started the indexer and it has currentBlockHeight=0", () => {
     let fetchState = makeInitial()
     Assert.equal(

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -105,7 +105,7 @@ let makeIndexingContractsWithDynamics = (dcs: array<FetchState.indexingContract>
 // instead of setting a value to undefined. It's fixed in v12.
 let undefined = (%raw(`undefined`): option<'a>)
 
-describe("FetchState.make", () => {
+describe_only("FetchState.make", () => {
   it("Creates FetchState with a single static address", () => {
     let fetchState = makeInitial()
 
@@ -117,7 +117,7 @@ describe("FetchState.make", () => {
             id: "0",
             status: {fetchingStateId: None},
             latestFetchedBlock: {
-              blockNumber: 0,
+              blockNumber: -1,
               blockTimestamp: 0,
             },
             selection: fetchState.normalSelection,
@@ -129,7 +129,7 @@ describe("FetchState.make", () => {
         isFetchingAtHead: false,
         maxAddrInPartition: 3,
         latestFullyFetchedBlock: {
-          blockNumber: 0,
+          blockNumber: -1,
           blockTimestamp: 0,
         },
         queue: [],
@@ -186,7 +186,7 @@ describe("FetchState.make", () => {
               id: "0",
               status: {fetchingStateId: None},
               latestFetchedBlock: {
-                blockNumber: 0,
+                blockNumber: -1,
                 blockTimestamp: 0,
               },
               selection: fetchState.normalSelection,
@@ -199,7 +199,7 @@ describe("FetchState.make", () => {
           isFetchingAtHead: false,
           maxAddrInPartition: 2,
           latestFullyFetchedBlock: {
-            blockNumber: 0,
+            blockNumber: -1,
             blockTimestamp: 0,
           },
           queue: [],
@@ -242,7 +242,7 @@ describe("FetchState.make", () => {
               id: "0",
               status: {fetchingStateId: None},
               latestFetchedBlock: {
-                blockNumber: 0,
+                blockNumber: -1,
                 blockTimestamp: 0,
               },
               selection: fetchState.normalSelection,
@@ -252,7 +252,7 @@ describe("FetchState.make", () => {
               id: "1",
               status: {fetchingStateId: None},
               latestFetchedBlock: {
-                blockNumber: 0,
+                blockNumber: -1,
                 blockTimestamp: 0,
               },
               selection: fetchState.normalSelection,
@@ -263,7 +263,7 @@ describe("FetchState.make", () => {
           isFetchingAtHead: false,
           maxAddrInPartition: 1,
           latestFullyFetchedBlock: {
-            blockNumber: 0,
+            blockNumber: -1,
             blockTimestamp: 0,
           },
           queue: [],
@@ -313,7 +313,7 @@ describe("FetchState.make", () => {
               id: "0",
               status: {fetchingStateId: None},
               latestFetchedBlock: {
-                blockNumber: 0,
+                blockNumber: -1,
                 blockTimestamp: 0,
               },
               selection: fetchState.normalSelection,
@@ -323,7 +323,7 @@ describe("FetchState.make", () => {
               id: "1",
               status: {fetchingStateId: None},
               latestFetchedBlock: {
-                blockNumber: 0,
+                blockNumber: -1,
                 blockTimestamp: 0,
               },
               selection: fetchState.normalSelection,
@@ -333,7 +333,7 @@ describe("FetchState.make", () => {
               id: "2",
               status: {fetchingStateId: None},
               latestFetchedBlock: {
-                blockNumber: 0,
+                blockNumber: -1,
                 blockTimestamp: 0,
               },
               selection: fetchState.normalSelection,
@@ -343,7 +343,7 @@ describe("FetchState.make", () => {
               id: "3",
               status: {fetchingStateId: None},
               latestFetchedBlock: {
-                blockNumber: 0,
+                blockNumber: -1,
                 blockTimestamp: 0,
               },
               selection: fetchState.normalSelection,
@@ -354,7 +354,7 @@ describe("FetchState.make", () => {
           isFetchingAtHead: false,
           maxAddrInPartition: 1,
           latestFullyFetchedBlock: {
-            blockNumber: 0,
+            blockNumber: -1,
             blockTimestamp: 0,
           },
           queue: [],
@@ -372,7 +372,7 @@ describe("FetchState.make", () => {
   )
 })
 
-describe("FetchState.registerDynamicContracts", () => {
+describe_only("FetchState.registerDynamicContracts", () => {
   // It shouldn't happen, but just in case
   it("Nothing breaks when provided an empty array", () => {
     let fetchState = makeInitial()
@@ -806,7 +806,7 @@ describe("FetchState.registerDynamicContracts", () => {
               id: "0",
               status: {fetchingStateId: None},
               latestFetchedBlock: {
-                blockNumber: 0,
+                blockNumber: -1,
                 blockTimestamp: 0,
               },
               selection: {
@@ -821,7 +821,7 @@ describe("FetchState.registerDynamicContracts", () => {
               id: "1",
               status: {fetchingStateId: None},
               latestFetchedBlock: {
-                blockNumber: 0,
+                blockNumber: -1,
                 blockTimestamp: 0,
               },
               selection: {
@@ -838,7 +838,7 @@ describe("FetchState.registerDynamicContracts", () => {
           isFetchingAtHead: false,
           maxAddrInPartition: 1000,
           latestFullyFetchedBlock: {
-            blockNumber: 0,
+            blockNumber: -1,
             blockTimestamp: 0,
           },
           queue: [],
@@ -856,7 +856,7 @@ describe("FetchState.registerDynamicContracts", () => {
   )
 })
 
-describe("FetchState.getNextQuery & integration", () => {
+describe_only("FetchState.getNextQuery & integration", () => {
   let dc1 = makeDynContractRegistration(~blockNumber=1, ~contractAddress=mockAddress1)
   let dc2 = makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress2)
   let dc3 = makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress3)
@@ -1006,7 +1006,7 @@ describe("FetchState.getNextQuery & integration", () => {
             id: "0",
             status: {fetchingStateId: Some(0)},
             latestFetchedBlock: {
-              blockNumber: 0,
+              blockNumber: -1,
               blockTimestamp: 0,
             },
             selection: fetchState.normalSelection,
@@ -1699,7 +1699,7 @@ describe("FetchState.getNextQuery & integration", () => {
             id: "0",
             status: {fetchingStateId: None},
             latestFetchedBlock: {
-              blockNumber: 0,
+              blockNumber: -1,
               blockTimestamp: 0,
             },
             selection: fetchState.normalSelection,
@@ -1707,7 +1707,7 @@ describe("FetchState.getNextQuery & integration", () => {
           },
         ],
         latestFullyFetchedBlock: {
-          blockNumber: 0,
+          blockNumber: -1,
           blockTimestamp: 0,
         },
         queue: [],
@@ -1780,7 +1780,7 @@ describe("FetchState.getNextQuery & integration", () => {
             id: "0",
             status: {fetchingStateId: None},
             latestFetchedBlock: {
-              blockNumber: 0,
+              blockNumber: -1,
               blockTimestamp: 0,
             },
             selection: {
@@ -1797,7 +1797,7 @@ describe("FetchState.getNextQuery & integration", () => {
   })
 })
 
-describe("FetchState unit tests for specific cases", () => {
+describe_only("FetchState unit tests for specific cases", () => {
   it("Should merge events in correct order on merging", () => {
     let normalSelection: FetchState.selection = {
       dependsOnAddresses: true,
@@ -2012,7 +2012,7 @@ describe("FetchState unit tests for specific cases", () => {
       fetchState->FetchState.getEarliestEvent,
       NoItem({
         latestFetchedBlock: {
-          blockNumber: 0,
+          blockNumber: -1,
           blockTimestamp: 0,
         },
       }),
@@ -2081,7 +2081,7 @@ describe("FetchState unit tests for specific cases", () => {
       fetchState->FetchState.getEarliestEvent,
       NoItem({
         latestFetchedBlock: {
-          blockNumber: 0,
+          blockNumber: -1,
           blockTimestamp: 0,
         },
       }),
@@ -2110,7 +2110,7 @@ describe("FetchState unit tests for specific cases", () => {
       updatedFetchState->FetchState.getEarliestEvent,
       NoItem({
         latestFetchedBlock: {
-          blockNumber: 0,
+          blockNumber: -1,
           blockTimestamp: 0,
         },
       }),
@@ -2370,8 +2370,13 @@ describe("FetchState unit tests for specific cases", () => {
     )
     Assert.deepEqual(
       {...makeInitial(), endBlock: Some(0)}->FetchState.isActivelyIndexing,
+      true,
+      ~message=`Should be active if endBlock is equal to the startBlock`,
+    )
+    Assert.deepEqual(
+      {...makeInitial(~startBlock=10), endBlock: Some(9)}->FetchState.isActivelyIndexing,
       false,
-      ~message=`But if endBlock is equal to the startBlock, initial state shouldn't be active`,
+      ~message=`Shouldn't be active if endBlock is less than the startBlock`,
     )
     let fetchState = {
       ...makeInitial(),
@@ -2389,7 +2394,7 @@ describe("FetchState unit tests for specific cases", () => {
           indexingContracts: fetchState.indexingContracts,
         },
         ~reversedNewItems=[mockEvent(~blockNumber=0)],
-        ~latestFetchedBlock={blockNumber: 0, blockTimestamp: 0},
+        ~latestFetchedBlock={blockNumber: -1, blockTimestamp: 0},
         ~currentBlockHeight=1,
       )
       ->Result.getExn
@@ -2527,7 +2532,7 @@ describe("FetchState unit tests for specific cases", () => {
   )
 })
 
-describe("Test queue item", () => {
+describe_only("Test queue item", () => {
   it("Correctly compares queue items", () => {
     Assert.deepEqual(
       FetchState.NoItem({
@@ -2643,7 +2648,7 @@ describe("Test queue item", () => {
   })
 })
 
-describe("FetchState.queueItemIsInReorgThreshold", () => {
+describe_only("FetchState.queueItemIsInReorgThreshold", () => {
   it("Returns false when we just started the indexer and it has currentBlockHeight=0", () => {
     let fetchState = makeInitial()
     Assert.equal(


### PR DESCRIPTION
This changes how we store the indexer buffer and prioritise partitions to query. After the change the initial buffer got bigger than before, but with the logic we prevent overfetching far from the processing block. We also prioritize partitions close to processing to ensure that we always have a buffer to process. For multichain indexer it doesn't shrink the buffer too much, so there's no perf regression in the unordered multichain mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized event queue management into a single global queue, improving event handling and metrics accuracy.
  - Renamed configuration parameters and environment variables from `maxQueueSize` to `targetBufferSize` for clearer semantics.
  - Updated Prometheus metrics to track indexing target buffer size and processing max batch size with new gauges.
- **Tests**
  - Revised test suites and helpers to support the global queue structure and updated parameter names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->