### PR TITLE
Optimize buffer merging with O(n+m) merge instead of concat+sort

### DIFF
--- a/codegenerator/cli/npm/envio/src/Batch.res
+++ b/codegenerator/cli/npm/envio/src/Batch.res
@@ -149,11 +149,15 @@ let getProgressedChainsById = {
         fetchState.chainId->Int.toString,
       ) {
       | Some(batchSize) =>
+        // Slice of a sorted buffer preserves order
         let leftItems = fetchState.buffer->Js.Array2.sliceFrom(batchSize)
         getChainAfterBatchIfProgressed(
           ~chainBeforeBatch,
           ~batchSize,
-          ~fetchStateAfterBatch=fetchState->FetchState.updateInternal(~mutItems=leftItems),
+          ~fetchStateAfterBatch=fetchState->FetchState.updateInternal(
+            ~mutItems=leftItems,
+            ~isSorted=true,
+          ),
           ~progressBlockNumberAfterBatch,
         )
       // Skip not affected chains


### PR DESCRIPTION
## Summary
This PR optimizes the buffer merging logic in the fetch state management by replacing the inefficient concat+sort approach with a proper merge algorithm that runs in O(n+m) time instead of O((n+m)*log(n+m)).

## Key Changes

- **Added `mergeSortedBuffers` function**: Implements a standard two-pointer merge algorithm that combines two sorted arrays in linear time. The incoming array is sorted first to handle potentially unsorted source data.

- **Added `isSorted` parameter to `updateInternal`**: New optional parameter (defaults to `false`) that allows callers to indicate when `mutItems` is already sorted, skipping redundant sorting operations.

- **Optimized `handleQueryResult`**: Replaced `Array.concat(newItems)` followed by sort with `mergeSortedBuffers`, since the existing buffer is always sorted and incoming items are sorted within the merge function.

- **Updated `rollback` function**: Marked the result as pre-sorted since `Array.keep` preserves the order of a sorted buffer.

- **Updated `Batch.getProgressedChainsById`**: Marked sliced buffer as pre-sorted since slicing a sorted array preserves order.

## Implementation Details

- The merge algorithm uses three pointers (i, j, k) to track positions in the existing array, incoming array, and result array respectively
- Early returns handle edge cases where either array is empty
- The `compareBufferItem` comparator is reused for consistency with existing sorting logic
- Comments clarify when sorting can be skipped and why, improving code maintainability

https://claude.ai/code/session_016UNHyN6pHB5FEEdHkxtft7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized data fetch and query result processing through improved buffer handling and sorting logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->