### PR TITLE
Add `envio config list`

### DIFF
--- a/codegenerator/cli/src/cli_args/clap_definitions.rs
+++ b/codegenerator/cli/src/cli_args/clap_definitions.rs
@@ -69,6 +69,16 @@ pub enum CommandType {
     #[clap(hide = true)]
     #[command(subcommand)]
     Script(Script),
+
+    /// Configuration commands
+    #[command(subcommand)]
+    Config(ConfigSubcommands),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ConfigSubcommands {
+    /// Print the base config as JSON with camelCase fields
+    List,
 }
 
 #[derive(Debug, Subcommand)]

--- a/codegenerator/cli/src/config_parsing/human_config.rs
+++ b/codegenerator/cli/src/config_parsing/human_config.rs
@@ -89,6 +89,38 @@ pub struct BaseConfig {
     pub full_batch_size: Option<u64>,
 }
 
+/// BaseConfig with camelCase JSON serialization for CLI output
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BaseConfigJson {
+    pub version: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handlers: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub full_batch_size: Option<u64>,
+}
+
+impl BaseConfigJson {
+    pub fn new(config: &BaseConfig, version: &str) -> Self {
+        BaseConfigJson {
+            version: version.to_string(),
+            name: config.name.clone(),
+            description: config.description.clone(),
+            schema: config.schema.clone(),
+            output: config.output.clone(),
+            handlers: config.handlers.clone(),
+            full_batch_size: config.full_batch_size,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct GlobalContract<T> {


### PR DESCRIPTION
An idea to use later to get config as a JSON on a hosted service, as well as for generating. I want to consume json instead of generating code in rust.

I also want to add entities and events types using a superset of JSON schema.