### PR TITLE
Fix missing prom-client dependency

### DIFF
--- a/codegenerator/cli/npm/envio/package.json.tmpl
+++ b/codegenerator/cli/npm/envio/package.json.tmpl
@@ -37,7 +37,8 @@
     "viem": "2.21.0",
     "bignumber.js": "9.1.2",
     "pino": "8.16.1",
-    "pino-pretty": "10.2.3"
+    "pino-pretty": "10.2.3",
+    "prom-client": "15.0.0"
   },
   "files": [
     "bin.js",

--- a/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/package.json.hbs
@@ -58,6 +58,7 @@
     "rescript-schema": "9.3.0",
     "envio": "{{envio_version}}",
     "viem": "2.21.0",
-    "yargs": "17.7.2"
+    "yargs": "17.7.2",
+    "prom-client": "15.0.0"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package templates to include the "prom-client" dependency (version 15.0.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->