### PR TITLE
Update README path from envio-rust to cli package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-packages/envio-rust/README.md
+packages/cli/README.md


### PR DESCRIPTION
## Summary
Updated the README.md file path reference to point to the CLI package instead of the envio-rust package.

## Changes
- Changed README reference from `packages/envio-rust/README.md` to `packages/cli/README.md`

## Details
This appears to be a documentation path correction, likely reflecting a restructuring or renaming of the package organization where the CLI functionality has been moved from or is now primarily located in the `packages/cli` directory.

https://claude.ai/code/session_011b5sA4gmdniTGjx4tbaE5f