### PR TITLE
Fix hashing logic for config strings

### DIFF
--- a/codegenerator/cli/src/persisted_state/hash_string.rs
+++ b/codegenerator/cli/src/persisted_state/hash_string.rs
@@ -52,8 +52,9 @@ impl HashString {
     pub fn from_string(string: String) -> Self {
         let mut hasher = Sha256::new();
         hasher.update(string);
-        let hash = hasher.finalize().to_vec();
-        HashString(format!("{:?}", hash))
+        let hash = hasher.finalize();
+        // Use hexadecimal encoding to match other hash functions
+        HashString(format!("{:x}", hash))
     }
 
     #[cfg(test)]
@@ -104,6 +105,15 @@ mod test {
         assert_eq!(
             hash.inner(),
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string()
+        );
+    }
+
+    #[test]
+    fn string_hash() {
+        let hash = HashString::from_string("config".to_string());
+        assert_eq!(
+            hash.inner(),
+            "b79606fb3afea5bd1609ed40b622142f1c98125abcfe89a76a661b0e8e343910".to_string()
         );
     }
 


### PR DESCRIPTION
This is my first time using codex, It isn't actually fixing a bug really since the hex can just be a string but I agree it should be should be a proper hex string


## Summary
- ensure `HashString::from_string` uses hex formatting like other hashing helpers
- test string hashing to cover new code path

## Testing
- `cargo test -p cli --quiet` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_68530385f0e88327bb4e08463ecfe0cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hash formatting for string inputs to use lowercase hexadecimal, ensuring consistency with other hash outputs.

- **Tests**
  - Added a unit test to verify correct hashing of the string "config".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->