### PR TITLE
Make an option to make addresses lower case

### DIFF
--- a/codegenerator/cli/npm/envio/evm.schema.json
+++ b/codegenerator/cli/npm/envio/evm.schema.json
@@ -113,6 +113,17 @@
         "boolean",
         "null"
       ]
+    },
+    "address_format": {
+      "description": "Address format for Ethereum addresses: 'checksum' or 'lowercase' (default: checksum)",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/AddressFormat"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "additionalProperties": false,
@@ -652,6 +663,13 @@
       "enum": [
         "viem",
         "hypersync-client"
+      ]
+    },
+    "AddressFormat": {
+      "type": "string",
+      "enum": [
+        "checksum",
+        "lowercase"
       ]
     }
   }

--- a/codegenerator/cli/npm/envio/src/Address.res
+++ b/codegenerator/cli/npm/envio/src/Address.res
@@ -31,7 +31,7 @@ module Evm = {
   }
 
   let fromAddressLowercaseOrThrow = address =>
-    address->toString->fromStringLowercaseOrThrow
+    address->toString->Js.String2.toLowerCase
 
   // Reassign since the function might be used in the handler code
   // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency

--- a/codegenerator/cli/npm/envio/src/Address.res
+++ b/codegenerator/cli/npm/envio/src/Address.res
@@ -10,6 +10,28 @@ external unsafeFromString: string => t = "%identity"
 module Evm = {
   @module("viem")
   external fromStringOrThrow: string => t = "getAddress"
+
+  // NOTE: We could use a regex for this instead, not sure if it is faster/slower than viem's 'isAddress' function
+  //       `/^0x[a-fA-F0-9]{40}$/`
+  @module("viem") @private
+  external isAddress: string => bool = "isAddress"
+
+  // Validate that the string is a proper address but return a lowercased value
+  let fromStringLowercaseOrThrow = string => {
+    // NOTE: We could use a regex for this and make this function more strict, so it only accepts lower case addresses as input
+    //       eg this regex: `/^0x[a-f0-9]{40}$/`
+    if (isAddress(string)) {
+      unsafeFromString(string->Js.String2.toLowerCase)
+    } else {
+      Js.Exn.raiseError(
+        `Address "${string}" is invalid. Expected a 20-byte hex string starting with 0x.`,
+      )
+    }
+  }
+
+  let fromAddressLowercaseOrThrow = address =>
+    address->toString->fromStringLowercaseOrThrow
+
   // Reassign since the function might be used in the handler code
   // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
   // of generated code instead of adding it to the indexer project dependencies.

--- a/codegenerator/cli/npm/envio/src/Address.res
+++ b/codegenerator/cli/npm/envio/src/Address.res
@@ -11,9 +11,7 @@ module Evm = {
   @module("viem")
   external fromStringOrThrow: string => t = "getAddress"
 
-  // NOTE: We could use a regex for this instead, not sure if it is faster/slower than viem's 'isAddress' function
-  //       `/^0x[a-fA-F0-9]{40}$/`
-  // ALSO: the function is named to be overshadowed by the one below, so that we don't have to import viem in the handler code
+  // NOTE: the function is named to be overshadowed by the one below, so that we don't have to import viem in the handler code
   @module("viem")
   external fromStringLowercaseOrThrow: string => bool = "isAddress" 
 
@@ -23,8 +21,6 @@ module Evm = {
   // Also, we want a custom error message, which is searchable in our codebase.
   // Validate that the string is a proper address but return a lowercased value
   let fromStringLowercaseOrThrow = string => {
-    // NOTE: We could use a regex for this and make this function more strict, so it only accepts lower case addresses as input
-    //       eg this regex: `/^0x[a-f0-9]{40}$/`
     if (fromStringLowercaseOrThrow(string)) {
       unsafeFromString(string->Js.String2.toLowerCase)
     } else {

--- a/codegenerator/cli/npm/envio/src/Address.res
+++ b/codegenerator/cli/npm/envio/src/Address.res
@@ -13,7 +13,7 @@ module Evm = {
 
   // NOTE: the function is named to be overshadowed by the one below, so that we don't have to import viem in the handler code
   @module("viem")
-  external fromStringLowercaseOrThrow: string => bool = "isAddress" 
+  external fromStringLowercaseOrThrow: string => bool = "isAddress"
 
   // Reassign since the function might be used in the handler code
   // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
@@ -21,7 +21,7 @@ module Evm = {
   // Also, we want a custom error message, which is searchable in our codebase.
   // Validate that the string is a proper address but return a lowercased value
   let fromStringLowercaseOrThrow = string => {
-    if (fromStringLowercaseOrThrow(string)) {
+    if fromStringLowercaseOrThrow(string) {
       unsafeFromString(string->Js.String2.toLowerCase)
     } else {
       Js.Exn.raiseError(
@@ -31,7 +31,7 @@ module Evm = {
   }
 
   let fromAddressLowercaseOrThrow = address =>
-    address->toString->Js.String2.toLowerCase
+    address->toString->Js.String2.toLowerCase->(Utils.magic: string => t)
 
   // Reassign since the function might be used in the handler code
   // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency

--- a/codegenerator/cli/npm/envio/src/Address.res
+++ b/codegenerator/cli/npm/envio/src/Address.res
@@ -13,14 +13,19 @@ module Evm = {
 
   // NOTE: We could use a regex for this instead, not sure if it is faster/slower than viem's 'isAddress' function
   //       `/^0x[a-fA-F0-9]{40}$/`
-  @module("viem") @private
-  external isAddress: string => bool = "isAddress"
+  // ALSO: the function is named to be overshadowed by the one below, so that we don't have to import viem in the handler code
+  @module("viem")
+  external fromStringLowercaseOrThrow: string => bool = "isAddress" 
 
+  // Reassign since the function might be used in the handler code
+  // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
+  // of generated code instead of adding it to the indexer project dependencies.
+  // Also, we want a custom error message, which is searchable in our codebase.
   // Validate that the string is a proper address but return a lowercased value
   let fromStringLowercaseOrThrow = string => {
     // NOTE: We could use a regex for this and make this function more strict, so it only accepts lower case addresses as input
     //       eg this regex: `/^0x[a-f0-9]{40}$/`
-    if (isAddress(string)) {
+    if (fromStringLowercaseOrThrow(string)) {
       unsafeFromString(string->Js.String2.toLowerCase)
     } else {
       Js.Exn.raiseError(

--- a/codegenerator/cli/npm/envio/src/bindings/Ethers.res
+++ b/codegenerator/cli/npm/envio/src/bindings/Ethers.res
@@ -162,10 +162,23 @@ module JsonRpcProvider = {
     //       There might be a better way to do this in the `makeThrowingGetEventTransaction` function rather based on the schema.
     //       However this is not extremely expensive and good enough for now (only on rpc sync also).
     if lowercaseAddresses {
-      fields["from"] = fields["from"]->Js.Nullable.toOption->Belt.Option.map(Js.String2.toLowerCase)
-      fields["to"] = fields["to"]->Js.Nullable.toOption->Belt.Option.map(Js.String2.toLowerCase)
-      fields["contractAddress"] =
-        fields["contractAddress"]->Js.Nullable.toOption->Belt.Option.map(Js.String2.toLowerCase)
+      open Js.Nullable
+      switch fields["from"] {
+      | Value(from) => fields["from"] = from->Js.String2.toLowerCase
+      | Undefined => ()
+      | Null => ()
+      }
+      switch fields["to"] {
+      | Value(to) => fields["to"] = to->Js.String2.toLowerCase
+      | Undefined => ()
+      | Null => ()
+      }
+      switch fields["contractAddress"] {
+      | Value(contractAddress) =>
+        fields["contractAddress"] = contractAddress->Js.String2.toLowerCase
+      | Undefined => ()
+      | Null => ()
+      }
     }
 
     fields->Obj.magic

--- a/codegenerator/cli/npm/envio/src/sources/HyperSyncClient.res
+++ b/codegenerator/cli/npm/envio/src/sources/HyperSyncClient.res
@@ -448,10 +448,16 @@ type t = {
 }
 
 @module("@envio-dev/hypersync-client") @scope("HypersyncClient") external make: cfg => t = "new"
-let make = (~url, ~apiToken, ~httpReqTimeoutMillis, ~maxNumRetries) =>
+let make = (
+  ~url,
+  ~apiToken,
+  ~httpReqTimeoutMillis,
+  ~maxNumRetries,
+  ~enableChecksumAddresses=true,
+) =>
   make({
     url,
-    enableChecksumAddresses: true,
+    enableChecksumAddresses,
     bearerToken: apiToken,
     httpReqTimeoutMillis,
     maxNumRetries,

--- a/codegenerator/cli/npm/envio/src/sources/HyperSyncSource.res
+++ b/codegenerator/cli/npm/envio/src/sources/HyperSyncSource.res
@@ -181,7 +181,7 @@ let make = (
     ~url=endpointUrl,
     ~apiToken,
     ~maxNumRetries=clientMaxRetries,
-    ~httpReqTimeoutMillis=clientTimeoutMillis, 
+    ~httpReqTimeoutMillis=clientTimeoutMillis,
     ~enableChecksumAddresses=!lowercaseAddresses,
   )
 

--- a/codegenerator/cli/npm/envio/src/sources/HyperSyncSource.res
+++ b/codegenerator/cli/npm/envio/src/sources/HyperSyncSource.res
@@ -177,24 +177,13 @@ let make = (
 
   let apiToken = apiToken->Belt.Option.getWithDefault("3dc856dd-b0ea-494f-b27e-017b8b6b7e07")
 
-  let client =
-    if lowercaseAddresses {
-      HyperSyncClient.make(
-        ~url=endpointUrl,
-        ~apiToken,
-        ~maxNumRetries=clientMaxRetries,
-        ~httpReqTimeoutMillis=clientTimeoutMillis, 
-        ~enableChecksumAddresses=false,
-      )
-    } else {
-      HyperSyncClient.make(
-        ~url=endpointUrl,
-        ~apiToken,
-        ~maxNumRetries=clientMaxRetries,
-        ~httpReqTimeoutMillis=clientTimeoutMillis,
-        ~enableChecksumAddresses=true,
-      )
-    }
+  let client = HyperSyncClient.make(
+    ~url=endpointUrl,
+    ~apiToken,
+    ~maxNumRetries=clientMaxRetries,
+    ~httpReqTimeoutMillis=clientTimeoutMillis, 
+    ~enableChecksumAddresses=!lowercaseAddresses,
+  )
 
   let hscDecoder: ref<option<HyperSyncClient.Decoder.t>> = ref(None)
   let getHscDecoder = () => {

--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -171,6 +171,7 @@ pub mod evm {
                 field_selection: None,
                 raw_events: None,
                 preload_handlers: Some(true),
+                lowercase_addresses: None,
             })
         }
 

--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -171,7 +171,7 @@ pub mod evm {
                 field_selection: None,
                 raw_events: None,
                 preload_handlers: Some(true),
-                lowercase_addresses: None,
+                address_format: None,
             })
         }
 

--- a/codegenerator/cli/src/config_parsing/entity_parsing.rs
+++ b/codegenerator/cli/src/config_parsing/entity_parsing.rs
@@ -190,7 +190,7 @@ impl Schema {
         }
     }
 
-    fn try_get_type_def(&self, name: &String) -> anyhow::Result<TypeDef> {
+    fn try_get_type_def(&self, name: &String) -> anyhow::Result<TypeDef<'_>> {
         match (self.entities.get(name), self.enums.get(name)) {
             (None, None) => Err(anyhow!("No type definition '{}' exists in schema", name)),
             (Some(_), Some(_)) => Err(anyhow!(

--- a/codegenerator/cli/src/config_parsing/entity_parsing.rs
+++ b/codegenerator/cli/src/config_parsing/entity_parsing.rs
@@ -1469,7 +1469,7 @@ mod tests {
     use crate::config_parsing::postgres_types::Primitive as PGPrimitive;
     use graphql_parser::schema::{parse_schema, Definition, Document, ObjectType, TypeDefinition};
 
-    fn setup_document(schema: &str) -> anyhow::Result<Document<String>> {
+    fn setup_document(schema: &str) -> anyhow::Result<Document<'_, String>> {
         parse_schema::<String>(schema)
             .map_err(|e| anyhow!("EE201: Failed to parse schema: {:?}", e))
     }
@@ -1488,7 +1488,7 @@ mod tests {
             .collect()
     }
 
-    fn get_first_entity_from_string(schema_str: &str) -> ObjectType<String> {
+    fn get_first_entity_from_string(schema_str: &str) -> ObjectType<'_, String> {
         let gql_doc = setup_document(schema_str).unwrap();
         let entities = get_entities_from_document(gql_doc);
         entities.first().unwrap().clone()

--- a/codegenerator/cli/src/config_parsing/graph_migration/mod.rs
+++ b/codegenerator/cli/src/config_parsing/graph_migration/mod.rs
@@ -285,7 +285,7 @@ pub async fn generate_config_from_subgraph_id(
         field_selection: None,
         raw_events: None,
         preload_handlers: Some(true),
-        lowercase_addresses: None,
+        address_format: None,
     };
     let mut networks: Vec<Network> = vec![];
 

--- a/codegenerator/cli/src/config_parsing/graph_migration/mod.rs
+++ b/codegenerator/cli/src/config_parsing/graph_migration/mod.rs
@@ -285,6 +285,7 @@ pub async fn generate_config_from_subgraph_id(
         field_selection: None,
         raw_events: None,
         preload_handlers: Some(true),
+        lowercase_addresses: None,
     };
     let mut networks: Vec<Network> = vec![];
 

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -84,8 +84,9 @@ pub struct NetworkContract<T> {
     pub address: Addresses,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(
-        description = "The block at which the indexer should start ingesting data for this specific contract. \
-                       If not specified, uses the network start_block. Can be greater than the network start_block for more specific indexing."
+        description = "The block at which the indexer should start ingesting data for this \
+                       specific contract. If not specified, uses the network start_block. Can be \
+                       greater than the network start_block for more specific indexing."
     )]
     pub start_block: Option<u64>,
     #[serde(flatten)]
@@ -206,13 +207,14 @@ pub mod evm {
         pub raw_events: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
-            description = "Makes handlers run twice to enable preload optimisations. Removes handlerWithLoader API, since it's not needed. (recommended, default: false)"
+            description = "Makes handlers run twice to enable preload optimisations. Removes \
+                           handlerWithLoader API, since it's not needed. (recommended, default: \
+                           false)"
         )]
         pub preload_handlers: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        #[schemars(
-            description = "Address format for Ethereum addresses: 'checksum' or 'lowercase' (default: checksum)"
-        )]
+        #[schemars(description = "Address format for Ethereum addresses: 'checksum' or \
+                                  'lowercase' (default: checksum)")]
         pub address_format: Option<AddressFormat>,
     }
 
@@ -589,7 +591,9 @@ pub mod fuel {
         pub raw_events: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
-            description = "Makes handlers run twice to enable preload optimisations. Removes handlerWithLoader API, since it's not needed. (recommended, default: false)"
+            description = "Makes handlers run twice to enable preload optimisations. Removes \
+                           handlerWithLoader API, since it's not needed. (recommended, default: \
+                           false)"
         )]
         pub preload_handlers: Option<bool>,
     }

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -211,9 +211,16 @@ pub mod evm {
         pub preload_handlers: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
-            description = "If true, Ethereum addresses are kept lowercase (no checksum) across the indexer (default: false)"
+            description = "Address format for Ethereum addresses: 'checksum' or 'lowercase' (default: checksum)"
         )]
-        pub lowercase_addresses: Option<bool>,
+        pub address_format: Option<AddressFormat>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
+    #[serde(rename_all = "lowercase")]
+    pub enum AddressFormat {
+        Checksum,
+        Lowercase,
     }
 
     impl Display for HumanConfig {

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -209,6 +209,11 @@ pub mod evm {
             description = "Makes handlers run twice to enable preload optimisations. Removes handlerWithLoader API, since it's not needed. (recommended, default: false)"
         )]
         pub preload_handlers: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[schemars(
+            description = "If true, Ethereum addresses are kept lowercase (no checksum) across the indexer (default: false)"
+        )]
+        pub lowercase_addresses: Option<bool>,
     }
 
     impl Display for HumanConfig {

--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -723,7 +723,17 @@ impl SystemConfig {
                     enable_raw_events: evm_config.raw_events.unwrap_or(false),
                     preload_handlers: evm_config.preload_handlers.unwrap_or(false),
                     lowercase_addresses: match evm_config.address_format {
-                        Some(super::human_config::evm::AddressFormat::Lowercase) => true,
+                        Some(super::human_config::evm::AddressFormat::Lowercase) => {
+                            // Validate that USE_HYPERSYNC_CLIENT_DECODER is not set to false when address_format is lowercase
+                            if let Ok(use_hypersync_decoder) =
+                                std::env::var("USE_HYPERSYNC_CLIENT_DECODER")
+                            {
+                                if use_hypersync_decoder.to_lowercase() == "false" {
+                                    panic!("Error: address_format 'lowercase' is not supported when USE_HYPERSYNC_CLIENT_DECODER is set to false. Please either set USE_HYPERSYNC_CLIENT_DECODER to true or change address_format to 'checksum'.");
+                                }
+                            }
+                            true
+                        }
                         _ => false,
                     },
                     human_config,

--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -2091,7 +2091,7 @@ mod test {
             field_selection: None,
             raw_events: None,
             preload_handlers: None,
-            lowercase_addresses: None,
+            address_format: None,
         };
 
         let project_paths = ParsedProjectPaths::new(".", "generated", "config.yaml").unwrap();
@@ -2138,7 +2138,7 @@ mod test {
             field_selection: None,
             raw_events: None,
             preload_handlers: None,
-            lowercase_addresses: None,
+            address_format: None,
         };
 
         let system_config_with_output = SystemConfig::from_human_config(

--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -722,7 +722,10 @@ impl SystemConfig {
                     field_selection,
                     enable_raw_events: evm_config.raw_events.unwrap_or(false),
                     preload_handlers: evm_config.preload_handlers.unwrap_or(false),
-                    lowercase_addresses: evm_config.lowercase_addresses.unwrap_or(false),
+                    lowercase_addresses: match evm_config.address_format {
+                        Some(super::human_config::evm::AddressFormat::Lowercase) => true,
+                        _ => false,
+                    },
                     human_config,
                 })
             }

--- a/codegenerator/cli/src/config_parsing/system_config.rs
+++ b/codegenerator/cli/src/config_parsing/system_config.rs
@@ -414,6 +414,7 @@ pub struct SystemConfig {
     pub enable_raw_events: bool,
     pub preload_handlers: bool,
     pub human_config: HumanConfig,
+    pub lowercase_addresses: bool,
 }
 
 //Getter methods for system config
@@ -721,6 +722,7 @@ impl SystemConfig {
                     field_selection,
                     enable_raw_events: evm_config.raw_events.unwrap_or(false),
                     preload_handlers: evm_config.preload_handlers.unwrap_or(false),
+                    lowercase_addresses: evm_config.lowercase_addresses.unwrap_or(false),
                     human_config,
                 })
             }
@@ -858,6 +860,7 @@ impl SystemConfig {
                     field_selection: FieldSelection::fuel(),
                     enable_raw_events: fuel_config.raw_events.unwrap_or(false),
                     preload_handlers: fuel_config.preload_handlers.unwrap_or(false),
+                    lowercase_addresses: false,
                     human_config,
                 })
             }
@@ -2085,6 +2088,7 @@ mod test {
             field_selection: None,
             raw_events: None,
             preload_handlers: None,
+            lowercase_addresses: None,
         };
 
         let project_paths = ParsedProjectPaths::new(".", "generated", "config.yaml").unwrap();
@@ -2131,6 +2135,7 @@ mod test {
             field_selection: None,
             raw_events: None,
             preload_handlers: None,
+            lowercase_addresses: None,
         };
 
         let system_config_with_output = SystemConfig::from_human_config(

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -1123,7 +1123,8 @@ impl NetworkConfigTemplate {
                     format!(
                         "NetworkSources.evm(~chain, ~contracts=[{contracts_code}], ~hyperSync={hyper_sync_code}, \
                          ~allEventSignatures=[{all_event_signatures}]->Belt.Array.concatMany, \
-                         ~shouldUseHypersyncClientDecoder={is_client_decoder}, ~rpcs=[{rpcs}])"
+                         ~shouldUseHypersyncClientDecoder={is_client_decoder}, ~rpcs=[{rpcs}], ~lowercaseAddresses={})",
+                        if config.lowercase_addresses { "true" } else { "false" }
                     ),
                     deprecated_sync_source_code,
                 )
@@ -1279,6 +1280,7 @@ pub struct ProjectTemplate {
     types_code: String,
     //Used for the package.json reference to handlers in generated
     relative_path_to_root_from_generated: String,
+    lowercase_addresses: bool,
 }
 
 impl ProjectTemplate {
@@ -1399,6 +1401,7 @@ type chain = [{chain_id_type}]"#,
             types_code,
             //Used for the package.json reference to handlers in generated
             relative_path_to_root_from_generated,
+            lowercase_addresses: cfg.lowercase_addresses,
         })
     }
 }

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -1144,12 +1144,6 @@ impl NetworkConfigTemplate {
             is_fuel: matches!(network.sync_source, system_config::DataSource::Fuel { .. }),
             sources_code,
             deprecated_sync_source_code,
-            // event_decoder: config.event_decoder.as_ref().map(|decoder| match decoder {
-            //     crate::config_parsing::human_config::evm::EventDecoder::Viem => "viem".to_string(),
-            //     crate::config_parsing::human_config::evm::EventDecoder::HypersyncClient => {
-            //         "hypersync-client".to_string()
-            //     }
-            // }),
         })
     }
 }

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -44,12 +44,6 @@ pub struct EventParamTypeTemplate {
 }
 
 #[derive(Serialize, Debug, PartialEq, Clone)]
-pub struct EventRecordTypeTemplate {
-    pub name: CapitalizedOptions,
-    pub params: Vec<EventParamTypeTemplate>,
-}
-
-#[derive(Serialize, Debug, PartialEq, Clone)]
 pub struct GraphQlEnumTypeTemplate {
     pub name: CapitalizedOptions,
     pub params: Vec<CapitalizedOptions>,

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -362,9 +362,14 @@ impl EventMod {
 
         let event_filters_type_code = match self.event_filter_type.as_str() {
             "{}" => "@genType type eventFilters = Internal.noEventFilters".to_string(),
-            _ => "@genType type eventFiltersArgs = {/** The unique identifier of the blockchain network where this event occurred. */ chainId: chainId, /** Addresses of the contracts indexing the event. */ addresses: array<Address.t>}\n
-@genType @unboxed type eventFiltersDefinition = Single(eventFilter) | Multiple(array<eventFilter>)\n
-@genType @unboxed type eventFilters = | ...eventFiltersDefinition | Dynamic(eventFiltersArgs => eventFiltersDefinition)".to_string(),
+            _ => "@genType type eventFiltersArgs = {/** The unique identifier of the blockchain \
+                  network where this event occurred. */ chainId: chainId, /** Addresses of the \
+                  contracts indexing the event. */ addresses: array<Address.t>}\n
+@genType @unboxed type eventFiltersDefinition = Single(eventFilter) | \
+                  Multiple(array<eventFilter>)\n
+@genType @unboxed type eventFilters = | ...eventFiltersDefinition | Dynamic(eventFiltersArgs => \
+                  eventFiltersDefinition)"
+                .to_string(),
         };
 
         let fuel_event_kind_code = match self.fuel_event_kind {
@@ -580,16 +585,18 @@ impl EventTemplate {
                     params_code = format!("{params_code}\"{param_name}\",");
                     let _ = write!(
                         output,
-                        ", ~topic{topic_number}=({event_filter_arg}) => {event_filter_arg}->Utils.Dict.dangerouslyGetNonOption(\"{param_name}\")->Belt.Option.\
-                         mapWithDefault([], topicFilters => \
-                         topicFilters->Obj.magic->SingleOrMultiple.normalizeOrThrow{nested_type_flags}->Belt.\
-                         Array.map({topic_encoder}))"
+                        ", ~topic{topic_number}=({event_filter_arg}) => \
+                         {event_filter_arg}->Utils.Dict.dangerouslyGetNonOption(\"{param_name}\"\
+                         )->Belt.Option.mapWithDefault([], topicFilters => \
+                         topicFilters->Obj.magic->SingleOrMultiple.\
+                         normalizeOrThrow{nested_type_flags}->Belt.Array.map({topic_encoder}))"
                     );
                     output
                 });
 
         format!(
-            "LogSelection.parseEventFiltersOrThrow(~eventFilters=handlerRegister->EventRegister.getEventFilters, ~sighash, ~params=[{params_code}]{topic_filter_calls})"
+            "LogSelection.parseEventFiltersOrThrow(~eventFilters=handlerRegister->EventRegister.\
+             getEventFilters, ~sighash, ~params=[{params_code}]{topic_filter_calls})"
         )
     }
 
@@ -611,8 +618,7 @@ impl EventTemplate {
 
         for (index, param) in indexed_params.into_iter().enumerate() {
             code.push_str(&format!(
-                "{}: \
-                 decodedEvent.indexed->Js.Array2.unsafe_get({})->HyperSyncClient.Decoder.\
+                "{}: decodedEvent.indexed->Js.Array2.unsafe_get({})->HyperSyncClient.Decoder.\
                  toUnderlying->Utils.magic, ",
                 RescriptRecordField::to_valid_res_name(&param.name),
                 index
@@ -621,8 +627,7 @@ impl EventTemplate {
 
         for (index, param) in body_params.into_iter().enumerate() {
             code.push_str(&format!(
-                "{}: \
-                 decodedEvent.body->Js.Array2.unsafe_get({})->HyperSyncClient.Decoder.\
+                "{}: decodedEvent.body->Js.Array2.unsafe_get({})->HyperSyncClient.Decoder.\
                  toUnderlying->Utils.magic, ",
                 RescriptRecordField::to_valid_res_name(&param.name),
                 index
@@ -862,7 +867,8 @@ let eventSignatures = [{}]
                     ))?;
 
                 format!(
-                    "let abi = Fuel.transpileAbi(%raw(`require`)(`../${{Path.relativePathToRootFromGenerated}}/{}`))\n{}\n{}\n{chain_id_type_code}",
+                    "let abi = Fuel.transpileAbi(%raw(`require`)(`../${{Path.\
+                     relativePathToRootFromGenerated}}/{}`))\n{}\n{}\n{chain_id_type_code}",
                     // If we decide to inline the abi, instead of using require
                     // we need to remember that abi might contain ` and we should escape it
                     abi.path_buf.to_string_lossy(),
@@ -955,6 +961,7 @@ pub struct NetworkConfigTemplate {
     sources_code: String,
     // This is only used to prevent ConfigYAML free from breaking changes
     deprecated_sync_source_code: String,
+    // event_decoder: Option<String>,
 }
 
 impl NetworkConfigTemplate {
@@ -1008,13 +1015,13 @@ impl NetworkConfigTemplate {
             } => (
                 format!(
                     "[HyperFuelSource.make({{chain: chain, endpointUrl: \
-                         \"{hypersync_endpoint_url}\"}})]",
+                     \"{hypersync_endpoint_url}\"}})]",
                 ),
                 format!("HyperFuel({{endpointUrl: \"{hypersync_endpoint_url}\"}})"),
             ),
             system_config::DataSource::Evm {
                 main,
-                is_client_decoder,
+                is_client_decoder: _,
                 rpcs,
             } => {
                 let all_event_signatures = codegen_contracts
@@ -1115,10 +1122,16 @@ impl NetworkConfigTemplate {
 
                 (
                     format!(
-                        "NetworkSources.evm(~chain, ~contracts=[{contracts_code}], ~hyperSync={hyper_sync_code}, \
+                        "NetworkSources.evm(~chain, ~contracts=[{contracts_code}], \
+                         ~hyperSync={hyper_sync_code}, \
                          ~allEventSignatures=[{all_event_signatures}]->Belt.Array.concatMany, \
-                         ~shouldUseHypersyncClientDecoder={is_client_decoder}, ~rpcs=[{rpcs}], ~lowercaseAddresses={})",
-                        if config.lowercase_addresses { "true" } else { "false" }
+                         ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{rpcs}], \
+                         ~lowercaseAddresses={})",
+                        if config.lowercase_addresses {
+                            "true"
+                        } else {
+                            "false"
+                        }
                     ),
                     deprecated_sync_source_code,
                 )
@@ -1131,6 +1144,12 @@ impl NetworkConfigTemplate {
             is_fuel: matches!(network.sync_source, system_config::DataSource::Fuel { .. }),
             sources_code,
             deprecated_sync_source_code,
+            // event_decoder: config.event_decoder.as_ref().map(|decoder| match decoder {
+            //     crate::config_parsing::human_config::evm::EventDecoder::Viem => "viem".to_string(),
+            //     crate::config_parsing::human_config::evm::EventDecoder::HypersyncClient => {
+            //         "hypersync-client".to_string()
+            //     }
+            // }),
         })
     }
 }
@@ -1275,6 +1294,7 @@ pub struct ProjectTemplate {
     //Used for the package.json reference to handlers in generated
     relative_path_to_root_from_generated: String,
     lowercase_addresses: bool,
+    should_use_hypersync_client_decoder: bool,
 }
 
 impl ProjectTemplate {
@@ -1396,6 +1416,7 @@ type chain = [{chain_id_type}]"#,
             //Used for the package.json reference to handlers in generated
             relative_path_to_root_from_generated,
             lowercase_addresses: cfg.lowercase_addresses,
+            should_use_hypersync_client_decoder: cfg.should_use_hypersync_client_decoder,
         })
     }
 }
@@ -1478,6 +1499,7 @@ mod test {
             deprecated_sync_source_code: format!(
                 "HyperFuel({{endpointUrl: \"https://fuel-testnet.hypersync.xyz\"}})"
             ),
+            event_decoder: None,
         };
 
         let expected_chain_configs = vec![chain_config_1];
@@ -1519,6 +1541,7 @@ mod test {
             is_fuel: false,
             sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "Rpc({syncConfig: Config.getSyncConfig({accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,})})".to_string(),
+            event_decoder: None,
         };
 
         let expected_chain_configs = vec![chain_config_1];
@@ -1574,6 +1597,7 @@ mod test {
             is_fuel: false,
             sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "Rpc({syncConfig: Config.getSyncConfig({accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,})})".to_string(),
+            event_decoder: None,
         };
         let chain_config_2 = super::NetworkConfigTemplate {
             network_config: network2,
@@ -1581,6 +1605,7 @@ mod test {
             is_fuel: false,
             sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract2\",events: [Types.Contract2.NewGravatar.register(), Types.Contract2.UpdatedGravatar.register()],abi: Types.Contract2.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract2.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}, {url: \"https://eth.com/fallback\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "Rpc({syncConfig: Config.getSyncConfig({accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,})})".to_string(),
+            event_decoder: None,
         };
 
         let expected_chain_configs = vec![chain_config_1, chain_config_2];
@@ -1614,6 +1639,7 @@ mod test {
             is_fuel: false,
             sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=Some(\"https://1.hypersync.xyz\"), ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://fallback.eth.com\", sourceFor: Fallback, syncConfig: {}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "HyperSync({endpointUrl: \"https://1.hypersync.xyz\"})".to_string(),
+            event_decoder: None,
         };
 
         let expected_chain_configs = vec![chain_config_1];
@@ -1647,6 +1673,7 @@ mod test {
             deprecated_sync_source_code: format!(
                 "HyperSync({{endpointUrl: \"https://myskar.com\"}})"
             ),
+            event_decoder: None,
         };
 
         let chain_config_2 = super::NetworkConfigTemplate {
@@ -1655,6 +1682,7 @@ mod test {
             is_fuel: false,
             sources_code: format!("NetworkSources.evm(~chain, ~contracts=[], ~hyperSync=Some(\"https://137.hypersync.xyz\"), ~allEventSignatures=[]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[], ~lowercaseAddresses=false)"),
             deprecated_sync_source_code: format!("HyperSync({{endpointUrl: \"https://137.hypersync.xyz\"}})"),
+            event_decoder: None,
         };
 
         let expected_chain_configs = vec![chain_config_1, chain_config_2];

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -1499,7 +1499,6 @@ mod test {
             deprecated_sync_source_code: format!(
                 "HyperFuel({{endpointUrl: \"https://fuel-testnet.hypersync.xyz\"}})"
             ),
-            event_decoder: None,
         };
 
         let expected_chain_configs = vec![chain_config_1];
@@ -1541,7 +1540,6 @@ mod test {
             is_fuel: false,
             sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "Rpc({syncConfig: Config.getSyncConfig({accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,})})".to_string(),
-            event_decoder: None,
         };
 
         let expected_chain_configs = vec![chain_config_1];
@@ -1597,7 +1595,6 @@ mod test {
             is_fuel: false,
             sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "Rpc({syncConfig: Config.getSyncConfig({accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,})})".to_string(),
-            event_decoder: None,
         };
         let chain_config_2 = super::NetworkConfigTemplate {
             network_config: network2,
@@ -1605,7 +1602,6 @@ mod test {
             is_fuel: false,
             sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract2\",events: [Types.Contract2.NewGravatar.register(), Types.Contract2.UpdatedGravatar.register()],abi: Types.Contract2.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract2.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}, {url: \"https://eth.com/fallback\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "Rpc({syncConfig: Config.getSyncConfig({accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,})})".to_string(),
-            event_decoder: None,
         };
 
         let expected_chain_configs = vec![chain_config_1, chain_config_2];
@@ -1639,7 +1635,6 @@ mod test {
             is_fuel: false,
             sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=Some(\"https://1.hypersync.xyz\"), ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://fallback.eth.com\", sourceFor: Fallback, syncConfig: {}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "HyperSync({endpointUrl: \"https://1.hypersync.xyz\"})".to_string(),
-            event_decoder: None,
         };
 
         let expected_chain_configs = vec![chain_config_1];
@@ -1673,7 +1668,6 @@ mod test {
             deprecated_sync_source_code: format!(
                 "HyperSync({{endpointUrl: \"https://myskar.com\"}})"
             ),
-            event_decoder: None,
         };
 
         let chain_config_2 = super::NetworkConfigTemplate {
@@ -1682,7 +1676,6 @@ mod test {
             is_fuel: false,
             sources_code: format!("NetworkSources.evm(~chain, ~contracts=[], ~hyperSync=Some(\"https://137.hypersync.xyz\"), ~allEventSignatures=[]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[], ~lowercaseAddresses=false)"),
             deprecated_sync_source_code: format!("HyperSync({{endpointUrl: \"https://137.hypersync.xyz\"}})"),
-            event_decoder: None,
         };
 
         let expected_chain_configs = vec![chain_config_1, chain_config_2];

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -1523,7 +1523,7 @@ mod test {
             network_config: network1,
             codegen_contracts: vec![contract1],
             is_fuel: false,
-            sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}])".to_string(),
+            sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "Rpc({syncConfig: Config.getSyncConfig({accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,})})".to_string(),
         };
 
@@ -1578,14 +1578,14 @@ mod test {
             network_config: network1,
             codegen_contracts: vec![contract1],
             is_fuel: false,
-            sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}])".to_string(),
+            sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "Rpc({syncConfig: Config.getSyncConfig({accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,})})".to_string(),
         };
         let chain_config_2 = super::NetworkConfigTemplate {
             network_config: network2,
             codegen_contracts: vec![contract2],
             is_fuel: false,
-            sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract2\",events: [Types.Contract2.NewGravatar.register(), Types.Contract2.UpdatedGravatar.register()],abi: Types.Contract2.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract2.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}, {url: \"https://eth.com/fallback\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}])".to_string(),
+            sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract2\",events: [Types.Contract2.NewGravatar.register(), Types.Contract2.UpdatedGravatar.register()],abi: Types.Contract2.abi}], ~hyperSync=None, ~allEventSignatures=[Types.Contract2.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://eth.com\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}, {url: \"https://eth.com/fallback\", sourceFor: Sync, syncConfig: {accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "Rpc({syncConfig: Config.getSyncConfig({accelerationAdditive: 2000,initialBlockInterval: 10000,backoffMultiplicative: 0.8,intervalCeiling: 10000,backoffMillis: 5000,queryTimeoutMillis: 20000,})})".to_string(),
         };
 
@@ -1618,7 +1618,7 @@ mod test {
             network_config: network1,
             codegen_contracts: vec![contract1],
             is_fuel: false,
-            sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=Some(\"https://1.hypersync.xyz\"), ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://fallback.eth.com\", sourceFor: Fallback, syncConfig: {}}])".to_string(),
+            sources_code: "NetworkSources.evm(~chain, ~contracts=[{name: \"Contract1\",events: [Types.Contract1.NewGravatar.register(), Types.Contract1.UpdatedGravatar.register()],abi: Types.Contract1.abi}], ~hyperSync=Some(\"https://1.hypersync.xyz\"), ~allEventSignatures=[Types.Contract1.eventSignatures]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[{url: \"https://fallback.eth.com\", sourceFor: Fallback, syncConfig: {}}], ~lowercaseAddresses=false)".to_string(),
             deprecated_sync_source_code: "HyperSync({endpointUrl: \"https://1.hypersync.xyz\"})".to_string(),
         };
 
@@ -1648,7 +1648,7 @@ mod test {
             sources_code: format!(
                 "NetworkSources.evm(~chain, ~contracts=[], ~hyperSync=Some(\"https://myskar.com\"), \
                  ~allEventSignatures=[]->Belt.Array.concatMany, \
-                 ~shouldUseHypersyncClientDecoder=true, ~rpcs=[])"
+                 ~shouldUseHypersyncClientDecoder=true, ~rpcs=[], ~lowercaseAddresses=false)"
             ),
             deprecated_sync_source_code: format!(
                 "HyperSync({{endpointUrl: \"https://myskar.com\"}})"
@@ -1659,7 +1659,7 @@ mod test {
             network_config: network2,
             codegen_contracts: vec![],
             is_fuel: false,
-            sources_code: format!("NetworkSources.evm(~chain, ~contracts=[], ~hyperSync=Some(\"https://137.hypersync.xyz\"), ~allEventSignatures=[]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[])"),
+            sources_code: format!("NetworkSources.evm(~chain, ~contracts=[], ~hyperSync=Some(\"https://137.hypersync.xyz\"), ~allEventSignatures=[]->Belt.Array.concatMany, ~shouldUseHypersyncClientDecoder=true, ~rpcs=[], ~lowercaseAddresses=false)"),
             deprecated_sync_source_code: format!("HyperSync({{endpointUrl: \"https://137.hypersync.xyz\"}})"),
         };
 

--- a/codegenerator/cli/templates/dynamic/codegen/src/ConfigYAML.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/ConfigYAML.res.hbs
@@ -27,6 +27,7 @@ type configYaml = {
   startBlock: int,
   confirmedBlockThreshold: int,
   contracts: dict<contract>,
+  lowercaseAddresses: bool,
 }
 
 let publicConfig = ChainMap.fromArrayUnsafe([
@@ -60,7 +61,8 @@ let publicConfig = ChainMap.fromArrayUnsafe([
         confirmedBlockThreshold: {{chain_config.network_config.confirmed_block_threshold}},
         syncSource: {{chain_config.deprecated_sync_source_code}},
         startBlock: {{chain_config.network_config.start_block}},
-        contracts
+        contracts,
+        lowercaseAddresses: {{#if ../lowercase_addresses}}true{{else}}false{{/if}}
       }
     )
   },

--- a/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
@@ -35,7 +35,11 @@ let registerContractHandlers = (
             addresses: [
               {{#each contract.addresses as | address |}}
               {{#if ../../../is_evm_ecosystem}}
+              {{#if ../../../../lowercase_addresses}}
+              "{{address}}"->Address.Evm.fromStringLowercaseOrThrow
+              {{else}}
               "{{address}}"->Address.Evm.fromStringOrThrow
+              {{/if}}
               {{else}}
               "{{address}}"->Address.unsafeFromString
               {{/if}},
@@ -73,6 +77,7 @@ let registerContractHandlers = (
       ~enableRawEvents={{enable_raw_events}},
       ~batchSize=?Env.batchSize,
       ~preloadHandlers={{preload_handlers}},
+      ~lowercaseAddresses={{lowercase_addresses}},
       {{#if chain_config.is_fuel}}
       ~ecosystem=Fuel,
       {{/if}}

--- a/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
@@ -78,6 +78,7 @@ let registerContractHandlers = (
       ~batchSize=?Env.batchSize,
       ~preloadHandlers={{preload_handlers}},
       ~lowercaseAddresses={{lowercase_addresses}},
+      ~shouldUseHypersyncClientDecoder={{should_use_hypersync_client_decoder}},
       {{#if chain_config.is_fuel}}
       ~ecosystem=Fuel,
       {{/if}}

--- a/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
@@ -35,7 +35,7 @@ let registerContractHandlers = (
             addresses: [
               {{#each contract.addresses as | address |}}
               {{#if ../../../is_evm_ecosystem}}
-              {{#if ../../../../lowercase_addresses}}
+              {{#if ../../../lowercase_addresses}}
               "{{address}}"->Address.Evm.fromStringLowercaseOrThrow
               {{else}}
               "{{address}}"->Address.Evm.fromStringOrThrow

--- a/codegenerator/cli/templates/static/codegen/src/Config.res
+++ b/codegenerator/cli/templates/static/codegen/src/Config.res
@@ -115,6 +115,7 @@ type t = {
   maxAddrInPartition: int,
   registrations: option<EventRegister.registrations>,
   batchSize: int,
+  lowercaseAddresses: bool,
 }
 
 let make = (
@@ -128,6 +129,8 @@ let make = (
   ~ecosystem=InternalConfig.Evm,
   ~registrations=?,
   ~batchSize=5000,
+  ~ecosystem=Evm,
+  ~lowercaseAddresses=false,
 ) => {
   let chainMap =
     chains
@@ -171,6 +174,7 @@ let make = (
     registrations,
     preloadHandlers,
     batchSize,
+    lowercaseAddresses,
   }
 }
 

--- a/codegenerator/cli/templates/static/codegen/src/Config.res
+++ b/codegenerator/cli/templates/static/codegen/src/Config.res
@@ -132,6 +132,16 @@ let make = (
   ~ecosystem=Evm,
   ~lowercaseAddresses=false,
 ) => {
+  // NOTE: the `envio` cli also does this check on `envio dev` and `envio start`, here for redundancy.
+  if (
+    lowercaseAddresses &&
+    !(Env.Configurable.shouldUseHypersyncClientDecoder->Option.getWithDefault(true))
+  ) {
+    Js.Exn.raiseError(
+      "lowercase addresses is not supported when USE_HYPERSYNC_CLIENT_DECODER is false. Please set USE_HYPERSYNC_CLIENT_DECODER to true or change address_format to 'checksum'.",
+    )
+  }
+
   let chainMap =
     chains
     ->Js.Array2.map(n => {

--- a/codegenerator/cli/templates/static/codegen/src/Config.res
+++ b/codegenerator/cli/templates/static/codegen/src/Config.res
@@ -131,16 +131,19 @@ let make = (
   ~batchSize=5000,
   ~ecosystem=Evm,
   ~lowercaseAddresses=false,
+  ~shouldUseHypersyncClientDecoder=true,
 ) => {
-  // NOTE: the `envio` cli also does this check on `envio dev` and `envio start`, here for redundancy.
-  if (
-    lowercaseAddresses &&
-    !(Env.Configurable.shouldUseHypersyncClientDecoder->Option.getWithDefault(true))
-  ) {
-    Js.Exn.raiseError(
-      "lowercase addresses is not supported when USE_HYPERSYNC_CLIENT_DECODER is false. Please set USE_HYPERSYNC_CLIENT_DECODER to true or change address_format to 'checksum'.",
-    )
-  }
+  // Validate that lowercase addresses is not used with viem decoder
+  chains->Array.forEach(chain => {
+    if (
+      lowercaseAddresses &&
+      !shouldUseHypersyncClientDecoder
+    ) {
+      Js.Exn.raiseError(
+        "lowercase addresses is not supported when event_decoder is 'viem'. Please set event_decoder to 'hypersync-client' or change address_format to 'checksum'.",
+      )
+    }
+  })
 
   let chainMap =
     chains

--- a/codegenerator/cli/templates/static/codegen/src/Config.res
+++ b/codegenerator/cli/templates/static/codegen/src/Config.res
@@ -129,21 +129,18 @@ let make = (
   ~ecosystem=InternalConfig.Evm,
   ~registrations=?,
   ~batchSize=5000,
-  ~ecosystem=Evm,
   ~lowercaseAddresses=false,
   ~shouldUseHypersyncClientDecoder=true,
 ) => {
   // Validate that lowercase addresses is not used with viem decoder
-  chains->Array.forEach(chain => {
-    if (
-      lowercaseAddresses &&
-      !shouldUseHypersyncClientDecoder
-    ) {
-      Js.Exn.raiseError(
-        "lowercase addresses is not supported when event_decoder is 'viem'. Please set event_decoder to 'hypersync-client' or change address_format to 'checksum'.",
-      )
-    }
-  })
+  if (
+    lowercaseAddresses &&
+    !shouldUseHypersyncClientDecoder
+  ) {
+    Js.Exn.raiseError(
+      "lowercase addresses is not supported when event_decoder is 'viem'. Please set event_decoder to 'hypersync-client' or change address_format to 'checksum'.",
+    )
+  }
 
   let chainMap =
     chains

--- a/codegenerator/cli/templates/static/codegen/src/Env.res
+++ b/codegenerator/cli/templates/static/codegen/src/Env.res
@@ -185,8 +185,6 @@ module Hasura = {
 }
 
 module Configurable = {
-  let shouldUseHypersyncClientDecoder =
-    envSafe->EnvSafe.get("USE_HYPERSYNC_CLIENT_DECODER", S.option(S.bool))
 
   /**
     Used for backwards compatability

--- a/codegenerator/cli/templates/static/codegen/src/UserContext.res
+++ b/codegenerator/cli/templates/static/codegen/src/UserContext.res
@@ -287,8 +287,12 @@ let contractRegisterTraps: Utils.Proxy.traps<contractRegisterParams> = {
           let addFunction = (contractAddress: Address.t) => {
             let validatedAddress = if params.config.ecosystem === Evm {
               // The value is passed from the user-land,
-              // so we need to validate and checksum the address.
-              contractAddress->Address.Evm.fromAddressOrThrow
+              // so we need to validate and checksum/lowercase the address.
+              if params.config.lowercaseAddresses {
+                contractAddress->Address.Evm.fromAddressLowercaseOrThrow
+              } else {
+                contractAddress->Address.Evm.fromAddressOrThrow
+              }
             } else {
               // TODO: Ideally we should do the same for other ecosystems
               contractAddress

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/NetworkSources.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/NetworkSources.res
@@ -13,6 +13,7 @@ let evm = (
   ~allEventSignatures,
   ~shouldUseHypersyncClientDecoder,
   ~rpcs: array<rpc>,
+  ~lowercaseAddresses,
 ) => {
   let eventRouter =
     contracts
@@ -33,6 +34,7 @@ let evm = (
         apiToken: Env.envioApiToken,
         clientMaxRetries: Env.hyperSyncClientMaxRetries,
         clientTimeoutMillis: Env.hyperSyncClientTimeoutMillis,
+        lowercaseAddresses,
       }),
     ]
   | _ => []

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/NetworkSources.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/NetworkSources.res
@@ -52,6 +52,7 @@ let evm = (
         shouldUseHypersyncClientDecoder: Env.Configurable.shouldUseHypersyncClientDecoder->Option.getWithDefault(
           shouldUseHypersyncClientDecoder,
         ),
+        lowercaseAddresses,
       }),
     )
   })

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/NetworkSources.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/NetworkSources.res
@@ -28,9 +28,7 @@ let evm = (
         endpointUrl,
         allEventSignatures,
         eventRouter,
-        shouldUseHypersyncClientDecoder: Env.Configurable.shouldUseHypersyncClientDecoder->Option.getWithDefault(
-          shouldUseHypersyncClientDecoder,
-        ),
+        shouldUseHypersyncClientDecoder,
         apiToken: Env.envioApiToken,
         clientMaxRetries: Env.hyperSyncClientMaxRetries,
         clientTimeoutMillis: Env.hyperSyncClientTimeoutMillis,
@@ -49,9 +47,7 @@ let evm = (
         url,
         eventRouter,
         allEventSignatures,
-        shouldUseHypersyncClientDecoder: Env.Configurable.shouldUseHypersyncClientDecoder->Option.getWithDefault(
-          shouldUseHypersyncClientDecoder,
-        ),
+        shouldUseHypersyncClientDecoder,
         lowercaseAddresses,
       }),
     )

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/NetworkSources.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/NetworkSources.res
@@ -48,6 +48,10 @@ let evm = (
         syncConfig: Config.getSyncConfig(syncConfig->Option.getWithDefault({})),
         url,
         eventRouter,
+        allEventSignatures,
+        shouldUseHypersyncClientDecoder: Env.Configurable.shouldUseHypersyncClientDecoder->Option.getWithDefault(
+          shouldUseHypersyncClientDecoder,
+        ),
       }),
     )
   })

--- a/codegenerator/cli/templates/static/erc20_template/javascript/config.yaml
+++ b/codegenerator/cli/templates/static/erc20_template/javascript/config.yaml
@@ -19,3 +19,6 @@ unordered_multichain_mode: true
 # But be aware that your handlers will run twice,
 # so make sure to use Effect API for external calls.
 preload_handlers: true
+# Address format for Ethereum addresses: 'checksum' or 'lowercase'
+# using lowercase addresses is slightly faster
+address_format: lowercase

--- a/codegenerator/cli/templates/static/erc20_template/rescript/config.yaml
+++ b/codegenerator/cli/templates/static/erc20_template/rescript/config.yaml
@@ -19,3 +19,6 @@ unordered_multichain_mode: true
 # But be aware that your handlers will run twice,
 # so make sure to use Effect API for external calls.
 preload_handlers: true
+# Address format for Ethereum addresses: 'checksum' or 'lowercase'
+# using lowercase addresses is slightly faster
+address_format: lowercase

--- a/codegenerator/cli/templates/static/erc20_template/typescript/config.yaml
+++ b/codegenerator/cli/templates/static/erc20_template/typescript/config.yaml
@@ -19,3 +19,6 @@ unordered_multichain_mode: true
 # But be aware that your handlers will run twice,
 # so make sure to use Effect API for external calls.
 preload_handlers: true
+# Address format for Ethereum addresses: 'checksum' or 'lowercase'
+# using lowercase addresses is slightly faster
+address_format: lowercase

--- a/codegenerator/cli/templates/static/greeter_template/javascript/config.yaml
+++ b/codegenerator/cli/templates/static/greeter_template/javascript/config.yaml
@@ -30,3 +30,6 @@ unordered_multichain_mode: true
 # But be aware that your handlers will run twice,
 # so make sure to use Effect API for external calls.
 preload_handlers: true
+# Address format for Ethereum addresses: 'checksum' or 'lowercase'
+# using lowercase addresses is slightly faster
+address_format: lowercase

--- a/codegenerator/cli/templates/static/greeter_template/rescript/config.yaml
+++ b/codegenerator/cli/templates/static/greeter_template/rescript/config.yaml
@@ -30,3 +30,6 @@ unordered_multichain_mode: true
 # But be aware that your handlers will run twice,
 # so make sure to use Effect API for external calls.
 preload_handlers: true
+# Address format for Ethereum addresses: 'checksum' or 'lowercase'
+# using lowercase addresses is slightly faster
+address_format: lowercase

--- a/codegenerator/cli/templates/static/greeter_template/typescript/config.yaml
+++ b/codegenerator/cli/templates/static/greeter_template/typescript/config.yaml
@@ -30,3 +30,6 @@ unordered_multichain_mode: true
 # But be aware that your handlers will run twice,
 # so make sure to use Effect API for external calls.
 preload_handlers: true
+# Address format for Ethereum addresses: 'checksum' or 'lowercase'
+# using lowercase addresses is slightly faster
+address_format: lowercase

--- a/codegenerator/cli/templates/static/greeteronfuel_template/javascript/config.yaml
+++ b/codegenerator/cli/templates/static/greeteronfuel_template/javascript/config.yaml
@@ -16,3 +16,6 @@ networks:
 # But be aware that your handlers will run twice,
 # so make sure to use Effect API for external calls.
 preload_handlers: true
+# Address format for Ethereum addresses: 'checksum' or 'lowercase'
+# using lowercase addresses is slightly faster
+address_format: lowercase

--- a/codegenerator/cli/templates/static/greeteronfuel_template/rescript/config.yaml
+++ b/codegenerator/cli/templates/static/greeteronfuel_template/rescript/config.yaml
@@ -16,3 +16,6 @@ networks:
 # But be aware that your handlers will run twice,
 # so make sure to use Effect API for external calls.
 preload_handlers: true
+# Address format for Ethereum addresses: 'checksum' or 'lowercase'
+# using lowercase addresses is slightly faster
+address_format: lowercase

--- a/codegenerator/cli/templates/static/greeteronfuel_template/typescript/config.yaml
+++ b/codegenerator/cli/templates/static/greeteronfuel_template/typescript/config.yaml
@@ -16,3 +16,6 @@ networks:
 # But be aware that your handlers will run twice,
 # so make sure to use Effect API for external calls.
 preload_handlers: true
+# Address format for Ethereum addresses: 'checksum' or 'lowercase'
+# using lowercase addresses is slightly faster
+address_format: lowercase

--- a/scenarios/test_codegen/config.yaml
+++ b/scenarios/test_codegen/config.yaml
@@ -21,6 +21,7 @@ contracts:
       - event: EmptyFiltersArray(address indexed from)
       - event: "WildcardHandlerWithLoader()"
       - event: "FilterTestEvent(address indexed addr)"
+event_decoder: "hypersync-client" # default
 networks:
   - id: 1337
     rpc_config:

--- a/scenarios/test_codegen/pnpm-lock.yaml
+++ b/scenarios/test_codegen/pnpm-lock.yaml
@@ -35,10 +35,6 @@ importers:
       viem:
         specifier: 2.21.0
         version: 2.21.0(typescript@5.5.4)
-    optionalDependencies:
-      generated:
-        specifier: ./generated
-        version: link:generated
     devDependencies:
       '@glennsl/rescript-jest':
         specifier: ^0.9.2
@@ -94,6 +90,10 @@ importers:
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@18.19.47)(typescript@5.5.4)
+    optionalDependencies:
+      generated:
+        specifier: ./generated
+        version: link:generated
 
   ../helpers:
     dependencies:
@@ -143,7 +143,7 @@ importers:
         specifier: 16.4.5
         version: 16.4.5
       envio:
-        specifier: file:/Users/dzakh/code/envio/hyperindex/codegenerator/target/debug/envio/../../../cli/npm/envio
+        specifier: file:/home/jasoons/Documents/code/envio/indexer/codegenerator/target/debug/envio/../../../cli/npm/envio
         version: file:../../codegenerator/cli/npm/envio(typescript@5.5.4)
       ethers:
         specifier: 6.8.0

--- a/scenarios/test_codegen/rescript.json
+++ b/scenarios/test_codegen/rescript.json
@@ -36,5 +36,7 @@
     "helpers",
     "envio"
   ],
-  "bsc-flags": ["-open RescriptSchema"]
+  "bsc-flags": [
+    "-open RescriptSchema"
+  ]
 }

--- a/scenarios/test_codegen/test/AddressLowercase_test.res
+++ b/scenarios/test_codegen/test/AddressLowercase_test.res
@@ -1,0 +1,22 @@
+open RescriptMocha
+
+describe("Address lowercase helpers", () => {
+  it("lowercases a valid address", () => {
+    let input = "0x2C169DFe5fBbA12957Bdd0Ba47d9CEDbFE260CA7"
+    let out = input->Address.Evm.fromStringLowercaseOrThrow->Address.toString
+    Assert.strictEqual(out, "0x2c169dfe5fbba12957bdd0ba47d9cedbfe260ca7")
+  })
+
+  it("throws on invalid address", () => {
+    Assert.throws(() => Address.Evm.fromStringLowercaseOrThrow("invalid-address")->ignore)
+  })
+
+  it("fromAddressLowercaseOrThrow returns lowercase", () => {
+    let mixed = Address.Evm.fromStringOrThrow("0x2c169dfe5fbba12957bdd0ba47d9cedbfe260ca7")
+    let out = mixed->Address.Evm.fromAddressLowercaseOrThrow->Address.toString
+    Assert.strictEqual(out, "0x2c169dfe5fbba12957bdd0ba47d9cedbfe260ca7")
+  })
+})
+
+
+

--- a/scenarios/test_codegen/test/AddressLowercase_test.res
+++ b/scenarios/test_codegen/test/AddressLowercase_test.res
@@ -17,6 +17,3 @@ describe("Address lowercase helpers", () => {
     Assert.strictEqual(out, "0x2c169dfe5fbba12957bdd0ba47d9cedbfe260ca7")
   })
 })
-
-
-

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -9,6 +9,7 @@ describe("getGeneratedByChainId Test", () => {
         syncSource: HyperSync({endpointUrl: "https://1.hypersync.xyz"}),
         startBlock: 1,
         confirmedBlockThreshold: 200,
+        lowercaseAddresses: false,
         contracts: Js.Dict.fromArray([
           (
             "Noop",

--- a/scenarios/test_codegen/test/E2EEthNode_test.res
+++ b/scenarios/test_codegen/test/E2EEthNode_test.res
@@ -10,7 +10,7 @@ describe("E2E Integration Test", () => {
     DbHelpers.runUpDownMigration()
   })
 
-  Async.it("Complete E2E", async () => {
+  Async.it_only("Complete E2E", async () => {
     This.timeout(5 * 1000)
 
     let contracts = await SetupRpcNode.deployContracts()
@@ -61,6 +61,9 @@ describe("E2E Integration Test", () => {
             eventRouter: evmContracts
             ->Belt.Array.flatMap(contract => contract.events)
             ->EventRouter.fromEvmEventModsOrThrow(~chain),
+            allEventSignatures: [],
+            shouldUseHypersyncClientDecoder: false, // stick to viem.
+            lowercaseAddresses: false,
           }),
         ],
       }

--- a/scenarios/test_codegen/test/E2EEthNode_test.res
+++ b/scenarios/test_codegen/test/E2EEthNode_test.res
@@ -10,7 +10,7 @@ describe("E2E Integration Test", () => {
     DbHelpers.runUpDownMigration()
   })
 
-  Async.it_only("Complete E2E", async () => {
+  Async.it("Complete E2E", async () => {
     This.timeout(5 * 1000)
 
     let contracts = await SetupRpcNode.deployContracts()

--- a/scenarios/test_codegen/test/Integration_ts_helpers.res
+++ b/scenarios/test_codegen/test/Integration_ts_helpers.res
@@ -50,6 +50,9 @@ let getLocalChainConfig = (nftFactoryContractAddress): chainConfig => {
         eventRouter: evmContracts
         ->Belt.Array.flatMap(contract => contract.events)
         ->EventRouter.fromEvmEventModsOrThrow(~chain),
+        allEventSignatures: [], // Not used by viem.
+        shouldUseHypersyncClientDecoder: false, // stick to viem.
+        lowercaseAddresses: false,
       }),
     ],
   }

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -30,6 +30,9 @@ describe("RpcSource - name", () => {
       eventRouter: EventRouter.empty(),
       sourceFor: Sync,
       syncConfig: Config.getSyncConfig({}),
+      allEventSignatures: [],
+      shouldUseHypersyncClientDecoder: false,
+      lowercaseAddresses: false,
     })
     Assert.equal(source.name, "RPC (eth.rpc.hypersync.xyz)")
   })
@@ -44,6 +47,9 @@ describe("RpcSource - getHeightOrThrow", () => {
       eventRouter: EventRouter.empty(),
       sourceFor: Sync,
       syncConfig: Config.getSyncConfig({}),
+      allEventSignatures: ["a", "b", "c"],
+      shouldUseHypersyncClientDecoder: true,
+      lowercaseAddresses: false,
     })
     let height = await source.getHeightOrThrow()
     Assert.equal(height > 21994218, true)
@@ -167,6 +173,7 @@ describe("RpcSource - getEventTransactionOrThrow", () => {
     let getTransactionFields = Ethers.JsonRpcProvider.makeGetTransactionFields(
       ~getTransactionByHash=transactionHash =>
         provider->Ethers.JsonRpcProvider.getTransaction(~transactionHash),
+      ~lowercaseAddresses=false,
     )
 
     let getEventTransactionOrThrow = RpcSource.makeThrowingGetEventTransaction(

--- a/scenarios/test_codegen/test/__mocks__/MockConfig.res
+++ b/scenarios/test_codegen/test/__mocks__/MockConfig.res
@@ -61,6 +61,9 @@ let mockChainConfig: InternalConfig.chain = {
       eventRouter: evmContracts
       ->Belt.Array.flatMap(contract => contract.events)
       ->EventRouter.fromEvmEventModsOrThrow(~chain=chain1337),
+      shouldUseHypersyncClientDecoder: false,
+      lowercaseAddresses: false,
+      allEventSignatures: [],
     }),
   ],
 }


### PR DESCRIPTION
TODO:
- [x] add tests
- [x] manually test some scenarios
- [x] think of more edge cases
- [x] get feedback on config file layout. For example Denham was keen to make this under a 'subgraph_compatibility' section in the config. I feel like it could also just be a general flag that someone uses so maybe it shouldn't be completely tied only to subgraphs?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional lowercase formatting for Ethereum addresses across generated projects; address helpers now validate/return lowercased addresses and clients forward checksum/lowercase choice.

* **Configuration**
  * New address_format option (checksum or lowercase) in configs and schema.
  * Generated runtime flags: lowercaseAddresses, shouldUseHypersyncClientDecoder, and allEventSignatures; templates updated to emit and thread them.

* **Validation**
  * Runtime checks prevent incompatible combinations of lowercaseAddresses and decoder settings.

* **Tests**
  * Added tests for address lowercasing and updated config/generation expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->