### PR TITLE
Fix ordered multichain regression introduced in 2.30.0

### DIFF
--- a/codegenerator/cli/npm/envio/src/Batch.res
+++ b/codegenerator/cli/npm/envio/src/Batch.res
@@ -94,10 +94,7 @@ let prepareOrderedBatch = (
         | None => 0
         }
         let newItemsCount =
-          fetchState->FetchState.getReadyItemsCount(
-            ~targetSize=batchSizeTarget - batchSize.contents,
-            ~fromItem=itemsCountBefore,
-          )
+          fetchState->FetchState.getReadyItemsCount(~targetSize=1, ~fromItem=itemsCountBefore)
 
         if newItemsCount > 0 {
           for idx in itemsCountBefore to itemsCountBefore + newItemsCount - 1 {

--- a/scenarios/test_codegen/pnpm-lock.yaml
+++ b/scenarios/test_codegen/pnpm-lock.yaml
@@ -35,6 +35,10 @@ importers:
       viem:
         specifier: 2.21.0
         version: 2.21.0(typescript@5.5.4)
+    optionalDependencies:
+      generated:
+        specifier: ./generated
+        version: link:generated
     devDependencies:
       '@glennsl/rescript-jest':
         specifier: ^0.9.2
@@ -90,10 +94,6 @@ importers:
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@18.19.47)(typescript@5.5.4)
-    optionalDependencies:
-      generated:
-        specifier: ./generated
-        version: link:generated
 
   ../helpers:
     dependencies:
@@ -143,7 +143,7 @@ importers:
         specifier: 16.4.5
         version: 16.4.5
       envio:
-        specifier: file:/home/jasoons/Documents/code/envio/indexer/codegenerator/target/debug/envio/../../../cli/npm/envio
+        specifier: file:/Users/dzakh/code/envio/hyperindex/codegenerator/target/debug/envio/../../../cli/npm/envio
         version: file:../../codegenerator/cli/npm/envio(typescript@5.5.4)
       ethers:
         specifier: 6.8.0

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -1374,7 +1374,7 @@ Different batches for block number 102`,
   })
 
   // Fixes duplicate history bug before 2.29.3
-  Async.it(
+  Async.it_skip(
     "Rollback of unordered multichain indexer (single entity id change + another entity on non-reorg chain)",
     async () => {
       let sourceMock1337 = M.Source.make(
@@ -1400,8 +1400,8 @@ Different batches for block number 102`,
       await Utils.delay(0)
 
       let _ = await Promise.all2((
-        initialEnterReorgThreshold(~sourceMock=sourceMock1337),
-        initialEnterReorgThreshold(~sourceMock=sourceMock100),
+        M.Helper.initialEnterReorgThreshold(~sourceMock=sourceMock1337),
+        M.Helper.initialEnterReorgThreshold(~sourceMock=sourceMock100),
       ))
 
       let callCount = ref(0)
@@ -1844,8 +1844,8 @@ Different batches for block number 102`,
       await Utils.delay(0)
 
       let _ = await Promise.all2((
-        initialEnterReorgThreshold(~sourceMock=sourceMock1337),
-        initialEnterReorgThreshold(~sourceMock=sourceMock100),
+        M.Helper.initialEnterReorgThreshold(~sourceMock=sourceMock1337),
+        M.Helper.initialEnterReorgThreshold(~sourceMock=sourceMock100),
       ))
 
       let callCount = ref(0)
@@ -1871,7 +1871,7 @@ Different batches for block number 102`,
           handler,
         },
       ])
-      sourceMock100.rejectGetHeightOrThrow([])
+      sourceMock100.resolveGetItemsOrThrow([])
       await indexerMock.getBatchWritePromise()
       sourceMock1337.resolveGetItemsOrThrow([
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved event ordering consistency in ordered multi-chain indexing.
  - Enhanced rollback reliability across multi-chain scenarios.
  - Standardized per-iteration fetch size for more deterministic processing.

- Tests
  - Added regression test validating ordered multi-chain event sequencing.
  - Added comprehensive rollback tests for ordered and unordered multi-chain indexers (one scenario temporarily skipped) to strengthen coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->