### PR TITLE
Use indexer name for Docker container

### DIFF
--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -1179,6 +1179,8 @@ struct SelectedFieldTemplate {
 #[derive(Serialize)]
 pub struct ProjectTemplate {
     project_name: String,
+    /// Docker-safe name for container/volume naming (lowercase with hyphens)
+    docker_project_name: String,
     codegen_contracts: Vec<ContractTemplate>,
     entities: Vec<EntityRecordTypeTemplate>,
     gql_enums: Vec<GraphQlEnumTypeTemplate>,
@@ -1742,8 +1744,12 @@ let createTestIndexer: unit => TestIndexer.t<testIndexerProcessConfig> = TestInd
             parts.join("\n")
         };
 
+        // Convert project name to Docker-safe format (lowercase, hyphens instead of underscores)
+        let docker_project_name = cfg.name.to_lowercase().replace('_', "-");
+
         Ok(ProjectTemplate {
             project_name: cfg.name.clone(),
+            docker_project_name,
             codegen_contracts,
             entities,
             gql_enums,

--- a/codegenerator/cli/templates/dynamic/codegen/docker-compose.yaml.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/docker-compose.yaml.hbs
@@ -1,11 +1,12 @@
 services:
   envio-postgres:
+    container_name: envio-postgres-{{docker_project_name}}
     image: postgres:17.5
     restart: always
     ports:
       - "${ENVIO_PG_PORT:-5433}:5432"
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data_{{docker_project_name}}:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: ${ENVIO_PG_PASSWORD:-testing}
       POSTGRES_USER: ${ENVIO_PG_USER:-postgres}
@@ -13,6 +14,7 @@ services:
     networks:
       - my-proxy-net
   graphql-engine:
+    container_name: graphql-engine-{{docker_project_name}}
     image: hasura/graphql-engine:v2.43.0
     ports:
       - "${HASURA_EXTERNAL_PORT:-8080}:8080"
@@ -46,7 +48,7 @@ services:
     networks:
       - my-proxy-net
 volumes:
-  db_data:
+  db_data_{{docker_project_name}}:
 networks:
   my-proxy-net:
     name: local_test_network


### PR DESCRIPTION
Converts docker-compose.yaml from static to dynamic template using the project name from config.yaml. Container names now include the project name (e.g., envio-postgres-my-indexer) and volumes are project-specific to prevent data conflicts between multiple indexers.

Fixes #754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Docker containers and volumes are now automatically named using project-specific identifiers, preventing conflicts when managing multiple projects simultaneously.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->