### PR TITLE
Modernize ReScript bindings to use built-in modules

### DIFF
--- a/packages/envio/rescript.json
+++ b/packages/envio/rescript.json
@@ -16,5 +16,8 @@
     "version": 4
   },
   "bs-dependencies": ["rescript-schema", "@rescript/react"],
-  "bsc-flags": ["-open RescriptSchema"]
+  "bsc-flags": ["-open RescriptSchema"],
+  "warnings": {
+    "error": "+3"
+  }
 }

--- a/packages/envio/src/EnvSafe.res
+++ b/packages/envio/src/EnvSafe.res
@@ -9,7 +9,7 @@
 
 module Stdlib = {
   module Dict = {
-    @get_index external get: (Js.Dict.t<'a>, string) => option<'a> = ""
+    @get_index external get: (dict<'a>, string) => option<'a> = ""
   }
 
   module Option = {
@@ -39,7 +39,7 @@ module Stdlib = {
     @new
     external makeTypeError: string => error = "TypeError"
 
-    let raiseError = (error: error): 'a => error->magic->raise
+    let raiseError = (error: error): 'a => error->magic->throw
   }
 }
 
@@ -49,7 +49,7 @@ module Error = {
     Stdlib.Exn.raiseError(Stdlib.Exn.makeError(`[rescript-envsafe] ${message}`))
 }
 
-type env = Js.Dict.t<string>
+type env = dict<string>
 type invalidIssue = {name: string, error: S.error, input: option<string>}
 type missingIssue = {name: string, input: option<string>}
 type t = {
@@ -62,19 +62,19 @@ type t = {
 module Env = {
   @val
   external // FIXME: process might be missing
-  default: Js.Dict.t<string> = "process.env"
+  default: dict<string> = "process.env"
 }
 
 let mixinMissingIssue = (envSafe, issue) => {
   switch envSafe.maybeMissingIssues {
-  | Some(missingIssues) => missingIssues->Js.Array2.push(issue)->ignore
+  | Some(missingIssues) => missingIssues->Array.push(issue)->ignore
   | None => envSafe.maybeMissingIssues = Some([issue])
   }
 }
 
 let mixinInvalidIssue = (envSafe, issue: invalidIssue) => {
   switch envSafe.maybeInvalidIssues {
-  | Some(invalidIssues) => invalidIssues->Js.Array2.push(issue)->ignore
+  | Some(invalidIssues) => invalidIssues->Array.push(issue)->ignore
   | None => envSafe.maybeInvalidIssues = Some([issue])
   }
 }
@@ -96,17 +96,17 @@ let close = envSafe => {
         let output = [line]
 
         maybeInvalidIssues->Stdlib.Option.forEach(invalidIssues => {
-          output->Js.Array2.push("❌ Invalid environment variables:")->ignore
-          invalidIssues->Js.Array2.forEach(issue => {
-            output->Js.Array2.push(`    ${issue.name}: ${issue.error->S.Error.message}`)->ignore
+          output->Array.push("❌ Invalid environment variables:")->ignore
+          invalidIssues->Array.forEach(issue => {
+            output->Array.push(`    ${issue.name}: ${issue.error->S.Error.message}`)->ignore
           })
         })
 
         maybeMissingIssues->Stdlib.Option.forEach(missingIssues => {
-          output->Js.Array2.push("💨 Missing environment variables:")->ignore
-          missingIssues->Js.Array2.forEach(issue => {
+          output->Array.push("💨 Missing environment variables:")->ignore
+          missingIssues->Array.forEach(issue => {
             output
-            ->Js.Array2.push(
+            ->Array.push(
               `    ${issue.name}: ${switch issue.input {
                 | Some("") => "Disallowed empty string"
                 | _ => "Missing value"
@@ -116,11 +116,11 @@ let close = envSafe => {
           })
         })
 
-        output->Js.Array2.push(line)->ignore
-        output->Js.Array2.joinWith("\n")
+        output->Array.push(line)->ignore
+        output->Array.joinUnsafe("\n")
       }
 
-      Js.Console.error(text)
+      Console.error(text)
       Stdlib.Window.alert(text)
       Stdlib.Exn.raiseError(Stdlib.Exn.makeTypeError(text))
     }
@@ -142,7 +142,7 @@ let boolCoerce = string =>
 
 let numberCoerce = string => {
   let float = %raw(`+string`)
-  if Js.Float.isNaN(float) {
+  if Float.isNaN(float) {
     string
   } else {
     float->magic
@@ -150,13 +150,13 @@ let numberCoerce = string => {
 }
 
 let bigintCoerce = string => {
-  try string->Js.BigInt.fromStringExn->magic catch {
+  try string->BigInt.fromStringOrThrow->magic catch {
   | _ => string
   }
 }
 
 let jsonCoerce = string => {
-  try string->Js.Json.parseExn->magic catch {
+  try string->JSON.parseOrThrow->magic catch {
   | _ => string
   }
 }

--- a/packages/envio/src/Envio.res
+++ b/packages/envio/src/Envio.res
@@ -59,6 +59,7 @@ type logger = {
   errorWithExn: (string, exn) => unit,
 }
 
+@@warning("-30") // Duplicated type names (input)
 type rec effect<'input, 'output>
 @unboxed
 and rateLimitDuration =
@@ -90,6 +91,7 @@ and effectArgs<'input> = {
   input: 'input,
   context: effectContext,
 }
+@@warning("+30")
 
 let durationToMs = (duration: rateLimitDuration) =>
   switch duration {


### PR DESCRIPTION
## Summary
This PR modernizes the ReScript codebase by replacing deprecated `Js.*` bindings with their built-in ReScript equivalents, improving code compatibility with newer ReScript versions.

## Key Changes
- **Type annotations**: Replaced `Js.Dict.t<'a>` with `dict<'a>` throughout the codebase
- **Array operations**: Migrated from `Js.Array2` methods to built-in `Array` module:
  - `Js.Array2.push()` → `Array.push()`
  - `Js.Array2.forEach()` → `Array.forEach()`
  - `Js.Array2.joinWith()` → `Array.joinUnsafe()`
- **Console operations**: Changed `Js.Console.error()` to `Console.error()`
- **Numeric operations**: Replaced `Js.Float.isNaN()` with `Float.isNaN()`
- **BigInt operations**: Updated `Js.BigInt.fromStringExn()` to `BigInt.fromStringOrThrow()`
- **JSON operations**: Changed `Js.Json.parseExn()` to `JSON.parseOrThrow()`
- **Exception handling**: Updated `raise` to `throw` in error handling code
- **Compiler configuration**: Added warning configuration to treat warning 3 as an error in `rescript.json`
- **Warning suppression**: Added targeted `@@warning` directives to suppress warning 30 (duplicated type names) for the `effect` and `rateLimitDuration` type definitions

## Notable Details
These changes align with ReScript's modern standard library, which provides these utilities as built-in modules rather than JavaScript bindings. The updates maintain full backward compatibility while improving code clarity and reducing reliance on the `Js` namespace.

https://claude.ai/code/session_014R1BDyCP2ohQoRziwaqQW8