### PR TITLE
fix: remove skip token step now that tokens are required

### DIFF
--- a/codegenerator/cli/src/cli_args/interactive_init/mod.rs
+++ b/codegenerator/cli/src/cli_args/interactive_init/mod.rs
@@ -105,8 +105,6 @@ enum ApiTokenInput {
     Create,
     #[strum(serialize = "Add an existing API token")]
     AddExisting,
-    #[strum(serialize = "Skip for now, I'll add later")]
-    Skip,
 }
 pub async fn prompt_missing_init_args(
     init_args: InitArgs,
@@ -139,7 +137,7 @@ pub async fn prompt_missing_init_args(
 
     let language = match init_args.language {
         Some(args_language) => args_language,
-        None => Language::TypeScript
+        None => Language::TypeScript,
     };
 
     let ecosystem = prompt_ecosystem(init_args.init_commands)
@@ -169,13 +167,6 @@ pub async fn prompt_missing_init_args(
                 ApiTokenInput::AddExisting => Ok(token_prompt
                     .prompt_skippable()
                     .context("Prompting for add existing token")?),
-                ApiTokenInput::Skip => {
-                    println!(
-                        "You can always visit 'https://envio.dev/app/api-tokens' and add a token \
-                         later to your .env file."
-                    );
-                    Ok(None)
-                }
             }
         }
         None => Ok(None),


### PR DESCRIPTION
Since token's are required now, this change removes the option to skip as it won't work if the user tries to skip now. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the option to skip API token entry during interactive initialization. Users must now either create a new API token or add an existing token to complete setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->