### PR TITLE
Remove _num_batches_fetched tracking from chain state

### DIFF
--- a/packages/envio/src/ChainFetcher.res
+++ b/packages/envio/src/ChainFetcher.res
@@ -16,7 +16,6 @@ type t = {
   timestampCaughtUpToHeadOrEndblock: option<Js.Date.t>,
   committedProgressBlockNumber: int,
   numEventsProcessed: int,
-  numBatchesFetched: int,
   reorgDetection: ReorgDetection.t,
   safeCheckpointTracking: option<SafeCheckpointTracking.t>,
 }
@@ -35,7 +34,6 @@ let make = (
   ~logger,
   ~timestampCaughtUpToHeadOrEndblock,
   ~numEventsProcessed,
-  ~numBatchesFetched,
   ~isInReorgThreshold,
   ~reorgCheckpoints: array<Internal.reorgCheckpoint>,
   ~maxReorgDepth,
@@ -261,7 +259,6 @@ let make = (
     committedProgressBlockNumber: progressBlockNumber,
     timestampCaughtUpToHeadOrEndblock,
     numEventsProcessed,
-    numBatchesFetched,
   }
 }
 
@@ -285,7 +282,6 @@ let makeFromConfig = (
     ~progressBlockNumber=-1,
     ~timestampCaughtUpToHeadOrEndblock=None,
     ~numEventsProcessed=0,
-    ~numBatchesFetched=0,
     ~targetBufferSize,
     ~logger,
     ~dynamicContracts=[],
@@ -332,7 +328,6 @@ let makeFromDbState = async (
       ? None
       : resumedChainState.timestampCaughtUpToHeadOrEndblock,
     ~numEventsProcessed=resumedChainState.numEventsProcessed,
-    ~numBatchesFetched=0,
     ~logger,
     ~targetBufferSize,
     ~isInReorgThreshold,

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -162,7 +162,6 @@ let updateChainMetadataTable = (
         isHyperSync: (cf.sourceManager->SourceManager.getActiveSource).poweredByHyperSync,
         latestFetchedBlockNumber: cf.fetchState->FetchState.bufferBlockNumber,
         timestampCaughtUpToHeadOrEndblock: cf.timestampCaughtUpToHeadOrEndblock->Js.Null.fromOption,
-        numBatchesFetched: cf.numBatchesFetched,
       },
     )
   })
@@ -476,11 +475,6 @@ let submitPartitionQueryResponse = (
       ~newItemsWithDcs,
       ~knownHeight,
     )
-
-  let updatedChainFetcher = {
-    ...updatedChainFetcher,
-    numBatchesFetched: updatedChainFetcher.numBatchesFetched + 1,
-  }
 
   if !chainFetcher.isProgressAtHead && updatedChainFetcher.isProgressAtHead {
     updatedChainFetcher.logger->Logging.childInfo("All events have been fetched")

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -325,7 +325,7 @@ let start = async (
                 ).poweredByHyperSync,
                 latestFetchedBlockNumber,
                 knownHeight,
-                numBatchesFetched: cf.numBatchesFetched,
+                numBatchesFetched: 0,
                 startBlock: cf.fetchState.startBlock,
                 endBlock: cf.fetchState.endBlock,
                 firstEventBlockNumber: cf.fetchState.firstEventBlock,

--- a/packages/envio/src/db/InternalTable.res
+++ b/packages/envio/src/db/InternalTable.res
@@ -24,7 +24,6 @@ module Chains = {
     | #first_event_block
     | #buffer_block
     | #ready_at
-    | #_num_batches_fetched
     | #_is_hyper_sync
   ]
 
@@ -40,7 +39,6 @@ module Chains = {
     #ready_at,
     #events_processed,
     #_is_hyper_sync,
-    #_num_batches_fetched,
   ]
 
   type metaFields = {
@@ -49,7 +47,6 @@ module Chains = {
     @as("ready_at")
     timestampCaughtUpToHeadOrEndblock: Js.null<Js.Date.t>,
     @as("_is_hyper_sync") isHyperSync: bool,
-    @as("_num_batches_fetched") numBatchesFetched: int,
   }
 
   type t = {
@@ -95,8 +92,6 @@ module Chains = {
       mkField((#_is_hyper_sync: field :> string), Boolean, ~fieldSchema=S.bool),
       // Fully processed block number
       mkField((#progress_block: field :> string), Int32, ~fieldSchema=S.int),
-      // TODO: Should deprecate after changing the ETA calculation logic
-      mkField((#_num_batches_fetched: field :> string), Int32, ~fieldSchema=S.int),
     ],
   )
 
@@ -113,7 +108,6 @@ module Chains = {
       progressBlockNumber: -1,
       isHyperSync: false,
       numEventsProcessed: 0,
-      numBatchesFetched: 0,
     }
   }
 
@@ -154,7 +148,6 @@ VALUES ${valuesRows->Js.Array2.joinWith(",\n       ")};`,
     #first_event_block,
     #ready_at,
     #_is_hyper_sync,
-    #_num_batches_fetched,
   ]
 
   let makeMetaFieldsUpdateQuery = (~pgSchema) => {
@@ -573,7 +566,7 @@ SELECT
   "${(#_is_hyper_sync: Chains.field :> string)}" AS "is_hyper_sync",
   "${(#buffer_block: Chains.field :> string)}" AS "latest_fetched_block_number",
   "${(#progress_block: Chains.field :> string)}" AS "latest_processed_block",
-  "${(#_num_batches_fetched: Chains.field :> string)}" AS "num_batches_fetched",
+  0 AS "num_batches_fetched",
   "${(#events_processed: Chains.field :> string)}" AS "num_events_processed",
   "${(#start_block: Chains.field :> string)}" AS "start_block",
   "${(#ready_at: Chains.field :> string)}" AS "timestamp_caught_up_to_head_or_endblock"

--- a/packages/envio/src/tui/Tui.res
+++ b/packages/envio/src/tui/Tui.res
@@ -115,7 +115,7 @@ module App = {
       state.chainManager.chainFetchers
       ->ChainMap.values
       ->Array.map(cf => {
-        let {numEventsProcessed, fetchState, numBatchesFetched} = cf
+        let {numEventsProcessed, fetchState} = cf
         let latestFetchedBlockNumber = Pervasives.max(fetchState->FetchState.bufferBlockNumber, 0)
         let hasProcessedToEndblock = cf->ChainFetcher.hasProcessedToEndblock
         let knownHeight =
@@ -161,7 +161,6 @@ module App = {
             progress,
             knownHeight,
             latestFetchedBlockNumber,
-            numBatchesFetched,
             eventsProcessed: numEventsProcessed,
             chainId: cf.chainConfig.id->Int.toString,
             progressBlock: cf.committedProgressBlockNumber < cf.fetchState.startBlock

--- a/packages/envio/src/tui/components/SyncETA.res
+++ b/packages/envio/src/tui/components/SyncETA.res
@@ -58,32 +58,13 @@ let getTotalBlocksProcessed = (chains: array<TuiData.chain>) => {
 let useShouldDisplayEta = (~chains: array<TuiData.chain>) => {
   let (shouldDisplayEta, setShouldDisplayEta) = React.useState(_ => false)
   React.useEffect(() => {
-    //Only compute this while it is not displaying eta
     if !shouldDisplayEta {
-      //Each chain should have fetched at least one batch
-      let (allChainsHaveFetchedABatch, totalNumBatchesFetched) = chains->Array.reduce((true, 0), (
-        (allChainsHaveFetchedABatch, totalNumBatchesFetched),
-        chain,
-      ) => {
-        (
-          allChainsHaveFetchedABatch && chain.numBatchesFetched >= 1,
-          totalNumBatchesFetched + chain.numBatchesFetched,
-        )
+      // Display ETA once all chains have a known height and some blocks have been fetched
+      let allChainsStartedFetching = chains->Array.every(chain => {
+        chain.knownHeight > 0 && chain.latestFetchedBlockNumber > 0
       })
 
-      //Min num fetched batches is num of chains + 2. All
-      // Chains should have fetched at least 1 batch. (They
-      // could then be blocked from fetching if they are past
-      //the max queue size on first batch)
-      // Only display once an additinal 2 batches have been fetched to allow
-      // eta to realistically stabalize
-      let numChains = chains->Array.length
-      let minTotalBatches = numChains + 2
-      let hasMinNumBatches = totalNumBatchesFetched >= minTotalBatches
-
-      let shouldDisplayEta = allChainsHaveFetchedABatch && hasMinNumBatches
-
-      if shouldDisplayEta {
+      if allChainsStartedFetching {
         setShouldDisplayEta(_ => true)
       }
     }

--- a/packages/envio/src/tui/components/TuiData.res
+++ b/packages/envio/src/tui/components/TuiData.res
@@ -30,7 +30,6 @@ type chain = {
   progress: progress,
   latestFetchedBlockNumber: int,
   knownHeight: int,
-  numBatchesFetched: int,
 }
 
 let minOfOption: (int, option<int>) => int = (a: int, b: option<int>) => {

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -106,7 +106,6 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       timestampCaughtUpToHeadOrEndblock: None,
       committedProgressBlockNumber: -1,
       numEventsProcessed: 0,
-      numBatchesFetched: 0,
       fetchState: fetchState.contents,
       logger: Logging.getLogger(),
       sourceManager: SourceManager.make(

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -261,7 +261,7 @@ GRANT ALL ON SCHEMA "test_schema" TO "postgres";
 GRANT ALL ON SCHEMA "test_schema" TO public;
 CREATE TYPE "test_schema".AccountType AS ENUM('ADMIN', 'USER');
 CREATE TYPE "test_schema".GravatarSize AS ENUM('SMALL', 'MEDIUM', 'LARGE');
-CREATE TABLE IF NOT EXISTS "test_schema"."envio_chains"("id" INTEGER NOT NULL, "start_block" INTEGER NOT NULL, "end_block" INTEGER, "max_reorg_depth" INTEGER NOT NULL, "buffer_block" INTEGER NOT NULL, "source_block" INTEGER NOT NULL, "first_event_block" INTEGER, "ready_at" TIMESTAMP WITH TIME ZONE NULL, "events_processed" INTEGER NOT NULL, "_is_hyper_sync" BOOLEAN NOT NULL, "progress_block" INTEGER NOT NULL, "_num_batches_fetched" INTEGER NOT NULL, PRIMARY KEY("id"));
+CREATE TABLE IF NOT EXISTS "test_schema"."envio_chains"("id" INTEGER NOT NULL, "start_block" INTEGER NOT NULL, "end_block" INTEGER, "max_reorg_depth" INTEGER NOT NULL, "buffer_block" INTEGER NOT NULL, "source_block" INTEGER NOT NULL, "first_event_block" INTEGER, "ready_at" TIMESTAMP WITH TIME ZONE NULL, "events_processed" INTEGER NOT NULL, "_is_hyper_sync" BOOLEAN NOT NULL, "progress_block" INTEGER NOT NULL, PRIMARY KEY("id"));
 CREATE TABLE IF NOT EXISTS "test_schema"."persisted_state"("id" SERIAL NOT NULL, "envio_version" TEXT NOT NULL, "config_hash" TEXT NOT NULL, "schema_hash" TEXT NOT NULL, "abi_files_hash" TEXT NOT NULL, PRIMARY KEY("id"));
 CREATE TABLE IF NOT EXISTS "test_schema"."envio_checkpoints"("id" INTEGER NOT NULL, "chain_id" INTEGER NOT NULL, "block_number" INTEGER NOT NULL, "block_hash" TEXT, "events_processed" INTEGER NOT NULL, PRIMARY KEY("id"));
 CREATE TABLE IF NOT EXISTS "test_schema"."raw_events"("chain_id" INTEGER NOT NULL, "event_id" NUMERIC NOT NULL, "event_name" TEXT NOT NULL, "contract_name" TEXT NOT NULL, "block_number" INTEGER NOT NULL, "log_index" INTEGER NOT NULL, "src_address" TEXT NOT NULL, "block_hash" TEXT NOT NULL, "block_timestamp" INTEGER NOT NULL, "block_fields" JSONB NOT NULL, "transaction_fields" JSONB NOT NULL, "params" JSONB NOT NULL, "serial" SERIAL, PRIMARY KEY("serial"));
@@ -300,14 +300,14 @@ SELECT
   "_is_hyper_sync" AS "is_hyper_sync",
   "buffer_block" AS "latest_fetched_block_number",
   "progress_block" AS "latest_processed_block",
-  "_num_batches_fetched" AS "num_batches_fetched",
+  0 AS "num_batches_fetched",
   "events_processed" AS "num_events_processed",
   "start_block" AS "start_block",
   "ready_at" AS "timestamp_caught_up_to_head_or_endblock"
 FROM "test_schema"."envio_chains";
-INSERT INTO "test_schema"."envio_chains" ("id", "start_block", "end_block", "max_reorg_depth", "source_block", "first_event_block", "buffer_block", "progress_block", "ready_at", "events_processed", "_is_hyper_sync", "_num_batches_fetched")
-VALUES (1, 100, 200, 10, 0, NULL, -1, -1, NULL, 0, false, 0),
-       (137, 0, NULL, 200, 0, NULL, -1, -1, NULL, 0, false, 0);`
+INSERT INTO "test_schema"."envio_chains" ("id", "start_block", "end_block", "max_reorg_depth", "source_block", "first_event_block", "buffer_block", "progress_block", "ready_at", "events_processed", "_is_hyper_sync")
+VALUES (1, 100, 200, 10, 0, NULL, -1, -1, NULL, 0, false),
+       (137, 0, NULL, 200, 0, NULL, -1, -1, NULL, 0, false);`
 
         t.expect(
           mainQuery,
@@ -338,7 +338,7 @@ VALUES (1, 100, 200, 10, 0, NULL, -1, -1, NULL, 0, false, 0),
 CREATE SCHEMA "test_schema";
 GRANT ALL ON SCHEMA "test_schema" TO "postgres";
 GRANT ALL ON SCHEMA "test_schema" TO public;
-CREATE TABLE IF NOT EXISTS "test_schema"."envio_chains"("id" INTEGER NOT NULL, "start_block" INTEGER NOT NULL, "end_block" INTEGER, "max_reorg_depth" INTEGER NOT NULL, "buffer_block" INTEGER NOT NULL, "source_block" INTEGER NOT NULL, "first_event_block" INTEGER, "ready_at" TIMESTAMP WITH TIME ZONE NULL, "events_processed" INTEGER NOT NULL, "_is_hyper_sync" BOOLEAN NOT NULL, "progress_block" INTEGER NOT NULL, "_num_batches_fetched" INTEGER NOT NULL, PRIMARY KEY("id"));
+CREATE TABLE IF NOT EXISTS "test_schema"."envio_chains"("id" INTEGER NOT NULL, "start_block" INTEGER NOT NULL, "end_block" INTEGER, "max_reorg_depth" INTEGER NOT NULL, "buffer_block" INTEGER NOT NULL, "source_block" INTEGER NOT NULL, "first_event_block" INTEGER, "ready_at" TIMESTAMP WITH TIME ZONE NULL, "events_processed" INTEGER NOT NULL, "_is_hyper_sync" BOOLEAN NOT NULL, "progress_block" INTEGER NOT NULL, PRIMARY KEY("id"));
 CREATE TABLE IF NOT EXISTS "test_schema"."persisted_state"("id" SERIAL NOT NULL, "envio_version" TEXT NOT NULL, "config_hash" TEXT NOT NULL, "schema_hash" TEXT NOT NULL, "abi_files_hash" TEXT NOT NULL, PRIMARY KEY("id"));
 CREATE TABLE IF NOT EXISTS "test_schema"."envio_checkpoints"("id" INTEGER NOT NULL, "chain_id" INTEGER NOT NULL, "block_number" INTEGER NOT NULL, "block_hash" TEXT, "events_processed" INTEGER NOT NULL, PRIMARY KEY("id"));
 CREATE TABLE IF NOT EXISTS "test_schema"."raw_events"("chain_id" INTEGER NOT NULL, "event_id" NUMERIC NOT NULL, "event_name" TEXT NOT NULL, "contract_name" TEXT NOT NULL, "block_number" INTEGER NOT NULL, "log_index" INTEGER NOT NULL, "src_address" TEXT NOT NULL, "block_hash" TEXT NOT NULL, "block_timestamp" INTEGER NOT NULL, "block_fields" JSONB NOT NULL, "transaction_fields" JSONB NOT NULL, "params" JSONB NOT NULL, "serial" SERIAL, PRIMARY KEY("serial"));
@@ -365,7 +365,7 @@ SELECT
   "_is_hyper_sync" AS "is_hyper_sync",
   "buffer_block" AS "latest_fetched_block_number",
   "progress_block" AS "latest_processed_block",
-  "_num_batches_fetched" AS "num_batches_fetched",
+  0 AS "num_batches_fetched",
   "events_processed" AS "num_events_processed",
   "start_block" AS "start_block",
   "ready_at" AS "timestamp_caught_up_to_head_or_endblock"
@@ -417,7 +417,7 @@ $$ LANGUAGE plpgsql;`)
 CREATE SCHEMA "public";
 GRANT ALL ON SCHEMA "public" TO "postgres";
 GRANT ALL ON SCHEMA "public" TO public;
-CREATE TABLE IF NOT EXISTS "public"."envio_chains"("id" INTEGER NOT NULL, "start_block" INTEGER NOT NULL, "end_block" INTEGER, "max_reorg_depth" INTEGER NOT NULL, "buffer_block" INTEGER NOT NULL, "source_block" INTEGER NOT NULL, "first_event_block" INTEGER, "ready_at" TIMESTAMP WITH TIME ZONE NULL, "events_processed" INTEGER NOT NULL, "_is_hyper_sync" BOOLEAN NOT NULL, "progress_block" INTEGER NOT NULL, "_num_batches_fetched" INTEGER NOT NULL, PRIMARY KEY("id"));
+CREATE TABLE IF NOT EXISTS "public"."envio_chains"("id" INTEGER NOT NULL, "start_block" INTEGER NOT NULL, "end_block" INTEGER, "max_reorg_depth" INTEGER NOT NULL, "buffer_block" INTEGER NOT NULL, "source_block" INTEGER NOT NULL, "first_event_block" INTEGER, "ready_at" TIMESTAMP WITH TIME ZONE NULL, "events_processed" INTEGER NOT NULL, "_is_hyper_sync" BOOLEAN NOT NULL, "progress_block" INTEGER NOT NULL, PRIMARY KEY("id"));
 CREATE TABLE IF NOT EXISTS "public"."persisted_state"("id" SERIAL NOT NULL, "envio_version" TEXT NOT NULL, "config_hash" TEXT NOT NULL, "schema_hash" TEXT NOT NULL, "abi_files_hash" TEXT NOT NULL, PRIMARY KEY("id"));
 CREATE TABLE IF NOT EXISTS "public"."envio_checkpoints"("id" INTEGER NOT NULL, "chain_id" INTEGER NOT NULL, "block_number" INTEGER NOT NULL, "block_hash" TEXT, "events_processed" INTEGER NOT NULL, PRIMARY KEY("id"));
 CREATE TABLE IF NOT EXISTS "public"."raw_events"("chain_id" INTEGER NOT NULL, "event_id" NUMERIC NOT NULL, "event_name" TEXT NOT NULL, "contract_name" TEXT NOT NULL, "block_number" INTEGER NOT NULL, "log_index" INTEGER NOT NULL, "src_address" TEXT NOT NULL, "block_hash" TEXT NOT NULL, "block_timestamp" INTEGER NOT NULL, "block_fields" JSONB NOT NULL, "transaction_fields" JSONB NOT NULL, "params" JSONB NOT NULL, "serial" SERIAL, PRIMARY KEY("serial"));
@@ -447,7 +447,7 @@ SELECT
   "_is_hyper_sync" AS "is_hyper_sync",
   "buffer_block" AS "latest_fetched_block_number",
   "progress_block" AS "latest_processed_block",
-  "_num_batches_fetched" AS "num_batches_fetched",
+  0 AS "num_batches_fetched",
   "events_processed" AS "num_events_processed",
   "start_block" AS "start_block",
   "ready_at" AS "timestamp_caught_up_to_head_or_endblock"
@@ -622,8 +622,7 @@ VALUES($1,$2)ON CONFLICT("id") DO UPDATE SET "c_id" = EXCLUDED."c_id";`
 SET "buffer_block" = $2,
     "first_event_block" = $3,
     "ready_at" = $4,
-    "_is_hyper_sync" = $5,
-    "_num_batches_fetched" = $6
+    "_is_hyper_sync" = $5
 WHERE "id" = $1;`
 
         t.expect(
@@ -723,8 +722,8 @@ WHERE cp."block_hash" IS NOT NULL
           ~chainConfigs=[chainConfig],
         )
 
-        let expectedQuery = `INSERT INTO "test_schema"."envio_chains" ("id", "start_block", "end_block", "max_reorg_depth", "source_block", "first_event_block", "buffer_block", "progress_block", "ready_at", "events_processed", "_is_hyper_sync", "_num_batches_fetched")
-VALUES (1, 100, 200, 5, 0, NULL, -1, -1, NULL, 0, false, 0);`
+        let expectedQuery = `INSERT INTO "test_schema"."envio_chains" ("id", "start_block", "end_block", "max_reorg_depth", "source_block", "first_event_block", "buffer_block", "progress_block", "ready_at", "events_processed", "_is_hyper_sync")
+VALUES (1, 100, 200, 5, 0, NULL, -1, -1, NULL, 0, false);`
 
         t.expect(
           query,
@@ -751,8 +750,8 @@ VALUES (1, 100, 200, 5, 0, NULL, -1, -1, NULL, 0, false, 0);`
           ~chainConfigs=[chainConfig],
         )
 
-        let expectedQuery = `INSERT INTO "public"."envio_chains" ("id", "start_block", "end_block", "max_reorg_depth", "source_block", "first_event_block", "buffer_block", "progress_block", "ready_at", "events_processed", "_is_hyper_sync", "_num_batches_fetched")
-VALUES (1, 100, NULL, 5, 0, NULL, -1, -1, NULL, 0, false, 0);`
+        let expectedQuery = `INSERT INTO "public"."envio_chains" ("id", "start_block", "end_block", "max_reorg_depth", "source_block", "first_event_block", "buffer_block", "progress_block", "ready_at", "events_processed", "_is_hyper_sync")
+VALUES (1, 100, NULL, 5, 0, NULL, -1, -1, NULL, 0, false);`
 
         t.expect(
           query,
@@ -790,9 +789,9 @@ VALUES (1, 100, NULL, 5, 0, NULL, -1, -1, NULL, 0, false, 0);`
           ~chainConfigs=[chainConfig1, chainConfig2],
         )
 
-        let expectedQuery = `INSERT INTO "production"."envio_chains" ("id", "start_block", "end_block", "max_reorg_depth", "source_block", "first_event_block", "buffer_block", "progress_block", "ready_at", "events_processed", "_is_hyper_sync", "_num_batches_fetched")
-VALUES (1, 100, 200, 5, 0, NULL, -1, -1, NULL, 0, false, 0),
-       (42, 500, NULL, 0, 0, NULL, -1, -1, NULL, 0, false, 0);`
+        let expectedQuery = `INSERT INTO "production"."envio_chains" ("id", "start_block", "end_block", "max_reorg_depth", "source_block", "first_event_block", "buffer_block", "progress_block", "ready_at", "events_processed", "_is_hyper_sync")
+VALUES (1, 100, 200, 5, 0, NULL, -1, -1, NULL, 0, false),
+       (42, 500, NULL, 0, 0, NULL, -1, -1, NULL, 0, false);`
 
         t.expect(
           query,


### PR DESCRIPTION
## Summary
This PR removes the `_num_batches_fetched` field from chain state tracking and simplifies the ETA calculation logic. The batch count was previously used to determine when to display the sync ETA, but this approach has been replaced with a simpler check based on whether chains have started fetching blocks.

## Key Changes

- **Removed `_num_batches_fetched` field** from the `envio_chains` table schema and all related database operations
  - Removed from table creation DDL statements
  - Removed from INSERT and UPDATE queries
  - Removed from the `InternalTable.Chains` module definition

- **Simplified ETA display logic** in `SyncETA.res`
  - Replaced batch count-based logic with a simpler check: display ETA once all chains have a known height and have started fetching blocks
  - Removed the minimum batch threshold calculation that required `numChains + 2` batches before showing ETA

- **Removed `numBatchesFetched` field** from chain state types
  - Removed from `ChainFetcher.t` type definition
  - Removed from `TuiData.chain` type definition
  - Removed from `GlobalState` chain metadata updates
  - Removed initialization and increment logic in `GlobalState.submitPartitionQueryResponse`

- **Updated test expectations** in `PgStorage_test.res` to reflect the schema changes
  - Updated all expected SQL queries to exclude `_num_batches_fetched` column
  - Updated hardcoded query values in test cases

- **Updated TUI components** to remove references to `numBatchesFetched`
  - Removed from `Tui.res` chain data extraction
  - Hardcoded `numBatchesFetched: 0` in `Main.res` for display purposes

## Implementation Details

The removal is comprehensive across the codebase, affecting:
- Database schema and migrations
- Type definitions and state management
- ETA calculation heuristics
- TUI data structures and rendering
- Test fixtures and expectations

The new ETA display condition is more straightforward: show ETA when all chains have discovered the chain height and have begun fetching blocks, rather than waiting for a minimum number of batches to be processed.

https://claude.ai/code/session_01HMGtMLMwUFYaebQ6KKStUx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal chain synchronization metrics tracking by simplifying batch-count management across the system.
  * Updated ETA display logic in sync status monitoring. ETA now activates when chains detect block heights and complete block fetches, improving calculation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->