### PR TITLE
Upgrade NAPI dependencies to support NAPI10

### DIFF
--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -52,14 +52,14 @@ convert_case = "0.6.0"
 dotenvy = { git = "https://github.com/enviodev/dotenvy", rev = "e2da110668572cf2d67178f192eb1fc285224040" }
 bollard = "0.20"
 futures-util = "0.3"
-napi = { version = "3", features = ["napi9", "async", "serde-json"] }
-napi-derive = "3"
+napi = { version = "=3.8.5", features = ["napi10", "async", "serde-json"] }
+napi-derive = "=3.5.4"
 
 [features]
 integration_tests = []
 
 [build-dependencies]
-napi-build = "2"
+napi-build = "=2.3.1"
 
 [dev-dependencies]
 tempdir = "0.3.7"


### PR DESCRIPTION
## Summary
Updated NAPI-related dependencies to enable support for NAPI10 while pinning to specific patch versions for stability.

## Key Changes
- Upgraded `napi` from version 3 (with napi9 feature) to version 3.8.5 (with napi10 feature)
- Updated `napi-derive` to pinned version 3.5.4
- Updated `napi-build` to pinned version 2.3.1
- Changed version specifications from flexible ranges to exact pinned versions (using `=` prefix)

## Details
This upgrade enables the CLI to leverage NAPI10 features while maintaining compatibility with the Node.js native addon API. The pinned versions ensure consistent builds across environments and prevent unexpected breaking changes from minor version updates.

https://claude.ai/code/session_01UPjJBs6r3S3yp6X3Lkq17x