### PR TITLE
Move rescript to devDependencies and enforce in build verification

### DIFF
--- a/packages/build-envio/src/build-artifact.ts
+++ b/packages/build-envio/src/build-artifact.ts
@@ -73,6 +73,7 @@ export function buildPackageJson(
   pkg.version = version;
   delete pkg.private;
   delete pkg.scripts;
+  delete pkg.devDependencies;
 
   pkg.bin = "./bin.mjs";
 

--- a/packages/build-envio/src/verify-artifact.ts
+++ b/packages/build-envio/src/verify-artifact.ts
@@ -71,6 +71,11 @@ function verify(dir: string): void {
       if (pkg.bin !== "./bin.mjs") errors.push(`package.json bin is "${pkg.bin}", expected "./bin.mjs"`);
       if (!pkg.optionalDependencies) errors.push("package.json missing optionalDependencies");
       if (!pkg.dependencies) errors.push("package.json missing dependencies");
+      if (pkg.devDependencies) errors.push("package.json still has devDependencies");
+      const deps = pkg.dependencies as Record<string, unknown> | undefined;
+      if (deps && "rescript" in deps) {
+        errors.push("package.json dependencies must not include 'rescript' (compiler is build-time only)");
+      }
     }
   }
 

--- a/packages/envio/package.json
+++ b/packages/envio/package.json
@@ -61,7 +61,6 @@
     "pino-pretty": "13.1.3",
     "prom-client": "15.1.3",
     "yargs": "17.7.2",
-    "rescript": "12.2.0",
     "@rescript/runtime": "12.2.0",
     "rescript-schema": "9.5.1",
     "viem": "2.46.2",
@@ -74,5 +73,8 @@
     "ink-spinner": "5.0.0",
     "postgres": "3.4.8",
     "tsx": "4.21.0"
+  },
+  "devDependencies": {
+    "rescript": "12.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 22.19.7
       envio:
         specifier: file:../../packages/envio
-        version: file:packages/envio(react-dom@19.2.3(react@19.2.3))(typescript@5.9.3)
+        version: file:packages/envio(react-dom@19.2.3(react@19.2.3))(rescript@12.2.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -117,9 +117,6 @@ importers:
       react:
         specifier: 19.2.0
         version: 19.2.0
-      rescript:
-        specifier: 12.2.0
-        version: 12.2.0
       rescript-schema:
         specifier: 9.5.1
         version: 9.5.1(rescript@12.2.0)
@@ -132,12 +129,16 @@ importers:
       yargs:
         specifier: 17.7.2
         version: 17.7.2
+    devDependencies:
+      rescript:
+        specifier: 12.2.0
+        version: 12.2.0
 
   scenarios/e2e_test:
     dependencies:
       envio:
         specifier: file:../../packages/envio
-        version: link:../../packages/envio
+        version: file:packages/envio(react-dom@19.2.3(react@19.2.3))(rescript@12.2.0)(typescript@5.9.3)
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
@@ -157,7 +158,7 @@ importers:
     dependencies:
       envio:
         specifier: file:../../packages/envio
-        version: file:packages/envio(react-dom@19.2.3(react@19.2.3))(typescript@5.9.3)
+        version: link:../../packages/envio
       rescript:
         specifier: 12.2.0
         version: 12.2.0
@@ -195,7 +196,7 @@ importers:
         version: 12.2.0
       envio:
         specifier: file:../../packages/envio
-        version: file:packages/envio(react-dom@19.2.3(react@19.2.3))(typescript@5.9.3)
+        version: file:packages/envio(react-dom@19.2.3(react@19.2.3))(rescript@12.2.0)(typescript@5.9.3)
       rescript:
         specifier: 12.2.0
         version: 12.2.0
@@ -210,7 +211,7 @@ importers:
     dependencies:
       envio:
         specifier: file:../../packages/envio
-        version: file:packages/envio(react-dom@19.2.3(react@19.2.3))(typescript@5.9.3)
+        version: file:packages/envio(react-dom@19.2.3(react@19.2.3))(rescript@12.2.0)(typescript@5.9.3)
       rescript:
         specifier: 12.2.0
         version: 12.2.0
@@ -239,7 +240,7 @@ importers:
         version: 9.3.1
       envio:
         specifier: file:../../packages/envio
-        version: file:packages/envio(react-dom@19.2.3(react@19.2.3))(typescript@5.9.3)
+        version: file:packages/envio(react-dom@19.2.3(react@19.2.3))(rescript@12.2.0)(typescript@5.9.3)
       helpers:
         specifier: workspace:*
         version: link:../helpers
@@ -4210,7 +4211,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio@file:packages/envio(react-dom@19.2.3(react@19.2.3))(typescript@5.9.3):
+  envio@file:packages/envio(react-dom@19.2.3(react@19.2.3))(rescript@12.2.0)(typescript@5.9.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -4237,7 +4238,6 @@ snapshots:
       postgres: 3.4.8
       prom-client: 15.1.3
       react: 19.2.0
-      rescript: 12.2.0
       rescript-schema: 9.5.1(rescript@12.2.0)
       tsx: 4.21.0
       viem: 2.46.2(typescript@5.9.3)
@@ -4247,6 +4247,7 @@ snapshots:
       - bufferutil
       - react-devtools-core
       - react-dom
+      - rescript
       - supports-color
       - typescript
       - utf-8-validate


### PR DESCRIPTION
## Summary
This PR moves the `rescript` compiler from runtime dependencies to devDependencies in the envio package, since it's only needed at build time. It also adds verification checks to ensure devDependencies are properly removed from built artifacts and that rescript doesn't accidentally get included in production dependencies.

## Key Changes
- **packages/envio/package.json**: Moved `rescript` from `dependencies` to `devDependencies`
- **packages/build-envio/src/verify-artifact.ts**: Added validation checks to:
  - Ensure built artifacts don't contain `devDependencies`
  - Prevent `rescript` from being included in production dependencies
- **packages/build-envio/src/build-artifact.ts**: Updated build process to strip `devDependencies` when creating package artifacts

## Implementation Details
The verification logic checks that the final built artifact has no `devDependencies` field and that `rescript` is not present in the `dependencies` object, ensuring the compiler is truly build-time only and not shipped with the final package.

https://claude.ai/code/session_01C7LWPN21FvH1BHUY5HjyFf