### PR TITLE
Add .pnpm-store to .gitignore across all packages

### DIFF
--- a/packages/cli/templates/static/blank_template/shared/.gitignore
+++ b/packages/cli/templates/static/blank_template/shared/.gitignore
@@ -34,3 +34,4 @@ logs
 *.gen.ts
 build
 .env
+.pnpm-store

--- a/packages/cli/templates/static/codegen/.gitignore
+++ b/packages/cli/templates/static/codegen/.gitignore
@@ -30,3 +30,4 @@
 *.res.mjs
 logs/*
 *BenchmarkCache.json
+.pnpm-store

--- a/packages/cli/templates/static/erc20_template/shared/.gitignore
+++ b/packages/cli/templates/static/erc20_template/shared/.gitignore
@@ -33,3 +33,4 @@ cache
 *.res.mjs
 generated
 .env
+.pnpm-store

--- a/packages/cli/templates/static/factory_template/shared/.gitignore
+++ b/packages/cli/templates/static/factory_template/shared/.gitignore
@@ -32,3 +32,4 @@ logs
 *.gen.ts
 build
 .env
+.pnpm-store

--- a/packages/cli/templates/static/greeter_template/shared/.gitignore
+++ b/packages/cli/templates/static/greeter_template/shared/.gitignore
@@ -33,3 +33,4 @@ build
 *.res.mjs
 generated
 .env
+.pnpm-store

--- a/packages/cli/templates/static/greeteronfuel_template/shared/.gitignore
+++ b/packages/cli/templates/static/greeteronfuel_template/shared/.gitignore
@@ -33,3 +33,4 @@ build
 *.res.mjs
 generated
 .env
+.pnpm-store

--- a/packages/cli/templates/static/svmblock_template/typescript/.gitignore
+++ b/packages/cli/templates/static/svmblock_template/typescript/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 generated
 .env
+.pnpm-store

--- a/packages/envio/.gitignore
+++ b/packages/envio/.gitignore
@@ -133,3 +133,4 @@ dist
 lib
 *.res.js
 *.res.mjs
+.pnpm-store

--- a/scenarios/fuel_test/.gitignore
+++ b/scenarios/fuel_test/.gitignore
@@ -34,3 +34,4 @@ build
 *.bs.js
 generated
 .env
+.pnpm-store

--- a/scenarios/fuel_test/contracts/all-events/.gitignore
+++ b/scenarios/fuel_test/contracts/all-events/.gitignore
@@ -1,2 +1,3 @@
 out
 target
+.pnpm-store

--- a/scenarios/fuel_test/contracts/interaction-tools/.gitignore
+++ b/scenarios/fuel_test/contracts/interaction-tools/.gitignore
@@ -1,2 +1,3 @@
 target
 .env
+.pnpm-store

--- a/scenarios/fuel_test/contracts/ts-interaction-tools/.gitignore
+++ b/scenarios/fuel_test/contracts/ts-interaction-tools/.gitignore
@@ -1,2 +1,3 @@
 .env
 src/contract
+.pnpm-store

--- a/scenarios/helpers/.gitignore
+++ b/scenarios/helpers/.gitignore
@@ -6,3 +6,4 @@
 *.bs.js
 *.res.js
 *.res.mjs
+.pnpm-store

--- a/scenarios/test_codegen/.gitignore
+++ b/scenarios/test_codegen/.gitignore
@@ -36,3 +36,4 @@ logs
 build
 .nyc_output
 .env
+.pnpm-store


### PR DESCRIPTION
## Summary
This PR adds `.pnpm-store` to the `.gitignore` files across the repository to prevent pnpm's local store directory from being committed to version control.

## Changes
- Added `.pnpm-store` entry to `.gitignore` in the following locations:
  - `packages/envio/`
  - `packages/cli/templates/static/` (all template variants: blank_template, codegen, erc20_template, factory_template, greeter_template, greeteronfuel_template, svmblock_template)
  - `scenarios/fuel_test/` (root and contract subdirectories: all-events, interaction-tools, ts-interaction-tools)
  - `scenarios/helpers/`
  - `scenarios/test_codegen/`

## Details
The `.pnpm-store` directory is a local cache directory created by pnpm package manager and should not be tracked in version control. This change ensures consistency across all packages and templates in the monorepo by excluding this directory from git tracking.

https://claude.ai/code/session_01QGFLuHCFdXRoTBgAUMSpxC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore configuration across CLI templates, sample scenarios, and test directories to exclude pnpm package manager store artifacts from version control. Uniform application across blank, codegen, ERC20, factory, greeter templates and various test scenarios ensures repositories remain clean by preventing accidental cache file tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->