### PR TITLE
Improve Envio managed db schema logic

### DIFF
--- a/codegenerator/cli/src/config_parsing/chain_helpers.rs
+++ b/codegenerator/cli/src/config_parsing/chain_helpers.rs
@@ -259,7 +259,7 @@ pub enum Network {
     #[subenum(HypersyncNetwork, NetworkWithExplorer)]
     Morph = 2818,
 
-    #[subenum(HypersyncNetwork, NetworkWithExplorer)]
+    #[subenum(NetworkWithExplorer)]
     MorphTestnet = 2810,
 
     MosaicMatrix = 41454,
@@ -282,7 +282,6 @@ pub enum Network {
     #[subenum(HypersyncNetwork, NetworkWithExplorer)]
     OptimismSepolia = 11155420,
 
-    #[subenum(HypersyncNetwork)]
     PharosDevnet = 50002,
 
     #[subenum(GraphNetwork, NetworkWithExplorer)]
@@ -348,6 +347,9 @@ pub enum Network {
 
     #[subenum(NetworkWithExplorer)]
     Tangle = 5845,
+
+    #[subenum(HypersyncNetwork)]
+    Taraxa = 841,
 
     #[subenum(HypersyncNetwork)]
     Unichain = 130,
@@ -526,7 +528,8 @@ impl Network {
             | Network::Curtis
             | Network::Worldchain
             | Network::Sonic
-            | Network::Swell => DEFAULT_CONFIRMED_BLOCK_THRESHOLD,
+            | Network::Swell
+            | Network::Taraxa => DEFAULT_CONFIRMED_BLOCK_THRESHOLD,
         }
     }
 }
@@ -576,17 +579,16 @@ impl HypersyncNetwork {
             Xdc | Polygon | ArbitrumOne => Silver,
 
             Linea | Berachain | Blast | Amoy | Scroll | ZksyncEra | ArbitrumNova | Avalanche
-            | Bsc => Bronze,
+            | Bsc | Taraxa => Bronze,
 
-            Curtis | PolygonZkevm | Lukso | Abstract | PharosDevnet | Zora | Unichain | Aurora
-            | Zeta | Manta | Kroma | Flare | Mantle | ShimmerEvm | Boba | Ink | Metall2
-            | SophonTestnet | MorphTestnet | GaladrielDevnet | CitreaTestnet | BscTestnet
-            | UnichainSepolia | Zircuit | Celo | Opbnb | GnosisChiado | LuksoTestnet
-            | BlastSepolia | Holesky | BerachainBartio | OptimismSepolia | Fuji
-            | ArbitrumSepolia | Fraxtal | Soneium | BaseSepolia | MevCommit | Merlin | Mode
-            | MoonbaseAlpha | XdcTestnet | Morph | Harmony | Saakuru | Cyber | Superseed
-            | MegaethTestnet | Sonic | Worldchain | Sophon | Fantom | Sepolia | Rsk | Chiliz
-            | Lisk | Hyperliquid | Swell | Moonbeam => Stone,
+            Curtis | PolygonZkevm | Lukso | Abstract | Zora | Unichain | Aurora | Zeta | Manta
+            | Kroma | Flare | Mantle | ShimmerEvm | Boba | Ink | Metall2 | SophonTestnet
+            | GaladrielDevnet | CitreaTestnet | BscTestnet | UnichainSepolia | Zircuit | Celo
+            | Opbnb | GnosisChiado | LuksoTestnet | BlastSepolia | Holesky | BerachainBartio
+            | OptimismSepolia | Fuji | ArbitrumSepolia | Fraxtal | Soneium | BaseSepolia
+            | MevCommit | Merlin | Mode | MoonbaseAlpha | XdcTestnet | Morph | Harmony
+            | Saakuru | Cyber | Superseed | MegaethTestnet | Sonic | Worldchain | Sophon
+            | Fantom | Sepolia | Rsk | Chiliz | Lisk | Hyperliquid | Swell | Moonbeam => Stone,
         }
     }
 

--- a/codegenerator/cli/templates/static/codegen/src/db/Migrations.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/Migrations.res
@@ -27,7 +27,7 @@ let runUpMigrations = async (
   ~reset=false,
 ) => {
   let exitCode = try {
-    await Config.codegenPersistence->Persistence.init(~skipIsInitializedCheck=true, ~reset)
+    await Config.codegenPersistence->Persistence.init(~reset)
     Success
   } catch {
   | _ => Failure

--- a/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
+++ b/codegenerator/cli/templates/static/codegen/src/db/TablesStatic.res
@@ -21,7 +21,7 @@ module EventSyncState = {
   }
 
   let table = mkTable(
-    "event_sync_state",
+    PgStorage.eventSyncStateTableName,
     ~fields=[
       mkField("chain_id", Integer, ~fieldSchema=S.int, ~isPrimaryKey),
       mkField(blockNumberFieldName, Integer, ~fieldSchema=S.int),

--- a/scenarios/test_codegen/test/lib_tests/EntityHistory_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EntityHistory_test.res
@@ -3,6 +3,10 @@ open RescriptMocha
 //unsafe polymorphic toString binding for any type
 @send external toStringUnsafe: 'a => string = "toString"
 
+// These are mandatory tables that should be created for every schema
+// it allows us to distinguish whether the schema is controlled by Envio
+let generalTables = [TablesStatic.EventSyncState.table]
+
 let stripUndefinedFieldsInPlace = (val: 'a): 'a => {
   let json = val->(Utils.magic: 'a => Js.Json.t)
   //Hot fix for rescript equality check that removes optional fields
@@ -245,8 +249,8 @@ describe("Entity History Codegen", () => {
     try {
       await storage.initialize(
         ~entities=[module(TestEntity)->Entities.entityModToInternal],
+        ~generalTables,
         ~enums=[Persistence.entityHistoryActionEnumConfig->Internal.fromGenericEnumConfig],
-        ~cleanRun=true,
       )
     } catch {
     | exn =>
@@ -594,8 +598,8 @@ describe("Entity history rollbacks", () => {
       let storage = PgStorage.make(~sql=Db.sql, ~pgSchema="public", ~pgUser="postgres")
       await storage.initialize(
         ~entities=[module(TestEntity)->Entities.entityModToInternal],
+        ~generalTables,
         ~enums=[Persistence.entityHistoryActionEnumConfig->Internal.fromGenericEnumConfig],
-        ~cleanRun=true,
       )
 
       let _ = await Db.sql->Postgres.unsafe(TestEntity.entityHistory.createInsertFnQuery)
@@ -760,8 +764,8 @@ describe("Entity history rollbacks", () => {
       let storage = PgStorage.make(~sql=Db.sql, ~pgSchema="public", ~pgUser="postgres")
       await storage.initialize(
         ~entities=[module(TestEntity)->Entities.entityModToInternal],
+        ~generalTables,
         ~enums=[Persistence.entityHistoryActionEnumConfig->Internal.fromGenericEnumConfig],
-        ~cleanRun=true,
       )
 
       let _ = await Db.sql->Postgres.unsafe(TestEntity.entityHistory.createInsertFnQuery)
@@ -1037,8 +1041,8 @@ describe_skip("Prune performance test", () => {
     let storage = PgStorage.make(~sql=Db.sql, ~pgSchema="public", ~pgUser="postgres")
     await storage.initialize(
       ~entities=[module(TestEntity)->Entities.entityModToInternal],
+      ~generalTables,
       ~enums=[Persistence.entityHistoryActionEnumConfig->Internal.fromGenericEnumConfig],
-      ~cleanRun=true,
     )
 
     let _ = await Db.sql->Postgres.unsafe(TestEntity.entityHistory.createInsertFnQuery)


### PR DESCRIPTION
This is part of the Effects Cache project. The goal is to ensure that the schema used and managed by Envio does not contain any tables unrelated to the currently running indexer. And that we have a proper initialization step, which we can use to load persisted cache from jsons.

- This also adds a safeguard error message alerting about potential data loss if the indexer started on a db schema with some existing data.
- And it makes `pnpm envio start` work without the need for `pnpm envio local db-migrate up`.
- Additionally, it reduces the likelihood of encountering a strange database state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Simplified storage initialization by removing optional parameters and streamlining logic.
  * Enforced safety checks to prevent data loss by verifying schema usage before migration.
  * Replaced hardcoded table names with dynamic references for consistency.
  * Updated network configurations by adding a new network and adjusting tier classifications.

* **Tests**
  * Revised test suites to align with updated initialization logic and removed obsolete test cases.
  * Enhanced test clarity by adjusting SQL expectations and removing deprecated parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->