### PR TITLE
Use less memory for multichain indexers

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/Env.res
+++ b/codegenerator/cli/templates/static/codegen/src/Env.res
@@ -13,7 +13,7 @@ Dotenv.initialize()
 let updateSyncTimeOnRestart =
   envSafe->EnvSafe.get("UPDATE_SYNC_TIME_ON_RESTART", S.bool, ~fallback=true)
 let maxProcessBatchSize = envSafe->EnvSafe.get("MAX_BATCH_SIZE", S.int, ~fallback=5_000)
-let targetBufferSize = envSafe->EnvSafe.get("ENVIO_INDEXING_MAX_BUFFER_SIZE", S.int, ~fallback=maxProcessBatchSize * 3)
+let targetBufferSize = envSafe->EnvSafe.get("ENVIO_INDEXING_MAX_BUFFER_SIZE", S.option(S.int))
 let maxAddrInPartition = envSafe->EnvSafe.get("MAX_PARTITION_SIZE", S.int, ~fallback=5_000)
 let maxPartitionConcurrency =
   envSafe->EnvSafe.get("ENVIO_MAX_PARTITION_CONCURRENCY", S.int, ~fallback=10)

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -70,14 +70,19 @@ let make = (
   ~loadLayer: LoadLayer.t,
   ~shouldUseTui=false,
 ) => {
+  let targetBatchesInBuffer = 3
+  let targetBufferSize = switch Env.targetBufferSize {
+    | Some(size) => size
+    | None => Env.maxProcessBatchSize * (chainManager.chainFetchers->ChainMap.size > targetBatchesInBuffer ? 1 : targetBatchesInBuffer)
+  }
   Prometheus.ProcessingMaxBatchSize.set(~maxBatchSize=Env.maxProcessBatchSize)
-  Prometheus.IndexingTargetBufferSize.set(~targetBufferSize=Env.targetBufferSize)
+  Prometheus.IndexingTargetBufferSize.set(~targetBufferSize)
   {
     config,
     currentlyProcessingBatch: false,
     chainManager,
     maxBatchSize: Env.maxProcessBatchSize,
-    targetBufferSize: Env.targetBufferSize,
+    targetBufferSize,
     indexerStartTime: Js.Date.make(),
     rollbackState: NoRollback,
     writeThrottlers: WriteThrottlers.make(~config),

--- a/scenarios/test_codegen/pnpm-lock.yaml
+++ b/scenarios/test_codegen/pnpm-lock.yaml
@@ -175,9 +175,6 @@ importers:
       postgres:
         specifier: 3.4.1
         version: 3.4.1
-      prom-client:
-        specifier: 15.0.0
-        version: 15.0.0
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -190,6 +187,9 @@ importers:
       rescript-schema:
         specifier: 9.3.0
         version: 9.3.0(rescript@11.1.3)
+      ts-node:
+        specifier: 10.9.1
+        version: 10.9.1(@types/node@18.19.47)(typescript@5.5.4)
       viem:
         specifier: 2.21.0
         version: 2.21.0(typescript@5.5.4)
@@ -3203,6 +3203,20 @@ packages:
   ts-expect@1.3.0:
     resolution: {integrity: sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ==}
 
+  ts-node@10.9.1:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -5378,6 +5392,7 @@ snapshots:
       bignumber.js: 9.1.2
       pino: 8.16.1
       pino-pretty: 10.2.3
+      prom-client: 15.0.0
       rescript: 11.1.3
       rescript-schema: 9.3.0(rescript@11.1.3)
       viem: 2.21.0(typescript@5.5.4)
@@ -7470,6 +7485,24 @@ snapshots:
       typescript: 5.5.4
 
   ts-expect@1.3.0: {}
+
+  ts-node@10.9.1(@types/node@18.19.47)(typescript@5.5.4):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.19.47
+      acorn: 8.12.1
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
 
   ts-node@10.9.2(@types/node@18.19.47)(typescript@5.5.4):
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the indexing buffer size configuration, allowing the related environment variable to be optional and providing smarter defaults when not set.
- **Refactor**
  - Enhanced internal logic for determining buffer size, leading to more flexible and predictable behavior based on environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->