### PR TITLE
Fix is progress at head metric + test framework for prom metrics

### DIFF
--- a/codegenerator/cli/npm/envio/src/Batch.res
+++ b/codegenerator/cli/npm/envio/src/Batch.res
@@ -2,6 +2,7 @@ type progressedChain = {
   chainId: int,
   batchSize: int,
   progressBlockNumber: int,
+  isProgressAtHead: bool,
   totalEventsProcessed: int,
 }
 

--- a/codegenerator/cli/npm/envio/src/bindings/PromClient.res
+++ b/codegenerator/cli/npm/envio/src/bindings/PromClient.res
@@ -11,6 +11,14 @@ type registry
 @send external metrics: registry => Promise.t<string> = "metrics"
 @get external getContentType: registry => string = "contentType"
 
+type metricValue = {
+  value: int,
+  labels: dict<string>,
+}
+type metricInstance = {get: unit => promise<{"values": array<metricValue>}>}
+@send external getSingleMetric: (registry, string) => option<metricInstance> = "getSingleMetric"
+@send external resetMetrics: registry => unit = "resetMetrics"
+
 module Counter = {
   type counter
   @new @module("prom-client") external makeCounter: customMetric<'a> => counter = "Counter"
@@ -36,6 +44,8 @@ module Gauge = {
   @send external setFloat: (gauge, float) => unit = "set"
 
   @send external labels: (gauge, 'labelsObject) => gauge = "labels"
+
+  @send external get: gauge => promise<{"values": array<dict<string>>}> = "get"
 }
 
 module Histogram = {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -14,7 +14,7 @@ type t = {
   chainConfig: InternalConfig.chain,
   //The latest known block of the chain
   currentBlockHeight: int,
-  isFetchingAtHead: bool,
+  isProgressAtHead: bool,
   timestampCaughtUpToHeadOrEndblock: option<Js.Date.t>,
   committedProgressBlockNumber: int,
   firstEventBlockNumber: option<int>,
@@ -197,7 +197,7 @@ let make = (
     ),
     lastBlockScannedHashes,
     currentBlockHeight: 0,
-    isFetchingAtHead: false,
+    isProgressAtHead: false,
     fetchState,
     firstEventBlockNumber,
     committedProgressBlockNumber: progressBlockNumber,

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainManager.res
@@ -184,6 +184,10 @@ let createBatch = (chainManager: t, ~batchSizeTarget: int): Batch.t => {
             batchSize: chainBatchSize,
             progressBlockNumber: nextProgressBlockNumber,
             totalEventsProcessed: chainFetcher.numEventsProcessed + chainBatchSize,
+            // Snapshot the value at the moment of batch creation
+            // so we don't have a case where we can't catch up the head because of the
+            // defference between processing and new blocks
+            isProgressAtHead: nextProgressBlockNumber >= chainFetcher.currentBlockHeight,
           }: Batch.progressedChain
         ),
       )
@@ -200,10 +204,10 @@ let createBatch = (chainManager: t, ~batchSizeTarget: int): Batch.t => {
   }
 }
 
-let isFetchingAtHead = chainManager =>
+let isProgressAtHead = chainManager =>
   chainManager.chainFetchers
   ->ChainMap.values
-  ->Js.Array2.every(cf => cf.isFetchingAtHead)
+  ->Js.Array2.every(cf => cf.isProgressAtHead)
 
 let isActivelyIndexing = chainManager =>
   chainManager.chainFetchers

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -111,7 +111,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       lastBlockScannedHashes: ReorgDetection.LastBlockScannedHashes.empty(
         ~confirmedBlockThreshold=200,
       ),
-      isFetchingAtHead: false,
+      isProgressAtHead: false,
       currentBlockHeight: 0,
       processingFilters: None,
     }

--- a/scenarios/test_codegen/test/helpers/Mock.res
+++ b/scenarios/test_codegen/test/helpers/Mock.res
@@ -206,6 +206,10 @@ module Storage = {
 }
 
 module Indexer = {
+  type metric = {
+    value: string,
+    labels: dict<string>,
+  }
   type t = {
     getBatchWritePromise: unit => promise<unit>,
     getRollbackReadyPromise: unit => promise<unit>,
@@ -213,12 +217,15 @@ module Indexer = {
     queryHistory: 'entity. module(Entities.Entity with type t = 'entity) => promise<
       array<EntityHistory.historyRow<'entity>>,
     >,
+    metric: string => promise<array<metric>>,
   }
 
   type chainConfig = {chain: Types.chain, sources: array<Source.t>, startBlock?: int}
 
   let make = async (~chains: array<chainConfig>, ~multichain=InternalConfig.Unordered) => {
     DbHelpers.resetPostgresClient()
+    // TODO: Should stop using global client
+    PromClient.defaultRegister->PromClient.resetMetrics
 
     let config = RegisterHandlers.registerAllHandlers()
 
@@ -342,6 +349,16 @@ module Indexer = {
             array<EntityHistory.historyRow<entity>>,
           >
         )
+      },
+      metric: async name => {
+        switch PromClient.defaultRegister->PromClient.getSingleMetric(name) {
+        | Some(m) =>
+          (await m.get())["values"]->Js.Array2.map(v => {
+            value: v.value->Belt.Int.toString,
+            labels: v.labels,
+          })
+        | None => []
+        }
       },
     }
   }
@@ -569,6 +586,33 @@ module Source = {
         }
       },
     }
+  }
+}
+
+module Helper = {
+  let initialEnterReorgThreshold = async (~sourceMock: Source.t) => {
+    open RescriptMocha
+
+    Assert.deepEqual(
+      sourceMock.getHeightOrThrowCalls->Array.length,
+      1,
+      ~message="should have called getHeightOrThrow to get initial height",
+    )
+    sourceMock.resolveGetHeightOrThrow(300)
+    await Utils.delay(0)
+    await Utils.delay(0)
+
+    let expectedGetItemsCall1 = {"fromBlock": 0, "toBlock": Some(100), "retry": 0}
+
+    Assert.deepEqual(
+      sourceMock.getItemsOrThrowCalls,
+      [expectedGetItemsCall1],
+      ~message="Should request items until reorg threshold",
+    )
+    sourceMock.resolveGetItemsOrThrow([])
+    await Utils.delay(0)
+    await Utils.delay(0)
+    await Utils.delay(0)
   }
 }
 

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -417,29 +417,6 @@ describe("Single Chain Simple Rollback", () => {
 let undefined = (%raw(`undefined`): option<'a>)
 
 describe("E2E rollback tests", () => {
-  let initialEnterReorgThreshold = async (~sourceMock: M.Source.t) => {
-    Assert.deepEqual(
-      sourceMock.getHeightOrThrowCalls->Array.length,
-      1,
-      ~message="should have called getHeightOrThrow to get initial height",
-    )
-    sourceMock.resolveGetHeightOrThrow(300)
-    await Utils.delay(0)
-    await Utils.delay(0)
-
-    let expectedGetItemsCall1 = {"fromBlock": 0, "toBlock": Some(100), "retry": 0}
-
-    Assert.deepEqual(
-      sourceMock.getItemsOrThrowCalls,
-      [expectedGetItemsCall1],
-      ~message="Should request items until reorg threshold",
-    )
-    sourceMock.resolveGetItemsOrThrow([])
-    await Utils.delay(0)
-    await Utils.delay(0)
-    await Utils.delay(0)
-  }
-
   let testSingleChainRollback = async (~sourceMock: M.Source.t, ~indexerMock: M.Indexer.t) => {
     Assert.deepEqual(
       sourceMock.getItemsOrThrowCalls->Utils.Array.last,
@@ -736,7 +713,7 @@ describe("E2E rollback tests", () => {
     )
     await Utils.delay(0)
 
-    await initialEnterReorgThreshold(~sourceMock)
+    await M.Helper.initialEnterReorgThreshold(~sourceMock)
     await testSingleChainRollback(~sourceMock, ~indexerMock)
   })
 
@@ -766,8 +743,8 @@ describe("E2E rollback tests", () => {
       await Utils.delay(0)
 
       let _ = await Promise.all2((
-        initialEnterReorgThreshold(~sourceMock=sourceMock1),
-        initialEnterReorgThreshold(~sourceMock=sourceMock2),
+        M.Helper.initialEnterReorgThreshold(~sourceMock=sourceMock1),
+        M.Helper.initialEnterReorgThreshold(~sourceMock=sourceMock2),
       ))
 
       await testSingleChainRollback(~sourceMock=sourceMock1, ~indexerMock)
@@ -789,7 +766,7 @@ describe("E2E rollback tests", () => {
     )
     await Utils.delay(0)
 
-    await initialEnterReorgThreshold(~sourceMock)
+    await M.Helper.initialEnterReorgThreshold(~sourceMock)
 
     let calls = []
     let handler: Types.HandlerTypes.loader<unit, unit> = async ({event}) => {
@@ -1050,8 +1027,8 @@ This might be wrong after we start exposing a block hash for progress block.`,
     await Utils.delay(0)
 
     let _ = await Promise.all2((
-      initialEnterReorgThreshold(~sourceMock=sourceMock1337),
-      initialEnterReorgThreshold(~sourceMock=sourceMock100),
+      M.Helper.initialEnterReorgThreshold(~sourceMock=sourceMock1337),
+      M.Helper.initialEnterReorgThreshold(~sourceMock=sourceMock100),
     ))
 
     let callCount = ref(0)


### PR DESCRIPTION
Fixes https://github.com/enviodev/hyperindex/issues/767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Exposes metric retrieval and reset capabilities for improved observability.
  - Adds a progress-at-head indicator to progress reporting.

- Refactor
  - Renamed progress state to consistently reflect “progress at head” across components.

- Tests
  - Added end-to-end coverage validating Prometheus metrics (including reorg threshold and synced-to-head).
  - Consolidated and reused test helpers for reorg threshold setup.

- Chores
  - Reset Prometheus metrics during test initialization to ensure clean runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->