### PR TITLE
Fix slowdown during historical sync because of tracking reorgs too early

### DIFF
--- a/codegenerator/cli/npm/envio/src/FetchState.res
+++ b/codegenerator/cli/npm/envio/src/FetchState.res
@@ -901,10 +901,7 @@ let queueItemIsInReorgThreshold = (
   if currentBlockHeight === 0 {
     false
   } else {
-    switch queueItem {
-    | Item(_) => queueItem->queueItemBlockNumber > highestBlockBelowThreshold
-    | NoItem(_) => queueItem->queueItemBlockNumber > highestBlockBelowThreshold
-    }
+    queueItem->queueItemBlockNumber > highestBlockBelowThreshold
   }
 }
 


### PR DESCRIPTION
Fixes the bug of entering realtime indexing mode too early for unordered multichain mode. In this mode, we start saving entity history to be able to rollback on reorg, which drastically slows down historical sync if enabled during historical sync.

The issue was caused by invalid logic for checking whether we entered the reorg threshold. For the unordered multichain mode, it checked only the chain we used for batch creation, which became a single chain at a time after https://github.com/enviodev/hyperindex/releases/tag/v2.22.0 - causing the perf regression as soon as one of the chains reaches the head.

In older version the bug also existed, but there was a much slower chance of triggering it - one chain should reach the head and have some events, while all the other chains shouldn't have events to process (fetching).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logic for event selection and reorg threshold checks, leading to more streamlined control flow.
  * Removed or renamed several internal functions and types to reduce complexity and improve clarity.

* **Tests**
  * Updated tests to align with renamed and refactored functions, simplifying assertions and improving readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->