### PR TITLE
Improve Docker network/volume management with race condition handling

### DIFF
--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -626,10 +626,24 @@ pub async fn down() -> anyhow::Result<()> {
         stop_and_remove(&docker, PG_CONTAINER),
     );
 
-    let _ = tokio::join!(
+    let (vol_res, net_res) = tokio::join!(
         docker.remove_volume(VOLUME, None::<bollard::query_parameters::RemoveVolumeOptions>),
         docker.remove_network(NETWORK),
     );
+
+    let mut failed = false;
+    if let Err(e) = vol_res {
+        eprintln!("Failed to remove volume {VOLUME}: {e}");
+        failed = true;
+    }
+    if let Err(e) = net_res {
+        eprintln!("Failed to remove network {NETWORK}: {e}");
+        failed = true;
+    }
+
+    if failed {
+        anyhow::bail!("Environment cleanup finished with errors (see above)");
+    }
 
     println!("Environment cleaned up");
 


### PR DESCRIPTION
## Summary
This PR improves the reliability of Docker environment setup and teardown by adding race condition handling for network creation and better error reporting for resource cleanup.

## Key Changes
- **Network creation race condition handling**: Modified `ensure_network()` to tolerate 409 "already exists" errors that can occur when parallel pipelines both miss the inspect check and one loses the create race. The function now explicitly handles this case instead of treating it as a fatal error.

- **Enhanced error reporting in cleanup**: Updated the `down()` function to capture and report individual errors from volume and network removal operations instead of silently ignoring them. Errors are now printed to stderr and the function returns a failure if any cleanup operation fails.

- **Added clarifying comments**: Included comments explaining the fast path optimization in `ensure_network()` and the race condition tolerance logic.

## Implementation Details
- The network creation now uses a match statement to distinguish between successful creation, benign 409 conflicts (which are expected in concurrent scenarios), and actual errors
- The cleanup function now properly propagates cleanup failures to the caller while still attempting all cleanup operations
- Error messages provide context about which resource failed to be removed

https://claude.ai/code/session_01VoHFwyvdo4HDhff9DS4phT