### PR TITLE
Fix contract import with spaces in name

### DIFF
--- a/codegenerator/cli/src/cli_args/interactive_init/fuel_prompts.rs
+++ b/codegenerator/cli/src/cli_args/interactive_init/fuel_prompts.rs
@@ -5,7 +5,10 @@ use crate::{
         ContractImportArgs, InitFlow as ClapInitFlow, LocalImportArgs, LocalOrExplorerImport,
         TemplateArgs,
     },
-    config_parsing::human_config::fuel::EventConfig,
+    config_parsing::{
+        contract_import::converters::normalize_contract_name,
+        human_config::fuel::EventConfig,
+    },
     fuel::abi::{FuelAbi, BURN_EVENT_NAME, CALL_EVENT_NAME, MINT_EVENT_NAME, TRANSFER_EVENT_NAME},
     init_config::fuel::{ContractImportSelection, InitFlow, Network, SelectedContract, Template},
 };
@@ -163,7 +166,7 @@ async fn get_contract_import_selection(args: ContractImportArgs) -> Result<Selec
     let addresses = vec![prompt_contract_address(None)?];
 
     Ok(SelectedContract {
-        name,
+        name: normalize_contract_name(name),
         addresses,
         abi,
         selected_events,

--- a/codegenerator/cli/src/config_parsing/contract_import/converters.rs
+++ b/codegenerator/cli/src/config_parsing/contract_import/converters.rs
@@ -2,6 +2,11 @@ use crate::{config_parsing::chain_helpers::HypersyncNetwork, evm::address::Addre
 use anyhow::{Context, Result};
 use std::fmt::{self, Display};
 
+/// Normalizes a contract name by replacing spaces, hyphens, and dots with underscores.
+pub fn normalize_contract_name(name: String) -> String {
+    name.replace([' ', '-', '.'], "_")
+}
+
 ///The hierarchy is based on how you would add items to
 ///your selection as you go. Ie. Once you have constructed
 ///the selection of a contract you can add more addresses or
@@ -20,7 +25,7 @@ impl SelectedContract {
         events: Vec<ethers::abi::Event>,
     ) -> Self {
         Self {
-            name,
+            name: normalize_contract_name(name),
             chains: vec![network_selection],
             events,
         }
@@ -111,5 +116,49 @@ impl ContractImportNetworkSelection {
 
     pub fn uses_hypersync(&self) -> bool {
         self.network.uses_hypersync()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_contract_name() {
+        // Spaces are replaced with underscores
+        assert_eq!(
+            normalize_contract_name("Yearn V3 Vault".to_string()),
+            "Yearn_V3_Vault"
+        );
+
+        // Hyphens are replaced with underscores
+        assert_eq!(
+            normalize_contract_name("Uniswap-V3".to_string()),
+            "Uniswap_V3"
+        );
+
+        // Dots are replaced with underscores
+        assert_eq!(
+            normalize_contract_name("Token.Contract".to_string()),
+            "Token_Contract"
+        );
+
+        // Multiple special characters
+        assert_eq!(
+            normalize_contract_name("My-Contract.Name V2".to_string()),
+            "My_Contract_Name_V2"
+        );
+
+        // Already valid name remains unchanged
+        assert_eq!(
+            normalize_contract_name("ValidContractName".to_string()),
+            "ValidContractName"
+        );
+
+        // Underscores are preserved
+        assert_eq!(
+            normalize_contract_name("Valid_Contract_Name".to_string()),
+            "Valid_Contract_Name"
+        );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contract names are now normalized during import, converting spaces, hyphens, and dots to underscores for improved consistency and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->