### PR TITLE
add topics-only address filter mode for EVM sources

### DIFF
--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -450,6 +450,19 @@ pub mod evm {
     }
 
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
+    #[serde(rename_all = "snake_case")]
+    pub enum AddressFilterMode {
+        #[schemars(
+            description = "Filter logs by contract address in the upstream data source (default)."
+        )]
+        Exact,
+        #[schemars(
+            description = "Fetch logs by topics only, then filter indexed contract addresses inside HyperIndex. Useful when request-body egress is the bottleneck, but can increase response size and decode work. Not supported for address-derived `where` filters."
+        )]
+        TopicsOnly,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
     #[serde(deny_unknown_fields)]
     pub struct HypersyncConfig {
         #[serde(alias = "endpoint_url")] // TODO: Remove the alias in v3
@@ -458,6 +471,11 @@ pub mod evm {
                            endpoint for the network)"
         )]
         pub url: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[schemars(
+            description = "How HyperIndex should apply address filtering for HyperSync log queries. Defaults to `exact`."
+        )]
+        pub address_filter_mode: Option<AddressFilterMode>,
     }
 
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
@@ -494,6 +512,11 @@ pub mod evm {
         )]
         #[serde(rename = "for", skip_serializing_if = "Option::is_none")]
         pub source_for: Option<For>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[schemars(
+            description = "How HyperIndex should apply address filtering for log queries. Defaults to `exact`. `topics_only` reduces request-body size by omitting the address list and filtering indexed addresses inside HyperIndex instead. Not supported for address-derived `where` filters."
+        )]
+        pub address_filter_mode: Option<AddressFilterMode>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
             description = "Optional WebSocket endpoint URL (wss:// or ws://) for real-time block \

--- a/packages/cli/src/config_parsing/public_config_json.rs
+++ b/packages/cli/src/config_parsing/public_config_json.rs
@@ -1,7 +1,7 @@
 use super::{
     entity_parsing::IndexFieldDirection,
     field_types,
-    human_config::evm::For,
+    human_config::evm::{AddressFilterMode, For},
     system_config::{self, Abi, Ecosystem, EventKind, FuelEventKind, SystemConfig},
 };
 use crate::{config_parsing::chain_helpers::Network, persisted_state, utils::text::Capitalize};
@@ -140,6 +140,8 @@ struct RpcConfig {
     #[serde(rename = "for")]
     source_for: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
+    address_filter_mode: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ws: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     initial_block_interval: Option<u32>,
@@ -172,6 +174,8 @@ struct ChainConfig {
     block_lag: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hypersync: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hypersync_address_filter_mode: Option<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     rpcs: Vec<RpcConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -245,6 +249,13 @@ fn abi_type_to_components(
     }
 }
 
+fn address_filter_mode_to_str(mode: &AddressFilterMode) -> &'static str {
+    match mode {
+        AddressFilterMode::Exact => "exact",
+        AddressFilterMode::TopicsOnly => "topics_only",
+    }
+}
+
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct ContractEventItem {
@@ -292,44 +303,60 @@ impl SystemConfig {
             .map(|network| {
                 let chain_name = chain_id_to_name(network.id, &cfg.get_ecosystem());
 
-                let (hypersync, rpcs, rpc) = match &network.sync_source {
-                    system_config::DataSource::Evm { main, rpcs } => {
-                        let hypersync_url = match main {
-                            system_config::MainEvmDataSource::HyperSync {
-                                hypersync_endpoint_url,
-                            } => Some(hypersync_endpoint_url.clone()),
-                            system_config::MainEvmDataSource::Rpc(_) => None,
-                        };
-                        let rpc_configs: Vec<RpcConfig> = rpcs
-                            .iter()
-                            .map(|rpc| RpcConfig {
-                                url: rpc.url.clone(),
-                                source_for: match rpc.source_for {
-                                    Some(For::Sync) => "sync",
-                                    Some(For::Fallback) => "fallback",
-                                    Some(For::Live) => "live",
-                                    None => unreachable!(
+                let (hypersync, hypersync_address_filter_mode, rpcs, rpc) =
+                    match &network.sync_source {
+                        system_config::DataSource::Evm { main, rpcs } => {
+                            let (hypersync_url, hypersync_address_filter_mode) = match main {
+                                system_config::MainEvmDataSource::HyperSync {
+                                    hypersync_endpoint_url,
+                                    address_filter_mode,
+                                } => (
+                                    Some(hypersync_endpoint_url.clone()),
+                                    address_filter_mode.as_ref().map(address_filter_mode_to_str),
+                                ),
+                                system_config::MainEvmDataSource::Rpc(_) => (None, None),
+                            };
+                            let rpc_configs: Vec<RpcConfig> = rpcs
+                                .iter()
+                                .map(|rpc| RpcConfig {
+                                    url: rpc.url.clone(),
+                                    source_for: match rpc.source_for {
+                                        Some(For::Sync) => "sync",
+                                        Some(For::Fallback) => "fallback",
+                                        Some(For::Live) => "live",
+                                        None => unreachable!(
                                         "source_for should be resolved by from_evm_network_config"
                                     ),
-                                },
-                                ws: rpc.ws.clone(),
-                                initial_block_interval: rpc.initial_block_interval,
-                                backoff_multiplicative: rpc.backoff_multiplicative,
-                                acceleration_additive: rpc.acceleration_additive,
-                                interval_ceiling: rpc.interval_ceiling,
-                                backoff_millis: rpc.backoff_millis,
-                                fallback_stall_timeout: rpc.fallback_stall_timeout,
-                                query_timeout_millis: rpc.query_timeout_millis,
-                                polling_interval: rpc.polling_interval,
-                            })
-                            .collect();
-                        (hypersync_url, rpc_configs, None)
-                    }
-                    system_config::DataSource::Fuel {
-                        hypersync_endpoint_url,
-                    } => (Some(hypersync_endpoint_url.clone()), vec![], None),
-                    system_config::DataSource::Svm { rpc } => (None, vec![], Some(rpc.clone())),
-                };
+                                    },
+                                    address_filter_mode: rpc
+                                        .address_filter_mode
+                                        .as_ref()
+                                        .map(address_filter_mode_to_str),
+                                    ws: rpc.ws.clone(),
+                                    initial_block_interval: rpc.initial_block_interval,
+                                    backoff_multiplicative: rpc.backoff_multiplicative,
+                                    acceleration_additive: rpc.acceleration_additive,
+                                    interval_ceiling: rpc.interval_ceiling,
+                                    backoff_millis: rpc.backoff_millis,
+                                    fallback_stall_timeout: rpc.fallback_stall_timeout,
+                                    query_timeout_millis: rpc.query_timeout_millis,
+                                    polling_interval: rpc.polling_interval,
+                                })
+                                .collect();
+                            (
+                                hypersync_url,
+                                hypersync_address_filter_mode,
+                                rpc_configs,
+                                None,
+                            )
+                        }
+                        system_config::DataSource::Fuel {
+                            hypersync_endpoint_url,
+                        } => (Some(hypersync_endpoint_url.clone()), None, vec![], None),
+                        system_config::DataSource::Svm { rpc } => {
+                            (None, None, vec![], Some(rpc.clone()))
+                        }
+                    };
 
                 let chain_contracts: BTreeMap<String, ChainContractConfig> = network
                     .contracts
@@ -354,6 +381,7 @@ impl SystemConfig {
                         max_reorg_depth: network.max_reorg_depth,
                         block_lag: network.block_lag,
                         hypersync,
+                        hypersync_address_filter_mode,
                         rpcs,
                         rpc,
                         contracts: chain_contracts,

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -4,8 +4,8 @@ use super::{
     human_config::{
         self,
         evm::{
-            Chain as EvmChain, EventConfig as EvmEventConfig, For, HumanConfig as EvmConfig, Rpc,
-            RpcSelection,
+            AddressFilterMode, Chain as EvmChain, EventConfig as EvmEventConfig, For,
+            HumanConfig as EvmConfig, Rpc, RpcSelection,
         },
         fuel::{EventConfig as FuelEventConfig, HumanConfig as FuelConfig},
         HumanConfig,
@@ -1054,7 +1054,10 @@ type ServerUrl = String;
 /// for ConfigYAML, so we don't break backward compatibility
 #[derive(Debug, Clone, PartialEq)]
 pub enum MainEvmDataSource {
-    HyperSync { hypersync_endpoint_url: ServerUrl },
+    HyperSync {
+        hypersync_endpoint_url: ServerUrl,
+        address_filter_mode: Option<AddressFilterMode>,
+    },
     Rpc(Rpc),
 }
 
@@ -1110,6 +1113,7 @@ impl DataSource {
             Some(RpcSelection::Url(url)) => vec![Rpc {
                 url: url.to_string(),
                 source_for: Some(default_for.clone()),
+                address_filter_mode: None,
                 ws: None,
                 initial_block_interval: None,
                 backoff_multiplicative: None,
@@ -1190,6 +1194,10 @@ impl DataSource {
 
                 MainEvmDataSource::HyperSync {
                     hypersync_endpoint_url: parsed_url,
+                    address_filter_mode: network
+                        .hypersync_config
+                        .as_ref()
+                        .and_then(|config| config.address_filter_mode.clone()),
                 }
             }
         };
@@ -2338,12 +2346,15 @@ mod test {
 
     #[test]
     fn test_hypersync_url_trailing_slash_trimming() {
-        use crate::config_parsing::human_config::evm::{Chain as EvmChain, HypersyncConfig};
+        use crate::config_parsing::human_config::evm::{
+            AddressFilterMode, Chain as EvmChain, HypersyncConfig,
+        };
 
         let network = EvmChain {
             id: 1,
             hypersync_config: Some(HypersyncConfig {
                 url: "https://somechain.hypersync.xyz//".to_string(),
+                address_filter_mode: Some(AddressFilterMode::TopicsOnly),
             }),
             rpc: None,
             start_block: 0,
@@ -2360,8 +2371,51 @@ mod test {
             DataSource::Evm {
                 main: MainEvmDataSource::HyperSync {
                     hypersync_endpoint_url: "https://somechain.hypersync.xyz".to_string(),
+                    address_filter_mode: Some(AddressFilterMode::TopicsOnly),
                 },
                 rpcs: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_rpc_address_filter_mode_preserved() {
+        use crate::config_parsing::human_config::evm::{
+            AddressFilterMode, Chain as EvmChain, For, Rpc, RpcSelection,
+        };
+
+        let rpc = Rpc {
+            url: "https://rpc.example.com".to_string(),
+            source_for: Some(For::Sync),
+            address_filter_mode: Some(AddressFilterMode::TopicsOnly),
+            ws: None,
+            initial_block_interval: None,
+            backoff_multiplicative: None,
+            acceleration_additive: None,
+            interval_ceiling: None,
+            backoff_millis: None,
+            fallback_stall_timeout: None,
+            query_timeout_millis: None,
+            polling_interval: None,
+        };
+        let network = EvmChain {
+            id: 1,
+            hypersync_config: None,
+            rpc: Some(RpcSelection::Single(rpc.clone())),
+            start_block: 0,
+            end_block: None,
+            max_reorg_depth: None,
+            block_lag: None,
+            contracts: None,
+        };
+
+        let sync_source = DataSource::from_evm_network_config(network).unwrap();
+
+        assert_eq!(
+            sync_source,
+            DataSource::Evm {
+                main: MainEvmDataSource::Rpc(rpc.clone()),
+                rpcs: vec![rpc],
             }
         );
     }

--- a/packages/envio/evm.schema.json
+++ b/packages/envio/evm.schema.json
@@ -443,6 +443,17 @@
             }
           ]
         },
+        "address_filter_mode": {
+          "description": "How HyperIndex should apply address filtering for log queries. Defaults to `exact`. `topics_only` reduces request-body size by omitting the address list and filtering indexed addresses inside HyperIndex instead. Not supported for address-derived `where` filters.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AddressFilterMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "ws": {
           "description": "Optional WebSocket endpoint URL (wss:// or ws://) for real-time block header notifications via eth_subscribe(\"newHeads\"). Provides lower latency than HTTP polling for detecting new blocks.",
           "type": [
@@ -546,12 +557,37 @@
         }
       ]
     },
+    "AddressFilterMode": {
+      "oneOf": [
+        {
+          "description": "Filter logs by contract address in the upstream data source (default).",
+          "type": "string",
+          "const": "exact"
+        },
+        {
+          "description": "Fetch logs by topics only, then filter indexed contract addresses inside HyperIndex. Useful when request-body egress is the bottleneck, but can increase response size and decode work. Not supported for address-derived `where` filters.",
+          "type": "string",
+          "const": "topics_only"
+        }
+      ]
+    },
     "HypersyncConfig": {
       "type": "object",
       "properties": {
         "url": {
           "description": "URL of the HyperSync endpoint (default: The most performant HyperSync endpoint for the network)",
           "type": "string"
+        },
+        "address_filter_mode": {
+          "description": "How HyperIndex should apply address filtering for HyperSync log queries. Defaults to `exact`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AddressFilterMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,

--- a/packages/envio/src/ChainFetcher.res
+++ b/packages/envio/src/ChainFetcher.res
@@ -198,7 +198,7 @@ let make = (
   let chain = ChainMap.Chain.makeUnsafe(~chainId=chainConfig.id)
   let lowercaseAddresses = config.lowercaseAddresses
   let sources = switch chainConfig.sourceConfig {
-  | Config.EvmSourceConfig({hypersync, rpcs}) =>
+  | Config.EvmSourceConfig({hypersync, hypersyncAddressFilterMode, rpcs}) =>
     // Build Internal.evmContractConfig from contracts for EvmChain.makeSources
     let evmContracts: array<Internal.evmContractConfig> = chainConfig.contracts->Array.map((
       contract
@@ -219,6 +219,7 @@ let make = (
       {
         url: rpc.url,
         sourceFor: rpc.sourceFor,
+        addressFilterMode: rpc.addressFilterMode,
         ?syncConfig,
         ?ws,
       }
@@ -227,6 +228,7 @@ let make = (
       ~chain,
       ~contracts=evmContracts,
       ~hyperSync=hypersync,
+      ~hyperSyncAddressFilterMode=hypersyncAddressFilterMode,
       ~allEventSignatures,
       ~rpcs=evmRpcs,
       ~lowercaseAddresses,

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -20,15 +20,22 @@ type contract = {
 }
 
 // Source config parsed from internal.config.json - sources are created lazily in ChainFetcher
+type sourceAddressFilterMode = | @as("exact") Exact | @as("topics_only") TopicsOnly
+
 type evmRpcConfig = {
   url: string,
   sourceFor: Source.sourceFor,
+  addressFilterMode: sourceAddressFilterMode,
   syncConfig: option<sourceSyncOptions>,
   ws: option<string>,
 }
 
 type sourceConfig =
-  | EvmSourceConfig({hypersync: option<string>, rpcs: array<evmRpcConfig>})
+  | EvmSourceConfig({
+      hypersync: option<string>,
+      hypersyncAddressFilterMode: sourceAddressFilterMode,
+      rpcs: array<evmRpcConfig>,
+    })
   | FuelSourceConfig({hypersync: string})
   | SvmSourceConfig({rpc: string})
   // For tests: pass custom sources directly
@@ -156,11 +163,13 @@ module EnvioAddresses = {
 type rpcSourceFor = | @as("sync") Sync | @as("fallback") Fallback | @as("live") Live
 
 let rpcSourceForSchema = S.enum([Sync, Fallback, Live])
+let sourceAddressFilterModeSchema = S.enum([Exact, TopicsOnly])
 
 let rpcConfigSchema = S.schema(s =>
   {
     "url": s.matches(S.string),
     "for": s.matches(rpcSourceForSchema),
+    "addressFilterMode": s.matches(S.option(sourceAddressFilterModeSchema)),
     "ws": s.matches(S.option(S.string)),
     "initialBlockInterval": s.matches(S.option(S.int)),
     "backoffMultiplicative": s.matches(S.option(S.float)),
@@ -189,6 +198,7 @@ let publicConfigChainSchema = S.schema(s =>
     "blockLag": s.matches(S.option(S.int)),
     // EVM/Fuel source config (hypersync for EVM, hyperfuel for Fuel)
     "hypersync": s.matches(S.option(S.string)),
+    "hypersyncAddressFilterMode": s.matches(S.option(sourceAddressFilterModeSchema)),
     "rpcs": s.matches(S.option(S.array(rpcConfigSchema))),
     // SVM source config
     "rpc": s.matches(S.option(S.string)),
@@ -701,11 +711,18 @@ let fromPublic = (publicConfigJson: JSON.t, ~maxAddrInPartition=5000) => {
             {
               url: rpcConfig["url"],
               sourceFor: parseRpcSourceFor(rpcConfig["for"]),
+              addressFilterMode: rpcConfig["addressFilterMode"]->Option.getOr(Exact),
               syncConfig,
               ws: rpcConfig["ws"],
             }
           })
-        EvmSourceConfig({hypersync: publicChainConfig["hypersync"], rpcs})
+        EvmSourceConfig({
+          hypersync: publicChainConfig["hypersync"],
+          hypersyncAddressFilterMode: publicChainConfig["hypersyncAddressFilterMode"]->Option.getOr(
+            Exact,
+          ),
+          rpcs,
+        })
       | Ecosystem.Fuel =>
         switch publicChainConfig["hypersync"] {
         | Some(hypersync) => FuelSourceConfig({hypersync: hypersync})

--- a/packages/envio/src/sources/EvmChain.res
+++ b/packages/envio/src/sources/EvmChain.res
@@ -1,6 +1,7 @@
 type rpc = {
   url: string,
   sourceFor: Source.sourceFor,
+  addressFilterMode: Config.sourceAddressFilterMode,
   syncConfig?: Config.sourceSyncOptions,
   ws?: string,
 }
@@ -48,6 +49,7 @@ let makeSources = (
   ~chain,
   ~contracts: array<Internal.evmContractConfig>,
   ~hyperSync,
+  ~hyperSyncAddressFilterMode,
   ~allEventSignatures,
   ~rpcs: array<rpc>,
   ~lowercaseAddresses,
@@ -68,18 +70,20 @@ let makeSources = (
         clientMaxRetries: Env.hyperSyncClientMaxRetries,
         clientTimeoutMillis: Env.hyperSyncClientTimeoutMillis,
         lowercaseAddresses,
+        addressFilterMode: hyperSyncAddressFilterMode,
         serializationFormat: Env.hypersyncClientSerializationFormat,
         enableQueryCaching: Env.hypersyncClientEnableQueryCaching,
       }),
     ]
   | _ => []
   }
-  rpcs->Array.forEach(({?syncConfig, url, sourceFor, ?ws}) => {
+  rpcs->Array.forEach(({?syncConfig, url, sourceFor, addressFilterMode, ?ws}) => {
     let source = RpcSource.make({
       chain,
       sourceFor,
       syncConfig: getSyncConfig(syncConfig->Option.getOr({})),
       url,
+      addressFilterMode,
       eventRouter,
       allEventSignatures,
       lowercaseAddresses,

--- a/packages/envio/src/sources/HyperSyncSource.res
+++ b/packages/envio/src/sources/HyperSyncSource.res
@@ -9,7 +9,14 @@ type selectionConfig = {
   nonOptionalTransactionFieldNames: array<string>,
 }
 
-let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
+let topicsOnlyUnsupportedMessage =
+  "HyperSync topics_only address filter mode does not support event filters derived from `chain.<Contract>.addresses`. Remove the address-based `where` filter or switch back to address_filter_mode: exact."
+
+let getSelectionConfig = (
+  selection: FetchState.selection,
+  ~chain,
+  ~addressFilterMode=Config.Exact,
+) => {
   let nonOptionalBlockFieldNames = Utils.Set.make()
   let nonOptionalTransactionFieldNames = Utils.Set.make()
   let capitalizedBlockFields = Utils.Set.make()
@@ -20,6 +27,15 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
   let dynamicWildcardEventFiltersByContract = Dict.make()
   let noAddressesTopicSelections = []
   let contractNames = Utils.Set.make()
+
+  if (
+    addressFilterMode === Config.TopicsOnly &&
+      selection.eventConfigs->Array.some(ec => ec.filterByAddresses)
+  ) {
+    throw(
+      Source.GetItemsError(UnsupportedSelection({message: topicsOnlyUnsupportedMessage})),
+    )
+  }
 
   selection.eventConfigs
   ->(Utils.magic: array<Internal.eventConfig> => array<Internal.evmEventConfig>)
@@ -51,7 +67,7 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
     })
 
     let eventFilters = getEventFiltersOrThrow(chain)
-    if dependsOnAddresses {
+    if dependsOnAddresses && addressFilterMode === Config.Exact {
       let _ = contractNames->Utils.Set.add(contractName)
       switch eventFilters {
       | Static(topicSelections) =>
@@ -135,8 +151,8 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
   }
 }
 
-let memoGetSelectionConfig = (~chain) =>
-  Utils.WeakMap.memoize(selection => selection->getSelectionConfig(~chain))
+let memoGetSelectionConfig = (~chain, ~addressFilterMode) =>
+  Utils.WeakMap.memoize(selection => selection->getSelectionConfig(~chain, ~addressFilterMode))
 
 type options = {
   chain: ChainMap.Chain.t,
@@ -147,8 +163,63 @@ type options = {
   clientMaxRetries: int,
   clientTimeoutMillis: int,
   lowercaseAddresses: bool,
+  addressFilterMode: Config.sourceAddressFilterMode,
   serializationFormat: HyperSyncClient.serializationFormat,
   enableQueryCaching: bool,
+}
+
+type sharedTopicsOnlyPage = {
+  pageUnsafe: HyperSync.logsQueryPage,
+  parsedEvents: array<Nullable.t<HyperSyncClient.Decoder.decodedEvent>>,
+  knownHeight: int,
+  lastBlockQueriedPromise: promise<ReorgDetection.blockDataWithTimestamp>,
+}
+
+let sharedTopicsOnlyCacheMaxSize = 20
+
+let makeTopicsOnlyCacheKey = (~fromBlock, ~toBlock, ~selection: FetchState.selection) => {
+  let selectionKey =
+    selection.eventConfigs
+    ->Array.map(ec => ec.contractName ++ ":" ++ ec.id)
+    ->Array.joinUnsafe(",")
+  `${selectionKey}|${fromBlock->Int.toString}|${toBlock->Option.getOr(-1)->Int.toString}`
+}
+
+let rememberSharedTopicsOnlyPage = (
+  ~cache,
+  ~cacheKeys,
+  ~key,
+  ~promise: promise<sharedTopicsOnlyPage>,
+) => {
+  cache->Dict.set(key, promise)
+  cacheKeys->Array.push(key)->ignore
+  while cacheKeys->Array.length > sharedTopicsOnlyCacheMaxSize {
+    switch cacheKeys->Array.shift {
+    | Some(cacheKey) => cache->Utils.Dict.deleteInPlace(cacheKey)
+    | None => ()
+    }
+  }
+  let _ = promise->Promise.catch(err => {
+    cache->Utils.Dict.deleteInPlace(key)
+    throw(err)
+  })
+  promise
+}
+
+let partitionAllowsEventAddress = (
+  ~selection: FetchState.selection,
+  ~addressesByContractName,
+  ~eventConfig: Internal.evmEventConfig,
+  ~address,
+) => {
+  if !selection.dependsOnAddresses {
+    true
+  } else {
+    switch addressesByContractName->Utils.Dict.dangerouslyGetNonOption(eventConfig.contractName) {
+    | Some(addresses) => addresses->Array.some(a => a === address)
+    | None => false
+    }
+  }
 }
 
 let make = (
@@ -161,13 +232,14 @@ let make = (
     clientMaxRetries,
     clientTimeoutMillis,
     lowercaseAddresses,
+    addressFilterMode,
     serializationFormat,
     enableQueryCaching,
   }: options,
 ): t => {
   let name = "HyperSync"
 
-  let getSelectionConfig = memoGetSelectionConfig(~chain)
+  let getSelectionConfig = memoGetSelectionConfig(~chain, ~addressFilterMode)
 
   let apiToken = switch apiToken {
   | Some(token) => token
@@ -188,6 +260,8 @@ Learn more or get a free API token at: https://envio.dev/app/api-tokens`)
   )
 
   let hscDecoder: ref<option<HyperSyncClient.Decoder.t>> = ref(None)
+  let sharedTopicsOnlyPages: dict<promise<sharedTopicsOnlyPage>> = Dict.make()
+  let sharedTopicsOnlyPageKeys = []
   let getHscDecoder = () => {
     switch hscDecoder.contents {
     | Some(decoder) => decoder
@@ -260,132 +334,149 @@ Learn more or get a free API token at: https://envio.dev/app/api-tokens`)
 
     let startFetchingBatchTimeRef = Hrtime.makeTimer()
 
-    //fetch batch
-    Prometheus.SourceRequestCount.increment(
-      ~sourceName=name,
-      ~chainId=chain->ChainMap.Chain.toChainId,
-      ~method="getLogs",
-    )
-    let pageUnsafe = try await HyperSync.GetLogs.query(
-      ~client,
-      ~fromBlock,
-      ~toBlock,
-      ~logSelections,
-      ~fieldSelection=selectionConfig.fieldSelection,
-      ~nonOptionalBlockFieldNames=selectionConfig.nonOptionalBlockFieldNames,
-      ~nonOptionalTransactionFieldNames=selectionConfig.nonOptionalTransactionFieldNames,
-    ) catch {
-    | HyperSync.GetLogs.Error(error) =>
-      throw(
-        Source.GetItemsError(
-          Source.FailedGettingItems({
-            exn: %raw(`null`),
-            attemptedToBlock: toBlock->Option.getOr(knownHeight),
-            retry: switch error {
-            | WrongInstance =>
-              let backoffMillis = switch retry {
-              | 0 => 100
-              | _ => 500 * retry
-              }
-              WithBackoff({
-                message: `Block #${fromBlock->Int.toString} not found in HyperSync. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${backoffMillis->Int.toString}ms.`,
-                backoffMillis,
-              })
-            | UnexpectedMissingParams({missingParams}) =>
-              ImpossibleForTheQuery({
-                message: `Source returned invalid data with missing required fields: ${missingParams->Array.joinUnsafe(
-                    ", ",
-                  )}`,
-              })
-            },
-          }),
-        ),
+    let getSharedPage = async (~logSelections) => {
+      //fetch batch
+      Prometheus.SourceRequestCount.increment(
+        ~sourceName=name,
+        ~chainId=chain->ChainMap.Chain.toChainId,
+        ~method="getLogs",
       )
-    | exn =>
-      throw(
-        Source.GetItemsError(
-          Source.FailedGettingItems({
-            exn,
-            attemptedToBlock: toBlock->Option.getOr(knownHeight),
-            retry: WithBackoff({
-              message: `Unexpected issue while fetching events from HyperSync client. Attempt a retry.`,
-              backoffMillis: switch retry {
-              | 0 => 500
-              | _ => 1000 * retry
+      let pageUnsafe = try await HyperSync.GetLogs.query(
+        ~client,
+        ~fromBlock,
+        ~toBlock,
+        ~logSelections,
+        ~fieldSelection=selectionConfig.fieldSelection,
+        ~nonOptionalBlockFieldNames=selectionConfig.nonOptionalBlockFieldNames,
+        ~nonOptionalTransactionFieldNames=selectionConfig.nonOptionalTransactionFieldNames,
+      ) catch {
+      | HyperSync.GetLogs.Error(error) =>
+        throw(
+          Source.GetItemsError(
+            Source.FailedGettingItems({
+              exn: %raw(`null`),
+              attemptedToBlock: toBlock->Option.getOr(knownHeight),
+              retry: switch error {
+              | WrongInstance =>
+                let backoffMillis = switch retry {
+                | 0 => 100
+                | _ => 500 * retry
+                }
+                WithBackoff({
+                  message: `Block #${fromBlock->Int.toString} not found in HyperSync. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${backoffMillis->Int.toString}ms.`,
+                  backoffMillis,
+                })
+              | UnexpectedMissingParams({missingParams}) =>
+                ImpossibleForTheQuery({
+                  message: `Source returned invalid data with missing required fields: ${missingParams->Array.joinUnsafe(
+                      ", ",
+                    )}`,
+                })
               },
             }),
-          }),
-        ),
-      )
-    }
+          ),
+        )
+      | exn =>
+        throw(
+          Source.GetItemsError(
+            Source.FailedGettingItems({
+              exn,
+              attemptedToBlock: toBlock->Option.getOr(knownHeight),
+              retry: WithBackoff({
+                message: `Unexpected issue while fetching events from HyperSync client. Attempt a retry.`,
+                backoffMillis: switch retry {
+                | 0 => 500
+                | _ => 1000 * retry
+                },
+              }),
+            }),
+          ),
+        )
+      }
 
-    let pageFetchTime = startFetchingBatchTimeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
+      //set height and next from block
+      let knownHeight = pageUnsafe.archiveHeight
 
-    //set height and next from block
-    let knownHeight = pageUnsafe.archiveHeight
+      //The heighest (biggest) blocknumber that was accounted for in
+      //Our query. Not necessarily the blocknumber of the last log returned
+      //In the query
+      let heighestBlockQueried = pageUnsafe.nextBlock - 1
 
-    //The heighest (biggest) blocknumber that was accounted for in
-    //Our query. Not necessarily the blocknumber of the last log returned
-    //In the query
-    let heighestBlockQueried = pageUnsafe.nextBlock - 1
-
-    let lastBlockQueriedPromise = switch pageUnsafe.rollbackGuard {
-    //In the case a rollbackGuard is returned (this only happens at the head for unconfirmed blocks)
-    //use these values
-    | Some({blockNumber, timestamp, hash}) =>
-      (
-        {
-          blockNumber,
-          blockTimestamp: timestamp,
-          blockHash: hash,
-        }: ReorgDetection.blockDataWithTimestamp
-      )->Promise.resolve
-    | None =>
-      //The optional block and timestamp of the last item returned by the query
-      //(Optional in the case that there are no logs returned in the query)
-      switch pageUnsafe.items->Belt.Array.get(pageUnsafe.items->Belt.Array.length - 1) {
-      | Some({block}) if block.number->Belt.Option.getUnsafe == heighestBlockQueried =>
-        //If the last log item in the current page is equal to the
-        //heighest block acounted for in the query. Simply return this
-        //value without making an extra query
-
+      let lastBlockQueriedPromise = switch pageUnsafe.rollbackGuard {
+      | Some({blockNumber, timestamp, hash}) =>
         (
           {
-            blockNumber: block.number->Belt.Option.getUnsafe,
-            blockTimestamp: block.timestamp->Belt.Option.getUnsafe,
-            blockHash: block.hash->Belt.Option.getUnsafe,
+            blockNumber,
+            blockTimestamp: timestamp,
+            blockHash: hash,
           }: ReorgDetection.blockDataWithTimestamp
         )->Promise.resolve
-      //If it does not match it means that there were no matching logs in the last
-      //block so we should fetch the block data
-      | Some(_)
       | None =>
-        //If there were no logs at all in the current page query then fetch the
-        //timestamp of the heighest block accounted for
-        HyperSync.queryBlockData(
-          ~client,
-          ~blockNumber=heighestBlockQueried,
-          ~sourceName=name,
-          ~chainId=chain->ChainMap.Chain.toChainId,
-          ~logger,
-        )->Promise.thenResolve(res =>
-          switch res {
-          | Ok(Some(blockData)) => blockData
-          | Ok(None) =>
-            mkLogAndRaise(
-              Not_found,
-              ~msg=`Failure, blockData for block ${heighestBlockQueried->Int.toString} unexpectedly returned None`,
-            )
-          | Error(e) =>
-            HyperSync.queryErrorToMsq(e)
-            ->Obj.magic
-            ->mkLogAndRaise(
-              ~msg=`Failed to query blockData for block ${heighestBlockQueried->Int.toString}`,
-            )
-          }
+        switch pageUnsafe.items->Belt.Array.get(pageUnsafe.items->Belt.Array.length - 1) {
+        | Some({block}) if block.number->Belt.Option.getUnsafe == heighestBlockQueried =>
+          (
+            {
+              blockNumber: block.number->Belt.Option.getUnsafe,
+              blockTimestamp: block.timestamp->Belt.Option.getUnsafe,
+              blockHash: block.hash->Belt.Option.getUnsafe,
+            }: ReorgDetection.blockDataWithTimestamp
+          )->Promise.resolve
+        | Some(_)
+        | None =>
+          HyperSync.queryBlockData(
+            ~client,
+            ~blockNumber=heighestBlockQueried,
+            ~sourceName=name,
+            ~chainId=chain->ChainMap.Chain.toChainId,
+            ~logger,
+          )->Promise.thenResolve(res =>
+            switch res {
+            | Ok(Some(blockData)) => blockData
+            | Ok(None) =>
+              mkLogAndRaise(
+                Not_found,
+                ~msg=`Failure, blockData for block ${heighestBlockQueried->Int.toString} unexpectedly returned None`,
+              )
+            | Error(e) =>
+              HyperSync.queryErrorToMsq(e)
+              ->Obj.magic
+              ->mkLogAndRaise(
+                ~msg=`Failed to query blockData for block ${heighestBlockQueried->Int.toString}`,
+              )
+            }
+          )
+        }
+      }
+
+      let parsedEvents = switch await getHscDecoder().decodeEvents(pageUnsafe.events) {
+      | exception exn =>
+        exn->mkLogAndRaise(
+          ~msg="Failed to parse events using hypersync client, please double check your ABI.",
+        )
+      | parsedEvents => parsedEvents
+      }
+
+      {pageUnsafe, parsedEvents, knownHeight, lastBlockQueriedPromise}
+    }
+
+    let sharedPage = switch addressFilterMode {
+    | Config.Exact => getSharedPage(~logSelections)
+    | Config.TopicsOnly =>
+      let key = makeTopicsOnlyCacheKey(~fromBlock, ~toBlock, ~selection)
+      switch sharedTopicsOnlyPages->Utils.Dict.dangerouslyGetNonOption(key) {
+      | Some(page) => page
+      | None =>
+        rememberSharedTopicsOnlyPage(
+          ~cache=sharedTopicsOnlyPages,
+          ~cacheKeys=sharedTopicsOnlyPageKeys,
+          ~key,
+          ~promise=getSharedPage(~logSelections),
         )
       }
     }
+
+    let {pageUnsafe, parsedEvents, knownHeight, lastBlockQueriedPromise} = await sharedPage
+    let pageFetchTime = startFetchingBatchTimeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
 
     let parsingTimeRef = Hrtime.makeTimer()
 
@@ -417,15 +508,6 @@ Learn more or get a free API token at: https://envio.dev/app/api-tokens`)
       }
     }
 
-    //Parse page items into queue items
-    let parsedEvents = switch await getHscDecoder().decodeEvents(pageUnsafe.events) {
-    | exception exn =>
-      exn->mkLogAndRaise(
-        ~msg="Failed to parse events using hypersync client, please double check your ABI.",
-      )
-    | parsedEvents => parsedEvents
-    }
-
     pageUnsafe.items->Belt.Array.forEachWithIndex((index, item) => {
       let {block, log} = item
       let chainId = chain->ChainMap.Chain.toChainId
@@ -443,6 +525,15 @@ Learn more or get a free API token at: https://envio.dev/app/api-tokens`)
       let maybeDecodedEvent = parsedEvents->Array.getUnsafe(index)
 
       switch (maybeEventConfig, maybeDecodedEvent) {
+      | (Some(eventConfig), _)
+        if addressFilterMode === Config.TopicsOnly &&
+          !partitionAllowsEventAddress(
+            ~selection,
+            ~addressesByContractName,
+            ~eventConfig,
+            ~address=log.address,
+          ) =>
+        ()
       | (Some(eventConfig), Value(decoded)) =>
         parsedQueueItems
         ->Array.push(

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -310,7 +310,23 @@ type selectionConfig = {
   getLogSelectionOrThrow: (~addressesByContractName: dict<array<Address.t>>) => logSelection,
 }
 
-let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
+let topicsOnlyUnsupportedMessage =
+  "RPC topics_only address filter mode does not support event filters derived from `chain.<Contract>.addresses`. Remove the address-based `where` filter or switch back to address_filter_mode: exact."
+
+let getSelectionConfig = (
+  selection: FetchState.selection,
+  ~chain,
+  ~addressFilterMode=Config.Exact,
+) => {
+  if (
+    addressFilterMode === Config.TopicsOnly &&
+      selection.eventConfigs->Array.some(ec => ec.filterByAddresses)
+  ) {
+    throw(
+      Source.GetItemsError(UnsupportedSelection({message: topicsOnlyUnsupportedMessage})),
+    )
+  }
+
   let staticTopicSelections = []
   let dynamicEventFilters = []
 
@@ -338,9 +354,13 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
   | ([topicSelection], []) => {
       let topicQuery = topicSelection->Rpc.GetLogs.mapTopicQuery
       (~addressesByContractName) => {
-        addresses: switch addressesByContractName->FetchState.addressesByContractNameGetAll {
-        | [] => None
-        | addresses => Some(addresses)
+        addresses: switch addressFilterMode {
+        | Config.TopicsOnly => None
+        | Config.Exact =>
+          switch addressesByContractName->FetchState.addressesByContractNameGetAll {
+          | [] => None
+          | addresses => Some(addresses)
+          }
         },
         topicQuery,
       }
@@ -380,8 +400,8 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
   }
 }
 
-let memoGetSelectionConfig = (~chain) =>
-  Utils.WeakMap.memoize(selection => selection->getSelectionConfig(~chain))
+let memoGetSelectionConfig = (~chain, ~addressFilterMode) =>
+  Utils.WeakMap.memoize(selection => selection->getSelectionConfig(~chain, ~addressFilterMode))
 
 // Type-erase a schema for storage in the field registry
 external toFieldSchema: S.t<'a> => S.t<JSON.t> = "%identity"
@@ -836,6 +856,7 @@ type options = {
   sourceFor: Source.sourceFor,
   syncConfig: Config.sourceSync,
   url: string,
+  addressFilterMode: Config.sourceAddressFilterMode,
   chain: ChainMap.Chain.t,
   eventRouter: EventRouter.t<Internal.evmEventConfig>,
   allEventSignatures: array<string>,
@@ -843,11 +864,65 @@ type options = {
   ws?: string,
 }
 
+type sharedTopicsOnlyPage = {
+  logs: array<Rpc.GetLogs.log>,
+  parsedEvents: array<Nullable.t<HyperSyncClient.Decoder.decodedEvent>>,
+  latestFetchedBlockInfo: blockInfo,
+}
+
+let sharedTopicsOnlyCacheMaxSize = 20
+
+let makeTopicsOnlyCacheKey = (~fromBlock, ~toBlock, ~selection: FetchState.selection) => {
+  let selectionKey =
+    selection.eventConfigs
+    ->Array.map(ec => ec.contractName ++ ":" ++ ec.id)
+    ->Array.joinUnsafe(",")
+  `${selectionKey}|${fromBlock->Int.toString}|${toBlock->Int.toString}`
+}
+
+let rememberSharedTopicsOnlyPage = (
+  ~cache,
+  ~cacheKeys,
+  ~key,
+  ~promise: promise<sharedTopicsOnlyPage>,
+) => {
+  cache->Dict.set(key, promise)
+  cacheKeys->Array.push(key)->ignore
+  while cacheKeys->Array.length > sharedTopicsOnlyCacheMaxSize {
+    switch cacheKeys->Array.shift {
+    | Some(cacheKey) => cache->Utils.Dict.deleteInPlace(cacheKey)
+    | None => ()
+    }
+  }
+  let _ = promise->Promise.catch(err => {
+    cache->Utils.Dict.deleteInPlace(key)
+    throw(err)
+  })
+  promise
+}
+
+let partitionAllowsEventAddress = (
+  ~selection: FetchState.selection,
+  ~addressesByContractName,
+  ~eventConfig: Internal.evmEventConfig,
+  ~address,
+) => {
+  if !selection.dependsOnAddresses {
+    true
+  } else {
+    switch addressesByContractName->Utils.Dict.dangerouslyGetNonOption(eventConfig.contractName) {
+    | Some(addresses) => addresses->Array.some(a => a === address)
+    | None => false
+    }
+  }
+}
+
 let make = (
   {
     sourceFor,
     syncConfig,
     url,
+    addressFilterMode,
     chain,
     eventRouter,
     allEventSignatures,
@@ -865,9 +940,11 @@ let make = (
   }
   let name = `RPC (${urlHost})`
 
-  let getSelectionConfig = memoGetSelectionConfig(~chain)
+  let getSelectionConfig = memoGetSelectionConfig(~chain, ~addressFilterMode)
 
   let mutSuggestedBlockIntervals = Dict.make()
+  let sharedTopicsOnlyPages: dict<promise<sharedTopicsOnlyPage>> = Dict.make()
+  let sharedTopicsOnlyPageKeys = []
 
   let client = Rpc.makeClient(url)
 
@@ -1047,22 +1124,90 @@ let make = (
     let {getLogSelectionOrThrow} = getSelectionConfig(selection)
     let {addresses, topicQuery} = getLogSelectionOrThrow(~addressesByContractName)
 
-    let {logs, latestFetchedBlockInfo} = await getNextPage(
-      ~fromBlock,
-      ~toBlock=suggestedToBlock,
-      ~addresses,
-      ~topicQuery,
-      ~loadBlock=blockNumber =>
-        blockLoader.contents
-        ->LazyLoader.get(blockNumber)
-        ->Promise.thenResolve(parseBlockInfo),
-      ~syncConfig,
-      ~client,
-      ~mutSuggestedBlockIntervals,
-      ~partitionId,
-      ~sourceName=name,
-      ~chainId=chain->ChainMap.Chain.toChainId,
-    )
+    let sharedPage = switch addressFilterMode {
+    | Config.Exact =>
+      getNextPage(
+        ~fromBlock,
+        ~toBlock=suggestedToBlock,
+        ~addresses,
+        ~topicQuery,
+        ~loadBlock=blockNumber =>
+          blockLoader.contents
+          ->LazyLoader.get(blockNumber)
+          ->Promise.thenResolve(parseBlockInfo),
+        ~syncConfig,
+        ~client,
+        ~mutSuggestedBlockIntervals,
+        ~partitionId,
+        ~sourceName=name,
+        ~chainId=chain->ChainMap.Chain.toChainId,
+      )->Promise.then(async ({logs, latestFetchedBlockInfo}) => {
+        let parsedEvents = try await getHscDecoder().decodeEvents(
+          logs->Belt.Array.map(convertLogToHyperSyncEvent),
+        ) catch {
+        | exn =>
+          throw(
+            Source.GetItemsError(
+              FailedGettingItems({
+                exn,
+                attemptedToBlock: toBlock,
+                retry: ImpossibleForTheQuery({
+                  message: "Failed to parse events using hypersync client decoder. Please double-check your ABI.",
+                }),
+              }),
+            ),
+          )
+        }
+        {logs, parsedEvents, latestFetchedBlockInfo}
+      })
+    | Config.TopicsOnly =>
+      let key = makeTopicsOnlyCacheKey(~fromBlock, ~toBlock=suggestedToBlock, ~selection)
+      switch sharedTopicsOnlyPages->Utils.Dict.dangerouslyGetNonOption(key) {
+      | Some(page) => page
+      | None =>
+        rememberSharedTopicsOnlyPage(
+          ~cache=sharedTopicsOnlyPages,
+          ~cacheKeys=sharedTopicsOnlyPageKeys,
+          ~key,
+          ~promise=getNextPage(
+            ~fromBlock,
+            ~toBlock=suggestedToBlock,
+            ~addresses=None,
+            ~topicQuery,
+            ~loadBlock=blockNumber =>
+              blockLoader.contents
+              ->LazyLoader.get(blockNumber)
+              ->Promise.thenResolve(parseBlockInfo),
+            ~syncConfig,
+            ~client,
+            ~mutSuggestedBlockIntervals,
+            ~partitionId,
+            ~sourceName=name,
+            ~chainId=chain->ChainMap.Chain.toChainId,
+          )->Promise.then(async ({logs, latestFetchedBlockInfo}) => {
+            let parsedEvents = try await getHscDecoder().decodeEvents(
+              logs->Belt.Array.map(convertLogToHyperSyncEvent),
+            ) catch {
+            | exn =>
+              throw(
+                Source.GetItemsError(
+                  FailedGettingItems({
+                    exn,
+                    attemptedToBlock: toBlock,
+                    retry: ImpossibleForTheQuery({
+                      message: "Failed to parse events using hypersync client decoder. Please double-check your ABI.",
+                    }),
+                  }),
+                ),
+              )
+            }
+            {logs, parsedEvents, latestFetchedBlockInfo}
+          }),
+        )
+      }
+    }
+
+    let {logs, parsedEvents, latestFetchedBlockInfo} = await sharedPage
 
     let executedBlockInterval = suggestedToBlock - fromBlock + 1
 
@@ -1080,25 +1225,6 @@ let make = (
         Pervasives.min(
           executedBlockInterval + syncConfig.accelerationAdditive,
           syncConfig.intervalCeiling,
-        ),
-      )
-    }
-
-    // Convert RPC logs to HyperSync events
-    let hyperSyncEvents = logs->Belt.Array.map(convertLogToHyperSyncEvent)
-
-    // Decode using HyperSyncClient decoder
-    let parsedEvents = try await getHscDecoder().decodeEvents(hyperSyncEvents) catch {
-    | exn =>
-      throw(
-        Source.GetItemsError(
-          FailedGettingItems({
-            exn,
-            attemptedToBlock: toBlock,
-            retry: ImpossibleForTheQuery({
-              message: "Failed to parse events using hypersync client decoder. Please double-check your ABI.",
-            }),
-          }),
         ),
       )
     }
@@ -1123,6 +1249,15 @@ let make = (
         ~blockNumber=log.blockNumber,
       ) {
       | None => None
+      | Some(eventConfig)
+        if addressFilterMode === Config.TopicsOnly &&
+          !partitionAllowsEventAddress(
+            ~selection,
+            ~addressesByContractName,
+            ~eventConfig,
+            ~address=routedAddress,
+          ) =>
+        None
       | Some(eventConfig) =>
         switch maybeDecodedEvent {
         | Value(decoded) =>

--- a/scenarios/test_codegen/test/HyperSyncSource_test.res
+++ b/scenarios/test_codegen/test/HyperSyncSource_test.res
@@ -84,6 +84,31 @@ describe("HyperSyncSource - getSelectionConfig", () => {
     },
   )
 
+  Async.it("Topics_only omits upstream address filtering for normal events", async t => {
+    let selectionConfig = {
+      dependsOnAddresses: true,
+      eventConfigs: [(MockIndexer.evmEventConfig() :> Internal.eventConfig)],
+    }->HyperSyncSource.getSelectionConfig(~chain, ~addressFilterMode=Config.TopicsOnly)
+
+    t.expect(
+      selectionConfig.getLogSelectionOrThrow(
+        ~addressesByContractName=Dict.fromArray([("ERC20", [mockAddress0])]),
+      ),
+    ).toEqual([
+      {
+        addresses: [],
+        topicSelections: [
+          {
+            topic0: [MockIndexer.eventId->EvmTypes.Hex.fromStringUnsafe],
+            topic1: [],
+            topic2: [],
+            topic3: [],
+          },
+        ],
+      },
+    ])
+  })
+
   Async.it("Combines field selection from multiple events on different contracts", async t => {
     let selectionConfig = {
       dependsOnAddresses: true,
@@ -194,4 +219,22 @@ describe("HyperSyncSource - getSelectionConfig", () => {
       ])
     },
   )
+
+  it("Topics_only rejects address-derived event filters", t => {
+    try {
+      let _ = {
+        dependsOnAddresses: true,
+        eventConfigs: [
+          (MockIndexer.evmEventConfig(~filterByAddresses=true) :> Internal.eventConfig),
+        ],
+      }->HyperSyncSource.getSelectionConfig(~chain, ~addressFilterMode=Config.TopicsOnly)
+      JsError.throwWithMessage("Should have thrown")
+    } catch {
+    | Source.GetItemsError(UnsupportedSelection({message})) =>
+      t.expect(message).toBe(
+        "HyperSync topics_only address filter mode does not support event filters derived from `chain.<Contract>.addresses`. Remove the address-based `where` filter or switch back to address_filter_mode: exact.",
+      )
+    | _ => JsError.throwWithMessage("Should have thrown UnsupportedSelection")
+    }
+  })
 })

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -27,6 +27,7 @@ describe("RpcSource - name", () => {
       chain: MockConfig.chain1337,
       eventRouter: EventRouter.empty(),
       sourceFor: Sync,
+      addressFilterMode: Config.Exact,
       syncConfig: EvmChain.getSyncConfig({}),
       allEventSignatures: [],
       lowercaseAddresses: false,
@@ -42,6 +43,7 @@ describe("RpcSource - getHeightOrThrow", () => {
       chain: MockConfig.chain1337,
       eventRouter: EventRouter.empty(),
       sourceFor: Sync,
+      addressFilterMode: Config.Exact,
       syncConfig: EvmChain.getSyncConfig({}),
       allEventSignatures: ["a", "b", "c"],
       lowercaseAddresses: false,
@@ -752,6 +754,22 @@ describe("RpcSource - getSelectionConfig", () => {
     })
   })
 
+  it("Topics_only omits upstream address filtering for normal events", t => {
+    let selectionConfig = {
+      dependsOnAddresses: true,
+      eventConfigs: [(MockIndexer.evmEventConfig() :> Internal.eventConfig)],
+    }->RpcSource.getSelectionConfig(~chain, ~addressFilterMode=Config.TopicsOnly)
+
+    t.expect(
+      selectionConfig.getLogSelectionOrThrow(
+        ~addressesByContractName=Dict.fromArray([("ERC20", [mockAddress0])]),
+      ),
+    ).toEqual({
+      addresses: None,
+      topicQuery: [Single(MockIndexer.eventId)],
+    })
+  })
+
   Async.it("Wildcard topic selection which depends on addresses", async t => {
     let selectionConfig = {
       dependsOnAddresses: false,
@@ -794,6 +812,24 @@ describe("RpcSource - getSelectionConfig", () => {
       addresses: Some([mockAddress0]),
       topicQuery: [Single("event 2"), Single(mockAddress0->Address.toString)],
     })
+  })
+
+  it("Topics_only rejects address-derived event filters", t => {
+    try {
+      let _ = {
+        dependsOnAddresses: true,
+        eventConfigs: [
+          (MockIndexer.evmEventConfig(~filterByAddresses=true) :> Internal.eventConfig),
+        ],
+      }->RpcSource.getSelectionConfig(~chain, ~addressFilterMode=Config.TopicsOnly)
+      JsError.throwWithMessage("Should have thrown")
+    } catch {
+    | Source.GetItemsError(UnsupportedSelection({message})) =>
+      t.expect(message).toBe(
+        "RPC topics_only address filter mode does not support event filters derived from `chain.<Contract>.addresses`. Remove the address-based `where` filter or switch back to address_filter_mode: exact.",
+      )
+    | _ => JsError.throwWithMessage("Should have thrown UnsupportedSelection")
+    }
   })
 
   it("Panics when selection has empty event configs", t => {


### PR DESCRIPTION
Allow RPC and HyperSync EVM sources to omit upstream address filters and filter indexed addresses inside HyperIndex instead, so users can reduce request-body egress when exact address lists become too large.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable address filter mode for EVM data sources. Users can now select between "exact" mode (default, standard address filtering) and "topics_only" mode (optimized for reduced request body size through HyperIndex filtering). Important limitation: "topics_only" mode does not support address-derived where clause filters; use "exact" mode or remove address-based filters if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->