### PR TITLE
Handle missing networks gracefully in docker down operation

### DIFF
--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -1181,10 +1181,23 @@ pub async fn down() -> anyhow::Result<()> {
         Ok(())
     }
 
+    // 404 = network already gone (e.g. `up()` short-circuited when all
+    // services were reachable externally, so `ensure_network` never ran).
+    // Treat it as success — mirrors the 409 tolerance in `ensure_network`.
+    async fn remove_network_tolerant(docker: &Docker, name: &str) -> anyhow::Result<()> {
+        match docker.remove_network(name).await {
+            Ok(_) => Ok(()),
+            Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 404, ..
+            }) => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("Failed to remove network {name}")),
+        }
+    }
+
     let (pg_vol_res, ch_vol_res, net_res) = tokio::join!(
         remove_volume_if_exists(&docker, VOLUME, pg_vol_exists),
         remove_volume_if_exists(&docker, CH_VOLUME, ch_vol_exists),
-        docker.remove_network(NETWORK),
+        remove_network_tolerant(&docker, NETWORK),
     );
 
     let mut failed = false;
@@ -1197,7 +1210,7 @@ pub async fn down() -> anyhow::Result<()> {
         failed = true;
     }
     if let Err(e) = net_res {
-        eprintln!("Failed to remove network {NETWORK}: {e}");
+        eprintln!("{e:#}");
         failed = true;
     }
 


### PR DESCRIPTION
## Summary
This change makes the Docker network removal in the `down()` operation more resilient by tolerating cases where the network has already been removed or was never created.

## Key Changes
- Added `remove_network_tolerant()` helper function that gracefully handles 404 errors when removing Docker networks
- The function treats a 404 response (network not found) as success, mirroring the existing 409 conflict tolerance in `ensure_network()`
- Updated the `down()` operation to use the new tolerant removal function instead of directly calling `docker.remove_network()`
- Simplified error message output to use the error's display format instead of hardcoding the network name

## Implementation Details
The new `remove_network_tolerant()` function handles the scenario where `up()` may short-circuit early (when all services are already reachable externally) and never creates the network via `ensure_network()`. This prevents spurious failures during cleanup when the network doesn't exist. The 404 tolerance is consistent with the existing pattern of tolerating 409 conflicts during network creation.

https://claude.ai/code/session_012aDudk2aFUWCnwVyBrQApA