### PR TITLE
Improve ClickHouse env var validation to report all missing vars

### DIFF
--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1699,7 +1699,7 @@ let makeStorageFromEnv = (
           JsError.throwWithMessage(
             `ClickHouse storage is enabled but required env vars are not set: ${missing->Array.joinUnsafe(
                 ", ",
-              )}. Please set them or disable clickhouse in the \`storage\` config.`,
+              )}. Please set them, disable clickhouse in the \`storage\` config, or run \`envio dev\` for a pre-configured local ClickHouse.`,
           )
         }
         Some(

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1686,20 +1686,28 @@ let makeStorageFromEnv = (
       // Postgres storage. Required env vars are validated here only when
       // the user opts in via `storage.clickhouse: true` in config.yaml.
       if config.storage.clickhouse {
-        let requireEnv = (opt, name) =>
+        let missing = []
+        let checkEnv = (opt, name) =>
           switch opt {
-          | Some(v) => v
-          | None =>
-            JsError.throwWithMessage(
-              `ClickHouse storage is enabled but required env var ${name} is not set. Please set it or disable clickhouse in the \`storage\` config.`,
-            )
+          | Some(_) => ()
+          | None => missing->Array.push(name)->ignore
           }
+        Env.ClickHouse.host->checkEnv("ENVIO_CLICKHOUSE_HOST")
+        Env.ClickHouse.username->checkEnv("ENVIO_CLICKHOUSE_USERNAME")
+        Env.ClickHouse.password->checkEnv("ENVIO_CLICKHOUSE_PASSWORD")
+        if missing->Array.length > 0 {
+          JsError.throwWithMessage(
+            `ClickHouse storage is enabled but required env vars are not set: ${missing->Array.joinUnsafe(
+                ", ",
+              )}. Please set them or disable clickhouse in the \`storage\` config.`,
+          )
+        }
         Some(
           Sink.makeClickHouse(
-            ~host=Env.ClickHouse.host->requireEnv("ENVIO_CLICKHOUSE_HOST"),
+            ~host=Env.ClickHouse.host->Option.getUnsafe,
             ~database=Env.ClickHouse.database,
-            ~username=Env.ClickHouse.username->requireEnv("ENVIO_CLICKHOUSE_USERNAME"),
-            ~password=Env.ClickHouse.password->requireEnv("ENVIO_CLICKHOUSE_PASSWORD"),
+            ~username=Env.ClickHouse.username->Option.getUnsafe,
+            ~password=Env.ClickHouse.password->Option.getUnsafe,
           ),
         )
       } else {

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -943,7 +943,7 @@ describe("PgStorage.makeStorageFromEnv ClickHouse env var validation", () => {
         message,
         ~message="Should throw a helpful error naming every missing env var at once",
       ).toBe(
-        "ClickHouse storage is enabled but required env vars are not set: ENVIO_CLICKHOUSE_HOST, ENVIO_CLICKHOUSE_USERNAME, ENVIO_CLICKHOUSE_PASSWORD. Please set them or disable clickhouse in the `storage` config.",
+        "ClickHouse storage is enabled but required env vars are not set: ENVIO_CLICKHOUSE_HOST, ENVIO_CLICKHOUSE_USERNAME, ENVIO_CLICKHOUSE_PASSWORD. Please set them, disable clickhouse in the `storage` config, or run `envio dev` for a pre-configured local ClickHouse.",
       )
     },
   )

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -918,12 +918,12 @@ GROUP BY "chain_id";`
 })
 
 describe("PgStorage.makeStorageFromEnv ClickHouse env var validation", () => {
-  // Exercises the requireEnv path in makeStorageFromEnv that's only taken
+  // Exercises the validation path in makeStorageFromEnv that's only taken
   // when `storage.clickhouse: true` in config.yaml. The test suite does not
   // set any ENVIO_CLICKHOUSE_* vars, so this should throw a user-friendly
-  // error pointing at the first missing one (ENVIO_CLICKHOUSE_HOST).
+  // error listing every missing required env var in a single message.
   Async.it(
-    "Throws when storage.clickhouse=true but ENVIO_CLICKHOUSE_HOST is missing",
+    "Throws listing all missing ENVIO_CLICKHOUSE_* env vars when storage.clickhouse=true",
     async t => {
       let config = {
         ...MockIndexer.config,
@@ -941,8 +941,10 @@ describe("PgStorage.makeStorageFromEnv ClickHouse env var validation", () => {
       }
       t.expect(
         message,
-        ~message="Should throw a helpful error naming the missing env var",
-      ).toMatch(%re(`/ClickHouse storage is enabled.*ENVIO_CLICKHOUSE_HOST/`))
+        ~message="Should throw a helpful error naming every missing env var at once",
+      ).toBe(
+        "ClickHouse storage is enabled but required env vars are not set: ENVIO_CLICKHOUSE_HOST, ENVIO_CLICKHOUSE_USERNAME, ENVIO_CLICKHOUSE_PASSWORD. Please set them or disable clickhouse in the `storage` config.",
+      )
     },
   )
 


### PR DESCRIPTION
## Summary
Improved the ClickHouse environment variable validation to collect and report all missing required variables in a single error message, rather than failing on the first missing variable.

## Key Changes
- Refactored `requireEnv` function into a `checkEnv` function that collects missing variable names instead of throwing immediately
- Changed validation logic to check all three required ClickHouse env vars (HOST, USERNAME, PASSWORD) before throwing an error
- Updated error message to list all missing variables at once and provide additional guidance about using `envio dev` for a pre-configured local ClickHouse
- Updated corresponding test to verify the new behavior: expects a single error message listing all three missing variables instead of failing on the first one

## Implementation Details
- Uses an array to accumulate missing variable names during validation
- Only throws an error if the array is non-empty after all checks
- Uses `Option.getUnsafe` after validation since we've already confirmed the values exist
- Updated test assertion from regex matching to exact string comparison to verify the complete error message

https://claude.ai/code/session_01RKPzgf492dbudxzHDhRJHc