### PR TITLE
Remove dependency on root from generated

### DIFF
--- a/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
@@ -55,7 +55,6 @@
     "rescript": "11.1.3",
     "rescript-envsafe": "5.0.0",
     "rescript-schema": "9.3.0",
-    "root": "{{relative_path_to_root_from_generated}}",
     "viem": "2.21.0",
     "yargs": "17.7.2"
   }

--- a/codegenerator/cli/templates/dynamic/codegen/src/Path.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Path.res.hbs
@@ -1,0 +1,1 @@
+let relativePathToRootFromGenerated = "{{relative_path_to_root_from_generated}}"

--- a/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
@@ -6,7 +6,7 @@ let registerContractHandlers = (
   ~handlerPathRelativeToConfig,
 ) => {
   try {
-    require("root/" ++ handlerPathRelativeToRoot)
+    require(`../${Path.relativePathToRootFromGenerated}/${handlerPathRelativeToRoot}`)
   } catch {
   | exn =>
     let params = {

--- a/codegenerator/cli/templates/static/codegen/src/bindings/Dotenv.res
+++ b/codegenerator/cli/templates/static/codegen/src/bindings/Dotenv.res
@@ -8,7 +8,7 @@ module Utils = {
   external require: require = "require"
 
   let getEnvFilePath = () =>
-    switch require.resolve("root/.env") {
+    switch require.resolve(`../../${Path.relativePathToRootFromGenerated}/.env`) {
     | path => Some(path)
     | exception _exn => None
     }

--- a/scenarios/test_codegen/pnpm-lock.yaml
+++ b/scenarios/test_codegen/pnpm-lock.yaml
@@ -196,9 +196,6 @@ importers:
       rescript-schema:
         specifier: 9.3.0
         version: 9.3.0(rescript@11.1.3)
-      root:
-        specifier: ../.
-        version: link:..
       viem:
         specifier: 2.21.0
         version: 2.21.0(typescript@5.5.4)


### PR DESCRIPTION
This is the first PR to solve the issue of using HyperIndex as a part of another monorepo - https://github.com/enviodev/docs/issues/650

This solves a cycle dependency between the root and the generated project, as well as reduces the reliance of the generated dir on pnpm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration file to provide a dynamic relative path for generated code.

- **Refactor**
  - Updated path resolution for requiring handler files and locating the `.env` file to use the new dynamic relative path instead of hardcoded values.

- **Chores**
  - Removed an unused dependency entry from the package template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->