### PR TITLE
Don't query reorgable blocks before all chains reach reorg threshold

### DIFF
--- a/codegenerator/cli/npm/envio/src/FetchState.res
+++ b/codegenerator/cli/npm/envio/src/FetchState.res
@@ -718,13 +718,12 @@ let getNextQuery = (
   ~currentBlockHeight,
   ~stateId,
 ) => {
-  if currentBlockHeight === 0 {
+  let headBlock = currentBlockHeight - blockLag
+  if headBlock <= 0 {
     WaitingForNewBlock
   } else if concurrencyLimit === 0 {
     ReachedMaxConcurrency
   } else {
-    let headBlock = currentBlockHeight - blockLag
-
     let fullPartitions = []
     let mergingPartitions = []
     let areMergingPartitionsFetching = ref(false)

--- a/codegenerator/cli/npm/envio/src/Prometheus.res
+++ b/codegenerator/cli/npm/envio/src/Prometheus.res
@@ -472,6 +472,17 @@ module ReorgDetectionBlockNumber = {
   }
 }
 
+module ReorgThreshold = {
+  let gauge = PromClient.Gauge.makeGauge({
+    "name": "envio_reorg_threshold",
+    "help": "Whether indexing is currently within the reorg threshold",
+  })
+
+  let set = (~isInReorgThreshold) => {
+    gauge->PromClient.Gauge.set(isInReorgThreshold ? 1 : 0)
+  }
+}
+
 module RollbackEnabled = {
   let gauge = PromClient.Gauge.makeGauge({
     "name": "envio_rollback_enabled",

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -36,13 +36,13 @@ let make = (
   ~endBlock,
   ~dbFirstEventBlockNumber,
   ~latestProcessedBlock,
+  ~config: Config.t,
   ~logger,
   ~timestampCaughtUpToHeadOrEndblock,
   ~numEventsProcessed,
   ~numBatchesFetched,
   ~processingFilters,
   ~maxAddrInPartition,
-  ~enableRawEvents,
   ~isInReorgThreshold,
 ): t => {
   // We don't need the router itself, but only validation logic,
@@ -74,7 +74,7 @@ let make = (
 
       // Filter out non-preRegistration events on preRegistration phase
       // so we don't care about it in fetch state and workers anymore
-      let shouldBeIncluded = if enableRawEvents {
+      let shouldBeIncluded = if config.enableRawEvents {
         true
       } else {
         let isRegistered = hasContractRegister || eventConfig.handler->Option.isSome
@@ -135,7 +135,9 @@ let make = (
     ~eventConfigs,
     ~chainId=chainConfig.chain->ChainMap.Chain.toChainId,
     ~blockLag=Pervasives.max(
-      isInReorgThreshold ? 0 : chainConfig.confirmedBlockThreshold,
+      !(config->Config.shouldRollbackOnReorg) || isInReorgThreshold
+        ? 0
+        : chainConfig.confirmedBlockThreshold,
       Env.indexingBlockLag->Option.getWithDefault(0),
     ),
   )
@@ -160,7 +162,7 @@ let make = (
   }
 }
 
-let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition, ~enableRawEvents) => {
+let makeFromConfig = (chainConfig: Config.chainConfig, ~config, ~maxAddrInPartition) => {
   let logger = Logging.createChild(~params={"chainId": chainConfig.chain->ChainMap.Chain.toChainId})
   let lastBlockScannedHashes = ReorgDetection.LastBlockScannedHashes.empty(
     ~confirmedBlockThreshold=chainConfig.confirmedBlockThreshold,
@@ -168,6 +170,7 @@ let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition, ~ena
 
   make(
     ~chainConfig,
+    ~config,
     ~startBlock=chainConfig.startBlock,
     ~endBlock=chainConfig.endBlock,
     ~lastBlockScannedHashes,
@@ -180,7 +183,6 @@ let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition, ~ena
     ~processingFilters=None,
     ~dynamicContracts=[],
     ~maxAddrInPartition,
-    ~enableRawEvents,
     ~isInReorgThreshold=false,
   )
 }
@@ -191,8 +193,8 @@ let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition, ~ena
 let makeFromDbState = async (
   chainConfig: Config.chainConfig,
   ~maxAddrInPartition,
-  ~enableRawEvents,
   ~isInReorgThreshold,
+  ~config,
   ~sql=Db.sql,
 ) => {
   let logger = Logging.createChild(~params={"chainId": chainConfig.chain->ChainMap.Chain.toChainId})
@@ -294,6 +296,7 @@ let makeFromDbState = async (
     ~chainConfig,
     ~startBlock=restartBlockNumber,
     ~endBlock=chainConfig.endBlock,
+    ~config,
     ~lastBlockScannedHashes,
     ~dbFirstEventBlockNumber=firstEventBlockNumber,
     ~latestProcessedBlock=latestProcessedBlockChainMetadata,
@@ -303,7 +306,6 @@ let makeFromDbState = async (
     ~logger,
     ~processingFilters,
     ~maxAddrInPartition,
-    ~enableRawEvents,
     ~isInReorgThreshold,
   )
 }

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -43,6 +43,7 @@ let make = (
   ~processingFilters,
   ~maxAddrInPartition,
   ~enableRawEvents,
+  ~isInReorgThreshold,
 ): t => {
   // We don't need the router itself, but only validation logic,
   // since now event router is created for selection of events
@@ -133,7 +134,10 @@ let make = (
     ~endBlock,
     ~eventConfigs,
     ~chainId=chainConfig.chain->ChainMap.Chain.toChainId,
-    ~blockLag=?Env.indexingBlockLag,
+    ~blockLag=Pervasives.max(
+      isInReorgThreshold ? 0 : chainConfig.confirmedBlockThreshold,
+      Env.indexingBlockLag->Option.getWithDefault(0),
+    ),
   )
 
   {
@@ -177,6 +181,7 @@ let makeFromConfig = (chainConfig: Config.chainConfig, ~maxAddrInPartition, ~ena
     ~dynamicContracts=[],
     ~maxAddrInPartition,
     ~enableRawEvents,
+    ~isInReorgThreshold=false,
   )
 }
 
@@ -187,6 +192,7 @@ let makeFromDbState = async (
   chainConfig: Config.chainConfig,
   ~maxAddrInPartition,
   ~enableRawEvents,
+  ~isInReorgThreshold,
   ~sql=Db.sql,
 ) => {
   let logger = Logging.createChild(~params={"chainId": chainConfig.chain->ChainMap.Chain.toChainId})
@@ -298,6 +304,7 @@ let makeFromDbState = async (
     ~processingFilters,
     ~maxAddrInPartition,
     ~enableRawEvents,
+    ~isInReorgThreshold,
   )
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -33,17 +33,6 @@ let getQueueItemComparitor = (earliestQueueItem: FetchState.queueItem, ~chain) =
   }
 }
 
-type isInReorgThresholdRes<'payload> = {
-  isInReorgThreshold: bool,
-  val: 'payload,
-}
-
-type fetchStateWithData = {
-  fetchState: FetchState.t,
-  highestBlockBelowThreshold: int,
-  currentBlockHeight: int,
-}
-
 let isQueueItemEarlier = (a: multiChainEventComparitor, b: multiChainEventComparitor): bool => {
   a.earliestEvent->getQueueItemComparitor(~chain=a.chain) <
     b.earliestEvent->getQueueItemComparitor(~chain=b.chain)
@@ -52,12 +41,12 @@ let isQueueItemEarlier = (a: multiChainEventComparitor, b: multiChainEventCompar
 /**
  It either returnes an earliest item among all chains, or None if no chains are actively indexing
  */
-let getOrderedNextItem = (fetchStatesMap: ChainMap.t<fetchStateWithData>): option<
+let getOrderedNextItem = (fetchStates: ChainMap.t<FetchState.t>): option<
   multiChainEventComparitor,
 > => {
-  fetchStatesMap
+  fetchStates
   ->ChainMap.entries
-  ->Array.reduce(None, (accum, (chain, {fetchState})) => {
+  ->Array.reduce(None, (accum, (chain, fetchState)) => {
     // If the fetch state has reached the end block we don't need to consider it
     if fetchState->FetchState.isActivelyIndexing {
       let earliestEvent = fetchState->FetchState.getEarliestEvent
@@ -74,9 +63,7 @@ let getOrderedNextItem = (fetchStatesMap: ChainMap.t<fetchStateWithData>): optio
 
 let makeFromConfig = (~config: Config.t, ~maxAddrInPartition=Env.maxAddrInPartition): t => {
   let chainFetchers =
-    config.chainMap->ChainMap.map(
-      ChainFetcher.makeFromConfig(_, ~maxAddrInPartition, ~enableRawEvents=config.enableRawEvents),
-    )
+    config.chainMap->ChainMap.map(ChainFetcher.makeFromConfig(_, ~maxAddrInPartition, ~config))
   {
     chainFetchers,
     isUnorderedMultichainMode: config.isUnorderedMultichainMode,
@@ -103,8 +90,8 @@ let makeFromDbState = async (~config: Config.t, ~maxAddrInPartition=Env.maxAddrI
         chain,
         await chainConfig->ChainFetcher.makeFromDbState(
           ~maxAddrInPartition,
-          ~enableRawEvents=config.enableRawEvents,
           ~isInReorgThreshold,
+          ~config,
         ),
       )
     })
@@ -130,13 +117,9 @@ let setChainFetcher = (self: t, chainFetcher: ChainFetcher.t) => {
   }
 }
 
-let getFetchStateWithData = (self: t, ~shouldDeepCopy=false): ChainMap.t<fetchStateWithData> => {
+let getFetchStateWithData = (self: t, ~shouldDeepCopy=false): ChainMap.t<FetchState.t> => {
   self.chainFetchers->ChainMap.map(cf => {
-    {
-      fetchState: shouldDeepCopy ? cf.fetchState->FetchState.copy : cf.fetchState,
-      highestBlockBelowThreshold: cf->ChainFetcher.getHighestBlockBelowThreshold,
-      currentBlockHeight: cf.currentBlockHeight,
-    }
+    shouldDeepCopy ? cf.fetchState->FetchState.copy : cf.fetchState
   })
 }
 
@@ -155,49 +138,33 @@ type processingChainMetrics = {
 
 let createOrderedBatch = (
   ~maxBatchSize,
-  ~fetchStatesMap: ChainMap.t<fetchStateWithData>,
-  ~onlyBelowReorgThreshold,
+  ~fetchStates: ChainMap.t<FetchState.t>,
   ~mutProcessingMetricsByChainId: dict<processingChainMetrics>,
 ) => {
-  let isInReorgThresholdRef = ref(false)
   let items = []
 
   let rec loop = () =>
     if items->Array.length < maxBatchSize {
-      switch fetchStatesMap->getOrderedNextItem {
-      | Some({earliestEvent, chain}) =>
-        isInReorgThresholdRef :=
-          isInReorgThresholdRef.contents || {
-            let {currentBlockHeight, highestBlockBelowThreshold} =
-              fetchStatesMap->ChainMap.get(chain)
-            earliestEvent->FetchState.queueItemIsInReorgThreshold(
-              ~currentBlockHeight,
-              ~highestBlockBelowThreshold,
-            )
-          }
-
+      switch fetchStates->getOrderedNextItem {
+      | Some({earliestEvent}) =>
         switch earliestEvent {
         | NoItem(_) => ()
         | Item({item, popItemOffQueue}) => {
-            // To ensure history saving only starts when all chains have reached their reorg threshold
-            let shouldNotAddItem = onlyBelowReorgThreshold && isInReorgThresholdRef.contents
-            if !shouldNotAddItem {
-              popItemOffQueue()
-              items->Js.Array2.push(item)->ignore
-              mutProcessingMetricsByChainId->Js.Dict.set(
-                item.chain->ChainMap.Chain.toChainId->Int.toString,
-                {
-                  batchSize: switch mutProcessingMetricsByChainId->Utils.Dict.dangerouslyGetNonOption(
-                    item.chain->ChainMap.Chain.toChainId->Int.toString,
-                  ) {
-                  | Some(metrics) => metrics.batchSize + 1
-                  | None => 1
-                  },
-                  targetBlockNumber: item.blockNumber,
+            popItemOffQueue()
+            items->Js.Array2.push(item)->ignore
+            mutProcessingMetricsByChainId->Js.Dict.set(
+              item.chain->ChainMap.Chain.toChainId->Int.toString,
+              {
+                batchSize: switch mutProcessingMetricsByChainId->Utils.Dict.dangerouslyGetNonOption(
+                  item.chain->ChainMap.Chain.toChainId->Int.toString,
+                ) {
+                | Some(metrics) => metrics.batchSize + 1
+                | None => 1
                 },
-              )
-              loop()
-            }
+                targetBlockNumber: item.blockNumber,
+              },
+            )
+            loop()
           }
         }
       | _ => ()
@@ -205,7 +172,7 @@ let createOrderedBatch = (
     }
   loop()
 
-  (items, isInReorgThresholdRef.contents)
+  items
 }
 
 // Use a global pointer to spread the processing across chains
@@ -213,13 +180,12 @@ let nextChainIdx = ref(0)
 
 let createUnorderedBatch = (
   ~maxBatchSize,
-  ~fetchStatesMap: ChainMap.t<fetchStateWithData>,
-  ~onlyBelowReorgThreshold,
+  ~fetchStates: ChainMap.t<FetchState.t>,
   ~mutProcessingMetricsByChainId: dict<processingChainMetrics>,
 ) => {
   let items = []
 
-  let chains = fetchStatesMap->ChainMap.keys
+  let chains = fetchStates->ChainMap.keys
   let unprocessedChains = ref(chains->Array.length) // Prevent entering the same chain twice
   let batchSize = ref(0) // Faster than Array.length
 
@@ -232,8 +198,7 @@ let createUnorderedBatch = (
     switch chains->Array.get(chainIdx) {
     | None => nextChainIdx := 0
     | Some(chain) => {
-        let {fetchState, currentBlockHeight, highestBlockBelowThreshold} =
-          fetchStatesMap->ChainMap.get(chain)
+        let fetchState = fetchStates->ChainMap.get(chain)
 
         // If the fetch state has reached the end block we don't need to consider it
         if fetchState->FetchState.isActivelyIndexing {
@@ -245,19 +210,10 @@ let createUnorderedBatch = (
               switch earliestEvent {
               | NoItem(_) => ()
               | Item({item, popItemOffQueue}) =>
-                // To ensure history saving only starts when all chains have reached their reorg threshold
-                let shouldNotAddItem =
-                  onlyBelowReorgThreshold &&
-                  earliestEvent->FetchState.queueItemIsInReorgThreshold(
-                    ~currentBlockHeight,
-                    ~highestBlockBelowThreshold,
-                  )
-                if !shouldNotAddItem {
-                  popItemOffQueue()
-                  items->Js.Array2.push(item)->ignore
-                  batchSize := batchSize.contents + 1
-                  loop()
-                }
+                popItemOffQueue()
+                items->Js.Array2.push(item)->ignore
+                batchSize := batchSize.contents + 1
+                loop()
               }
             }
           loop()
@@ -282,76 +238,47 @@ let createUnorderedBatch = (
     }
   }
 
-  (
-    items,
-    // For unordered mode need to perform the check at the end of the batch
-    // using getOrderedNextItem, so we can determine that all chains reached unordered threshold
-    switch fetchStatesMap->getOrderedNextItem {
-    | None => false
-    | Some({earliestEvent, chain}) =>
-      let {currentBlockHeight, highestBlockBelowThreshold} = fetchStatesMap->ChainMap.get(chain)
-      earliestEvent->FetchState.queueItemIsInReorgThreshold(
-        ~currentBlockHeight,
-        ~highestBlockBelowThreshold,
-      )
-    },
-  )
+  items
 }
 
 type batch = {
   items: array<Internal.eventItem>,
   processingMetricsByChainId: dict<processingChainMetrics>,
-  fetchStatesMap: ChainMap.t<fetchStateWithData>,
+  fetchStates: ChainMap.t<FetchState.t>,
   dcsToStoreByChainId: dict<array<FetchState.indexingContract>>,
-  isInReorgThreshold: bool,
 }
 
-let createBatch = (self: t, ~maxBatchSize: int, ~onlyBelowReorgThreshold: bool) => {
+let createBatch = (self: t, ~maxBatchSize: int) => {
   let refTime = Hrtime.makeTimer()
 
   //Make a copy of the queues and fetch states since we are going to mutate them
-  let fetchStatesMap = self->getFetchStateWithData(~shouldDeepCopy=true)
+  let fetchStates = self->getFetchStateWithData(~shouldDeepCopy=true)
 
   let mutProcessingMetricsByChainId = Js.Dict.empty()
-  let (items, isInReorgThreshold) = if (
-    self.isUnorderedMultichainMode || fetchStatesMap->ChainMap.size === 1
-  ) {
-    createUnorderedBatch(
-      ~maxBatchSize,
-      ~fetchStatesMap,
-      ~onlyBelowReorgThreshold,
-      ~mutProcessingMetricsByChainId,
-    )
+  let items = if self.isUnorderedMultichainMode || fetchStates->ChainMap.size === 1 {
+    createUnorderedBatch(~maxBatchSize, ~fetchStates, ~mutProcessingMetricsByChainId)
   } else {
-    createOrderedBatch(
-      ~maxBatchSize,
-      ~fetchStatesMap,
-      ~onlyBelowReorgThreshold,
-      ~mutProcessingMetricsByChainId,
-    )
+    createOrderedBatch(~maxBatchSize, ~fetchStates, ~mutProcessingMetricsByChainId)
   }
 
   let dcsToStoreByChainId = Js.Dict.empty()
   // Needed to recalculate the computed queue sizes
-  let fetchStatesMap = fetchStatesMap->ChainMap.map(v => {
-    switch v.fetchState.dcsToStore {
-    | Some(dcs) => dcsToStoreByChainId->Js.Dict.set(v.fetchState.chainId->Int.toString, dcs)
+  let fetchStates = fetchStates->ChainMap.map(fetchState => {
+    switch fetchState.dcsToStore {
+    | Some(dcs) => dcsToStoreByChainId->Js.Dict.set(fetchState.chainId->Int.toString, dcs)
     | None => ()
     }
-    {
-      ...v,
-      fetchState: v.fetchState->FetchState.updateInternal(~dcsToStore=None),
-    }
+    fetchState->FetchState.updateInternal(~dcsToStore=None)
   })
 
   let batchSize = items->Array.length
   if batchSize > 0 {
     let fetchedEventsBuffer =
-      fetchStatesMap
+      fetchStates
       ->ChainMap.entries
-      ->Array.map(((chain, v)) => (
+      ->Array.map(((chain, fetchState)) => (
         chain->ChainMap.Chain.toString,
-        v.fetchState->FetchState.queueSize,
+        fetchState->FetchState.queueSize,
       ))
       ->Js.Dict.fromArray
 
@@ -378,9 +305,8 @@ let createBatch = (self: t, ~maxBatchSize: int, ~onlyBelowReorgThreshold: bool) 
   {
     items,
     processingMetricsByChainId: mutProcessingMetricsByChainId,
-    fetchStatesMap,
+    fetchStates,
     dcsToStoreByChainId,
-    isInReorgThreshold,
   }
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -75,6 +75,7 @@ let make = (~config: Config.t, ~chainManager: ChainManager.t, ~shouldUseTui=fals
   }
   Prometheus.ProcessingMaxBatchSize.set(~maxBatchSize=Env.maxProcessBatchSize)
   Prometheus.IndexingTargetBufferSize.set(~targetBufferSize)
+  Prometheus.ReorgThreshold.set(~isInReorgThreshold=chainManager.isInReorgThreshold)
   {
     config,
     currentlyProcessingBatch: false,
@@ -654,6 +655,7 @@ let actionReducer = (state: t, action: action) => {
     if isInReorgThreshold {
       Logging.info("Reorg threshold reached")
     }
+    Prometheus.ReorgThreshold.set(~isInReorgThreshold)
     ({...state, chainManager: {...state.chainManager, isInReorgThreshold}}, [])
   | SetSyncedChains => {
       let shouldExit = EventProcessing.allChainsEventsProcessedToEndblock(

--- a/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
+++ b/codegenerator/cli/templates/static/codegen/src/globalState/GlobalState.res
@@ -133,8 +133,8 @@ type action =
   | FinishWaitingForNewBlock({chain: chain, currentBlockHeight: int})
   | EventBatchProcessed({processingMetricsByChainId: dict<ChainManager.processingChainMetrics>})
   | SetCurrentlyProcessing(bool)
-  | SetIsInReorgThreshold(bool)
-  | UpdateQueues(ChainMap.t<ChainManager.fetchStateWithData>)
+  | EnterReorgThreshold
+  | UpdateQueues(ChainMap.t<FetchState.t>)
   | SetSyncedChains
   | SuccessExit
   | ErrorExit(ErrorHandling.t)
@@ -651,12 +651,30 @@ let actionReducer = (state: t, action: action) => {
       ),
     )
   | SetCurrentlyProcessing(currentlyProcessingBatch) => ({...state, currentlyProcessingBatch}, [])
-  | SetIsInReorgThreshold(isInReorgThreshold) =>
-    if isInReorgThreshold {
-      Logging.info("Reorg threshold reached")
-    }
-    Prometheus.ReorgThreshold.set(~isInReorgThreshold)
-    ({...state, chainManager: {...state.chainManager, isInReorgThreshold}}, [])
+  | EnterReorgThreshold =>
+    Logging.info("Reorg threshold reached")
+    Prometheus.ReorgThreshold.set(~isInReorgThreshold=true)
+
+    let chainFetchers = state.chainManager.chainFetchers->ChainMap.map(chainFetcher => {
+      {
+        ...chainFetcher,
+        fetchState: chainFetcher.fetchState->FetchState.updateInternal(
+          ~blockLag=Env.indexingBlockLag->Option.getWithDefault(0),
+        ),
+      }
+    })
+
+    (
+      {
+        ...state,
+        chainManager: {
+          ...state.chainManager,
+          chainFetchers,
+          isInReorgThreshold: true,
+        },
+      },
+      [],
+    )
   | SetSyncedChains => {
       let shouldExit = EventProcessing.allChainsEventsProcessedToEndblock(
         state.chainManager.chainFetchers,
@@ -664,6 +682,7 @@ let actionReducer = (state: t, action: action) => {
         ? {
             // state.config.persistence.storage
             Logging.info("All chains are caught up to the endblock.")
+
             // Keep the indexer process running in TUI mode
             // so the Dev Console server stays working
             if state.shouldUseTui {
@@ -685,7 +704,7 @@ let actionReducer = (state: t, action: action) => {
     let chainFetchers = state.chainManager.chainFetchers->ChainMap.mapWithKey((chain, cf) => {
       {
         ...cf,
-        fetchState: ChainMap.get(fetchStatesMap, chain).fetchState,
+        fetchState: ChainMap.get(fetchStatesMap, chain),
       }
     })
 
@@ -890,119 +909,99 @@ let injectedTaskReducer = (
     }
   | ProcessEventBatch =>
     if !state.currentlyProcessingBatch && !isRollingBack(state) {
-      //Allows us to process events all the way up until we hit the reorg threshold
-      //across all chains before starting to capture entity history
-      let onlyBelowReorgThreshold = if state.config->Config.shouldRollbackOnReorg {
-        state.chainManager.isInReorgThreshold ? false : true
+      let batch = state.chainManager->ChainManager.createBatch(~maxBatchSize=state.maxBatchSize)
+
+      let updatedFetchStates = batch.fetchStates
+
+      let isInReorgThreshold = state.chainManager.isInReorgThreshold
+      let isBelowReorgThreshold = if state.config->Config.shouldRollbackOnReorg {
+        isInReorgThreshold ? false : true
       } else {
         false
       }
-
-      let batch =
-        state.chainManager->ChainManager.createBatch(
-          ~maxBatchSize=state.maxBatchSize,
-          ~onlyBelowReorgThreshold,
-        )
-
-      let handleBatch = async (batch: ChainManager.batch) => {
-        switch batch {
-        | {items: []} => dispatchAction(SetSyncedChains) //Known that there are no items available on the queue so safely call this action
-        | {
-            isInReorgThreshold,
-            items,
-            processingMetricsByChainId,
-            fetchStatesMap,
-            dcsToStoreByChainId,
-          } =>
-          dispatchAction(SetCurrentlyProcessing(true))
-          dispatchAction(UpdateQueues(fetchStatesMap))
-          if (
-            state.config->Config.shouldRollbackOnReorg &&
-            isInReorgThreshold &&
-            !state.chainManager.isInReorgThreshold
-          ) {
-            //On the first time we enter the reorg threshold, copy all entities to entity history
-            //And set the isInReorgThreshold isInReorgThreshold state to true
-            dispatchAction(SetIsInReorgThreshold(true))
-          }
-
-          let isInReorgThreshold = state.chainManager.isInReorgThreshold || isInReorgThreshold
-
-          //In the case of a rollback, use the provided in memory store
-          //With rolled back values
-          let rollbackInMemStore = switch state.rollbackState {
-          | RollbackInMemStore(inMemoryStore) => Some(inMemoryStore)
-          | NoRollback
-          | RollingBack(
-            _,
-          ) /* This is an impossible case due to the surrounding if statement check */ =>
-            None
-          }
-
-          let inMemoryStore = rollbackInMemStore->Option.getWithDefault(InMemoryStore.make())
-
-          if dcsToStoreByChainId->Utils.Dict.size > 0 {
-            let shouldSaveHistory = state.config->Config.shouldSaveHistory(~isInReorgThreshold)
-            inMemoryStore->InMemoryStore.setDcsToStore(dcsToStoreByChainId, ~shouldSaveHistory)
-          }
-
-          state.chainManager.chainFetchers
-          ->ChainMap.keys
-          ->Array.forEach(chain => {
-            let chainId = chain->ChainMap.Chain.toChainId
-            switch processingMetricsByChainId->Utils.Dict.dangerouslyGetNonOption(
-              chain->ChainMap.Chain.toString,
-            ) {
-            | Some(metrics) =>
-              Prometheus.ProcessingBatchSize.set(~batchSize=metrics.batchSize, ~chainId)
-              Prometheus.ProcessingBlockNumber.set(~blockNumber=metrics.targetBlockNumber, ~chainId)
-            | None => Prometheus.ProcessingBatchSize.set(~batchSize=0, ~chainId)
-            }
-          })
-
-          switch await EventProcessing.processEventBatch(
-            ~items,
-            ~processingMetricsByChainId,
-            ~inMemoryStore,
-            ~isInReorgThreshold,
-            ~loadManager=state.loadManager,
-            ~config=state.config,
-          ) {
-          | exception exn =>
-            //All casese should be handled/caught before this with better user messaging.
-            //This is just a safety in case something unexpected happens
-            let errHandler =
-              exn->ErrorHandling.make(
-                ~msg="A top level unexpected error occurred during processing",
-              )
-            dispatchAction(ErrorExit(errHandler))
-          | res =>
-            if rollbackInMemStore->Option.isSome {
-              //if the batch was executed with a rollback inMemoryStore
-              //reset the rollback state once the batch has been processed
-              dispatchAction(ResetRollbackState)
-            }
-            switch res {
-            | Ok() =>
-              dispatchAction(
-                EventBatchProcessed({processingMetricsByChainId: processingMetricsByChainId}),
-              )
-            | Error(errHandler) => dispatchAction(ErrorExit(errHandler))
-            }
-          }
-        }
+      if (
+        isBelowReorgThreshold &&
+        updatedFetchStates
+        ->ChainMap.keys
+        ->Array.every(chain => {
+          updatedFetchStates
+          ->ChainMap.get(chain)
+          ->FetchState.isReadyToEnterReorgThreshold(
+            ~currentBlockHeight=(
+              state.chainManager.chainFetchers->ChainMap.get(chain)
+            ).currentBlockHeight,
+          )
+        })
+      ) {
+        dispatchAction(EnterReorgThreshold)
       }
 
       switch batch {
-      | {isInReorgThreshold: true, items: []} if onlyBelowReorgThreshold =>
-        dispatchAction(SetIsInReorgThreshold(true))
-        let batch =
-          state.chainManager->ChainManager.createBatch(
-            ~maxBatchSize=state.maxBatchSize,
-            ~onlyBelowReorgThreshold=false,
-          )
-        await handleBatch(batch)
-      | _ => await handleBatch(batch)
+      | {items: []} => dispatchAction(SetSyncedChains) //Known that there are no items available on the queue so safely call this action
+      | {items, processingMetricsByChainId, fetchStates, dcsToStoreByChainId} =>
+        dispatchAction(SetCurrentlyProcessing(true))
+        dispatchAction(UpdateQueues(fetchStates))
+
+        //In the case of a rollback, use the provided in memory store
+        //With rolled back values
+        let rollbackInMemStore = switch state.rollbackState {
+        | RollbackInMemStore(inMemoryStore) => Some(inMemoryStore)
+        | NoRollback
+        | RollingBack(
+          _,
+        ) /* This is an impossible case due to the surrounding if statement check */ =>
+          None
+        }
+
+        let inMemoryStore = rollbackInMemStore->Option.getWithDefault(InMemoryStore.make())
+
+        if dcsToStoreByChainId->Utils.Dict.size > 0 {
+          let shouldSaveHistory = state.config->Config.shouldSaveHistory(~isInReorgThreshold)
+          inMemoryStore->InMemoryStore.setDcsToStore(dcsToStoreByChainId, ~shouldSaveHistory)
+        }
+
+        state.chainManager.chainFetchers
+        ->ChainMap.keys
+        ->Array.forEach(chain => {
+          let chainId = chain->ChainMap.Chain.toChainId
+          switch processingMetricsByChainId->Utils.Dict.dangerouslyGetNonOption(
+            chain->ChainMap.Chain.toString,
+          ) {
+          | Some(metrics) =>
+            Prometheus.ProcessingBatchSize.set(~batchSize=metrics.batchSize, ~chainId)
+            Prometheus.ProcessingBlockNumber.set(~blockNumber=metrics.targetBlockNumber, ~chainId)
+          | None => Prometheus.ProcessingBatchSize.set(~batchSize=0, ~chainId)
+          }
+        })
+
+        switch await EventProcessing.processEventBatch(
+          ~items,
+          ~processingMetricsByChainId,
+          ~inMemoryStore,
+          ~isInReorgThreshold,
+          ~loadManager=state.loadManager,
+          ~config=state.config,
+        ) {
+        | exception exn =>
+          //All casese should be handled/caught before this with better user messaging.
+          //This is just a safety in case something unexpected happens
+          let errHandler =
+            exn->ErrorHandling.make(~msg="A top level unexpected error occurred during processing")
+          dispatchAction(ErrorExit(errHandler))
+        | res =>
+          if rollbackInMemStore->Option.isSome {
+            //if the batch was executed with a rollback inMemoryStore
+            //reset the rollback state once the batch has been processed
+            dispatchAction(ResetRollbackState)
+          }
+          switch res {
+          | Ok() =>
+            dispatchAction(
+              EventBatchProcessed({processingMetricsByChainId: processingMetricsByChainId}),
+            )
+          | Error(errHandler) => dispatchAction(ErrorExit(errHandler))
+          }
+        }
       }
     }
   | Rollback =>

--- a/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
+++ b/scenarios/erc20_multichain_factory/test/DynamicContractRecovery_test.res
@@ -143,7 +143,8 @@ describe("Dynamic contract restart resistance test", () => {
     let chainFetcher = await ChainFetcher.makeFromDbState(
       config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId)),
       ~maxAddrInPartition=Env.maxAddrInPartition,
-      ~enableRawEvents=config.enableRawEvents,
+      ~config,
+      ~isInReorgThreshold=true,
       ~sql?,
     )
 
@@ -158,7 +159,6 @@ describe("Dynamic contract restart resistance test", () => {
       let chainManager = {
         ...ChainManager.makeFromConfig(~config),
         isUnorderedMultichainMode: true,
-        isInReorgThreshold: true,
       }
 
       //Setup initial state stub that will be used for both

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -2791,6 +2791,24 @@ describe("FetchState.isReadyToEnterReorgThreshold", () => {
     let fsWithQueue = fs->FetchState.updateInternal(~queue=[mockEvent(~blockNumber=6)])
     Assert.equal(fsWithQueue->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=10), false)
   })
+
+   it("Returns true when the queue is empty and threshold is more than current block height", () => {
+    let fs = FetchState.make(
+      ~eventConfigs=[baseEventConfig, baseEventConfig2],
+      ~contracts=[{
+        FetchState.address: mockAddress0,
+        contractName: "Gravatar",
+        startBlock: 6,
+        register: Config,
+      }],
+      ~startBlock=6,
+      ~endBlock=Some(5),
+      ~maxAddrInPartition=3,
+      ~chainId,
+      ~blockLag=200,
+    )
+    Assert.equal(fs->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=10), true)
+  })
 })
 
 describe("Dynamic contracts with start blocks", () => {

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1123,6 +1123,12 @@ describe("FetchState.getNextQuery & integration", () => {
 
     Assert.deepEqual(fetchState->getNextQuery(~currentBlockHeight=0), WaitingForNewBlock)
 
+    Assert.deepEqual(
+      fetchState->getNextQuery(~currentBlockHeight=1),
+      WaitingForNewBlock,
+      ~message="Should wait for new block when current block height - block lag is less than 0",
+    )
+
     let nextQuery = fetchState->getNextQuery(~endBlock=Some(8), ~currentBlockHeight=10)
     Assert.deepEqual(
       nextQuery,
@@ -2681,12 +2687,14 @@ describe("FetchState.isReadyToEnterReorgThreshold", () => {
     // latestFullyFetchedBlock = startBlock - 1 = 5, endBlock = 5
     let fs = FetchState.make(
       ~eventConfigs=[baseEventConfig, baseEventConfig2],
-      ~contracts=[{
-        FetchState.address: mockAddress0,
-        contractName: "Gravatar",
-        startBlock: 6,
-        register: Config,
-      }],
+      ~contracts=[
+        {
+          FetchState.address: mockAddress0,
+          contractName: "Gravatar",
+          startBlock: 6,
+          register: Config,
+        },
+      ],
       ~startBlock=6,
       ~endBlock=Some(5),
       ~maxAddrInPartition=3,
@@ -2700,12 +2708,14 @@ describe("FetchState.isReadyToEnterReorgThreshold", () => {
     // latestFullyFetchedBlock = 49, endBlock = 100, head - lag = 50
     let fs = FetchState.make(
       ~eventConfigs=[baseEventConfig, baseEventConfig2],
-      ~contracts=[{
-        FetchState.address: mockAddress0,
-        contractName: "Gravatar",
-        startBlock: 50,
-        register: Config,
-      }],
+      ~contracts=[
+        {
+          FetchState.address: mockAddress0,
+          contractName: "Gravatar",
+          startBlock: 50,
+          register: Config,
+        },
+      ],
       ~startBlock=50,
       ~endBlock=Some(100),
       ~maxAddrInPartition=3,
@@ -2719,12 +2729,14 @@ describe("FetchState.isReadyToEnterReorgThreshold", () => {
     // latestFullyFetchedBlock = 49, head - lag = 49
     let fs = FetchState.make(
       ~eventConfigs=[baseEventConfig, baseEventConfig2],
-      ~contracts=[{
-        FetchState.address: mockAddress0,
-        contractName: "Gravatar",
-        startBlock: 50,
-        register: Config,
-      }],
+      ~contracts=[
+        {
+          FetchState.address: mockAddress0,
+          contractName: "Gravatar",
+          startBlock: 50,
+          register: Config,
+        },
+      ],
       ~startBlock=50,
       ~endBlock=Some(100),
       ~maxAddrInPartition=3,
@@ -2738,12 +2750,14 @@ describe("FetchState.isReadyToEnterReorgThreshold", () => {
     // latestFullyFetchedBlock = 50, head - lag = 50
     let fs = FetchState.make(
       ~eventConfigs=[baseEventConfig, baseEventConfig2],
-      ~contracts=[{
-        FetchState.address: mockAddress0,
-        contractName: "Gravatar",
-        startBlock: 51,
-        register: Config,
-      }],
+      ~contracts=[
+        {
+          FetchState.address: mockAddress0,
+          contractName: "Gravatar",
+          startBlock: 51,
+          register: Config,
+        },
+      ],
       ~startBlock=51,
       ~endBlock=None,
       ~maxAddrInPartition=3,
@@ -2757,12 +2771,14 @@ describe("FetchState.isReadyToEnterReorgThreshold", () => {
     // latestFullyFetchedBlock = 49, head - lag = 50
     let fs = FetchState.make(
       ~eventConfigs=[baseEventConfig, baseEventConfig2],
-      ~contracts=[{
-        FetchState.address: mockAddress0,
-        contractName: "Gravatar",
-        startBlock: 50,
-        register: Config,
-      }],
+      ~contracts=[
+        {
+          FetchState.address: mockAddress0,
+          contractName: "Gravatar",
+          startBlock: 50,
+          register: Config,
+        },
+      ],
       ~startBlock=50,
       ~endBlock=None,
       ~maxAddrInPartition=3,
@@ -2776,12 +2792,14 @@ describe("FetchState.isReadyToEnterReorgThreshold", () => {
     // EndBlock reached but queue has items
     let fs = FetchState.make(
       ~eventConfigs=[baseEventConfig, baseEventConfig2],
-      ~contracts=[{
-        FetchState.address: mockAddress0,
-        contractName: "Gravatar",
-        startBlock: 6,
-        register: Config,
-      }],
+      ~contracts=[
+        {
+          FetchState.address: mockAddress0,
+          contractName: "Gravatar",
+          startBlock: 6,
+          register: Config,
+        },
+      ],
       ~startBlock=6,
       ~endBlock=Some(5),
       ~maxAddrInPartition=3,
@@ -2789,18 +2807,23 @@ describe("FetchState.isReadyToEnterReorgThreshold", () => {
       ~blockLag=0,
     )
     let fsWithQueue = fs->FetchState.updateInternal(~queue=[mockEvent(~blockNumber=6)])
-    Assert.equal(fsWithQueue->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=10), false)
+    Assert.equal(
+      fsWithQueue->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=10),
+      false,
+    )
   })
 
-   it("Returns true when the queue is empty and threshold is more than current block height", () => {
+  it("Returns true when the queue is empty and threshold is more than current block height", () => {
     let fs = FetchState.make(
       ~eventConfigs=[baseEventConfig, baseEventConfig2],
-      ~contracts=[{
-        FetchState.address: mockAddress0,
-        contractName: "Gravatar",
-        startBlock: 6,
-        register: Config,
-      }],
+      ~contracts=[
+        {
+          FetchState.address: mockAddress0,
+          contractName: "Gravatar",
+          startBlock: 6,
+          register: Config,
+        },
+      ],
       ~startBlock=6,
       ~endBlock=Some(5),
       ~maxAddrInPartition=3,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -154,7 +154,7 @@ describe("FetchState.make", () => {
         indexingContracts: fetchState.indexingContracts,
         contractConfigs: fetchState.contractConfigs,
         dcsToStore: None,
-        blockLag: None,
+        blockLag: 0,
       },
     )
   })
@@ -223,7 +223,7 @@ describe("FetchState.make", () => {
           indexingContracts: fetchState.indexingContracts,
           contractConfigs: fetchState.contractConfigs,
           dcsToStore: None,
-          blockLag: None,
+          blockLag: 0,
         },
         ~message=`Should create only one partition`,
       )
@@ -286,7 +286,7 @@ describe("FetchState.make", () => {
           indexingContracts: fetchState.indexingContracts,
           contractConfigs: fetchState.contractConfigs,
           dcsToStore: None,
-          blockLag: None,
+          blockLag: 0,
         },
       )
 
@@ -381,7 +381,7 @@ describe("FetchState.make", () => {
           indexingContracts: fetchState.indexingContracts,
           contractConfigs: fetchState.contractConfigs,
           dcsToStore: None,
-          blockLag: None,
+          blockLag: 0,
         },
       )
     },
@@ -863,7 +863,7 @@ describe("FetchState.registerDynamicContracts", () => {
           indexingContracts: fetchState.indexingContracts,
           contractConfigs: fetchState.contractConfigs,
           dcsToStore: None,
-          blockLag: None,
+          blockLag: 0,
         },
         ~message=`The static addresses for the Gravatar contract should be skipped, since they don't have non-wildcard event configs`,
       )
@@ -902,7 +902,7 @@ describe("FetchState.getNextQuery & integration", () => {
       firstEventBlockNumber: Some(1),
       endBlock: None,
       dcsToStore: None,
-      blockLag: None,
+      blockLag: 0,
       normalSelection,
       chainId,
       indexingContracts: Js.Dict.fromArray([
@@ -962,7 +962,7 @@ describe("FetchState.getNextQuery & integration", () => {
       chainId,
       indexingContracts: makeIndexingContractsWithDynamics([dc3, dc2, dc1], ~static=[mockAddress0]),
       contractConfigs: makeInitial().contractConfigs,
-      blockLag: undefined,
+      blockLag: 0,
     }
   }
 
@@ -1863,7 +1863,7 @@ describe("FetchState unit tests for specific cases", () => {
         ("NftFactory", {FetchState.filterByAddresses: false}),
       ]),
       dcsToStore: None,
-      blockLag: None,
+      blockLag: 0,
     }
 
     let updatedFetchState =
@@ -2177,7 +2177,7 @@ describe("FetchState unit tests for specific cases", () => {
         ("NftFactory", {FetchState.filterByAddresses: false}),
       ]),
       dcsToStore: None,
-      blockLag: None,
+      blockLag: 0,
     }
 
     Assert.deepEqual(
@@ -2660,18 +2660,10 @@ describe("Test queue item", () => {
   })
 })
 
-describe("FetchState.queueItemIsInReorgThreshold", () => {
+describe("FetchState.isReadyToEnterReorgThreshold", () => {
   it("Returns false when we just started the indexer and it has currentBlockHeight=0", () => {
     let fetchState = makeInitial()
-    Assert.equal(
-      fetchState
-      ->FetchState.getEarliestEvent
-      ->FetchState.queueItemIsInReorgThreshold(
-        ~currentBlockHeight=0,
-        ~highestBlockBelowThreshold=0,
-      ),
-      false,
-    )
+    Assert.equal(fetchState->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=0), false)
   })
 
   it(
@@ -2679,16 +2671,126 @@ describe("FetchState.queueItemIsInReorgThreshold", () => {
     () => {
       let fetchState = makeInitial(~startBlock=6000)
       Assert.equal(
-        fetchState
-        ->FetchState.getEarliestEvent
-        ->FetchState.queueItemIsInReorgThreshold(
-          ~currentBlockHeight=0,
-          ~highestBlockBelowThreshold=0,
-        ),
+        fetchState->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=0),
         false,
       )
     },
   )
+
+  it("Returns true when endBlock is reached and queue is empty", () => {
+    // latestFullyFetchedBlock = startBlock - 1 = 5, endBlock = 5
+    let fs = FetchState.make(
+      ~eventConfigs=[baseEventConfig, baseEventConfig2],
+      ~contracts=[{
+        FetchState.address: mockAddress0,
+        contractName: "Gravatar",
+        startBlock: 6,
+        register: Config,
+      }],
+      ~startBlock=6,
+      ~endBlock=Some(5),
+      ~maxAddrInPartition=3,
+      ~chainId,
+      ~blockLag=0,
+    )
+    Assert.equal(fs->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=10), true)
+  })
+
+  it("Returns false when endBlock not reached and below head - blockLag", () => {
+    // latestFullyFetchedBlock = 49, endBlock = 100, head - lag = 50
+    let fs = FetchState.make(
+      ~eventConfigs=[baseEventConfig, baseEventConfig2],
+      ~contracts=[{
+        FetchState.address: mockAddress0,
+        contractName: "Gravatar",
+        startBlock: 50,
+        register: Config,
+      }],
+      ~startBlock=50,
+      ~endBlock=Some(100),
+      ~maxAddrInPartition=3,
+      ~chainId,
+      ~blockLag=10,
+    )
+    Assert.equal(fs->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=60), false)
+  })
+
+  it("Returns true when endBlock not reached but latest >= head - blockLag", () => {
+    // latestFullyFetchedBlock = 49, head - lag = 49
+    let fs = FetchState.make(
+      ~eventConfigs=[baseEventConfig, baseEventConfig2],
+      ~contracts=[{
+        FetchState.address: mockAddress0,
+        contractName: "Gravatar",
+        startBlock: 50,
+        register: Config,
+      }],
+      ~startBlock=50,
+      ~endBlock=Some(100),
+      ~maxAddrInPartition=3,
+      ~chainId,
+      ~blockLag=10,
+    )
+    Assert.equal(fs->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=59), true)
+  })
+
+  it("Returns true when no endBlock and latest >= head - blockLag (boundary)", () => {
+    // latestFullyFetchedBlock = 50, head - lag = 50
+    let fs = FetchState.make(
+      ~eventConfigs=[baseEventConfig, baseEventConfig2],
+      ~contracts=[{
+        FetchState.address: mockAddress0,
+        contractName: "Gravatar",
+        startBlock: 51,
+        register: Config,
+      }],
+      ~startBlock=51,
+      ~endBlock=None,
+      ~maxAddrInPartition=3,
+      ~chainId,
+      ~blockLag=10,
+    )
+    Assert.equal(fs->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=60), true)
+  })
+
+  it("Returns false when no endBlock and latest < head - blockLag", () => {
+    // latestFullyFetchedBlock = 49, head - lag = 50
+    let fs = FetchState.make(
+      ~eventConfigs=[baseEventConfig, baseEventConfig2],
+      ~contracts=[{
+        FetchState.address: mockAddress0,
+        contractName: "Gravatar",
+        startBlock: 50,
+        register: Config,
+      }],
+      ~startBlock=50,
+      ~endBlock=None,
+      ~maxAddrInPartition=3,
+      ~chainId,
+      ~blockLag=10,
+    )
+    Assert.equal(fs->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=60), false)
+  })
+
+  it("Returns false when queue is not empty even if thresholds are met", () => {
+    // EndBlock reached but queue has items
+    let fs = FetchState.make(
+      ~eventConfigs=[baseEventConfig, baseEventConfig2],
+      ~contracts=[{
+        FetchState.address: mockAddress0,
+        contractName: "Gravatar",
+        startBlock: 6,
+        register: Config,
+      }],
+      ~startBlock=6,
+      ~endBlock=Some(5),
+      ~maxAddrInPartition=3,
+      ~chainId,
+      ~blockLag=0,
+    )
+    let fsWithQueue = fs->FetchState.updateInternal(~queue=[mockEvent(~blockNumber=6)])
+    Assert.equal(fsWithQueue->FetchState.isReadyToEnterReorgThreshold(~currentBlockHeight=10), false)
+  })
 })
 
 describe("Dynamic contracts with start blocks", () => {

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -294,7 +294,7 @@ describe("SourceManager fetchNext", () => {
       indexingContracts,
       contractConfigs: Js.Dict.empty(),
       dcsToStore: None,
-      blockLag: None,
+      blockLag: 0,
       // All the null values should be computed during updateInternal
     }->FetchState.updateInternal
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Prometheus gauge reporting whether indexing is within the reorg threshold.
  - Automatic entry into reorg threshold when chains meet readiness checks.

- **Refactor**
  - Simplified per-chain fetch state and batch construction; unified reorg-threshold flow.
  - Block-lag became a concrete, configurable numeric parameter with a safe default.

- **Tests**
  - Updated tests to cover reorg-threshold behavior and block-lag defaulting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->