### PR TITLE
Add regression test for multi-chain reorg→rollback→reorg loop

### DIFF
--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -2363,6 +2363,181 @@ Sorted by timestamp and chain id`,
     },
   )
 
+  Async.it(
+    "Multi-chain reorg→rollback→reorg loop: reorg chain repeatedly reorgs while other chain's events get rolled back each time (negative counter regression)",
+    async t => {
+      // Reproduces the bug where:
+      // 1. Both chains process events, then chain 1337 detects reorg → rollback to block 100
+      // 2. After rollback, chain 1337 detects ANOTHER reorg at block 100 → rollback to block 100 again
+      // 3. Second rollback subtracts events that were already rolled back → counter goes negative
+      // The root cause: only the reorg chain's counter is restored (line 412-424 in GlobalState),
+      // but the non-reorg chain's counter stays at 0 while DB still has the old checkpoints.
+      let sourceMock1337 = Mock.Source.make(
+        [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+        ~chain=#1337,
+      )
+      let sourceMock100 = Mock.Source.make(
+        [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+        ~chain=#100,
+      )
+      let indexerMock = await Mock.Indexer.make(
+        ~chains=[
+          {
+            chain: #1337,
+            sourceConfig: Config.CustomSources([sourceMock1337.source]),
+          },
+          {
+            chain: #100,
+            sourceConfig: Config.CustomSources([sourceMock100.source]),
+          },
+        ],
+      )
+      await Utils.delay(0)
+
+      // Both chains enter reorg threshold (blocks 1-100 fetched, knownHeight=300)
+      let _ = await Promise.all2((
+        Mock.Helper.initialEnterReorgThreshold(~t, ~indexerMock, ~sourceMock=sourceMock1337),
+        Mock.Helper.initialEnterReorgThreshold(~t, ~indexerMock, ~sourceMock=sourceMock100),
+      ))
+
+      // Both chains process events at blocks 102-103
+      sourceMock100.resolveGetItemsOrThrow(
+        [
+          {
+            blockNumber: 102,
+            logIndex: 0,
+            handler: async ({context}) => {
+              context.simpleEntity.set({id: "1", value: "value-1"})
+            },
+          },
+          {
+            blockNumber: 103,
+            logIndex: 0,
+            handler: async ({context}) => {
+              context.simpleEntity.set({id: "2", value: "value-2"})
+            },
+          },
+        ],
+        ~latestFetchedBlockNumber=103,
+        ~resolveAt=#first,
+      )
+      sourceMock1337.resolveGetItemsOrThrow(
+        [
+          {
+            blockNumber: 102,
+            logIndex: 0,
+            handler: async ({context}) => {
+              context.simpleEntity.set({id: "3", value: "value-3"})
+            },
+          },
+        ],
+        ~latestFetchedBlockNumber=103,
+        ~resolveAt=#first,
+      )
+      await indexerMock.getBatchWritePromise()
+
+      t.expect(
+        {
+          let metrics = await indexerMock.metric("envio_progress_events")
+          metrics->Js.Array2.sortInPlaceWith((a, b) => a.value->Obj.magic - b.value->Obj.magic)
+        },
+        ~message="Events count before rollback",
+      ).toEqual(
+        [
+          {value: "1", labels: Js.Dict.fromArray([("chainId", "1337")])},
+          {value: "2", labels: Js.Dict.fromArray([("chainId", "100")])},
+        ],
+      )
+
+      // === FIRST REORG on chain 1337 at block 103 ===
+      sourceMock1337.resolveGetItemsOrThrow(
+        [],
+        ~prevRangeLastBlock={
+          blockNumber: 103,
+          blockHash: "0x103-reorged",
+        },
+        ~resolveAt=#first,
+      )
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      // getBlockHashes called with [100] (only stored block in threshold below 103)
+      // Block 100 hash matches → rollback target = 100
+      sourceMock1337.resolveGetBlockHashes([
+        {blockNumber: 100, blockHash: "0x100", blockTimestamp: 100},
+      ])
+
+      // Clean up pending calls from before rollback
+      sourceMock100.resolveGetItemsOrThrow([], ~resolveAt=#all)
+
+      await indexerMock.getRollbackReadyPromise()
+
+      t.expect(
+        {
+          let metrics = await indexerMock.metric("envio_progress_events")
+          metrics->Js.Array2.sortInPlaceWith((a, b) => a.value->Obj.magic - b.value->Obj.magic)
+        },
+        ~message="After first rollback: all events should be rolled back to 0",
+      ).toEqual(
+        [
+          {value: "0", labels: Js.Dict.fromArray([("chainId", "100")])},
+          {value: "0", labels: Js.Dict.fromArray([("chainId", "1337")])},
+        ],
+      )
+
+      // === SECOND REORG on chain 1337 at block 100 ===
+      // After first rollback, stored blocks: {0: "0x0", 100: "0x100"}
+      // Chain 1337 re-fetches from block 101, prevRangeLastBlock auto = {100, "0x100"}
+      // We override to trigger reorg: block 100 hash changed
+      // No getBlockHashes call needed: getThresholdBlockNumbersBelowBlock(~blockNumber=100) = []
+      // so getHighestBlockBelowThreshold = 300 - 200 = 100 is used directly.
+      // Wait for the SetRollbackState tasks (NextQuery, ProcessEventBatch) to be scheduled
+      await Utils.delay(0)
+
+      sourceMock1337.resolveGetItemsOrThrow(
+        [],
+        ~prevRangeLastBlock={
+          blockNumber: 100,
+          blockHash: "0x100-reorged",
+        },
+        ~resolveAt=#first,
+      )
+
+      // Clean up any pending calls for chain 100
+      sourceMock100.resolveGetItemsOrThrow([], ~resolveAt=#all)
+
+      // Allow microtask queue to process the fetch response callbacks,
+      // which dispatch ValidatePartitionQueryResponse and transition
+      // the state from RollbackReady → ReorgDetected.
+      // Without this, getRollbackReadyPromise would immediately resolve
+      // from the FIRST rollback's RollbackReady state.
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      await indexerMock.getRollbackReadyPromise()
+
+      // THE BUG: After second rollback, chain 100's event counter goes negative
+      // because the rollback subtracts events that were already rolled back.
+      // Only chain 1337's counter was restored (GlobalState line 412-424),
+      // but chain 100's counter stayed at 0 while DB still had the old checkpoints.
+      t.expect(
+        {
+          let metrics = await indexerMock.metric("envio_progress_events")
+          metrics->Js.Array2.sortInPlaceWith((a, b) =>
+            (a.labels->Js.Dict.get("chainId")->Option.getWithDefault(""))->Obj.magic -
+              (b.labels->Js.Dict.get("chainId")->Option.getWithDefault(""))->Obj.magic
+          )
+        },
+        ~message="After second rollback: event counters should NOT be negative",
+      ).toEqual(
+        [
+          {value: "0", labels: Js.Dict.fromArray([("chainId", "100")])},
+          {value: "0", labels: Js.Dict.fromArray([("chainId", "1337")])},
+        ],
+      )
+    },
+  )
+
   Async.it("Should NOT have duplicate queries after rollback with chunked partitions", async t => {
     // 1. Setup mock source and indexer
     let sourceMock = Mock.Source.make(


### PR DESCRIPTION
## Summary
This PR adds a comprehensive regression test for a bug where repeated reorgs on one chain cause event counters to go negative on other chains during rollback operations.

## Key Changes
- Added new test case `"Multi-chain reorg→rollback→reorg loop: reorg chain repeatedly reorgs while other chain's events get rolled back each time (negative counter regression)"` to `Rollback_test.res`
- The test reproduces a scenario where:
  1. Two chains (1337 and 100) process events and enter reorg threshold
  2. Chain 1337 detects a reorg and triggers rollback to block 100
  3. Chain 1337 detects another reorg at block 100, triggering a second rollback
  4. The second rollback incorrectly subtracts events that were already rolled back, causing chain 100's counter to go negative

## Implementation Details
- Sets up mock sources for two chains with different chain IDs (1337 and 100)
- Simulates event processing at blocks 102-103 on both chains
- Triggers first reorg on chain 1337 at block 103, verifying rollback to block 100
- Triggers second reorg on chain 1337 at block 100 with a hash mismatch
- Validates that event counters remain at 0 (non-negative) after the second rollback
- Includes detailed comments explaining the root cause: only the reorg chain's counter is restored in GlobalState (lines 412-424), while the non-reorg chain's counter stays at 0 despite DB still containing old checkpoints

https://claude.ai/code/session_01KKaUKvowFVunuSdhDqjT6T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test scenario for multi-chain reorg and rollback sequences to validate correct state restoration and counter integrity across consecutive rollback operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->