### PR TITLE
Remove allEntities from Generated module exports

### DIFF
--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -1809,10 +1809,10 @@ type testIndexer = {{
         //
         // The config is loaded lazily via `Config.load()` — either from the
         // primed CLI payload (no I/O) or via the `getConfigJson` NAPI call.
-        // Exposed values (`configWithoutRegistrations`, `allEntities`,
-        // `indexer`) are JS Proxies that defer the load until the first
-        // property read, so modules that import types from "generated" but
-        // never read config values don't pay the cost at module load time.
+        // Exposed values (`configWithoutRegistrations`, `indexer`) are JS
+        // Proxies that defer the load until the first property read, so
+        // modules that import types from "generated" but never read config
+        // values don't pay the cost at module load time.
         let generated_module = r#"module Generated = {
 let makeGeneratedConfig = () => Config.load()
 
@@ -1847,7 +1847,6 @@ let makeLazy: (unit => 'a, 'a) => 'a = %raw(`function (make, target) {
 }`)
 
 let configWithoutRegistrations: Config.t = makeLazy(getCachedConfig, %raw(`Object.create(null)`))
-let allEntities: array<Internal.entityConfig> = makeLazy(() => getCachedConfig().allEntities, %raw(`[]`))
 
 }"#;
 

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
@@ -483,7 +483,6 @@ let makeLazy: (unit => 'a, 'a) => 'a = %raw(`function (make, target) {
 }`)
 
 let configWithoutRegistrations: Config.t = makeLazy(getCachedConfig, %raw(`Object.create(null)`))
-let allEntities: array<Internal.entityConfig> = makeLazy(() => getCachedConfig().allEntities, %raw(`[]`))
 
 }
 

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
@@ -553,7 +553,6 @@ let makeLazy: (unit => 'a, 'a) => 'a = %raw(`function (make, target) {
 }`)
 
 let configWithoutRegistrations: Config.t = makeLazy(getCachedConfig, %raw(`Object.create(null)`))
-let allEntities: array<Internal.entityConfig> = makeLazy(() => getCachedConfig().allEntities, %raw(`[]`))
 
 }
 

--- a/scenarios/test_codegen/test/EventOrigin_test.res
+++ b/scenarios/test_codegen/test/EventOrigin_test.res
@@ -39,7 +39,9 @@ describe("Chains State", () => {
       async t => {
         // This test verifies that the chain field is accessible
         // The actual integration test is in EventHandlers.res with the EmptyEvent handler
-        let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.allEntities)
+        let inMemoryStore = InMemoryStore.make(
+          ~entities=Indexer.Generated.configWithoutRegistrations.allEntities,
+        )
         let loadManager = LoadManager.make()
 
         let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem

--- a/scenarios/test_codegen/test/LoadLayer_test.res
+++ b/scenarios/test_codegen/test/LoadLayer_test.res
@@ -3,7 +3,7 @@ open Vitest
 describe("LoadLayer", () => {
   Async.it("Trys to load non existing entity from db", async t => {
     let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
-    let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.allEntities)
+    let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.configWithoutRegistrations.allEntities)
     let loadManager = LoadManager.make()
 
     let getUser = entityId =>
@@ -31,7 +31,7 @@ describe("LoadLayer", () => {
   Async.it("Does two round trips to db when requesting non existing entity one by one", async t => {
     let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
     let loadManager = LoadManager.make()
-    let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.allEntities)
+    let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.configWithoutRegistrations.allEntities)
 
     let getUser = entityId =>
       LoadLayer.loadById(
@@ -66,7 +66,7 @@ describe("LoadLayer", () => {
     async t => {
       let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
       let loadManager = LoadManager.make()
-      let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.allEntities)
+      let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.configWithoutRegistrations.allEntities)
       let getUser = entityId =>
         LoadLayer.loadById(
           ~loadManager,

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -22,7 +22,7 @@ module InMemoryStore = {
   }
 
   let make = (~entities=[]) => {
-    let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.allEntities)
+    let inMemoryStore = InMemoryStore.make(~entities=config.allEntities)
     entities->Array.forEach(((entityConfig, items)) => {
       items->Array.forEach(entity => {
         inMemoryStore->setEntity(~entityConfig, entity)


### PR DESCRIPTION
## Summary
This PR removes the `allEntities` export from the Generated module and updates all references to access it through `configWithoutRegistrations.allEntities` instead.

## Key Changes
- Removed the `allEntities` lazy-loaded export from the Generated module in `codegen_templates.rs`
- Updated all test files to access `allEntities` via `configWithoutRegistrations.allEntities`:
  - `LoadLayer_test.res` (3 occurrences)
  - `EventOrigin_test.res` (1 occurrence)
  - `MockIndexer.res` (1 occurrence)
- Updated code generation snapshots to reflect the removal of the `allEntities` export
- Updated the comment in `codegen_templates.rs` to remove mention of `allEntities` from the list of exposed values

## Implementation Details
The change consolidates access to entity configuration through the `configWithoutRegistrations` proxy rather than exposing `allEntities` as a separate top-level export. This maintains the same lazy-loading behavior while reducing the number of exported values from the Generated module.

https://claude.ai/code/session_01GieoFkX4TXTQsFgXsv2Fdx