### PR TITLE
Allow set from loaders

### DIFF
--- a/codegenerator/cli/npm/envio/src/Logging.res
+++ b/codegenerator/cli/npm/envio/src/Logging.res
@@ -168,6 +168,14 @@ let logForItem = (eventItem, level: Pino.logLevel, message: string, ~params=?) =
   (eventItem->getEventLogger->Utils.magic->Js.Dict.unsafeGet((level :> string)))(params, message)
 }
 
+let noopLogger: Envio.logger = {
+  info: (_message: string, ~params as _=?) => (),
+  debug: (_message: string, ~params as _=?) => (),
+  warn: (_message: string, ~params as _=?) => (),
+  error: (_message: string, ~params as _=?) => (),
+  errorWithExn: (_message: string, _exn) => (),
+}
+
 let getUserLogger = (eventItem): Envio.logger => {
   info: (message: string, ~params=?) => eventItem->logForItem(#uinfo, message, ~params?),
   debug: (message: string, ~params=?) => eventItem->logForItem(#udebug, message, ~params?),

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -17,6 +17,9 @@ type entityLoaderContext<'entity, 'indexedFieldOperations> = {
   get: id => promise<option<'entity>>,
   getOrThrow: (id, ~message: string=?) => promise<'entity>,
   getWhere: 'indexedFieldOperations,
+  getOrCreate: ('entity) => promise<'entity>,
+  set: 'entity => unit,
+  deleteUnsafe: id => unit,
 }
 
 @genType.import(("./Types.ts", "LoaderContext"))

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.res.hbs
@@ -26,6 +26,7 @@ type entityLoaderContext<'entity, 'indexedFieldOperations> = {
 type loaderContext = {
   log: Envio.logger,
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
+  isPreload: bool,
   {{#each entities as | entity |}}
   @as("{{entity.name.original}}") {{entity.name.uncapitalized}}: entityLoaderContext<Entities.{{entity.name.capitalized}}.t, Entities.{{entity.name.capitalized}}.indexedFieldOperations>,
   {{/each}}

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.ts.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.ts.hbs
@@ -29,6 +29,21 @@ export type LoaderContext = {
      */
     readonly getOrThrow: (id: string, message?: string) => Promise<Entities.{{entity.name.capitalized}}_t>,
     readonly getWhere: Entities.{{entity.name.capitalized}}_indexedFieldOperations,
+    /**
+     * Returns the entity {{entity.name.original}} from the storage by ID.
+     * If the entity is not found, creates it using provided parameters and returns it.
+     */
+    readonly getOrCreate: (entity: Entities.{{entity.name.capitalized}}_t) => Promise<Entities.{{entity.name.capitalized}}_t>,
+    /**
+     * Set the entity {{entity.name.original}} in the storage.
+     */
+    readonly set: (entity: Entities.{{entity.name.capitalized}}_t) => void,
+    /**
+     * Delete the entity {{entity.name.original}} from the storage.
+     *
+     * The 'deleteUnsafe' method is experimental and unsafe. You should manually handle all entity references after deletion to maintain database consistency.
+     */
+    readonly deleteUnsafe: (id: string) => void,
   }
   {{/each}}
 };

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.ts.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.ts.hbs
@@ -16,6 +16,13 @@ export type LoaderContext = {
    * Define a new Effect using createEffect outside of the handler.
    */
   readonly effect: EffectCaller;
+  /**
+   * True when the loaders run in parallel for the whole batch.
+   * During preload entities aren't set, logs are ignored and exceptions are silently swallowed.
+   * But the mode is the best to populate data to in-memory cache.
+   * After preload the loader will run the second before handler one at a time.
+   */
+  readonly isPreload: boolean;
   {{#each entities as | entity |}}
   readonly {{entity.name.original}}: {
     /**

--- a/codegenerator/cli/templates/dynamic/codegen/src/Types.ts.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/Types.ts.hbs
@@ -18,9 +18,10 @@ export type LoaderContext = {
   readonly effect: EffectCaller;
   /**
    * True when the loaders run in parallel for the whole batch.
+   * Loaders are run twice per batch of events, and the first time is the "preload" run
    * During preload entities aren't set, logs are ignored and exceptions are silently swallowed.
-   * But the mode is the best to populate data to in-memory cache.
-   * After preload the loader will run the second before handler one at a time.
+   * Preload mode is the best time to populate data to in-memory cache.
+   * After preload the loader will run for the second time before its handler in sequentially order of events.
    */
   readonly isPreload: boolean;
   {{#each entities as | entity |}}

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -114,7 +114,8 @@ let runEventHandlerOrThrow = async (
           eventItem,
           inMemoryStore,
           loadLayer,
-          shouldGroup: false,
+          unorderedRun: false,
+          shouldSaveHistory,
         }),
       )
     } catch {
@@ -138,7 +139,7 @@ let runEventHandlerOrThrow = async (
           inMemoryStore,
           loadLayer,
           shouldSaveHistory,
-          shouldGroup: false,
+          unorderedRun: false,
         },
         ~loaderReturn,
       ),
@@ -213,7 +214,8 @@ let runBatchLoadersOrThrow = async (
                 eventItem,
                 inMemoryStore,
                 loadLayer,
-                shouldGroup: true,
+                unorderedRun: true,
+                shouldSaveHistory: false,
               }),
               // Must have Promise.catch as well as normal catch,
               // because if user throws an error before await in the handler,

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -106,18 +106,18 @@ let runEventHandlerOrThrow = async (
   //Include the load in time before handler
   let timeBeforeHandler = Hrtime.makeTimer()
 
+  let contextParams: UserContext.contextParams = {
+    eventItem,
+    inMemoryStore,
+    loadLayer,
+    shouldSaveHistory,
+    isPreload: false,
+  }
+
   let loaderReturn = switch loader {
   | Some(loader) =>
     try {
-      await loader(
-        UserContext.getLoaderArgs({
-          eventItem,
-          inMemoryStore,
-          loadLayer,
-          unorderedRun: false,
-          shouldSaveHistory,
-        }),
-      )
+      await loader(UserContext.getLoaderArgs(contextParams))
     } catch {
     | exn =>
       raise(
@@ -133,16 +133,7 @@ let runEventHandlerOrThrow = async (
 
   try {
     await handler(
-      UserContext.getHandlerArgs(
-        {
-          eventItem,
-          inMemoryStore,
-          loadLayer,
-          shouldSaveHistory,
-          unorderedRun: false,
-        },
-        ~loaderReturn,
-      ),
+      UserContext.getHandlerArgs(contextParams, ~loaderReturn),
     )
   } catch {
   | exn =>
@@ -214,7 +205,7 @@ let runBatchLoadersOrThrow = async (
                 eventItem,
                 inMemoryStore,
                 loadLayer,
-                unorderedRun: true,
+                isPreload: true,
                 shouldSaveHistory: false,
               }),
               // Must have Promise.catch as well as normal catch,

--- a/codegenerator/cli/templates/static/codegen/src/UserContext.res
+++ b/codegenerator/cli/templates/static/codegen/src/UserContext.res
@@ -14,14 +14,15 @@ let getEventId = (eventItem: Internal.eventItem) => {
   EventUtils.packEventIndex(~blockNumber=eventItem.blockNumber, ~logIndex=eventItem.event.logIndex)
 }
 
-type baseContextParams = {
+type contextParams = {
   eventItem: Internal.eventItem,
   inMemoryStore: InMemoryStore.t,
   loadLayer: LoadLayer.t,
-  shouldGroup: bool,
+  unorderedRun: bool,
+  shouldSaveHistory: bool,
 }
 
-let rec initEffect = (params: baseContextParams) => (
+let rec initEffect = (params: contextParams) => (
   effect: Internal.effect,
   input: Internal.effectInput,
 ) =>
@@ -33,9 +34,9 @@ let rec initEffect = (params: baseContextParams) => (
       cacheKey: input->Utils.Hash.makeOrThrow,
     },
     ~inMemoryStore=params.inMemoryStore,
-    ~shouldGroup=params.shouldGroup,
+    ~shouldGroup=params.unorderedRun,
   )
-and effectTraps: Utils.Proxy.traps<baseContextParams> = {
+and effectTraps: Utils.Proxy.traps<contextParams> = {
   get: (~target as params, ~prop: unknown) => {
     let prop = prop->(Utils.magic: unknown => string)
     switch prop {
@@ -53,11 +54,6 @@ and effectTraps: Utils.Proxy.traps<baseContextParams> = {
       )
     }
   },
-}
-
-type handlerContextParams = {
-  ...baseContextParams,
-  shouldSaveHistory: bool,
 }
 
 let makeEntityHandlerContext = (
@@ -123,13 +119,13 @@ let makeEntityHandlerContext = (
   }
 }
 
-let handlerTraps: Utils.Proxy.traps<handlerContextParams> = {
+let handlerTraps: Utils.Proxy.traps<contextParams> = {
   get: (~target as params, ~prop: unknown) => {
     let prop = prop->(Utils.magic: unknown => string)
     switch prop {
     | "log" => params.eventItem->Logging.getUserLogger->Utils.magic
     | "effect" =>
-      initEffect((params :> baseContextParams))->(
+      initEffect((params :> contextParams))->(
         Utils.magic: (
           (Internal.effect, Internal.effectInput) => promise<Internal.effectOutput>
         ) => unknown
@@ -145,22 +141,22 @@ let handlerTraps: Utils.Proxy.traps<handlerContextParams> = {
   },
 }
 
-let getHandlerContext = (params: handlerContextParams): Internal.handlerContext => {
+let getHandlerContext = (params: contextParams): Internal.handlerContext => {
   params->Utils.Proxy.make(handlerTraps)->Utils.magic
 }
 
-let getHandlerArgs = (params: handlerContextParams, ~loaderReturn): Internal.handlerArgs => {
+let getHandlerArgs = (params: contextParams, ~loaderReturn): Internal.handlerArgs => {
   event: params.eventItem.event,
   context: getHandlerContext(params),
   loaderReturn,
 }
 
-type loaderEntityContextParams = {
-  ...baseContextParams,
+type entityContextParams = {
+  ...contextParams,
   entityConfig: Internal.entityConfig,
 }
 
-let getWhereTraps: Utils.Proxy.traps<loaderEntityContextParams> = {
+let getWhereTraps: Utils.Proxy.traps<entityContextParams> = {
   get: (~target as params, ~prop: unknown) => {
     let entityConfig = params.entityConfig
     if prop->Js.typeof !== "string" {
@@ -187,7 +183,7 @@ let getWhereTraps: Utils.Proxy.traps<loaderEntityContextParams> = {
               ~fieldName=dbFieldName,
               ~fieldValueSchema,
               ~inMemoryStore=params.inMemoryStore,
-              ~shouldGroup=params.shouldGroup,
+              ~shouldGroup=params.unorderedRun,
               ~eventItem=params.eventItem,
               ~fieldValue,
             ),
@@ -198,7 +194,7 @@ let getWhereTraps: Utils.Proxy.traps<loaderEntityContextParams> = {
               ~fieldName=dbFieldName,
               ~fieldValueSchema,
               ~inMemoryStore=params.inMemoryStore,
-              ~shouldGroup=params.shouldGroup,
+              ~shouldGroup=params.unorderedRun,
               ~eventItem=params.eventItem,
               ~fieldValue,
             ),
@@ -208,43 +204,99 @@ let getWhereTraps: Utils.Proxy.traps<loaderEntityContextParams> = {
   },
 }
 
-let makeEntityLoaderContext = (params): Types.entityLoaderContext<
-  Entities.internalEntity,
-  unknown,
-> => {
-  let get = entityId =>
-    params.loadLayer->LoadLayer.loadById(
-      ~entityConfig=params.entityConfig,
-      ~inMemoryStore=params.inMemoryStore,
-      ~shouldGroup=params.shouldGroup,
-      ~eventItem=params.eventItem,
-      ~entityId,
-    )
-  {
-    get,
-    getOrThrow: (entityId, ~message=?) =>
-      get(entityId)->Promise.thenResolve(entity => {
-        switch entity {
-        | Some(entity) => entity
-        | None =>
-          Js.Exn.raiseError(
-            message->Belt.Option.getWithDefault(
-              `Entity '${params.entityConfig.name}' with ID '${entityId}' is expected to exist.`,
+let noopSet = (_entity: Internal.entity) => ()
+
+let entityTraps: Utils.Proxy.traps<entityContextParams> = {
+  get: (~target as params, ~prop: unknown) => {
+    let prop = prop->(Utils.magic: unknown => string)
+
+    let set = params.unorderedRun
+      ? noopSet
+      : (entity: Internal.entity) => {
+          params.inMemoryStore
+          ->InMemoryStore.getInMemTable(~entityConfig=params.entityConfig)
+          ->InMemoryTable.Entity.set(
+            Set(entity)->Types.mkEntityUpdate(
+              ~eventIdentifier=params.eventItem->makeEventIdentifier,
+              ~entityId=entity.id,
             ),
+            ~shouldSaveHistory=params.shouldSaveHistory,
           )
         }
-      }),
-    getWhere: params->Utils.Proxy.make(getWhereTraps)->Utils.magic,
-  }
+
+    switch prop {
+    | "get" =>
+      (
+        entityId =>
+          params.loadLayer->LoadLayer.loadById(
+            ~entityConfig=params.entityConfig,
+            ~inMemoryStore=params.inMemoryStore,
+            ~shouldGroup=params.unorderedRun,
+            ~eventItem=params.eventItem,
+            ~entityId,
+          )
+      )->Utils.magic
+    | "getWhere" => params->Utils.Proxy.make(getWhereTraps)->Utils.magic
+    | "getOrThrow" =>
+      (
+        (entityId, ~message=?) =>
+          params.loadLayer
+          ->LoadLayer.loadById(
+            ~entityConfig=params.entityConfig,
+            ~inMemoryStore=params.inMemoryStore,
+            ~shouldGroup=params.unorderedRun,
+            ~eventItem=params.eventItem,
+            ~entityId,
+          )
+          ->Promise.thenResolve(entity => {
+            switch entity {
+            | Some(entity) => entity
+            | None =>
+              Js.Exn.raiseError(
+                message->Belt.Option.getWithDefault(
+                  `Entity '${params.entityConfig.name}' with ID '${entityId}' is expected to exist.`,
+                ),
+              )
+            }
+          })
+      )->Utils.magic
+    | "getOrCreate" =>
+      (
+        (entity: Internal.entity) =>
+          params.loadLayer
+          ->LoadLayer.loadById(
+            ~entityConfig=params.entityConfig,
+            ~inMemoryStore=params.inMemoryStore,
+            ~shouldGroup=params.unorderedRun,
+            ~eventItem=params.eventItem,
+            ~entityId=entity.id,
+          )
+          ->Promise.thenResolve(storageEntity => {
+            switch storageEntity {
+            | Some(entity) => entity
+            | None => {
+                set(entity)
+                entity
+              }
+            }
+          })
+      )->Utils.magic
+    | "set" => set->Utils.magic
+    | _ => Js.Exn.raiseError(`Invalid context.${params.entityConfig.name}.${prop} operation.`)
+    }
+  },
 }
 
-let loaderTraps: Utils.Proxy.traps<baseContextParams> = {
+let loaderTraps: Utils.Proxy.traps<contextParams> = {
   get: (~target as params, ~prop: unknown) => {
     let prop = prop->(Utils.magic: unknown => string)
     switch prop {
-    | "log" => params.eventItem->Logging.getUserLogger->Utils.magic
+    | "log" =>
+      (
+        params.unorderedRun ? Logging.noopLogger : params.eventItem->Logging.getUserLogger
+      )->Utils.magic
     | "effect" =>
-      initEffect((params :> baseContextParams))->(
+      initEffect((params :> contextParams))->(
         Utils.magic: (
           (Internal.effect, Internal.effectInput) => promise<Internal.effectOutput>
         ) => unknown
@@ -253,13 +305,16 @@ let loaderTraps: Utils.Proxy.traps<baseContextParams> = {
     | _ =>
       switch Entities.byName->Utils.Dict.dangerouslyGetNonOption(prop) {
       | Some(entityConfig) =>
-        makeEntityLoaderContext({
+        {
           eventItem: params.eventItem,
-          shouldGroup: params.shouldGroup,
+          unorderedRun: params.unorderedRun,
           inMemoryStore: params.inMemoryStore,
           loadLayer: params.loadLayer,
+          shouldSaveHistory: params.shouldSaveHistory,
           entityConfig,
-        })->Utils.magic
+        }
+        ->Utils.Proxy.make(entityTraps)
+        ->Utils.magic
       | None =>
         Js.Exn.raiseError(`Invalid context access by '${prop}' property. ${codegenHelpMessage}`)
       }
@@ -267,11 +322,11 @@ let loaderTraps: Utils.Proxy.traps<baseContextParams> = {
   },
 }
 
-let getLoaderContext = (params: baseContextParams): Internal.loaderContext => {
+let getLoaderContext = (params: contextParams): Internal.loaderContext => {
   params->Utils.Proxy.make(loaderTraps)->Utils.magic
 }
 
-let getLoaderArgs = (params: baseContextParams): Internal.loaderArgs => {
+let getLoaderArgs = (params: contextParams): Internal.loaderArgs => {
   event: params.eventItem.event,
   context: getLoaderContext(params),
 }

--- a/scenarios/test_codegen/src/EventHandlers.ts
+++ b/scenarios/test_codegen/src/EventHandlers.ts
@@ -468,11 +468,13 @@ Gravatar.FactoryEvent.handlerWithLoader({
           case 0:
             deepEqual(entity, undefined);
             deepEqual(await context.User.get("0"), undefined);
+            deepEqual(context.isPreload, true);
             break;
           case 1:
             // It should only apply set only on the second loader run
             deepEqual(entity, undefined);
             deepEqual(await context.User.get("0"), newEntity);
+            deepEqual(context.isPreload, false);
             break;
         }
         loaderSetCount++;

--- a/scenarios/test_codegen/src/EventHandlers.ts
+++ b/scenarios/test_codegen/src/EventHandlers.ts
@@ -429,6 +429,7 @@ Gravatar.FactoryEvent.contractRegister(({ event, context }) => {
 });
 
 let getOrThrowInLoaderCount = 0;
+let loaderSetCount = 0;
 
 Gravatar.FactoryEvent.handlerWithLoader({
   loader: async ({ event, context }) => {
@@ -451,6 +452,30 @@ Gravatar.FactoryEvent.handlerWithLoader({
             break;
           }
         }
+        break;
+      }
+      case "loaderSetCount": {
+        const entity = await context.User.get("0");
+        const newEntity: User = {
+          id: "0",
+          address: "0x",
+          updatesCountOnUserForTesting: 0,
+          gravatar_id: undefined,
+          accountType: "USER",
+        };
+        context.User.set(newEntity);
+        switch (loaderSetCount) {
+          case 0:
+            deepEqual(entity, undefined);
+            deepEqual(await context.User.get("0"), undefined);
+            break;
+          case 1:
+            // It should only apply set only on the second loader run
+            deepEqual(entity, undefined);
+            deepEqual(await context.User.get("0"), newEntity);
+            break;
+        }
+        loaderSetCount++;
         break;
       }
     }

--- a/scenarios/test_codegen/test/EventHandler_test.ts
+++ b/scenarios/test_codegen/test/EventHandler_test.ts
@@ -250,4 +250,31 @@ describe("Use Envio test framework to test event handlers", () => {
       }
     );
   });
+
+  it("entity.set should be ignored in unordered loader run", async () => {
+    const mockDbInitial = MockDb.createMockDb();
+
+    const dcAddress = "0x1234567890123456789012345678901234567890";
+
+    const event = Gravatar.FactoryEvent.createMockEvent({
+      contract: dcAddress,
+      testCase: "loaderSetCount",
+    });
+
+    const updatedMockDb = await Gravatar.FactoryEvent.processEvent({
+      event: event,
+      mockDb: mockDbInitial,
+    });
+
+    const users = updatedMockDb.entities.User.getAll();
+    assert.deepEqual(users, [
+      {
+        id: "0",
+        address: "0x",
+        updatesCountOnUserForTesting: 0,
+        gravatar_id: undefined,
+        accountType: "USER",
+      },
+    ] satisfies typeof users);
+  });
 });

--- a/scenarios/test_codegen/test/schema_types/BigDecimal_test.res
+++ b/scenarios/test_codegen/test/schema_types/BigDecimal_test.res
@@ -43,7 +43,8 @@ describe("Load and save an entity with a BigDecimal from DB", () => {
       eventItem,
       loadLayer,
       inMemoryStore,
-      shouldGroup: true,
+      shouldSaveHistory: false,
+      isPreload: false,
     })->(Utils.magic: Internal.loaderContext => Types.loaderContext)
 
     let _ = loaderContext.entityWithBigDecimal.get(testEntity1.id)
@@ -54,7 +55,7 @@ describe("Load and save an entity with a BigDecimal from DB", () => {
       inMemoryStore,
       loadLayer,
       shouldSaveHistory: false,
-      shouldGroup: false,
+      isPreload: false,
     })->(Utils.magic: Internal.handlerContext => Types.handlerContext)
 
     switch await handlerContext.entityWithBigDecimal.get(testEntity1.id) {

--- a/scenarios/test_codegen/test/schema_types/Timestamp_test.res
+++ b/scenarios/test_codegen/test/schema_types/Timestamp_test.res
@@ -35,7 +35,8 @@ describe("Load and save an entity with a Timestamp from DB", () => {
       eventItem,
       loadLayer,
       inMemoryStore,
-      shouldGroup: true,
+      shouldSaveHistory: false,
+      isPreload: false,
     })->(Utils.magic: Internal.loaderContext => Types.loaderContext)
 
     let _ = loaderContext.entityWithTimestamp.get(testEntity.id)
@@ -45,7 +46,7 @@ describe("Load and save an entity with a Timestamp from DB", () => {
       inMemoryStore,
       loadLayer,
       shouldSaveHistory: false,
-      shouldGroup: false,
+      isPreload: false,
     })->(Utils.magic: Internal.handlerContext => Types.handlerContext)
 
     switch await handlerContext.entityWithTimestamp.get(testEntity.id) {


### PR DESCRIPTION
Also, hide logs on the first loader run.

I decided not to add `context.once` for now, since the API is arguable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a silent logger option that ignores all logging calls.
	- Enhanced entity loader context with new methods for getting, setting, and deleting entities, plus a preload mode indicator.
	- Introduced a preload mode flag to loader contexts, influencing entity management and logging behavior.

- **Refactor**
	- Unified and streamlined context parameter handling by replacing grouping logic with preload and save-history flags.
	- Converted entity loader context to a dynamic, proxy-based handler for flexible entity operations.

- **Tests**
	- Added tests verifying entity setting and retrieval behavior during preload mode.
	- Updated tests to support new context parameters and preload mode semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->