### PR TITLE
Fix error on writing invalid utf8 string to PG

### DIFF
--- a/codegenerator/cli/npm/envio/src/Utils.res
+++ b/codegenerator/cli/npm/envio/src/Utils.res
@@ -301,6 +301,23 @@ module String = {
     str->Js.String2.slice(~from=0, ~to_=1)->Js.String.toUpperCase ++
       str->Js.String2.sliceToEnd(~from=1)
   }
+
+  /**
+`replaceAll(str, substr, newSubstr)` returns a new `string` which is
+identical to `str` except with all matching instances of `substr` replaced
+by `newSubstr`. `substr` is treated as a verbatim string to match, not a
+regular expression.
+See [`String.replaceAll`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll) on MDN.
+
+## Examples
+
+```rescript
+String.replaceAll("old old string", "old", "new") == "new new string"
+String.replaceAll("the cat and the dog", "the", "this") == "this cat and this dog"
+```
+*/
+  @send
+  external replaceAll: (string, string, string) => string = "replaceAll"
 }
 
 module Result = {

--- a/codegenerator/cli/npm/envio/src/bindings/Promise.res
+++ b/codegenerator/cli/npm/envio/src/bindings/Promise.res
@@ -1,15 +1,15 @@
 type t<+'a> = promise<'a>
 
 @new
-external make: ((@uncurry ('a => unit), 'e => unit) => unit) => t<'a> = "Promise"
+external make: ((@uncurry 'a => unit, 'e => unit) => unit) => t<'a> = "Promise"
 
 @val @scope("Promise")
 external resolve: 'a => t<'a> = "resolve"
 
-@send external then: (t<'a>, @uncurry ('a => t<'b>)) => t<'b> = "then"
+@send external then: (t<'a>, @uncurry 'a => t<'b>) => t<'b> = "then"
 
 @send
-external thenResolve: (t<'a>, @uncurry ('a => 'b)) => t<'b> = "then"
+external thenResolve: (t<'a>, @uncurry 'a => 'b) => t<'b> = "then"
 
 @send external finally: (t<'a>, unit => unit) => t<'a> = "finally"
 
@@ -52,7 +52,6 @@ let catch = (promise: promise<'a>, callback: exn => promise<'a>): promise<'a> =>
 external race: array<t<'a>> => t<'a> = "race"
 
 external done: promise<'a> => unit = "%ignore"
-external ignoreResolve: promise<'a> => promise<unit> = "%ignore"
 
 external unsafe_async: 'a => promise<'a> = "%identity"
 external unsafe_await: promise<'a> => 'a = "?await"

--- a/codegenerator/cli/npm/envio/src/bindings/Promise.res
+++ b/codegenerator/cli/npm/envio/src/bindings/Promise.res
@@ -1,15 +1,15 @@
 type t<+'a> = promise<'a>
 
 @new
-external make: ((@uncurry 'a => unit, 'e => unit) => unit) => t<'a> = "Promise"
+external make: ((@uncurry ('a => unit), 'e => unit) => unit) => t<'a> = "Promise"
 
 @val @scope("Promise")
 external resolve: 'a => t<'a> = "resolve"
 
-@send external then: (t<'a>, @uncurry 'a => t<'b>) => t<'b> = "then"
+@send external then: (t<'a>, @uncurry ('a => t<'b>)) => t<'b> = "then"
 
 @send
-external thenResolve: (t<'a>, @uncurry 'a => 'b) => t<'b> = "then"
+external thenResolve: (t<'a>, @uncurry ('a => 'b)) => t<'b> = "then"
 
 @send external finally: (t<'a>, unit => unit) => t<'a> = "finally"
 
@@ -52,6 +52,7 @@ let catch = (promise: promise<'a>, callback: exn => promise<'a>): promise<'a> =>
 external race: array<t<'a>> => t<'a> = "race"
 
 external done: promise<'a> => unit = "%ignore"
+external ignoreResolve: promise<'a> => promise<unit> = "%ignore"
 
 external unsafe_async: 'a => promise<'a> = "%identity"
 external unsafe_await: promise<'a> => 'a = "?await"

--- a/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventProcessing.res
@@ -318,35 +318,48 @@ let processEventBatch = async (
     let elapsedTimeAfterProcessing =
       timeRef->Hrtime.timeSince->Hrtime.toMillis->Hrtime.intFromMillis
 
-    switch await Db.sql->IO.executeBatch(~inMemoryStore, ~isInReorgThreshold, ~config) {
-    | exception Persistence.StorageError({message, reason}) =>
-      reason->ErrorHandling.make(~msg=message, ~logger)->Error
-    | exception exn =>
-      exn->ErrorHandling.make(~msg="Failed writing batch to database", ~logger)->Error
-    | () => {
-        let elapsedTimeAfterDbWrite =
-          timeRef->Hrtime.timeSince->Hrtime.toMillis->Hrtime.intFromMillis
-        let loaderDuration = elapsedTimeAfterLoaders
-        let handlerDuration = elapsedTimeAfterProcessing - loaderDuration
-        let dbWriteDuration = elapsedTimeAfterDbWrite - elapsedTimeAfterProcessing
-        registerProcessEventBatchMetrics(
-          ~logger,
-          ~loadDuration=loaderDuration,
-          ~handlerDuration,
-          ~dbWriteDuration,
-        )
-        if Env.Benchmark.shouldSaveData {
-          Benchmark.addEventProcessing(
-            ~batchSize,
+    let rec executeBatch = async (~escapeTables=?) => {
+      switch await Db.sql->IO.executeBatch(~inMemoryStore, ~isInReorgThreshold, ~config, ~escapeTables?) {
+      | exception Persistence.StorageError({message, reason}) =>
+        reason->ErrorHandling.make(~msg=message, ~logger)->Error
+
+      | exception PgStorage.PgEncodingError({table}) =>
+        let escapeTables = switch escapeTables {
+        | Some(set) => set
+        | None => Utils.Set.make()
+        }
+        let _ = escapeTables->Utils.Set.add(table)
+        // Retry with specifying which tables to escape.
+        await executeBatch(~escapeTables)
+      | exception exn =>
+        exn->ErrorHandling.make(~msg="Failed writing batch to database", ~logger)->Error
+      | () => {
+          let elapsedTimeAfterDbWrite =
+            timeRef->Hrtime.timeSince->Hrtime.toMillis->Hrtime.intFromMillis
+          let loaderDuration = elapsedTimeAfterLoaders
+          let handlerDuration = elapsedTimeAfterProcessing - loaderDuration
+          let dbWriteDuration = elapsedTimeAfterDbWrite - elapsedTimeAfterProcessing
+          registerProcessEventBatchMetrics(
+            ~logger,
             ~loadDuration=loaderDuration,
             ~handlerDuration,
             ~dbWriteDuration,
-            ~totalTimeElapsed=elapsedTimeAfterDbWrite,
           )
+          if Env.Benchmark.shouldSaveData {
+            Benchmark.addEventProcessing(
+              ~batchSize,
+              ~loadDuration=loaderDuration,
+              ~handlerDuration,
+              ~dbWriteDuration,
+              ~totalTimeElapsed=elapsedTimeAfterDbWrite,
+            )
+          }
+          Ok()
         }
-        Ok()
       }
     }
+
+    await executeBatch()
   } catch {
   | ProcessingError({message, exn, eventItem}) =>
     exn

--- a/codegenerator/cli/templates/static/codegen/src/IO.res
+++ b/codegenerator/cli/templates/static/codegen/src/IO.res
@@ -48,133 +48,14 @@ let getEntityHistoryItems = (entityUpdates, ~containsRollbackDiffChange) => {
   entityHistoryItems
 }
 
-let executeSetEntityWithHistory = (
-  sql: Postgres.sql,
+let executeBatch = async (
+  sql,
   ~inMemoryStore: InMemoryStore.t,
-  ~entityConfig,
-): promise<unit> => {
-  let rows =
-    inMemoryStore
-    ->InMemoryStore.getInMemTable(~entityConfig)
-    ->InMemoryTable.Entity.rows
-  let (entitiesToSet, idsToDelete, entityHistoryItemsToSet) = rows->Belt.Array.reduce(
-    ([], [], []),
-    ((entitiesToSet, idsToDelete, entityHistoryItemsToSet), row) => {
-      switch row {
-      | Updated({latest, history, containsRollbackDiffChange}) =>
-        let entityHistoryItems = history->getEntityHistoryItems(~containsRollbackDiffChange)
-
-        switch latest.entityUpdateAction {
-        | Set(entity) => (
-            entitiesToSet->Belt.Array.concat([entity]),
-            idsToDelete,
-            entityHistoryItemsToSet->Belt.Array.concat([entityHistoryItems]),
-          )
-        | Delete => (
-            entitiesToSet,
-            idsToDelete->Belt.Array.concat([latest.entityId]),
-            entityHistoryItemsToSet->Belt.Array.concat([entityHistoryItems]),
-          )
-        }
-      | _ => (entitiesToSet, idsToDelete, entityHistoryItemsToSet)
-      }
-    },
-  )
-  // Keep history items in the order of the events. Without sorting,
-  // they will only be in order per row, but not across the whole entity
-  // table.
-
-  let orderedHistoryItems =
-    entityHistoryItemsToSet
-    ->Array.concatMany
-    ->Js.Array2.sortInPlaceWith((a, b) => {
-      EventUtils.isEarlierEvent(
-        {
-          timestamp: a.current.block_timestamp,
-          chainId: a.current.chain_id,
-          blockNumber: a.current.block_number,
-          logIndex: a.current.log_index,
-        },
-        {
-          timestamp: b.current.block_timestamp,
-          chainId: b.current.chain_id,
-          blockNumber: b.current.block_number,
-          logIndex: b.current.log_index,
-        },
-      )
-        ? -1
-        : 1
-    })
-
-  [
-    entityConfig.entityHistory->EntityHistory.batchInsertRows(~sql, ~rows=orderedHistoryItems),
-    if entitiesToSet->Array.length > 0 {
-      sql->PgStorage.setOrThrow(
-        ~items=entitiesToSet,
-        ~table=entityConfig.table,
-        ~itemSchema=entityConfig.schema,
-        ~pgSchema=Config.storagePgSchema,
-      )
-    } else {
-      Promise.resolve()
-    },
-    if idsToDelete->Array.length > 0 {
-      sql->DbFunctionsEntities.batchDelete(~entityConfig)(idsToDelete)
-    } else {
-      Promise.resolve()
-    },
-  ]
-  ->Promise.all
-  ->Promise.thenResolve(_ => ())
-}
-
-let executeDbFunctionsEntity = (
-  sql: Postgres.sql,
-  ~inMemoryStore: InMemoryStore.t,
-  ~entityConfig: Internal.entityConfig,
-): promise<unit> => {
-  let rows =
-    inMemoryStore
-    ->InMemoryStore.getInMemTable(~entityConfig)
-    ->InMemoryTable.Entity.rows
-
-  let entitiesToSet = []
-  let idsToDelete = []
-
-  rows->Array.forEach(row => {
-    switch row {
-    | Updated({latest: {entityUpdateAction: Set(entity)}}) => entitiesToSet->Array.push(entity)
-    | Updated({latest: {entityUpdateAction: Delete, entityId}}) => idsToDelete->Array.push(entityId)
-    | _ => ()
-    }
-  })
-
-  let promises =
-    (
-      entitiesToSet->Array.length > 0
-        ? [
-            sql->PgStorage.setOrThrow(
-              ~items=entitiesToSet,
-              ~table=entityConfig.table,
-              ~itemSchema=entityConfig.schema,
-              ~pgSchema=Config.storagePgSchema,
-            ),
-          ]
-        : []
-    )->Belt.Array.concat(
-      idsToDelete->Array.length > 0
-        ? [sql->DbFunctionsEntities.batchDelete(~entityConfig)(idsToDelete)]
-        : [],
-    )
-
-  promises->Promise.all->Promise.thenResolve(_ => ())
-}
-
-let executeBatch = async (sql, ~inMemoryStore: InMemoryStore.t, ~isInReorgThreshold, ~config) => {
-  let entityDbExecutionComposer =
-    config->Config.shouldSaveHistory(~isInReorgThreshold)
-      ? executeSetEntityWithHistory
-      : executeDbFunctionsEntity
+  ~isInReorgThreshold,
+  ~config,
+  ~escapeTables=?,
+) => {
+  let specificError = ref(None)
 
   let setEventSyncState = executeSet(
     _,
@@ -196,7 +77,125 @@ let executeBatch = async (sql, ~inMemoryStore: InMemoryStore.t, ~isInReorgThresh
   )
 
   let setEntities = Entities.allEntities->Belt.Array.map(entityConfig => {
-    entityDbExecutionComposer(_, ~entityConfig, ~inMemoryStore)
+    let entitiesToSet = []
+    let idsToDelete = []
+    let entityHistoryItemsToSet = []
+
+    let rows =
+      inMemoryStore
+      ->InMemoryStore.getInMemTable(~entityConfig)
+      ->InMemoryTable.Entity.rows
+
+    rows->Js.Array2.forEach(row => {
+      switch row {
+      | Updated({latest: {entityUpdateAction: Set(entity)}}) => entitiesToSet->Array.push(entity)
+      | Updated({latest: {entityUpdateAction: Delete, entityId}}) =>
+        idsToDelete->Array.push(entityId)
+      | _ => ()
+      }
+    })
+
+    if config->Config.shouldSaveHistory(~isInReorgThreshold) {
+      rows->Js.Array2.forEach(row => {
+        switch row {
+        | Updated({history, containsRollbackDiffChange}) =>
+          let entityHistoryItems = history->getEntityHistoryItems(~containsRollbackDiffChange)
+          entityHistoryItemsToSet->Js.Array2.pushMany(entityHistoryItems)->ignore
+        | _ => ()
+        }
+      })
+
+      // Keep history items in the order of the events. Without sorting,
+      // they will only be in order per row, but not across the whole entity
+      // table.
+      let _ = entityHistoryItemsToSet->Js.Array2.sortInPlaceWith((a, b) => {
+        EventUtils.isEarlierEvent(
+          {
+            timestamp: a.current.block_timestamp,
+            chainId: a.current.chain_id,
+            blockNumber: a.current.block_number,
+            logIndex: a.current.log_index,
+          },
+          {
+            timestamp: b.current.block_timestamp,
+            chainId: b.current.chain_id,
+            blockNumber: b.current.block_number,
+            logIndex: b.current.log_index,
+          },
+        )
+          ? -1
+          : 1
+      })
+    }
+
+    switch escapeTables {
+    | Some(tables) if tables->Utils.Set.has(entityConfig.table) =>
+      entitiesToSet->Js.Array2.forEach(item => {
+        let dict = item->(Utils.magic: 'a => dict<unknown>)
+        dict->Utils.Dict.forEachWithKey(
+          (key, value) => {
+            if value->Js.typeof === "string" {
+              let value = value->(Utils.magic: unknown => string)
+              // We mutate here, since we don't care
+              // about the original value with \x00 anyways.
+              //
+              // This is unsafe, but we rely that it'll use
+              // the mutated reference on retry.
+              // TODO: Test it properly after we start using
+              // in-memory PGLite for indexer test framework.
+              dict->Js.Dict.set(
+                key,
+                value
+                ->Js.String2.replaceByRe(%re("/\x00/g"), "")
+                ->(Utils.magic: string => unknown),
+              )
+            }
+          },
+        )
+      })
+    | _ => ()
+    }
+
+    sql => {
+      let promises = []
+      if entityHistoryItemsToSet->Utils.Array.notEmpty {
+        promises->Array.push(
+          entityConfig.entityHistory->EntityHistory.batchInsertRows(
+            ~sql,
+            ~rows=entityHistoryItemsToSet,
+          ),
+        )
+      }
+      if entitiesToSet->Utils.Array.notEmpty {
+        promises->Array.push(
+          sql->PgStorage.setOrThrow(
+            ~items=entitiesToSet,
+            ~table=entityConfig.table,
+            ~itemSchema=entityConfig.schema,
+            ~pgSchema=Config.storagePgSchema,
+          ),
+        )
+      }
+      if idsToDelete->Utils.Array.notEmpty {
+        promises->Array.push(sql->DbFunctionsEntities.batchDelete(~entityConfig)(idsToDelete))
+      }
+      // This should have await, to properly propagate errors to the caller.
+      promises
+      ->Promise.all
+      ->Promise.catch(exn => {
+        // There's a race condition that sql->Postgres.beginSql
+        // might throw PG error, earlier, than the handled error
+        // from setOrThrow will be passed through.
+        // This is needed for the utf8 encoding fix.
+        specificError.contents = Some(exn)
+        // Improtant: Don't rethrow here, since it'll result in
+        // an unhandled rejected promise error.
+        // That's fine not to throw, since sql->Postgres.beginSql
+        // will fail anyways.
+        Promise.resolve([])
+      })
+      ->Promise.ignoreResolve
+    }
   })
 
   //In the event of a rollback, rollback all meta tables based on the given
@@ -218,16 +217,29 @@ let executeBatch = async (sql, ~inMemoryStore: InMemoryStore.t, ~isInReorgThresh
   | None => []
   }
 
-  let res = await sql->Postgres.beginSql(sql => {
-    Belt.Array.concatMany([
-      //Rollback tables need to happen first in the traction
-      rollbackTables,
-      [setEventSyncState, setRawEvents],
-      setEntities,
-    ])->Belt.Array.map(dbFunc => sql->dbFunc)
-  })
-
-  res
+  try {
+    await sql->Postgres.beginSql(sql => {
+      Belt.Array.concatMany([
+        //Rollback tables need to happen first in the traction
+        rollbackTables,
+        [setEventSyncState, setRawEvents],
+        setEntities,
+      ])->Belt.Array.map(dbFunc => sql->dbFunc)
+    })
+    // Just in case, if there's a not PG-specific error.
+    switch specificError.contents {
+    | Some(specificError) => raise(specificError)
+    | None => ()
+    }
+  } catch {
+  | exn =>
+    raise(
+      switch specificError.contents {
+      | Some(specificError) => specificError
+      | None => exn
+      },
+    )
+  }
 }
 
 module RollBack = {

--- a/codegenerator/cli/templates/static/codegen/src/ink/components/CustomHooks.res
+++ b/codegenerator/cli/templates/static/codegen/src/ink/components/CustomHooks.res
@@ -101,7 +101,7 @@ let useMessages = (~config) => {
       switch res {
       | Ok(data) => setRequest(_ => Data(data))
       | Error(e) =>
-        Logging.error({"msg": "Failed to load messages from envio server", "err": e})
+        Logging.error({"msg": "Failed to load messages from envio server", "err": e->Internal.prettifyExn})
         setRequest(_ => Err(e))
       }
     )

--- a/scenarios/test_codegen/test/SerDe_Test.res
+++ b/scenarios/test_codegen/test/SerDe_Test.res
@@ -73,7 +73,10 @@ describe("SerDe Test", () => {
       )
 
     let setHistory = (sql, row) =>
-      Entities.EntityWithAllTypes.entityHistory->EntityHistory.batchInsertRows(~sql, ~rows=[row])
+      sql->PgStorage.setEntityHistoryOrThrow(
+        ~entityHistory=Entities.EntityWithAllTypes.entityHistory,
+        ~rows=[row],
+      )
 
     try await Db.sql->setHistory(entityHistoryItem) catch {
     | exn =>
@@ -183,8 +186,8 @@ SELECT * FROM unnest($1::NUMERIC[],$2::NUMERIC[],$3::INTEGER[]::BOOLEAN[],$4::DO
       )
 
     let setHistory = (sql, row) =>
-      Entities.EntityWithAllNonArrayTypes.entityHistory->EntityHistory.batchInsertRows(
-        ~sql,
+      sql->PgStorage.setEntityHistoryOrThrow(
+        ~entityHistory=Entities.EntityWithAllNonArrayTypes.entityHistory,
         ~rows=[row],
       )
 


### PR DESCRIPTION
Fixes #446 

For normal cases we don't do anything, but if we encounter the error, we walkthrough all the entity string fields and try to remove the invalid sequence. This should make the case work, while not affecting performance for the events with valid data.

There was an annoying race condition, which took me much more to fix the bug than I expected 🫠

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic removal of invalid UTF-8 null byte characters from entity history data before database insertion.
  * Introduced enhanced error handling for PostgreSQL UTF-8 encoding errors, with retry logic for affected tables.
  * Added a string utility for replacing all occurrences of a substring within a string.

* **Bug Fixes**
  * Improved error message clarity in CLI output for easier debugging.

* **Refactor**
  * Unified and streamlined database batch execution logic for entity and history operations.
  * Improved error propagation and handling during asynchronous database operations.

* **Chores**
  * Removed unused functions related to entity history row insertion.
  * Updated test code to use the new unified entity history insertion method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->