### PR TITLE
Set indexer test start and end blocks equal

### DIFF
--- a/codegenerator/cli/templates/static/erc20_template/typescript/src/indexer.test.ts
+++ b/codegenerator/cli/templates/static/erc20_template/typescript/src/indexer.test.ts
@@ -11,12 +11,12 @@ describe("Indexer Testing", () => {
       await indexer.process({
         chains: {
           1: {
-            startBlock: 0,
+            startBlock: 10_861_674,
             endBlock: 10_861_674,
           },
         },
       }),
-      "Should instantly scan through the chain and find the first mint at block 10_861_674"
+      "Should find the first mint at block 10_861_674"
     ).toMatchInlineSnapshot(`
       {
         "changes": [


### PR DESCRIPTION
Instead of scanning from block 0, set startBlock to match endBlock (10_861_674) for more efficient targeted block testing.