### PR TITLE
Add API token to GitHub Actions tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,6 +12,7 @@ defaults:
 
 env:
   CARGO_TERM_COLOR: always
+  ENVIO_API_TOKEN: ${{ secrets.ENVIO_API_TOKEN }}
 
 jobs:
   build_and_test:

--- a/.github/workflows/templates_integration_test.yml
+++ b/.github/workflows/templates_integration_test.yml
@@ -13,6 +13,7 @@ defaults:
 
 env:
   CARGO_TERM_COLOR: always
+  ENVIO_API_TOKEN: ${{ secrets.ENVIO_API_TOKEN }}
 
 jobs:
   build_and_test:


### PR DESCRIPTION
Set ENVIO_API_TOKEN environment variable from secrets in build_and_test.yml and templates_integration_test.yml to enable HyperSync API access during tests.