### PR TITLE
Fix ecs-pino-format import

### DIFF
--- a/codegenerator/cli/npm/envio/src/Envio.gen.ts
+++ b/codegenerator/cli/npm/envio/src/Envio.gen.ts
@@ -35,19 +35,6 @@ export type rateLimit =
     false
   | { readonly calls: number; readonly per: rateLimitDuration };
 
-export type experimental_effectOptions<input,output> = {
-  /** The name of the effect. Used for logging and debugging. */
-  readonly name: string; 
-  /** The input schema of the effect. */
-  readonly input: RescriptSchema_S_t<input>; 
-  /** The output schema of the effect. */
-  readonly output: RescriptSchema_S_t<output>; 
-  /** Rate limit for the effect. Set to false to disable or provide {calls: number, per: "second" | "minute"} to enable. */
-  readonly rateLimit?: rateLimit; 
-  /** Whether the effect should be cached. */
-  readonly cache?: boolean
-};
-
 export type effectOptions<input,output> = {
   /** The name of the effect. Used for logging and debugging. */
   readonly name: string; 

--- a/codegenerator/cli/npm/envio/src/bindings/Pino.res
+++ b/codegenerator/cli/npm/envio/src/bindings/Pino.res
@@ -108,8 +108,8 @@ let createChildParams: 'a => childParams = Utils.magic
 @send external child: (t, childParams) => t = "child"
 
 module ECS = {
-  @module
-  external make: 'a => options = "@elastic/ecs-pino-format"
+  @module("@elastic/ecs-pino-format")
+  external make: 'a => options = "default"
   let make = make
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `experimental_effectOptions` type; migrate to standard `effectOptions` configuration.
  * `rateLimit` field is now mandatory in effect options (previously optional); explicit configuration required.

* **Chores**
  * Updated logging service module binding configurations for enhanced compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->