### PR TITLE
Rename ENVIO_PG_PUBLIC_SCHEMA to ENVIO_PG_SCHEMA with fallback

### DIFF
--- a/packages/cli/src/persisted_state/db.rs
+++ b/packages/cli/src/persisted_state/db.rs
@@ -28,7 +28,8 @@ impl PersistedState {
     async fn upsert_to_db_with_pool(&self, pool: &PgPool) -> Result<PgQueryResult, sqlx::Error> {
         let mut env_state = EnvState::new(&std::env::current_dir().unwrap_or_default());
         let public_schema = env_state
-            .var("ENVIO_PG_PUBLIC_SCHEMA")
+            .var("ENVIO_PG_SCHEMA")
+            .or_else(|| env_state.var("ENVIO_PG_PUBLIC_SCHEMA"))
             .unwrap_or_else(|| "public".to_string());
 
         sqlx::query(&format!(
@@ -75,7 +76,8 @@ impl PersistedStateExists {
     ) -> Result<PersistedStateExists, sqlx::Error> {
         let mut env_state = EnvState::new(&std::env::current_dir().unwrap_or_default());
         let public_schema = env_state
-            .var("ENVIO_PG_PUBLIC_SCHEMA")
+            .var("ENVIO_PG_SCHEMA")
+            .or_else(|| env_state.var("ENVIO_PG_PUBLIC_SCHEMA"))
             .unwrap_or_else(|| "public".to_string());
 
         let val = sqlx::query_as::<_, PersistedState>(&format!(

--- a/packages/envio/src/Env.res
+++ b/packages/envio/src/Env.res
@@ -144,7 +144,13 @@ module Db = {
     },
   )
   let database = envSafe->EnvSafe.get("ENVIO_PG_DATABASE", S.string, ~devFallback="envio-dev")
-  let publicSchema = envSafe->EnvSafe.get("ENVIO_PG_PUBLIC_SCHEMA", S.string, ~fallback="public")
+  let publicSchema = envSafe->EnvSafe.get(
+    "ENVIO_PG_SCHEMA",
+    S.string,
+    ~fallback={
+      envSafe->EnvSafe.get("ENVIO_PG_PUBLIC_SCHEMA", S.string, ~fallback="public")
+    },
+  )
   let ssl = envSafe->EnvSafe.get(
     "ENVIO_PG_SSL_MODE",
     Postgres.sslOptionsSchema,

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1226,7 +1226,7 @@ let make = (
         )
     ) {
       Js.Exn.raiseError(
-        `Cannot run Envio migrations on PostgreSQL schema "${pgSchema}" because it contains non-Envio tables. Running migrations would delete all data in this schema.\n\nTo resolve this:\n1. If you want to use this schema, first backup any important data, then drop it with: "pnpm envio local db-migrate down"\n2. Or specify a different schema name by setting the "ENVIO_PG_PUBLIC_SCHEMA" environment variable\n3. Or manually drop the schema in your database if you're certain the data is not needed.`,
+        `Cannot run Envio migrations on PostgreSQL schema "${pgSchema}" because it contains non-Envio tables. Running migrations would delete all data in this schema.\n\nTo resolve this:\n1. If you want to use this schema, first backup any important data, then drop it with: "pnpm envio local db-migrate down"\n2. Or specify a different schema name by setting the "ENVIO_PG_SCHEMA" environment variable\n3. Or manually drop the schema in your database if you're certain the data is not needed.`,
       )
     }
 


### PR DESCRIPTION
## Summary
This PR renames the PostgreSQL schema environment variable from `ENVIO_PG_PUBLIC_SCHEMA` to `ENVIO_PG_SCHEMA` while maintaining backward compatibility through a fallback mechanism.

## Key Changes
- **Environment variable rename**: Changed primary environment variable from `ENVIO_PG_PUBLIC_SCHEMA` to `ENVIO_PG_SCHEMA` across all packages
- **Backward compatibility**: Implemented fallback logic to check `ENVIO_PG_PUBLIC_SCHEMA` if `ENVIO_PG_SCHEMA` is not set, ensuring existing configurations continue to work
- **Updated error messages**: Updated user-facing error message in PgStorage to reference the new environment variable name
- **Consistent implementation**: Applied the same pattern across ReScript (Env.res) and Rust (db.rs) codebases

## Implementation Details
- In `packages/envio/src/Env.res`: Modified the `publicSchema` configuration to first check `ENVIO_PG_SCHEMA`, then fall back to `ENVIO_PG_PUBLIC_SCHEMA` with a default of "public"
- In `packages/cli/src/persisted_state/db.rs`: Updated two locations where the schema is retrieved to use the same fallback pattern
- In `packages/envio/src/PgStorage.res`: Updated the error message to guide users to set `ENVIO_PG_SCHEMA` instead of the deprecated variable name

https://claude.ai/code/session_017AjCTxHGfGic1FfyQaWCDe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ENVIO_PG_SCHEMA` as the primary environment variable for PostgreSQL schema configuration, with automatic fallback to the previous `ENVIO_PG_PUBLIC_SCHEMA` variable for backward compatibility. Default schema remains "public" when neither variable is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->