### PR TITLE
Prevent silent database wipes on incompatible schema changes

### DIFF
--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -248,7 +248,7 @@ Development commands for starting, stopping, and restarting the indexer with aut
 
 ###### **Options:**
 
-* `-r`, `--restart` — Force restart: clear the database and re-index from scratch. Dev mode restarts automatically on config/schema changes, use this flag when you need a restart without making changes
+* `-r`, `--restart` — Force restart: clear the database and re-index from scratch. Required when config/schema/ABI changes are incompatible with the existing indexer state
 
 
 

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -87,7 +87,7 @@ pub enum JsonSchema {
 
 #[derive(Debug, Args)]
 pub struct DevArgs {
-    ///Force restart: clear the database and re-index from scratch. Dev mode restarts automatically on config/schema changes, use this flag when you need a restart without making changes
+    ///Force restart: clear the database and re-index from scratch. Required when config/schema/ABI changes are incompatible with the existing indexer state.
     #[arg(short = 'r', long, action)]
     pub restart: bool,
 }

--- a/packages/cli/src/executor/dev.rs
+++ b/packages/cli/src/executor/dev.rs
@@ -97,36 +97,43 @@ pub async fn run_dev(project_paths: ParsedProjectPaths, restart: bool) -> Result
         )
     };
 
-    let (should_run_db_migrations, changes_detected) = match &persisted_state_db {
-        None => (true, vec![]),
-        Some(PersistedStateExists::Exists(persisted_state)) =>
-        //In the case where the persisted state exists, compare it to current state
-        //determine whether to run migrations and which changes have occured to
-        //cause that.
-        {
-            let (should_run_db_migrations, changes_detected) =
-                current_state.should_run_db_migrations(persisted_state);
+    // When the DB already has indexer state for this project, refuse to silently
+    // wipe it — the user must explicitly opt in with `envio dev -r`.
+    if let Some(PersistedStateExists::Exists(persisted_state)) = &persisted_state_db {
+        let (_, changes_detected) = current_state.should_run_db_migrations(persisted_state);
+        if !changes_detected.is_empty() {
+            let fields = changes_detected
+                .iter()
+                .map(|f| f.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(anyhow!(
+                "Incompatible change detected in {fields}. Reverse the changes to continue \
+                 indexing with the existing state, or run `envio dev -r` to clear the database \
+                 and re-index from scratch."
+            ));
+        }
+    }
 
-            (should_run_db_migrations, changes_detected)
+    let needs_migration = match &persisted_state_db {
+        None => {
+            println!("Resetting the database for a fresh indexer run");
+            true
         }
-        //Otherwise we should run db migrations
-        Some(PersistedStateExists::NotExists) | Some(PersistedStateExists::Corrupted) => {
-            (true, vec![])
+        Some(PersistedStateExists::NotExists) => {
+            println!("No existing database schema found — creating one");
+            true
         }
+        Some(PersistedStateExists::Corrupted) => {
+            println!("Could not read the previous indexer state from the database — resetting");
+            true
+        }
+        // `Exists` with a diff returned above; this arm means no diff, so the
+        // existing indexer state is reused and no migrations are needed.
+        Some(PersistedStateExists::Exists(_)) => false,
     };
 
-    let migrate = if should_run_db_migrations {
-        match persisted_state_db {
-            None => println!("Resetting the database for a fresh indexer run"),
-            Some(PersistedStateExists::NotExists) => {
-                println!("No existing database schema found — creating one")
-            }
-            Some(PersistedStateExists::Corrupted) => {
-                println!("Could not read the previous indexer state from the database — resetting")
-            }
-            Some(PersistedStateExists::Exists(_)) => print_changes_detected(changes_detected),
-        }
-
+    let migrate = if needs_migration {
         Some(MigrateOpts {
             // `envio dev` always does a full reset when migrations are needed
             // (matches prior behavior of `run_db_setup`).


### PR DESCRIPTION
## Summary
This PR changes the behavior of `envio dev` to prevent silently wiping the database when incompatible schema/config/ABI changes are detected. Instead of automatically running migrations, the command now fails with a helpful error message directing users to either revert their changes or explicitly use `envio dev -r` to clear the database.

## Key Changes
- **Early validation**: Added an upfront check that returns an error if incompatible changes are detected in an existing persisted state, before any migrations occur
- **Improved error messaging**: Users now receive a clear error message listing which fields changed and instructing them on how to proceed
- **Simplified migration logic**: Refactored the migration decision logic from a complex match expression into a cleaner `needs_migration` boolean that only handles the three cases where migrations should actually run (no state, missing schema, or corrupted state)
- **Updated documentation**: Updated CLI help text and argument descriptions to reflect that the `-r/--restart` flag is now required when schema/config/ABI changes are incompatible with existing state

## Implementation Details
- The validation happens early in the `run_dev` function, before any database operations
- When incompatible changes are detected, the function returns immediately with an `anyhow!` error
- The migration logic now explicitly handles the "Exists with no changes" case by returning `false` for `needs_migration`, ensuring existing indexer state is preserved
- Error messages are user-friendly and actionable, listing the specific fields that changed

https://claude.ai/code/session_01V9kw9xxNgMtdWmkJuFe2cW