### PR TITLE
Fix infinite loop of the reorg depth check

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -496,7 +496,7 @@ let getLastKnownValidBlock = async (
         switch chainFetcher.lastBlockScannedHashes->ReorgDetection.LastBlockScannedHashes.getLatestValidScannedBlock(
           ~blockNumbersAndHashes,
           ~currentBlockHeight=chainFetcher.currentBlockHeight,
-          ~skipReorgDuplicationCheck=retryCount.contents > 1,
+          ~skipReorgDuplicationCheck=retryCount.contents > 2,
         ) {
         | Ok(block) => blockRef := Some(block)
         | Error(NotFound) => blockRef := Some(await fallback())

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -488,6 +488,7 @@ let getLastKnownValidBlock = async (
   | [] => await fallback()
   | _ => {
       let blockRef = ref(None)
+      let retryCount = ref(0)
 
       while blockRef.contents->Option.isNone {
         let blockNumbersAndHashes = await getBlockHashes(scannedBlockNumbers)
@@ -495,6 +496,7 @@ let getLastKnownValidBlock = async (
         switch chainFetcher.lastBlockScannedHashes->ReorgDetection.LastBlockScannedHashes.getLatestValidScannedBlock(
           ~blockNumbersAndHashes,
           ~currentBlockHeight=chainFetcher.currentBlockHeight,
+          ~skipReorgDuplicationCheck=retryCount.contents > 1,
         ) {
         | Ok(block) => blockRef := Some(block)
         | Error(NotFound) => blockRef := Some(await fallback())
@@ -504,6 +506,7 @@ let getLastKnownValidBlock = async (
             `Failed to find a valid block to rollback to, since received already reorged hashes from another HyperSync instance. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${delayMilliseconds->Int.toString}ms.`,
           )
           await Utils.delay(delayMilliseconds)
+          retryCount := retryCount.contents + 1
         }
       }
 

--- a/scenarios/test_codegen/pnpm-lock.yaml
+++ b/scenarios/test_codegen/pnpm-lock.yaml
@@ -35,6 +35,10 @@ importers:
       viem:
         specifier: 2.21.0
         version: 2.21.0(typescript@5.5.4)
+    optionalDependencies:
+      generated:
+        specifier: ./generated
+        version: link:generated
     devDependencies:
       '@glennsl/rescript-fetch':
         specifier: 0.2.0
@@ -93,10 +97,6 @@ importers:
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@18.19.47)(typescript@5.5.4)
-    optionalDependencies:
-      generated:
-        specifier: ./generated
-        version: link:generated
 
   ../helpers:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of block reorganization detection with an option to skip duplication checks after multiple retries, reducing the risk of infinite loops during block validation.

- **Bug Fixes**
  - Enhanced reliability when searching for the latest valid block by adding a retry mechanism and conditional logic to handle conflicting block hashes more gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->