### PR TITLE
Upgrade to ReScript 12 and remove v11 workarounds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Verify that tests pass by running a compiler `pnpm rescript-legacy` and tests `p
 ## ReScript
 
 - When using `Utils.magic` for type casting, always add explicit type annotations: `value->(Utils.magic: inputType => outputType)`
-- Always use ReScript 11 documentation. Never suggest ReasonML syntax.
+- Always use ReScript 12 documentation. Never suggest ReasonML syntax.
 - Never use `[| item |]` to create an array. Use `[ item ]` instead.
 - Must always use `=` for setting value to a field. Use `:=` only for ref values created using `ref` function.
 - Never use `%raw` to access object fields if you know the type.

--- a/packages/envio/src/Utils.res
+++ b/packages/envio/src/Utils.res
@@ -380,13 +380,6 @@ Helper to check if a value exists in an array
     loop(arr->Array.length - 1)
   }
 
-  /** 
-  Currently a bug in rescript if you ignore the return value of spliceInPlace 
-  https://github.com/rescript-lang/rescript-compiler/issues/6991
-  */
-  @send
-  external spliceInPlace: (array<'a>, ~pos: int, ~remove: int) => array<'a> = "splice"
-
   /**
   Interleaves an array with a separator
 

--- a/packages/envio/src/bindings/Express.res
+++ b/packages/envio/src/bindings/Express.res
@@ -2,9 +2,6 @@
 
 type app
 
-// "default" &  seem to conflict a bit right now
-// https://github.com/rescript-lang/rescript-compiler/issues/5004
-@module external makeCjs: unit => app = "express"
 @module("express") external make: unit => app = "default"
 
 type req = private {

--- a/scenarios/test_codegen/test/E2E_test.res
+++ b/scenarios/test_codegen/test/E2E_test.res
@@ -1,10 +1,6 @@
 open Belt
 open Vitest
 
-// A workaround for ReScript v11 issue, where it makes the field optional
-// instead of setting a value to undefined. It's fixed in v12.
-let undefined = (%raw(`undefined`): option<'a>)
-
 describe("E2E tests", () => {
   Async.it("Currectly starts indexing from a non-zero start block", async t => {
     let sourceMock = MockIndexer.Source.make(

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -141,10 +141,6 @@ let makeIndexingContractsWithDynamics = (
   dict
 }
 
-// A workaround for ReScript v11 issue, where it makes the field optional
-// instead of setting a value to undefined. It's fixed in v12.
-let undefined = (%raw(`undefined`): option<'a>)
-
 describe("FetchState.make", () => {
   it("Creates FetchState with a single static address", t => {
     let fetchState = makeInitial()
@@ -173,7 +169,7 @@ describe("FetchState.make", () => {
           ~dynamicContracts=Utils.Set.make(),
         ),
         startBlock: 0,
-        endBlock: undefined,
+        endBlock: None,
         latestOnBlockBlockNumber: -1,
         targetBufferSize: 5000,
         buffer: [],
@@ -253,7 +249,7 @@ describe("FetchState.make", () => {
           latestOnBlockBlockNumber: -1,
           buffer: [],
           startBlock: 0,
-          endBlock: undefined,
+          endBlock: None,
           normalSelection: fetchState.normalSelection,
           chainId,
           indexingContracts: fetchState.indexingContracts,
@@ -326,7 +322,7 @@ describe("FetchState.make", () => {
           latestOnBlockBlockNumber: -1,
           buffer: [],
           startBlock: 0,
-          endBlock: undefined,
+          endBlock: None,
           normalSelection: fetchState.normalSelection,
           chainId,
           indexingContracts: fetchState.indexingContracts,
@@ -441,7 +437,7 @@ describe("FetchState.make", () => {
           latestOnBlockBlockNumber: -1,
           buffer: [],
           startBlock: 0,
-          endBlock: undefined,
+          endBlock: None,
           normalSelection: fetchState.normalSelection,
           chainId,
           indexingContracts: fetchState.indexingContracts,
@@ -1353,7 +1349,7 @@ describe("FetchState.registerDynamicContracts", () => {
             ~dynamicContracts=Utils.Set.fromArray(["NftFactory"]),
           ),
           startBlock: 0,
-          endBlock: undefined,
+          endBlock: None,
           latestOnBlockBlockNumber: -1,
           targetBufferSize,
           buffer: [],
@@ -1472,7 +1468,7 @@ describe("FetchState.getNextQuery & integration", () => {
       targetBufferSize,
       buffer: [mockEvent(~blockNumber=1), mockEvent(~blockNumber=2)],
       startBlock: 0,
-      endBlock: undefined,
+      endBlock: None,
       normalSelection,
       chainId,
       indexingContracts: makeIndexingContractsWithDynamics([dc3, dc2, dc1], ~static=[mockAddress0]),
@@ -2027,7 +2023,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           partitionId: "1",
           fromBlock: 0,
-          toBlock: undefined,
+          toBlock: None,
           isChunk: false,
           selection: fetchState.normalSelection,
           addressesByContractName: Js.Dict.fromArray([("ContractA", [mockAddress1])]),
@@ -2036,7 +2032,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           partitionId: "2",
           fromBlock: 2,
-          toBlock: undefined,
+          toBlock: None,
           isChunk: false,
           selection: fetchState.normalSelection,
           addressesByContractName: Js.Dict.fromArray([("Gravatar", [mockAddress2])]),

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -1,10 +1,6 @@
 open Belt
 open Vitest
 
-// A workaround for ReScript v11 issue, where it makes the field optional
-// instead of setting a value to undefined. It's fixed in v12.
-let undefined = (%raw(`undefined`): option<'a>)
-
 describe("E2E rollback tests", () => {
   let testSingleChainRollback = async (
     ~t,


### PR DESCRIPTION
## Summary
This PR upgrades the codebase to ReScript 12 and removes workarounds that were specific to ReScript v11 limitations. The changes simplify the code by leveraging fixes available in ReScript 12.

## Key Changes
- **Removed ReScript v11 workarounds**: Deleted the `undefined` helper function that was used as a workaround for ReScript v11's issue with optional fields. Replaced all usages with `None`, which is the proper ReScript way to represent undefined values.
- **Removed unused binding**: Deleted the `makeCjs` external binding in Express.res that was a workaround for a ReScript compiler issue (rescript-lang/rescript-compiler#5004).
- **Removed unused utility**: Deleted the `spliceInPlace` external binding in Utils.res that had a documented bug in ReScript (rescript-lang/rescript-compiler#6991).
- **Updated documentation**: Changed CLAUDE.md to reference ReScript 12 documentation instead of ReScript 11.

## Implementation Details
- All test files that used the `undefined` workaround (FetchState_test.res, E2E_test.res, Rollback_test.res) now use `None` for optional field values.
- The changes maintain backward compatibility in functionality while improving code clarity and reducing technical debt.
- No functional behavior changes; this is purely a cleanup and upgrade to leverage ReScript 12's improvements.

https://claude.ai/code/session_01SFpqYv69VyXJdfmQqFFUzh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance to reference ReScript 12 documentation.

* **Refactor**
  * Removed deprecated compatibility workarounds and obsolete utility bindings, streamlining the codebase for ReScript 12.
  * Updated test suite to align with current ReScript semantics and removed ReScript v11-specific workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->