### PR TITLE
Block fork PR merge until /ok-to-test CI passes

### DIFF
--- a/.github/workflows/build_and_verify.yml
+++ b/.github/workflows/build_and_verify.yml
@@ -32,6 +32,36 @@ env:
 jobs:
   # ── Gate ────────────────────────────────────────────────────────────
 
+  # Block fork PRs from merging until /ok-to-test CI passes. Posts a
+  # "pending" build-verify commit status to the fork PR's head SHA.
+  # Branch protection must require the `build-verify` context — this
+  # is what makes the PR show "Expected — Waiting for status" instead
+  # of treating skipped checks as passing.
+  #
+  # The report job (at the bottom) overrides this with success/failure
+  # after CI runs via /ok-to-test. Each new fork push re-triggers
+  # pull_request → re-posts pending → re-blocks merge.
+  pending-status:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      statuses: write
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'pending',
+              context: 'build-verify',
+              description: 'Awaiting /ok-to-test approval from a maintainer',
+            });
+
   # Resolves the commit SHA downstream jobs check out, and authorizes
   # fork PRs via /ok-to-test comment. Admits:
   #   - push to main


### PR DESCRIPTION
## Summary

Fork PRs currently show all checks as "Skipped" (because the `gate` job blocks forks on `pull_request` events). GitHub branch protection treats "Skipped" as passing, so **fork PRs are mergeable without any CI running** — observed on #1098.

When a maintainer later triggers CI via `/ok-to-test <sha>`, the `report` job posts a `build-verify` commit status to the PR head SHA. But without branch protection *requiring* that context, and without an initial blocking status, the merge button is green from the moment the PR opens.

## Change

Add a `pending-status` job that fires only on `pull_request` events from forks. It posts `build-verify: pending` to the fork PR's head SHA, so branch protection (once configured to require `build-verify`) blocks merge until CI actually passes.

### End-to-end flow after this lands

1. Fork PR opens → `pending-status` posts `build-verify: pending` → **merge blocked**
2. Contributor pushes → re-triggers `pull_request` → re-posts pending → **still blocked**
3. Reviewer comments `/ok-to-test <sha>` → CI runs → `report` posts `build-verify: success` → **merge unblocked**
4. Contributor pushes again → back to step 2 → **re-blocked**

## Required: one-time branch protection config (after merge)

**Settings → Branches → main → Require status checks → add `build-verify`**

This is the single context all three paths produce:
- Same-repo PRs: `report` job posts it after CI
- Fork PRs before approval: `pending-status` posts `pending`
- Fork PRs after `/ok-to-test`: `report` overrides with `success`/`failure`

## Test plan

- [ ] Open a fork PR; confirm `build-verify` shows as "Pending" and merge is blocked
- [ ] Comment `/ok-to-test <sha>`; confirm CI runs and `build-verify` updates to success/failure on the PR
- [ ] Push to the fork branch; confirm `build-verify` resets to "Pending"

https://claude.ai/code/session_01Pumpmi2wk6LRyMvaLJuHcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request status reporting for repositories forked from the main project. Contributors will now see a pending status indicator until the build verification workflow completes, providing clearer feedback on the verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->