### PR TITLE
Remove address_format configuration from template configs

### DIFF
--- a/codegenerator/cli/templates/static/erc20_template/typescript/config.yaml
+++ b/codegenerator/cli/templates/static/erc20_template/typescript/config.yaml
@@ -17,6 +17,3 @@ chains:
     contracts:
       - name: ERC20
         address: 0x4537e328Bf7e4eFA29D05CAeA260D7fE26af9D74 #UNI
-# Address format for Ethereum addresses: 'checksum' or 'lowercase'
-# using lowercase addresses is slightly faster
-address_format: lowercase

--- a/codegenerator/cli/templates/static/greeter_template/typescript/config.yaml
+++ b/codegenerator/cli/templates/static/greeter_template/typescript/config.yaml
@@ -21,6 +21,3 @@ chains:
     contracts:
       - name: Greeter #A reference to the global contract definition
         address: 0xdEe21B97AB77a16B4b236F952e586cf8408CF32A
-# Address format for Ethereum addresses: 'checksum' or 'lowercase'
-# using lowercase addresses is slightly faster
-address_format: lowercase


### PR DESCRIPTION
## Summary
Removed the `address_format` configuration option and its associated comments from the ERC20 and Greeter template configuration files.

## Changes
- Removed `address_format: lowercase` configuration from `erc20_template/typescript/config.yaml`
- Removed `address_format: lowercase` configuration from `greeter_template/typescript/config.yaml`
- Removed explanatory comments about address format options ('checksum' vs 'lowercase') from both templates

## Details
The `address_format` configuration and its documentation have been stripped from both template files. This suggests either:
- The configuration option is no longer supported or needed
- A default behavior has been established that makes explicit configuration unnecessary
- The setting is now handled elsewhere in the codebase

https://claude.ai/code/session_0168y16Gw2hqSrZmoWJGLWNK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified code generation templates by removing explicit address formatting configuration and associated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->