### PR TITLE
Add package version to internal.config.json

### DIFF
--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -18,7 +18,7 @@ use crate::{
             SystemConfig,
         },
     },
-    persisted_state::{PersistedState, PersistedStateJsonString},
+    persisted_state::{PersistedState, PersistedStateJsonString, CURRENT_CRATE_VERSION},
     project_paths::{
         path_utils::{add_leading_relative_dot, add_trailing_relative_dot},
         ParsedProjectPaths,
@@ -47,6 +47,7 @@ fn is_false(v: &bool) -> bool {
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct InternalConfigJson<'a> {
+    version: &'a str,
     name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<&'a str>,
@@ -1575,6 +1576,7 @@ let createTestIndexer: unit => TestIndexer.t<testIndexerProcessConfig> = TestInd
             };
 
             let config = InternalConfigJson {
+                version: CURRENT_CRATE_VERSION,
                 name: &cfg.name,
                 description: cfg.human_config.get_base_config().description.as_deref(),
                 handlers: cfg.handlers.as_deref(),

--- a/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_generated_for_evm.snap
+++ b/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_generated_for_evm.snap
@@ -3,6 +3,7 @@ source: cli/src/hbs_templating/codegen_templates.rs
 expression: project_template.internal_config_json_code
 ---
 {
+  "version": "0.0.1-dev",
   "name": "config1",
   "description": "Gravatar for Ethereum",
   "evm": {

--- a/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_generated_for_fuel.snap
+++ b/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_generated_for_fuel.snap
@@ -3,6 +3,7 @@ source: cli/src/hbs_templating/codegen_templates.rs
 expression: project_template.internal_config_json_code
 ---
 {
+  "version": "0.0.1-dev",
   "name": "Fuel indexer",
   "rollbackOnReorg": false,
   "fuel": {

--- a/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_omits_default_values.snap
+++ b/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_omits_default_values.snap
@@ -3,6 +3,7 @@ source: cli/src/hbs_templating/codegen_templates.rs
 expression: project_template.internal_config_json_code
 ---
 {
+  "version": "0.0.1-dev",
   "name": "config1",
   "description": "Gravatar for Ethereum",
   "evm": {

--- a/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_with_all_options.snap
+++ b/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_with_all_options.snap
@@ -3,6 +3,7 @@ source: cli/src/hbs_templating/codegen_templates.rs
 expression: project_template.internal_config_json_code
 ---
 {
+  "version": "0.0.1-dev",
   "name": "test-all-options",
   "description": "Test config with all options set",
   "handlers": "custom/handlers",

--- a/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_with_multiple_contracts.snap
+++ b/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_with_multiple_contracts.snap
@@ -3,6 +3,7 @@ source: cli/src/hbs_templating/codegen_templates.rs
 expression: project_template.internal_config_json_code
 ---
 {
+  "version": "0.0.1-dev",
   "name": "config2",
   "description": "Gravatar for Ethereum",
   "evm": {

--- a/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_with_no_contracts.snap
+++ b/codegenerator/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_with_no_contracts.snap
@@ -3,6 +3,7 @@ source: cli/src/hbs_templating/codegen_templates.rs
 expression: project_template.internal_config_json_code
 ---
 {
+  "version": "0.0.1-dev",
   "name": "config4",
   "description": "Gravatar for Ethereum",
   "evm": {


### PR DESCRIPTION
Include the envio CLI version in the generated internal.config.json file. This helps track which version of envio was used to generate the config.

NOT used for anything now, but will be useful in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated configuration files now include version tracking information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->