### PR TITLE
Persist DC addresses without matching events

### DIFF
--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1086,7 +1086,7 @@ let registerDynamicContracts = (
   }
 
   let dcContractNamesToStore = registeringContractsByContract->Dict.keysToArray
-  let hasNoEventsUpdates = noEventsAddresses->Dict.keysToArray->Array.length > 0
+  let hasNoEventsUpdates = !(noEventsAddresses->Utils.Dict.isEmpty)
   switch (dcContractNamesToStore, hasNoEventsUpdates) {
   // Dont update anything when everything was filter out
   | ([], false) => fetchState

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -947,6 +947,11 @@ let registerDynamicContracts = (
   let registeringContractsByContract: dict<dict<indexingAddress>> = Dict.make()
   let earliestRegisteringEventBlockNumber = ref(%raw(`Infinity`))
   let hasDCWithFilterByAddresses = ref(false)
+  // Addresses registered for contracts without matching events. These are not
+  // added to partitions, but they are tracked on fetchState.indexingAddresses
+  // so that later conflicting registrations are detected, and are persisted
+  // to envio_addresses so they can be picked up on restart with updated config.
+  let noEventsAddresses: dict<indexingAddress> = Dict.make()
 
   for itemIdx in 0 to items->Array.length - 1 {
     let item = items->Array.getUnsafe(itemIdx)
@@ -1024,18 +1029,48 @@ let registerDynamicContracts = (
               shouldRemove := true
             }
           }
-        | None => {
-            let logger = Logging.createChild(
-              ~params={
-                "chainId": fetchState.chainId,
-                "contractAddress": dc.address->Address.toString,
-                "contractName": dc.contractName,
-              },
-            )
-            // Persist the address to the db so a future config change that adds
-            // events for this contract can pick it up on restart, but skip
-            // in-memory registration since there's nothing to fetch right now.
-            logger->Logging.childWarn(`Persisting contract registration without fetching: Contract doesn't have any events to fetch. It'll be picked up on restart if you add events for the contract.`)
+        | None =>
+          let dcAsIndexingAddress: indexingAddress = {
+            address: dc.address,
+            contractName: dc.contractName,
+            registrationBlock: dc.registrationBlock,
+            effectiveStartBlock: deriveEffectiveStartBlock(
+              ~registrationBlock=dc.registrationBlock,
+              ~contractStartBlock=None,
+            ),
+          }
+          // Prevent duplicate logging/persistence when the same address is
+          // already tracked on fetchState, either from the db on startup or
+          // from an earlier registration in this batch.
+          switch indexingAddresses->Utils.Dict.dangerouslyGetNonOption(
+            dc.address->Address.toString,
+          ) {
+          | Some(existingContract) =>
+            if existingContract.contractName != dc.contractName {
+              fetchState->warnDifferentContractType(~existingContract, ~dc=dcAsIndexingAddress)
+            }
+            shouldRemove := true
+          | None =>
+            switch noEventsAddresses->Utils.Dict.dangerouslyGetNonOption(
+              dc.address->Address.toString,
+            ) {
+            | Some(_) =>
+              // Already queued for persistence by an earlier item in this batch.
+              shouldRemove := true
+            | None =>
+              let logger = Logging.createChild(
+                ~params={
+                  "chainId": fetchState.chainId,
+                  "contractAddress": dc.address->Address.toString,
+                  "contractName": dc.contractName,
+                },
+              )
+              // Persist the address to the db so a future config change that
+              // adds events for this contract can pick it up on restart, but
+              // skip partition registration since there's nothing to fetch.
+              logger->Logging.childWarn(`Persisting contract registration without fetching: Contract doesn't have any events to fetch. It'll be picked up on restart if you add events for the contract.`)
+              noEventsAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
+            }
           }
         }
 
@@ -1051,10 +1086,18 @@ let registerDynamicContracts = (
   }
 
   let dcContractNamesToStore = registeringContractsByContract->Dict.keysToArray
-  switch dcContractNamesToStore {
+  let hasNoEventsUpdates = noEventsAddresses->Dict.keysToArray->Array.length > 0
+  switch (dcContractNamesToStore, hasNoEventsUpdates) {
   // Dont update anything when everything was filter out
-  | [] => fetchState
-  | _ => {
+  | ([], false) => fetchState
+  | ([], true) =>
+    // Only dcs for contracts without events. Track them on
+    // indexingAddresses so subsequent registrations see them, but don't touch
+    // partitions since there's nothing to fetch for them.
+    let newIndexingContracts = indexingAddresses->Utils.Dict.shallowCopy
+    let _ = Utils.Dict.mergeInPlace(newIndexingContracts, noEventsAddresses)
+    fetchState->updateInternal(~indexingAddresses=newIndexingContracts)
+  | (_, _) => {
       let newPartitions = []
       let newIndexingAddresses = indexingAddresses->Utils.Dict.shallowCopy
       let dynamicContractsRef = ref(fetchState.optimizedPartitions.dynamicContracts)
@@ -1139,6 +1182,8 @@ let registerDynamicContracts = (
         let registeringContracts = registeringContractsByContract->Dict.getUnsafe(contractName)
         let _ = Utils.Dict.mergeInPlace(newIndexingAddresses, registeringContracts)
       }
+      // Include no-events dcs so later batches detect conflicts against them.
+      let _ = Utils.Dict.mergeInPlace(newIndexingContracts, noEventsAddresses)
 
       let optimizedPartitions = createPartitionsFromIndexingAddresses(
         ~registeringContractsByContract,

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1032,8 +1032,10 @@ let registerDynamicContracts = (
                 "contractName": dc.contractName,
               },
             )
-            logger->Logging.childWarn(`Skipping contract registration: Contract doesn't have any events to fetch.`)
-            shouldRemove := true
+            // Persist the address to the db so a future config change that adds
+            // events for this contract can pick it up on restart, but skip
+            // in-memory registration since there's nothing to fetch right now.
+            logger->Logging.childWarn(`Persisting contract registration without fetching: Contract doesn't have any events to fetch. It'll be picked up on restart if you add events for the contract.`)
           }
         }
 
@@ -1565,36 +1567,41 @@ let make = (
   let registeringContractsByContract: dict<dict<indexingAddress>> = Dict.make()
   let dynamicContracts = Utils.Set.make()
 
-  switch normalEventConfigs {
-  | [] => ()
-  | _ =>
-    addresses->Array.forEach(contract => {
-      let contractName = contract.contractName
-      switch contractConfigs->Utils.Dict.dangerouslyGetNonOption(contractName) {
-      | Some({startBlock: contractStartBlock})
-        if contractNamesWithNormalEvents->Utils.Set.has(contractName) =>
-        let ia: indexingAddress = {
-          address: contract.address,
-          contractName: contract.contractName,
-          registrationBlock: contract.registrationBlock,
-          effectiveStartBlock: deriveEffectiveStartBlock(
-            ~registrationBlock=contract.registrationBlock,
-            ~contractStartBlock,
-          ),
-        }
-        let registeringContracts =
-          registeringContractsByContract->Utils.Dict.getOrInsertEmptyDict(contractName)
-        registeringContracts->Dict.set(contract.address->Address.toString, ia)
-        indexingAddresses->Dict.set(contract.address->Address.toString, ia)
+  addresses->Array.forEach(contract => {
+    let contractName = contract.contractName
+    let contractStartBlock = switch contractConfigs->Utils.Dict.dangerouslyGetNonOption(
+      contractName,
+    ) {
+    | Some({startBlock}) => startBlock
+    | None => None
+    }
+    let ia: indexingAddress = {
+      address: contract.address,
+      contractName: contract.contractName,
+      registrationBlock: contract.registrationBlock,
+      effectiveStartBlock: deriveEffectiveStartBlock(
+        ~registrationBlock=contract.registrationBlock,
+        ~contractStartBlock,
+      ),
+    }
+    // Track the address on fetchState regardless of whether it currently has
+    // matching events. This way, if the config is updated later to add events
+    // for this contract, the address is already known.
+    indexingAddresses->Dict.set(contract.address->Address.toString, ia)
 
-        // Detect dynamic contracts by registrationBlock
-        if contract.registrationBlock !== -1 {
-          dynamicContracts->Utils.Set.add(contractName)->ignore
-        }
-      | _ => ()
+    // Only addresses whose contract has events that depend on addresses get
+    // registered for active fetching via partitions.
+    if contractNamesWithNormalEvents->Utils.Set.has(contractName) {
+      let registeringContracts =
+        registeringContractsByContract->Utils.Dict.getOrInsertEmptyDict(contractName)
+      registeringContracts->Dict.set(contract.address->Address.toString, ia)
+
+      // Detect dynamic contracts by registrationBlock
+      if contract.registrationBlock !== -1 {
+        dynamicContracts->Utils.Set.add(contractName)->ignore
       }
-    })
-  }
+    }
+  })
 
   let optimizedPartitions = createPartitionsFromIndexingAddresses(
     ~registeringContractsByContract,

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1183,7 +1183,7 @@ let registerDynamicContracts = (
         let _ = Utils.Dict.mergeInPlace(newIndexingAddresses, registeringContracts)
       }
       // Include no-events dcs so later batches detect conflicts against them.
-      let _ = Utils.Dict.mergeInPlace(newIndexingContracts, noEventsAddresses)
+      let _ = Utils.Dict.mergeInPlace(newIndexingAddresses, noEventsAddresses)
 
       let optimizedPartitions = createPartitionsFromIndexingAddresses(
         ~registeringContractsByContract,

--- a/packages/envio/src/sources/EventRouter.res
+++ b/packages/envio/src/sources/EventRouter.res
@@ -41,7 +41,14 @@ module Group = {
       ) {
       | Some(indexingContract) =>
         if indexingContract.effectiveStartBlock <= blockNumber {
-          byContractName->Utils.Dict.dangerouslyGetNonOption(indexingContract.contractName)
+          switch byContractName->Utils.Dict.dangerouslyGetNonOption(indexingContract.contractName) {
+          // Fall back to the wildcard handler when the indexed contract has no
+          // matching event for this tag. This covers addresses registered for
+          // contracts without events (persisted for future config changes) as
+          // well as addresses whose contract has other events but not this one.
+          | None => wildcard
+          | Some(_) as event => event
+          }
         } else {
           None
         }

--- a/scenarios/test_codegen/test/lib_tests/EventRouter_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EventRouter_test.res
@@ -178,6 +178,49 @@ describe("EventRouter", () => {
     },
   )
 
+  it(
+    "get falls back to wildcard when the address is indexed for a contract without a matching event",
+    t => {
+      // Covers the case where FetchState seeds indexingAddresses with an
+      // address for a contract that has no events (persisted for future config
+      // changes). A wildcard event at that address should still fire.
+      let indexedAddress = mockAddress1
+      let noEventsContractName = "UnknownContract"
+
+      let router = EventRouter.empty()
+
+      router->EventRouter.addOrThrow(
+        "test-event-tag",
+        "wildcard",
+        ~contractName="WildcardContract",
+        ~eventName="Event1",
+        ~chain=mockChain,
+        ~isWildcard=true,
+      )
+
+      let indexingAddresses: dict<FetchState.indexingAddress> = Dict.make()
+      indexingAddresses->Dict.set(
+        indexedAddress->Address.toString,
+        {
+          contractName: noEventsContractName,
+          address: indexedAddress,
+          registrationBlock: 5,
+          effectiveStartBlock: 5,
+        },
+      )
+
+      t.expect(
+        router->EventRouter.get(
+          ~tag="test-event-tag",
+          ~contractAddress=indexedAddress,
+          ~blockNumber=10,
+          ~indexingAddresses,
+        ),
+        ~message="Should fall back to the wildcard handler when the contract has no registered event for this tag",
+      ).toEqual(Some("wildcard"))
+    },
+  )
+
   it("fromEvmEventModsOrThrow works", t => {
     let item = MockConfig.getEvmEventConfig(~contractName="Gravatar", ~eventName="NewGravatar")
     let router = EventRouter.fromEvmEventModsOrThrow([item], ~chain=mockChain)

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -211,6 +211,51 @@ describe("FetchState.make", () => {
     )
   })
 
+  it(
+    "Keeps addresses without a matching contract on fetchState so they can be picked up after config changes",
+    t => {
+      let fetchState = FetchState.make(
+        ~eventConfigs=[baseEventConfig],
+        ~addresses=[
+          makeConfigContract("Gravatar", mockAddress0),
+          // Address for a contract that currently has no events configured.
+          // Should still be tracked on fetchState and counted via numAddresses.
+          makeDynContractRegistration(
+            ~blockNumber=42,
+            ~contractAddress=mockAddress1,
+            ~contractName="NftFactory",
+          ),
+        ],
+        ~startBlock=0,
+        ~endBlock=None,
+        ~maxAddrInPartition=3,
+        ~targetBufferSize,
+        ~chainId,
+        ~knownHeight,
+      )
+
+      t.expect(
+        (
+          fetchState->FetchState.numAddresses,
+          fetchState.indexingAddresses
+          ->Dict.get(mockAddress1->Address.toString)
+          ->Option.map(ia => ia.contractName),
+          // No partition is created for the contract without events
+          fetchState.optimizedPartitions.entities
+          ->Dict.valuesToArray
+          ->Array.every(p =>
+            p.addressesByContractName
+            ->Utils.Dict.dangerouslyGetNonOption("NftFactory")
+            ->Option.isNone
+          ),
+        ),
+        ~message=`numAddresses counts both addresses,
+          the no-events address is tracked under its contract name,
+          and no partition is created for the contract without events`,
+      ).toEqual((2, Some("NftFactory"), true))
+    },
+  )
+
   it("Creates FetchState with static and dc addresses reaching the maxAddrInPartition limit", t => {
     let dc = makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress2)
     let fetchState = FetchState.make(

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1001,6 +1001,42 @@ describe("FetchState.registerDynamicContracts", () => {
     },
   )
 
+  it(
+    "Warns and skips a no-events dc when the address is already registered under a different contract name",
+    t => {
+      // makeInitial puts mockAddress0 in indexingAddresses under contractName
+      // "Gravatar" (which has events). Now try to register the same address
+      // for a contract without events and a different name - should trigger
+      // warnDifferentContractType via the None-branch conflict path.
+      let fetchState = makeInitial()
+
+      let conflictingDc = makeDynContractRegistration(
+        ~blockNumber=10,
+        ~contractAddress=mockAddress0,
+        ~contractName="UnknownContract",
+      )
+      let item = conflictingDc->dcToItem
+
+      let updatedFetchState = fetchState->FetchState.registerDynamicContracts([item])
+
+      t.expect(
+        (
+          // dc spliced out - won't overwrite the existing Gravatar entry in db
+          item->Internal.getItemDcs,
+          // indexingAddresses still has the original contract name
+          updatedFetchState.indexingAddresses
+          ->Dict.get(mockAddress0->Address.toString)
+          ->Option.map(ia => ia.contractName),
+          // fetchState unchanged - nothing new registered
+          updatedFetchState === fetchState,
+        ),
+        ~message=`conflicting no-events dc is spliced out,
+          original Gravatar registration preserved,
+          and fetchState is unchanged`,
+      ).toEqual((Some([]), Some("Gravatar"), true))
+    },
+  )
+
   it("Correctly registers all valid contracts even when some are skipped in the middle", t => {
     let fetchState = makeInitial()
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -851,6 +851,42 @@ describe("FetchState.registerDynamicContracts", () => {
     ).toBe(fetchState)
   })
 
+  it(
+    "Keeps dc for a contract with no events on the item so it is persisted to the db (but doesn't register it for fetching)",
+    t => {
+      let fetchState = makeInitial()
+
+      // Contract has no event configs in fetchState, so no partition is
+      // created. We still want the dc to stay on the item so that
+      // InMemoryStore.setBatchDcs writes it to envio_addresses.
+      let dc = makeDynContractRegistration(
+        ~blockNumber=10,
+        ~contractAddress=mockAddress1,
+        ~contractName="UnknownContract",
+      )
+      let item = dc->dcToItem
+
+      let updatedFetchState = fetchState->FetchState.registerDynamicContracts([item])
+
+      t.expect(
+        (
+          // dc not spliced out of the item - will be saved to db by setBatchDcs
+          item->Internal.getItemDcs,
+          // not registered for fetching
+          updatedFetchState.indexingAddresses
+          ->Dict.get(mockAddress1->Address.toString)
+          ->Option.isSome,
+          updatedFetchState.optimizedPartitions->FetchState.OptimizedPartitions.count,
+          // fetchState unchanged
+          updatedFetchState === fetchState,
+        ),
+        ~message=`dc stays on the item (persisted to db),
+          is NOT added to fetchState runtime state,
+          and fetchState is unchanged`,
+      ).toEqual((Some([dc]), false, 1, true))
+    },
+  )
+
   it("Correctly registers all valid contracts even when some are skipped in the middle", t => {
     let fetchState = makeInitial()
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -852,13 +852,10 @@ describe("FetchState.registerDynamicContracts", () => {
   })
 
   it(
-    "Keeps dc for a contract with no events on the item so it is persisted to the db (but doesn't register it for fetching)",
+    "Keeps dc for a contract with no events on the item (persisted to db) and tracks it on indexingAddresses without affecting partitions",
     t => {
       let fetchState = makeInitial()
 
-      // Contract has no event configs in fetchState, so no partition is
-      // created. We still want the dc to stay on the item so that
-      // InMemoryStore.setBatchDcs writes it to envio_addresses.
       let dc = makeDynContractRegistration(
         ~blockNumber=10,
         ~contractAddress=mockAddress1,
@@ -872,18 +869,135 @@ describe("FetchState.registerDynamicContracts", () => {
         (
           // dc not spliced out of the item - will be saved to db by setBatchDcs
           item->Internal.getItemDcs,
-          // not registered for fetching
+          // tracked on indexingAddresses so later conflicting registrations
+          // are detected, and so numAddresses reflects it
           updatedFetchState.indexingAddresses
           ->Dict.get(mockAddress1->Address.toString)
-          ->Option.isSome,
-          updatedFetchState.optimizedPartitions->FetchState.OptimizedPartitions.count,
-          // fetchState unchanged
-          updatedFetchState === fetchState,
+          ->Option.map(ia => ia.contractName),
+          // partitions unchanged - no fetching for contracts without events
+          updatedFetchState.optimizedPartitions === fetchState.optimizedPartitions,
+          updatedFetchState.optimizedPartitions.entities,
         ),
         ~message=`dc stays on the item (persisted to db),
-          is NOT added to fetchState runtime state,
-          and fetchState is unchanged`,
-      ).toEqual((Some([dc]), false, 1, true))
+          is added to indexingAddresses under its contract name,
+          and partitions are left untouched`,
+      ).toEqual((
+        Some([dc]),
+        Some("UnknownContract"),
+        true,
+        fetchState.optimizedPartitions.entities,
+      ))
+    },
+  )
+
+  it(
+    "Deduplicates a second registration for the same no-events address and warns on contract-name conflict",
+    t => {
+      let fetchState = makeInitial()
+
+      // Register mockAddress1 for a contract without events - should persist
+      // and land in indexingAddresses.
+      let dc1 = makeDynContractRegistration(
+        ~blockNumber=10,
+        ~contractAddress=mockAddress1,
+        ~contractName="UnknownContract",
+      )
+      let item1 = dc1->dcToItem
+      let afterFirst = fetchState->FetchState.registerDynamicContracts([item1])
+
+      // Register the SAME address for a DIFFERENT contract name that also has
+      // no events. This should be spliced out of the item (already tracked)
+      // and warn about the contract-name conflict.
+      let dc2 = makeDynContractRegistration(
+        ~blockNumber=11,
+        ~contractAddress=mockAddress1,
+        ~contractName="AnotherUnknownContract",
+      )
+      let item2 = dc2->dcToItem
+      let afterSecond = afterFirst->FetchState.registerDynamicContracts([item2])
+
+      // Register the same address a third time for the same "UnknownContract"
+      // - should dedup silently (no duplicate db write).
+      let dc3 = makeDynContractRegistration(
+        ~blockNumber=12,
+        ~contractAddress=mockAddress1,
+        ~contractName="UnknownContract",
+      )
+      let item3 = dc3->dcToItem
+      let afterThird = afterSecond->FetchState.registerDynamicContracts([item3])
+
+      t.expect(
+        (
+          item1->Internal.getItemDcs,
+          // Second dc spliced out - already tracked.
+          item2->Internal.getItemDcs,
+          // Third dc also spliced out - same contract name, already tracked.
+          item3->Internal.getItemDcs,
+          // First registration is the tracked one (first wins).
+          afterThird.indexingAddresses
+          ->Dict.get(mockAddress1->Address.toString)
+          ->Option.map(ia => ia.contractName),
+          // No new partition created across any of the registrations.
+          afterThird.optimizedPartitions.entities === fetchState.optimizedPartitions.entities,
+        ),
+        ~message=`first dc kept, subsequent same-address dcs spliced out,
+          fetchState still tracks the first contract name,
+          and partitions are never affected`,
+      ).toEqual((Some([dc1]), Some([]), Some([]), Some("UnknownContract"), true))
+    },
+  )
+
+  it(
+    "Registers a no-events address on indexingAddresses in the same batch as a has-events dc without affecting its partition",
+    t => {
+      let fetchState = makeInitial()
+
+      let noEventsDc = makeDynContractRegistration(
+        ~blockNumber=5,
+        ~contractAddress=mockAddress2,
+        ~contractName="UnknownContract",
+      )
+      let regularDc = makeDynContractRegistration(
+        ~blockNumber=5,
+        ~contractAddress=mockAddress1,
+        ~contractName="Gravatar",
+      )
+
+      let updatedFetchState =
+        fetchState->FetchState.registerDynamicContracts([
+          noEventsDc->dcToItem,
+          regularDc->dcToItem,
+        ])
+
+      t.expect(
+        (
+          updatedFetchState.indexingAddresses
+          ->Dict.get(mockAddress2->Address.toString)
+          ->Option.map(ia => ia.contractName),
+          updatedFetchState.indexingAddresses
+          ->Dict.get(mockAddress1->Address.toString)
+          ->Option.map(ia => ia.contractName),
+          // Only the Gravatar address lands in a partition.
+          updatedFetchState.optimizedPartitions.entities
+          ->Dict.valuesToArray
+          ->Array.some(p =>
+            p.addressesByContractName
+            ->Utils.Dict.dangerouslyGetNonOption("Gravatar")
+            ->Option.map(addrs => addrs->Array.includes(mockAddress1))
+            ->Option.getOr(false)
+          ),
+          updatedFetchState.optimizedPartitions.entities
+          ->Dict.valuesToArray
+          ->Array.every(p =>
+            p.addressesByContractName
+            ->Utils.Dict.dangerouslyGetNonOption("UnknownContract")
+            ->Option.isNone
+          ),
+        ),
+        ~message=`no-events dc tracked on indexingAddresses,
+          has-events dc creates a partition as usual,
+          and the no-events contract never enters any partition`,
+      ).toEqual((Some("UnknownContract"), Some("Gravatar"), true, true))
     },
   )
 


### PR DESCRIPTION
## Summary

- `FetchState.registerDynamicContracts`: DCs whose contract has no events in the current config are no longer spliced out — they remain in the item's `dcs` array and get persisted to `envio_addresses` via `InMemoryStore.setBatchDcs`.
- `FetchState.make`: all input addresses are tracked on `fetchState.indexingAddresses`; only contracts with events that depend on addresses enter partitions.
- On restart with an updated config that adds events for the contract, the persisted addresses are picked up automatically.

## Test plan

- [x] `pnpm rescript-legacy && pnpm vitest run FetchState_test` — 55 tests pass, including a new test that asserts `numAddresses` counts an address whose contract has no events.
- [x] Confirmed pre-existing `WriteRead_test` / `RpcSource_test` timeouts are unrelated to this change (reproduce on base without the diff).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Persist registrations for contracts that lack configured events (track addresses without creating partitions)
  * Ensure all provided addresses are indexed at startup regardless of event configuration
  * Deduplicate repeated registrations and preserve the first-seen contract mapping when names conflict; emit warnings on type conflicts
  * Only include contracts with configured events in active partition fetching; tolerate missing start-block entries

* **Tests**
  * Added coverage for mixed contract configurations to verify persistence, deduplication, conflict handling, and partition behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->