### PR TITLE
Fix nullable schema type definition and implementation

### DIFF
--- a/packages/cli/templates/static/svmblock_template/typescript/src/handlers/BlockHandler.ts
+++ b/packages/cli/templates/static/svmblock_template/typescript/src/handlers/BlockHandler.ts
@@ -49,7 +49,7 @@ const getBlockEffect = createEffect(
       data = await res.json();
     } catch (error) {
       context.log.warn(`Failed to parse block data`);
-      return undefined;
+      return null;
     }
     const parsedData = S.parseOrThrow(data, getBlockDataSchema);
     if (parsedData.error) {

--- a/packages/cli/templates/static/svmblock_template/typescript/src/handlers/BlockHandler.ts
+++ b/packages/cli/templates/static/svmblock_template/typescript/src/handlers/BlockHandler.ts
@@ -55,7 +55,7 @@ const getBlockEffect = createEffect(
     if (parsedData.error) {
       throw new Error(parsedData.error);
     }
-    return parsedData.result;
+    return parsedData.result ?? null;
   }
 );
 

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -181,7 +181,9 @@ export declare namespace S {
   export const tuple: typeof Sury.tuple;
   export const merge: typeof Sury.merge;
   export const optional: typeof Sury.optional;
-  export const nullable: typeof Sury.nullable;
+  export function nullable<Output, Input>(
+    schema: Sury.Schema<Output, Input>
+  ): Sury.Schema<Output | null, Input | null>;
   export const bigDecimal: typeof bigDecimalSchema;
   export const unknown: typeof Sury.unknown;
   // Nullish type will change in "sury@10"

--- a/packages/envio/index.js
+++ b/packages/envio/index.js
@@ -38,7 +38,7 @@ export const S = {
   tuple: Sury.tuple,
   merge: Sury.merge,
   optional: Sury.optional,
-  nullable: Sury.nullable,
+  nullable: (schema) => Sury.union([schema, null]),
   bigDecimal: bigDecimalSchema,
   // Nullish type will change in "sury@10"
   // nullish: Sury.nullish,


### PR DESCRIPTION
## Summary
This PR fixes the `nullable` schema function to properly handle null values in both input and output types, and updates related code to use `null` instead of `undefined` for consistency.

## Key Changes
- **Type Definition**: Updated the `nullable` function signature in `index.d.ts` to explicitly define the return type as `Sury.Schema<Output | null, Input | null>`, making it clear that both input and output can be null
- **Implementation**: Changed the `nullable` implementation in `index.js` from a direct reference to `Sury.nullable` to an explicit union with null: `(schema) => Sury.union([schema, null])`
- **Error Handling**: Updated `BlockHandler.ts` to return `null` instead of `undefined` when block data parsing fails, aligning with the nullable schema semantics

## Implementation Details
The change from `Sury.nullable` to `Sury.union([schema, null])` ensures that the nullable function properly creates a union type that accepts either the schema's valid input/output or null, providing more explicit and predictable behavior.

https://claude.ai/code/session_01X1rwpWUxV4jLyXzQvtZRjg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Block data handling now returns null consistently when JSON parsing or retrieval fails, making missing-data checks more predictable.

* **Type System Updates**
  * Nullable schema behavior clarified and made explicit so validators and consumers treat null-inclusive schemas consistently; runtime nullable construction updated to explicitly include null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->