### PR TITLE
Use correct config path for integration tests

### DIFF
--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -863,7 +863,7 @@ impl SystemConfig {
         let human_config_string =
             std::fs::read_to_string(&project_paths.config).context(format!(
                 "EE104: Failed to resolve config path {0}. Make sure you're in the correct \
-                 directory and that a config file with the name {0} exists",
+                 directory and that a config file with the name {0} exists. I can configure another path by using the --config flag.",
                 &project_paths.config.to_str().unwrap_or("{unknown}"),
             ))?;
 

--- a/codegenerator/integration_tests/tests/testIndexerExits.sh
+++ b/codegenerator/integration_tests/tests/testIndexerExits.sh
@@ -38,7 +38,7 @@ $envio_cmd codegen --config ./$CONFIG_FILE
 
 # clear everything before we start
 echo "Clearing old docker state"
-$envio_cmd stop || true
+$envio_cmd stop --config ./$CONFIG_FILE || true
 
 # start the indexer function, and check if it fails or exits with success
 # will exit the test if failure occurs (expected or not)
@@ -67,7 +67,7 @@ start_indexer() {
 }
 
 # run the setup commands and start indexer
-$envio_cmd local docker up
+$envio_cmd local docker up --config ./$CONFIG_FILE
 sleep 10
 $envio_cmd local db-migrate up --config ./$CONFIG_FILE
 echo "Starting indexer"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message when failing to read the configuration file, now suggesting the use of the `--config` flag to specify an alternative config path.

- **Chores**
  - Updated integration test scripts to explicitly specify the configuration file when starting and stopping the environment, ensuring consistent use of the correct configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->