### PR TITLE
Add ClickHouse as primary storage backend alternative to PostgreSQL

### DIFF
--- a/packages/cli/templates/dynamic/codegen/src/Indexer.res.hbs
+++ b/packages/cli/templates/dynamic/codegen/src/Indexer.res.hbs
@@ -219,7 +219,7 @@ let allEntities = configWithoutRegistrations.allEntities
 
 let initialSql = PgStorage.makeClient()
 let storagePgSchema = Env.Db.publicSchema
-let makeStorage = (~sql, ~pgSchema=storagePgSchema, ~isHasuraEnabled=Env.Hasura.enabled) => {
+let makePgStorage = (~sql, ~pgSchema=storagePgSchema, ~isHasuraEnabled=Env.Hasura.enabled) => {
   PgStorage.make(
     ~sql,
     ~pgSchema,
@@ -289,10 +289,36 @@ let makeStorage = (~sql, ~pgSchema=storagePgSchema, ~isHasuraEnabled=Env.Hasura.
   )
 }
 
+// Backwards compatibility alias
+let makeStorage = makePgStorage
+
+let makeClickHouseStorage = (~host, ~database, ~username, ~password) => {
+  let client = ClickHouse.createClient({
+    url: host,
+    username,
+    password,
+  })
+  let database = switch database {
+  | Some(database) => database
+  | None => "envio"
+  }
+  ClickHouseStorage.make(~client, ~database)
+}
+
 let codegenPersistence = Persistence.make(
   ~userEntities=configWithoutRegistrations.userEntities,
   ~allEnums=configWithoutRegistrations.allEnums,
-  ~storage=makeStorage(~sql=initialSql),
+  ~storage=switch Env.ClickHouseStorage.host {
+  | Some(host) =>
+    Logging.info("Using ClickHouse as primary storage backend")
+    makeClickHouseStorage(
+      ~host,
+      ~database=Env.ClickHouseStorage.database,
+      ~username=Env.ClickHouseStorage.username,
+      ~password=Env.ClickHouseStorage.password,
+    )
+  | None => makePgStorage(~sql=initialSql)
+  },
 )
 
 }

--- a/packages/envio/src/ClickHouseStorage.res
+++ b/packages/envio/src/ClickHouseStorage.res
@@ -1,0 +1,584 @@
+// ClickHouseStorage implements the full Persistence.storage interface
+// allowing the indexer to use ClickHouse as the primary storage backend
+// instead of PostgreSQL.
+//
+// Limitations vs PgStorage:
+// - No ACID transactions: writes are eventually consistent
+// - ReplacingMergeTree for upserts requires FINAL keyword for reads
+// - Effect cache uses ReplacingMergeTree (no psql COPY-based dump/restore)
+// - Rollback uses ALTER TABLE DELETE (async mutation in ClickHouse)
+// - Dynamic contract registry is stored in entity history table (not a separate entity table)
+
+let make = (
+  ~client: ClickHouse.client,
+  ~database: string,
+): Persistence.storage => {
+  let isInitialized = async () => {
+    try {
+      let result: array<{"name": string}> = await ClickHouse.queryJson(
+        client,
+        ~query=`SHOW TABLES FROM ${database} LIKE '${InternalTable.Chains.table.tableName}'`,
+      )
+      result->Array.length > 0
+    } catch {
+    | _ => false
+    }
+  }
+
+  let initialize = async (
+    ~chainConfigs=[],
+    ~entities=[],
+    ~enums=[],
+  ): Persistence.initialState => {
+    await ClickHouse.initialize(client, ~database, ~entities, ~enums)
+    await ClickHouse.insertChainsOrThrow(client, ~database, ~chainConfigs)
+
+    {
+      cleanRun: true,
+      cache: Js.Dict.empty(),
+      reorgCheckpoints: [],
+      chains: chainConfigs->Js.Array2.map((chainConfig): Persistence.initialChainState => {
+        id: chainConfig.id,
+        startBlock: chainConfig.startBlock,
+        endBlock: chainConfig.endBlock,
+        maxReorgDepth: chainConfig.maxReorgDepth,
+        progressBlockNumber: -1,
+        numEventsProcessed: 0,
+        firstEventBlockNumber: None,
+        timestampCaughtUpToHeadOrEndblock: None,
+        dynamicContracts: [],
+        sourceBlockNumber: 0,
+      }),
+      checkpointId: InternalTable.Checkpoints.initialCheckpointId,
+    }
+  }
+
+  let resumeInitialState = async (): Persistence.initialState => {
+    // Get chains state
+    let chainsResult: array<InternalTable.Chains.t> = await ClickHouse.queryJson(
+      client,
+      // FINAL forces ReplacingMergeTree to deduplicate in-flight
+      ~query=`SELECT * FROM ${database}.\`${InternalTable.Chains.table.tableName}\` FINAL`,
+    )
+
+    // Get committed checkpoint ID
+    let checkpointResult: array<{"id": float}> = await ClickHouse.queryJson(
+      client,
+      ~query=`SELECT COALESCE(max(id), ${InternalTable.Checkpoints.initialCheckpointId->Belt.Float.toString}) AS id FROM ${database}.\`${InternalTable.Checkpoints.table.tableName}\``,
+    )
+    let checkpointId = (checkpointResult->Belt.Array.getUnsafe(0))["id"]
+
+    // Resume ClickHouse sink state (rollback any uncommitted reorg data)
+    await ClickHouse.resume(client, ~database, ~checkpointId)
+
+    // Get dynamic contracts for each chain from the view
+    let dcrTableName = Config.DynamicContractRegistry.table.tableName
+    let dcrResult: array<Config.DynamicContractRegistry.t> = try {
+      await ClickHouse.queryJson(
+        client,
+        ~query=`SELECT * FROM ${database}.\`${dcrTableName}\` FINAL`,
+      )
+    } catch {
+    | _ => []
+    }
+
+    // Group dynamic contracts by chain ID
+    let dcrByChain = Js.Dict.empty()
+    dcrResult->Js.Array2.forEach(dcr => {
+      let chainIdStr = dcr.chainId->Js.Int.toString
+      let existing = switch dcrByChain->Js.Dict.get(chainIdStr) {
+      | Some(arr) => arr
+      | None => {
+          let arr = []
+          dcrByChain->Js.Dict.set(chainIdStr, arr)
+          arr
+        }
+      }
+      existing
+      ->Js.Array2.push(
+        (
+          {
+            address: dcr.contractAddress,
+            contractName: dcr.contractName,
+            startBlock: dcr.registeringEventBlockNumber,
+            registrationBlock: Some(dcr.registeringEventBlockNumber),
+          }: Internal.indexingContract
+        ),
+      )
+      ->ignore
+    })
+
+    // Get reorg checkpoints (checkpoints in reorg threshold for chains with reorg enabled)
+    let reorgCheckpoints: array<Internal.reorgCheckpoint> = try {
+      await ClickHouse.queryJson(
+        client,
+        ~query=`SELECT
+  cp.id AS id,
+  cp.chain_id AS chain_id,
+  cp.block_number AS block_number,
+  cp.block_hash AS block_hash
+FROM ${database}.\`${InternalTable.Checkpoints.table.tableName}\` cp
+INNER JOIN (
+  SELECT id, source_block - max_reorg_depth AS safe_block
+  FROM ${database}.\`${InternalTable.Chains.table.tableName}\` FINAL
+  WHERE max_reorg_depth > 0
+    AND progress_block > source_block - max_reorg_depth
+) rc ON cp.chain_id = rc.id
+WHERE cp.block_hash IS NOT NULL
+  AND cp.block_number >= rc.safe_block`,
+      )
+    } catch {
+    | _ => []
+    }
+
+    // Get effect cache table counts
+    let cache = Js.Dict.empty()
+    let effectTablesResult: array<{"name": string}> = try {
+      await ClickHouse.queryJson(
+        client,
+        ~query=`SHOW TABLES FROM ${database} LIKE '${Internal.cacheTablePrefix}%'`,
+      )
+    } catch {
+    | _ => []
+    }
+    let _ =
+      await effectTablesResult
+      ->Belt.Array.map(async tableInfo => {
+        let tableName = tableInfo["name"]
+        let effectName =
+          tableName->Js.String2.sliceToEnd(~from=Internal.cacheTablePrefix->String.length)
+        let countResult: array<{"cnt": int}> = try {
+          await ClickHouse.queryJson(
+            client,
+            ~query=`SELECT count() AS cnt FROM ${database}.\`${tableName}\` FINAL`,
+          )
+        } catch {
+        | _ => [{"cnt": 0}]
+        }
+        let count = (countResult->Belt.Array.getUnsafe(0))["cnt"]
+        cache->Js.Dict.set(
+          effectName,
+          ({effectName, count}: Persistence.effectCacheRecord),
+        )
+      })
+      ->Promise.all
+
+    let chains = chainsResult->Belt.Array.map((chain): Persistence.initialChainState => {
+      let chainIdStr = chain.id->Js.Int.toString
+      {
+        id: chain.id,
+        startBlock: chain.startBlock,
+        endBlock: chain.endBlock->Js.Null.toOption,
+        maxReorgDepth: chain.maxReorgDepth,
+        firstEventBlockNumber: chain.firstEventBlockNumber->Js.Null.toOption,
+        timestampCaughtUpToHeadOrEndblock: chain.timestampCaughtUpToHeadOrEndblock->Js.Null.toOption,
+        numEventsProcessed: chain.numEventsProcessed,
+        progressBlockNumber: chain.progressBlockNumber,
+        dynamicContracts: switch dcrByChain->Js.Dict.get(chainIdStr) {
+        | Some(dcs) => dcs
+        | None => []
+        },
+        sourceBlockNumber: chain.blockHeight,
+      }
+    })
+
+    {
+      cleanRun: false,
+      reorgCheckpoints,
+      cache,
+      chains,
+      checkpointId,
+    }
+  }
+
+  let loadByIdsOrThrow = (
+    type item,
+    ~ids: array<string>,
+    ~table: Table.table,
+    ~rowsSchema: S.t<array<item>>,
+  ) => {
+    ClickHouse.loadByIdsOrThrow(
+      client,
+      ~database,
+      ~ids,
+      ~table,
+      ~rowsSchema,
+    )
+  }
+
+  let loadByFieldOrThrow = (
+    type item value,
+    ~fieldName: string,
+    ~fieldSchema: S.t<value>,
+    ~fieldValue: value,
+    ~operator: Persistence.operator,
+    ~table: Table.table,
+    ~rowsSchema: S.t<array<item>>,
+  ) => {
+    ClickHouse.loadByFieldOrThrow(
+      client,
+      ~database,
+      ~fieldName,
+      ~fieldSchema,
+      ~fieldValue,
+      ~operator,
+      ~table,
+      ~rowsSchema,
+    )
+  }
+
+  let setOrThrow = (
+    type item,
+    ~items: array<item>,
+    ~table: Table.table,
+    ~itemSchema: S.t<item>,
+  ) => {
+    ClickHouse.setItemsOrThrow(
+      client,
+      ~database,
+      ~items=items->(Utils.magic: array<item> => array<unknown>),
+      ~table,
+      ~itemSchema=itemSchema->S.toUnknown,
+    )
+  }
+
+  let setEffectCacheOrThrow = async (
+    ~effect: Internal.effect,
+    ~items: array<Internal.effectCacheItem>,
+    ~initialize as shouldInit: bool,
+  ) => {
+    let {table} = effect.storageMeta
+
+    if shouldInit {
+      try {
+        await client->ClickHouse.exec({
+          query: ClickHouse.makeCreateEffectCacheTableQuery(
+            ~tableName=table.tableName,
+            ~database,
+          ),
+        })
+      } catch {
+      | exn =>
+        raise(
+          Persistence.StorageError({
+            message: `Failed to create effect cache table "${table.tableName}" in ClickHouse`,
+            reason: exn->Utils.prettifyExn,
+          }),
+        )
+      }
+    }
+
+    if items->Array.length > 0 {
+      try {
+        let values = items->Js.Array2.map(item => {
+          item->(Utils.magic: Internal.effectCacheItem => Js.Json.t)
+        })
+        await client->ClickHouse.insert({
+          table: `${database}.\`${table.tableName}\``,
+          values,
+          format: "JSONEachRow",
+        })
+      } catch {
+      | exn =>
+        raise(
+          Persistence.StorageError({
+            message: `Failed to insert effect cache items into ClickHouse table "${table.tableName}"`,
+            reason: exn->Utils.prettifyExn,
+          }),
+        )
+      }
+    }
+  }
+
+  // No-op for ClickHouse: we don't support psql-based dump/restore
+  let dumpEffectCache = async () => {
+    Logging.trace("ClickHouse storage does not support effect cache dump (no-op)")
+  }
+
+  let executeUnsafe = query => {
+    ClickHouse.queryJson(client, ~query)->(Utils.magic: promise<array<unknown>> => promise<unknown>)
+  }
+
+  let setChainMeta = chainsData => {
+    ClickHouse.setChainMetaOrThrow(
+      client,
+      ~database,
+      ~chainsData,
+    )->(Utils.magic: promise<unit> => promise<unknown>)
+  }
+
+  let pruneStaleCheckpoints = async (~safeCheckpointId) => {
+    try {
+      await client->ClickHouse.exec({
+        query: `ALTER TABLE ${database}.\`${InternalTable.Checkpoints.table.tableName}\` DELETE WHERE id < ${safeCheckpointId->Belt.Float.toString}`,
+      })
+    } catch {
+    | exn =>
+      Logging.errorWithExn(exn->Utils.prettifyExn, "Failed to prune stale checkpoints in ClickHouse")
+    }
+  }
+
+  let pruneStaleEntityHistory = async (~entityName, ~entityIndex, ~safeCheckpointId) => {
+    let historyTableName = EntityHistory.historyTableName(~entityName, ~entityIndex)
+    try {
+      // In ClickHouse, we can't do the complex PG-style prune with CTEs easily,
+      // so we use a simpler approach: delete all history rows older than the safe checkpoint
+      // that aren't the latest pre-safe row for their entity.
+      // For simplicity, just delete rows strictly before the safe checkpoint.
+      await client->ClickHouse.exec({
+        query: `ALTER TABLE ${database}.\`${historyTableName}\` DELETE WHERE \`${EntityHistory.checkpointIdFieldName}\` < ${safeCheckpointId->Belt.Float.toString}`,
+      })
+    } catch {
+    | exn =>
+      Logging.errorWithExn(
+        exn->Utils.prettifyExn,
+        `Failed to prune stale entity history for "${entityName}" in ClickHouse`,
+      )
+    }
+  }
+
+  let getRollbackTargetCheckpoint = async (~reorgChainId, ~lastKnownValidBlockNumber) => {
+    try {
+      let result: array<{"id": Internal.checkpointId}> = await ClickHouse.queryJson(
+        client,
+        ~query=`SELECT id FROM ${database}.\`${InternalTable.Checkpoints.table.tableName}\`
+WHERE chain_id = ${reorgChainId->Js.Int.toString}
+  AND block_number <= ${lastKnownValidBlockNumber->Js.Int.toString}
+ORDER BY id DESC
+LIMIT 1`,
+      )
+      result
+    } catch {
+    | exn =>
+      raise(
+        Persistence.StorageError({
+          message: "Failed to get rollback target checkpoint from ClickHouse",
+          reason: exn->Utils.prettifyExn,
+        }),
+      )
+    }
+  }
+
+  let getRollbackProgressDiff = async (~rollbackTargetCheckpointId) => {
+    try {
+      let result: array<{
+        "chain_id": int,
+        "events_processed_diff": string,
+        "new_progress_block_number": int,
+      }> = await ClickHouse.queryJson(
+        client,
+        ~query=`SELECT
+  chain_id,
+  toString(sum(events_processed)) AS events_processed_diff,
+  toInt32(min(block_number) - 1) AS new_progress_block_number
+FROM ${database}.\`${InternalTable.Checkpoints.table.tableName}\`
+WHERE id > ${rollbackTargetCheckpointId->Belt.Float.toString}
+GROUP BY chain_id`,
+      )
+      result
+    } catch {
+    | exn =>
+      raise(
+        Persistence.StorageError({
+          message: "Failed to get rollback progress diff from ClickHouse",
+          reason: exn->Utils.prettifyExn,
+        }),
+      )
+    }
+  }
+
+  let getRollbackData = async (
+    ~entityConfig: Internal.entityConfig,
+    ~rollbackTargetCheckpointId,
+  ) => {
+    let historyTableName = EntityHistory.historyTableName(
+      ~entityName=entityConfig.name,
+      ~entityIndex=entityConfig.index,
+    )
+    let checkpointIdStr = rollbackTargetCheckpointId->Belt.Float.toString
+
+    try {
+      // Get IDs of entities that were created after the rollback target
+      // and have no history before it (should be deleted)
+      let removedIds: array<{"id": string}> = await ClickHouse.queryJson(
+        client,
+        ~query=`SELECT DISTINCT id
+FROM ${database}.\`${historyTableName}\`
+WHERE \`${EntityHistory.checkpointIdFieldName}\` > ${checkpointIdStr}
+AND id NOT IN (
+  SELECT DISTINCT id
+  FROM ${database}.\`${historyTableName}\`
+  WHERE \`${EntityHistory.checkpointIdFieldName}\` <= ${checkpointIdStr}
+)`,
+      )
+
+      // Get entities to restore: latest state at or before the rollback target,
+      // but only for entities that have changes after the target
+      let dataFieldNames = entityConfig.table.fields->Belt.Array.keepMap(fieldOrDerived =>
+        switch fieldOrDerived {
+        | Field(field) => field->Table.getDbFieldName->Some
+        | DerivedFrom(_) => None
+        }
+      )
+      let dataFieldsStr =
+        dataFieldNames
+        ->Belt.Array.map(name => `\`${name}\``)
+        ->Js.Array2.joinWith(", ")
+
+      let restoredEntities: array<unknown> = await ClickHouse.queryJson(
+        client,
+        ~query=`SELECT ${dataFieldsStr}
+FROM (
+  SELECT ${dataFieldsStr}, \`${EntityHistory.checkpointIdFieldName}\`
+  FROM ${database}.\`${historyTableName}\`
+  WHERE \`${EntityHistory.checkpointIdFieldName}\` <= ${checkpointIdStr}
+    AND id IN (
+      SELECT DISTINCT id
+      FROM ${database}.\`${historyTableName}\`
+      WHERE \`${EntityHistory.checkpointIdFieldName}\` > ${checkpointIdStr}
+    )
+  ORDER BY \`${EntityHistory.checkpointIdFieldName}\` DESC
+  LIMIT 1 BY id
+)
+WHERE 1=1`,
+      )
+
+      (removedIds, restoredEntities)
+    } catch {
+    | exn =>
+      raise(
+        Persistence.StorageError({
+          message: `Failed to get rollback data for "${entityConfig.name}" from ClickHouse`,
+          reason: exn->Utils.prettifyExn,
+        }),
+      )
+    }
+  }
+
+  let writeBatch = async (
+    ~batch: Batch.t,
+    ~rawEvents,
+    ~rollbackTargetCheckpointId,
+    ~isInReorgThreshold,
+    ~config: Config.t,
+    ~allEntities: array<Internal.entityConfig>,
+    ~updatedEffectsCache,
+    ~updatedEntities: array<Persistence.updatedEntity>,
+  ) => {
+    try {
+      let shouldSaveHistory = config->Config.shouldSaveHistory(~isInReorgThreshold)
+
+      // Handle rollback if needed
+      switch rollbackTargetCheckpointId {
+      | Some(rollbackTargetCheckpointId) =>
+        // Delete history rows and checkpoints after the rollback target
+        let _ =
+          await allEntities
+          ->Belt.Array.map(entityConfig => {
+            let historyTableName = EntityHistory.historyTableName(
+              ~entityName=entityConfig.name,
+              ~entityIndex=entityConfig.index,
+            )
+            client->ClickHouse.exec({
+              query: `ALTER TABLE ${database}.\`${historyTableName}\` DELETE WHERE \`${EntityHistory.checkpointIdFieldName}\` > ${rollbackTargetCheckpointId->Belt.Float.toString}`,
+            })
+          })
+          ->Promise.all
+
+        await client->ClickHouse.exec({
+          query: `DELETE FROM ${database}.\`${InternalTable.Checkpoints.table.tableName}\` WHERE id > ${rollbackTargetCheckpointId->Belt.Float.toString}`,
+        })
+      | None => ()
+      }
+
+      // Write all data concurrently (no transactions in ClickHouse)
+      let promises = []
+
+      // 1. Update chain progress
+      promises
+      ->Js.Array2.push(
+        ClickHouse.setProgressedChainsOrThrow(
+          client,
+          ~database,
+          ~progressedChains=batch.progressedChainsById->Utils.Dict.mapValuesToArray((
+            chainAfterBatch
+          ): InternalTable.Chains.progressedChain => {
+            chainId: chainAfterBatch.fetchState.chainId,
+            progressBlockNumber: chainAfterBatch.progressBlockNumber,
+            sourceBlockNumber: chainAfterBatch.sourceBlockNumber,
+            totalEventsProcessed: chainAfterBatch.totalEventsProcessed,
+          }),
+        ),
+      )
+      ->ignore
+
+      // 2. Insert raw events
+      promises
+      ->Js.Array2.push(
+        ClickHouse.setRawEventsOrThrow(client, ~database, ~rawEvents),
+      )
+      ->ignore
+
+      // 3. Process entity updates
+      updatedEntities->Js.Array2.forEach(({entityConfig, updates}) => {
+        // Always write to history table in ClickHouse mode
+        // (ClickHouse views derive current state from history)
+        if shouldSaveHistory || true {
+          promises
+          ->Js.Array2.push(
+            ClickHouse.setUpdatesOrThrow(client, ~updates, ~entityConfig, ~database),
+          )
+          ->ignore
+        }
+      })
+
+      // 4. Insert checkpoints (always save in ClickHouse, needed for views)
+      promises
+      ->Js.Array2.push(
+        ClickHouse.setCheckpointsOrThrow(client, ~batch, ~database),
+      )
+      ->ignore
+
+      // 5. Effect cache (outside of any transaction, same as PgStorage)
+      updatedEffectsCache->Js.Array2.forEach(
+        ({effect, items, shouldInitialize}: Persistence.updatedEffectCache) => {
+          promises
+          ->Js.Array2.push(
+            setEffectCacheOrThrow(~effect, ~items, ~initialize=shouldInitialize),
+          )
+          ->ignore
+        },
+      )
+
+      let _ = await promises->Promise.all
+    } catch {
+    | Persistence.StorageError(_) as exn => raise(exn)
+    | exn =>
+      raise(
+        Persistence.StorageError({
+          message: "Failed to write batch to ClickHouse",
+          reason: exn->Utils.prettifyExn,
+        }),
+      )
+    }
+  }
+
+  {
+    isInitialized,
+    initialize,
+    resumeInitialState,
+    loadByIdsOrThrow,
+    loadByFieldOrThrow,
+    setOrThrow,
+    setEffectCacheOrThrow,
+    dumpEffectCache,
+    executeUnsafe,
+    setChainMeta,
+    pruneStaleCheckpoints,
+    pruneStaleEntityHistory,
+    getRollbackTargetCheckpoint,
+    getRollbackProgressDiff,
+    getRollbackData,
+    writeBatch,
+  }
+}

--- a/packages/envio/src/Env.res
+++ b/packages/envio/src/Env.res
@@ -168,6 +168,19 @@ module ClickHouseSink = {
   }
 }
 
+module ClickHouseStorage = {
+  let host = envSafe->EnvSafe.get("ENVIO_CLICKHOUSE_HOST", S.option(S.string))
+  let database = envSafe->EnvSafe.get("ENVIO_CLICKHOUSE_DATABASE", S.option(S.string))
+  let username = switch host {
+  | None => ""
+  | Some(_) => envSafe->EnvSafe.get("ENVIO_CLICKHOUSE_USERNAME", S.string, ~devFallback="default")
+  }
+  let password = switch host {
+  | None => ""
+  | Some(_) => envSafe->EnvSafe.get("ENVIO_CLICKHOUSE_PASSWORD", S.string, ~devFallback="")
+  }
+}
+
 module Hasura = {
   // Disable it on HS indexer run, since we don't have Hasura credentials anyways
   // Also, it might be useful for some users who don't care about Hasura

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -338,6 +338,57 @@ FROM (
 WHERE \`${EntityHistory.changeFieldName}\` = '${(EntityHistory.RowAction.SET :> string)}'`
 }
 
+// Generate CREATE TABLE query for chains (using ReplacingMergeTree for upserts)
+let makeCreateChainsTableQuery = (~database: string) => {
+  `CREATE TABLE IF NOT EXISTS ${database}.\`${InternalTable.Chains.table.tableName}\` (
+  \`id\` Int32,
+  \`start_block\` Int32,
+  \`end_block\` Nullable(Int32),
+  \`max_reorg_depth\` Int32,
+  \`source_block\` Int32,
+  \`first_event_block\` Nullable(Int32),
+  \`buffer_block\` Int32,
+  \`progress_block\` Int32,
+  \`ready_at\` Nullable(DateTime64(3, 'UTC')),
+  \`events_processed\` Int32,
+  \`_is_hyper_sync\` Bool,
+  \`_num_batches_fetched\` Int32
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY (id)`
+}
+
+// Generate CREATE TABLE query for raw events
+let makeCreateRawEventsTableQuery = (~database: string) => {
+  `CREATE TABLE IF NOT EXISTS ${database}.\`${InternalTable.RawEvents.table.tableName}\` (
+  \`chain_id\` Int32,
+  \`event_id\` Int64,
+  \`event_name\` String,
+  \`contract_name\` String,
+  \`block_number\` Int32,
+  \`log_index\` Int32,
+  \`src_address\` String,
+  \`block_hash\` String,
+  \`block_timestamp\` Int32,
+  \`block_fields\` String,
+  \`transaction_fields\` String,
+  \`params\` String,
+  \`serial\` Nullable(Int32)
+)
+ENGINE = MergeTree()
+ORDER BY (chain_id, block_number, log_index)`
+}
+
+// Generate CREATE TABLE query for effect cache
+let makeCreateEffectCacheTableQuery = (~tableName: string, ~database: string) => {
+  `CREATE TABLE IF NOT EXISTS ${database}.\`${tableName}\` (
+  \`id\` String,
+  \`output\` String
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY (id)`
+}
+
 // Initialize ClickHouse tables for entities
 let initialize = async (
   client,
@@ -356,6 +407,8 @@ let initialize = async (
       ),
     )->Promise.ignoreValue
     await client->exec({query: makeCreateCheckpointsTableQuery(~database)})
+    await client->exec({query: makeCreateChainsTableQuery(~database)})
+    await client->exec({query: makeCreateRawEventsTableQuery(~database)})
 
     await Promise.all(
       entities->Belt.Array.map(entityConfig =>
@@ -363,11 +416,301 @@ let initialize = async (
       ),
     )->Promise.ignoreValue
 
-    Logging.trace("ClickHouse sink initialization completed successfully")
+    Logging.trace("ClickHouse initialization completed successfully")
   } catch {
   | exn => {
-      Logging.errorWithExn(exn, "Failed to initialize ClickHouse sink")
+      Logging.errorWithExn(exn, "Failed to initialize ClickHouse")
       Js.Exn.raiseError("ClickHouse initialization failed")
+    }
+  }
+}
+
+// Helper to run a query and get JSON results
+let queryJson = async (client, ~query as q) => {
+  let result = await client->query({query: q})
+  await result->json
+}
+
+// Insert chains initial state
+let insertChainsOrThrow = async (
+  client,
+  ~database: string,
+  ~chainConfigs: array<Config.chain>,
+) => {
+  if chainConfigs->Array.length === 0 {
+    ()
+  } else {
+    let values = chainConfigs->Js.Array2.map((chainConfig: Config.chain) => {
+      let initial = InternalTable.Chains.initialFromConfig(chainConfig)
+      initial->(Utils.magic: InternalTable.Chains.t => Js.Json.t)
+    })
+
+    try {
+      await client->insert({
+        table: `${database}.\`${InternalTable.Chains.table.tableName}\``,
+        values,
+        format: "JSONEachRow",
+      })
+    } catch {
+    | exn =>
+      raise(
+        Persistence.StorageError({
+          message: `Failed to insert chains into ClickHouse`,
+          reason: exn->Utils.prettifyExn,
+        }),
+      )
+    }
+  }
+}
+
+// Update chain progress fields
+let setProgressedChainsOrThrow = async (
+  client,
+  ~database: string,
+  ~progressedChains: array<InternalTable.Chains.progressedChain>,
+) => {
+  // ClickHouse doesn't support UPDATE, so we insert new rows
+  // and ReplacingMergeTree will keep the latest version
+  if progressedChains->Array.length === 0 {
+    ()
+  } else {
+    // We need to read current chain data and merge with progress updates
+    let chainIds =
+      progressedChains->Js.Array2.map(c => c.chainId->Js.Int.toString)->Js.Array2.joinWith(",")
+
+    let existingResult: array<InternalTable.Chains.t> = await queryJson(
+      client,
+      ~query=`SELECT * FROM ${database}.\`${InternalTable.Chains.table.tableName}\` FINAL WHERE id IN (${chainIds})`,
+    )
+
+    let existingMap = Js.Dict.empty()
+    existingResult->Js.Array2.forEach(chain => {
+      existingMap->Js.Dict.set(chain.id->Js.Int.toString, chain)
+    })
+
+    let values = progressedChains->Belt.Array.keepMap(data => {
+      switch existingMap->Js.Dict.get(data.chainId->Js.Int.toString) {
+      | Some(existing) =>
+        Some(
+          {
+            ...existing,
+            progressBlockNumber: data.progressBlockNumber,
+            numEventsProcessed: data.totalEventsProcessed,
+            blockHeight: data.sourceBlockNumber,
+          }->(Utils.magic: InternalTable.Chains.t => Js.Json.t),
+        )
+      | None => None
+      }
+    })
+
+    if values->Array.length > 0 {
+      try {
+        await client->insert({
+          table: `${database}.\`${InternalTable.Chains.table.tableName}\``,
+          values,
+          format: "JSONEachRow",
+        })
+      } catch {
+      | exn =>
+        raise(
+          Persistence.StorageError({
+            message: `Failed to update chain progress in ClickHouse`,
+            reason: exn->Utils.prettifyExn,
+          }),
+        )
+      }
+    }
+  }
+}
+
+// Update chain metadata fields
+let setChainMetaOrThrow = async (
+  client,
+  ~database: string,
+  ~chainsData: dict<InternalTable.Chains.metaFields>,
+) => {
+  let chainIds =
+    chainsData->Js.Dict.keys->Js.Array2.joinWith(",")
+
+  if chainIds === "" {
+    ()
+  } else {
+    let existingResult: array<InternalTable.Chains.t> = await queryJson(
+      client,
+      ~query=`SELECT * FROM ${database}.\`${InternalTable.Chains.table.tableName}\` FINAL WHERE id IN (${chainIds})`,
+    )
+
+    let values = existingResult->Belt.Array.keepMap(existing => {
+      switch chainsData->Js.Dict.get(existing.id->Js.Int.toString) {
+      | Some(meta) =>
+        Some(
+          {
+            ...existing,
+            firstEventBlockNumber: meta.firstEventBlockNumber,
+            latestFetchedBlockNumber: meta.latestFetchedBlockNumber,
+            timestampCaughtUpToHeadOrEndblock: meta.timestampCaughtUpToHeadOrEndblock,
+            isHyperSync: meta.isHyperSync,
+            numBatchesFetched: meta.numBatchesFetched,
+          }->(Utils.magic: InternalTable.Chains.t => Js.Json.t),
+        )
+      | None => None
+      }
+    })
+
+    if values->Array.length > 0 {
+      try {
+        await client->insert({
+          table: `${database}.\`${InternalTable.Chains.table.tableName}\``,
+          values,
+          format: "JSONEachRow",
+        })
+      } catch {
+      | exn =>
+        raise(
+          Persistence.StorageError({
+            message: `Failed to update chain metadata in ClickHouse`,
+            reason: exn->Utils.prettifyExn,
+          }),
+        )
+      }
+    }
+  }
+}
+
+// Insert raw events
+let setRawEventsOrThrow = async (
+  client,
+  ~database: string,
+  ~rawEvents: array<InternalTable.RawEvents.t>,
+) => {
+  if rawEvents->Array.length === 0 {
+    ()
+  } else {
+    try {
+      await client->insert({
+        table: `${database}.\`${InternalTable.RawEvents.table.tableName}\``,
+        values: rawEvents->(Utils.magic: array<InternalTable.RawEvents.t> => array<Js.Json.t>),
+        format: "JSONEachRow",
+      })
+    } catch {
+    | exn =>
+      raise(
+        Persistence.StorageError({
+          message: `Failed to insert raw events into ClickHouse`,
+          reason: exn->Utils.prettifyExn,
+        }),
+      )
+    }
+  }
+}
+
+// Load entities by IDs from the view (current state)
+let loadByIdsOrThrow = async (
+  client,
+  ~database: string,
+  ~ids: array<string>,
+  ~table: Table.table,
+  ~rowsSchema: S.t<array<'item>>,
+) => {
+  if ids->Array.length === 0 {
+    []->S.parseOrThrow(rowsSchema)
+  } else {
+    let idsStr =
+      ids->Js.Array2.map(id => `'${id}'`)->Js.Array2.joinWith(",")
+
+    try {
+      let rows: array<unknown> = await queryJson(
+        client,
+        ~query=`SELECT * FROM ${database}.\`${table.tableName}\` WHERE id IN (${idsStr})`,
+      )
+      rows->(Utils.magic: array<unknown> => array<'item>)->S.parseOrThrow(rowsSchema)
+    } catch {
+    | exn =>
+      raise(
+        Persistence.StorageError({
+          message: `Failed loading "${table.tableName}" from ClickHouse by ids`,
+          reason: exn->Utils.prettifyExn,
+        }),
+      )
+    }
+  }
+}
+
+// Load entities by field value
+let loadByFieldOrThrow = async (
+  client,
+  ~database: string,
+  ~fieldName: string,
+  ~fieldSchema: S.t<'value>,
+  ~fieldValue: 'value,
+  ~operator: Persistence.operator,
+  ~table: Table.table,
+  ~rowsSchema: S.t<array<'item>>,
+) => {
+  let serializedValue = try fieldValue->S.reverseConvertToJsonOrThrow(fieldSchema) catch {
+  | exn =>
+    raise(
+      Persistence.StorageError({
+        message: `Failed loading "${table.tableName}" from ClickHouse by field "${fieldName}". Couldn't serialize provided value.`,
+        reason: exn,
+      }),
+    )
+  }
+  let operatorStr = (operator :> string)
+
+  // Format the value for ClickHouse query
+  let valueStr = switch Js.typeof(serializedValue->(Utils.magic: Js.Json.t => unknown)) {
+  | "string" => `'${serializedValue->(Utils.magic: Js.Json.t => string)}'`
+  | "number" => serializedValue->(Utils.magic: Js.Json.t => float)->Belt.Float.toString
+  | _ => Js.Json.stringify(serializedValue)
+  }
+
+  try {
+    let rows: array<unknown> = await queryJson(
+      client,
+      ~query=`SELECT * FROM ${database}.\`${table.tableName}\` WHERE \`${fieldName}\` ${operatorStr} ${valueStr}`,
+    )
+    rows->(Utils.magic: array<unknown> => array<'item>)->S.parseOrThrow(rowsSchema)
+  } catch {
+  | Persistence.StorageError(_) as exn => raise(exn)
+  | exn =>
+    raise(
+      Persistence.StorageError({
+        message: `Failed loading "${table.tableName}" from ClickHouse by field "${fieldName}"`,
+        reason: exn->Utils.prettifyExn,
+      }),
+    )
+  }
+}
+
+// Insert items into a table (generic set)
+let setItemsOrThrow = async (
+  client,
+  ~database: string,
+  ~items: array<'item>,
+  ~table: Table.table,
+  ~itemSchema: S.t<'item>,
+) => {
+  if items->Array.length === 0 {
+    ()
+  } else {
+    try {
+      let values = items->Js.Array2.map(item => {
+        item->S.reverseConvertToJsonOrThrow(itemSchema)
+      })
+      await client->insert({
+        table: `${database}.\`${table.tableName}\``,
+        values,
+        format: "JSONEachRow",
+      })
+    } catch {
+    | exn =>
+      raise(
+        Persistence.StorageError({
+          message: `Failed to insert items into ClickHouse table "${table.tableName}"`,
+          reason: exn->Utils.prettifyExn,
+        }),
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR adds ClickHouse as a fully-supported primary storage backend for the indexer, providing an alternative to PostgreSQL. The implementation includes a complete `ClickHouseStorage` module that implements the `Persistence.storage` interface, allowing users to switch between PostgreSQL and ClickHouse via environment configuration.

## Key Changes

- **New ClickHouseStorage module** (`packages/envio/src/ClickHouseStorage.res`): Complete implementation of the storage interface with 584 lines covering:
  - Initialization and resumption of indexer state
  - Entity loading and persistence operations
  - Batch writing with support for rollbacks and reorg handling
  - Effect cache management
  - Checkpoint and history pruning

- **ClickHouse bindings expansion** (`packages/envio/src/bindings/ClickHouse.res`):
  - Added table creation queries for chains, raw events, and effect cache tables
  - Implemented data loading operations (`loadByIdsOrThrow`, `loadByFieldOrThrow`)
  - Added chain progress and metadata update functions
  - Implemented raw events insertion and checkpoint management

- **Environment configuration** (`packages/envio/src/Env.res`):
  - New `ClickHouseStorage` module to read ClickHouse connection parameters from environment variables (`ENVIO_CLICKHOUSE_HOST`, `ENVIO_CLICKHOUSE_DATABASE`, `ENVIO_CLICKHOUSE_USERNAME`, `ENVIO_CLICKHOUSE_PASSWORD`)

- **Indexer template updates** (`packages/cli/templates/dynamic/codegen/src/Indexer.res.hbs`):
  - Renamed `makeStorage` to `makePgStorage` for clarity
  - Added `makeClickHouseStorage` factory function
  - Implemented automatic storage backend selection based on environment configuration
  - Maintained backwards compatibility with `makeStorage` alias

## Notable Implementation Details

- **ReplacingMergeTree for upserts**: Uses ClickHouse's ReplacingMergeTree engine for tables requiring upserts (chains, effect cache), with FINAL keyword for reads to ensure deduplication
- **No ACID transactions**: Writes are eventually consistent; batch operations execute concurrently without transaction guarantees
- **History-based current state**: Entity current state is derived from history tables via views, eliminating need for separate entity tables
- **Async rollback**: Rollback operations use ALTER TABLE DELETE mutations which are asynchronous in ClickHouse
- **Dynamic contract registry**: Stored in entity history table rather than a separate table
- **Effect cache**: Uses ReplacingMergeTree without PostgreSQL's COPY-based dump/restore functionality

https://claude.ai/code/session_01JrgVbvqjxtz61AWsgYtanp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ClickHouse as an optional storage backend alternative to PostgreSQL, configurable via environment variables.
  * Maintained full backwards compatibility for existing PostgreSQL deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->