### PR TITLE
Upgrade PostgreSQL image from 18.1 to 18.2

### DIFF
--- a/codegenerator/cli/templates/static/codegen/docker-compose.yaml
+++ b/codegenerator/cli/templates/static/codegen/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   envio-postgres:
-    image: postgres:18.1
+    image: postgres:18.2
     restart: always
     ports:
       - "${ENVIO_PG_PORT:-5433}:5432"


### PR DESCRIPTION
## Summary
Updated the PostgreSQL Docker image version in the docker-compose configuration to the latest 18.2 release.

(https://www.postgresql.org/docs/release/18.2/) fixes to 18.1

## Changes
- Bumped PostgreSQL image version from `postgres:18.1` to `postgres:18.2` in the docker-compose template

## Details
This update ensures the development environment uses the latest PostgreSQL 18 patch release, which includes bug fixes and security improvements from the 18.1 version.

https://claude.ai/code/session_016kTboFNhH9eTenQMvmUV5n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL database service to version 18.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->