### PR TITLE
Fix cli link

### DIFF
--- a/codegenerator/cli/templates/static/codegen/src/ink/EnvioInkApp.res
+++ b/codegenerator/cli/templates/static/codegen/src/ink/EnvioInkApp.res
@@ -52,7 +52,12 @@ module App = {
         <Text>
           {"GraphQL Interface:    "->React.string}
         </Text>
-        <Text color={Info} underline=true> {`${Env.Hasura.url}`->React.string} </Text>
+        <Text color={Info} underline=true>
+          {`${Env.Hasura.url}`->React.string}
+        </Text>
+        <Text color={Info}>
+          {" (password: testing)"->React.string}
+        </Text>
       </Box>
       <Messages config />
     </Box>


### PR DESCRIPTION
<img width="847" height="195" alt="Screenshot 2025-08-27 at 13 06 31" src="https://github.com/user-attachments/assets/d49c48b4-f246-40a3-a0cb-583495b3b8ec" />
Currently a footgun, you click on this link in the tui here and it takes you here in browser which confuses some users, easier to take them to the dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Renamed label from “GraphQL Endpoint” to “GraphQL Interface”.
  * Reformatted connection details: show the root URL on its own underlined line; display “(password: testing)” on a separate info-colored line.
  * Replaced the inline full endpoint path with the root URL.
  * Improves readability and reduces visual clutter in the connection panel; no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->