### PR TITLE
Add per-event startBlock override via where.block filter

### DIFF
--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -336,6 +336,11 @@ impl EventMod {
         // filter shapes are expressed inside `params` itself via
         // `SingleOrMultiple` — there's no top-level `Multiple` constructor.
         //
+        // The `block` sibling carries the per-event startBlock override
+        // (`block.number._gte` → overrides contract `start_block`). Only
+        // `_gte` is valid; `_lte` / `_every` are rejected at registration
+        // time and aren't part of the generated type.
+        //
         // - Events with no indexed params (Fuel, or EVM events without indexed
         //   fields) get the `Internal.noOnEventWhere` stub so the option field
         //   exists but cannot be populated.
@@ -345,7 +350,9 @@ impl EventMod {
         let where_type_code = match self.event_filter_type.as_str() {
             "{}" => "type onEventWhere = Internal.noOnEventWhere".to_string(),
             _ => format!(
-                "type onEventWhereCondition = {{params?: SingleOrMultiple.t<whereParams>}}\n\
+                "type onEventWhereBlockNumber = {{@as(\"_gte\") _gte?: int}}\n\
+type onEventWhereBlock = {{@as(\"number\") number?: onEventWhereBlockNumber}}\n\
+type onEventWhereCondition = {{params?: SingleOrMultiple.t<whereParams>, block?: onEventWhereBlock}}\n\
 type onEventWhereChainContract = {{/** Addresses of the {contract_capitalized} contract on this chain. */ addresses: array<Address.t>}}\n\
 type onEventWhereChain = {{/** The unique identifier of the blockchain network where this event occurred. */ id: chainId, \\\"{contract_capitalized}\": onEventWhereChainContract}}\n\
 type onEventWhereArgs = {{chain: onEventWhereChain}}\n\

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -350,13 +350,13 @@ impl EventMod {
         let where_type_code = match self.event_filter_type.as_str() {
             "{}" => "type onEventWhere = Internal.noOnEventWhere".to_string(),
             _ => format!(
-                "type onEventWhereBlockNumber = {{@as(\"_gte\") _gte?: int}}\n\
-type onEventWhereBlock = {{@as(\"number\") number?: onEventWhereBlockNumber}}\n\
-type onEventWhereCondition = {{params?: SingleOrMultiple.t<whereParams>, block?: onEventWhereBlock}}\n\
+                "type onEventWhereBlockNumber = {{_gte?: int}}\n\
+type onEventWhereBlock = {{number?: onEventWhereBlockNumber}}\n\
+type onEventWhereFilter = {{params?: SingleOrMultiple.t<whereParams>, block?: onEventWhereBlock}}\n\
 type onEventWhereChainContract = {{/** Addresses of the {contract_capitalized} contract on this chain. */ addresses: array<Address.t>}}\n\
 type onEventWhereChain = {{/** The unique identifier of the blockchain network where this event occurred. */ id: chainId, \\\"{contract_capitalized}\": onEventWhereChainContract}}\n\
 type onEventWhereArgs = {{chain: onEventWhereChain}}\n\
-@unboxed type onEventWhereResult = Filter(onEventWhereCondition) | @as(false) SkipAll | @as(true) KeepAll\n\
+@unboxed type onEventWhereResult = Filter(onEventWhereFilter) | @as(false) SkipAll | @as(true) KeepAll\n\
 type onEventWhere = onEventWhereArgs => onEventWhereResult",
                 contract_capitalized = self.contract_name.capitalized,
             ),

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__event_template_named_struct_rescript_snapshot.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__event_template_named_struct_rescript_snapshot.snap
@@ -32,7 +32,9 @@ type event = {
 
 type whereParams = {@as("streamId") streamId?: SingleOrMultiple.t<bigint>}
 
-type onEventWhereCondition = {params?: SingleOrMultiple.t<whereParams>}
+type onEventWhereBlockNumber = {@as("_gte") _gte?: int}
+type onEventWhereBlock = {@as("number") number?: onEventWhereBlockNumber}
+type onEventWhereCondition = {params?: SingleOrMultiple.t<whereParams>, block?: onEventWhereBlock}
 type onEventWhereChainContract = {/** Addresses of the SablierLockup contract on this chain. */ addresses: array<Address.t>}
 type onEventWhereChain = {/** The unique identifier of the blockchain network where this event occurred. */ id: chainId, \"SablierLockup": onEventWhereChainContract}
 type onEventWhereArgs = {chain: onEventWhereChain}

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__event_template_named_struct_rescript_snapshot.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__event_template_named_struct_rescript_snapshot.snap
@@ -32,11 +32,11 @@ type event = {
 
 type whereParams = {@as("streamId") streamId?: SingleOrMultiple.t<bigint>}
 
-type onEventWhereBlockNumber = {@as("_gte") _gte?: int}
-type onEventWhereBlock = {@as("number") number?: onEventWhereBlockNumber}
-type onEventWhereCondition = {params?: SingleOrMultiple.t<whereParams>, block?: onEventWhereBlock}
+type onEventWhereBlockNumber = {_gte?: int}
+type onEventWhereBlock = {number?: onEventWhereBlockNumber}
+type onEventWhereFilter = {params?: SingleOrMultiple.t<whereParams>, block?: onEventWhereBlock}
 type onEventWhereChainContract = {/** Addresses of the SablierLockup contract on this chain. */ addresses: array<Address.t>}
 type onEventWhereChain = {/** The unique identifier of the blockchain network where this event occurred. */ id: chainId, \"SablierLockup": onEventWhereChainContract}
 type onEventWhereArgs = {chain: onEventWhereChain}
-@unboxed type onEventWhereResult = Filter(onEventWhereCondition) | @as(false) SkipAll | @as(true) KeepAll
+@unboxed type onEventWhereResult = Filter(onEventWhereFilter) | @as(false) SkipAll | @as(true) KeepAll
 type onEventWhere = onEventWhereArgs => onEventWhereResult

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-blocks/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-blocks/SKILL.md
@@ -64,6 +64,7 @@ indexer.onBlock(
 - No events or contract address required
 - The handler context has the same entity API as event handlers
 - If `where` returns `false` for every configured chain, a warning is logged at registration time
+- For per-event startBlock (not stride), use `indexer.onEvent` with `where.block.number._gte` (see `indexing-filters`). Event filters accept `_gte` only; `_lte`/`_every` are reserved for `onBlock`.
 
 ## Deep Documentation
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-filters/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-filters/SKILL.md
@@ -8,9 +8,9 @@ description: >-
 
 # Event Filters (`where`)
 
-The `where` handler option filters events by indexed parameters. Works with or without `wildcard: true`.
+The `where` handler option filters events by indexed parameters and restricts the per-event block range. Works with or without `wildcard: true`.
 
-The filter value is a `{ params: ... }` record. `params` can be a **single object** (AND-conjunction across indexed parameters) or an **array** of objects (OR across multiple AND-conjunctions). The `{params}` wrapper reserves room for future filter dimensions (block, transaction, …) as sibling fields.
+The filter value is a `{ params?, block? }` record. `params` can be a **single object** (AND-conjunction across indexed parameters) or an **array** of objects (OR across multiple AND-conjunctions). `block.number._gte` (or `block.height._gte` on Fuel) promotes to the event's **startBlock** and overrides the contract-level `start_block` from `config.yaml`.
 
 ## Single Object Form
 
@@ -106,12 +106,55 @@ indexer.onEvent(
 );
 ```
 
+## Per-Event `startBlock` via `block.number._gte`
+
+Use `where.block` as a sibling of `params` to restrict an event to blocks at or after a given number. Overrides the contract's `start_block` from `config.yaml` — useful for narrowing a single event without touching the whole contract.
+
+```ts
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: {
+      block: { number: { _gte: 18000000 } },
+      params: { from: ZERO_ADDRESS },
+    },
+  },
+  async ({ event, context }) => {
+    /* ... */
+  },
+);
+```
+
+Dynamic per-chain form:
+
+```ts
+indexer.onEvent(
+  {
+    contract: "ERC20",
+    event: "Transfer",
+    wildcard: true,
+    where: ({ chain }) => ({
+      block: { number: { _gte: chain.id === 1 ? 18000000 : 0 } },
+      params: [{ from: chain.ERC20.addresses }, { to: chain.ERC20.addresses }],
+    }),
+  },
+  async ({ event, context }) => {
+    /* ... */
+  },
+);
+```
+
+On Fuel, key the block range on `block.height` instead of `block.number`. SVM has no event handlers. Only `_gte` is accepted on event filters — for `_lte` or `_every` (stride), use `indexer.onBlock`. The `block` filter is only valid at the top level of `where`, not nested inside `params` array entries.
+
 ## Filter Semantics
 
 - Filter fields inside each `params` entry correspond to the event's **indexed parameters** only
 - Multiple entries in the `params` array → OR (match any)
 - Multiple fields in one entry → AND (match all)
 - Array value in a field → match any value in the array
+- `block.number._gte` (EVM) / `block.height._gte` (Fuel) → per-event startBlock, overrides contract `start_block`
 - `return false` → skip the chain entirely (no events processed for that chain)
 - `return true` → accept all events (no filtering, default topic0-only selection)
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-filters/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-filters/SKILL.md
@@ -110,7 +110,7 @@ indexer.onEvent(
 
 Use `where.block` as a sibling of `params` to restrict an event to blocks at or after a given number. Overrides the contract's `start_block` from `config.yaml` — useful for narrowing a single event without touching the whole contract.
 
-Branch by `chain.id` with a `switch` so the type system flags any unconfigured chain via the `default: never` exhaustiveness check:
+Use a `switch` on `chain.id` to pick the `startBlock` only, so the shared `params` filter isn't duplicated per chain. The `default: never` branch makes TypeScript flag any chain added to `config.yaml` but not handled here:
 
 ```ts
 indexer.onEvent(
@@ -119,17 +119,14 @@ indexer.onEvent(
     event: "Transfer",
     wildcard: true,
     where: ({ chain }) => {
+      let startBlock: number;
       switch (chain.id) {
         case 1:
-          return {
-            block: { number: { _gte: 18000000 } },
-            params: [{ from: chain.ERC20.addresses }, { to: chain.ERC20.addresses }],
-          };
+          startBlock = 18000000;
+          break;
         case 8453:
-          return {
-            block: { number: { _gte: 2000000 } },
-            params: [{ from: chain.ERC20.addresses }, { to: chain.ERC20.addresses }],
-          };
+          startBlock = 2000000;
+          break;
         default: {
           // Exhaustiveness check: TypeScript errors here if a new chain ID
           // is added to config.yaml but not handled above.
@@ -137,6 +134,10 @@ indexer.onEvent(
           return false;
         }
       }
+      return {
+        block: { number: { _gte: startBlock } },
+        params: [{ from: chain.ERC20.addresses }, { to: chain.ERC20.addresses }],
+      };
     },
   },
   async ({ event, context }) => {

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-filters/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-filters/SKILL.md
@@ -110,35 +110,34 @@ indexer.onEvent(
 
 Use `where.block` as a sibling of `params` to restrict an event to blocks at or after a given number. Overrides the contract's `start_block` from `config.yaml` — useful for narrowing a single event without touching the whole contract.
 
+Branch by `chain.id` with a `switch` so the type system flags any unconfigured chain via the `default: never` exhaustiveness check:
+
 ```ts
 indexer.onEvent(
   {
     contract: "ERC20",
     event: "Transfer",
     wildcard: true,
-    where: {
-      block: { number: { _gte: 18000000 } },
-      params: { from: ZERO_ADDRESS },
+    where: ({ chain }) => {
+      switch (chain.id) {
+        case 1:
+          return {
+            block: { number: { _gte: 18000000 } },
+            params: [{ from: chain.ERC20.addresses }, { to: chain.ERC20.addresses }],
+          };
+        case 8453:
+          return {
+            block: { number: { _gte: 2000000 } },
+            params: [{ from: chain.ERC20.addresses }, { to: chain.ERC20.addresses }],
+          };
+        default: {
+          // Exhaustiveness check: TypeScript errors here if a new chain ID
+          // is added to config.yaml but not handled above.
+          const _exhaustive: never = chain.id;
+          return false;
+        }
+      }
     },
-  },
-  async ({ event, context }) => {
-    /* ... */
-  },
-);
-```
-
-Dynamic per-chain form:
-
-```ts
-indexer.onEvent(
-  {
-    contract: "ERC20",
-    event: "Transfer",
-    wildcard: true,
-    where: ({ chain }) => ({
-      block: { number: { _gte: chain.id === 1 ? 18000000 : 0 } },
-      params: [{ from: chain.ERC20.addresses }, { to: chain.ERC20.addresses }],
-    }),
   },
   async ({ event, context }) => {
     /* ... */

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -596,10 +596,8 @@ export type EvmOnEventWhere<Params, ContractName extends string> =
 export type FuelOnEventWhereChain<ContractName extends string> = EvmOnEventWhereChain<ContractName>;
 /** Arguments passed to the Fuel dynamic `where` callback form. */
 export type FuelOnEventWhereArgs<ContractName extends string> = EvmOnEventWhereArgs<ContractName>;
-/** A single Fuel `where` filter condition. Mirrors the EVM shape but keys the
- * block range on `block.height` instead of `block.number`. `height._gte`
- * promotes to the event's startBlock (overriding contract-level
- * `start_block`). Only `_gte` is supported on event filters. */
+/** A single Fuel `where` filter condition. Keyed on `block.height` instead
+ * of `block.number`. */
 export type FuelOnEventWhereFilter<Params> = {
   readonly params?: Params | readonly Params[];
   readonly block?: {

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -607,7 +607,9 @@ export type FuelOnEventWhereFilter<Params> = {
   };
 };
 /** The `where` option value of `indexer.onEvent` / `indexer.contractRegister` in the Fuel ecosystem. */
-export type FuelOnEventWhere<Params, ContractName extends string> = EvmOnEventWhere<Params, ContractName>;
+export type FuelOnEventWhere<Params, ContractName extends string> =
+  | FuelOnEventWhereFilter<Params>
+  | ((args: FuelOnEventWhereArgs<ContractName>) => FuelOnEventWhereFilter<Params> | boolean);
 
 /** Options for registering an EVM onEvent handler. Contract and event literal names are derived from the Event type.
  * The conditional `Event extends EventLike` distributes over union members so that each member's

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -563,12 +563,19 @@ export type EvmOnEventWhereArgs<ContractName extends string> = {
   readonly chain: EvmOnEventWhereChain<ContractName>;
 };
 
-/** A single EVM `where` filter condition. The `{params}` wrapper reserves room
- * for future filter dimensions (block, transaction, …) as sibling fields.
- * `params` accepts either a single AND-conjunction of indexed-parameter
- * narrowings, or an array of them (OR semantics). */
+/** A single EVM `where` filter condition. `params` accepts either a single
+ * AND-conjunction of indexed-parameter narrowings, or an array of them (OR
+ * semantics). `block.number._gte` promotes to the event's startBlock and
+ * overrides the contract-level `start_block` — use it to restrict per-event
+ * processing without touching `config.yaml`. Only `_gte` is supported on
+ * event filters; use `indexer.onBlock` for `_lte` / `_every`. */
 export type EvmOnEventWhereFilter<Params> = {
   readonly params?: Params | readonly Params[];
+  readonly block?: {
+    readonly number?: {
+      readonly _gte?: number;
+    };
+  };
 };
 
 /** The `where` option value of `indexer.onEvent` / `indexer.contractRegister`
@@ -589,8 +596,18 @@ export type EvmOnEventWhere<Params, ContractName extends string> =
 export type FuelOnEventWhereChain<ContractName extends string> = EvmOnEventWhereChain<ContractName>;
 /** Arguments passed to the Fuel dynamic `where` callback form. */
 export type FuelOnEventWhereArgs<ContractName extends string> = EvmOnEventWhereArgs<ContractName>;
-/** A single Fuel `where` filter condition. */
-export type FuelOnEventWhereFilter<Params> = EvmOnEventWhereFilter<Params>;
+/** A single Fuel `where` filter condition. Mirrors the EVM shape but keys the
+ * block range on `block.height` instead of `block.number`. `height._gte`
+ * promotes to the event's startBlock (overriding contract-level
+ * `start_block`). Only `_gte` is supported on event filters. */
+export type FuelOnEventWhereFilter<Params> = {
+  readonly params?: Params | readonly Params[];
+  readonly block?: {
+    readonly height?: {
+      readonly _gte?: number;
+    };
+  };
+};
 /** The `where` option value of `indexer.onEvent` / `indexer.contractRegister` in the Fuel ecosystem. */
 export type FuelOnEventWhere<Params, ContractName extends string> = EvmOnEventWhere<Params, ContractName>;
 

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -291,7 +291,7 @@ let getFieldTypeAndSchema = (prop, ~enumConfigsByName: dict<Table.enumConfig<Tab
   | "bigint" => (Table.BigInt({precision: ?prop["precision"]}), Utils.BigInt.schema->S.toUnknown)
   | "bigdecimal" => (
       Table.BigDecimal({
-        config: ?prop["precision"]->Option.map(p => (p, prop["scale"]->Option.getOr(0))),
+        config: ?(prop["precision"]->Option.map(p => (p, prop["scale"]->Option.getOr(0)))),
       }),
       BigDecimal.schema->S.toUnknown,
     )
@@ -480,6 +480,12 @@ let fromPublic = (publicConfigJson: JSON.t, ~maxAddrInPartition=5000) => {
     )
   }
 
+  let ecosystem = switch ecosystemName {
+  | Ecosystem.Evm => Evm.ecosystem
+  | Ecosystem.Fuel => Fuel.ecosystem
+  | Ecosystem.Svm => Svm.ecosystem
+  }
+
   // Extract EVM-specific options with defaults
   let lowercaseAddresses = switch publicConfig["evm"] {
   | Some(evm) => evm["addressFormat"]->Option.getOr(Checksum) == Lowercase
@@ -584,6 +590,7 @@ let fromPublic = (publicConfigJson: JSON.t, ~maxAddrInPartition=5000) => {
             ~contractRegister,
             ~eventFilters=HandlerRegister.getOnEventWhere(~contractName, ~eventName),
             ~probeChainId=chainId,
+            ~onEventBlockFilterSchema=ecosystem.onEventBlockFilterSchema,
             ~blockFields=?eventItem["blockFields"],
             ~transactionFields=?eventItem["transactionFields"],
             ~startBlock?,
@@ -741,12 +748,6 @@ let fromPublic = (publicConfigJson: JSON.t, ~maxAddrInPartition=5000) => {
       (ChainMap.Chain.makeUnsafe(~chainId=chain.id), chain)
     })
     ->ChainMap.fromArrayUnsafe
-
-  let ecosystem = switch ecosystemName {
-  | Ecosystem.Evm => Evm.ecosystem
-  | Ecosystem.Fuel => Fuel.ecosystem
-  | Ecosystem.Svm => Svm.ecosystem
-  }
 
   // Parse enums and entities from JSON config
   let allEnums =

--- a/packages/envio/src/Ecosystem.res
+++ b/packages/envio/src/Ecosystem.res
@@ -23,6 +23,15 @@ type t = {
       a second time in `Main.res` by the shared `blockRangeSchema` — that
       keeps range-field validation in one place for every ecosystem. */
   onBlockFilterSchema: S.t<option<unknown>>,
+  /** Schema that unwraps the ecosystem-specific `block` wrapper from the
+      user's `onEvent` `where` value (`block.number` on EVM, `block.height`
+      on Fuel) and surfaces the raw inner `{_gte?}` chunk as
+      `option<unknown>`. Separate from `onBlockFilterSchema` because event
+      block filters support only `_gte` (→ per-event `startBlock`) — `_lte`
+      and `_every` are rejected by the inner `eventBlockRangeSchema` in
+      `LogSelection.res`. SVM does not support event handlers, so its
+      schema always surfaces `None`. */
+  onEventBlockFilterSchema: S.t<option<unknown>>,
 }
 
 let makeOnBlockArgs = (~blockNumber: int, ~ecosystem: t, ~context): Internal.onBlockArgs => {

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -430,6 +430,7 @@ let buildEvmEventConfig = (
   ~contractRegister: option<Internal.contractRegister>,
   ~eventFilters: option<JSON.t>,
   ~probeChainId: int,
+  ~onEventBlockFilterSchema: S.t<option<unknown>>,
   ~blockFields: option<array<Internal.evmBlockField>>=?,
   ~transactionFields: option<array<Internal.evmTransactionField>>=?,
   ~startBlock: option<int>=?,
@@ -439,16 +440,30 @@ let buildEvmEventConfig = (
   let topicCount = params->Array.reduce(1, (acc, p) => p.indexed ? acc + 1 : acc)
   let indexedParams = params->Array.filter(p => p.indexed)
 
-  let {getEventFiltersOrThrow, filterByAddresses} = LogSelection.parseEventFiltersOrThrow(
+  let {
+    getEventFiltersOrThrow,
+    filterByAddresses,
+    startBlock: whereStartBlock,
+  } = LogSelection.parseEventFiltersOrThrow(
     ~eventFilters,
     ~sighash,
     ~params=indexedParams->Array.map(p => p.name),
     ~contractName,
     ~probeChainId,
+    ~onEventBlockFilterSchema,
     ~topic1=?indexedParams->Array.get(0)->Option.map(buildTopicGetter),
     ~topic2=?indexedParams->Array.get(1)->Option.map(buildTopicGetter),
     ~topic3=?indexedParams->Array.get(2)->Option.map(buildTopicGetter),
   )
+
+  // `where.block.number._gte` overrides the contract-level startBlock
+  // when present. The user opts into this explicitly in handler code so
+  // it should win over the `config.yaml` contract `start_block`; absent
+  // `where.block`, the caller's contract-level value passes through.
+  let resolvedStartBlock = switch whereStartBlock {
+  | Some(_) as sb => sb
+  | None => startBlock
+  }
 
   let (selectedBlockFields, selectedTransactionFields) = resolveFieldSelection(
     ~blockFields,
@@ -469,7 +484,7 @@ let buildEvmEventConfig = (
     getEventFiltersOrThrow,
     filterByAddresses,
     dependsOnAddresses: !isWildcard || filterByAddresses,
-    startBlock,
+    startBlock: resolvedStartBlock,
     convertHyperSyncEventArgs: buildHyperSyncDecoder(params),
     selectedBlockFields,
     selectedTransactionFields,

--- a/packages/envio/src/LogSelection.res
+++ b/packages/envio/src/LogSelection.res
@@ -60,6 +60,63 @@ let make = (~addresses, ~topicSelections) => {
 type parsedEventFilters = {
   getEventFiltersOrThrow: ChainMap.Chain.t => Internal.eventFilters,
   filterByAddresses: bool,
+  // `_gte` from the top-level `block` filter of the user's `where`,
+  // resolved at build time (per-chain via the `probeChainId`). The
+  // caller uses this to override the per-event `startBlock` — a
+  // `where`-derived startBlock always wins over contract-level
+  // config, so users can widen or narrow individual event ranges
+  // without touching `config.yaml`.
+  startBlock: option<int>,
+}
+
+// Inner schema for the event `block` filter chunk: `{_gte?}`.
+// `S.strict` rejects `_lte` / `_every` — those are stride/range concepts
+// that only make sense for `onBlock` handlers, not event filters. Typos
+// like `_gt` surface through the same strict-schema error path.
+type eventBlockRange = {_gte: option<int>}
+let eventBlockRangeSchema: S.t<eventBlockRange> = S.object(s => {
+  _gte: s.field("_gte", S.option(S.int)),
+})->S.strict
+
+// Extract the per-event `startBlock` from a `where` result (or static
+// value). Two-stage parse mirroring `onBlock`: the ecosystem schema
+// strips the outer `block.number` / `block.height` wrapper, then
+// `eventBlockRangeSchema` validates `{_gte?}` strictly — `_lte` and
+// `_every` are rejected with a user-friendly message pointing users
+// at `onBlock` for stride/endBlock semantics.
+//
+// Returns `None` for boolean `where` results, missing `block`, and
+// `block.number: {}` (no `_gte`). Wraps schema errors with the
+// contract/event context so the call-site is obvious in the log.
+let extractStartBlock = (
+  where: JSON.t,
+  ~onEventBlockFilterSchema: S.t<option<unknown>>,
+  ~contractName: string,
+): option<int> => {
+  // `where` may be a bool at runtime even though the static type is
+  // `JSON.t` — the user callbacks can return `true`/`false` to keep/skip
+  // a chain, and the value reaches here unwrapped. Detect with
+  // `typeof` instead of an identity-equal check so ReScript doesn't
+  // constant-fold the comparison away for the `JSON.t` nominal type.
+  if typeof(where) === #boolean {
+    None
+  } else {
+    try {
+      switch where->S.parseOrThrow(onEventBlockFilterSchema) {
+      | None => None
+      | Some(inner) => (inner->S.parseOrThrow(eventBlockRangeSchema))._gte
+      }
+    } catch {
+    | S.Raised(exn) =>
+      JsError.throwWithMessage(
+        `Invalid where configuration for ${contractName}. \`block\` filter is invalid: ${exn
+          ->Utils.prettifyExn
+          ->(
+            Utils.magic: exn => string
+          )}. Only \`_gte\` is supported on event filters — use \`indexer.onBlock\` for \`_lte\` or \`_every\`.`,
+      )
+    }
+  }
 }
 
 // Build the runtime `chain` argument passed into a `where` callback.
@@ -104,11 +161,13 @@ let parseEventFiltersOrThrow = {
     ~params,
     ~contractName: string,
     ~probeChainId: int,
+    ~onEventBlockFilterSchema: S.t<option<unknown>>,
     ~topic1=noopGetter,
     ~topic2=noopGetter,
     ~topic3=noopGetter,
   ): parsedEventFilters => {
     let filterByAddresses = ref(false)
+    let startBlock = ref(None)
     let topic0 = [sighash->EvmTypes.Hex.fromStringUnsafe]
     let default = {
       Internal.topic0,
@@ -143,6 +202,12 @@ let parseEventFiltersOrThrow = {
       }
     }
 
+    // Known top-level `where` keys. `block` is a sibling of `params` — its
+    // `_gte` promotes to the event's `startBlock` (extracted separately
+    // by `extractStartBlock`). Unknown keys are rejected to catch typos
+    // like `parmas` or `blocks` at registration time.
+    let acceptedWhereKeys = ["params", "block"]
+
     // Parse a `where` value (or the result of calling the dynamic callback)
     // into a list of topic selections.
     //
@@ -152,6 +217,8 @@ let parseEventFiltersOrThrow = {
     // - `{}` (or `{params: undefined}`) → no narrowing
     // - `{params: {...}}` → single AND-conjunction
     // - `{params: [{...}, {...}]}` → OR of multiple AND-conjunctions
+    // - `{block: {number: {_gte: N}}}` → no topic narrowing; startBlock only
+    // - `{params: ..., block: ...}` → combined
     //
     // The runtime accepts both the function form (the only form ReScript
     // exposes) and a top-level static object form (TypeScript convenience).
@@ -161,40 +228,42 @@ let parseEventFiltersOrThrow = {
       } else if where === Obj.magic(false) {
         []
       } else {
-        // A `where` condition is shaped as `{params?: ..., ...}` where
-        // `params` carries the indexed-parameter filter record. Future
-        // filter dimensions (block, transaction, …) can slot in as sibling
-        // fields alongside `params`.
+        // A `where` condition is shaped as `{params?: ..., block?: ...}`.
+        // `params` carries the indexed-parameter filter record; `block`
+        // carries the per-event block-range filter handled by
+        // `extractStartBlock`.
         switch where {
-        | Object(obj) =>
-          switch obj->Dict.get("params") {
-          | None =>
-            // Reject non-empty objects without `params` — almost always a
-            // typo (e.g. `parmas:`) or the legacy flat-filter shape
-            // (`{from: ...}`). Empty `{}` is fine and means "match all".
-            if obj->Dict.keysToArray->Array.length > 0 {
-              JsError.throwWithMessage(
-                "Invalid where configuration. Indexed parameter filters must be nested under `params`",
-              )
-            } else {
-              [default]
-            }
-          | Some(Object(p)) => [paramsRecordToTopicSelection(p)]
-          | Some(Array([])) => [default]
-          | Some(Array(arr)) =>
-            arr->Array.map(item =>
-              switch item {
-              | Object(p) => paramsRecordToTopicSelection(p)
-              | _ =>
+        | Object(obj) => {
+            // Catch typos (e.g. `parmas:`) and the legacy flat-filter
+            // shape (`{from: ...}`) by rejecting any unknown sibling.
+            obj
+            ->Dict.keysToArray
+            ->Array.forEach(key => {
+              if acceptedWhereKeys->Array.includes(key)->not {
                 JsError.throwWithMessage(
-                  "Invalid where configuration. Each entry in `params` must be an object",
+                  `Invalid where configuration. Unknown field "${key}". Indexed parameter filters must be nested under \`params\` and block-range filters under \`block\``,
                 )
               }
-            )
-          | Some(_) =>
-            JsError.throwWithMessage(
-              "Invalid where configuration. Expected `params` to be an object or an array of objects",
-            )
+            })
+            switch obj->Dict.get("params") {
+            | None => [default]
+            | Some(Object(p)) => [paramsRecordToTopicSelection(p)]
+            | Some(Array([])) => [default]
+            | Some(Array(arr)) =>
+              arr->Array.map(item =>
+                switch item {
+                | Object(p) => paramsRecordToTopicSelection(p)
+                | _ =>
+                  JsError.throwWithMessage(
+                    "Invalid where configuration. Each entry in `params` must be an object",
+                  )
+                }
+              )
+            | Some(_) =>
+              JsError.throwWithMessage(
+                "Invalid where configuration. Expected `params` to be an object or an array of objects",
+              )
+            }
           }
         | _ => JsError.throwWithMessage("Invalid where configuration. Expected an object")
         }
@@ -216,7 +285,12 @@ let parseEventFiltersOrThrow = {
         // they take for this chain. Event configs are built per-chain, so
         // each chain gets a `filterByAddresses` verdict that matches its
         // own callback behaviour.
-        try {
+        //
+        // The probe result is also reused to extract the per-event
+        // `startBlock` (from `where.block`) for this chain — a second
+        // invocation would risk observing different state for callbacks
+        // that close over mutable references.
+        let probedResult = try {
           let chain = makeDetectionChainArg(
             ~contractName,
             ~chainId=probeChainId,
@@ -225,9 +299,14 @@ let parseEventFiltersOrThrow = {
               []
             },
           )
-          let _ = fn({chain: chain->Obj.magic})
+          Some(fn({chain: chain->Obj.magic}))
         } catch {
-        | _ => ()
+        | _ => None
+        }
+        switch probedResult {
+        | Some(result) =>
+          startBlock := extractStartBlock(~onEventBlockFilterSchema, ~contractName, result)
+        | None => ()
         }
         if filterByAddresses.contents {
           chain => Internal.Dynamic(
@@ -259,6 +338,7 @@ let parseEventFiltersOrThrow = {
           }
         }
       } else {
+        startBlock := extractStartBlock(~onEventBlockFilterSchema, ~contractName, eventFilters)
         let static: Internal.eventFilters = Static(eventFilters->parse)
         _ => static
       }
@@ -267,6 +347,7 @@ let parseEventFiltersOrThrow = {
     {
       getEventFiltersOrThrow,
       filterByAddresses: filterByAddresses.contents,
+      startBlock: startBlock.contents,
     }
   }
 }

--- a/packages/envio/src/sources/Evm.res
+++ b/packages/envio/src/sources/Evm.res
@@ -88,4 +88,13 @@ let ecosystem: Ecosystem.t = {
   onBlockFilterSchema: S.object(s =>
     s.field("block", S.option(S.object(s2 => s2.field("number", S.unknown))))
   ),
+  // EVM event filter shape: `{block: {number: {_gte?}}, params?, ...}`.
+  // Only the `block.number` wrapper is unwrapped here; sibling fields
+  // like `params` are left for `LogSelection` to consume. The inner
+  // range chunk is validated by `eventBlockRangeSchema` in
+  // `LogSelection.res` which rejects `_lte`/`_every` (use `onBlock` for
+  // stride- and endBlock-based block handlers).
+  onEventBlockFilterSchema: S.object(s =>
+    s.field("block", S.option(S.object(s2 => s2.field("number", S.unknown))))
+  ),
 }

--- a/packages/envio/src/sources/Fuel.res
+++ b/packages/envio/src/sources/Fuel.res
@@ -25,4 +25,11 @@ let ecosystem: Ecosystem.t = {
   onBlockFilterSchema: S.object(s =>
     s.field("block", S.option(S.object(s2 => s2.field("height", S.unknown))))
   ),
+  // Fuel event filter shape: `{block: {height: {_gte?}}, params?, ...}`.
+  // Analogous to EVM, but keyed by `block.height` instead of
+  // `block.number`. See `Evm.res` for the rationale on the two-stage
+  // parse and the `_lte`/`_every` rejection.
+  onEventBlockFilterSchema: S.object(s =>
+    s.field("block", S.option(S.object(s2 => s2.field("height", S.unknown))))
+  ),
 }

--- a/packages/envio/src/sources/Svm.res
+++ b/packages/envio/src/sources/Svm.res
@@ -23,6 +23,9 @@ let ecosystem: Ecosystem.t = {
   // SVM filter shape: `{slot: {_gte?, _lte?, _every?}}`.
   // Inner range chunk parsed by `blockRangeSchema` in `Main.res`.
   onBlockFilterSchema: S.object(s => s.field("slot", S.option(S.unknown))),
+  // SVM has no event handlers, so there is no `onEvent` `where` value to
+  // parse. The schema is a no-op object that always surfaces `None`.
+  onEventBlockFilterSchema: S.object(_ => None),
 }
 
 module GetFinalizedSlot = {

--- a/scenarios/fuel_test/src/GreeterHandlers.ts
+++ b/scenarios/fuel_test/src/GreeterHandlers.ts
@@ -1,5 +1,51 @@
 import { indexer, type User } from "generated";
 
+// Type-level regression guards for `where.block` on Fuel. Declared as an
+// unreached function so `tsc --noEmit` checks the types without runtime
+// re-registering events. The `@ts-expect-error` assertions catch the
+// class of bug where `FuelOnEventWhere` was previously aliased to
+// `EvmOnEventWhere`, bypassing `FuelOnEventWhereFilter` and typing Fuel
+// users against EVM's `block.number` shape — a silent runtime no-op.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function _typeCheckFuelWhereBlockShape() {
+  indexer.onEvent(
+    {
+      contract: "Greeter",
+      event: "NewGreeting",
+      where: { block: { height: { _gte: 1 } } },
+    },
+    async () => {},
+  );
+  indexer.onEvent(
+    {
+      contract: "Greeter",
+      event: "NewGreeting",
+      where: {
+        block: {
+          // @ts-expect-error Fuel keys block by `height`, not `number`.
+          number: { _gte: 1 },
+        },
+      },
+    },
+    async () => {},
+  );
+  indexer.onEvent(
+    {
+      contract: "Greeter",
+      event: "NewGreeting",
+      where: {
+        block: {
+          height: {
+            // @ts-expect-error Only `_gte` is supported on event filters.
+            _lte: 1,
+          },
+        },
+      },
+    },
+    async () => {},
+  );
+}
+
 /**
 Registers a handler that handles any values from the
 NewGreeting event on the Greeter contract and index these values into

--- a/scenarios/fuel_test/src/_regression-check.ts
+++ b/scenarios/fuel_test/src/_regression-check.ts
@@ -1,0 +1,41 @@
+// Regression guards for the public TypeScript surface of event-level
+// `where.block` filters. CodeRabbit caught a class of bug on PR #1131
+// where `FuelOnEventWhere` was aliased to `EvmOnEventWhere`, bypassing
+// `FuelOnEventWhereFilter` and quietly typing Fuel users against EVM's
+// `block.number` shape. Keep these checks next to a real handler file so
+// they run under the project's normal `tsc --noEmit` gate.
+import type {
+  EvmOnEventWhere,
+  EvmOnEventWhereFilter,
+  FuelOnEventWhere,
+  FuelOnEventWhereFilter,
+} from "envio";
+
+// Filter-shape invariant: Fuel's block key is `height`, EVM's is `number`.
+// Catches a field rename / swap in `index.d.ts`.
+type _FuelBlockKeys = keyof NonNullable<FuelOnEventWhereFilter<{}>["block"]>;
+type _EvmBlockKeys = keyof NonNullable<EvmOnEventWhereFilter<{}>["block"]>;
+const _fuelHeight: "height" extends _FuelBlockKeys ? true : false = true;
+const _fuelNoNumber: "number" extends _FuelBlockKeys ? false : true = true;
+const _evmNumber: "number" extends _EvmBlockKeys ? true : false = true;
+const _evmNoHeight: "height" extends _EvmBlockKeys ? false : true = true;
+void _fuelHeight; void _fuelNoNumber; void _evmNumber; void _evmNoHeight;
+
+// Wrapper-alias guard: the two ecosystems' wrappers must NOT be mutually
+// assignable. If `FuelOnEventWhere = EvmOnEventWhere` sneaks back in,
+// their component filters collapse to the same structural type and this
+// asymmetry check flips to `true`.
+type _FuelAssignableToEvm = FuelOnEventWhere<{}, "C"> extends EvmOnEventWhere<{}, "C"> ? true : false;
+type _EvmAssignableToFuel = EvmOnEventWhere<{}, "C"> extends FuelOnEventWhere<{}, "C"> ? true : false;
+const _fuelNotEvm: _FuelAssignableToEvm = false;
+const _evmNotFuel: _EvmAssignableToFuel = false;
+void _fuelNotEvm; void _evmNotFuel;
+
+// Inner-range invariant: only `_gte` is public; `_lte` and `_every`
+// would be caught by `S.strict` at runtime, but document the TS surface
+// too so handler authors see the same constraint at edit time.
+type _FuelRangeKeys = keyof NonNullable<NonNullable<FuelOnEventWhereFilter<{}>["block"]>["height"]>;
+type _EvmRangeKeys = keyof NonNullable<NonNullable<EvmOnEventWhereFilter<{}>["block"]>["number"]>;
+const _fuelGteOnly: [_FuelRangeKeys] extends ["_gte"] ? true : false = true;
+const _evmGteOnly: [_EvmRangeKeys] extends ["_gte"] ? true : false = true;
+void _fuelGteOnly; void _evmGteOnly;

--- a/scenarios/fuel_test/src/_regression-check.ts
+++ b/scenarios/fuel_test/src/_regression-check.ts
@@ -34,8 +34,13 @@ void _fuelNotEvm; void _evmNotFuel;
 // Inner-range invariant: only `_gte` is public; `_lte` and `_every`
 // would be caught by `S.strict` at runtime, but document the TS surface
 // too so handler authors see the same constraint at edit time.
+// Bidirectional equality check — `[never] extends ["_gte"]` is `true`
+// (never is the bottom type), so a one-way check would silently pass if
+// `_gte` were accidentally removed. `_ExactlyGte` requires the keyset
+// to be exactly `"_gte"`, rejecting both `never` and any wider union.
 type _FuelRangeKeys = keyof NonNullable<NonNullable<FuelOnEventWhereFilter<{}>["block"]>["height"]>;
 type _EvmRangeKeys = keyof NonNullable<NonNullable<EvmOnEventWhereFilter<{}>["block"]>["number"]>;
-const _fuelGteOnly: [_FuelRangeKeys] extends ["_gte"] ? true : false = true;
-const _evmGteOnly: [_EvmRangeKeys] extends ["_gte"] ? true : false = true;
+type _ExactlyGte<T> = [T] extends ["_gte"] ? (["_gte"] extends [T] ? true : false) : false;
+const _fuelGteOnly: _ExactlyGte<_FuelRangeKeys> = true;
+const _evmGteOnly: _ExactlyGte<_EvmRangeKeys> = true;
 void _fuelGteOnly; void _evmGteOnly;

--- a/scenarios/test_codegen/src/handlers/EventHandlers.ts
+++ b/scenarios/test_codegen/src/handlers/EventHandlers.ts
@@ -931,3 +931,69 @@ indexer.onBlock(
   { name: "test_onblock_skip_all", where: () => false },
   async () => {},
 );
+
+// Type-level regression guards for `where.block` on EVM. Declared as an
+// unreached function so `tsc --noEmit` checks the types without runtime
+// re-registering events. The `@ts-expect-error` assertions catch the
+// class of bug where `EvmOnEventWhere` might get wired through the wrong
+// filter shape (e.g. Fuel's `block.height`) — a regression would flip
+// the directive from "expected" to "unused", failing the build.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function _typeCheckEvmWhereBlockShape() {
+  indexer.onEvent(
+    {
+      contract: "EventFiltersTest",
+      event: "Transfer",
+      wildcard: true,
+      where: { block: { number: { _gte: 1 } } },
+    },
+    async () => {},
+  );
+  indexer.onEvent(
+    {
+      contract: "EventFiltersTest",
+      event: "Transfer",
+      wildcard: true,
+      where: {
+        block: {
+          // @ts-expect-error EVM keys block by `number`, not `height`.
+          height: { _gte: 1 },
+        },
+      },
+    },
+    async () => {},
+  );
+  indexer.onEvent(
+    {
+      contract: "EventFiltersTest",
+      event: "Transfer",
+      wildcard: true,
+      where: {
+        block: {
+          number: {
+            // @ts-expect-error Only `_gte` is supported on event filters.
+            _lte: 1,
+          },
+        },
+      },
+    },
+    async () => {},
+  );
+  indexer.onEvent(
+    {
+      contract: "EventFiltersTest",
+      event: "Transfer",
+      wildcard: true,
+      where: {
+        block: {
+          number: {
+            // @ts-expect-error Only `_gte` is supported on event filters.
+            _every: 100,
+          },
+        },
+      },
+    },
+    async () => {},
+  );
+}
+

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -166,19 +166,19 @@ describe("parseEventFiltersOrThrow — Fuel block.height", () => {
   })
 })
 
-// Compile-time check that the generated `onEventWhereCondition` type on a
+// Compile-time check that the generated `onEventWhereFilter` type on a
 // real codegen'd event module carries the `block` sibling of `params`.
 // Running this test as a value also verifies that the optional fields'
 // shape is preserved end-to-end — the ReScript record unwrapped to JSON
 // matches exactly what `LogSelection.parseEventFiltersOrThrow` expects.
-describe("Generated onEventWhereCondition — block field exists on EVM events", () => {
+describe("Generated onEventWhereFilter — block field exists on EVM events", () => {
   it("compiles a `Filter` with combined params + block.number._gte", t => {
     let fromFilter: Indexer.EventFiltersTest.Transfer.whereParams = {
       from: Indexer.SingleOrMultiple.single(
         "0x0000000000000000000000000000000000000000"->Address.unsafeFromString,
       ),
     }
-    let condition: Indexer.EventFiltersTest.Transfer.onEventWhereCondition = {
+    let condition: Indexer.EventFiltersTest.Transfer.onEventWhereFilter = {
       params: Indexer.SingleOrMultiple.single(fromFilter),
       block: {number: {_gte: 1000}},
     }
@@ -188,7 +188,7 @@ describe("Generated onEventWhereCondition — block field exists on EVM events",
     let {startBlock} = parseEvm(
       ~eventFilters=Some(
         condition->(
-          Utils.magic: Indexer.EventFiltersTest.Transfer.onEventWhereCondition => JSON.t
+          Utils.magic: Indexer.EventFiltersTest.Transfer.onEventWhereFilter => JSON.t
         ),
       ),
     )
@@ -196,13 +196,13 @@ describe("Generated onEventWhereCondition — block field exists on EVM events",
   })
 
   it("compiles a `Filter` with only block (no params)", t => {
-    let condition: Indexer.EventFiltersTest.Transfer.onEventWhereCondition = {
+    let condition: Indexer.EventFiltersTest.Transfer.onEventWhereFilter = {
       block: {number: {_gte: 2500}},
     }
     // Round-trip through the runtime parser to prove the record encodes to
     // the shape the parser understands — catches any drift between
     // codegen'd types and runtime expectations.
-    let {startBlock} = parseEvm(~eventFilters=Some(condition->(Utils.magic: Indexer.EventFiltersTest.Transfer.onEventWhereCondition => JSON.t)))
+    let {startBlock} = parseEvm(~eventFilters=Some(condition->(Utils.magic: Indexer.EventFiltersTest.Transfer.onEventWhereFilter => JSON.t)))
     t.expect(startBlock).toEqual(Some(2500))
   })
 })

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -1,0 +1,167 @@
+open Vitest
+
+// Tests for the per-event `startBlock` extracted from `where.block` on the
+// `onEvent` filter. The parser lives in `LogSelection.parseEventFiltersOrThrow`
+// and composes the ecosystem-specific `onEventBlockFilterSchema` (strips
+// `block.number` on EVM, `block.height` on Fuel) with the shared
+// `eventBlockRangeSchema` (strict, `_gte`-only). These tests drive the parser
+// directly so we don't have to bring up a full indexer.
+//
+// The canonical ERC-20 Transfer sighash is used as a valid topic0 — the
+// parser requires a sighash but the content doesn't matter for these cases.
+
+let transferSighash = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+let parseEvm = (~eventFilters: option<JSON.t>, ~probeChainId=1) =>
+  LogSelection.parseEventFiltersOrThrow(
+    ~eventFilters,
+    ~sighash=transferSighash,
+    ~params=["from", "to"],
+    ~contractName="ERC20",
+    ~probeChainId,
+    ~onEventBlockFilterSchema=Evm.ecosystem.onEventBlockFilterSchema,
+  )
+
+let parseFuel = (~eventFilters: option<JSON.t>, ~probeChainId=1) =>
+  LogSelection.parseEventFiltersOrThrow(
+    ~eventFilters,
+    ~sighash=transferSighash,
+    ~params=["from", "to"],
+    ~contractName="ERC20",
+    ~probeChainId,
+    ~onEventBlockFilterSchema=Fuel.ecosystem.onEventBlockFilterSchema,
+  )
+
+describe("eventBlockRangeSchema (strict, _gte-only)", () => {
+  it("parses a lone _gte", t => {
+    let parsed = %raw(`{_gte: 10}`)->S.parseOrThrow(LogSelection.eventBlockRangeSchema)
+    t.expect(parsed).toEqual(({_gte: Some(10)}: LogSelection.eventBlockRange))
+  })
+
+  it("rejects _lte (use onBlock for ranges)", t => {
+    t.expect(() =>
+      %raw(`{_gte: 10, _lte: 100}`)->S.parseOrThrow(LogSelection.eventBlockRangeSchema)
+    ).toThrow()
+  })
+
+  it("rejects _every (use onBlock for stride)", t => {
+    t.expect(() =>
+      %raw(`{_gte: 10, _every: 5}`)->S.parseOrThrow(LogSelection.eventBlockRangeSchema)
+    ).toThrow()
+  })
+
+  it("rejects typos (_gt)", t => {
+    t.expect(() => %raw(`{_gt: 10}`)->S.parseOrThrow(LogSelection.eventBlockRangeSchema)).toThrow()
+  })
+
+  it("accepts an empty object (no startBlock)", t => {
+    let parsed = %raw(`{}`)->S.parseOrThrow(LogSelection.eventBlockRangeSchema)
+    t.expect(parsed).toEqual(({_gte: None}: LogSelection.eventBlockRange))
+  })
+})
+
+describe("parseEventFiltersOrThrow — static `where` with block filter (EVM)", () => {
+  it("extracts startBlock from a bare block filter", t => {
+    let {startBlock, filterByAddresses} = parseEvm(
+      ~eventFilters=Some(%raw(`{block: {number: {_gte: 1000}}}`)),
+    )
+    t.expect((startBlock, filterByAddresses)).toEqual((Some(1000), false))
+  })
+
+  it("extracts startBlock alongside params (combined filter)", t => {
+    let {startBlock} = parseEvm(
+      ~eventFilters=Some(
+        %raw(`{block: {number: {_gte: 2000}}, params: {from: "0x0000000000000000000000000000000000000000"}}`),
+      ),
+    )
+    t.expect(startBlock).toEqual(Some(2000))
+  })
+
+  it("returns None when `where` has no block filter", t => {
+    let {startBlock} = parseEvm(
+      ~eventFilters=Some(%raw(`{params: {from: "0x0000000000000000000000000000000000000000"}}`)),
+    )
+    t.expect(startBlock).toEqual(None)
+  })
+
+  it("returns None when `where` is `{block: {}}` (no number field)", t => {
+    let {startBlock} = parseEvm(~eventFilters=Some(%raw(`{block: {}}`)))
+    t.expect(startBlock).toEqual(None)
+  })
+
+  it("returns None when `block.number: {}` (no _gte)", t => {
+    let {startBlock} = parseEvm(~eventFilters=Some(%raw(`{block: {number: {}}}`)))
+    t.expect(startBlock).toEqual(None)
+  })
+
+  it("returns None when `eventFilters` is None (no where option)", t => {
+    let {startBlock} = parseEvm(~eventFilters=None)
+    t.expect(startBlock).toEqual(None)
+  })
+
+  it("rejects `_lte` on event filters with a helpful message", t => {
+    t.expect(() =>
+      parseEvm(
+        ~eventFilters=Some(%raw(`{block: {number: {_gte: 10, _lte: 200}}}`)),
+      )->ignore
+    ).toThrowError("Only `_gte` is supported on event filters")
+  })
+
+  it("rejects `_every` on event filters", t => {
+    t.expect(() =>
+      parseEvm(
+        ~eventFilters=Some(%raw(`{block: {number: {_gte: 10, _every: 5}}}`)),
+      )->ignore
+    ).toThrowError("Only `_gte` is supported on event filters")
+  })
+
+  it("rejects unknown top-level keys (typo catches)", t => {
+    t.expect(() =>
+      parseEvm(~eventFilters=Some(%raw(`{blocks: {number: {_gte: 10}}}`)))->ignore
+    ).toThrowError(`Unknown field "blocks"`)
+  })
+})
+
+describe("parseEventFiltersOrThrow — dynamic `where` callback (EVM)", () => {
+  it("extracts startBlock from the probe result for the configured chain", t => {
+    // The callback is evaluated once at build time against `probeChainId`
+    // so the probe exercises the branch this event config is built for.
+    let whereFn = %raw(`({chain}) => ({
+      block: {number: {_gte: chain.id === 137 ? 5000 : 1000}},
+      params: {from: "0x0000000000000000000000000000000000000000"},
+    })`)
+    let {startBlock: startBlockChain137} = parseEvm(
+      ~eventFilters=Some(whereFn),
+      ~probeChainId=137,
+    )
+    let {startBlock: startBlockChain1} = parseEvm(~eventFilters=Some(whereFn), ~probeChainId=1)
+    t.expect((startBlockChain137, startBlockChain1)).toEqual((Some(5000), Some(1000)))
+  })
+
+  it("returns None when the callback returns `false` for this chain", t => {
+    let whereFn = %raw(`({chain}) => chain.id === 137 ? {block: {number: {_gte: 5000}}} : false`)
+    let {startBlock} = parseEvm(~eventFilters=Some(whereFn), ~probeChainId=1)
+    t.expect(startBlock).toEqual(None)
+  })
+
+  it("returns None when the callback returns `true`", t => {
+    let whereFn = %raw(`({chain: _chain}) => true`)
+    let {startBlock} = parseEvm(~eventFilters=Some(whereFn))
+    t.expect(startBlock).toEqual(None)
+  })
+})
+
+describe("parseEventFiltersOrThrow — Fuel block.height", () => {
+  it("extracts startBlock from `block.height._gte`", t => {
+    let {startBlock} = parseFuel(~eventFilters=Some(%raw(`{block: {height: {_gte: 42}}}`)))
+    t.expect(startBlock).toEqual(Some(42))
+  })
+
+  it("Fuel rejects `block.number` (must use height)", t => {
+    // The ecosystem schema key is `height`, so `number` is ignored at the
+    // outer level (surfaces as None) and the event runs with no startBlock
+    // override — the user opts into Fuel's shape via the TS type.
+    let {startBlock} = parseFuel(~eventFilters=Some(%raw(`{block: {number: {_gte: 42}}}`)))
+    t.expect(startBlock).toEqual(None)
+  })
+})

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -290,14 +290,14 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
 })
 
 // End-to-end through FetchState: the per-event `startBlock` (derived from
-// `where.block.number._gte`) propagates to the partition's per-address
-// `effectiveStartBlock`, which is what the fetcher reads to gate
-// `getItemsOrThrow` calls for non-wildcard events. Mirrors the existing
-// dynamic-contract startBlock tests but exercises the static-address path
-// a `where`-filtered `onEvent` call takes.
-describe("FetchState — eventConfig.startBlock from where.block gates address start", () => {
-  let mockAddress =
-    Envio.TestHelpers.Addresses.mockAddresses[0]->Option.getOrThrow
+// `where.block.number._gte`) must drive the first query's `fromBlock` so
+// the fetcher doesn't over-fetch (asking for blocks before the filter)
+// or under-fetch (skipping past it). Observe the query the scheduler
+// would hand to the source, not the internal FetchState fields, so the
+// test survives any internal refactor as long as the fetcher contract
+// holds.
+describe("FetchState — where.block._gte drives the first query's fromBlock", () => {
+  let mockAddress = Envio.TestHelpers.Addresses.mockAddresses[0]->Option.getOrThrow
 
   let buildEvmTransfer = (~startBlock: option<int>) =>
     EventConfigBuilder.buildEvmEventConfig(
@@ -318,10 +318,9 @@ describe("FetchState — eventConfig.startBlock from where.block gates address s
       ~startBlock?,
     )
 
-  it("partition addressable entry's effectiveStartBlock reflects where.block._gte", t => {
-    let ec = buildEvmTransfer(~startBlock=None)
-    let fetchState = FetchState.make(
-      ~eventConfigs=[(ec :> Internal.eventConfig)],
+  let makeFetchState = (~contractStartBlock: option<int>) =>
+    FetchState.make(
+      ~eventConfigs=[(buildEvmTransfer(~startBlock=contractStartBlock) :> Internal.eventConfig)],
       ~addresses=[
         {
           Internal.address: mockAddress,
@@ -336,41 +335,34 @@ describe("FetchState — eventConfig.startBlock from where.block gates address s
       ~chainId=1,
       ~knownHeight=10000,
     )
-    let indexingAddress =
-      fetchState.indexingAddresses
-      ->Dict.get(mockAddress->Address.toString)
-      ->Option.getOrThrow
-    // `-1` registrationBlock + `contractStartBlock=Some(5000)` collapses
-    // to `effectiveStartBlock=5000`. The fetcher uses this as the floor
-    // for this address's event queries.
-    t.expect(indexingAddress.effectiveStartBlock).toEqual(5000)
+
+  // Pull the first query the scheduler would dispatch. `updateKnownHeight`
+  // is needed so `getNextQuery` sees a non-zero head; `concurrencyLimit` is
+  // generous to avoid `ReachedMaxConcurrency` masking the real result.
+  let firstQuery = (fetchState: FetchState.t) =>
+    switch fetchState
+    ->FetchState.updateKnownHeight(~knownHeight=10000)
+    ->FetchState.getNextQuery(~concurrencyLimit=10) {
+    | Ready([q]) => q
+    | Ready(qs) =>
+      JsError.throwWithMessage(
+        `Expected a single query, got ${qs->Array.length->Int.toString}`,
+      )
+    | ReachedMaxConcurrency => JsError.throwWithMessage("Unexpected ReachedMaxConcurrency")
+    | WaitingForNewBlock => JsError.throwWithMessage("Unexpected WaitingForNewBlock")
+    | NothingToQuery => JsError.throwWithMessage("Unexpected NothingToQuery")
+    }
+
+  it("first query fromBlock equals where.block._gte (no over- or under-fetching)", t => {
+    let q = firstQuery(makeFetchState(~contractStartBlock=None))
+    t.expect((q.fromBlock, q.toBlock)).toEqual((5000, None))
   })
 
-  it("where.block._gte overrides a smaller contract-level startBlock on the partition", t => {
+  it("where.block._gte overrides a smaller contract-level startBlock", t => {
     // Contract-level startBlock (from `config.yaml`) is 100; the where
-    // filter bumps it to 5000 — the partition sees the override, not the
-    // config value.
-    let ec = buildEvmTransfer(~startBlock=Some(100))
-    let fetchState = FetchState.make(
-      ~eventConfigs=[(ec :> Internal.eventConfig)],
-      ~addresses=[
-        {
-          Internal.address: mockAddress,
-          contractName: "ERC20",
-          registrationBlock: -1,
-        },
-      ],
-      ~startBlock=0,
-      ~endBlock=None,
-      ~maxAddrInPartition=3,
-      ~targetBufferSize=5000,
-      ~chainId=1,
-      ~knownHeight=10000,
-    )
-    let indexingAddress =
-      fetchState.indexingAddresses
-      ->Dict.get(mockAddress->Address.toString)
-      ->Option.getOrThrow
-    t.expect(indexingAddress.effectiveStartBlock).toEqual(5000)
+    // filter bumps it to 5000 — the first query must start at 5000, not
+    // 100, so we don't waste a fetch on blocks 100–4999.
+    let q = firstQuery(makeFetchState(~contractStartBlock=Some(100)))
+    t.expect(q.fromBlock).toEqual(5000)
   })
 })

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -157,10 +157,11 @@ describe("parseEventFiltersOrThrow — Fuel block.height", () => {
     t.expect(startBlock).toEqual(Some(42))
   })
 
-  it("Fuel rejects `block.number` (must use height)", t => {
-    // The ecosystem schema key is `height`, so `number` is ignored at the
-    // outer level (surfaces as None) and the event runs with no startBlock
-    // override — the user opts into Fuel's shape via the TS type.
+  it("Fuel ignores `block.number` — typed API forbids it, runtime stays permissive", t => {
+    // `FuelOnEventWhereFilter` types out `block.number`, so typed users
+    // can't reach this path; the runtime still accepts the shape and
+    // surfaces `None` rather than throwing, which keeps untyped or JSON
+    // callers from seeing a cryptic schema error.
     let {startBlock} = parseFuel(~eventFilters=Some(%raw(`{block: {number: {_gte: 42}}}`)))
     t.expect(startBlock).toEqual(None)
   })

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -165,3 +165,212 @@ describe("parseEventFiltersOrThrow — Fuel block.height", () => {
     t.expect(startBlock).toEqual(None)
   })
 })
+
+// Compile-time check that the generated `onEventWhereCondition` type on a
+// real codegen'd event module carries the `block` sibling of `params`.
+// Running this test as a value also verifies that the optional fields'
+// shape is preserved end-to-end — the ReScript record unwrapped to JSON
+// matches exactly what `LogSelection.parseEventFiltersOrThrow` expects.
+describe("Generated onEventWhereCondition — block field exists on EVM events", () => {
+  it("compiles a `Filter` with combined params + block.number._gte", t => {
+    let fromFilter: Indexer.EventFiltersTest.Transfer.whereParams = {
+      from: Indexer.SingleOrMultiple.single(
+        "0x0000000000000000000000000000000000000000"->Address.unsafeFromString,
+      ),
+    }
+    let condition: Indexer.EventFiltersTest.Transfer.onEventWhereCondition = {
+      params: Indexer.SingleOrMultiple.single(fromFilter),
+      block: {number: {_gte: 1000}},
+    }
+    // Round-trip the generated record through the runtime parser to prove
+    // the codegen'd shape decodes into the expected startBlock — the only
+    // guarantee that really matters downstream.
+    let {startBlock} = parseEvm(
+      ~eventFilters=Some(
+        condition->(
+          Utils.magic: Indexer.EventFiltersTest.Transfer.onEventWhereCondition => JSON.t
+        ),
+      ),
+    )
+    t.expect(startBlock).toEqual(Some(1000))
+  })
+
+  it("compiles a `Filter` with only block (no params)", t => {
+    let condition: Indexer.EventFiltersTest.Transfer.onEventWhereCondition = {
+      block: {number: {_gte: 2500}},
+    }
+    // Round-trip through the runtime parser to prove the record encodes to
+    // the shape the parser understands — catches any drift between
+    // codegen'd types and runtime expectations.
+    let {startBlock} = parseEvm(~eventFilters=Some(condition->(Utils.magic: Indexer.EventFiltersTest.Transfer.onEventWhereCondition => JSON.t)))
+    t.expect(startBlock).toEqual(Some(2500))
+  })
+})
+
+// Integration: the full `buildEvmEventConfig` path sees the `block` filter
+// and writes it to `eventConfig.startBlock`, overriding the contract-level
+// value. This is the seam that `FetchState` reads when partitioning —
+// unit-testing it here avoids a full-indexer bring-up while still proving
+// the override semantics.
+describe("EventConfigBuilder — where.block.number._gte overrides contract startBlock", () => {
+  let transferParams: array<EventConfigBuilder.eventParam> = [
+    {name: "from", abiType: "address", indexed: true},
+    {name: "to", abiType: "address", indexed: true},
+    {name: "value", abiType: "uint256", indexed: false},
+  ]
+
+  let build = (~eventFilters: option<JSON.t>, ~startBlock: option<int>=?) =>
+    EventConfigBuilder.buildEvmEventConfig(
+      ~contractName="ERC20",
+      ~eventName="Transfer",
+      ~sighash=transferSighash,
+      ~params=transferParams,
+      ~isWildcard=true,
+      ~handler=None,
+      ~contractRegister=None,
+      ~eventFilters,
+      ~probeChainId=1,
+      ~onEventBlockFilterSchema=Evm.ecosystem.onEventBlockFilterSchema,
+      ~startBlock?,
+    )
+
+  it("promotes `where.block.number._gte` to eventConfig.startBlock", t => {
+    let ec = build(~eventFilters=Some(%raw(`{block: {number: {_gte: 1000}}}`)))
+    t.expect(ec.startBlock).toEqual(Some(1000))
+  })
+
+  it("overrides the contract-level startBlock when where.block is present", t => {
+    let ec = build(~eventFilters=Some(%raw(`{block: {number: {_gte: 1500}}}`)), ~startBlock=100)
+    t.expect(ec.startBlock).toEqual(Some(1500))
+  })
+
+  it("falls back to the contract-level startBlock when where.block is absent", t => {
+    let ec = build(
+      ~eventFilters=Some(%raw(`{params: {from: "0x0000000000000000000000000000000000000000"}}`)),
+      ~startBlock=100,
+    )
+    t.expect(ec.startBlock).toEqual(Some(100))
+  })
+
+  it("leaves startBlock as None when neither is provided", t => {
+    let ec = build(~eventFilters=None)
+    t.expect(ec.startBlock).toEqual(None)
+  })
+
+  it("dynamic where callback — per-chain startBlock wins over contract value", t => {
+    let whereFn = %raw(`({chain}) => ({block: {number: {_gte: chain.id === 137 ? 5000 : 250}}})`)
+    let chain137 = EventConfigBuilder.buildEvmEventConfig(
+      ~contractName="ERC20",
+      ~eventName="Transfer",
+      ~sighash=transferSighash,
+      ~params=transferParams,
+      ~isWildcard=true,
+      ~handler=None,
+      ~contractRegister=None,
+      ~eventFilters=Some(whereFn),
+      ~probeChainId=137,
+      ~onEventBlockFilterSchema=Evm.ecosystem.onEventBlockFilterSchema,
+      ~startBlock=1,
+    )
+    let chain1 = EventConfigBuilder.buildEvmEventConfig(
+      ~contractName="ERC20",
+      ~eventName="Transfer",
+      ~sighash=transferSighash,
+      ~params=transferParams,
+      ~isWildcard=true,
+      ~handler=None,
+      ~contractRegister=None,
+      ~eventFilters=Some(whereFn),
+      ~probeChainId=1,
+      ~onEventBlockFilterSchema=Evm.ecosystem.onEventBlockFilterSchema,
+      ~startBlock=1,
+    )
+    t.expect((chain137.startBlock, chain1.startBlock)).toEqual((Some(5000), Some(250)))
+  })
+})
+
+// End-to-end through FetchState: the per-event `startBlock` (derived from
+// `where.block.number._gte`) propagates to the partition's per-address
+// `effectiveStartBlock`, which is what the fetcher reads to gate
+// `getItemsOrThrow` calls for non-wildcard events. Mirrors the existing
+// dynamic-contract startBlock tests but exercises the static-address path
+// a `where`-filtered `onEvent` call takes.
+describe("FetchState — eventConfig.startBlock from where.block gates address start", () => {
+  let mockAddress =
+    Envio.TestHelpers.Addresses.mockAddresses[0]->Option.getOrThrow
+
+  let buildEvmTransfer = (~startBlock: option<int>) =>
+    EventConfigBuilder.buildEvmEventConfig(
+      ~contractName="ERC20",
+      ~eventName="Transfer",
+      ~sighash=transferSighash,
+      ~params=[
+        {name: "from", abiType: "address", indexed: true},
+        {name: "to", abiType: "address", indexed: true},
+        {name: "value", abiType: "uint256", indexed: false},
+      ],
+      ~isWildcard=false,
+      ~handler=None,
+      ~contractRegister=None,
+      ~eventFilters=Some(%raw(`{block: {number: {_gte: 5000}}}`)),
+      ~probeChainId=1,
+      ~onEventBlockFilterSchema=Evm.ecosystem.onEventBlockFilterSchema,
+      ~startBlock?,
+    )
+
+  it("partition addressable entry's effectiveStartBlock reflects where.block._gte", t => {
+    let ec = buildEvmTransfer(~startBlock=None)
+    let fetchState = FetchState.make(
+      ~eventConfigs=[(ec :> Internal.eventConfig)],
+      ~addresses=[
+        {
+          Internal.address: mockAddress,
+          contractName: "ERC20",
+          registrationBlock: -1,
+        },
+      ],
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=3,
+      ~targetBufferSize=5000,
+      ~chainId=1,
+      ~knownHeight=10000,
+    )
+    let indexingAddress =
+      fetchState.indexingAddresses
+      ->Dict.get(mockAddress->Address.toString)
+      ->Option.getOrThrow
+    // `-1` registrationBlock + `contractStartBlock=Some(5000)` collapses
+    // to `effectiveStartBlock=5000`. The fetcher uses this as the floor
+    // for this address's event queries.
+    t.expect(indexingAddress.effectiveStartBlock).toEqual(5000)
+  })
+
+  it("where.block._gte overrides a smaller contract-level startBlock on the partition", t => {
+    // Contract-level startBlock (from `config.yaml`) is 100; the where
+    // filter bumps it to 5000 — the partition sees the override, not the
+    // config value.
+    let ec = buildEvmTransfer(~startBlock=Some(100))
+    let fetchState = FetchState.make(
+      ~eventConfigs=[(ec :> Internal.eventConfig)],
+      ~addresses=[
+        {
+          Internal.address: mockAddress,
+          contractName: "ERC20",
+          registrationBlock: -1,
+        },
+      ],
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=3,
+      ~targetBufferSize=5000,
+      ~chainId=1,
+      ~knownHeight=10000,
+    )
+    let indexingAddress =
+      fetchState.indexingAddresses
+      ->Dict.get(mockAddress->Address.toString)
+      ->Option.getOrThrow
+    t.expect(indexingAddress.effectiveStartBlock).toEqual(5000)
+  })
+})

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -245,6 +245,15 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
     t.expect(ec.startBlock).toEqual(Some(1500))
   })
 
+  // Guard against a regression to `max(contract, where)` semantics: the
+  // where-derived value must win even when it's LOWER than the config
+  // value, so users can widen an event below its contract's start_block
+  // without touching config.yaml.
+  it("overrides even when contract-level startBlock is larger than where.block", t => {
+    let ec = build(~eventFilters=Some(%raw(`{block: {number: {_gte: 1500}}}`)), ~startBlock=7000)
+    t.expect(ec.startBlock).toEqual(Some(1500))
+  })
+
   it("falls back to the contract-level startBlock when where.block is absent", t => {
     let ec = build(
       ~eventFilters=Some(%raw(`{params: {from: "0x0000000000000000000000000000000000000000"}}`)),
@@ -364,6 +373,15 @@ describe("FetchState — where.block._gte drives the first query's fromBlock", (
     // filter bumps it to 5000 — the first query must start at 5000, not
     // 100, so we don't waste a fetch on blocks 100–4999.
     let q = firstQuery(makeFetchState(~contractStartBlock=Some(100)))
+    t.expect(q.fromBlock).toEqual(5000)
+  })
+
+  // Guard against a regression to `max(contract, where)` semantics: the
+  // where-derived value must win even when it's LOWER than the config
+  // value. A `max` implementation would start at 7000 and miss events
+  // on blocks 5000–6999 that the user explicitly opted into.
+  it("where.block._gte overrides a larger contract-level startBlock", t => {
+    let q = firstQuery(makeFetchState(~contractStartBlock=Some(7000)))
     t.expect(q.fromBlock).toEqual(5000)
   })
 })


### PR DESCRIPTION
## Summary

This PR adds support for per-event `startBlock` configuration through the `where` filter's `block` field. Users can now override the contract-level `start_block` from `config.yaml` on a per-event basis by specifying `block.number._gte` (EVM) or `block.height._gte` (Fuel) in their event filter conditions.

## Key Changes

- **LogSelection.res**: Added `extractStartBlock` function to parse the `block` filter from `where` conditions and extract the `_gte` value as the per-event `startBlock`. Implemented strict validation that rejects `_lte` and `_every` (which belong on `onBlock` handlers) with helpful error messages. Added `startBlock` field to `parsedEventFilters` return type.

- **EventConfigBuilder.res**: Updated `buildEvmEventConfig` to accept `onEventBlockFilterSchema` parameter and use the extracted `startBlock` from `where.block` to override the contract-level `startBlock` when present.

- **Ecosystem.res, Evm.res, Fuel.res, Svm.res**: Added `onEventBlockFilterSchema` to the ecosystem configuration. EVM and Fuel schemas unwrap their respective `block.number` and `block.height` wrappers; SVM has a stub since it doesn't support event handlers.

- **Type definitions (index.d.ts)**: Extended `EvmOnEventWhereFilter` and `FuelOnEventWhereFilter` TypeScript types to include optional `block` field with ecosystem-specific keys (`number` for EVM, `height` for Fuel).

- **Code generation (codegen_templates.rs)**: Updated ReScript event module generation to include `onEventWhereBlock` and `onEventWhereBlockNumber` types, allowing users to specify block filters in their handler configurations.

- **Documentation**: Updated SKILL.md guides to explain the new per-event `startBlock` feature, including examples of how to use it with dynamic `where` callbacks for per-chain configuration.

- **Tests**: Added comprehensive test suite (`EventBlockFilter_test.res`) covering:
  - Schema validation for `eventBlockRangeSchema` (strict `_gte`-only)
  - Static and dynamic `where` filter parsing
  - EVM vs Fuel block field differences
  - Generated type compilation checks
  - Integration with `EventConfigBuilder`
  - End-to-end `FetchState` behavior ensuring correct `fromBlock` in queries

## Implementation Details

- The `block` filter is a sibling of `params` in the `where` condition, allowing combined filters like `{params: {...}, block: {number: {_gte: N}}}`
- Per-event `startBlock` always takes precedence over contract-level `start_block`
- Only `_gte` is supported on event filters; `_lte` and `_every` are rejected with a message directing users to `indexer.onBlock`
- Dynamic `where` callbacks can use `chain.id` to specify different `startBlock` values per chain
- The extraction happens at build time during probe evaluation, ensuring consistent behavior across chains

https://claude.ai/code/session_01BqKALmRE3EBjck2hzoMXZd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event filters accept a top-level block._gte to set a per-event startBlock (EVM: block.number._gte, Fuel: block.height._gte), overriding contract-level startBlock.

* **Documentation**
  * Guides updated with examples, chain-specific notes, and explicit constraint that only _gte is supported for per-event block filters; other operators directed to block-level handlers.

* **Types**
  * Public event filter types include an optional top-level block sibling alongside params.

* **Tests**
  * Added unit, integration, and compile-time type-regression tests for parsing, overrides, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->