### PR TITLE
Trim comments per CLAUDE.md rules

### DIFF
--- a/packages/cli/src/executor/mod.rs
+++ b/packages/cli/src/executor/mod.rs
@@ -17,36 +17,30 @@ use anyhow::{Context, Result};
 use schemars::schema_for;
 
 /// A deferred work item the executor asks its host to run after Rust returns.
-///
-/// Rust handles config parsing, codegen, docker, persisted state — everything
-/// that doesn't need JS. Work that must run in the JS event loop (migrations,
-/// indexer start — anything that loads `envio/src/*.res.mjs` modules) is
-/// returned as a `Command`. The CLI layer knows nothing about how the host
-/// dispatches it: the NAPI shim forwards it to JS, a test harness could
-/// run it inline, a future standalone binary could spawn a Node subprocess,
-/// etc.
+/// Anything that must run in the JS event loop — migrations, indexer start,
+/// anything that loads `envio/src/*.res.mjs` — is encoded as a `Command`.
 ///
 /// Wire format: serde-tagged JSON on the `kind` field.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum Command {
-    /// Run the indexer. If `migrate` is `Some`, also run the migration as
-    /// part of the same persistence initialization (single `init()` call).
+    /// `migrate: Some` folds the migration into the same `init()` call as
+    /// the indexer startup.
     Start {
         migrate: Option<MigrateOpts>,
         cwd: String,
         env: serde_json::Map<String, serde_json::Value>,
         config: serde_json::Value,
     },
-    /// Run migrations without starting the indexer (`local db up`, `local db setup`).
     Migrate {
         reset: bool,
         #[serde(rename = "persistedState")]
         persisted_state: PersistedState,
         config: serde_json::Value,
     },
-    /// Drop the schema (`local db down`).
-    DropSchema { config: serde_json::Value },
+    DropSchema {
+        config: serde_json::Value,
+    },
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -56,17 +50,14 @@ pub struct MigrateOpts {
     pub persisted_state: PersistedState,
 }
 
-/// `envio_package_dir` is the absolute path of the running envio JS package
-/// when this executor is invoked via NAPI (the JS host resolves it from
-/// `import.meta.url`). Used only to stamp the `envio` `file:{dir}` dep
-/// into generated / init project `package.json`s for dev builds. `None`
-/// is fine for commands that don't call `get_envio_version` (e.g.
-/// `script` subcommands); init/codegen/dev/start on a dev build without
-/// it will error out of `get_envio_version`.
+/// `envio_package_dir` is only consumed by `get_envio_version` on dev builds
+/// (to stamp the `envio` `file:{dir}` dep into generated / init
+/// `package.json`s). Commands that don't call it — `script` subcommands —
+/// may pass `None`; init/codegen/dev/start on a dev build without it will
+/// error out of `get_envio_version`.
 ///
-/// Returns `None` for commands that finish entirely in Rust (codegen, init,
-/// stop, docker up/down, help/version, scripts). The NAPI shim maps `None`
-/// to a JS `null`, signalling the JS host to exit cleanly.
+/// Returns `None` for commands that finish entirely in Rust. The NAPI shim
+/// forwards that to JS as `null` so the host exits cleanly.
 pub async fn execute(
     command_line_args: CommandLineArgs,
     envio_package_dir: Option<&str>,
@@ -187,9 +178,7 @@ pub async fn execute(
     }
 }
 
-/// Build a `Start` command payload. The indexer's entry is `Main.start` in the
-/// envio runtime — Bin.res calls it directly, so Rust no longer computes an
-/// indexer module path. `ENVIO_CONFIG` is always present in `env`; callers may
+/// `ENVIO_CONFIG` is always present in the returned `env`; callers may
 /// append extra env pairs (e.g. `ENVIO_DEV_MODE` for `envio dev`).
 pub fn build_start_command(
     config: &SystemConfig,
@@ -219,9 +208,8 @@ pub fn build_start_command(
     })
 }
 
-/// Parse the config JSON (a string) into a `serde_json::Value` so it
-/// serializes as a nested JSON object in the command payload. Bin.res then
-/// passes it to `Config.prime` without an extra `JSON.parse`.
+/// Returns a `Value` (not a string) so the serde payload embeds the config
+/// as a nested JSON object — the JS side then skips the extra `JSON.parse`.
 pub fn public_config_value(config: &SystemConfig) -> Result<serde_json::Value> {
     serde_json::from_str(&config.to_public_config_json()?)
         .context("Failed parsing public config JSON")

--- a/packages/cli/src/napi.rs
+++ b/packages/cli/src/napi.rs
@@ -26,8 +26,7 @@ pub fn get_config_json(
         .map_err(|e| napi::Error::from_reason(format!("Failed serializing config: {e}")))
 }
 
-/// Upsert persisted state to the database.
-/// Called from JS after migrations have run (tables exist).
+/// Requires the migration tables to already exist.
 #[napi_derive::napi]
 pub async fn upsert_persisted_state(json: String) -> napi::Result<()> {
     let state: crate::persisted_state::PersistedState = serde_json::from_str(&json)
@@ -39,15 +38,9 @@ pub async fn upsert_persisted_state(json: String) -> napi::Result<()> {
     Ok(())
 }
 
-/// Run the envio CLI. Returns a JSON-encoded `Command` for JS to dispatch, or
-/// `None` when there's nothing left for JS to do — the Node process exits
-/// naturally with code 0 (covers `--help`/`--version` and commands like
-/// `envio codegen` / `envio init` / `envio stop` / `local docker up|down`
-/// that finish entirely in Rust).
-///
-/// The executor layer doesn't know about NAPI; it returns an
-/// `Option<Command>` that this shim serializes for the JS host. A pure-Rust
-/// host (tests, future binary) could consume the same return value directly.
+/// Returns a JSON-encoded `Command` for JS to dispatch, or `None` when
+/// Rust has handled the command end-to-end (help/version, codegen, init,
+/// stop, docker up/down). The Node process then exits with code 0.
 #[napi_derive::napi]
 pub async fn run_cli(
     args: Vec<String>,

--- a/packages/envio/src/Bin.res
+++ b/packages/envio/src/Bin.res
@@ -8,14 +8,12 @@ NodeJs.globalProcess->NodeJs.onUnhandledRejection(reason => {
   NodeJs.process->NodeJs.exitWithCode(Failure)
 })
 
-// Wire format mirrors the Rust `executor::Command` enum: a tagged JSON object
-// with a `kind` discriminator. `Bin.res` decodes once and dispatches to the
-// matching `Main.*` entry point — there's no per-step queue.
-// `migrate` is `Null.t` (not `option`) because Rust's serde encodes
-// `Option::None` as JSON `null`, and `Utils.magic` casts straight through.
-// ReScript's `option` expects `undefined` for `None`, so a `null` value
-// would wrongly pass `Option.map`'s `!== undefined` check. Callers
-// convert with `Null.toOption` at use time.
+// Wire format mirrors the Rust `executor::Command` enum — a tagged JSON
+// object with a `kind` discriminator.
+// `migrate` is `Null.t`, not `option`: Rust serde encodes `None` as JSON
+// `null`, but ReScript's `option` expects `undefined`, so a `null` value
+// wrongly passes `Option.map`'s `!== undefined` check. Callers convert via
+// `Null.toOption` at use time.
 type startCmd = {
   migrate: Null.t<Main.migrateOpts>,
   cwd: string,

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -19,7 +19,7 @@ type contract = {
   eventSignatures: array<string>,
 }
 
-// Source config parsed from `envio config view` - sources are created lazily in ChainFetcher
+// Sources are instantiated lazily in ChainFetcher from this config.
 type evmRpcConfig = {
   url: string,
   sourceFor: Source.sourceFor,
@@ -152,7 +152,6 @@ module EnvioAddresses = {
   }->Internal.fromGenericEntityConfig
 }
 
-// Types for parsing source config from the JSON emitted by `envio config view`
 type rpcSourceFor = | @as("sync") Sync | @as("fallback") Fallback | @as("live") Live
 
 let rpcSourceForSchema = S.enum([Sync, Fallback, Live])
@@ -852,11 +851,9 @@ let getChain = (config, ~chainId) => {
       )
 }
 
-// When the CLI hands us a command, the Rust side already parsed the config
-// and embedded the resolved JSON in the payload. `Bin.res` calls `prime`
-// with that JSON before dispatching to `Main.start` / `Main.migrate` /
-// `Main.dropSchema`, so those functions skip the NAPI `getConfigJson`
-// round-trip. Module-private — only Bin.res should set it.
+// A CLI command payload already contains the resolved JSON; priming lets
+// downstream callers skip the NAPI `getConfigJson` round-trip. Calling
+// `prime` again invalidates the memo.
 %%private(let primedJson: ref<option<JSON.t>> = ref(None))
 %%private(let cached: ref<option<t>> = ref(None))
 let prime = (json: JSON.t): unit => {
@@ -864,23 +861,10 @@ let prime = (json: JSON.t): unit => {
   cached := None
 }
 
-// Load the base indexer config — no handler registrations applied. When
-// `Bin.res` has primed a JSON payload from the CLI command, parse from
-// that; otherwise invoke the native NAPI addon (Rust config parser,
-// ENVIO_CONFIG-respecting). The NAPI path keeps non-CLI callers (worker
-// threads spawned via `TestIndexer`, direct imports from test harnesses)
-// working without a primed payload.
-//
-// The `Config` module deliberately knows nothing about handler
-// registrations: the returned value is a pure function of the JSON, so
-// memoization is safe without invalidation. Post-registration configs are
-// produced by `HandlerLoader.applyRegistrations`, which folds the
-// registered handler state into each event (via spread+override for
-// EVM/Fuel; SVM doesn't support per-event handlers).
-//
-// `prime` must be called before the first `loadWithoutRegistrations` read
-// if a primed JSON is going to be used; calling `prime` later invalidates
-// the memo so subsequent reads reparse.
+// The returned value is a pure function of the JSON — no handler
+// registrations are applied here. Post-registration configs come from
+// `HandlerLoader.applyRegistrations`. That purity is what lets this
+// memoize without invalidation.
 let loadWithoutRegistrations = () =>
   switch cached.contents {
   | Some(c) => c

--- a/packages/envio/src/Core.res
+++ b/packages/envio/src/Core.res
@@ -1,10 +1,8 @@
-// Bindings to the native envio NAPI addon.
-//
 // Resolution order:
 //   1. Production: require("envio-{os}-{arch}") — platform-specific npm package
 //   2. Dev build:  find repo → cargo build --lib → load from target/debug/
 
-// NAPI returns `null | T` (never `undefined`) for Rust `Option<T>`, so the
+// NAPI encodes Rust `Option<T>` as `null | T` (never `undefined`), so the
 // tighter `Null.t` captures the exact boundary shape.
 type addon = {
   getConfigJson: (~configPath: Null.t<string>, ~directory: Null.t<string>) => string,
@@ -23,8 +21,8 @@ external execSyncRaw: (string, {..}) => string = "execSync"
 @val external processPlatform: string = "process.platform"
 @val external processArch: string = "process.arch"
 
-// No-ops keep the `node:fs` / `node:child_process` imports alive for the
-// %raw loadDevAddon block, which references them as Nodefs / Nodechild_process.
+// Keeps `node:fs` / `node:child_process` imports alive for the %raw
+// loadDevAddon block, which references them as Nodefs / Nodechild_process.
 let _keepFs = existsSync
 let _keepCp = execSyncRaw
 
@@ -32,8 +30,7 @@ let callRequire: ({..}, string) => addon = %raw(`(req, id) => req(id)`)
 
 let envioPackageDir = pathDirname(pathDirname(fileURLToPath(importMetaUrl)))
 
-// Local dev: find repo root, cargo build, load from target/debug/.
-// Runs cargo build on every invocation (like cargo run).
+// Runs `cargo build` on every invocation (like `cargo run`).
 let loadDevAddon: ({..}, string) => addon = %raw(`function(req, envioDir) {
   var cp = Nodechild_process;
   var path = Nodepath;

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -72,15 +72,10 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
   ->Promise.all
 }
 
-// Produce a post-registration Config.t by walking the chainMap and folding
-// the just-registered handler state into each event. Fuel keeps all its
-// fields from build time and only overrides the three registration fields
-// (+ `dependsOnAddresses`). EVM also re-runs `parseEventFiltersOrThrow` with
-// the newly-registered `where:` JSON so per-event filters propagate into
-// `getEventFiltersOrThrow` / `filterByAddresses` — that's why
-// `evmEventConfig` retains `sighash` and `indexedParams`.
-//
-// `dependsOnAddresses` goes through `Internal.dependsOnAddresses` so the
+// EVM re-runs `parseEventFiltersOrThrow` with the registered `where:` JSON so
+// per-event filters propagate into `getEventFiltersOrThrow` / `filterByAddresses`
+// — which is why `evmEventConfig` has to retain `sighash` and `indexedParams`.
+// `dependsOnAddresses` is routed through `Internal.dependsOnAddresses` so the
 // formula stays in sync with `EventConfigBuilder.build{Evm,Fuel}EventConfig`.
 let applyRegistrations = (~config: Config.t): Config.t => {
   let newChainMap = config.chainMap->ChainMap.map(chain => {
@@ -158,13 +153,8 @@ let applyRegistrations = (~config: Config.t): Config.t => {
   {...config, chainMap: newChainMap}
 }
 
-// Register all handlers and return `(configWithRegistrations, registrations)`.
-// The input `~config` is the pre-registration snapshot (from
-// `Config.loadWithoutRegistrations`); the returned config applies
-// `HandlerRegister` state to each event via `applyRegistrations` above.
-// `Config` itself never reads `HandlerRegister` — the knowledge of
-// "post-registration config" lives here and flows to downstream callers via
-// the return value.
+// `Config` never reads `HandlerRegister`. The only way to get a config that
+// reflects registration state is through the returned value here.
 let registerAllHandlers = async (~config: Config.t) => {
   HandlerRegister.startRegistration(~ecosystem=config.ecosystem, ~multichain=config.multichain)
 

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -99,9 +99,8 @@ let getInitialChainState = (~chainId: int): option<Persistence.initialChainState
   }
 }
 
-// Build the chains object from config. Extracted so the exported indexer
-// value can call this lazily (on first `indexer.chains` access) rather than
-// eagerly at module load — importing `generated` must not trigger Config.loadWithoutRegistrations().
+// Importing `generated` must not trigger `Config.loadWithoutRegistrations()`,
+// so the exported indexer calls this lazily on first `indexer.chains` access.
 let buildChainsObject = (~config: Config.t) => {
   let chainIds = []
   let chains = Utils.Object.createNullObject()
@@ -241,9 +240,7 @@ let buildChainsObject = (~config: Config.t) => {
   (chains, chainIds)
 }
 
-// Attach an enumerable property whose value is produced lazily on read.
-// Wraps `Utils.Object.defineProperty` + the `Utils.magic` erasure required
-// by the getter signature (`unknown`) so getter call sites stay terse.
+// The `Utils.magic` erasure is what the getter signature (`unknown`) demands.
 let defineValueGetter = (obj, name, get: unit => 'a) =>
   obj->Utils.Object.defineProperty(
     name,
@@ -483,11 +480,9 @@ let getGlobalIndexer = (): 'indexer => {
     }
   }
 
-  // Attach both `onBlock` (EVM/Fuel) and `onSlot` (SVM) unconditionally.
-  // The property name is ecosystem-dependent and we don't want to load
-  // config at `getGlobalIndexer()` call time; each invocation of the shared
-  // handler reads `ecosystem.onBlockMethodName` at call time so user-facing
-  // error messages still cite the name that matches their ecosystem.
+  // Attach `onBlock` and `onSlot` unconditionally so `getGlobalIndexer()`
+  // needn't load config; the handler reads `ecosystem.onBlockMethodName` at
+  // call time so error messages cite the ecosystem-appropriate name.
   indexer
   ->Utils.Object.definePropertyWithValue("onEvent", {enumerable: true, value: onEventFn})
   ->Utils.Object.definePropertyWithValue(
@@ -626,8 +621,7 @@ let start = async (
 
   // Initialize persistence first so the exported indexer value contains state from the database
   // when handler files are loaded (they may access the indexer at module top level).
-  // `migrate`, when provided, folds the DB setup into this single `init()` call
-  // (no separate `db setup` → `start` double-init).
+  // `migrate`, when provided, folds the DB setup into the same `init()` call.
   let configWithoutRegistrations = Config.loadWithoutRegistrations()
   let persistence = switch persistence {
   | Some(p) => p
@@ -644,10 +638,9 @@ let start = async (
   | None => ()
   }
 
-  // Register all handlers. The returned config has handler/contractRegister/
-  // eventFilters baked into each event config. Downstream code uses this
-  // enriched value; `Config.loadWithoutRegistrations` itself never sees
-  // registration state.
+  // `Config.loadWithoutRegistrations` never sees registration state; handler,
+  // contractRegister, and eventFilters are baked into each event config only
+  // by the returned value here.
   let (config, registrations) = await HandlerLoader.registerAllHandlers(
     ~config=configWithoutRegistrations,
   )


### PR DESCRIPTION
## Summary

Applies CLAUDE.md's comment rules to the new code in #1116. The rules: no comments that restate what well-named code already says, no narration of the refactor itself, only keep comments that capture a non-obvious constraint or invariant.

## Changes

- **`packages/envio/src/Config.res`** — drop stale `envio config view` references (the command was removed in this PR); compress the `prime` / `loadWithoutRegistrations` docstrings to the invariants (purity + memoization safety).
- **`packages/envio/src/Main.res`** — drop "Extracted so…" and function-purpose restatements (`buildChainsObject`, `defineValueGetter`). Shorten the `onBlock/onSlot` and `registerAllHandlers`-callsite comments to the actual invariant.
- **`packages/envio/src/HandlerLoader.res`** — on `applyRegistrations`, drop the opening paragraph that walks through what the code already shows; keep the EVM event-filter rationale and the `dependsOnAddresses` sync note. On `registerAllHandlers`, keep only the `Config`-never-sees-`HandlerRegister` invariant.
- **`packages/envio/src/Bin.res`** — drop "there's no per-step queue" (implicit refactor narration); keep the `Null.t` vs `option` constraint.
- **`packages/envio/src/Core.res`** — drop the "Bindings to …" header restatement and pre-function narration; keep the resolution-order list and the `Null.t` boundary note.
- **`packages/cli/src/executor/mod.rs`** — drop docstrings on `Migrate` / `DropSchema` that restate the variant; rewrite `build_start_command` and `public_config_value` docstrings to state the invariant instead of narrating the refactor.
- **`packages/cli/src/napi.rs`** — drop caller description on `upsert_persisted_state`; trim `run_cli` to the actual contract.

Net: **55 insertions, 112 deletions**.

## Test plan

- [x] `cargo build --lib`
- [x] `pnpm rescript-legacy` (packages/envio)

https://claude.ai/code/session_01As8Vehnjkp6FZaCRiBapMY

---
_Generated by [Claude Code](https://claude.ai/code/session_01As8Vehnjkp6FZaCRiBapMY)_