### PR TITLE
Decouple Config from handler registrations; lazy indexer getters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,7 +104,7 @@ checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "proc-macro-error2",
  "proc-macro2",
@@ -135,7 +122,7 @@ checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
 dependencies = [
  "const-hex",
  "dunce",
- "heck 0.5.0",
+ "heck",
  "macro-string",
  "proc-macro2",
  "quote",
@@ -657,7 +644,7 @@ version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -693,6 +680,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1259,9 +1255,14 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -1605,20 +1606,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1635,20 +1628,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2215,11 +2199,10 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2283,12 +2266,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -2404,16 +2381,6 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2599,6 +2566,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3232,13 +3205,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "once_cell",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3251,12 +3227,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -3323,16 +3309,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sec1"
@@ -3601,6 +3577,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3642,20 +3621,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
-dependencies = [
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -3666,68 +3635,62 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "ahash",
- "atoi",
- "byteorder",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
  "either",
  "event-listener",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
+ "hashbrown 0.15.5",
  "hashlink",
- "hex",
  "indexmap",
  "log",
  "memchr",
  "once_cell",
- "paste",
  "percent-encoding",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2",
  "smallvec",
- "sqlformat",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy 0.15.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "either",
- "heck 0.4.1",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -3739,20 +3702,19 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 1.0.109",
- "tempfile",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.11.0",
  "byteorder",
  "bytes",
@@ -3782,19 +3744,19 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.11.0",
  "byteorder",
  "crc",
@@ -3802,7 +3764,6 @@ dependencies = [
  "etcetera",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",
@@ -3820,16 +3781,16 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "flume",
@@ -3842,10 +3803,11 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
+ "serde_urlencoded",
  "sqlx-core",
+ "thiserror 2.0.18",
  "tracing",
  "url",
- "urlencoding",
 ]
 
 [[package]]
@@ -3892,7 +3854,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3905,7 +3867,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3d08fe7078c57309d5c3d938e50eba95ba1d33b9c3a101a8465fc6861a5416"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4329,12 +4291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,12 +4313,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -4547,9 +4497,21 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"
@@ -4855,7 +4817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -4866,7 +4828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -40,7 +40,7 @@ subenum = "1.1.3"
 async-recursion = "1.1"
 itertools = "0.11.0"
 colored = "2.0.4"
-sqlx = { version = "0.7.2", features = [
+sqlx = { version = "0.8", features = [
   "runtime-tokio",
   "tls-rustls",
   "postgres",

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -1787,73 +1787,16 @@ type testIndexer = {{
             indexer_code = format!("{}\n\n{}", indexer_code, get_entity_operations);
         }
 
-        // Append the Generated module (was in Indexer.res.hbs, now in Rust).
-        //
-        // The config is loaded lazily via `Config.load()` — either from the
-        // primed CLI payload (no I/O) or via the `getConfigJson` NAPI call.
-        // Exposed values (`configWithoutRegistrations`, `indexer`) are JS
-        // Proxies that defer the load until the first property read, so
-        // modules that import types from "generated" but never read config
-        // values don't pay the cost at module load time.
-        let generated_module = r#"module Generated = {
-let makeGeneratedConfig = () => Config.load()
-
-// Memoized loader. `envio config view` is invoked at most once per process;
-// subsequent callers get the same parsed Config.t.
-let getCachedConfig = {
-  let cache = ref(None)
-  () =>
-    switch cache.contents {
-    | Some(c) => c
-    | None => {
-        let c = makeGeneratedConfig()
-        cache := Some(c)
-        c
-      }
-    }
-}
-
-// Proxy factory: returns a value that lazy-initializes on first read and
-// delegates all property-access traps to the real underlying value.
-// `target` controls the shape seen by `Array.isArray` / `typeof`, so use
-// `[]` for array-like values and a null-prototype object for records.
-let makeLazy: (unit => 'a, 'a) => 'a = %raw(`function (make, target) {
-  let cache;
-  const get = () => (cache === undefined ? (cache = make()) : cache);
-  return new Proxy(target, {
-    get: (_t, prop) => get()[prop],
-    has: (_t, prop) => prop in get(),
-    ownKeys: () => Reflect.ownKeys(get()),
-    getOwnPropertyDescriptor: (_t, prop) => Object.getOwnPropertyDescriptor(get(), prop),
-  });
-}`)
-
-let configWithoutRegistrations: Config.t = makeLazy(getCachedConfig, %raw(`Object.create(null)`))
-
-}"#;
-
-        indexer_code = format!("{}\n\n{}", indexer_code, generated_module);
-
-        // Build the top-level `indexer` value as a lazy Proxy over the memoized
-        // `Main.getGlobalIndexer`. `createTestIndexer` is already a function so
-        // we just lazy-load the config inside its body.
+        // `Main.getGlobalIndexer` returns an object with getters that defer
+        // the `Config.load()` call until a property is actually read, so
+        // modules that import types from "generated" but never touch config
+        // values don't pay the parse cost at module load time.
+        // `createTestIndexer` is a thunk for the same reason.
         let generated_top_level_bindings = format!(
             "{}\n\n{}",
-            r#"let indexer: indexer = {
-  let cache = ref(None)
-  let getCachedIndexer = () =>
-    switch cache.contents {
-    | Some(i) => i
-    | None => {
-        let i = Main.getGlobalIndexer(~config=Generated.getCachedConfig())
-        cache := Some(i)
-        i
-      }
-    }
-  Generated.makeLazy(getCachedIndexer, %raw(`Object.create(null)`))
-}"#,
+            r#"let indexer: indexer = Main.getGlobalIndexer()"#,
             r#"let createTestIndexer: unit => testIndexer = (() => {
-  TestIndexer.makeCreateTestIndexer(~config=Generated.getCachedConfig(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
+  TestIndexer.makeCreateTestIndexer(~config=Config.load(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
 })->(Utils.magic: (unit => TestIndexer.t<testIndexerProcessConfig>) => (unit => testIndexer))"#,
         );
 

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -1788,15 +1788,15 @@ type testIndexer = {{
         }
 
         // `Main.getGlobalIndexer` returns an object with getters that defer
-        // the `Config.load()` call until a property is actually read, so
-        // modules that import types from "generated" but never touch config
-        // values don't pay the parse cost at module load time.
-        // `createTestIndexer` is a thunk for the same reason.
+        // the `Config.loadWithoutRegistrations()` call until a property is
+        // actually read, so modules that import types from "generated" but
+        // never touch config values don't pay the parse cost at module
+        // load time. `createTestIndexer` is a thunk for the same reason.
         let generated_top_level_bindings = format!(
             "{}\n\n{}",
             r#"let indexer: indexer = Main.getGlobalIndexer()"#,
             r#"let createTestIndexer: unit => testIndexer = (() => {
-  TestIndexer.makeCreateTestIndexer(~config=Config.load(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
+  TestIndexer.makeCreateTestIndexer(~config=Config.loadWithoutRegistrations(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
 })->(Utils.magic: (unit => TestIndexer.t<testIndexerProcessConfig>) => (unit => testIndexer))"#,
         );
 

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
@@ -440,5 +440,5 @@ type testIndexer = {
 let indexer: indexer = Main.getGlobalIndexer()
 
 let createTestIndexer: unit => testIndexer = (() => {
-  TestIndexer.makeCreateTestIndexer(~config=Config.load(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
+  TestIndexer.makeCreateTestIndexer(~config=Config.loadWithoutRegistrations(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
 })->(Utils.magic: (unit => TestIndexer.t<testIndexerProcessConfig>) => (unit => testIndexer))

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
@@ -437,57 +437,8 @@ type testIndexer = {
 
 @get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
 
-module Generated = {
-let makeGeneratedConfig = () => Config.load()
-
-// Memoized loader. `envio config view` is invoked at most once per process;
-// subsequent callers get the same parsed Config.t.
-let getCachedConfig = {
-  let cache = ref(None)
-  () =>
-    switch cache.contents {
-    | Some(c) => c
-    | None => {
-        let c = makeGeneratedConfig()
-        cache := Some(c)
-        c
-      }
-    }
-}
-
-// Proxy factory: returns a value that lazy-initializes on first read and
-// delegates all property-access traps to the real underlying value.
-// `target` controls the shape seen by `Array.isArray` / `typeof`, so use
-// `[]` for array-like values and a null-prototype object for records.
-let makeLazy: (unit => 'a, 'a) => 'a = %raw(`function (make, target) {
-  let cache;
-  const get = () => (cache === undefined ? (cache = make()) : cache);
-  return new Proxy(target, {
-    get: (_t, prop) => get()[prop],
-    has: (_t, prop) => prop in get(),
-    ownKeys: () => Reflect.ownKeys(get()),
-    getOwnPropertyDescriptor: (_t, prop) => Object.getOwnPropertyDescriptor(get(), prop),
-  });
-}`)
-
-let configWithoutRegistrations: Config.t = makeLazy(getCachedConfig, %raw(`Object.create(null)`))
-
-}
-
-let indexer: indexer = {
-  let cache = ref(None)
-  let getCachedIndexer = () =>
-    switch cache.contents {
-    | Some(i) => i
-    | None => {
-        let i = Main.getGlobalIndexer(~config=Generated.getCachedConfig())
-        cache := Some(i)
-        i
-      }
-    }
-  Generated.makeLazy(getCachedIndexer, %raw(`Object.create(null)`))
-}
+let indexer: indexer = Main.getGlobalIndexer()
 
 let createTestIndexer: unit => testIndexer = (() => {
-  TestIndexer.makeCreateTestIndexer(~config=Generated.getCachedConfig(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
+  TestIndexer.makeCreateTestIndexer(~config=Config.load(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
 })->(Utils.magic: (unit => TestIndexer.t<testIndexerProcessConfig>) => (unit => testIndexer))

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
@@ -506,57 +506,8 @@ type testIndexer = {
 
 @get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
 
-module Generated = {
-let makeGeneratedConfig = () => Config.load()
-
-// Memoized loader. `envio config view` is invoked at most once per process;
-// subsequent callers get the same parsed Config.t.
-let getCachedConfig = {
-  let cache = ref(None)
-  () =>
-    switch cache.contents {
-    | Some(c) => c
-    | None => {
-        let c = makeGeneratedConfig()
-        cache := Some(c)
-        c
-      }
-    }
-}
-
-// Proxy factory: returns a value that lazy-initializes on first read and
-// delegates all property-access traps to the real underlying value.
-// `target` controls the shape seen by `Array.isArray` / `typeof`, so use
-// `[]` for array-like values and a null-prototype object for records.
-let makeLazy: (unit => 'a, 'a) => 'a = %raw(`function (make, target) {
-  let cache;
-  const get = () => (cache === undefined ? (cache = make()) : cache);
-  return new Proxy(target, {
-    get: (_t, prop) => get()[prop],
-    has: (_t, prop) => prop in get(),
-    ownKeys: () => Reflect.ownKeys(get()),
-    getOwnPropertyDescriptor: (_t, prop) => Object.getOwnPropertyDescriptor(get(), prop),
-  });
-}`)
-
-let configWithoutRegistrations: Config.t = makeLazy(getCachedConfig, %raw(`Object.create(null)`))
-
-}
-
-let indexer: indexer = {
-  let cache = ref(None)
-  let getCachedIndexer = () =>
-    switch cache.contents {
-    | Some(i) => i
-    | None => {
-        let i = Main.getGlobalIndexer(~config=Generated.getCachedConfig())
-        cache := Some(i)
-        i
-      }
-    }
-  Generated.makeLazy(getCachedIndexer, %raw(`Object.create(null)`))
-}
+let indexer: indexer = Main.getGlobalIndexer()
 
 let createTestIndexer: unit => testIndexer = (() => {
-  TestIndexer.makeCreateTestIndexer(~config=Generated.getCachedConfig(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
+  TestIndexer.makeCreateTestIndexer(~config=Config.load(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
 })->(Utils.magic: (unit => TestIndexer.t<testIndexerProcessConfig>) => (unit => testIndexer))

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
@@ -509,5 +509,5 @@ type testIndexer = {
 let indexer: indexer = Main.getGlobalIndexer()
 
 let createTestIndexer: unit => testIndexer = (() => {
-  TestIndexer.makeCreateTestIndexer(~config=Config.load(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
+  TestIndexer.makeCreateTestIndexer(~config=Config.loadWithoutRegistrations(), ~workerPath=NodeJs.Path.join(NodeJs.Path.dirname(NodeJs.Url.fileURLToPath(NodeJs.ImportMeta.importMeta.url)), "TestIndexerWorker.res.mjs")->NodeJs.Path.toString)()
 })->(Utils.magic: (unit => TestIndexer.t<testIndexerProcessConfig>) => (unit => testIndexer))

--- a/packages/cli/templates/static/codegen/src/TestIndexerWorker.res
+++ b/packages/cli/templates/static/codegen/src/TestIndexerWorker.res
@@ -2,5 +2,5 @@
 // This file runs in a worker thread when createTestIndexer().process() is called
 
 TestIndexer.initTestWorker(
-  ~makeGeneratedConfig=Config.load,
+  ~makeGeneratedConfig=Config.loadWithoutRegistrations,
 )

--- a/packages/cli/templates/static/codegen/src/TestIndexerWorker.res
+++ b/packages/cli/templates/static/codegen/src/TestIndexerWorker.res
@@ -2,5 +2,5 @@
 // This file runs in a worker thread when createTestIndexer().process() is called
 
 TestIndexer.initTestWorker(
-  ~makeGeneratedConfig=Indexer.Generated.makeGeneratedConfig,
+  ~makeGeneratedConfig=Config.load,
 )

--- a/packages/envio/rescript.json
+++ b/packages/envio/rescript.json
@@ -16,5 +16,8 @@
     "version": 4
   },
   "bs-dependencies": ["rescript-schema", "@rescript/react"],
-  "bsc-flags": ["-open RescriptSchema"]
+  "bsc-flags": ["-open RescriptSchema"],
+  "warnings": {
+    "error": "+3"
+  }
 }

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -535,12 +535,11 @@ let fromPublic = (publicConfigJson: JSON.t) => {
 
   // Build event configs for a contract from JSON event items. Events are
   // built with an empty handler-registration state (isWildcard=false,
-  // handler/contractRegister=None, eventFilters=None). The built event
-  // records carry a `rebuildWithRegistration` closure; after handler
-  // modules register, callers walk the config and rebuild each event with
-  // its registered state. Keeping `Config` oblivious to `HandlerRegister`
-  // means `Config.loadWithoutRegistrations` is a pure function of the JSON
-  // and safe to memoize without invalidation.
+  // handler/contractRegister=None, eventFilters=None). Post-registration
+  // configs are produced by `HandlerLoader.applyRegistrations`, which folds
+  // the registered handler state into each event. Keeping `Config` oblivious
+  // to `HandlerRegister` means `Config.loadWithoutRegistrations` is a pure
+  // function of the JSON and safe to memoize without invalidation.
   let buildContractEvents = (~contractName, ~events: option<array<_>>, ~abi, ~chainId: int) => {
     switch events {
     | None => []
@@ -871,8 +870,13 @@ let prime = (json: JSON.t): unit => {
 // The `Config` module deliberately knows nothing about handler
 // registrations: the returned value is a pure function of the JSON, so
 // memoization is safe without invalidation. Post-registration configs are
-// produced by `HandlerLoader.registerAllHandlers` via
-// `Internal.{evm,fuel}EventConfig.rebuildWithRegistration`.
+// produced by `HandlerLoader.applyRegistrations`, which folds the
+// registered handler state into each event (via spread+override for
+// EVM/Fuel; SVM doesn't support per-event handlers).
+//
+// `prime` must be called before the first `loadWithoutRegistrations` read
+// if a primed JSON is going to be used; calling `prime` later invalidates
+// the memo so subsequent reads reparse.
 let loadWithoutRegistrations = () =>
   switch cached.contents {
   | Some(c) => c

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -454,7 +454,8 @@ let publicConfigSchema = S.schema(s =>
   }
 )
 
-let fromPublic = (publicConfigJson: JSON.t, ~maxAddrInPartition=5000) => {
+let fromPublic = (publicConfigJson: JSON.t) => {
+  let maxAddrInPartition = Env.maxAddrInPartition
   // Parse public config
   let publicConfig = try publicConfigJson->S.parseOrThrow(publicConfigSchema) catch {
   | S.Raised(exn) =>
@@ -532,7 +533,14 @@ let fromPublic = (publicConfigJson: JSON.t, ~maxAddrInPartition=5000) => {
   | None => ()
   }
 
-  // Build event configs for a contract from JSON event items
+  // Build event configs for a contract from JSON event items. Events are
+  // built with an empty handler-registration state (isWildcard=false,
+  // handler/contractRegister=None, eventFilters=None). The built event
+  // records carry a `rebuildWithRegistration` closure; after handler
+  // modules register, callers walk the config and rebuild each event with
+  // its registered state. Keeping `Config` oblivious to `HandlerRegister`
+  // means `Config.loadWithoutRegistrations` is a pure function of the JSON
+  // and safe to memoize without invalidation.
   let buildContractEvents = (~contractName, ~events: option<array<_>>, ~abi, ~chainId: int) => {
     switch events {
     | None => []
@@ -542,10 +550,6 @@ let fromPublic = (publicConfigJson: JSON.t, ~maxAddrInPartition=5000) => {
         let sighash = eventItem["sighash"]
         let params = eventItem["params"]->Option.getOr([])
         let kind = eventItem["kind"]
-        // Get handler registration data
-        let isWildcard = HandlerRegister.isWildcard(~contractName, ~eventName)
-        let handler = HandlerRegister.getHandler(~contractName, ~eventName)
-        let contractRegister = HandlerRegister.getContractRegister(~contractName, ~eventName)
 
         switch ecosystemName {
         | Ecosystem.Fuel =>
@@ -557,9 +561,9 @@ let fromPublic = (publicConfigJson: JSON.t, ~maxAddrInPartition=5000) => {
               ~kind=fuelKind,
               ~sighash,
               ~rawAbi=abi->(Utils.magic: EvmTypes.Abi.t => JSON.t),
-              ~isWildcard,
-              ~handler,
-              ~contractRegister,
+              ~isWildcard=false,
+              ~handler=None,
+              ~contractRegister=None,
             ) :> Internal.eventConfig)
           | None =>
             JsError.throwWithMessage(
@@ -572,10 +576,10 @@ let fromPublic = (publicConfigJson: JSON.t, ~maxAddrInPartition=5000) => {
             ~eventName,
             ~sighash,
             ~params,
-            ~isWildcard,
-            ~handler,
-            ~contractRegister,
-            ~eventFilters=HandlerRegister.getOnEventWhere(~contractName, ~eventName),
+            ~isWildcard=false,
+            ~handler=None,
+            ~contractRegister=None,
+            ~eventFilters=None,
             ~probeChainId=chainId,
             ~blockFields=?eventItem["blockFields"],
             ~transactionFields=?eventItem["transactionFields"],
@@ -857,18 +861,19 @@ let prime = (json: JSON.t): unit => {
   cached := None
 }
 
-// Invalidate the memoized config. Used by `HandlerRegister.finishRegistration`
-// so the next `load()` reparses and picks up registered handlers.
-let reset = () => cached := None
-
-// Load the resolved indexer config. When `Bin.res` has primed a JSON payload
-// from the CLI command, parse from that; otherwise invoke the native NAPI
-// addon (Rust config parser, ENVIO_CONFIG-respecting). The NAPI path keeps
-// non-CLI callers (worker threads spawned via `TestIndexer`, direct imports
-// from test harnesses) working without a primed payload. Memoized — callers
-// that need a fresh parse after handler registration go through
-// `HandlerRegister.finishRegistration`.
-let load = () =>
+// Load the base indexer config — no handler registrations applied. When
+// `Bin.res` has primed a JSON payload from the CLI command, parse from
+// that; otherwise invoke the native NAPI addon (Rust config parser,
+// ENVIO_CONFIG-respecting). The NAPI path keeps non-CLI callers (worker
+// threads spawned via `TestIndexer`, direct imports from test harnesses)
+// working without a primed payload.
+//
+// The `Config` module deliberately knows nothing about handler
+// registrations: the returned value is a pure function of the JSON, so
+// memoization is safe without invalidation. Post-registration configs are
+// produced by `HandlerLoader.registerAllHandlers` via
+// `Internal.{evm,fuel}EventConfig.rebuildWithRegistration`.
+let loadWithoutRegistrations = () =>
   switch cached.contents {
   | Some(c) => c
   | None => {

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -851,15 +851,32 @@ let getChain = (config, ~chainId) => {
 // `Main.dropSchema`, so those functions skip the NAPI `getConfigJson`
 // round-trip. Module-private — only Bin.res should set it.
 %%private(let primedJson: ref<option<JSON.t>> = ref(None))
-let prime = (json: JSON.t): unit => primedJson := Some(json)
+%%private(let cached: ref<option<t>> = ref(None))
+let prime = (json: JSON.t): unit => {
+  primedJson := Some(json)
+  cached := None
+}
+
+// Invalidate the memoized config. Used by `HandlerRegister.finishRegistration`
+// so the next `load()` reparses and picks up registered handlers.
+let reset = () => cached := None
 
 // Load the resolved indexer config. When `Bin.res` has primed a JSON payload
 // from the CLI command, parse from that; otherwise invoke the native NAPI
 // addon (Rust config parser, ENVIO_CONFIG-respecting). The NAPI path keeps
 // non-CLI callers (worker threads spawned via `TestIndexer`, direct imports
-// from test harnesses) working without a primed payload.
+// from test harnesses) working without a primed payload. Memoized — callers
+// that need a fresh parse after handler registration go through
+// `HandlerRegister.finishRegistration`.
 let load = () =>
-  switch primedJson.contents {
-  | Some(json) => json->fromPublic
-  | None => Core.getConfigJson()->JSON.parseOrThrow->fromPublic
+  switch cached.contents {
+  | Some(c) => c
+  | None => {
+      let c = switch primedJson.contents {
+      | Some(json) => json->fromPublic
+      | None => Core.getConfigJson()->JSON.parseOrThrow->fromPublic
+      }
+      cached := Some(c)
+      c
+    }
   }

--- a/packages/envio/src/EnvSafe.res
+++ b/packages/envio/src/EnvSafe.res
@@ -9,7 +9,7 @@
 
 module Stdlib = {
   module Dict = {
-    @get_index external get: (Js.Dict.t<'a>, string) => option<'a> = ""
+    @get_index external get: (dict<'a>, string) => option<'a> = ""
   }
 
   module Option = {
@@ -39,7 +39,7 @@ module Stdlib = {
     @new
     external makeTypeError: string => error = "TypeError"
 
-    let raiseError = (error: error): 'a => error->magic->raise
+    let raiseError = (error: error): 'a => error->magic->throw
   }
 }
 
@@ -49,7 +49,7 @@ module Error = {
     Stdlib.Exn.raiseError(Stdlib.Exn.makeError(`[rescript-envsafe] ${message}`))
 }
 
-type env = Js.Dict.t<string>
+type env = dict<string>
 type invalidIssue = {name: string, error: S.error, input: option<string>}
 type missingIssue = {name: string, input: option<string>}
 type t = {
@@ -62,19 +62,19 @@ type t = {
 module Env = {
   @val
   external // FIXME: process might be missing
-  default: Js.Dict.t<string> = "process.env"
+  default: dict<string> = "process.env"
 }
 
 let mixinMissingIssue = (envSafe, issue) => {
   switch envSafe.maybeMissingIssues {
-  | Some(missingIssues) => missingIssues->Js.Array2.push(issue)->ignore
+  | Some(missingIssues) => missingIssues->Array.push(issue)->ignore
   | None => envSafe.maybeMissingIssues = Some([issue])
   }
 }
 
 let mixinInvalidIssue = (envSafe, issue: invalidIssue) => {
   switch envSafe.maybeInvalidIssues {
-  | Some(invalidIssues) => invalidIssues->Js.Array2.push(issue)->ignore
+  | Some(invalidIssues) => invalidIssues->Array.push(issue)->ignore
   | None => envSafe.maybeInvalidIssues = Some([issue])
   }
 }
@@ -96,17 +96,17 @@ let close = envSafe => {
         let output = [line]
 
         maybeInvalidIssues->Stdlib.Option.forEach(invalidIssues => {
-          output->Js.Array2.push("❌ Invalid environment variables:")->ignore
-          invalidIssues->Js.Array2.forEach(issue => {
-            output->Js.Array2.push(`    ${issue.name}: ${issue.error->S.Error.message}`)->ignore
+          output->Array.push("❌ Invalid environment variables:")->ignore
+          invalidIssues->Array.forEach(issue => {
+            output->Array.push(`    ${issue.name}: ${issue.error->S.Error.message}`)->ignore
           })
         })
 
         maybeMissingIssues->Stdlib.Option.forEach(missingIssues => {
-          output->Js.Array2.push("💨 Missing environment variables:")->ignore
-          missingIssues->Js.Array2.forEach(issue => {
+          output->Array.push("💨 Missing environment variables:")->ignore
+          missingIssues->Array.forEach(issue => {
             output
-            ->Js.Array2.push(
+            ->Array.push(
               `    ${issue.name}: ${switch issue.input {
                 | Some("") => "Disallowed empty string"
                 | _ => "Missing value"
@@ -116,11 +116,11 @@ let close = envSafe => {
           })
         })
 
-        output->Js.Array2.push(line)->ignore
-        output->Js.Array2.joinWith("\n")
+        output->Array.push(line)->ignore
+        output->Array.joinUnsafe("\n")
       }
 
-      Js.Console.error(text)
+      Console.error(text)
       Stdlib.Window.alert(text)
       Stdlib.Exn.raiseError(Stdlib.Exn.makeTypeError(text))
     }
@@ -142,7 +142,7 @@ let boolCoerce = string =>
 
 let numberCoerce = string => {
   let float = %raw(`+string`)
-  if Js.Float.isNaN(float) {
+  if Float.isNaN(float) {
     string
   } else {
     float->magic
@@ -150,13 +150,13 @@ let numberCoerce = string => {
 }
 
 let bigintCoerce = string => {
-  try string->Js.BigInt.fromStringExn->magic catch {
+  try string->BigInt.fromStringOrThrow->magic catch {
   | _ => string
   }
 }
 
 let jsonCoerce = string => {
-  try string->Js.Json.parseExn->magic catch {
+  try string->JSON.parseOrThrow->magic catch {
   | _ => string
   }
 }

--- a/packages/envio/src/Envio.res
+++ b/packages/envio/src/Envio.res
@@ -59,6 +59,7 @@ type logger = {
   errorWithExn: (string, exn) => unit,
 }
 
+@@warning("-30") // Duplicated type names (input)
 type rec effect<'input, 'output>
 @unboxed
 and rateLimitDuration =
@@ -90,6 +91,7 @@ and effectArgs<'input> = {
   input: 'input,
   context: effectContext,
 }
+@@warning("+30")
 
 let durationToMs = (duration: rateLimitDuration) =>
   switch duration {

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -420,7 +420,7 @@ let resolveFieldSelection = (
 
 // ============== Build complete EVM event config ==============
 
-let rec buildEvmEventConfig = (
+let buildEvmEventConfig = (
   ~contractName: string,
   ~eventName: string,
   ~sighash: string,
@@ -471,28 +471,12 @@ let rec buildEvmEventConfig = (
     convertHyperSyncEventArgs: buildHyperSyncDecoder(params),
     selectedBlockFields,
     selectedTransactionFields,
-    rebuildWithRegistration: (~isWildcard, ~handler, ~contractRegister, ~eventFilters) =>
-      buildEvmEventConfig(
-        ~contractName,
-        ~eventName,
-        ~sighash,
-        ~params,
-        ~isWildcard,
-        ~handler,
-        ~contractRegister,
-        ~eventFilters,
-        ~probeChainId,
-        ~blockFields?,
-        ~transactionFields?,
-        ~globalBlockFieldsSet,
-        ~globalTransactionFieldsSet,
-      ),
   }
 }
 
 // ============== Build Fuel event config ==============
 
-let rec buildFuelEventConfig = (
+let buildFuelEventConfig = (
   ~contractName: string,
   ~eventName: string,
   ~kind: string,
@@ -548,16 +532,5 @@ let rec buildFuelEventConfig = (
     filterByAddresses: false,
     dependsOnAddresses: !isWildcard,
     kind: fuelKind,
-    rebuildWithRegistration: (~isWildcard, ~handler, ~contractRegister) =>
-      buildFuelEventConfig(
-        ~contractName,
-        ~eventName,
-        ~kind,
-        ~sighash,
-        ~rawAbi,
-        ~isWildcard,
-        ~handler,
-        ~contractRegister,
-      ),
   }
 }

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -1,19 +1,8 @@
-// Recursive tuple/struct component metadata emitted by the CLI when an event
-// param (or any nested field) is a Solidity struct. `name` is always non-empty —
-// the CLI fills in `"0"`, `"1"`, ... for anonymous components in mixed-name
-// tuples — so the runtime can always rebuild a keyed object.
-type rec eventParamComponent = {
-  name: string,
-  abiType: string,
-  components?: array<eventParamComponent>,
-}
-
-type eventParam = {
-  name: string,
-  abiType: string,
-  indexed: bool,
-  components?: array<eventParamComponent>,
-}
+// Types moved to `Internal` so `Internal.evmEventConfig` can retain
+// `indexedParams: array<eventParam>` for post-registration filter rebuild.
+// Re-exported here as aliases for existing call sites.
+type eventParamComponent = Internal.eventParamComponent
+type eventParam = Internal.eventParam
 
 let eventParamComponentSchema = S.recursive(self =>
   S.object((s): eventParamComponent => {
@@ -471,6 +460,8 @@ let buildEvmEventConfig = (
     convertHyperSyncEventArgs: buildHyperSyncDecoder(params),
     selectedBlockFields,
     selectedTransactionFields,
+    sighash,
+    indexedParams,
   }
 }
 

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -456,7 +456,7 @@ let buildEvmEventConfig = (
     simulateParamsSchema: buildSimulateParamsSchema(params),
     getEventFiltersOrThrow,
     filterByAddresses,
-    dependsOnAddresses: !isWildcard || filterByAddresses,
+    dependsOnAddresses: Internal.dependsOnAddresses(~isWildcard, ~filterByAddresses),
     convertHyperSyncEventArgs: buildHyperSyncDecoder(params),
     selectedBlockFields,
     selectedTransactionFields,
@@ -521,7 +521,7 @@ let buildFuelEventConfig = (
     paramsRawEventSchema: paramsSchema,
     simulateParamsSchema: paramsSchema,
     filterByAddresses: false,
-    dependsOnAddresses: !isWildcard,
+    dependsOnAddresses: Internal.dependsOnAddresses(~isWildcard, ~filterByAddresses=false),
     kind: fuelKind,
   }
 }

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -420,7 +420,7 @@ let resolveFieldSelection = (
 
 // ============== Build complete EVM event config ==============
 
-let buildEvmEventConfig = (
+let rec buildEvmEventConfig = (
   ~contractName: string,
   ~eventName: string,
   ~sighash: string,
@@ -471,12 +471,28 @@ let buildEvmEventConfig = (
     convertHyperSyncEventArgs: buildHyperSyncDecoder(params),
     selectedBlockFields,
     selectedTransactionFields,
+    rebuildWithRegistration: (~isWildcard, ~handler, ~contractRegister, ~eventFilters) =>
+      buildEvmEventConfig(
+        ~contractName,
+        ~eventName,
+        ~sighash,
+        ~params,
+        ~isWildcard,
+        ~handler,
+        ~contractRegister,
+        ~eventFilters,
+        ~probeChainId,
+        ~blockFields?,
+        ~transactionFields?,
+        ~globalBlockFieldsSet,
+        ~globalTransactionFieldsSet,
+      ),
   }
 }
 
 // ============== Build Fuel event config ==============
 
-let buildFuelEventConfig = (
+let rec buildFuelEventConfig = (
   ~contractName: string,
   ~eventName: string,
   ~kind: string,
@@ -532,5 +548,16 @@ let buildFuelEventConfig = (
     filterByAddresses: false,
     dependsOnAddresses: !isWildcard,
     kind: fuelKind,
+    rebuildWithRegistration: (~isWildcard, ~handler, ~contractRegister) =>
+      buildFuelEventConfig(
+        ~contractName,
+        ~eventName,
+        ~kind,
+        ~sighash,
+        ~rawAbi,
+        ~isWildcard,
+        ~handler,
+        ~contractRegister,
+      ),
   }
 }

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -74,11 +74,13 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
 }
 
 // Register all handlers and return `(configWithRegistrations, registrations)`.
-// The input `~config` is the pre-registration snapshot; the returned config
-// is the post-registration snapshot used downstream by `Main.start`. The
-// reset+reload dance lives here rather than in `HandlerRegister` to avoid
-// a `Config ↔ HandlerRegister` cycle — `Config.fromPublic` reads from
-// `HandlerRegister`, so `HandlerRegister` itself can't depend on `Config`.
+// The input `~config` is the pre-registration snapshot (from
+// `Config.loadWithoutRegistrations`); the returned config applies
+// `HandlerRegister` state to each event via the
+// `rebuildWithRegistration` closure that `EventConfigBuilder` baked in
+// at build time. `Config` itself never reads `HandlerRegister` — the
+// knowledge of "post-registration config" lives here and flows to
+// downstream callers via the return value.
 let registerAllHandlers = async (~config: Config.t) => {
   HandlerRegister.startRegistration(~ecosystem=config.ecosystem, ~multichain=config.multichain)
 
@@ -94,6 +96,52 @@ let registerAllHandlers = async (~config: Config.t) => {
     ->Promise.all
 
   let registrations = HandlerRegister.finishRegistration()
-  Config.reset()
-  (Config.load(), registrations)
+
+  let newChainMap = config.chainMap->ChainMap.map(chain => {
+    let newContracts = chain.contracts->Array.map(contract => {
+      let newEvents = contract.events->Array.map(
+        event => {
+          let isWildcard = HandlerRegister.isWildcard(
+            ~contractName=event.contractName,
+            ~eventName=event.name,
+          )
+          let handler = HandlerRegister.getHandler(
+            ~contractName=event.contractName,
+            ~eventName=event.name,
+          )
+          let contractRegister = HandlerRegister.getContractRegister(
+            ~contractName=event.contractName,
+            ~eventName=event.name,
+          )
+          switch config.ecosystem.name {
+          | Fuel =>
+            let fuelEv = event->(Utils.magic: Internal.eventConfig => Internal.fuelEventConfig)
+
+            (fuelEv.rebuildWithRegistration(
+              ~isWildcard,
+              ~handler,
+              ~contractRegister,
+            ) :> Internal.eventConfig)
+          | Evm | Svm =>
+            let evmEv = event->(Utils.magic: Internal.eventConfig => Internal.evmEventConfig)
+            let eventFilters = HandlerRegister.getOnEventWhere(
+              ~contractName=event.contractName,
+              ~eventName=event.name,
+            )
+
+            (evmEv.rebuildWithRegistration(
+              ~isWildcard,
+              ~handler,
+              ~contractRegister,
+              ~eventFilters,
+            ) :> Internal.eventConfig)
+          }
+        },
+      )
+      {...contract, events: newEvents}
+    })
+    {...chain, contracts: newContracts}
+  })
+
+  ({...config, chainMap: newChainMap}, registrations)
 }

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -61,19 +61,24 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
   }
 
   // Import handler files using absolute file:// URLs resolved from cwd
-  let _ = await handlerFiles
-  ->Array.map(file => {
-    Utils.importPath(toImportUrl(file))->Promise.catch(exn => {
-      let cause = exn->Utils.prettifyExn->Obj.magic
-      Logging.errorWithExn(exn, `Failed to auto-load handler file: ${file}`)
-      JsError.throwWithMessage(`Failed to auto-load handler file: ${file}. Cause: ${cause}`)
+  let _ =
+    await handlerFiles
+    ->Array.map(file => {
+      Utils.importPath(toImportUrl(file))->Promise.catch(exn => {
+        let cause = exn->Utils.prettifyExn->Obj.magic
+        Logging.errorWithExn(exn, `Failed to auto-load handler file: ${file}`)
+        JsError.throwWithMessage(`Failed to auto-load handler file: ${file}. Cause: ${cause}`)
+      })
     })
-  })
-  ->Promise.all
+    ->Promise.all
 }
 
-// Register all handlers - must be called BEFORE creating the final config
-// so that event registrations are captured in the config
+// Register all handlers and return `(configWithRegistrations, registrations)`.
+// The input `~config` is the pre-registration snapshot; the returned config
+// is the post-registration snapshot used downstream by `Main.start`. The
+// reset+reload dance lives here rather than in `HandlerRegister` to avoid
+// a `Config ↔ HandlerRegister` cycle — `Config.fromPublic` reads from
+// `HandlerRegister`, so `HandlerRegister` itself can't depend on `Config`.
 let registerAllHandlers = async (~config: Config.t) => {
   HandlerRegister.startRegistration(~ecosystem=config.ecosystem, ~multichain=config.multichain)
 
@@ -81,11 +86,14 @@ let registerAllHandlers = async (~config: Config.t) => {
   await autoLoadFromSrcHandlers(~handlers=config.handlers)
 
   // Load contract-specific handlers
-  let _ = await config.contractHandlers
-  ->Array.map(({name, handler}) => {
-    registerContractHandlers(~contractName=name, ~handler)
-  })
-  ->Promise.all
+  let _ =
+    await config.contractHandlers
+    ->Array.map(({name, handler}) => {
+      registerContractHandlers(~contractName=name, ~handler)
+    })
+    ->Promise.all
 
-  HandlerRegister.finishRegistration()
+  let registrations = HandlerRegister.finishRegistration()
+  Config.reset()
+  (Config.load(), registrations)
 }

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -73,14 +73,77 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
     ->Promise.all
 }
 
+// Produce a post-registration Config.t by walking the chainMap and folding
+// the just-registered handler state into each event. We intentionally do not
+// re-run `EventConfigBuilder.build{Evm,Fuel}EventConfig` — everything the new
+// event record needs is already a field on the existing event config, so a
+// spread with three overrides + a derived `dependsOnAddresses` suffices.
+//
+// `dependsOnAddresses` formula must stay in sync with
+// `EventConfigBuilder.buildEvmEventConfig` / `buildFuelEventConfig`.
+//
+// Known limitation: `indexer.onEvent({..., where: …})` filters are not
+// propagated into `getEventFiltersOrThrow` / `filterByAddresses` here — those
+// closures reflect the state captured at original build time (always no
+// filter, since `Config.fromPublic` now passes `eventFilters=None`). A
+// separate mechanism will need to re-apply user-registered filters.
+let applyRegistrations = (~config: Config.t): Config.t => {
+  let newChainMap = config.chainMap->ChainMap.map(chain => {
+    let newContracts = chain.contracts->Array.map(contract => {
+      let newEvents = contract.events->Array.map(
+        ev => {
+          let isWildcard = HandlerRegister.isWildcard(
+            ~contractName=ev.contractName,
+            ~eventName=ev.name,
+          )
+          let handler = HandlerRegister.getHandler(
+            ~contractName=ev.contractName,
+            ~eventName=ev.name,
+          )
+          let contractRegister = HandlerRegister.getContractRegister(
+            ~contractName=ev.contractName,
+            ~eventName=ev.name,
+          )
+          switch config.ecosystem.name {
+          | Fuel =>
+            let fuelEv = ev->(Utils.magic: Internal.eventConfig => Internal.fuelEventConfig)
+
+            ({
+              ...fuelEv,
+              isWildcard,
+              handler,
+              contractRegister,
+              dependsOnAddresses: !isWildcard,
+            } :> Internal.eventConfig)
+          | Evm =>
+            let evmEv = ev->(Utils.magic: Internal.eventConfig => Internal.evmEventConfig)
+
+            ({
+              ...evmEv,
+              isWildcard,
+              handler,
+              contractRegister,
+              dependsOnAddresses: !isWildcard || evmEv.filterByAddresses,
+            } :> Internal.eventConfig)
+          | Svm =>
+            JsError.throwWithMessage(`SVM does not support indexer.onEvent or indexer.contractRegister. Use indexer.onSlot for per-slot handlers.`)
+          }
+        },
+      )
+      {...contract, events: newEvents}
+    })
+    {...chain, contracts: newContracts}
+  })
+  {...config, chainMap: newChainMap}
+}
+
 // Register all handlers and return `(configWithRegistrations, registrations)`.
 // The input `~config` is the pre-registration snapshot (from
 // `Config.loadWithoutRegistrations`); the returned config applies
-// `HandlerRegister` state to each event via the
-// `rebuildWithRegistration` closure that `EventConfigBuilder` baked in
-// at build time. `Config` itself never reads `HandlerRegister` — the
-// knowledge of "post-registration config" lives here and flows to
-// downstream callers via the return value.
+// `HandlerRegister` state to each event via `applyRegistrations` above.
+// `Config` itself never reads `HandlerRegister` — the knowledge of
+// "post-registration config" lives here and flows to downstream callers via
+// the return value.
 let registerAllHandlers = async (~config: Config.t) => {
   HandlerRegister.startRegistration(~ecosystem=config.ecosystem, ~multichain=config.multichain)
 
@@ -96,52 +159,5 @@ let registerAllHandlers = async (~config: Config.t) => {
     ->Promise.all
 
   let registrations = HandlerRegister.finishRegistration()
-
-  let newChainMap = config.chainMap->ChainMap.map(chain => {
-    let newContracts = chain.contracts->Array.map(contract => {
-      let newEvents = contract.events->Array.map(
-        event => {
-          let isWildcard = HandlerRegister.isWildcard(
-            ~contractName=event.contractName,
-            ~eventName=event.name,
-          )
-          let handler = HandlerRegister.getHandler(
-            ~contractName=event.contractName,
-            ~eventName=event.name,
-          )
-          let contractRegister = HandlerRegister.getContractRegister(
-            ~contractName=event.contractName,
-            ~eventName=event.name,
-          )
-          switch config.ecosystem.name {
-          | Fuel =>
-            let fuelEv = event->(Utils.magic: Internal.eventConfig => Internal.fuelEventConfig)
-
-            (fuelEv.rebuildWithRegistration(
-              ~isWildcard,
-              ~handler,
-              ~contractRegister,
-            ) :> Internal.eventConfig)
-          | Evm | Svm =>
-            let evmEv = event->(Utils.magic: Internal.eventConfig => Internal.evmEventConfig)
-            let eventFilters = HandlerRegister.getOnEventWhere(
-              ~contractName=event.contractName,
-              ~eventName=event.name,
-            )
-
-            (evmEv.rebuildWithRegistration(
-              ~isWildcard,
-              ~handler,
-              ~contractRegister,
-              ~eventFilters,
-            ) :> Internal.eventConfig)
-          }
-        },
-      )
-      {...contract, events: newEvents}
-    })
-    {...chain, contracts: newContracts}
-  })
-
-  ({...config, chainMap: newChainMap}, registrations)
+  (applyRegistrations(~config), registrations)
 }

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -81,8 +81,8 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
 // `getEventFiltersOrThrow` / `filterByAddresses` — that's why
 // `evmEventConfig` retains `sighash` and `indexedParams`.
 //
-// `dependsOnAddresses` formula must stay in sync with
-// `EventConfigBuilder.buildEvmEventConfig` / `buildFuelEventConfig`.
+// `dependsOnAddresses` goes through `Internal.dependsOnAddresses` so the
+// formula stays in sync with `EventConfigBuilder.build{Evm,Fuel}EventConfig`.
 let applyRegistrations = (~config: Config.t): Config.t => {
   let newChainMap = config.chainMap->ChainMap.map(chain => {
     let newContracts = chain.contracts->Array.map(contract => {
@@ -109,7 +109,10 @@ let applyRegistrations = (~config: Config.t): Config.t => {
               isWildcard,
               handler,
               contractRegister,
-              dependsOnAddresses: !isWildcard,
+              dependsOnAddresses: Internal.dependsOnAddresses(
+                ~isWildcard,
+                ~filterByAddresses=false,
+              ),
             } :> Internal.eventConfig)
           | Evm =>
             let evmEv = ev->(Utils.magic: Internal.eventConfig => Internal.evmEventConfig)
@@ -141,7 +144,7 @@ let applyRegistrations = (~config: Config.t): Config.t => {
               contractRegister,
               getEventFiltersOrThrow,
               filterByAddresses,
-              dependsOnAddresses: !isWildcard || filterByAddresses,
+              dependsOnAddresses: Internal.dependsOnAddresses(~isWildcard, ~filterByAddresses),
             } :> Internal.eventConfig)
           | Svm =>
             JsError.throwWithMessage(`SVM does not support indexer.onEvent or indexer.contractRegister. Use indexer.onSlot for per-slot handlers.`)

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -74,19 +74,15 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
 }
 
 // Produce a post-registration Config.t by walking the chainMap and folding
-// the just-registered handler state into each event. We intentionally do not
-// re-run `EventConfigBuilder.build{Evm,Fuel}EventConfig` — everything the new
-// event record needs is already a field on the existing event config, so a
-// spread with three overrides + a derived `dependsOnAddresses` suffices.
+// the just-registered handler state into each event. Fuel keeps all its
+// fields from build time and only overrides the three registration fields
+// (+ `dependsOnAddresses`). EVM also re-runs `parseEventFiltersOrThrow` with
+// the newly-registered `where:` JSON so per-event filters propagate into
+// `getEventFiltersOrThrow` / `filterByAddresses` — that's why
+// `evmEventConfig` retains `sighash` and `indexedParams`.
 //
 // `dependsOnAddresses` formula must stay in sync with
 // `EventConfigBuilder.buildEvmEventConfig` / `buildFuelEventConfig`.
-//
-// Known limitation: `indexer.onEvent({..., where: …})` filters are not
-// propagated into `getEventFiltersOrThrow` / `filterByAddresses` here — those
-// closures reflect the state captured at original build time (always no
-// filter, since `Config.fromPublic` now passes `eventFilters=None`). A
-// separate mechanism will need to re-apply user-registered filters.
 let applyRegistrations = (~config: Config.t): Config.t => {
   let newChainMap = config.chainMap->ChainMap.map(chain => {
     let newContracts = chain.contracts->Array.map(contract => {
@@ -117,13 +113,35 @@ let applyRegistrations = (~config: Config.t): Config.t => {
             } :> Internal.eventConfig)
           | Evm =>
             let evmEv = ev->(Utils.magic: Internal.eventConfig => Internal.evmEventConfig)
+            let eventFilters = HandlerRegister.getOnEventWhere(
+              ~contractName=ev.contractName,
+              ~eventName=ev.name,
+            )
+            let {getEventFiltersOrThrow, filterByAddresses} = LogSelection.parseEventFiltersOrThrow(
+              ~eventFilters,
+              ~sighash=evmEv.sighash,
+              ~params=evmEv.indexedParams->Array.map(p => p.name),
+              ~contractName=ev.contractName,
+              ~probeChainId=chain.id,
+              ~topic1=?evmEv.indexedParams
+              ->Array.get(0)
+              ->Option.map(EventConfigBuilder.buildTopicGetter),
+              ~topic2=?evmEv.indexedParams
+              ->Array.get(1)
+              ->Option.map(EventConfigBuilder.buildTopicGetter),
+              ~topic3=?evmEv.indexedParams
+              ->Array.get(2)
+              ->Option.map(EventConfigBuilder.buildTopicGetter),
+            )
 
             ({
               ...evmEv,
               isWildcard,
               handler,
               contractRegister,
-              dependsOnAddresses: !isWildcard || evmEv.filterByAddresses,
+              getEventFiltersOrThrow,
+              filterByAddresses,
+              dependsOnAddresses: !isWildcard || filterByAddresses,
             } :> Internal.eventConfig)
           | Svm =>
             JsError.throwWithMessage(`SVM does not support indexer.onEvent or indexer.contractRegister. Use indexer.onSlot for per-slot handlers.`)

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -352,9 +352,17 @@ type fuelEventKind =
   | Burn
   | Transfer
   | Call
-type fuelEventConfig = {
+type rec fuelEventConfig = {
   ...eventConfig,
   kind: fuelEventKind,
+  // Rebuild this event with a different handler registration state. Captures
+  // the original build inputs so callers (after handler modules register)
+  // can produce a new event config without knowing raw sighash/kind/abi.
+  rebuildWithRegistration: (
+    ~isWildcard: bool,
+    ~handler: option<handler>,
+    ~contractRegister: option<contractRegister>,
+  ) => fuelEventConfig,
 }
 type fuelContractConfig = {
   name: string,
@@ -377,12 +385,21 @@ type onEventWhereArgs<'chain> = {chain: 'chain}
 type eventFilters =
   Static(array<topicSelection>) | Dynamic(array<Address.t> => array<topicSelection>)
 
-type evmEventConfig = {
+type rec evmEventConfig = {
   ...eventConfig,
   getEventFiltersOrThrow: ChainMap.Chain.t => eventFilters,
   convertHyperSyncEventArgs: HyperSyncClient.Decoder.decodedEvent => eventParams,
   selectedBlockFields: Utils.Set.t<evmBlockField>,
   selectedTransactionFields: Utils.Set.t<evmTransactionField>,
+  // Rebuild this event with a different handler registration state. Captures
+  // the original build inputs so callers (after handler modules register)
+  // can produce a new event config without knowing raw params/sighash/etc.
+  rebuildWithRegistration: (
+    ~isWildcard: bool,
+    ~handler: option<handler>,
+    ~contractRegister: option<contractRegister>,
+    ~eventFilters: option<JSON.t>,
+  ) => evmEventConfig,
 }
 type evmContractConfig = {
   name: string,

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -407,6 +407,14 @@ type evmEventConfig = {
   sighash: string,
   indexedParams: array<eventParam>,
 }
+
+// Shared formula for `eventConfig.dependsOnAddresses`. Kept here so
+// `EventConfigBuilder.build{Evm,Fuel}EventConfig` and
+// `HandlerLoader.applyRegistrations` stay in sync when handler state flips
+// the value. Fuel events always have `filterByAddresses=false`, so callers
+// there simply pass it through as `false`.
+let dependsOnAddresses = (~isWildcard, ~filterByAddresses) => !isWildcard || filterByAddresses
+
 type evmContractConfig = {
   name: string,
   abi: EvmTypes.Abi.t,

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -352,17 +352,9 @@ type fuelEventKind =
   | Burn
   | Transfer
   | Call
-type rec fuelEventConfig = {
+type fuelEventConfig = {
   ...eventConfig,
   kind: fuelEventKind,
-  // Rebuild this event with a different handler registration state. Captures
-  // the original build inputs so callers (after handler modules register)
-  // can produce a new event config without knowing raw sighash/kind/abi.
-  rebuildWithRegistration: (
-    ~isWildcard: bool,
-    ~handler: option<handler>,
-    ~contractRegister: option<contractRegister>,
-  ) => fuelEventConfig,
 }
 type fuelContractConfig = {
   name: string,
@@ -385,21 +377,12 @@ type onEventWhereArgs<'chain> = {chain: 'chain}
 type eventFilters =
   Static(array<topicSelection>) | Dynamic(array<Address.t> => array<topicSelection>)
 
-type rec evmEventConfig = {
+type evmEventConfig = {
   ...eventConfig,
   getEventFiltersOrThrow: ChainMap.Chain.t => eventFilters,
   convertHyperSyncEventArgs: HyperSyncClient.Decoder.decodedEvent => eventParams,
   selectedBlockFields: Utils.Set.t<evmBlockField>,
   selectedTransactionFields: Utils.Set.t<evmTransactionField>,
-  // Rebuild this event with a different handler registration state. Captures
-  // the original build inputs so callers (after handler modules register)
-  // can produce a new event config without knowing raw params/sighash/etc.
-  rebuildWithRegistration: (
-    ~isWildcard: bool,
-    ~handler: option<handler>,
-    ~contractRegister: option<contractRegister>,
-    ~eventFilters: option<JSON.t>,
-  ) => evmEventConfig,
 }
 type evmContractConfig = {
   name: string,

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -326,6 +326,23 @@ type genericHandlerWithLoader<'loader, 'handler, 'where> = {
   where?: 'where,
 }
 
+// Recursive tuple/struct component metadata emitted by the CLI when an event
+// param (or any nested field) is a Solidity struct. `name` is always non-empty —
+// the CLI fills in `"0"`, `"1"`, ... for anonymous components in mixed-name
+// tuples — so the runtime can always rebuild a keyed object.
+type rec eventParamComponent = {
+  name: string,
+  abiType: string,
+  components?: array<eventParamComponent>,
+}
+
+type eventParam = {
+  name: string,
+  abiType: string,
+  indexed: bool,
+  components?: array<eventParamComponent>,
+}
+
 // This is private so it's not manually constructed internally
 // The idea is that it can only be coerced from fuel/evmEventConfig
 // and it can include their fields. We prevent manual creation,
@@ -383,6 +400,12 @@ type evmEventConfig = {
   convertHyperSyncEventArgs: HyperSyncClient.Decoder.decodedEvent => eventParams,
   selectedBlockFields: Utils.Set.t<evmBlockField>,
   selectedTransactionFields: Utils.Set.t<evmTransactionField>,
+  // Retained so `HandlerLoader.applyRegistrations` can re-run
+  // `LogSelection.parseEventFiltersOrThrow` after handler modules register
+  // with a `where:` filter. Only indexed params are kept — they're all the
+  // filter parser needs for topic-getter construction + key validation.
+  sighash: string,
+  indexedParams: array<eventParam>,
 }
 type evmContractConfig = {
   name: string,

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -101,7 +101,7 @@ let getInitialChainState = (~chainId: int): option<Persistence.initialChainState
 
 // Build the chains object from config. Extracted so the exported indexer
 // value can call this lazily (on first `indexer.chains` access) rather than
-// eagerly at module load — importing `generated` must not trigger Config.load().
+// eagerly at module load — importing `generated` must not trigger Config.loadWithoutRegistrations().
 let buildChainsObject = (~config: Config.t) => {
   let chainIds = []
   let chains = Utils.Object.createNullObject()
@@ -246,14 +246,14 @@ let getGlobalIndexer = (): 'indexer => {
 
   // `indexer.chains` needs stable identity across repeated reads
   // (`Indexer_test.res:51` asserts `toBe` on the same reference), so memoize
-  // the built chains object on first access. `Config.load()` is itself
+  // the built chains object on first access. `Config.loadWithoutRegistrations()` is itself
   // memoized, so downstream property reads on chains are cheap.
   let chainsMemo: ref<option<(unknown, array<int>)>> = ref(None)
   let getChainsMemo = () =>
     switch chainsMemo.contents {
     | Some(c) => c
     | None => {
-        let (chains, chainIds) = buildChainsObject(~config=Config.load())
+        let (chains, chainIds) = buildChainsObject(~config=Config.loadWithoutRegistrations())
         let memo = (chains->(Utils.magic: {..} => unknown), chainIds)
         chainsMemo := Some(memo)
         memo
@@ -263,13 +263,17 @@ let getGlobalIndexer = (): 'indexer => {
   indexer
   ->Utils.Object.defineProperty(
     "name",
-    {enumerable: true, get: () => Config.load().name->(Utils.magic: string => unknown)},
+    {
+      enumerable: true,
+      get: () => Config.loadWithoutRegistrations().name->(Utils.magic: string => unknown),
+    },
   )
   ->Utils.Object.defineProperty(
     "description",
     {
       enumerable: true,
-      get: () => Config.load().description->(Utils.magic: option<string> => unknown),
+      get: () =>
+        Config.loadWithoutRegistrations().description->(Utils.magic: option<string> => unknown),
     },
   )
   ->Utils.Object.defineProperty(
@@ -389,7 +393,7 @@ let getGlobalIndexer = (): 'indexer => {
   // so the fetcher's `(blockNumber - handlerStartBlock) % interval === 0`
   // math at `FetchState.res:619` stays untouched.
   let onBlockFn = (rawOptions: 'a, handler: 'b) => {
-    let config = Config.load()
+    let config = Config.loadWithoutRegistrations()
     let ecosystem = config.ecosystem
     let raw =
       rawOptions->(
@@ -593,14 +597,14 @@ type mainArgs = Yargs.parsedArgs<args>
 type migrateOpts = {reset: bool, persistedState: JSON.t}
 
 let migrate = async (~reset, ~persistedState) => {
-  let config = Config.load()
+  let config = Config.loadWithoutRegistrations()
   let persistence = PgStorage.makePersistenceFromConfig(~config)
   await persistence->Persistence.init(~reset, ~chainConfigs=config.chainMap->ChainMap.values)
   await Core.upsertPersistedState(persistedState->JSON.stringify)
 }
 
 let dropSchema = async () => {
-  let config = Config.load()
+  let config = Config.loadWithoutRegistrations()
   let persistence = PgStorage.makePersistenceFromConfig(~config)
   await persistence.storage.reset()
 }
@@ -624,7 +628,7 @@ let start = async (
   // when handler files are loaded (they may access the indexer at module top level).
   // `migrate`, when provided, folds the DB setup into this single `init()` call
   // (no separate `db setup` → `start` double-init).
-  let configWithoutRegistrations = Config.load()
+  let configWithoutRegistrations = Config.loadWithoutRegistrations()
   let persistence = switch persistence {
   | Some(p) => p
   | None => PgStorage.makePersistenceFromConfig(~config=configWithoutRegistrations)
@@ -640,11 +644,13 @@ let start = async (
   | None => ()
   }
 
-  // Register all handlers, then get the config with registrations
-  let (_, registrations) = await HandlerLoader.registerAllHandlers(
+  // Register all handlers. The returned config has handler/contractRegister/
+  // eventFilters baked into each event config. Downstream code uses this
+  // enriched value; `Config.loadWithoutRegistrations` itself never sees
+  // registration state.
+  let (config, registrations) = await HandlerLoader.registerAllHandlers(
     ~config=configWithoutRegistrations,
   )
-  let config = Config.load()
   let config = if isTest {
     {...config, shouldRollbackOnReorg: false}
   } else {

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -99,20 +99,11 @@ let getInitialChainState = (~chainId: int): option<Persistence.initialChainState
   }
 }
 
-let getGlobalIndexer = (~config: Config.t): 'indexer => {
-  let indexer = Utils.Object.createNullObject()
-
-  indexer
-  ->Utils.Object.definePropertyWithValue("name", {enumerable: true, value: config.name})
-  ->Utils.Object.definePropertyWithValue(
-    "description",
-    {enumerable: true, value: config.description},
-  )
-  ->ignore
-
+// Build the chains object from config. Extracted so the exported indexer
+// value can call this lazily (on first `indexer.chains` access) rather than
+// eagerly at module load — importing `generated` must not trigger Config.load().
+let buildChainsObject = (~config: Config.t) => {
   let chainIds = []
-
-  // Build chains object with chain ID as string key
   let chains = Utils.Object.createNullObject()
   config.chainMap
   ->ChainMap.values
@@ -247,10 +238,61 @@ let getGlobalIndexer = (~config: Config.t): 'indexer => {
       ->ignore
     }
   })
+  (chains, chainIds)
+}
+
+let getGlobalIndexer = (): 'indexer => {
+  let indexer = Utils.Object.createNullObject()
+
+  // `indexer.chains` needs stable identity across repeated reads
+  // (`Indexer_test.res:51` asserts `toBe` on the same reference), so memoize
+  // the built chains object on first access. `Config.load()` is itself
+  // memoized, so downstream property reads on chains are cheap.
+  let chainsMemo: ref<option<(unknown, array<int>)>> = ref(None)
+  let getChainsMemo = () =>
+    switch chainsMemo.contents {
+    | Some(c) => c
+    | None => {
+        let (chains, chainIds) = buildChainsObject(~config=Config.load())
+        let memo = (chains->(Utils.magic: {..} => unknown), chainIds)
+        chainsMemo := Some(memo)
+        memo
+      }
+    }
+
   indexer
-  ->Utils.Object.definePropertyWithValue("chainIds", {enumerable: true, value: chainIds})
+  ->Utils.Object.defineProperty(
+    "name",
+    {enumerable: true, get: () => Config.load().name->(Utils.magic: string => unknown)},
+  )
+  ->Utils.Object.defineProperty(
+    "description",
+    {
+      enumerable: true,
+      get: () => Config.load().description->(Utils.magic: option<string> => unknown),
+    },
+  )
+  ->Utils.Object.defineProperty(
+    "chainIds",
+    {
+      enumerable: true,
+      get: () => {
+        let (_, chainIds) = getChainsMemo()
+        chainIds->(Utils.magic: array<int> => unknown)
+      },
+    },
+  )
+  ->Utils.Object.defineProperty(
+    "chains",
+    {
+      enumerable: true,
+      get: () => {
+        let (chains, _) = getChainsMemo()
+        chains
+      },
+    },
+  )
   ->ignore
-  indexer->Utils.Object.definePropertyWithValue("chains", {enumerable: true, value: chains})->ignore
 
   // Parse eventIdentity config to extract contractName, eventName, and options.
   // Supports two runtime formats:
@@ -321,29 +363,22 @@ let getGlobalIndexer = (~config: Config.t): 'indexer => {
     )
   }
 
-  // SVM exposes the block handler as `indexer.onSlot`; EVM/Fuel expose it as
-  // `indexer.onBlock`. The choice lives on the ecosystem record so adding a
-  // new ecosystem doesn't require editing this file. Used both as the
-  // attached property name and in error messages so the cited call-site
-  // matches what the user wrote.
-  let onBlockMethodName = config.ecosystem.onBlockMethodName
-
   // Two-stage parse: first the ecosystem-specific outer schema unwraps the
   // wrapper (`block.number` / `block.height` / `slot`) and surfaces the
   // inner chunk as raw `unknown`; then the shared `blockRangeSchema`
   // validates the `{_gte?, _lte?, _every?}` fields. Keeping the inner
   // validation in one place means typos and shape mismatches surface with
   // the same user-friendly error regardless of ecosystem.
-  let extractRange = (filter: unknown, ~name): blockRange =>
+  let extractRange = (filter: unknown, ~name, ~ecosystem: Ecosystem.t): blockRange =>
     try {
-      switch filter->S.parseOrThrow(config.ecosystem.onBlockFilterSchema) {
+      switch filter->S.parseOrThrow(ecosystem.onBlockFilterSchema) {
       | None => defaultBlockRange
       | Some(inner) => inner->S.parseOrThrow(blockRangeSchema)
       }
     } catch {
     | S.Raised(exn) =>
       JsError.throwWithMessage(
-        `\`indexer.${onBlockMethodName}("${name}")\` \`where\` returned an invalid filter: ${exn
+        `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` \`where\` returned an invalid filter: ${exn
           ->Utils.prettifyExn
           ->(Utils.magic: exn => string)}`,
       )
@@ -354,6 +389,8 @@ let getGlobalIndexer = (~config: Config.t): 'indexer => {
   // so the fetcher's `(blockNumber - handlerStartBlock) % interval === 0`
   // math at `FetchState.res:619` stays untouched.
   let onBlockFn = (rawOptions: 'a, handler: 'b) => {
+    let config = Config.load()
+    let ecosystem = config.ecosystem
     let raw =
       rawOptions->(
         Utils.magic: 'a => {
@@ -362,7 +399,8 @@ let getGlobalIndexer = (~config: Config.t): 'indexer => {
         }
       )
     let typedHandler = handler->(Utils.magic: 'b => Internal.onBlockArgs => promise<unit>)
-    let chainsDict = chains->(Utils.magic: {..} => dict<unknown>)
+    let (chains, _) = getChainsMemo()
+    let chainsDict = chains->(Utils.magic: unknown => dict<unknown>)
     let name = raw["name"]
     let logger = Logging.createChild(~params={"onBlock": name})
 
@@ -377,7 +415,7 @@ let getGlobalIndexer = (~config: Config.t): 'indexer => {
     | w if typeof(w) === #function => Some(raw["where"]->Option.getUnsafe)
     | w =>
       JsError.throwWithMessage(
-        `\`indexer.${onBlockMethodName}("${name}")\` expected \`where\` to be a function or omitted, but got ${(typeof(
+        `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` expected \`where\` to be a function or omitted, but got ${(typeof(
             w,
           ) :> string)}.`,
       )
@@ -405,13 +443,13 @@ let getGlobalIndexer = (~config: Config.t): 'indexer => {
       } else if result === %raw(`false`) {
         (false, defaultBlockRange)
       } else if typeof(result) === #object && !(result->Array.isArray) && result !== %raw(`null`) {
-        (true, extractRange(result, ~name))
+        (true, extractRange(result, ~name, ~ecosystem))
       } else {
         // Reject numbers, strings, functions, arrays, undefined, null —
         // anything that isn't bool or a plain object would silently
         // misregister.
         JsError.throwWithMessage(
-          `\`indexer.${onBlockMethodName}("${name}")\` \`where\` predicate returned an invalid value of type ${(typeof(
+          `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` \`where\` predicate returned an invalid value of type ${(typeof(
               result,
             ) :> string)}. Expected boolean or a filter object.`,
         )
@@ -436,18 +474,24 @@ let getGlobalIndexer = (~config: Config.t): 'indexer => {
     // and don't get confused looking for a "Block handler" they never wrote.
     if !matchedAny.contents {
       logger->Logging.childWarn(
-        `\`indexer.${onBlockMethodName}\` matched 0 chains. Check the \`where\` predicate.`,
+        `\`indexer.${ecosystem.onBlockMethodName}\` matched 0 chains. Check the \`where\` predicate.`,
       )
     }
   }
 
+  // Attach both `onBlock` (EVM/Fuel) and `onSlot` (SVM) unconditionally.
+  // The property name is ecosystem-dependent and we don't want to load
+  // config at `getGlobalIndexer()` call time; each invocation of the shared
+  // handler reads `ecosystem.onBlockMethodName` at call time so user-facing
+  // error messages still cite the name that matches their ecosystem.
   indexer
   ->Utils.Object.definePropertyWithValue("onEvent", {enumerable: true, value: onEventFn})
   ->Utils.Object.definePropertyWithValue(
     "contractRegister",
     {enumerable: true, value: contractRegisterFn},
   )
-  ->Utils.Object.definePropertyWithValue(onBlockMethodName, {enumerable: true, value: onBlockFn})
+  ->Utils.Object.definePropertyWithValue("onBlock", {enumerable: true, value: onBlockFn})
+  ->Utils.Object.definePropertyWithValue("onSlot", {enumerable: true, value: onBlockFn})
   ->ignore
 
   indexer->(Utils.magic: 'a => 'indexer)
@@ -597,7 +641,9 @@ let start = async (
   }
 
   // Register all handlers, then get the config with registrations
-  let registrations = await HandlerLoader.registerAllHandlers(~config=configWithoutRegistrations)
+  let (_, registrations) = await HandlerLoader.registerAllHandlers(
+    ~config=configWithoutRegistrations,
+  )
   let config = Config.load()
   let config = if isTest {
     {...config, shouldRollbackOnReorg: false}

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -241,6 +241,15 @@ let buildChainsObject = (~config: Config.t) => {
   (chains, chainIds)
 }
 
+// Attach an enumerable property whose value is produced lazily on read.
+// Wraps `Utils.Object.defineProperty` + the `Utils.magic` erasure required
+// by the getter signature (`unknown`) so getter call sites stay terse.
+let defineValueGetter = (obj, name, get: unit => 'a) =>
+  obj->Utils.Object.defineProperty(
+    name,
+    {enumerable: true, get: () => get()->(Utils.magic: 'a => unknown)},
+  )
+
 let getGlobalIndexer = (): 'indexer => {
   let indexer = Utils.Object.createNullObject()
 
@@ -261,41 +270,16 @@ let getGlobalIndexer = (): 'indexer => {
     }
 
   indexer
-  ->Utils.Object.defineProperty(
-    "name",
-    {
-      enumerable: true,
-      get: () => Config.loadWithoutRegistrations().name->(Utils.magic: string => unknown),
-    },
-  )
-  ->Utils.Object.defineProperty(
-    "description",
-    {
-      enumerable: true,
-      get: () =>
-        Config.loadWithoutRegistrations().description->(Utils.magic: option<string> => unknown),
-    },
-  )
-  ->Utils.Object.defineProperty(
-    "chainIds",
-    {
-      enumerable: true,
-      get: () => {
-        let (_, chainIds) = getChainsMemo()
-        chainIds->(Utils.magic: array<int> => unknown)
-      },
-    },
-  )
-  ->Utils.Object.defineProperty(
-    "chains",
-    {
-      enumerable: true,
-      get: () => {
-        let (chains, _) = getChainsMemo()
-        chains
-      },
-    },
-  )
+  ->defineValueGetter("name", () => Config.loadWithoutRegistrations().name)
+  ->defineValueGetter("description", () => Config.loadWithoutRegistrations().description)
+  ->defineValueGetter("chainIds", () => {
+    let (_, chainIds) = getChainsMemo()
+    chainIds
+  })
+  ->defineValueGetter("chains", () => {
+    let (chains, _) = getChainsMemo()
+    chains
+  })
   ->ignore
 
   // Parse eventIdentity config to extract contractName, eventName, and options.
@@ -337,8 +321,23 @@ let getGlobalIndexer = (): 'indexer => {
     (contractName, eventName, eventOptions)
   }
 
+  // Reject `indexer.onEvent` / `indexer.contractRegister` on SVM at the
+  // call site so the user's stack trace points at their handler module,
+  // rather than throwing later during `HandlerLoader.applyRegistrations`.
+  let throwIfSvm = (~methodName) => {
+    let ecosystem = Config.loadWithoutRegistrations().ecosystem
+    switch ecosystem.name {
+    | Svm =>
+      JsError.throwWithMessage(
+        `\`indexer.${methodName}\` is not supported on SVM. Use \`indexer.${ecosystem.onBlockMethodName}\` for per-slot handlers.`,
+      )
+    | Evm | Fuel => ()
+    }
+  }
+
   // onEvent: delegates to HandlerRegister.setHandler
   let onEventFn = (identityConfig: 'a, handler: 'b) => {
+    throwIfSvm(~methodName="onEvent")
     let (contractName, eventName, eventOptions) = parseIdentityConfig(identityConfig)
     HandlerRegister.setHandler(
       ~contractName,
@@ -354,6 +353,7 @@ let getGlobalIndexer = (): 'indexer => {
 
   // contractRegister: delegates to HandlerRegister.setContractRegister
   let contractRegisterFn = (identityConfig: 'a, handler: 'b) => {
+    throwIfSvm(~methodName="contractRegister")
     let (contractName, eventName, eventOptions) = parseIdentityConfig(identityConfig)
     HandlerRegister.setContractRegister(
       ~contractName,

--- a/scenarios/test_codegen/test/ApplyRegistrations_test.res
+++ b/scenarios/test_codegen/test/ApplyRegistrations_test.res
@@ -1,0 +1,55 @@
+open Vitest
+
+// Covers `HandlerLoader.applyRegistrations`: the handler-state fields
+// (`handler`, `contractRegister`, `isWildcard`) registered via
+// `indexer.onEvent` / `indexer.contractRegister` land on the enriched
+// event config, and `dependsOnAddresses` follows the shared
+// `Internal.dependsOnAddresses` formula. Filter-parsing behavior is
+// covered separately by `EventFilters_test.res`.
+let (configWithRegistrations, _) = await HandlerLoader.registerAllHandlers(
+  ~config=Config.loadWithoutRegistrations(),
+)
+
+let getEvmEventConfig = MockConfig.getEvmEventConfig(~config=configWithRegistrations, ...)
+
+describe("HandlerLoader.applyRegistrations", () => {
+  it("propagates handler from onEvent into the event config", t => {
+    // `indexer.onEvent({ contract: "SimpleNft", event: "Transfer" }, …)`
+    // is registered in EventHandlers.ts at module top level.
+    let eventConfig = getEvmEventConfig(~contractName="SimpleNft", ~eventName="Transfer")
+    t.expect(eventConfig.handler->Belt.Option.isSome).toBe(true)
+  })
+
+  it("propagates contractRegister from indexer.contractRegister", t => {
+    // `indexer.contractRegister({ contract: "NftFactory", event: "SimpleNftCreated" }, …)`.
+    let eventConfig = getEvmEventConfig(~contractName="NftFactory", ~eventName="SimpleNftCreated")
+    t.expect(eventConfig.contractRegister->Belt.Option.isSome).toBe(true)
+  })
+
+  it("marks wildcard: true registrations as isWildcard", t => {
+    // `EventFiltersTest.Transfer` is registered with `wildcard: true`.
+    let eventConfig = getEvmEventConfig(~contractName="EventFiltersTest", ~eventName="Transfer")
+    t.expect(eventConfig.isWildcard).toBe(true)
+  })
+
+  it(
+    "computes dependsOnAddresses via Internal.dependsOnAddresses for the wildcard+where case",
+    t => {
+      // `EventFiltersTest.Transfer` is a wildcard registration with a `where`
+      // callback that does not filter by addresses, so
+      // `filterByAddresses=false` and `dependsOnAddresses=false`.
+      let eventConfig = getEvmEventConfig(
+        ~contractName="EventFiltersTest",
+        ~eventName="Transfer",
+      )
+      t.expect(
+        eventConfig.dependsOnAddresses,
+      ).toBe(
+        Internal.dependsOnAddresses(
+          ~isWildcard=eventConfig.isWildcard,
+          ~filterByAddresses=eventConfig.filterByAddresses,
+        ),
+      )
+    },
+  )
+})

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -1,7 +1,7 @@
 open Vitest
 
 let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) => {
-  let config = Indexer.Generated.configWithoutRegistrations
+  let config = Config.load()
   let allEvents = []
   let numberOfMockEventsCreated = ref(0)
 

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -1,7 +1,7 @@
 open Vitest
 
 let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) => {
-  let config = Config.load()
+  let config = Config.loadWithoutRegistrations()
   let allEvents = []
   let numberOfMockEventsCreated = ref(0)
 

--- a/scenarios/test_codegen/test/EventFilters_test.res
+++ b/scenarios/test_codegen/test/EventFilters_test.res
@@ -3,7 +3,7 @@ open Vitest
 // `registerAllHandlers` returns `(configWithRegistrations, _)` — the returned
 // config captures the event filters registered by the handler modules.
 let (configWithRegistrations, _) = await HandlerLoader.registerAllHandlers(
-  ~config=Config.load(),
+  ~config=Config.loadWithoutRegistrations(),
 )
 
 let getEvmEventConfig = MockConfig.getEvmEventConfig(~config=configWithRegistrations, ...)

--- a/scenarios/test_codegen/test/EventFilters_test.res
+++ b/scenarios/test_codegen/test/EventFilters_test.res
@@ -1,10 +1,10 @@
 open Vitest
 
-let _ = await HandlerLoader.registerAllHandlers(
-  ~config=Indexer.Generated.configWithoutRegistrations,
+// `registerAllHandlers` returns `(configWithRegistrations, _)` — the returned
+// config captures the event filters registered by the handler modules.
+let (configWithRegistrations, _) = await HandlerLoader.registerAllHandlers(
+  ~config=Config.load(),
 )
-// Rebuild config after handler registration to pick up event filters
-let configWithRegistrations = Indexer.Generated.makeGeneratedConfig()
 
 let getEvmEventConfig = MockConfig.getEvmEventConfig(~config=configWithRegistrations, ...)
 

--- a/scenarios/test_codegen/test/EventOrigin_test.res
+++ b/scenarios/test_codegen/test/EventOrigin_test.res
@@ -39,7 +39,7 @@ describe("Chains State", () => {
       async t => {
         // This test verifies that the chain field is accessible
         // The actual integration test is in EventHandlers.res with the EmptyEvent handler
-        let inMemoryStore = InMemoryStore.make(~entities=(Config.load()).allEntities)
+        let inMemoryStore = InMemoryStore.make(~entities=(Config.loadWithoutRegistrations()).allEntities)
         let loadManager = LoadManager.make()
 
         let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem
@@ -51,7 +51,7 @@ describe("Chains State", () => {
           item,
           loadManager,
           persistence: PgStorage.makePersistenceFromConfig(
-            ~config=Config.load(),
+            ~config=Config.loadWithoutRegistrations(),
           ),
           inMemoryStore,
           shouldSaveHistory: false,
@@ -59,7 +59,7 @@ describe("Chains State", () => {
           checkpointId: 0n,
           chains,
           isResolved: false,
-          config: Config.load(),
+          config: Config.loadWithoutRegistrations(),
         })
 
         // Verify we can access current event's chain info

--- a/scenarios/test_codegen/test/EventOrigin_test.res
+++ b/scenarios/test_codegen/test/EventOrigin_test.res
@@ -39,9 +39,7 @@ describe("Chains State", () => {
       async t => {
         // This test verifies that the chain field is accessible
         // The actual integration test is in EventHandlers.res with the EmptyEvent handler
-        let inMemoryStore = InMemoryStore.make(
-          ~entities=Indexer.Generated.configWithoutRegistrations.allEntities,
-        )
+        let inMemoryStore = InMemoryStore.make(~entities=(Config.load()).allEntities)
         let loadManager = LoadManager.make()
 
         let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem
@@ -53,7 +51,7 @@ describe("Chains State", () => {
           item,
           loadManager,
           persistence: PgStorage.makePersistenceFromConfig(
-            ~config=Indexer.Generated.configWithoutRegistrations,
+            ~config=Config.load(),
           ),
           inMemoryStore,
           shouldSaveHistory: false,
@@ -61,7 +59,7 @@ describe("Chains State", () => {
           checkpointId: 0n,
           chains,
           isResolved: false,
-          config: Indexer.Generated.configWithoutRegistrations,
+          config: Config.load(),
         })
 
         // Verify we can access current event's chain info

--- a/scenarios/test_codegen/test/LoadLayer_test.res
+++ b/scenarios/test_codegen/test/LoadLayer_test.res
@@ -3,7 +3,7 @@ open Vitest
 describe("LoadLayer", () => {
   Async.it("Trys to load non existing entity from db", async t => {
     let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
-    let inMemoryStore = InMemoryStore.make(~entities=(Config.load()).allEntities)
+    let inMemoryStore = InMemoryStore.make(~entities=(Config.loadWithoutRegistrations()).allEntities)
     let loadManager = LoadManager.make()
 
     let getUser = entityId =>
@@ -31,7 +31,7 @@ describe("LoadLayer", () => {
   Async.it("Does two round trips to db when requesting non existing entity one by one", async t => {
     let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
     let loadManager = LoadManager.make()
-    let inMemoryStore = InMemoryStore.make(~entities=(Config.load()).allEntities)
+    let inMemoryStore = InMemoryStore.make(~entities=(Config.loadWithoutRegistrations()).allEntities)
 
     let getUser = entityId =>
       LoadLayer.loadById(
@@ -66,7 +66,7 @@ describe("LoadLayer", () => {
     async t => {
       let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
       let loadManager = LoadManager.make()
-      let inMemoryStore = InMemoryStore.make(~entities=(Config.load()).allEntities)
+      let inMemoryStore = InMemoryStore.make(~entities=(Config.loadWithoutRegistrations()).allEntities)
       let getUser = entityId =>
         LoadLayer.loadById(
           ~loadManager,

--- a/scenarios/test_codegen/test/LoadLayer_test.res
+++ b/scenarios/test_codegen/test/LoadLayer_test.res
@@ -3,7 +3,7 @@ open Vitest
 describe("LoadLayer", () => {
   Async.it("Trys to load non existing entity from db", async t => {
     let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
-    let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.configWithoutRegistrations.allEntities)
+    let inMemoryStore = InMemoryStore.make(~entities=(Config.load()).allEntities)
     let loadManager = LoadManager.make()
 
     let getUser = entityId =>
@@ -31,7 +31,7 @@ describe("LoadLayer", () => {
   Async.it("Does two round trips to db when requesting non existing entity one by one", async t => {
     let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
     let loadManager = LoadManager.make()
-    let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.configWithoutRegistrations.allEntities)
+    let inMemoryStore = InMemoryStore.make(~entities=(Config.load()).allEntities)
 
     let getUser = entityId =>
       LoadLayer.loadById(
@@ -66,7 +66,7 @@ describe("LoadLayer", () => {
     async t => {
       let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
       let loadManager = LoadManager.make()
-      let inMemoryStore = InMemoryStore.make(~entities=Indexer.Generated.configWithoutRegistrations.allEntities)
+      let inMemoryStore = InMemoryStore.make(~entities=(Config.load()).allEntities)
       let getUser = entityId =>
         LoadLayer.loadById(
           ~loadManager,

--- a/scenarios/test_codegen/test/__mocks__/MockConfig.res
+++ b/scenarios/test_codegen/test/__mocks__/MockConfig.res
@@ -5,7 +5,7 @@ let chain1337 = ChainMap.Chain.makeUnsafe(~chainId=1337)
 let getEventConfig = (~config=?, ~contractName, ~eventName, ~chainId=?) => {
   let config = switch config {
   | Some(c) => c
-  | None => Config.load()
+  | None => Config.loadWithoutRegistrations()
   }
   config
   ->Config.getEventConfig(~contractName, ~eventName, ~chainId?)

--- a/scenarios/test_codegen/test/__mocks__/MockConfig.res
+++ b/scenarios/test_codegen/test/__mocks__/MockConfig.res
@@ -2,15 +2,15 @@ let chain1 = ChainMap.Chain.makeUnsafe(~chainId=1)
 let chain137 = ChainMap.Chain.makeUnsafe(~chainId=137)
 let chain1337 = ChainMap.Chain.makeUnsafe(~chainId=1337)
 
-let getEventConfig = (
-  ~config=Indexer.Generated.configWithoutRegistrations,
-  ~contractName,
-  ~eventName,
-  ~chainId=?,
-) =>
+let getEventConfig = (~config=?, ~contractName, ~eventName, ~chainId=?) => {
+  let config = switch config {
+  | Some(c) => c
+  | None => Config.load()
+  }
   config
   ->Config.getEventConfig(~contractName, ~eventName, ~chainId?)
   ->Belt.Option.getExn
+}
 
 let getEvmEventConfig = (~config=?, ~contractName, ~eventName, ~chainId=?) =>
   getEventConfig(~config?, ~contractName, ~eventName, ~chainId?)->(

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -778,12 +778,6 @@ module Source = {
                               JsError.throwWithMessage("Not implemented"),
                             selectedBlockFields: Utils.Set.make(),
                             selectedTransactionFields: Utils.Set.make(),
-                            rebuildWithRegistration: (
-                              ~isWildcard as _,
-                              ~handler as _,
-                              ~contractRegister as _,
-                              ~eventFilters as _,
-                            ) => JsError.throwWithMessage("Not implemented"),
                           }: Internal.evmEventConfig :> Internal.eventConfig),
                           timestamp: item.blockNumber,
                           chain,
@@ -940,11 +934,5 @@ let evmEventConfig = (
     convertHyperSyncEventArgs: _ => JsError.throwWithMessage("Not implemented"),
     selectedBlockFields: Utils.Set.fromArray(blockFieldNames),
     selectedTransactionFields: Utils.Set.fromArray(transactionFieldNames),
-    rebuildWithRegistration: (
-      ~isWildcard as _,
-      ~handler as _,
-      ~contractRegister as _,
-      ~eventFilters as _,
-    ) => JsError.throwWithMessage("Not implemented"),
   }
 }

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -778,6 +778,8 @@ module Source = {
                               JsError.throwWithMessage("Not implemented"),
                             selectedBlockFields: Utils.Set.make(),
                             selectedTransactionFields: Utils.Set.make(),
+                            sighash: "",
+                            indexedParams: [],
                           }: Internal.evmEventConfig :> Internal.eventConfig),
                           timestamp: item.blockNumber,
                           chain,
@@ -934,5 +936,7 @@ let evmEventConfig = (
     convertHyperSyncEventArgs: _ => JsError.throwWithMessage("Not implemented"),
     selectedBlockFields: Utils.Set.fromArray(blockFieldNames),
     selectedTransactionFields: Utils.Set.fromArray(transactionFieldNames),
+    sighash: id,
+    indexedParams: [],
   }
 }

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -1,6 +1,6 @@
 type chainId = Indexer.chainId
 
-let config = Config.load()
+let config = Config.loadWithoutRegistrations()
 
 let entityConfig = (name: Indexer.Entities.name<_>): Internal.entityConfig =>
   config.userEntitiesByName
@@ -201,7 +201,7 @@ module Storage = {
   let toPersistence = (storageMock: t) => {
     {
       ...PgStorage.makePersistenceFromConfig(
-        ~config=Config.load(),
+        ~config=Config.loadWithoutRegistrations(),
         ~storage=storageMock.storage,
       ),
       storageStatus: Ready({
@@ -273,7 +273,7 @@ module Indexer = {
     }
 
     let (postRegistrationConfig, registrations) = await HandlerLoader.registerAllHandlers(
-      ~config=Config.load(),
+      ~config=Config.loadWithoutRegistrations(),
     )
 
     let config = {
@@ -778,6 +778,12 @@ module Source = {
                               JsError.throwWithMessage("Not implemented"),
                             selectedBlockFields: Utils.Set.make(),
                             selectedTransactionFields: Utils.Set.make(),
+                            rebuildWithRegistration: (
+                              ~isWildcard as _,
+                              ~handler as _,
+                              ~contractRegister as _,
+                              ~eventFilters as _,
+                            ) => JsError.throwWithMessage("Not implemented"),
                           }: Internal.evmEventConfig :> Internal.eventConfig),
                           timestamp: item.blockNumber,
                           chain,
@@ -934,5 +940,11 @@ let evmEventConfig = (
     convertHyperSyncEventArgs: _ => JsError.throwWithMessage("Not implemented"),
     selectedBlockFields: Utils.Set.fromArray(blockFieldNames),
     selectedTransactionFields: Utils.Set.fromArray(transactionFieldNames),
+    rebuildWithRegistration: (
+      ~isWildcard as _,
+      ~handler as _,
+      ~contractRegister as _,
+      ~eventFilters as _,
+    ) => JsError.throwWithMessage("Not implemented"),
   }
 }

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -1,6 +1,6 @@
 type chainId = Indexer.chainId
 
-let config = Indexer.Generated.configWithoutRegistrations
+let config = Config.load()
 
 let entityConfig = (name: Indexer.Entities.name<_>): Internal.entityConfig =>
   config.userEntitiesByName
@@ -201,7 +201,7 @@ module Storage = {
   let toPersistence = (storageMock: t) => {
     {
       ...PgStorage.makePersistenceFromConfig(
-        ~config=Indexer.Generated.configWithoutRegistrations,
+        ~config=Config.load(),
         ~storage=storageMock.storage,
       ),
       storageStatus: Ready({
@@ -272,12 +272,12 @@ module Indexer = {
     | Some(_) => ()
     }
 
-    let registrations = await HandlerLoader.registerAllHandlers(
-      ~config=Indexer.Generated.configWithoutRegistrations,
+    let (postRegistrationConfig, registrations) = await HandlerLoader.registerAllHandlers(
+      ~config=Config.load(),
     )
 
     let config = {
-      let config = Indexer.Generated.makeGeneratedConfig()
+      let config = postRegistrationConfig
 
       let chainMap =
         chains

--- a/scenarios/test_codegen/test/rollback/ChainDataHelpers.res
+++ b/scenarios/test_codegen/test/rollback/ChainDataHelpers.res
@@ -13,7 +13,7 @@ let makeTransaction = (~transactionIndex, ~transactionHash) =>
 
 module Gravatar = {
   let contractName = "Gravatar"
-  let chainConfig = (Config.load()).chainMap->ChainMap.get(MockConfig.chain1337)
+  let chainConfig = (Config.loadWithoutRegistrations()).chainMap->ChainMap.get(MockConfig.chain1337)
   let contract = chainConfig.contracts->Array.find(c => c.name == contractName)->Option.getOrThrow
   let defaultAddress = contract.addresses[0]->Option.getOrThrow
 

--- a/scenarios/test_codegen/test/rollback/ChainDataHelpers.res
+++ b/scenarios/test_codegen/test/rollback/ChainDataHelpers.res
@@ -13,8 +13,7 @@ let makeTransaction = (~transactionIndex, ~transactionHash) =>
 
 module Gravatar = {
   let contractName = "Gravatar"
-  let chainConfig =
-    Indexer.Generated.makeGeneratedConfig().chainMap->ChainMap.get(MockConfig.chain1337)
+  let chainConfig = (Config.load()).chainMap->ChainMap.get(MockConfig.chain1337)
   let contract = chainConfig.contracts->Array.find(c => c.name == contractName)->Option.getOrThrow
   let defaultAddress = contract.addresses[0]->Option.getOrThrow
 

--- a/scenarios/test_codegen/test/rollback/MockChainData_test.res
+++ b/scenarios/test_codegen/test/rollback/MockChainData_test.res
@@ -2,7 +2,7 @@ open Vitest
 
 describe("Check that MockChainData works as expected", () => {
   let mockChainDataInit = MockChainData.make(
-    ~chainConfig=(Config.load()).chainMap->ChainMap.get(MockConfig.chain1337),
+    ~chainConfig=(Config.loadWithoutRegistrations()).chainMap->ChainMap.get(MockConfig.chain1337),
     ~maxBlocksReturned=3,
     ~blockTimestampInterval=25,
   )

--- a/scenarios/test_codegen/test/rollback/MockChainData_test.res
+++ b/scenarios/test_codegen/test/rollback/MockChainData_test.res
@@ -2,9 +2,7 @@ open Vitest
 
 describe("Check that MockChainData works as expected", () => {
   let mockChainDataInit = MockChainData.make(
-    ~chainConfig=Indexer.Generated.makeGeneratedConfig().chainMap->ChainMap.get(
-      MockConfig.chain1337,
-    ),
+    ~chainConfig=(Config.load()).chainMap->ChainMap.get(MockConfig.chain1337),
     ~maxBlocksReturned=3,
     ~blockTimestampInterval=25,
   )


### PR DESCRIPTION
## Summary

Refactor how `Config.t` and the exported `indexer` value are constructed. Three threads:

1. **Make `Config` oblivious to handler registrations.** `fromPublic` is now a pure function of the JSON payload (no `HandlerRegister` reads), so `Config.loadWithoutRegistrations` (the renamed `Config.load`) is safely memoized with no invalidation. The old `Config.reset` dance is gone.
2. **Move post-registration enrichment to `HandlerLoader.applyRegistrations`.** After handler modules finish registering, `applyRegistrations` walks `chainMap → contracts → events` and produces a new `Config.t` by spread+override:
   - Fuel events get new `handler` / `contractRegister` / `isWildcard` (+ derived `dependsOnAddresses`).
   - EVM events do the same, and also re-run `LogSelection.parseEventFiltersOrThrow` with the registered `where:` JSON so `getEventFiltersOrThrow` / `filterByAddresses` reflect user-supplied filters. To keep this possible, `Internal.evmEventConfig` now retains `sighash` and `indexedParams`.
   - SVM throws — per-event handlers aren't supported there. A `throwIfSvm` in `Main.getGlobalIndexer::onEventFn` / `contractRegisterFn` fast-fails at the user's call site; `applyRegistrations` keeps the throw as a defensive backstop.
   - Both call sites go through a shared `Internal.dependsOnAddresses(~isWildcard, ~filterByAddresses)` formula.
3. **Lazy `indexer` with getters.** `Main.getGlobalIndexer()` no longer takes `~config`. It returns a null-prototype object where `name`, `description`, `chainIds`, and `chains` are getters that call `Config.loadWithoutRegistrations()` on first access. `chains` is memoized with a local ref (stable identity for `toBe` assertions). Both `onBlock` and `onSlot` are attached unconditionally; error messages read `ecosystem.onBlockMethodName` at call time. The old `Generated` module (JS-Proxy-based `makeLazy`, `configWithoutRegistrations`, etc.) is deleted.

## Notable details

- `Config.fromPublic` drops the unused `~maxAddrInPartition` default; it now reads `Env.maxAddrInPartition` inline.
- `eventParam` / `eventParamComponent` types moved from `EventConfigBuilder` to `Internal` (EventConfigBuilder keeps aliases so existing call sites in `Config.res` and test files are unchanged).
- `Main.res` adds a small `defineValueGetter(obj, name, get)` helper to collapse the four `Utils.Object.defineProperty` + `Utils.magic` erasure sites.
- `TestIndexerWorker.res`, `scenarios/test_codegen/test/**`, and the codegen template all point at `Config.loadWithoutRegistrations` directly.

## Test plan

- [x] `cargo test --lib` → 236/236, Rust snapshots refreshed.
- [x] `pnpm rescript-legacy` clean in `packages/envio` and `scenarios/test_codegen`.
- [x] Focus vitest sweep (EventFilters + Indexer + ChainManager + EventOrigin + LoadLayer + HyperSyncSource + OnBlockSchema + the new `ApplyRegistrations_test`) = **53/53 green**.
- [x] New `scenarios/test_codegen/test/ApplyRegistrations_test.res` directly asserts handler / contractRegister / isWildcard propagation + `dependsOnAddresses` formula.
- [ ] Full `pnpm vitest run` expected to match the pre-PR baseline (env-driven RPC/Hasura test failures unchanged).

## Heads-up

This branch was rebased twice during development onto `claude/refactor-cli-command-structure-SwrBw`. The diff includes hunks from two commits pulled in during those rebases that are **unrelated** to this PR's intent and are already merged upstream:
- `#1138` "Restore @@warning(\"-30\") in Envio.res, treat warning 3 as error" → `packages/envio/rescript.json`, `packages/envio/src/EnvSafe.res`, `packages/envio/src/Envio.res`.
- `#1140` "Upgrade sqlx to 0.8 to silence future-incompat warning" (dep/Cargo.lock only — not in the visible diff).

These should not block review of the refactor.

https://claude.ai/code/session_01UjYn1uxFEqoAs3YeBXV9xF