### PR TITLE
Refactor BigInt module to use direct imports instead of Utils namespace

### DIFF
--- a/packages/envio/src/Batch.res
+++ b/packages/envio/src/Batch.res
@@ -199,7 +199,7 @@ let addReorgCheckpoints = (
     for blockNumber in fromBlockExclusive + 1 to toBlockExclusive - 1 {
       switch reorgDetection->ReorgDetection.getHashByBlockNumber(~blockNumber) {
       | Js.Null.Value(hash) =>
-        let checkpointId = prevCheckpointId.contents->Utils.BigInt.add(1n)
+        let checkpointId = prevCheckpointId.contents->BigInt.add(1n)
         prevCheckpointId := checkpointId
 
         mutCheckpointIds->Js.Array2.push(checkpointId)->ignore
@@ -280,7 +280,7 @@ let prepareOrderedBatch = (
               ~mutCheckpointEventsProcessed=checkpointEventsProcessed,
             )
 
-          let checkpointId = prevCheckpointId.contents->Utils.BigInt.add(1n)
+          let checkpointId = prevCheckpointId.contents->BigInt.add(1n)
 
           items
           ->Js.Array2.push(item0)
@@ -424,7 +424,7 @@ let prepareUnorderedBatch = (
               ~mutCheckpointEventsProcessed=checkpointEventsProcessed,
             )
 
-          let checkpointId = prevCheckpointId.contents->Utils.BigInt.add(1n)
+          let checkpointId = prevCheckpointId.contents->BigInt.add(1n)
 
           checkpointIds->Js.Array2.push(checkpointId)->ignore
           checkpointChainIds->Js.Array2.push(fetchState.chainId)->ignore

--- a/packages/envio/src/ChainManager.res
+++ b/packages/envio/src/ChainManager.res
@@ -131,7 +131,7 @@ let nextItemIsNone = (chainManager: t): bool => {
 
 let createBatch = (chainManager: t, ~batchSizeTarget: int, ~isRollback: bool): Batch.t => {
   Batch.make(
-    ~checkpointIdBeforeBatch=chainManager.committedCheckpointId->Utils.BigInt.add(
+    ~checkpointIdBeforeBatch=chainManager.committedCheckpointId->BigInt.add(
       // Since for rollback we have a diff checkpoint id.
       // This is needed to currectly overwrite old state
       // in an append-only ClickHouse insert.

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -43,7 +43,7 @@ let convertFieldsToJson = (fields: option<dict<unknown>>) => {
           Js.typeof(value) === "bigint"
             ? value
               ->(Utils.magic: unknown => bigint)
-              ->Utils.BigInt.toString
+              ->BigInt.toString
               ->(Utils.magic: string => unknown)
             : value,
         )
@@ -102,7 +102,7 @@ let addItemToRawEvents = (
     params,
   }
 
-  let eventIdStr = eventId->Utils.BigInt.toString
+  let eventIdStr = eventId->BigInt.toString
 
   inMemoryStore.rawEvents->InMemoryTable.set({chainId, eventId: eventIdStr}, rawEvent)
 }

--- a/packages/envio/src/EventUtils.res
+++ b/packages/envio/src/EventUtils.res
@@ -29,42 +29,42 @@ let isEarlierUnordered = (item1: (int, int, int), item2: (int, int, int)) => {
 // takes blockNumber, logIndex and packs them into a number with
 //32 bits, 16 bits and 16 bits respectively
 let packEventIndex = (~blockNumber, ~logIndex) => {
-  let blockNumber = blockNumber->Utils.BigInt.fromInt
-  let logIndex = logIndex->Utils.BigInt.fromInt
-  let blockNumber = Utils.BigInt.Bitwise.shift_left(blockNumber, 16->Utils.BigInt.fromInt)
+  let blockNumber = blockNumber->BigInt.fromInt
+  let logIndex = logIndex->BigInt.fromInt
+  let blockNumber = BigInt.shiftLeft(blockNumber, 16->BigInt.fromInt)
 
-  blockNumber->Utils.BigInt.Bitwise.logor(logIndex)
+  blockNumber->BigInt.bitwiseOr(logIndex)
 }
 
 // //Currently not used but keeping in utils
 // //using @live flag for dead code analyser
 // @live
 // let packMultiChainEventIndex = (~timestamp, ~chainId, ~blockNumber, ~logIndex) => {
-//   let timestamp = timestamp->Utils.BigInt.fromInt
-//   let chainId = chainId->Utils.BigInt.fromInt
-//   let blockNumber = blockNumber->Utils.BigInt.fromInt
-//   let logIndex = logIndex->Utils.BigInt.fromInt
+//   let timestamp = timestamp->BigInt.fromInt
+//   let chainId = chainId->BigInt.fromInt
+//   let blockNumber = blockNumber->BigInt.fromInt
+//   let logIndex = logIndex->BigInt.fromInt
 
-//   let timestamp = Utils.BigInt.Bitwise.shift_left(timestamp, 48->Utils.BigInt.fromInt)
-//   let chainId = Utils.BigInt.Bitwise.shift_left(chainId, 16->Utils.BigInt.fromInt)
-//   let blockNumber = Utils.BigInt.Bitwise.shift_left(blockNumber, 16->Utils.BigInt.fromInt)
+//   let timestamp = BigInt.shiftLeft(timestamp, 48->BigInt.fromInt)
+//   let chainId = BigInt.shiftLeft(chainId, 16->BigInt.fromInt)
+//   let blockNumber = BigInt.shiftLeft(blockNumber, 16->BigInt.fromInt)
 
 //   timestamp
-//   ->Utils.BigInt.Bitwise.logor(chainId)
-//   ->Utils.BigInt.Bitwise.logor(blockNumber)
-//   ->Utils.BigInt.Bitwise.logor(logIndex)
+//   ->BigInt.bitwiseOr(chainId)
+//   ->BigInt.bitwiseOr(blockNumber)
+//   ->BigInt.bitwiseOr(logIndex)
 // }
 
 // //Currently not used but keeping in utils
 // //using @live flag for dead code analyser
 // @live
 // let unpackEventIndex = (packedEventIndex: bigint) => {
-//   let blockNumber = packedEventIndex->Utils.BigInt.Bitwise.shift_right(16->Utils.BigInt.fromInt)
-//   let logIndexMask = 65535->Utils.BigInt.fromInt
-//   let logIndex = packedEventIndex->Utils.BigInt.Bitwise.logand(logIndexMask)
+//   let blockNumber = packedEventIndex->BigInt.shiftRight(16->BigInt.fromInt)
+//   let logIndexMask = 65535->BigInt.fromInt
+//   let logIndex = packedEventIndex->BigInt.bitwiseAnd(logIndexMask)
 //   {
-//     blockNumber: blockNumber->Utils.BigInt.toString->Belt.Int.fromString->Belt.Option.getUnsafe,
-//     logIndex: logIndex->Utils.BigInt.toString->Belt.Int.fromString->Belt.Option.getUnsafe,
+//     blockNumber: blockNumber->BigInt.toString->Belt.Int.fromString->Belt.Option.getUnsafe,
+//     logIndex: logIndex->BigInt.toString->Belt.Int.fromString->Belt.Option.getUnsafe,
 //   }
 // }
 

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -1184,7 +1184,7 @@ let injectedTaskReducer = (
       let diff =
         await state.ctx.persistence->Persistence.prepareRollbackDiff(
           ~rollbackTargetCheckpointId,
-          ~rollbackDiffCheckpointId=state.chainManager.committedCheckpointId->Utils.BigInt.add(1n),
+          ~rollbackDiffCheckpointId=state.chainManager.committedCheckpointId->BigInt.add(1n),
         )
 
       let chainManager = {

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1511,12 +1511,11 @@ let make = (
       ),
     ))
 
-    let checkpointId =
-      (checkpointIdResult->Belt.Array.getUnsafe(0))["id"]->Utils.BigInt.fromStringUnsafe
+    let checkpointId = (checkpointIdResult->Belt.Array.getUnsafe(0))["id"]->BigInt.fromStringOrThrow
 
     // Convert string checkpoint IDs from DB to bigint
     let reorgCheckpoints = Belt.Array.map(reorgCheckpoints, (raw): Internal.reorgCheckpoint => {
-      checkpointId: raw["id"]->Utils.BigInt.fromStringUnsafe,
+      checkpointId: raw["id"]->BigInt.fromStringOrThrow,
       chainId: raw["chain_id"],
       blockNumber: raw["block_number"],
       blockHash: raw["block_hash"],
@@ -1579,18 +1578,14 @@ let make = (
       sql
       ->Postgres.preparedUnsafe(
         makeGetRollbackRemovedIdsQuery(~entityConfig, ~pgSchema),
-        [rollbackTargetCheckpointId->Utils.BigInt.toString]->(
-          Utils.magic: array<string> => unknown
-        ),
+        [rollbackTargetCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
       )
       ->(Utils.magic: promise<unknown> => promise<array<{"id": string}>>),
       // Get entities that should be restored to their state at or before rollback target
       sql
       ->Postgres.preparedUnsafe(
         makeGetRollbackRestoredEntitiesQuery(~entityConfig, ~pgSchema),
-        [rollbackTargetCheckpointId->Utils.BigInt.toString]->(
-          Utils.magic: array<string> => unknown
-        ),
+        [rollbackTargetCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
       )
       ->(Utils.magic: promise<unknown> => promise<array<unknown>>),
     ))
@@ -1704,10 +1699,7 @@ let makeStorageFromEnv = (
               ~schema=Schema.make(config.allEntities->Belt.Array.map(e => e.table)),
               ~aggregateEntities=Env.Hasura.aggregateEntities,
             )->Promise.catch(err => {
-              Logging.errorWithExn(
-                err->Utils.prettifyExn,
-                `Error tracking tables`,
-              )->Promise.resolve
+              Logging.errorWithExn(err->Utils.prettifyExn, `Error tracking tables`)->Promise.resolve
             })
           },
         )

--- a/packages/envio/src/TableIndices.res
+++ b/packages/envio/src/TableIndices.res
@@ -12,7 +12,7 @@ module FieldValue = {
   let rec toString = tNonOptional =>
     switch tNonOptional {
     | String(v) => v
-    | BigInt(v) => v->Utils.BigInt.toString
+    | BigInt(v) => v->BigInt.toString
     | Int(v) => v->Int.toString
     | BigDecimal(v) => v->BigDecimal.toString
     | Bool(v) => v ? "true" : "false"

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -152,7 +152,7 @@ let handleWriteBatch = (
           entityDict->Js.Dict.set(entityId, parsedEntity)
 
           // Track change by checkpoint
-          let checkpointKey = checkpointId->Utils.BigInt.toString
+          let checkpointKey = checkpointId->BigInt.toString
           let entityChanges = switch changesByCheckpoint->Js.Dict.get(checkpointKey) {
           | Some(changes) => changes
           | None =>
@@ -174,7 +174,7 @@ let handleWriteBatch = (
           Js.Dict.unsafeDeleteKey(entityDict->Obj.magic, entityId)
 
           // Track change by checkpoint
-          let checkpointKey = checkpointId->Utils.BigInt.toString
+          let checkpointKey = checkpointId->BigInt.toString
           let entityChanges = switch changesByCheckpoint->Js.Dict.get(checkpointKey) {
           | Some(changes) => changes
           | None =>
@@ -223,7 +223,7 @@ let handleWriteBatch = (
     )
 
     // Add entity changes for this checkpoint
-    let checkpointKey = checkpointId->Utils.BigInt.toString
+    let checkpointKey = checkpointId->BigInt.toString
     switch changesByCheckpoint->Js.Dict.get(checkpointKey) {
     | Some(entityChanges) =>
       entityChanges

--- a/packages/envio/src/TopicFilter.res
+++ b/packages/envio/src/TopicFilter.res
@@ -1,7 +1,7 @@
 let toTwosComplement = (num: bigint, ~bytesLen: int) => {
-  let maxValue = 1n->Utils.BigInt.Bitwise.shift_left(Utils.BigInt.fromInt(bytesLen * 8))
-  let mask = maxValue->Utils.BigInt.sub(1n)
-  num->Utils.BigInt.add(maxValue)->Utils.BigInt.Bitwise.logand(mask)
+  let maxValue = 1n->BigInt.shiftLeft(BigInt.fromInt(bytesLen * 8))
+  let mask = maxValue->BigInt.sub(1n)
+  num->BigInt.add(maxValue)->BigInt.bitwiseAnd(mask)
 }
 
 let fromSignedBigInt = val => {

--- a/packages/envio/src/Utils.res
+++ b/packages/envio/src/Utils.res
@@ -768,50 +768,6 @@ module EnvioPackage = {
 }
 
 module BigInt = {
-  %%private(
-    @inline
-    let unsafeToOption: (unit => 'a) => option<'a> = unsafeFunc => {
-      try {
-        unsafeFunc()->Some
-      } catch {
-      | Js.Exn.Error(_obj) => None
-      }
-    }
-  )
-
-  // constructors and methods
-  @val external fromInt: int => bigint = "BigInt"
-  @val external fromStringUnsafe: string => bigint = "BigInt"
-  @val external fromUnknownUnsafe: unknown => bigint = "BigInt"
-  let fromString = str => unsafeToOption(() => str->fromStringUnsafe)
-  @send external toString: bigint => string = "toString"
-  let toInt = (b: bigint): option<int> => b->toString->Belt.Int.fromString
-
-  //silence unused var warnings for raw bindings
-  @@warning("-27")
-  // operation
-  let add = (a: bigint, b: bigint): bigint => %raw("a + b")
-  let sub = (a: bigint, b: bigint): bigint => %raw("a - b")
-  let mul = (a: bigint, b: bigint): bigint => %raw("a * b")
-  let div = (a: bigint, b: bigint): bigint => %raw("b > 0n ? a / b : 0n")
-  let pow = (a: bigint, b: bigint): bigint => %raw("a ** b")
-  let mod = (a: bigint, b: bigint): bigint => %raw("b > 0n ? a % b : 0n")
-
-  // comparison
-  let eq = (a: bigint, b: bigint): bool => %raw("a === b")
-  let neq = (a: bigint, b: bigint): bool => %raw("a !== b")
-  let gt = (a: bigint, b: bigint): bool => %raw("a > b")
-  let gte = (a: bigint, b: bigint): bool => %raw("a >= b")
-  let lt = (a: bigint, b: bigint): bool => %raw("a < b")
-  let lte = (a: bigint, b: bigint): bool => %raw("a <= b")
-
-  module Bitwise = {
-    let shift_left = (a: bigint, b: bigint): bigint => %raw("a << b")
-    let shift_right = (a: bigint, b: bigint): bigint => %raw("a >> b")
-    let logor = (a: bigint, b: bigint): bigint => %raw("a | b")
-    let logand = (a: bigint, b: bigint): bigint => %raw("a & b")
-  }
-
   let arrayToStringArray: array<bigint> => array<string> = %raw(`(arr) => {
     const res = new Array(arr.length);
     for (let i = 0; i < arr.length; i++) {
@@ -820,20 +776,16 @@ module BigInt = {
     return res;
   }`)
 
-  let zero = fromInt(0)
-  let toFloat: bigint => float = %raw(`(n) => Number(n)`)
-  let toIntUnsafe: bigint => int = %raw(`(n) => Number(n)`)
-
   let schema =
     S.string
     ->S.setName("BigInt")
     ->S.transform(s => {
       parser: string =>
-        switch string->fromString {
+        switch string->BigInt.fromString {
         | Some(bigInt) => bigInt
         | None => s.fail("The string is not valid BigInt")
         },
-      serializer: bigint => bigint->toString,
+      serializer: bigint => bigint->BigInt.toString,
     })
 
   let nativeSchema = S.bigint

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -204,7 +204,7 @@ let setCheckpointsOrThrow = async (client, ~batch: Batch.t, ~database: string) =
     for idx in 0 to checkpointsCount - 1 {
       checkpointRows
       ->Js.Array2.push((
-        batch.checkpointIds->Belt.Array.getUnsafe(idx)->Utils.BigInt.toString,
+        batch.checkpointIds->Belt.Array.getUnsafe(idx)->BigInt.toString,
         batch.checkpointChainIds->Belt.Array.getUnsafe(idx),
         batch.checkpointBlockNumbers->Belt.Array.getUnsafe(idx),
         batch.checkpointBlockHashes->Belt.Array.getUnsafe(idx),
@@ -467,14 +467,14 @@ let resume = async (client, ~database: string, ~checkpointId: Internal.checkpoin
       tables->Belt.Array.map(table => {
         let tableName = table["name"]
         client->exec({
-          query: `ALTER TABLE ${database}.\`${tableName}\` DELETE WHERE \`${EntityHistory.checkpointIdFieldName}\` > ${checkpointId->Utils.BigInt.toString}`,
+          query: `ALTER TABLE ${database}.\`${tableName}\` DELETE WHERE \`${EntityHistory.checkpointIdFieldName}\` > ${checkpointId->BigInt.toString}`,
         })
       }),
     )->Utils.Promise.ignoreValue
 
     // Delete stale checkpoints
     await client->exec({
-      query: `DELETE FROM ${database}.\`${InternalTable.Checkpoints.table.tableName}\` WHERE \`${Table.idFieldName}\` > ${checkpointId->Utils.BigInt.toString}`,
+      query: `DELETE FROM ${database}.\`${InternalTable.Checkpoints.table.tableName}\` WHERE \`${Table.idFieldName}\` > ${checkpointId->BigInt.toString}`,
     })
   } catch {
   | Persistence.StorageError(_) as exn => raise(exn)

--- a/packages/envio/src/db/EntityHistory.res
+++ b/packages/envio/src/db/EntityHistory.res
@@ -23,11 +23,11 @@ let unsafeCheckpointIdSchema =
   ->S.setName("CheckpointId")
   ->S.transform(s => {
     parser: string =>
-      switch Utils.BigInt.fromString(string) {
+      switch BigInt.fromString(string) {
       | None => s.fail("The string is not valid CheckpointId")
       | Some(v) => v
       },
-    serializer: bigint => bigint->Utils.BigInt.toString,
+    serializer: bigint => bigint->BigInt.toString,
   })
 
 let makeSetUpdateSchema: S.t<'entity> => S.t<Change.t<'entity>> = entitySchema => {
@@ -112,7 +112,7 @@ let pruneStaleEntityHistory = (
 ): promise<unit> => {
   sql->Postgres.preparedUnsafe(
     makePruneStaleEntityHistoryQuery(~entityName, ~entityIndex, ~pgSchema),
-    [safeCheckpointId->Utils.BigInt.toString]->(Utils.magic: array<string> => unknown),
+    [safeCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
   )
 }
 
@@ -157,7 +157,7 @@ let rollback = (
         ~entityName,
         ~entityIndex,
       )}" WHERE "${checkpointIdFieldName}" > $1;`,
-    [rollbackTargetCheckpointId->Utils.BigInt.toString]->(Utils.magic: array<string> => unknown),
+    [rollbackTargetCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
   )
   ->Utils.Promise.ignoreValue
 }

--- a/packages/envio/src/db/InternalTable.res
+++ b/packages/envio/src/db/InternalTable.res
@@ -127,7 +127,7 @@ module Chains = {
           switch Js.typeof(value) {
           | "object" => "NULL"
           | "number" => value->(Utils.magic: option<unknown> => int)->Belt.Int.toString
-          | "bigint" => value->(Utils.magic: option<unknown> => bigint)->Utils.BigInt.toString
+          | "bigint" => value->(Utils.magic: option<unknown> => bigint)->BigInt.toString
           | "boolean" => value->(Utils.magic: option<unknown> => bool) ? "true" : "false"
           | _ => Js.Exn.raiseError("Invalid envio_chains value type")
           }
@@ -378,7 +378,7 @@ WHERE cp."${(#block_hash: field :> string)}" IS NOT NULL
   }
 
   let makeCommitedCheckpointIdQuery = (~pgSchema) => {
-    `SELECT COALESCE(MAX(${(#id: field :> string)}), ${initialCheckpointId->Utils.BigInt.toString}) AS id FROM "${pgSchema}"."${table.tableName}";`
+    `SELECT COALESCE(MAX(${(#id: field :> string)}), ${initialCheckpointId->BigInt.toString}) AS id FROM "${pgSchema}"."${table.tableName}";`
   }
 
   let makeInsertCheckpointQuery = (~pgSchema) => {
@@ -421,7 +421,7 @@ SELECT * FROM unnest($1::${(BigInt: Postgres.columnType :> string)}[],$2::${(Int
     sql
     ->Postgres.preparedUnsafe(
       `DELETE FROM "${pgSchema}"."${table.tableName}" WHERE "${(#id: field :> string)}" > $1;`,
-      [rollbackTargetCheckpointId->Utils.BigInt.toString]->(Utils.magic: array<string> => unknown),
+      [rollbackTargetCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
     )
     ->Utils.Promise.ignoreValue
   }
@@ -434,7 +434,7 @@ SELECT * FROM unnest($1::${(BigInt: Postgres.columnType :> string)}[],$2::${(Int
     sql
     ->Postgres.preparedUnsafe(
       makePruneStaleCheckpointsQuery(~pgSchema),
-      [safeCheckpointId->Utils.BigInt.toString]->Obj.magic,
+      [safeCheckpointId->BigInt.toString]->Obj.magic,
     )
     ->Utils.Promise.ignoreValue
   }
@@ -462,7 +462,7 @@ LIMIT 1;`
       )
       ->(Utils.magic: promise<unknown> => promise<array<{"id": string}>>)
     rawResult->Promise.thenResolve(rows => {
-      rows->Belt.Array.get(0)->Belt.Option.map(row => row["id"]->Utils.BigInt.fromStringUnsafe)
+      rows->Belt.Array.get(0)->Belt.Option.map(row => row["id"]->BigInt.fromStringOrThrow)
     })
   }
 
@@ -484,7 +484,7 @@ GROUP BY "${(#chain_id: field :> string)}";`
     sql
     ->Postgres.preparedUnsafe(
       makeGetRollbackProgressDiffQuery(~pgSchema),
-      [rollbackTargetCheckpointId->Utils.BigInt.toString]->Obj.magic,
+      [rollbackTargetCheckpointId->BigInt.toString]->Obj.magic,
     )
     ->(
       Utils.magic: promise<unknown> => promise<

--- a/packages/envio/src/sources/HyperFuelSource.res
+++ b/packages/envio/src/sources/HyperFuelSource.res
@@ -159,7 +159,7 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
     | {kind: Call} =>
       Js.Exn.raiseError("Call receipt indexing currently supported only in wildcard mode")
     | {kind: LogData({logId}), isWildcard} => {
-        let rb = logId->Utils.BigInt.fromStringUnsafe
+        let rb = logId->BigInt.fromStringOrThrow
         if isWildcard {
           wildcardLogDataRbs->Array.push(rb)->ignore
         } else {
@@ -356,7 +356,7 @@ let make = ({chain, endpointUrl}: options): t => {
 
       let chainId = chain->ChainMap.Chain.toChainId
       let eventId = switch receipt {
-      | LogData({rb}) => Utils.BigInt.toString(rb)
+      | LogData({rb}) => BigInt.toString(rb)
       | Mint(_) => mintEventTag
       | Burn(_) => burnEventTag
       | Transfer(_)

--- a/packages/envio/src/sources/Rpc.res
+++ b/packages/envio/src/sources/Rpc.res
@@ -51,7 +51,7 @@ let makeHexSchema = fromStr =>
     serializer: value => value->Viem.toHex->(Utils.magic: EvmTypes.Hex.t => 'a),
   })
 
-let hexBigintSchema: S.schema<bigint> = makeHexSchema(Utils.BigInt.fromString)
+let hexBigintSchema: S.schema<bigint> = makeHexSchema(BigInt.fromString)
 external number: string => int = "Number"
 let hexIntSchema: S.schema<int> = makeHexSchema(v => v->number->Some)
 

--- a/scenarios/test_codegen/src/handlers/EventHandlers.res
+++ b/scenarios/test_codegen/src/handlers/EventHandlers.res
@@ -36,11 +36,11 @@ Indexer.indexer.onEvent({event: Indexer.Gravatar(NewGravatar)}, async ({event, c
 
   let gravatarSize: Indexer.Enums.GravatarSize.t = SMALL
   let gravatarObject: Indexer.Entities.Gravatar.t = {
-    id: event.params.id->Utils.BigInt.toString,
+    id: event.params.id->BigInt.toString,
     owner_id: event.params.owner->Address.toString,
     displayName: event.params.displayName,
     imageUrl: event.params.imageUrl,
-    updatesCount: Utils.BigInt.fromInt(1),
+    updatesCount: BigInt.fromInt(1),
     size: gravatarSize,
   }
 
@@ -48,7 +48,7 @@ Indexer.indexer.onEvent({event: Indexer.Gravatar(NewGravatar)}, async ({event, c
 })
 
 Indexer.indexer.onEvent({event: Indexer.Gravatar(UpdatedGravatar)}, async ({event, context}) => {
-  let maybeGravatar = await context.\"Gravatar".get(event.params.id->Utils.BigInt.toString)
+  let maybeGravatar = await context.\"Gravatar".get(event.params.id->BigInt.toString)
 
   /// Some examples of user logging
   context.log.debug(`We are processing the event, ${event.block.hash} (debug)`)
@@ -100,13 +100,13 @@ Indexer.indexer.onEvent({event: Indexer.Gravatar(UpdatedGravatar)}, async ({even
   )
 
   let updatesCount =
-    maybeGravatar->Belt.Option.mapWithDefault(Utils.BigInt.fromInt(1), gravatar =>
-      gravatar.Indexer.Entities.Gravatar.updatesCount->Utils.BigInt.add(Utils.BigInt.fromInt(1))
+    maybeGravatar->Belt.Option.mapWithDefault(BigInt.fromInt(1), gravatar =>
+      gravatar.Indexer.Entities.Gravatar.updatesCount->BigInt.add(BigInt.fromInt(1))
     )
 
   let gravatarSize: Indexer.Enums.GravatarSize.t = MEDIUM
   let gravatar: Indexer.Entities.Gravatar.t = {
-    id: event.params.id->Utils.BigInt.toString,
+    id: event.params.id->BigInt.toString,
     owner_id: event.params.owner->Address.toString,
     displayName: event.params.displayName,
     imageUrl: event.params.imageUrl,
@@ -114,7 +114,7 @@ Indexer.indexer.onEvent({event: Indexer.Gravatar(UpdatedGravatar)}, async ({even
     size: gravatarSize,
   }
 
-  if event.params.id->Utils.BigInt.toString == "1001" {
+  if event.params.id->BigInt.toString == "1001" {
     context.log.info("id matched, deleting gravatar 1004")
     context.\"Gravatar".deleteUnsafe("1004")
   }

--- a/scenarios/test_codegen/test/WriteRead_test.res
+++ b/scenarios/test_codegen/test/WriteRead_test.res
@@ -42,9 +42,9 @@ describe("Write/read tests", () => {
       optBool: Some(false),
       //TODO: get array of bools working
       // arrayOfBool: [true, false],
-      bigInt: Utils.BigInt.fromInt(1),
-      optBigInt: Some(Utils.BigInt.fromInt(2)),
-      arrayOfBigInts: [Utils.BigInt.fromInt(3), Utils.BigInt.fromInt(4)],
+      bigInt: BigInt.fromInt(1),
+      optBigInt: Some(BigInt.fromInt(2)),
+      arrayOfBigInts: [BigInt.fromInt(3), BigInt.fromInt(4)],
       bigDecimal: BigDecimal.fromStringUnsafe("1.1"),
       bigDecimalWithConfig: BigDecimal.fromStringUnsafe("1.1"),
       optBigDecimal: Some(BigDecimal.fromStringUnsafe("2.2")),
@@ -67,8 +67,8 @@ describe("Write/read tests", () => {
       optFloat: Some(2.2),
       bool: true,
       optBool: Some(false),
-      bigInt: Utils.BigInt.fromInt(1),
-      optBigInt: Some(Utils.BigInt.fromInt(2)),
+      bigInt: BigInt.fromInt(1),
+      optBigInt: Some(BigInt.fromInt(2)),
       bigDecimal: BigDecimal.fromStringUnsafe("1.1"),
       optBigDecimal: Some(BigDecimal.fromStringUnsafe("2.2")),
       bigDecimalWithConfig: BigDecimal.fromStringUnsafe("1.1"),
@@ -249,42 +249,42 @@ breaking precicion on big values. https://github.com/enviodev/hyperindex/issues/
             contractAddress: "0xabcdef0123456789abcdef0123456789abcdef01"->Utils.magic,
             name: "Test Collection",
             symbol: "TEST",
-            maxSupply: Utils.BigInt.fromInt(100),
+            maxSupply: BigInt.fromInt(100),
             currentSupply: 1,
           })
 
           context.\"Token".set({
             id: "token-1",
-            tokenId: Utils.BigInt.fromInt(50),
+            tokenId: BigInt.fromInt(50),
             collection_id: testCollectionId,
             owner_id: testUserId,
           })
 
           context.\"Token".set({
             id: "token-2",
-            tokenId: Utils.BigInt.fromInt(60),
+            tokenId: BigInt.fromInt(60),
             collection_id: testCollectionId,
             owner_id: testUserId,
           })
 
           // Execute getWhere queries
           whereEqOwnerTest := (await context.\"Token".getWhere({owner: {_eq: testUserId}}))
-          whereEqTokenIdTest := (await context.\"Token".getWhere({tokenId: {_eq: Utils.BigInt.fromInt(50)}}))
-          whereTokenIdGt50Test := (await context.\"Token".getWhere({tokenId: {_gt: Utils.BigInt.fromInt(50)}}))
-          whereTokenIdGt49Test := (await context.\"Token".getWhere({tokenId: {_gt: Utils.BigInt.fromInt(49)}}))
-          whereTokenIdLt50Test := (await context.\"Token".getWhere({tokenId: {_lt: Utils.BigInt.fromInt(50)}}))
-          whereTokenIdLt51Test := (await context.\"Token".getWhere({tokenId: {_lt: Utils.BigInt.fromInt(51)}}))
+          whereEqTokenIdTest := (await context.\"Token".getWhere({tokenId: {_eq: BigInt.fromInt(50)}}))
+          whereTokenIdGt50Test := (await context.\"Token".getWhere({tokenId: {_gt: BigInt.fromInt(50)}}))
+          whereTokenIdGt49Test := (await context.\"Token".getWhere({tokenId: {_gt: BigInt.fromInt(49)}}))
+          whereTokenIdLt50Test := (await context.\"Token".getWhere({tokenId: {_lt: BigInt.fromInt(50)}}))
+          whereTokenIdLt51Test := (await context.\"Token".getWhere({tokenId: {_lt: BigInt.fromInt(51)}}))
 
           // Execute _gte and _lte queries
-          whereTokenIdGte50Test := (await context.\"Token".getWhere({tokenId: {_gte: Utils.BigInt.fromInt(50)}}))
-          whereTokenIdGte51Test := (await context.\"Token".getWhere({tokenId: {_gte: Utils.BigInt.fromInt(51)}}))
-          whereTokenIdLte50Test := (await context.\"Token".getWhere({tokenId: {_lte: Utils.BigInt.fromInt(50)}}))
-          whereTokenIdLte49Test := (await context.\"Token".getWhere({tokenId: {_lte: Utils.BigInt.fromInt(49)}}))
+          whereTokenIdGte50Test := (await context.\"Token".getWhere({tokenId: {_gte: BigInt.fromInt(50)}}))
+          whereTokenIdGte51Test := (await context.\"Token".getWhere({tokenId: {_gte: BigInt.fromInt(51)}}))
+          whereTokenIdLte50Test := (await context.\"Token".getWhere({tokenId: {_lte: BigInt.fromInt(50)}}))
+          whereTokenIdLte49Test := (await context.\"Token".getWhere({tokenId: {_lte: BigInt.fromInt(49)}}))
 
           // Execute _in queries
           whereInOwnerTest := (await context.\"Token".getWhere({owner: {_in: [testUserId, "non-existent-user"]}}))
-          whereInTokenIdTest := (await context.\"Token".getWhere({tokenId: {_in: [Utils.BigInt.fromInt(50), Utils.BigInt.fromInt(60)]}}))
-          whereInTokenIdNoMatchTest := (await context.\"Token".getWhere({tokenId: {_in: [Utils.BigInt.fromInt(999)]}}))
+          whereInTokenIdTest := (await context.\"Token".getWhere({tokenId: {_in: [BigInt.fromInt(50), BigInt.fromInt(60)]}}))
+          whereInTokenIdNoMatchTest := (await context.\"Token".getWhere({tokenId: {_in: [BigInt.fromInt(999)]}}))
           whereInTokenIdEmptyTest := (await context.\"Token".getWhere({tokenId: {_in: []}}))
         },
       },

--- a/scenarios/test_codegen/test/__mocks__/MockEntities.res
+++ b/scenarios/test_codegen/test/__mocks__/MockEntities.res
@@ -3,7 +3,7 @@ let gravatarEntity1: Indexer.Entities.Gravatar.t = {
   owner_id: "0x123",
   displayName: "gravatar1",
   imageUrl: "https://gravatar1.com",
-  updatesCount: Utils.BigInt.fromInt(0),
+  updatesCount: BigInt.fromInt(0),
   size: LARGE,
 }
 
@@ -12,6 +12,6 @@ let gravatarEntity2: Indexer.Entities.Gravatar.t = {
   owner_id: "0x678",
   displayName: "gravatar2",
   imageUrl: "https://gravatar2.com",
-  updatesCount: Utils.BigInt.fromInt(1),
+  updatesCount: BigInt.fromInt(1),
   size: MEDIUM,
 }

--- a/scenarios/test_codegen/test/__mocks__/MockEvents.res
+++ b/scenarios/test_codegen/test/__mocks__/MockEvents.res
@@ -1,53 +1,53 @@
 let newGravatar1: Indexer.Gravatar.NewGravatar.params = {
-  id: 1001->Utils.BigInt.fromInt,
+  id: 1001->BigInt.fromInt,
   owner: "0x1230000000000000000000000000000000000000"->Address.Evm.fromStringOrThrow,
   displayName: "gravatar1",
   imageUrl: "https://gravatar1.com",
 }
 
 let newGravatar2: Indexer.Gravatar.NewGravatar.params = {
-  id: 1002->Utils.BigInt.fromInt,
+  id: 1002->BigInt.fromInt,
   owner: "0x4560000000000000000000000000000000000000"->Address.Evm.fromStringOrThrow,
   displayName: "gravatar2",
   imageUrl: "https://gravatar2.com",
 }
 
 let newGravatar3: Indexer.Gravatar.NewGravatar.params = {
-  id: 1003->Utils.BigInt.fromInt,
+  id: 1003->BigInt.fromInt,
   owner: "0x7890000000000000000000000000000000000000"->Address.Evm.fromStringOrThrow,
   displayName: "gravatar3",
   imageUrl: "https://gravatar3.com",
 }
 
 let newGravatar4_deleted: Indexer.Gravatar.NewGravatar.params = {
-  id: 1004->Utils.BigInt.fromInt,
+  id: 1004->BigInt.fromInt,
   owner: "0x9990000000000000000000000000000000000000"->Address.Evm.fromStringOrThrow,
   displayName: "gravatar4_deleted",
   imageUrl: "https://gravatar4.com",
 }
 
 let setGravatar1: Indexer.Gravatar.UpdatedGravatar.params = {
-  id: 1001->Utils.BigInt.fromInt,
+  id: 1001->BigInt.fromInt,
   owner: "0x1230000000000000000000000000000000000000"->Address.Evm.fromStringOrThrow,
   displayName: "update1",
   imageUrl: "https://gravatar1.com",
 }
 
 let setGravatar2: Indexer.Gravatar.UpdatedGravatar.params = {
-  id: 1002->Utils.BigInt.fromInt,
+  id: 1002->BigInt.fromInt,
   owner: "0x4560000000000000000000000000000000000000"->Address.Evm.fromStringOrThrow,
   displayName: "update2",
   imageUrl: "https://gravatar2.com",
 }
 
 let setGravatar3: Indexer.Gravatar.UpdatedGravatar.params = {
-  id: 1003->Utils.BigInt.fromInt,
+  id: 1003->BigInt.fromInt,
   owner: "0x7890000000000000000000000000000000000000"->Address.Evm.fromStringOrThrow,
   displayName: "update3",
   imageUrl: "https://gravatar3.com",
 }
 let setGravatar4: Indexer.Gravatar.UpdatedGravatar.params = {
-  id: 1004->Utils.BigInt.fromInt,
+  id: 1004->BigInt.fromInt,
   owner: "0x9990000000000000000000000000000000000000"->Address.Evm.fromStringOrThrow,
   displayName: "update4",
   imageUrl: "https://gravatar4.com",

--- a/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
@@ -22,7 +22,7 @@ describe("Test makeClickHouseEntitySchema", () => {
       arrayOfFloats: [],
       bool: true,
       optBool: None,
-      bigInt: Utils.BigInt.fromInt(1),
+      bigInt: BigInt.fromInt(1),
       optBigInt: None,
       arrayOfBigInts: [],
       bigDecimal: BigDecimal.fromFloat(1.0),

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -115,7 +115,7 @@ describe("E2E rollback tests", () => {
             eventsProcessed: 2,
           },
           {
-            id: firstHistoryCheckpointId->Utils.BigInt.add(1n),
+            id: firstHistoryCheckpointId->BigInt.add(1n),
             blockHash: Js.Null.Value("0x102"),
             blockNumber: 102,
             chainId: 1337,
@@ -154,7 +154,7 @@ describe("E2E rollback tests", () => {
             },
           }),
           Set({
-            checkpointId: firstHistoryCheckpointId->Utils.BigInt.add(1n),
+            checkpointId: firstHistoryCheckpointId->BigInt.add(1n),
             entityId: "3",
             entity: {
               Indexer.Entities.SimpleEntity.id: "3",
@@ -170,7 +170,7 @@ describe("E2E rollback tests", () => {
             },
           }),
           Delete({
-            checkpointId: firstHistoryCheckpointId->Utils.BigInt.add(1n),
+            checkpointId: firstHistoryCheckpointId->BigInt.add(1n),
             entityId: "4",
           }),
         ],
@@ -269,7 +269,7 @@ describe("E2E rollback tests", () => {
       (
         [
           {
-            id: firstHistoryCheckpointId->Utils.BigInt.add(3n),
+            id: firstHistoryCheckpointId->BigInt.add(3n),
             blockHash: Js.Null.Value("0x101"),
             blockNumber: 101,
             chainId: 1337,
@@ -288,7 +288,7 @@ describe("E2E rollback tests", () => {
         ],
         [
           Set({
-            checkpointId: firstHistoryCheckpointId->Utils.BigInt.add(3n),
+            checkpointId: firstHistoryCheckpointId->BigInt.add(3n),
             entityId: "1",
             entity: {
               Indexer.Entities.SimpleEntity.id: "1",
@@ -296,7 +296,7 @@ describe("E2E rollback tests", () => {
             },
           }),
           Set({
-            checkpointId: firstHistoryCheckpointId->Utils.BigInt.add(3n),
+            checkpointId: firstHistoryCheckpointId->BigInt.add(3n),
             entityId: "2",
             entity: {
               Indexer.Entities.SimpleEntity.id: "2",


### PR DESCRIPTION
## Summary
This PR refactors the codebase to use direct `BigInt` module imports instead of accessing BigInt functions through the `Utils` namespace. Additionally, it removes the BigInt module implementation from Utils.res and renames some bitwise operations for consistency.

## Key Changes

- **Removed BigInt module from Utils.res**: The entire BigInt module implementation (constructors, operations, comparisons, and bitwise operations) has been removed from `packages/envio/src/Utils.res`
- **Updated all BigInt references**: Changed all `Utils.BigInt.*` calls to direct `BigInt.*` calls throughout the codebase
- **Renamed bitwise operations**: 
  - `Utils.BigInt.Bitwise.shift_left` → `BigInt.shiftLeft`
  - `Utils.BigInt.Bitwise.shift_right` → `BigInt.shiftRight`
  - `Utils.BigInt.Bitwise.logor` → `BigInt.bitwiseOr`
  - `Utils.BigInt.Bitwise.logand` → `BigInt.bitwiseAnd`
- **Added new function**: `BigInt.fromStringOrThrow` (replacing `fromStringUnsafe` in some contexts)
- **Updated schema implementations**: Modified BigInt schema in Utils.res to use the new direct `BigInt` module references

## Files Modified
- `packages/envio/src/Utils.res` - Removed BigInt module, updated schema
- `packages/envio/src/EventUtils.res` - Updated BigInt references and bitwise operations
- `packages/envio/src/PgStorage.res` - Updated BigInt function calls
- `packages/envio/src/db/InternalTable.res` - Updated BigInt references
- `packages/envio/src/db/EntityHistory.res` - Updated BigInt references
- `packages/envio/src/Batch.res` - Updated BigInt operations
- `packages/envio/src/TestIndexer.res` - Updated BigInt references
- `packages/envio/src/TopicFilter.res` - Updated bitwise operations
- `packages/envio/src/bindings/ClickHouse.res` - Updated BigInt references
- `packages/envio/src/EventProcessing.res` - Updated BigInt references
- `packages/envio/src/sources/HyperFuelSource.res` - Updated BigInt references
- `packages/envio/src/ChainManager.res` - Updated BigInt references
- `packages/envio/src/GlobalState.res` - Updated BigInt references
- `packages/envio/src/TableIndices.res` - Updated BigInt references
- `packages/envio/src/sources/Rpc.res` - Updated BigInt schema
- Test and scenario files - Updated all BigInt references

## Implementation Details
The BigInt module is now accessed directly without the Utils namespace prefix, making the code cleaner and more maintainable. The bitwise operations have been renamed to use camelCase convention (`shiftLeft`, `shiftRight`, `bitwiseOr`, `bitwiseAnd`) for consistency with ReScript naming conventions.

https://claude.ai/code/session_01Xz4xkYkoC8pXAT3WbgLnVY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced internal BigInt utility wrappers with the native BigInt module across the codebase, simplifying numeric handling and reducing internal utility usage while preserving existing behaviors and external APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->