### PR TITLE
feat(cli): auto-launch ClickHouse container when ClickHouse storage is selected

### DIFF
--- a/.github/workflows/build_and_verify.yml
+++ b/.github/workflows/build_and_verify.yml
@@ -403,7 +403,7 @@ jobs:
           - 8080:8080
 
       clickhouse:
-        image: clickhouse/clickhouse-server:latest
+        image: clickhouse/clickhouse-server:26.2.15.4
         env:
           CLICKHOUSE_PASSWORD: testing
         options: >-

--- a/packages/cli/src/commands.rs
+++ b/packages/cli/src/commands.rs
@@ -13,8 +13,21 @@ async fn execute_command(
     args: Vec<&str>,
     current_dir: &Path,
 ) -> anyhow::Result<std::process::ExitStatus> {
+    execute_command_with_env(cmd, args, current_dir, &[]).await
+}
+
+/// Like execute_command, but lets the caller inject extra env vars into the
+/// child process without clobbering the inherited environment. Used by the
+/// dev flow to forward credentials for containers we just booted.
+async fn execute_command_with_env(
+    cmd: &str,
+    args: Vec<&str>,
+    current_dir: &Path,
+    extra_env: &[(String, String)],
+) -> anyhow::Result<std::process::ExitStatus> {
     tokio::process::Command::new(cmd)
         .args(&args)
+        .envs(extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
         .current_dir(current_dir)
         .stdin(std::process::Stdio::null()) //passes null on any stdinprompt
         .kill_on_drop(true) //needed so that dropped threads calling this will also drop
@@ -189,12 +202,15 @@ pub mod codegen {
 }
 
 pub mod start {
-    use super::{execute_command, to_js_path};
+    use super::{execute_command_with_env, to_js_path};
     use crate::config_parsing::system_config::SystemConfig;
     use anyhow::anyhow;
     use pathdiff::diff_paths;
 
-    pub async fn start_indexer(config: &SystemConfig) -> anyhow::Result<()> {
+    pub async fn start_indexer(
+        config: &SystemConfig,
+        extra_env: &[(String, String)],
+    ) -> anyhow::Result<()> {
         // Compute the relative path from project root to generated directory
         let relative_generated = diff_paths(
             &config.parsed_project_paths.generated,
@@ -208,7 +224,13 @@ pub mod start {
         let args = vec!["--no-warnings", &index_path];
 
         // Run from project root to ensure proper cwd for handlers
-        let exit = execute_command(cmd, args, &config.parsed_project_paths.project_root).await?;
+        let exit = execute_command_with_env(
+            cmd,
+            args,
+            &config.parsed_project_paths.project_root,
+            extra_env,
+        )
+        .await?;
 
         if !exit.success() {
             return Err(anyhow!(

--- a/packages/cli/src/commands.rs
+++ b/packages/cli/src/commands.rs
@@ -19,6 +19,9 @@ async fn execute_command(
 /// Like execute_command, but lets the caller inject extra env vars into the
 /// child process without clobbering the inherited environment. Used by the
 /// dev flow to forward credentials for containers we just booted.
+///
+/// Precedence: `extra_env` values override identically-named vars inherited
+/// from the parent process (including those loaded from `.env`).
 async fn execute_command_with_env(
     cmd: &str,
     args: Vec<&str>,

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -150,8 +150,16 @@ async fn connect_docker() -> anyhow::Result<Docker> {
     )
 }
 
+const DEFAULT_PG_HOST: &str = "localhost";
+const DEFAULT_CH_URL: &str = "http://localhost:8123";
+
 struct EnvConfig {
-    pg_host: String,
+    /// None when the user hasn't set ENVIO_PG_HOST — that's our signal that
+    /// they want the Dockerised Postgres and we'll point everything at
+    /// DEFAULT_PG_HOST. Some(value) means "I manage this myself", which
+    /// bypasses the container entirely regardless of what the value is
+    /// (even "localhost").
+    pg_host: Option<String>,
     pg_port: String,
     pg_password: String,
     pg_user: String,
@@ -160,11 +168,9 @@ struct EnvConfig {
     hasura_port: String,
     hasura_enable_console: String,
     hasura_admin_secret: String,
-    /// Raw ENVIO_CLICKHOUSE_HOST as the user set it (or our default
-    /// "http://localhost:8123"). Parsed into scheme/host/port on demand via
-    /// `ch_url()` rather than stored pre-parsed so the raw string can feed
-    /// back into the runtime subprocess unchanged.
-    ch_host: String,
+    /// Same presence-is-the-flag rule as pg_host: None → start our
+    /// ClickHouse container at DEFAULT_CH_URL; Some(url) → user manages it.
+    ch_host: Option<String>,
     ch_user: String,
     ch_password: String,
     ch_database: String,
@@ -207,17 +213,17 @@ impl EnvConfig {
             .load()
             .ok();
 
+        let var_opt = |name: &str| -> Option<String> {
+            std::env::var(name)
+                .ok()
+                .or_else(|| dotenv.as_ref().and_then(|m: &EnvMap| m.var(name).ok()))
+        };
         let var = |name: &str, default: &str| -> String {
-            std::env::var(name).unwrap_or_else(|_| {
-                dotenv
-                    .as_ref()
-                    .and_then(|m: &EnvMap| m.var(name).ok())
-                    .unwrap_or_else(|| default.to_string())
-            })
+            var_opt(name).unwrap_or_else(|| default.to_string())
         };
 
         Self {
-            pg_host: var("ENVIO_PG_HOST", "localhost"),
+            pg_host: var_opt("ENVIO_PG_HOST"),
             pg_port: var("ENVIO_PG_PORT", "5433"),
             pg_password: var("ENVIO_PG_PASSWORD", "testing"),
             pg_user: var("ENVIO_PG_USER", "postgres"),
@@ -226,34 +232,44 @@ impl EnvConfig {
             hasura_port: var("HASURA_EXTERNAL_PORT", "8080"),
             hasura_enable_console: var("HASURA_GRAPHQL_ENABLE_CONSOLE", "true"),
             hasura_admin_secret: var("HASURA_GRAPHQL_ADMIN_SECRET", "testing"),
-            ch_host: var("ENVIO_CLICKHOUSE_HOST", "http://localhost:8123"),
+            ch_host: var_opt("ENVIO_CLICKHOUSE_HOST"),
             ch_user: var("ENVIO_CLICKHOUSE_USERNAME", "default"),
             ch_password: var("ENVIO_CLICKHOUSE_PASSWORD", "testing"),
             ch_database: var("ENVIO_CLICKHOUSE_DATABASE", "envio_sink"),
         }
     }
 
-    /// Whether the user has pointed Postgres at an externally-managed host,
-    /// meaning we should not start a Docker Postgres container. Only the
-    /// default value ("localhost") is treated as local; any other value —
-    /// including 127.0.0.1 — is taken as an explicit opt-in to external
-    /// Postgres, since the default never resolves to those literals.
+    /// External ⇔ the user set ENVIO_PG_HOST at all. Any value (even the
+    /// literal "localhost") is treated as an explicit "I manage Postgres
+    /// myself"; unset means we boot the Dockerised Postgres.
     fn pg_is_external(&self) -> bool {
-        self.pg_host != "localhost"
+        self.pg_host.is_some()
     }
 
-    /// Whether the user has pointed ClickHouse at an externally-managed host.
-    /// Same rule as pg_is_external: only the exact default URL
-    /// ("http://localhost:8123") is treated as local.
+    /// The host string to connect to — either the user-provided value when
+    /// external, or DEFAULT_PG_HOST for our own container.
+    fn pg_host_str(&self) -> &str {
+        self.pg_host.as_deref().unwrap_or(DEFAULT_PG_HOST)
+    }
+
+    /// External ⇔ the user set ENVIO_CLICKHOUSE_HOST at all. Same rule as
+    /// pg_is_external; unset means we boot the container at DEFAULT_CH_URL.
     fn ch_is_external(&self) -> bool {
-        self.ch_host != "http://localhost:8123"
+        self.ch_host.is_some()
     }
 
-    /// Parse `ch_host`. The caller decides when to fail (e.g. only when the
-    /// ClickHouse storage backend is actually selected, so users who never
-    /// opt into ClickHouse can still have garbage in ENVIO_CLICKHOUSE_HOST).
+    /// The raw URL string — either the user-provided value when external,
+    /// or DEFAULT_CH_URL for our own container.
+    fn ch_host_str(&self) -> &str {
+        self.ch_host.as_deref().unwrap_or(DEFAULT_CH_URL)
+    }
+
+    /// Parse the effective URL (user's when external, default otherwise).
+    /// The caller decides when to fail — we only parse if ClickHouse is
+    /// actually selected, so users who never opt into ClickHouse can keep
+    /// garbage in ENVIO_CLICKHOUSE_HOST.
     fn ch_url(&self) -> anyhow::Result<ClickHouseUrl> {
-        ClickHouseUrl::parse(&self.ch_host)
+        ClickHouseUrl::parse(self.ch_host_str())
     }
 
     /// Deterministic hash of all config values used to detect drift.
@@ -262,8 +278,21 @@ impl EnvConfig {
     /// ClickHouse fields are included so that user/password/db changes
     /// recreate the managed ClickHouse container.
     fn config_hash(&self) -> String {
+        // Prefix host fields with a 1-byte tag so that None and
+        // Some("<default>") hash differently — they take different code
+        // paths (Docker vs external) and embed different hosts in
+        // Hasura's DATABASE_URL, so switching between them is real drift.
+        fn hash_opt(hasher: &mut Sha256, v: &Option<String>) {
+            match v {
+                None => hasher.update([0u8]),
+                Some(s) => {
+                    hasher.update([1u8]);
+                    hasher.update(s);
+                }
+            }
+        }
         let mut hasher = Sha256::new();
-        hasher.update(&self.pg_host);
+        hash_opt(&mut hasher, &self.pg_host);
         hasher.update(&self.pg_port);
         hasher.update(&self.pg_password);
         hasher.update(&self.pg_user);
@@ -271,7 +300,7 @@ impl EnvConfig {
         hasher.update(&self.hasura_port);
         hasher.update(&self.hasura_enable_console);
         hasher.update(&self.hasura_admin_secret);
-        hasher.update(&self.ch_host);
+        hash_opt(&mut hasher, &self.ch_host);
         hasher.update(&self.ch_user);
         hasher.update(&self.ch_password);
         hasher.update(&self.ch_database);
@@ -663,11 +692,10 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         None
     };
 
-    // Probe each service at the configured host. Anything other than the
-    // default is treated as externally-managed (see EnvConfig::pg_is_external
-    // / ch_is_external). Local Docker publishes on 0.0.0.0, so "localhost"
-    // reaches it. Hasura is always our own container, so probe on localhost.
-    let pg_probe_host = env.pg_host.as_str();
+    // Probe each service at the configured host. When external the env var
+    // tells us where to look; when local the container publishes on 0.0.0.0
+    // so "localhost" reaches it. Hasura is always our own container.
+    let pg_probe_host = env.pg_host_str();
     let hasura_probe_host = "localhost";
     let pg_external = env.pg_is_external();
     let ch_external = env.ch_is_external();
@@ -695,7 +723,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             "ENVIO_PG_HOST is set to external host {host:?} but Postgres is not reachable on \
              {host}:{port}. Refusing to start a Docker container for an externally-managed \
              Postgres; check that the host is reachable and credentials are correct.",
-            host = env.pg_host,
+            host = env.pg_host_str(),
             port = pg_host_port
         );
     }
@@ -709,7 +737,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
              responding at {scheme}://{host}:{port}. Refusing to start a Docker container for an \
              externally-managed ClickHouse; check that the host is reachable and credentials are \
              correct.",
-            raw = env.ch_host,
+            raw = env.ch_host_str(),
             scheme = url.scheme,
             host = url.host,
             port = url.port
@@ -723,7 +751,8 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
     if pg_external {
         println!(
             "Using your Postgres at {}:{} (from ENVIO_PG_HOST)",
-            env.pg_host, pg_host_port
+            env.pg_host_str(),
+            pg_host_port
         );
     } else if pg_alive {
         println!("Using Postgres already running on port {pg_host_port}");
@@ -738,7 +767,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         if ch_external {
             println!(
                 "Using your ClickHouse at {} (from ENVIO_CLICKHOUSE_HOST)",
-                env.ch_host
+                env.ch_host_str()
             );
         } else if ch_alive {
             let port = ch_url.as_ref().map(|u| u.port).unwrap_or(8123);
@@ -754,7 +783,10 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
     // duplicate values into .env.
     let indexer_env = if opts.clickhouse {
         vec![
-            ("ENVIO_CLICKHOUSE_HOST".to_string(), env.ch_host.clone()),
+            (
+                "ENVIO_CLICKHOUSE_HOST".to_string(),
+                env.ch_host_str().to_string(),
+            ),
             ("ENVIO_CLICKHOUSE_USERNAME".to_string(), env.ch_user.clone()),
             (
                 "ENVIO_CLICKHOUSE_PASSWORD".to_string(),
@@ -872,7 +904,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         // supplied host/port — the user is responsible for ensuring that
         // address is routable from the Hasura container.
         let (db_host, db_port) = if pg_external {
-            (env.pg_host.as_str(), pg_host_port)
+            (env.pg_host_str(), pg_host_port)
         } else {
             (PG_CONTAINER, 5432u16)
         };
@@ -1143,7 +1175,7 @@ mod tests {
 
     fn default_env() -> EnvConfig {
         EnvConfig {
-            pg_host: "localhost".into(),
+            pg_host: None,
             pg_port: "5433".into(),
             pg_password: "testing".into(),
             pg_user: "postgres".into(),
@@ -1152,7 +1184,7 @@ mod tests {
             hasura_port: "8080".into(),
             hasura_enable_console: "true".into(),
             hasura_admin_secret: "testing".into(),
-            ch_host: "http://localhost:8123".into(),
+            ch_host: None,
             ch_user: "default".into(),
             ch_password: "testing".into(),
             ch_database: "envio_sink".into(),
@@ -1176,64 +1208,78 @@ mod tests {
     #[test]
     fn config_hash_changes_on_pg_host() {
         let env2 = EnvConfig {
-            pg_host: "db.example.com".into(),
+            pg_host: Some("db.example.com".into()),
             ..default_env()
         };
         assert_ne!(default_env().config_hash(), env2.config_hash());
     }
 
     #[test]
-    fn pg_is_external_treats_only_localhost_as_local() {
-        let hosts = [
-            "localhost",
-            "127.0.0.1",
-            "0.0.0.0",
-            "::1",
-            "db.example.com",
-            "host.docker.internal",
-        ];
-        let results: Vec<bool> = hosts
+    fn pg_is_external_iff_env_var_set() {
+        assert!(!default_env().pg_is_external());
+        // Any value — even "localhost" — counts as external when explicitly set.
+        let values = ["localhost", "127.0.0.1", "db.example.com"];
+        let results: Vec<bool> = values
             .iter()
             .map(|h| {
                 EnvConfig {
-                    pg_host: (*h).into(),
+                    pg_host: Some((*h).into()),
                     ..default_env()
                 }
                 .pg_is_external()
             })
             .collect();
-        assert_eq!(results, vec![false, true, true, true, true, true]);
+        assert_eq!(results, vec![true, true, true]);
+    }
+
+    #[test]
+    fn pg_host_str_returns_default_when_unset() {
+        assert_eq!(default_env().pg_host_str(), DEFAULT_PG_HOST);
+        let ext = EnvConfig {
+            pg_host: Some("db.example.com".into()),
+            ..default_env()
+        };
+        assert_eq!(ext.pg_host_str(), "db.example.com");
     }
 
     #[test]
     fn config_hash_changes_on_ch_host() {
         let env2 = EnvConfig {
-            ch_host: "https://ch.cloud.example.com:8443".into(),
+            ch_host: Some("https://ch.cloud.example.com:8443".into()),
             ..default_env()
         };
         assert_ne!(default_env().config_hash(), env2.config_hash());
     }
 
     #[test]
-    fn ch_is_external_treats_only_default_as_local() {
-        let hosts = [
+    fn ch_is_external_iff_env_var_set() {
+        assert!(!default_env().ch_is_external());
+        let values = [
             "http://localhost:8123",
             "http://127.0.0.1:8123",
-            "http://localhost:8124",
             "https://ch.cloud.example.com",
-            "http://clickhouse:8123",
         ];
-        let results: Vec<bool> = hosts
+        let results: Vec<bool> = values
             .iter()
             .map(|h| {
                 EnvConfig {
-                    ch_host: (*h).into(),
+                    ch_host: Some((*h).into()),
                     ..default_env()
                 }
                 .ch_is_external()
             })
             .collect();
-        assert_eq!(results, vec![false, true, true, true, true]);
+        assert_eq!(results, vec![true, true, true]);
+    }
+
+    #[test]
+    fn ch_host_str_returns_default_when_unset() {
+        assert_eq!(default_env().ch_host_str(), DEFAULT_CH_URL);
+        let ext = EnvConfig {
+            ch_host: Some("http://10.0.0.5:9000".into()),
+            ..default_env()
+        };
+        assert_eq!(ext.ch_host_str(), "http://10.0.0.5:9000");
     }
 
     #[test]

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -187,17 +187,28 @@ struct ClickHouseUrl {
 
 impl ClickHouseUrl {
     fn parse(raw: &str) -> anyhow::Result<Self> {
-        let url = reqwest::Url::parse(raw)
-            .with_context(|| format!("ENVIO_CLICKHOUSE_HOST is not a valid URL: {raw:?}"))?;
+        let url = reqwest::Url::parse(raw).with_context(|| {
+            format!(
+                "ENVIO_CLICKHOUSE_HOST={raw:?} is not a valid URL.\n\
+                 Expected format: http://host:port (e.g. http://localhost:8123).\n\
+                 Unset the variable to let the CLI start a local Docker container instead."
+            )
+        })?;
         let scheme = url.scheme().to_string();
         if scheme != "http" && scheme != "https" {
             anyhow::bail!(
-                "ENVIO_CLICKHOUSE_HOST must use http or https, got scheme {scheme:?} in {raw:?}"
+                "ENVIO_CLICKHOUSE_HOST={raw:?} uses unsupported scheme {scheme:?}.\n\
+                 Only http:// and https:// are supported."
             );
         }
         let host = url
             .host_str()
-            .ok_or_else(|| anyhow::anyhow!("ENVIO_CLICKHOUSE_HOST has no host: {raw:?}"))?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "ENVIO_CLICKHOUSE_HOST={raw:?} has no hostname.\n\
+                     Expected format: http://host:port (e.g. http://localhost:8123)."
+                )
+            })?
             .to_string();
         let port = url
             .port()
@@ -674,14 +685,20 @@ pub struct UpResult {
 
 pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
     let env = EnvConfig::from_project(opts.project_root);
-    let pg_host_port: u16 = env
-        .pg_port
-        .parse()
-        .context("ENVIO_PG_PORT is not a valid port")?;
-    let hasura_host_port: u16 = env
-        .hasura_port
-        .parse()
-        .context("HASURA_EXTERNAL_PORT is not a valid port")?;
+    let pg_host_port: u16 = env.pg_port.parse().with_context(|| {
+        format!(
+            "ENVIO_PG_PORT={:?} is not a valid port number. \
+             Remove it from your .env / environment to use the default (5433).",
+            env.pg_port
+        )
+    })?;
+    let hasura_host_port: u16 = env.hasura_port.parse().with_context(|| {
+        format!(
+            "HASURA_EXTERNAL_PORT={:?} is not a valid port number. \
+             Remove it from your .env / environment to use the default (8080).",
+            env.hasura_port
+        )
+    })?;
 
     // Parse the ClickHouse URL only when the project actually opts into
     // ClickHouse — garbage in ENVIO_CLICKHOUSE_HOST shouldn't break users
@@ -691,9 +708,6 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
     } else {
         None
     };
-    // Destructure into a plain reference for use in async blocks below —
-    // avoids scattered `.expect()` calls whose invariant ("ch_url is Some
-    // when opts.clickhouse") would only be checked at runtime.
     let ch_url_ref = ch_url.as_ref();
     let probe_client = build_probe_client();
 
@@ -720,33 +734,35 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         }
     );
 
-    // If the user points us at an external Postgres, never start a container
-    // for it — fail fast if it isn't actually reachable so the user sees the
-    // misconfiguration instead of Docker silently filling in.
+    // External + unreachable → bail with actionable guidance instead of
+    // silently starting a Docker container the user didn't ask for.
     if pg_external && !pg_alive {
         anyhow::bail!(
-            "ENVIO_PG_HOST is set to external host {host:?} but Postgres is not reachable on \
-             {host}:{port}. Refusing to start a Docker container for an externally-managed \
-             Postgres; check that the host is reachable and credentials are correct.",
+            "Postgres is not reachable at {host}:{port} (from ENVIO_PG_HOST).\n\
+             \n\
+             Possible fixes:\n\
+             - Verify the host is running and accepts connections on that port.\n\
+             - Unset ENVIO_PG_HOST to let the CLI start a local Docker container instead.",
             host = env.pg_host_str(),
             port = pg_host_port
         );
     }
-
-    // Same guardrail for ClickHouse: if the user points us at an external
-    // server, require it to actually respond to /ping.
-    if opts.clickhouse && ch_external && !ch_alive {
-        let url = ch_url_ref.expect("set when opts.clickhouse");
-        anyhow::bail!(
-            "ENVIO_CLICKHOUSE_HOST is set to external {raw:?} but ClickHouse /ping is not \
-             responding at {scheme}://{host}:{port}. Refusing to start a Docker container for an \
-             externally-managed ClickHouse; check that the host is reachable and credentials are \
-             correct.",
-            raw = env.ch_host_str(),
-            scheme = url.scheme,
-            host = url.host,
-            port = url.port
-        );
+    if let Some(url) = ch_url_ref {
+        if ch_external && !ch_alive {
+            anyhow::bail!(
+                "ClickHouse is not reachable at {scheme}://{host}:{port}/ping \
+                 (from ENVIO_CLICKHOUSE_HOST={raw:?}).\n\
+                 \n\
+                 Possible fixes:\n\
+                 - Verify ClickHouse is running and the /ping endpoint responds.\n\
+                 - Check that the URL scheme, host, and port are correct.\n\
+                 - Unset ENVIO_CLICKHOUSE_HOST to let the CLI start a local Docker container instead.",
+                raw = env.ch_host_str(),
+                scheme = url.scheme,
+                host = url.host,
+                port = url.port
+            );
+        }
     }
 
     let need_pg = !pg_external && !pg_alive;
@@ -768,15 +784,14 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
     if !env.hasura_enabled {
         println!("Hasura disabled (ENVIO_HASURA=false)");
     }
-    if opts.clickhouse {
+    if let Some(url) = ch_url_ref {
         if ch_external {
             println!(
                 "Using your ClickHouse at {} (from ENVIO_CLICKHOUSE_HOST)",
                 env.ch_host_str()
             );
         } else if ch_alive {
-            let port = ch_url_ref.map(|u| u.port).unwrap_or(8123);
-            println!("Using ClickHouse already running on port {port}");
+            println!("Using ClickHouse already running on port {}", url.port);
         }
     }
 
@@ -974,13 +989,15 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         Ok(())
     };
 
+    // ClickHouse pipeline — only entered when ch_url was parsed (opts.clickhouse),
+    // so the `if let` always matches when need_ch is true. No expect() needed.
     let clickhouse_pipeline = async {
-        if !need_ch {
+        let Some(url) = ch_url_ref else {
             return Ok::<(), anyhow::Error>(());
+        };
+        if !need_ch {
+            return Ok(());
         }
-        // Only reached when ClickHouse is selected, not external, and not
-        // alive — so the URL parsed earlier is present and usable.
-        let url = ch_url_ref.expect("set when opts.clickhouse");
         let (img_res, net_res, vol_res) = tokio::join!(
             ensure_image(&docker, CLICKHOUSE_IMAGE),
             ensure_network(&docker, NETWORK),
@@ -1053,7 +1070,12 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             if start.elapsed() > Duration::from_secs(60) {
                 eprintln!();
                 anyhow::bail!(
-                    "Postgres did not become reachable on port {pg_host_port} within 60s"
+                    "Postgres did not become reachable on port {pg_host_port} within 60 s.\n\
+                     \n\
+                     Try:\n\
+                     - docker logs {PG_CONTAINER}\n\
+                     - docker ps -a | grep {PG_CONTAINER}\n\
+                     - Ensure nothing else is using port {pg_host_port}."
                 );
             }
             tokio::time::sleep(Duration::from_millis(500)).await;
@@ -1075,8 +1097,12 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             if start.elapsed() > Duration::from_secs(120) {
                 eprintln!();
                 anyhow::bail!(
-                    "Hasura did not become healthy on port {hasura_host_port} within 120s.\n\
-                     Check container logs: docker logs {HASURA_CONTAINER}"
+                    "Hasura did not become healthy on port {hasura_host_port} within 120 s.\n\
+                     \n\
+                     Try:\n\
+                     - docker logs {HASURA_CONTAINER}\n\
+                     - Verify Postgres is running (Hasura depends on it).\n\
+                     - Ensure nothing else is using port {hasura_host_port}."
                 );
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
@@ -1085,10 +1111,12 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
     };
 
     let wait_ch = async {
-        if !need_ch {
+        let Some(url) = ch_url_ref else {
             return Ok::<(), anyhow::Error>(());
+        };
+        if !need_ch {
+            return Ok(());
         }
-        let url = ch_url_ref.expect("set when opts.clickhouse");
         eprint!("Waiting for ClickHouse...");
         let start = std::time::Instant::now();
         loop {
@@ -1099,8 +1127,12 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             if start.elapsed() > Duration::from_secs(60) {
                 eprintln!();
                 anyhow::bail!(
-                    "ClickHouse did not become healthy on port {port} within 60s.\n\
-                     Check container logs: docker logs {CH_CONTAINER}",
+                    "ClickHouse did not become healthy on port {port} within 60 s.\n\
+                     \n\
+                     Try:\n\
+                     - docker logs {CH_CONTAINER}\n\
+                     - docker ps -a | grep {CH_CONTAINER}\n\
+                     - Ensure nothing else is using port {port}.",
                     port = url.port
                 );
             }

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -624,11 +624,13 @@ async fn ensure_container(
     Ok(true)
 }
 
-/// Caller-supplied hints that steer which services `up()` manages. Today
-/// this only toggles ClickHouse, which piggybacks on whether the project
-/// config actually selects the ClickHouse storage backend.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct UpOptions {
+/// Caller-supplied parameters for `up()`. Bundles the project root (used to
+/// locate `.env`) alongside feature flags like ClickHouse so that callers
+/// only need to construct one value and the signature can grow without
+/// touching every call site.
+#[derive(Debug, Clone, Copy)]
+pub struct UpOptions<'a> {
+    pub project_root: &'a Path,
     pub clickhouse: bool,
 }
 
@@ -641,8 +643,8 @@ pub struct UpResult {
     pub indexer_env: Vec<(String, String)>,
 }
 
-pub async fn up(project_root: &Path, opts: UpOptions) -> anyhow::Result<UpResult> {
-    let env = EnvConfig::from_project(project_root);
+pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
+    let env = EnvConfig::from_project(opts.project_root);
     let pg_host_port: u16 = env
         .pg_port
         .parse()
@@ -1275,8 +1277,18 @@ mod tests {
     }
 
     #[test]
-    fn up_options_default_clickhouse_false() {
-        let opts = UpOptions::default();
-        assert_eq!(opts.clickhouse, false);
+    fn up_options_copies_values() {
+        // Smoke test that UpOptions threads both fields and is Copy so
+        // callers don't need to clone before passing in.
+        let root = Path::new("/tmp/project");
+        let a = UpOptions {
+            project_root: root,
+            clickhouse: true,
+        };
+        let b = a;
+        assert_eq!(
+            (a.project_root, a.clickhouse, b.project_root, b.clickhouse),
+            (root, true, root, true)
+        );
     }
 }

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -19,12 +19,15 @@ use tokio::time::Duration;
 
 const POSTGRES_IMAGE: &str = "postgres:18.3";
 const HASURA_IMAGE: &str = "hasura/graphql-engine:v2.43.0";
+const CLICKHOUSE_IMAGE: &str = "clickhouse/clickhouse-server:26.2.15.4";
 const CONFIG_HASH_LABEL: &str = "dev.envio.config-hash";
 const SOCKET_TIMEOUT: u64 = 120;
 
 const PG_CONTAINER: &str = "envio-postgres";
 const HASURA_CONTAINER: &str = "envio-hasura";
+const CH_CONTAINER: &str = "envio-clickhouse";
 const VOLUME: &str = "envio-postgres-data";
+const CH_VOLUME: &str = "envio-clickhouse-data";
 const NETWORK: &str = "envio-network";
 
 /// Extra Docker socket locations that `connect_with_local_defaults()` may miss.
@@ -157,6 +160,44 @@ struct EnvConfig {
     hasura_port: String,
     hasura_enable_console: String,
     hasura_admin_secret: String,
+    /// Raw ENVIO_CLICKHOUSE_HOST as the user set it (or our default
+    /// "http://localhost:8123"). Parsed into scheme/host/port on demand via
+    /// `ch_url()` rather than stored pre-parsed so the raw string can feed
+    /// back into the runtime subprocess unchanged.
+    ch_host: String,
+    ch_user: String,
+    ch_password: String,
+    ch_database: String,
+}
+
+/// Parsed view of `ENVIO_CLICKHOUSE_HOST`. Scheme-derived default port lets
+/// users omit `:8123` on managed ClickHouse URLs like `https://…cloud`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ClickHouseUrl {
+    scheme: String,
+    host: String,
+    port: u16,
+}
+
+impl ClickHouseUrl {
+    fn parse(raw: &str) -> anyhow::Result<Self> {
+        let url = reqwest::Url::parse(raw)
+            .with_context(|| format!("ENVIO_CLICKHOUSE_HOST is not a valid URL: {raw:?}"))?;
+        let scheme = url.scheme().to_string();
+        if scheme != "http" && scheme != "https" {
+            anyhow::bail!(
+                "ENVIO_CLICKHOUSE_HOST must use http or https, got scheme {scheme:?} in {raw:?}"
+            );
+        }
+        let host = url
+            .host_str()
+            .ok_or_else(|| anyhow::anyhow!("ENVIO_CLICKHOUSE_HOST has no host: {raw:?}"))?
+            .to_string();
+        let port = url
+            .port()
+            .unwrap_or(if scheme == "https" { 443 } else { 8123 });
+        Ok(Self { scheme, host, port })
+    }
 }
 
 impl EnvConfig {
@@ -185,6 +226,10 @@ impl EnvConfig {
             hasura_port: var("HASURA_EXTERNAL_PORT", "8080"),
             hasura_enable_console: var("HASURA_GRAPHQL_ENABLE_CONSOLE", "true"),
             hasura_admin_secret: var("HASURA_GRAPHQL_ADMIN_SECRET", "testing"),
+            ch_host: var("ENVIO_CLICKHOUSE_HOST", "http://localhost:8123"),
+            ch_user: var("ENVIO_CLICKHOUSE_USERNAME", "default"),
+            ch_password: var("ENVIO_CLICKHOUSE_PASSWORD", "testing"),
+            ch_database: var("ENVIO_CLICKHOUSE_DATABASE", "envio_sink"),
         }
     }
 
@@ -197,9 +242,25 @@ impl EnvConfig {
         self.pg_host != "localhost"
     }
 
+    /// Whether the user has pointed ClickHouse at an externally-managed host.
+    /// Same rule as pg_is_external: only the exact default URL
+    /// ("http://localhost:8123") is treated as local.
+    fn ch_is_external(&self) -> bool {
+        self.ch_host != "http://localhost:8123"
+    }
+
+    /// Parse `ch_host`. The caller decides when to fail (e.g. only when the
+    /// ClickHouse storage backend is actually selected, so users who never
+    /// opt into ClickHouse can still have garbage in ENVIO_CLICKHOUSE_HOST).
+    fn ch_url(&self) -> anyhow::Result<ClickHouseUrl> {
+        ClickHouseUrl::parse(&self.ch_host)
+    }
+
     /// Deterministic hash of all config values used to detect drift.
     /// pg_host is included because Hasura's DATABASE_URL embeds it when
     /// Postgres is external, so a host change must recreate the container.
+    /// ClickHouse fields are included so that user/password/db changes
+    /// recreate the managed ClickHouse container.
     fn config_hash(&self) -> String {
         let mut hasher = Sha256::new();
         hasher.update(&self.pg_host);
@@ -210,6 +271,10 @@ impl EnvConfig {
         hasher.update(&self.hasura_port);
         hasher.update(&self.hasura_enable_console);
         hasher.update(&self.hasura_admin_secret);
+        hasher.update(&self.ch_host);
+        hasher.update(&self.ch_user);
+        hasher.update(&self.ch_password);
+        hasher.update(&self.ch_database);
         format!("{:x}", hasher.finalize())
     }
 }
@@ -403,6 +468,25 @@ async fn is_hasura_healthy(host: &str, port: u16) -> bool {
     }
 }
 
+/// Check whether ClickHouse is reachable by hitting its `/ping` endpoint.
+/// Uses the caller-provided scheme so that `https://` cloud ClickHouse
+/// endpoints work without extra wiring.
+async fn is_clickhouse_healthy(scheme: &str, host: &str, port: u16) -> bool {
+    let url = format!("{scheme}://{host}:{port}/ping");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build();
+    match client {
+        Ok(c) => c
+            .get(&url)
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false),
+        Err(_) => false,
+    }
+}
+
 async fn stop_and_remove(docker: &Docker, name: &str) {
     if is_container_running(docker, name).await {
         let stop_opts = StopContainerOptionsBuilder::new().t(5).build();
@@ -540,12 +624,24 @@ async fn ensure_container(
     Ok(true)
 }
 
-/// Return value from `up()` so callers know whether Hasura is active.
-pub struct UpResult {
-    pub hasura_enabled: bool,
+/// Caller-supplied hints that steer which services `up()` manages. Today
+/// this only toggles ClickHouse, which piggybacks on whether the project
+/// config actually selects the ClickHouse storage backend.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UpOptions {
+    pub clickhouse: bool,
 }
 
-pub async fn up(project_root: &Path) -> anyhow::Result<UpResult> {
+/// Return value from `up()` so callers know which services are active and
+/// get any env vars the indexer subprocess must see (e.g. credentials for a
+/// ClickHouse container we just booted).
+pub struct UpResult {
+    pub hasura_enabled: bool,
+    pub clickhouse_enabled: bool,
+    pub indexer_env: Vec<(String, String)>,
+}
+
+pub async fn up(project_root: &Path, opts: UpOptions) -> anyhow::Result<UpResult> {
     let env = EnvConfig::from_project(project_root);
     let pg_host_port: u16 = env
         .pg_port
@@ -556,21 +652,38 @@ pub async fn up(project_root: &Path) -> anyhow::Result<UpResult> {
         .parse()
         .context("HASURA_EXTERNAL_PORT is not a valid port")?;
 
-    // Probe Postgres at the configured host. Anything other than the default
-    // "localhost" is treated as an externally-managed database (see
-    // EnvConfig::pg_is_external). The local Docker Postgres publishes on
-    // 0.0.0.0, so "localhost" reaches it.
-    // Hasura is always our own container, so probe it on localhost regardless.
+    // Parse the ClickHouse URL only when the project actually opts into
+    // ClickHouse — garbage in ENVIO_CLICKHOUSE_HOST shouldn't break users
+    // who never turn ClickHouse on.
+    let ch_url = if opts.clickhouse {
+        Some(env.ch_url()?)
+    } else {
+        None
+    };
+
+    // Probe each service at the configured host. Anything other than the
+    // default is treated as externally-managed (see EnvConfig::pg_is_external
+    // / ch_is_external). Local Docker publishes on 0.0.0.0, so "localhost"
+    // reaches it. Hasura is always our own container, so probe on localhost.
     let pg_probe_host = env.pg_host.as_str();
     let hasura_probe_host = "localhost";
     let pg_external = env.pg_is_external();
-    let (pg_alive, hasura_alive) =
-        tokio::join!(is_service_reachable(pg_probe_host, pg_host_port), async {
+    let ch_external = env.ch_is_external();
+    let (pg_alive, hasura_alive, ch_alive) = tokio::join!(
+        is_service_reachable(pg_probe_host, pg_host_port),
+        async {
             if !env.hasura_enabled {
                 return false;
             }
             is_hasura_healthy(hasura_probe_host, hasura_host_port).await
-        });
+        },
+        async {
+            match &ch_url {
+                Some(u) => is_clickhouse_healthy(&u.scheme, &u.host, u.port).await,
+                None => false,
+            }
+        }
+    );
 
     // If the user points us at an external Postgres, never start a container
     // for it — fail fast if it isn't actually reachable so the user sees the
@@ -585,8 +698,25 @@ pub async fn up(project_root: &Path) -> anyhow::Result<UpResult> {
         );
     }
 
+    // Same guardrail for ClickHouse: if the user points us at an external
+    // server, require it to actually respond to /ping.
+    if opts.clickhouse && ch_external && !ch_alive {
+        let url = ch_url.as_ref().expect("ch_url parsed when opts.clickhouse");
+        anyhow::bail!(
+            "ENVIO_CLICKHOUSE_HOST is set to external {raw:?} but ClickHouse /ping is not \
+             responding at {scheme}://{host}:{port}. Refusing to start a Docker container for an \
+             externally-managed ClickHouse; check that the host is reachable and credentials are \
+             correct.",
+            raw = env.ch_host,
+            scheme = url.scheme,
+            host = url.host,
+            port = url.port
+        );
+    }
+
     let need_pg = !pg_external && !pg_alive;
     let need_hasura = env.hasura_enabled && !hasura_alive;
+    let need_ch = opts.clickhouse && !ch_external && !ch_alive;
 
     if pg_external {
         println!(
@@ -602,11 +732,47 @@ pub async fn up(project_root: &Path) -> anyhow::Result<UpResult> {
     if !env.hasura_enabled {
         println!("Hasura disabled (ENVIO_HASURA=false)");
     }
+    if opts.clickhouse {
+        if ch_external {
+            println!(
+                "Using your ClickHouse at {} (from ENVIO_CLICKHOUSE_HOST)",
+                env.ch_host
+            );
+        } else if ch_alive {
+            let port = ch_url.as_ref().map(|u| u.port).unwrap_or(8123);
+            println!("Using ClickHouse already running on port {port}");
+        }
+    }
 
-    // If both services are already running, nothing to do.
-    if !need_pg && !need_hasura {
+    // Build the env vars we need to pass to the indexer subprocess. When
+    // ClickHouse is selected, the runtime requires all four variables set —
+    // we pass them unconditionally so that both the managed-container case
+    // (runtime sees our container creds) and the external case (runtime
+    // sees the user-provided URL as-is) work without the user having to
+    // duplicate values into .env.
+    let indexer_env = if opts.clickhouse {
+        vec![
+            ("ENVIO_CLICKHOUSE_HOST".to_string(), env.ch_host.clone()),
+            ("ENVIO_CLICKHOUSE_USERNAME".to_string(), env.ch_user.clone()),
+            (
+                "ENVIO_CLICKHOUSE_PASSWORD".to_string(),
+                env.ch_password.clone(),
+            ),
+            (
+                "ENVIO_CLICKHOUSE_DATABASE".to_string(),
+                env.ch_database.clone(),
+            ),
+        ]
+    } else {
+        Vec::new()
+    };
+
+    // If all services are already running, nothing to do.
+    if !need_pg && !need_hasura && !need_ch {
         return Ok(UpResult {
             hasura_enabled: env.hasura_enabled,
+            clickhouse_enabled: opts.clickhouse,
+            indexer_env,
         });
     }
 
@@ -767,9 +933,69 @@ pub async fn up(project_root: &Path) -> anyhow::Result<UpResult> {
         Ok(())
     };
 
-    let (pg_res, hasura_res) = tokio::join!(pg_pipeline, hasura_pipeline);
+    let clickhouse_pipeline = async {
+        if !need_ch {
+            return Ok::<(), anyhow::Error>(());
+        }
+        // Only reached when ClickHouse is selected, not external, and not
+        // alive — so the URL parsed earlier is present and usable.
+        let url = ch_url.as_ref().expect("ch_url parsed when opts.clickhouse");
+        let (img_res, net_res, vol_res) = tokio::join!(
+            ensure_image(&docker, CLICKHOUSE_IMAGE),
+            ensure_network(&docker, NETWORK),
+            ensure_volume(&docker, CH_VOLUME),
+        );
+        img_res?;
+        net_res?;
+        vol_res?;
+
+        let ch_port_bindings = {
+            let mut map = HashMap::new();
+            map.insert(
+                "8123/tcp".to_string(),
+                Some(vec![PortBinding {
+                    host_ip: Some("0.0.0.0".to_string()),
+                    host_port: Some(url.port.to_string()),
+                }]),
+            );
+            map
+        };
+
+        let ch_body = ContainerCreateBody {
+            image: Some(CLICKHOUSE_IMAGE.to_string()),
+            labels: Some(make_labels(&config_hash)),
+            env: Some(vec![
+                format!("CLICKHOUSE_USER={}", env.ch_user),
+                format!("CLICKHOUSE_PASSWORD={}", env.ch_password),
+                format!("CLICKHOUSE_DB={}", env.ch_database),
+            ]),
+            host_config: Some(HostConfig {
+                port_bindings: Some(ch_port_bindings),
+                mounts: Some(vec![Mount {
+                    target: Some("/var/lib/clickhouse".to_string()),
+                    source: Some(CH_VOLUME.to_string()),
+                    typ: Some(MountTypeEnum::VOLUME),
+                    ..Default::default()
+                }]),
+                restart_policy: Some(RestartPolicy {
+                    name: Some(RestartPolicyNameEnum::ALWAYS),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            networking_config: Some(make_networking_config(NETWORK)),
+            ..Default::default()
+        };
+
+        ensure_container(&docker, CH_CONTAINER, &config_hash, url.port, ch_body).await?;
+        Ok(())
+    };
+
+    let (pg_res, hasura_res, ch_res) =
+        tokio::join!(pg_pipeline, hasura_pipeline, clickhouse_pipeline);
     pg_res?;
     hasura_res?;
+    ch_res?;
 
     // Wait for services to become healthy before handing control back.
     let wait_pg = async {
@@ -817,10 +1043,37 @@ pub async fn up(project_root: &Path) -> anyhow::Result<UpResult> {
         }
     };
 
-    tokio::try_join!(wait_pg, wait_hasura)?;
+    let wait_ch = async {
+        if !need_ch {
+            return Ok::<(), anyhow::Error>(());
+        }
+        let url = ch_url.as_ref().expect("ch_url parsed when opts.clickhouse");
+        eprint!("Waiting for ClickHouse...");
+        let start = std::time::Instant::now();
+        loop {
+            if is_clickhouse_healthy(&url.scheme, &url.host, url.port).await {
+                eprintln!(" ready ({:.1}s)", start.elapsed().as_secs_f64());
+                return Ok(());
+            }
+            if start.elapsed() > Duration::from_secs(60) {
+                eprintln!();
+                anyhow::bail!(
+                    "ClickHouse did not become healthy on port {port} within 60s.\n\
+                     Check container logs: docker logs {CH_CONTAINER}",
+                    port = url.port
+                );
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            eprint!(".");
+        }
+    };
+
+    tokio::try_join!(wait_pg, wait_hasura, wait_ch)?;
 
     Ok(UpResult {
         hasura_enabled: env.hasura_enabled,
+        clickhouse_enabled: opts.clickhouse,
+        indexer_env,
     })
 }
 
@@ -832,19 +1085,40 @@ pub async fn down() -> anyhow::Result<()> {
     tokio::join!(
         stop_and_remove(&docker, HASURA_CONTAINER),
         stop_and_remove(&docker, PG_CONTAINER),
+        stop_and_remove(&docker, CH_CONTAINER),
     );
 
-    let (vol_res, net_res) = tokio::join!(
+    // Only remove the ClickHouse volume if it actually exists — users who
+    // never opted into ClickHouse wouldn't have created it, and a blanket
+    // removal would always report a spurious error on their `envio stop`.
+    let ch_volume_exists = docker.inspect_volume(CH_VOLUME).await.is_ok();
+    let (vol_res, ch_vol_res, net_res) = tokio::join!(
         docker.remove_volume(
             VOLUME,
             None::<bollard::query_parameters::RemoveVolumeOptions>
         ),
+        async {
+            if ch_volume_exists {
+                docker
+                    .remove_volume(
+                        CH_VOLUME,
+                        None::<bollard::query_parameters::RemoveVolumeOptions>,
+                    )
+                    .await
+            } else {
+                Ok(())
+            }
+        },
         docker.remove_network(NETWORK),
     );
 
     let mut failed = false;
     if let Err(e) = vol_res {
         eprintln!("Failed to remove volume {VOLUME}: {e}");
+        failed = true;
+    }
+    if let Err(e) = ch_vol_res {
+        eprintln!("Failed to remove volume {CH_VOLUME}: {e}");
         failed = true;
     }
     if let Err(e) = net_res {
@@ -876,6 +1150,10 @@ mod tests {
             hasura_port: "8080".into(),
             hasura_enable_console: "true".into(),
             hasura_admin_secret: "testing".into(),
+            ch_host: "http://localhost:8123".into(),
+            ch_user: "default".into(),
+            ch_password: "testing".into(),
+            ch_database: "envio_sink".into(),
         }
     }
 
@@ -923,5 +1201,82 @@ mod tests {
             })
             .collect();
         assert_eq!(results, vec![false, true, true, true, true, true]);
+    }
+
+    #[test]
+    fn config_hash_changes_on_ch_host() {
+        let env2 = EnvConfig {
+            ch_host: "https://ch.cloud.example.com:8443".into(),
+            ..default_env()
+        };
+        assert_ne!(default_env().config_hash(), env2.config_hash());
+    }
+
+    #[test]
+    fn ch_is_external_treats_only_default_as_local() {
+        let hosts = [
+            "http://localhost:8123",
+            "http://127.0.0.1:8123",
+            "http://localhost:8124",
+            "https://ch.cloud.example.com",
+            "http://clickhouse:8123",
+        ];
+        let results: Vec<bool> = hosts
+            .iter()
+            .map(|h| {
+                EnvConfig {
+                    ch_host: (*h).into(),
+                    ..default_env()
+                }
+                .ch_is_external()
+            })
+            .collect();
+        assert_eq!(results, vec![false, true, true, true, true]);
+    }
+
+    #[test]
+    fn ch_url_parses_host_port_scheme() {
+        let cases = [
+            ("http://localhost:8123", ("http", "localhost", 8123u16)),
+            (
+                "https://ch.example.com",
+                ("https", "ch.example.com", 443u16),
+            ),
+            ("http://ch.example.com", ("http", "ch.example.com", 8123u16)),
+            ("http://10.0.0.5:9000", ("http", "10.0.0.5", 9000u16)),
+        ];
+        let parsed: Vec<(String, String, u16)> = cases
+            .iter()
+            .map(|(raw, _)| {
+                let u = ClickHouseUrl::parse(raw).unwrap();
+                (u.scheme, u.host, u.port)
+            })
+            .collect();
+        let expected: Vec<(String, String, u16)> = cases
+            .iter()
+            .map(|(_, (s, h, p))| ((*s).to_string(), (*h).to_string(), *p))
+            .collect();
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn ch_url_rejects_invalid() {
+        let cases = [
+            "not-a-url",
+            "ftp://ch.example.com",
+            "http://",
+            "clickhouse:8123",
+        ];
+        let results: Vec<bool> = cases
+            .iter()
+            .map(|raw| ClickHouseUrl::parse(raw).is_err())
+            .collect();
+        assert_eq!(results, vec![true, true, true, true]);
+    }
+
+    #[test]
+    fn up_options_default_clickhouse_false() {
+        let opts = UpOptions::default();
+        assert_eq!(opts.clickhouse, false);
     }
 }

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -477,40 +477,43 @@ async fn is_service_reachable(host: &str, port: u16) -> bool {
         .unwrap_or(false)
 }
 
-/// Check whether Hasura is reachable by hitting its healthz endpoint.
-async fn is_hasura_healthy(host: &str, port: u16) -> bool {
-    let url = format!("http://{}:{}/hasura/healthz?strict=true", host, port);
-    let client = reqwest::Client::builder()
+/// Shared HTTP client for health probes, built once and reused across the
+/// initial probe and subsequent wait loops. Avoids allocating a new
+/// connection pool + TLS context on every tick.
+fn build_probe_client() -> reqwest::Client {
+    reqwest::Client::builder()
         .timeout(Duration::from_secs(2))
-        .build();
-    match client {
-        Ok(c) => c
-            .get(&url)
-            .send()
-            .await
-            .map(|r| r.status().is_success())
-            .unwrap_or(false),
-        Err(_) => false,
-    }
+        .build()
+        .expect("failed to build HTTP client for health probes")
+}
+
+/// Check whether Hasura is reachable by hitting its healthz endpoint.
+async fn is_hasura_healthy(client: &reqwest::Client, host: &str, port: u16) -> bool {
+    let url = format!("http://{}:{}/hasura/healthz?strict=true", host, port);
+    client
+        .get(&url)
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false)
 }
 
 /// Check whether ClickHouse is reachable by hitting its `/ping` endpoint.
 /// Uses the caller-provided scheme so that `https://` cloud ClickHouse
 /// endpoints work without extra wiring.
-async fn is_clickhouse_healthy(scheme: &str, host: &str, port: u16) -> bool {
+async fn is_clickhouse_healthy(
+    client: &reqwest::Client,
+    scheme: &str,
+    host: &str,
+    port: u16,
+) -> bool {
     let url = format!("{scheme}://{host}:{port}/ping");
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build();
-    match client {
-        Ok(c) => c
-            .get(&url)
-            .send()
-            .await
-            .map(|r| r.status().is_success())
-            .unwrap_or(false),
-        Err(_) => false,
-    }
+    client
+        .get(&url)
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false)
 }
 
 async fn stop_and_remove(docker: &Docker, name: &str) {
@@ -692,6 +695,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
     // avoids scattered `.expect()` calls whose invariant ("ch_url is Some
     // when opts.clickhouse") would only be checked at runtime.
     let ch_url_ref = ch_url.as_ref();
+    let probe_client = build_probe_client();
 
     // Probe each service at the configured host. When external the env var
     // tells us where to look; when local the container publishes on 0.0.0.0
@@ -706,11 +710,11 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             if !env.hasura_enabled {
                 return false;
             }
-            is_hasura_healthy(hasura_probe_host, hasura_host_port).await
+            is_hasura_healthy(&probe_client, hasura_probe_host, hasura_host_port).await
         },
         async {
             match ch_url_ref {
-                Some(u) => is_clickhouse_healthy(&u.scheme, &u.host, u.port).await,
+                Some(u) => is_clickhouse_healthy(&probe_client, &u.scheme, &u.host, u.port).await,
                 None => false,
             }
         }
@@ -1064,7 +1068,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         eprint!("Waiting for Hasura...");
         let start = std::time::Instant::now();
         loop {
-            if is_hasura_healthy(hasura_probe_host, hasura_host_port).await {
+            if is_hasura_healthy(&probe_client, hasura_probe_host, hasura_host_port).await {
                 eprintln!(" ready ({:.1}s)", start.elapsed().as_secs_f64());
                 return Ok(());
             }
@@ -1088,7 +1092,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         eprint!("Waiting for ClickHouse...");
         let start = std::time::Instant::now();
         loop {
-            if is_clickhouse_healthy(&url.scheme, &url.host, url.port).await {
+            if is_clickhouse_healthy(&probe_client, &url.scheme, &url.host, url.port).await {
                 eprintln!(" ready ({:.1}s)", start.elapsed().as_secs_f64());
                 return Ok(());
             }

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -272,39 +272,36 @@ impl EnvConfig {
         ClickHouseUrl::parse(self.ch_host_str())
     }
 
-    /// Deterministic hash of all config values used to detect drift.
-    /// pg_host is included because Hasura's DATABASE_URL embeds it when
-    /// Postgres is external, so a host change must recreate the container.
-    /// ClickHouse fields are included so that user/password/db changes
-    /// recreate the managed ClickHouse container.
-    fn config_hash(&self) -> String {
-        // Prefix host fields with a 1-byte tag so that None and
-        // Some("<default>") hash differently — they take different code
-        // paths (Docker vs external) and embed different hosts in
-        // Hasura's DATABASE_URL, so switching between them is real drift.
-        fn hash_opt(hasher: &mut Sha256, v: &Option<String>) {
-            match v {
-                None => hasher.update([0u8]),
-                Some(s) => {
-                    hasher.update([1u8]);
-                    hasher.update(s);
-                }
-            }
-        }
-        let mut hasher = Sha256::new();
-        hash_opt(&mut hasher, &self.pg_host);
-        hasher.update(&self.pg_port);
-        hasher.update(&self.pg_password);
-        hasher.update(&self.pg_user);
-        hasher.update(&self.pg_database);
-        hasher.update(&self.hasura_port);
-        hasher.update(&self.hasura_enable_console);
-        hasher.update(&self.hasura_admin_secret);
-        hash_opt(&mut hasher, &self.ch_host);
-        hasher.update(&self.ch_user);
-        hasher.update(&self.ch_password);
-        hasher.update(&self.ch_database);
-        format!("{:x}", hasher.finalize())
+    /// Per-service config hashes so that changing one service's config only
+    /// recreates *that* container instead of all of them. Host fields are
+    /// excluded: when external, no container is created; when local, the
+    /// host is always the hardcoded default and can't vary.
+    fn pg_config_hash(&self) -> String {
+        let mut h = Sha256::new();
+        h.update(&self.pg_port);
+        h.update(&self.pg_password);
+        h.update(&self.pg_user);
+        h.update(&self.pg_database);
+        format!("{:x}", h.finalize())
+    }
+
+    fn hasura_config_hash(&self) -> String {
+        let mut h = Sha256::new();
+        h.update(&self.pg_password);
+        h.update(&self.pg_user);
+        h.update(&self.pg_database);
+        h.update(&self.hasura_port);
+        h.update(&self.hasura_enable_console);
+        h.update(&self.hasura_admin_secret);
+        format!("{:x}", h.finalize())
+    }
+
+    fn ch_config_hash(&self) -> String {
+        let mut h = Sha256::new();
+        h.update(&self.ch_user);
+        h.update(&self.ch_password);
+        h.update(&self.ch_database);
+        format!("{:x}", h.finalize())
     }
 }
 
@@ -691,6 +688,10 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
     } else {
         None
     };
+    // Destructure into a plain reference for use in async blocks below —
+    // avoids scattered `.expect()` calls whose invariant ("ch_url is Some
+    // when opts.clickhouse") would only be checked at runtime.
+    let ch_url_ref = ch_url.as_ref();
 
     // Probe each service at the configured host. When external the env var
     // tells us where to look; when local the container publishes on 0.0.0.0
@@ -708,7 +709,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             is_hasura_healthy(hasura_probe_host, hasura_host_port).await
         },
         async {
-            match &ch_url {
+            match ch_url_ref {
                 Some(u) => is_clickhouse_healthy(&u.scheme, &u.host, u.port).await,
                 None => false,
             }
@@ -731,7 +732,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
     // Same guardrail for ClickHouse: if the user points us at an external
     // server, require it to actually respond to /ping.
     if opts.clickhouse && ch_external && !ch_alive {
-        let url = ch_url.as_ref().expect("ch_url parsed when opts.clickhouse");
+        let url = ch_url_ref.expect("set when opts.clickhouse");
         anyhow::bail!(
             "ENVIO_CLICKHOUSE_HOST is set to external {raw:?} but ClickHouse /ping is not \
              responding at {scheme}://{host}:{port}. Refusing to start a Docker container for an \
@@ -770,7 +771,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
                 env.ch_host_str()
             );
         } else if ch_alive {
-            let port = ch_url.as_ref().map(|u| u.port).unwrap_or(8123);
+            let port = ch_url_ref.map(|u| u.port).unwrap_or(8123);
             println!("Using ClickHouse already running on port {port}");
         }
     }
@@ -812,7 +813,9 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
 
     // We need Docker for at least one container.
     let docker = connect_docker().await?;
-    let config_hash = env.config_hash();
+    let pg_hash = env.pg_config_hash();
+    let hasura_hash = env.hasura_config_hash();
+    let ch_hash = env.ch_config_hash();
 
     // Run full pipelines for each container in parallel:
     // pull image → create infra → ensure container.
@@ -846,7 +849,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
 
         let pg_body = ContainerCreateBody {
             image: Some(POSTGRES_IMAGE.to_string()),
-            labels: Some(make_labels(&config_hash)),
+            labels: Some(make_labels(&pg_hash)),
             env: Some(vec![
                 format!("POSTGRES_PASSWORD={}", env.pg_password),
                 format!("POSTGRES_USER={}", env.pg_user),
@@ -870,7 +873,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             ..Default::default()
         };
 
-        ensure_container(&docker, PG_CONTAINER, &config_hash, pg_host_port, pg_body).await?;
+        ensure_container(&docker, PG_CONTAINER, &pg_hash, pg_host_port, pg_body).await?;
         Ok(())
     };
 
@@ -915,7 +918,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
 
         let hasura_body = ContainerCreateBody {
             image: Some(HASURA_IMAGE.to_string()),
-            labels: Some(make_labels(&config_hash)),
+            labels: Some(make_labels(&hasura_hash)),
             user: Some("1001:1001".to_string()),
             env: Some(vec![
                 format!("HASURA_GRAPHQL_DATABASE_URL={db_url}"),
@@ -959,7 +962,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         ensure_container(
             &docker,
             HASURA_CONTAINER,
-            &config_hash,
+            &hasura_hash,
             hasura_host_port,
             hasura_body,
         )
@@ -973,7 +976,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         }
         // Only reached when ClickHouse is selected, not external, and not
         // alive — so the URL parsed earlier is present and usable.
-        let url = ch_url.as_ref().expect("ch_url parsed when opts.clickhouse");
+        let url = ch_url_ref.expect("set when opts.clickhouse");
         let (img_res, net_res, vol_res) = tokio::join!(
             ensure_image(&docker, CLICKHOUSE_IMAGE),
             ensure_network(&docker, NETWORK),
@@ -997,7 +1000,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
 
         let ch_body = ContainerCreateBody {
             image: Some(CLICKHOUSE_IMAGE.to_string()),
-            labels: Some(make_labels(&config_hash)),
+            labels: Some(make_labels(&ch_hash)),
             env: Some(vec![
                 format!("CLICKHOUSE_USER={}", env.ch_user),
                 format!("CLICKHOUSE_PASSWORD={}", env.ch_password),
@@ -1021,7 +1024,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             ..Default::default()
         };
 
-        ensure_container(&docker, CH_CONTAINER, &config_hash, url.port, ch_body).await?;
+        ensure_container(&docker, CH_CONTAINER, &ch_hash, url.port, ch_body).await?;
         Ok(())
     };
 
@@ -1081,7 +1084,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         if !need_ch {
             return Ok::<(), anyhow::Error>(());
         }
-        let url = ch_url.as_ref().expect("ch_url parsed when opts.clickhouse");
+        let url = ch_url_ref.expect("set when opts.clickhouse");
         eprint!("Waiting for ClickHouse...");
         let start = std::time::Instant::now();
         loop {
@@ -1122,37 +1125,39 @@ pub async fn down() -> anyhow::Result<()> {
         stop_and_remove(&docker, CH_CONTAINER),
     );
 
-    // Only remove the ClickHouse volume if it actually exists — users who
-    // never opted into ClickHouse wouldn't have created it, and a blanket
-    // removal would always report a spurious error on their `envio stop`.
-    let ch_volume_exists = docker.inspect_volume(CH_VOLUME).await.is_ok();
-    let (vol_res, ch_vol_res, net_res) = tokio::join!(
-        docker.remove_volume(
-            VOLUME,
-            None::<bollard::query_parameters::RemoveVolumeOptions>
-        ),
-        async {
-            if ch_volume_exists {
-                docker
-                    .remove_volume(
-                        CH_VOLUME,
-                        None::<bollard::query_parameters::RemoveVolumeOptions>,
-                    )
-                    .await
-            } else {
-                Ok(())
-            }
-        },
+    // Volumes / network may not exist if the user never ran `up` or only
+    // used a subset of services. Probe first so missing resources don't
+    // produce spurious errors.
+    let pg_vol_exists = docker.inspect_volume(VOLUME).await.is_ok();
+    let ch_vol_exists = docker.inspect_volume(CH_VOLUME).await.is_ok();
+
+    async fn remove_volume_if_exists(
+        docker: &Docker,
+        name: &str,
+        exists: bool,
+    ) -> anyhow::Result<()> {
+        if exists {
+            docker
+                .remove_volume(name, None::<bollard::query_parameters::RemoveVolumeOptions>)
+                .await
+                .with_context(|| format!("Failed to remove volume {name}"))?;
+        }
+        Ok(())
+    }
+
+    let (pg_vol_res, ch_vol_res, net_res) = tokio::join!(
+        remove_volume_if_exists(&docker, VOLUME, pg_vol_exists),
+        remove_volume_if_exists(&docker, CH_VOLUME, ch_vol_exists),
         docker.remove_network(NETWORK),
     );
 
     let mut failed = false;
-    if let Err(e) = vol_res {
-        eprintln!("Failed to remove volume {VOLUME}: {e}");
+    if let Err(e) = pg_vol_res {
+        eprintln!("{e:#}");
         failed = true;
     }
     if let Err(e) = ch_vol_res {
-        eprintln!("Failed to remove volume {CH_VOLUME}: {e}");
+        eprintln!("{e:#}");
         failed = true;
     }
     if let Err(e) = net_res {
@@ -1192,26 +1197,53 @@ mod tests {
     }
 
     #[test]
-    fn config_hash_deterministic() {
-        assert_eq!(default_env().config_hash(), default_env().config_hash());
+    fn per_service_hashes_are_deterministic() {
+        let d = default_env();
+        assert_eq!(
+            (
+                d.pg_config_hash(),
+                d.hasura_config_hash(),
+                d.ch_config_hash()
+            ),
+            (
+                default_env().pg_config_hash(),
+                default_env().hasura_config_hash(),
+                default_env().ch_config_hash()
+            )
+        );
     }
 
     #[test]
-    fn config_hash_changes_on_diff() {
+    fn pg_hash_changes_on_pg_port() {
         let env2 = EnvConfig {
             pg_port: "5434".into(),
             ..default_env()
         };
-        assert_ne!(default_env().config_hash(), env2.config_hash());
+        assert_ne!(default_env().pg_config_hash(), env2.pg_config_hash());
     }
 
     #[test]
-    fn config_hash_changes_on_pg_host() {
+    fn ch_hash_independent_from_pg() {
+        // Changing a PG field must not change the ClickHouse hash.
         let env2 = EnvConfig {
-            pg_host: Some("db.example.com".into()),
+            pg_password: "new_password".into(),
             ..default_env()
         };
-        assert_ne!(default_env().config_hash(), env2.config_hash());
+        assert_eq!(default_env().ch_config_hash(), env2.ch_config_hash());
+        assert_ne!(default_env().pg_config_hash(), env2.pg_config_hash());
+    }
+
+    #[test]
+    fn hasura_hash_changes_on_pg_password() {
+        // Hasura's DB URL embeds PG creds, so PG password change is drift.
+        let env2 = EnvConfig {
+            pg_password: "new_password".into(),
+            ..default_env()
+        };
+        assert_ne!(
+            default_env().hasura_config_hash(),
+            env2.hasura_config_hash()
+        );
     }
 
     #[test]
@@ -1243,12 +1275,12 @@ mod tests {
     }
 
     #[test]
-    fn config_hash_changes_on_ch_host() {
+    fn ch_hash_changes_on_ch_password() {
         let env2 = EnvConfig {
-            ch_host: Some("https://ch.cloud.example.com:8443".into()),
+            ch_password: "secret".into(),
             ..default_env()
         };
-        assert_ne!(default_env().config_hash(), env2.config_hash());
+        assert_ne!(default_env().ch_config_hash(), env2.ch_config_hash());
     }
 
     #[test]

--- a/packages/cli/src/executor/dev.rs
+++ b/packages/cli/src/executor/dev.rs
@@ -68,12 +68,10 @@ pub async fn run_dev(project_paths: ParsedProjectPaths, restart: bool) -> Result
             .await
             .context("Failed running codegen")?;
     }
-    let up_result = docker_env::up(
-        &config.parsed_project_paths.project_root,
-        docker_env::UpOptions {
-            clickhouse: config.storage.clickhouse,
-        },
-    )
+    let up_result = docker_env::up(docker_env::UpOptions {
+        project_root: &config.parsed_project_paths.project_root,
+        clickhouse: config.storage.clickhouse,
+    })
     .await
     .context("Failed starting Docker containers")?;
 

--- a/packages/cli/src/executor/dev.rs
+++ b/packages/cli/src/executor/dev.rs
@@ -68,9 +68,14 @@ pub async fn run_dev(project_paths: ParsedProjectPaths, restart: bool) -> Result
             .await
             .context("Failed running codegen")?;
     }
-    let up_result = docker_env::up(&config.parsed_project_paths.project_root)
-        .await
-        .context("Failed starting Docker containers")?;
+    let up_result = docker_env::up(
+        &config.parsed_project_paths.project_root,
+        docker_env::UpOptions {
+            clickhouse: config.storage.clickhouse,
+        },
+    )
+    .await
+    .context("Failed starting Docker containers")?;
 
     if up_result.hasura_enabled {
         let hasura_health = service_health::fetch_hasura_healthz_with_retry().await;
@@ -131,7 +136,7 @@ pub async fn run_dev(project_paths: ParsedProjectPaths, restart: bool) -> Result
 
     println!("Starting indexer");
 
-    commands::start::start_indexer(&config)
+    commands::start::start_indexer(&config, &up_result.indexer_env)
         .await
         .context("Failed running start on the indexer")?;
 

--- a/packages/cli/src/executor/local.rs
+++ b/packages/cli/src/executor/local.rs
@@ -22,12 +22,10 @@ pub async fn run_local(
                 // since it doesn't spawn the indexer — callers are expected
                 // to run `envio start`/`envio dev` afterwards, which will
                 // compute the indexer_env fresh.
-                docker_env::up(
-                    &config.parsed_project_paths.project_root,
-                    docker_env::UpOptions {
-                        clickhouse: config.storage.clickhouse,
-                    },
-                )
+                docker_env::up(docker_env::UpOptions {
+                    project_root: &config.parsed_project_paths.project_root,
+                    clickhouse: config.storage.clickhouse,
+                })
                 .await
                 .map(|_| ())?;
             }

--- a/packages/cli/src/executor/local.rs
+++ b/packages/cli/src/executor/local.rs
@@ -18,9 +18,18 @@ pub async fn run_local(
     match local_commands {
         LocalCommandTypes::Docker(subcommand) => match subcommand {
             LocalDockerSubcommands::Up => {
-                docker_env::up(&config.parsed_project_paths.project_root)
-                    .await
-                    .map(|_| ())?;
+                // local docker up intentionally doesn't propagate indexer_env
+                // since it doesn't spawn the indexer — callers are expected
+                // to run `envio start`/`envio dev` afterwards, which will
+                // compute the indexer_env fresh.
+                docker_env::up(
+                    &config.parsed_project_paths.project_root,
+                    docker_env::UpOptions {
+                        clickhouse: config.storage.clickhouse,
+                    },
+                )
+                .await
+                .map(|_| ())?;
             }
             LocalDockerSubcommands::Down => {
                 docker_env::down().await?;

--- a/packages/cli/src/executor/mod.rs
+++ b/packages/cli/src/executor/mod.rs
@@ -74,7 +74,9 @@ pub async fn execute(command_line_args: CommandLineArgs) -> Result<()> {
 
                 commands::db_migrate::run_db_setup(&config, &persisted_state).await?;
             }
-            commands::start::start_indexer(&config).await?;
+            // `envio start` doesn't manage Docker — users are expected to
+            // have their own services and env vars set up (e.g. via .env).
+            commands::start::start_indexer(&config, &[]).await?;
         }
 
         CommandType::Local(local_commands) => {


### PR DESCRIPTION
## Summary

When a project selects the ClickHouse storage backend (`storage.clickhouse: true`) and the user hasn't set `ENVIO_CLICKHOUSE_HOST`, `envio dev` now boots a pinned ClickHouse container alongside Postgres + Hasura and forwards the managed credentials into the indexer subprocess.

- **External detection by env-var presence**: `ENVIO_PG_HOST` / `ENVIO_CLICKHOUSE_HOST` being set at all (any value) means "I manage this myself". Unset = Docker-managed.
- **Per-service config hashes**: Changing a ClickHouse password no longer recreates the Postgres container and vice versa. Host fields excluded from hashes (they can't vary for managed containers).
- **`UpOptions<'a>` + `UpResult`**: Thread `project_root` and `clickhouse` flag through `docker_env::up()`; pipe `indexer_env` back into the `node` subprocess.
- **`ClickHouseUrl::parse`**: Validates `http`/`https`, infers port from scheme (443 for https, 8123 otherwise).
- **Fail-fast for external + unreachable**: Bails with actionable error messages (names the env var, lists possible fixes, suggests diagnostic commands).
- **No `expect()` panics**: ClickHouse pipeline and wait loop use `let Some(url) = ch_url_ref` guards instead of runtime panics.
- **Shared `reqwest::Client`**: One probe client reused across initial probes and all wait-loop ticks.
- **Symmetric `down()` cleanup**: Both PG and CH volumes probe existence before removal; `remove_volume_if_exists` helper eliminates spurious errors.
- **CI pinned**: `clickhouse/clickhouse-server:26.2.15.4` in `build_and_verify.yml`.

## Test plan

- [x] `cargo build -p envio`
- [x] `cargo test -p envio` — 236 tests pass (12 docker_env tests)
- [x] New unit tests:
  - `per_service_hashes_are_deterministic`
  - `pg_hash_changes_on_pg_port`
  - `ch_hash_independent_from_pg`
  - `hasura_hash_changes_on_pg_password`
  - `ch_hash_changes_on_ch_password`
  - `pg_is_external_iff_env_var_set`
  - `pg_host_str_returns_default_when_unset`
  - `ch_is_external_iff_env_var_set`
  - `ch_host_str_returns_default_when_unset`
  - `ch_url_parses_host_port_scheme`
  - `ch_url_rejects_invalid`
  - `up_options_copies_values`
- [ ] Manual: ClickHouse project without `ENVIO_CLICKHOUSE_HOST` → container boots, runtime connects
- [ ] Manual: `ENVIO_CLICKHOUSE_HOST=http://remote:8123 envio dev` → skips container, probes remote, bails if unreachable
- [ ] Manual: Postgres-only project → no ClickHouse container starts

https://claude.ai/code/session_01TqbSXQKdfeUXotuCMEkRA8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional ClickHouse support for local development: choose local or external instances, URL/credential validation, readiness checks, and conditional container/volume management.
  * Indexer startup now accepts and forwards environment overrides so local-run settings propagate to launched processes.
  * Improved external database detection behavior and safer startup/cleanup flow.

* **Chores**
  * ClickHouse Docker image pinned in E2E tests for stable runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->