### PR TITLE
Improve chain selection for unordered batch creation

### DIFF
--- a/codegenerator/cli/npm/envio/src/Utils.res
+++ b/codegenerator/cli/npm/envio/src/Utils.res
@@ -250,6 +250,8 @@ Helper to check if a value exists in an array
 
   let last = (arr: array<'a>): option<'a> => arr->Belt.Array.get(arr->Array.length - 1)
 
+  let lastUnsafe = (arr: array<'a>): 'a => arr->Belt.Array.getUnsafe(arr->Array.length - 1)
+
   let findReverseWithIndex = (arr: array<'a>, fn: 'a => bool): option<('a, int)> => {
     let rec loop = (index: int) => {
       if index < 0 {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -497,7 +497,7 @@ let hasProcessedToEndblock = (self: t) => {
 }
 
 let hasNoMoreEventsToProcess = (self: t) => {
-  self.fetchState->FetchState.queueSize === 0
+  self.fetchState->FetchState.bufferSize === 0
 }
 
 let getHighestBlockBelowThreshold = (cf: t): int => {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -175,9 +175,6 @@ let createOrderedBatch = (
   items
 }
 
-// Use a global pointer to spread the processing across chains
-let nextChainIdx = ref(0)
-
 let createUnorderedBatch = (
   ~maxBatchSize,
   ~fetchStates: ChainMap.t<FetchState.t>,
@@ -185,57 +182,51 @@ let createUnorderedBatch = (
 ) => {
   let items = []
 
-  let chains = fetchStates->ChainMap.keys
-  let unprocessedChains = ref(chains->Array.length) // Prevent entering the same chain twice
-  let batchSize = ref(0) // Faster than Array.length
+  let preparedFetchStates =
+    fetchStates
+    ->ChainMap.values
+    ->FetchState.filterAndSortForUnorderedBatch
+
+  let idx = ref(0)
+  let preparedNumber = preparedFetchStates->Array.length
+  let batchSize = ref(0)
 
   // Accumulate items for all actively indexing chains
   // the way to group as many items from a single chain as possible
   // This way the loaders optimisations will hit more often
-  // Also, keep the nextChainIdx global, so we start with a new chain every batch
-  while batchSize.contents < maxBatchSize && unprocessedChains.contents > 0 {
-    let chainIdx = nextChainIdx.contents
-    switch chains->Array.get(chainIdx) {
-    | None => nextChainIdx := 0
-    | Some(chain) => {
-        let fetchState = fetchStates->ChainMap.get(chain)
+  while batchSize.contents < maxBatchSize && idx.contents < preparedNumber {
+    let fetchState = sortedFetchStates->Array.getUnsafe(idx.contents)
+    let batchSizeBeforeTheChain = batchSize.contents
 
-        // If the fetch state has reached the end block we don't need to consider it
-        if fetchState->FetchState.isActivelyIndexing {
-          let batchSizeBeforeTheChain = batchSize.contents
-
-          let rec loop = () =>
-            if batchSize.contents < maxBatchSize {
-              let earliestEvent = fetchState->FetchState.getEarliestEvent
-              switch earliestEvent {
-              | NoItem(_) => ()
-              | Item({item, popItemOffQueue}) =>
-                popItemOffQueue()
-                items->Js.Array2.push(item)->ignore
-                batchSize := batchSize.contents + 1
-                loop()
-              }
-            }
-          loop()
-
-          let chainBatchSize = batchSize.contents - batchSizeBeforeTheChain
-          if chainBatchSize > 0 {
-            mutProcessingMetricsByChainId->Js.Dict.set(
-              chain->ChainMap.Chain.toChainId->Int.toString,
-              {
-                batchSize: chainBatchSize,
-                // If there's the chainBatchSize,
-                // then it's guaranteed that the last item belongs to the chain
-                targetBlockNumber: (items->Utils.Array.last->Option.getUnsafe).blockNumber,
-              },
-            )
+    let rec loop = () =>
+      if batchSize.contents < maxBatchSize {
+        let earliestEvent = fetchState->FetchState.getEarliestEvent
+        switch earliestEvent {
+        | NoItem(_) => ()
+        | Item({item, popItemOffQueue}) => {
+            popItemOffQueue()
+            items->Js.Array2.push(item)->ignore
+            batchSize := batchSize.contents + 1
+            loop()
           }
         }
-
-        nextChainIdx := nextChainIdx.contents + 1
-        unprocessedChains := unprocessedChains.contents - 1
       }
+    loop()
+
+    let chainBatchSize = batchSize.contents - batchSizeBeforeTheChain
+    if chainBatchSize > 0 {
+      mutProcessingMetricsByChainId->Js.Dict.set(
+        fetchState.chainId->Int.toString,
+        {
+          batchSize: chainBatchSize,
+          // If there's the chainBatchSize,
+          // then it's guaranteed that the last item belongs to the chain
+          targetBlockNumber: (items->Utils.Array.last->Option.getUnsafe).blockNumber,
+        },
+      )
     }
+
+    idx := idx.contents + 1
   }
 
   items
@@ -278,7 +269,7 @@ let createBatch = (self: t, ~maxBatchSize: int) => {
       ->ChainMap.entries
       ->Array.map(((chain, fetchState)) => (
         chain->ChainMap.Chain.toString,
-        fetchState->FetchState.queueSize,
+        fetchState->FetchState.bufferSize,
       ))
       ->Js.Dict.fromArray
 

--- a/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackDynamicContract_test.res
@@ -179,7 +179,7 @@ module Sql = RollbackMultichain_test.Sql
 //       ->ChainMap.values
 //       ->Array.reduce(
 //         0,
-//         (accum, chainFetcher) => accum + chainFetcher.fetchState->FetchState.queueSize,
+//         (accum, chainFetcher) => accum + chainFetcher.fetchState->FetchState.bufferSize,
 //       )
 //     }
 

--- a/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
+++ b/scenarios/erc20_multichain_factory/test/RollbackMultichain_test.res
@@ -272,7 +272,7 @@ let setupDb = async () => {
 //       ->ChainMap.values
 //       ->Array.reduce(
 //         0,
-//         (accum, chainFetcher) => accum + chainFetcher.fetchState->FetchState.queueSize,
+//         (accum, chainFetcher) => accum + chainFetcher.fetchState->FetchState.bufferSize,
 //       )
 //     }
 

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -207,7 +207,7 @@ describe("ChainManager", () => {
           ->Belt.Array.reduce(
             0,
             (accum, val) => {
-              accum + val.fetchState->FetchState.queueSize
+              accum + val.fetchState->FetchState.bufferSize
             },
           )
 

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -190,7 +190,7 @@ describe("Single Chain Simple Rollback", () => {
     )
 
     Assert.equal(
-      getChainFetcher().fetchState->FetchState.queueSize,
+      getChainFetcher().fetchState->FetchState.bufferSize,
       3,
       ~message="should have 3 events on the queue from the first 3 blocks of inital chainData",
     )
@@ -256,7 +256,7 @@ describe("Single Chain Simple Rollback", () => {
     )
 
     Assert.equal(
-      getChainFetcher().fetchState->FetchState.queueSize,
+      getChainFetcher().fetchState->FetchState.bufferSize,
       3,
       ~message="should have 3 events on the queue from the first 3 blocks of inital chainData",
     )


### PR DESCRIPTION
Previously, when we created a batch, we tried to get items from a new chain every time. 

The updated logic now prefers chains which are most behind. This is especially nice for indexers like UNIV4 where after indexing for a few hours, all chains besides base and optimism catch up to head, and we are left only with two chains left. We lose the HyperSync concurrency optimization. With this change, Base and optimism will have higher priority and progress with all the other changes simultaneously. Always guaranteeing that we have events and buffers to process (processing a full batch)

So there's no drop from 10k events per second to 4k events per second.