### PR TITLE
Allow independent Effect API fails

### DIFF
--- a/codegenerator/cli/npm/envio/src/bindings/Promise.res
+++ b/codegenerator/cli/npm/envio/src/bindings/Promise.res
@@ -51,6 +51,9 @@ let catch = (promise: promise<'a>, callback: exn => promise<'a>): promise<'a> =>
   })
 }
 
+@send
+external catchResolve: (t<'a>, exn => 'a) => t<'a> = "catch"
+
 @scope("Promise") @val
 external race: array<t<'a>> => t<'a> = "race"
 


### PR DESCRIPTION
Previously if a single effect API call from a batch fails, it would cause a failure of the whole batch. With the change every effect API call can fail independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error isolation in concurrent batch operations—failures in individual calls no longer cause other concurrent calls to fail.
  * Enhanced error tracking and logging for cache loading failures to prevent silent failures.
  * Cache now stores only successful results, preventing corrupted cache entries from failed operations.

* **Tests**
  * Added end-to-end test coverage for concurrent error handling and selective caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->