### PR TITLE
error-endpoint

### DIFF
--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -1014,15 +1014,16 @@ impl DataSource {
         let main = match rpc_for_sync {
             Some(rpc) => {
                 if network.hypersync_config.is_some() {
-                    Err(anyhow!("EE106: Cannot define both hypersync_config and rpc as a data-source for historical sync at the same time, please choose only one option or set RPC to be a fallback. Read more in our docs https://docs.envio.dev/docs/configuration-file"))?
+                    Err(anyhow!("EE106: Cannot define both hypersync_config and rpc as a data-source for historical sync at the same time, please choose only one option or set RPC to be a fallback. Read more in our docs {}", links::DOC_CONFIGURATION_FILE))?
                 };
 
                 MainEvmDataSource::Rpc(rpc.clone())
             }
             None => {
                 let url = hypersync_endpoint_url.ok_or(anyhow!(
-                  "EE106: Failed to automatically find HyperSync endpoint for the network {}. Please provide it manually via the hypersync_config option, or provide an RPC URL for historical sync. Read more in our docs: https://docs.envio.dev/docs/configuration-file",
-                  network.id
+                  "EE106: Failed to automatically find HyperSync endpoint for the network {}. Please provide it manually via the hypersync_config option, or provide an RPC URL for historical sync. Read more in our docs: {}",
+                  network.id,
+                  links::DOC_CONFIGURATION_SCHEMA_HYPERSYNC_CONFIG
                 ))?;
 
                 let parsed_url = parse_url(&url).ok_or(anyhow!(

--- a/codegenerator/cli/src/constants.rs
+++ b/codegenerator/cli/src/constants.rs
@@ -9,6 +9,8 @@ pub mod project_paths {
 
 pub mod links {
     pub const DOC_CONFIGURATION_FILE: &str = "https://docs.envio.dev/docs/configuration-file";
+    pub const DOC_CONFIGURATION_SCHEMA_HYPERSYNC_CONFIG: &str =
+        "https://docs.envio.dev/docs/HyperIndex/config-schema-reference#hypersyncconfig";
 }
 
 pub mod reserved_keywords {

--- a/scenarios/test_codegen/test/SerDe_Test.res
+++ b/scenarios/test_codegen/test/SerDe_Test.res
@@ -7,7 +7,7 @@ let mockDate = (~year=2024, ~month=1, ~day=1) => {
   Js.Date.fromString(`${year->padInt}-${month->padInt}-${day->padInt}T00:00:00Z`)
 }
 
-describe_only("SerDe Test", () => {
+describe("SerDe Test", () => {
   Async.before(async () => {
     await DbHelpers.runUpDownMigration()
   })
@@ -27,7 +27,7 @@ describe_only("SerDe Test", () => {
       optFloat: Some(2.2),
       arrayOfFloats: [3.3, 4.4],
       bool: true,
-      optBool: Some(true),
+      optBool: Some(false),
       //TODO: get array of bools working
       // arrayOfBool: [true, false],
       bigInt: BigInt.fromInt(1),
@@ -151,7 +151,7 @@ SELECT * FROM unnest($1::NUMERIC[],$2::NUMERIC[],$3::INTEGER[]::BOOLEAN[],$4::TE
       float_: 1.1,
       optFloat: Some(2.2),
       bool: true,
-      optBool: Some(true),
+      optBool: Some(false),
       bigInt: BigInt.fromInt(1),
       optBigInt: Some(BigInt.fromInt(2)),
       bigDecimal: BigDecimal.fromStringUnsafe("1.1"),


### PR DESCRIPTION
improve error msg to hypersync_config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Error messages now reference centralized documentation links, offering clearer guidance when a sync RPC is set alongside HyperSync settings and when HyperSync endpoint auto-discovery fails.
  - Added a direct link to the HyperSync configuration schema reference to streamline troubleshooting and setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->