### PR TITLE
Use OIDC trusted publishing instead of long-lived NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,11 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
 jobs:
   # Determine npm tag from release tag name:
   #   v1.2.3, v1.2.3-alpha.1, v1.2.3-rc.1 → next
@@ -79,7 +84,6 @@ jobs:
       - name: Patch version and publish
         working-directory: ./pkg
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           if [ ! -f envio.node ]; then
@@ -117,7 +121,6 @@ jobs:
       - name: Patch version and publish
         working-directory: ./pkg
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ needs.prepare.outputs.version }}
           NPM_TAG: ${{ needs.prepare.outputs.npm_tag }}
         run: |


### PR DESCRIPTION
~TODO: I need to still configure this in all the packages in npm. But will let you know when I do!~ Done
<img width="786" height="208" alt="image" src="https://github.com/user-attachments/assets/f6f9c926-7e64-4ec3-9d8a-37ee3b6eaec1" />

## Summary
- Remove `NODE_AUTH_TOKEN`/`NPM_TOKEN` from both publish jobs (`publish-platform-packages` and `publish-envio-package`)
- Add explicit `permissions` block with `id-token: write` for OIDC token generation and `actions: read` for the workflow run query in the prepare job

## Setup required before merging
Configure trusted publisher on npmjs.com for **all 5 packages**, each with:
- **Organization or user**: `enviodev`
- **Repository**: `hyperindex`
- **Workflow filename**: `publish.yml`
- **Environment name**: _(leave blank)_

Packages to configure:
1. `envio`
2. `envio-linux-x64`
3. `envio-linux-arm64`
4. `envio-darwin-x64`
5. `envio-darwin-arm64`

## After verifying it works
- Restrict token access on all 5 packages (Settings → Publishing access → "Require two-factor authentication and disallow tokens")
- Revoke the `NPM_TOKEN` secret from GitHub repo settings and the token on npmjs.com

## Test plan
- [ ] Configure trusted publishers on npmjs.com for all 5 packages before merging
- [ ] Push a tag to trigger publish and verify all 5 packages publish successfully with OIDC auth
- [ ] Revoke old NPM_TOKEN after confirming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD publishing workflow updated to declare explicit job permissions for actions and tighten how auth tokens are provided to publish steps.
  * Reduced step-level exposure of authentication credentials during package publication to improve pipeline security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->