### PR TITLE
Add error handling for server startup failures

### DIFF
--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -243,7 +243,20 @@ let startServer = (~getState, ~ctx: Ctx.t, ~isDevelopmentMode: bool) => {
       ->Promise.thenResolve(metrics => res->endWithData(metrics))
   })
 
-  let _ = app->listen(Env.serverPort)
+  let server = app->listen(Env.serverPort)
+  server->Express.onError(err => {
+    let code = (err->(Utils.magic: Js.Exn.t => {..}))["code"]
+    if code === "EADDRINUSE" {
+      Logging.error(
+        `Port ${Env.serverPort->Int.toString} is already in use. To fix this either:` ++
+        `\n  1. Kill the process using the port: lsof -ti :${Env.serverPort->Int.toString} | xargs kill -9` ++
+        `\n  2. Use a different port by setting the ENVIO_INDEXER_PORT environment variable: ENVIO_INDEXER_PORT=9899 envio start`,
+      )
+    } else {
+      Logging.errorWithExn(err, "Failed to start indexer server")
+    }
+    NodeJs.process->NodeJs.exitWithCode(Failure)
+  })
 }
 
 type args = {@as("tui-off") tuiOff?: bool}

--- a/packages/envio/src/bindings/Express.res
+++ b/packages/envio/src/bindings/Express.res
@@ -28,6 +28,7 @@ type middleware = (req, res, unit => unit) => unit
 type server
 
 @send external listen: (app, int) => server = "listen"
+@send external onError: (server, @as("error") _, Js.Exn.t => unit) => unit = "on"
 
 // res methods
 @send external sendStatus: (res, int) => unit = "sendStatus"


### PR DESCRIPTION
## Summary
Added error handling for the indexer server startup to gracefully handle and report port conflicts and other server initialization errors.

## Key Changes
- Modified server initialization in `Main.res` to capture the server instance and attach an error handler
- Added `onError` binding in `Express.res` to expose Express server error event handling
- Implemented specific error handling for `EADDRINUSE` errors with helpful troubleshooting instructions
- Generic error logging for other server startup failures
- Process exits with failure code when server startup errors occur

## Implementation Details
- The error handler checks for the `EADDRINUSE` error code and provides users with two solutions: killing the process using the port or setting the `ENVIO_INDEXER_PORT` environment variable
- Uses unsafe type coercion (`Utils.magic`) to access the error code property from the exception object
- Leverages existing `Logging.error` and `Logging.errorWithExn` utilities for consistent error reporting

https://claude.ai/code/session_015bJE957VaNtnX45R8vwc7Y