### PR TITLE
Return dynamic contract registrations in indexer changes

### DIFF
--- a/codegenerator/cli/npm/envio/index.d.ts
+++ b/codegenerator/cli/npm/envio/index.d.ts
@@ -506,6 +506,14 @@ type EntityChangeValue<Entity> = {
   readonly deleted?: readonly string[];
 };
 
+/** A dynamic contract address registration. */
+type AddressRegistration = {
+  /** The contract address. */
+  readonly address: Address;
+  /** The contract name. */
+  readonly contract: string;
+};
+
 /** Extract entities from config. */
 type ConfigEntities<Config extends IndexerConfigTypes> =
   Config["entities"] extends Record<string, object> ? Config["entities"] : {};
@@ -520,6 +528,10 @@ type EntityChange<Config extends IndexerConfigTypes> = {
   readonly chainId: number;
   /** Number of events processed in this block. */
   readonly eventsProcessed: number;
+  /** Dynamic contract address registrations for this block. */
+  readonly addresses?: {
+    readonly sets?: readonly AddressRegistration[];
+  };
 } & {
   readonly [K in keyof ConfigEntities<Config>]?: EntityChangeValue<
     ConfigEntities<Config>[K]

--- a/codegenerator/cli/templates/static/factory_template/typescript/src/indexer.test.ts
+++ b/codegenerator/cli/templates/static/factory_template/typescript/src/indexer.test.ts
@@ -14,25 +14,17 @@ describe("Indexer Testing", () => {
       {
         "changes": [
           {
-            "block": 12369739,
-            "blockHash": "0xe8228e3e736a42c7357d2ce6882a1662c588ce608897dd53c3053bcbefb4309a",
-            "chainId": 1,
-            "dynamic_contract_registry": {
+            "addresses": {
               "sets": [
                 {
-                  "chain_id": 1,
-                  "contract_address": "0x1d42064Fc4Beb5F8aAF85F4617AE8b3b5B8Bd801",
-                  "contract_name": "UniswapV3Pool",
-                  "id": "1-0x1d42064Fc4Beb5F8aAF85F4617AE8b3b5B8Bd801",
-                  "registering_event_block_number": 12369739,
-                  "registering_event_block_timestamp": 1620157956,
-                  "registering_event_contract_name": "UniswapV3Factory",
-                  "registering_event_log_index": 24,
-                  "registering_event_name": "PoolCreated",
-                  "registering_event_src_address": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+                  "address": "0x1d42064Fc4Beb5F8aAF85F4617AE8b3b5B8Bd801",
+                  "contract": "UniswapV3Pool",
                 },
               ],
             },
+            "block": 12369739,
+            "blockHash": "0xe8228e3e736a42c7357d2ce6882a1662c588ce608897dd53c3053bcbefb4309a",
+            "chainId": 1,
             "eventsProcessed": 1,
           },
         ],


### PR DESCRIPTION
Change test indexer to return dynamic contract registrations as a simplified `addresses` field instead of the internal `dynamic_contract_registry` entity. The new structure has sets with `{address, contract}` objects instead of the full internal entity structure.