### PR TITLE
Add retry option to flaky Throttler test

### DIFF
--- a/scenarios/test_codegen/test/lib_tests/Throttler_test.res
+++ b/scenarios/test_codegen/test/lib_tests/Throttler_test.res
@@ -29,7 +29,7 @@ describe("Throttler", () => {
     )
   })
 
-  Async.it("Does not continuously increase schedule time", async t => {
+  Async.itWithOptions("Does not continuously increase schedule time", {retry: 3}, async t => {
     let throttler = Throttler.make(~intervalMillis=20, ~logger=Logging.getLogger())
     let actionsCalled = []
     throttler->Throttler.schedule(async () => actionsCalled->Js.Array2.push(1)->ignore)


### PR DESCRIPTION
## Summary
Updated a flaky test in the Throttler test suite to use the `itWithOptions` function with a retry configuration, improving test reliability.

## Key Changes
- Changed `Async.it` to `Async.itWithOptions` for the "Does not continuously increase schedule time" test
- Added `{retry: 3}` option to allow the test to retry up to 3 times on failure
- This addresses intermittent test failures without modifying the test logic itself

## Details
The test was experiencing occasional failures, likely due to timing-sensitive assertions in the throttler scheduling behavior. By enabling retries at the test framework level, transient failures are automatically handled while still catching genuine bugs that consistently fail.

https://claude.ai/code/session_019EsgwvJKKEAQ9LYGYhkH78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability with automatic retry configuration for critical test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->