### PR TITLE
Complete small todo from codebase

### DIFF
--- a/scenarios/test_codegen/test/__mocks__/MockEvents.res
+++ b/scenarios/test_codegen/test/__mocks__/MockEvents.res
@@ -67,7 +67,6 @@ let tx1: Types.Transaction.t = {
 let newGravatarLog1: Types.eventLog<Types.Gravatar.NewGravatar.eventArgs> = {
   params: newGravatar1,
   chainId: 54321,
-  // TODO: this should be an address type
   srcAddress: "0xabc0000000000000000000000000000000000000"->Address.Evm.fromStringOrThrow,
   logIndex: 11,
   transaction: tx1,


### PR DESCRIPTION
The srcAddress field is already using Address.Evm.fromStringOrThrow, so the TODO comment about making it an address type was obsolete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unnecessary TODO comment from test mock files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->