### PR TITLE
Require explicit Postgres opt-in when using ClickHouse

### DIFF
--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -130,17 +130,36 @@ impl JsonSchema for StorageConfig {
                 }
             },
             "additionalProperties": false,
-            // Storage::resolve rejects any `postgres: false` config: with
-            // `clickhouse: true` it fails as "ClickHouse not supported as a
-            // single storage yet"; with clickhouse absent or false the
-            // defaults resolve to all-backends-disabled. So the only
-            // schema-valid shape is one without an explicit `postgres: false`.
-            "not": {
-                "properties": {
-                    "postgres": { "const": false }
+            // Storage::resolve rejects two shapes:
+            //   1. `postgres: false` (with any clickhouse value) — either
+            //      fails as "ClickHouse not supported as a single storage
+            //      yet" or resolves to all-backends-disabled.
+            //   2. `clickhouse: true` without an explicit `postgres: true` —
+            //      the user must opt in to Postgres alongside ClickHouse.
+            "allOf": [
+                {
+                    "not": {
+                        "properties": {
+                            "postgres": { "const": false }
+                        },
+                        "required": ["postgres"]
+                    }
                 },
-                "required": ["postgres"]
-            }
+                {
+                    "if": {
+                        "properties": {
+                            "clickhouse": { "const": true }
+                        },
+                        "required": ["clickhouse"]
+                    },
+                    "then": {
+                        "properties": {
+                            "postgres": { "const": true }
+                        },
+                        "required": ["postgres"]
+                    }
+                }
+            ]
         })
     }
 }

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -450,7 +450,14 @@ impl Storage {
         let (postgres, clickhouse) = match config {
             // Default: only Postgres enabled
             None => (true, false),
-            Some(s) => (s.postgres.unwrap_or(true), s.clickhouse.unwrap_or(false)),
+            Some(s) => {
+                let clickhouse = s.clickhouse.unwrap_or(false);
+                // When clickhouse is enabled, postgres must be set explicitly
+                // so that the validation below catches a clickhouse-only config
+                // instead of silently defaulting postgres to true.
+                let postgres = s.postgres.unwrap_or(!clickhouse);
+                (postgres, clickhouse)
+            }
         };
         if clickhouse && !postgres {
             return Err(anyhow!(
@@ -2547,6 +2554,19 @@ mod test {
         // ClickHouse without Postgres -> user-friendly error
         let err = super::Storage::resolve(Some(&StorageConfig {
             postgres: Some(false),
+            clickhouse: Some(true),
+        }))
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("ClickHouse is not supported as a single storage yet"),
+            "Unexpected error: {err}"
+        );
+
+        // ClickHouse enabled with Postgres omitted -> same error; user must
+        // opt in to Postgres explicitly rather than relying on the default.
+        let err = super::Storage::resolve(Some(&StorageConfig {
+            postgres: None,
             clickhouse: Some(true),
         }))
         .unwrap_err();

--- a/packages/envio/evm.schema.json
+++ b/packages/envio/evm.schema.json
@@ -153,16 +153,42 @@
         }
       },
       "additionalProperties": false,
-      "not": {
-        "properties": {
-          "postgres": {
-            "const": false
+      "allOf": [
+        {
+          "not": {
+            "properties": {
+              "postgres": {
+                "const": false
+              }
+            },
+            "required": [
+              "postgres"
+            ]
           }
         },
-        "required": [
-          "postgres"
-        ]
-      }
+        {
+          "if": {
+            "properties": {
+              "clickhouse": {
+                "const": true
+              }
+            },
+            "required": [
+              "clickhouse"
+            ]
+          },
+          "then": {
+            "properties": {
+              "postgres": {
+                "const": true
+              }
+            },
+            "required": [
+              "postgres"
+            ]
+          }
+        }
+      ]
     },
     "EcosystemTag": {
       "type": "string",

--- a/packages/envio/fuel.schema.json
+++ b/packages/envio/fuel.schema.json
@@ -111,16 +111,42 @@
         }
       },
       "additionalProperties": false,
-      "not": {
-        "properties": {
-          "postgres": {
-            "const": false
+      "allOf": [
+        {
+          "not": {
+            "properties": {
+              "postgres": {
+                "const": false
+              }
+            },
+            "required": [
+              "postgres"
+            ]
           }
         },
-        "required": [
-          "postgres"
-        ]
-      }
+        {
+          "if": {
+            "properties": {
+              "clickhouse": {
+                "const": true
+              }
+            },
+            "required": [
+              "clickhouse"
+            ]
+          },
+          "then": {
+            "properties": {
+              "postgres": {
+                "const": true
+              }
+            },
+            "required": [
+              "postgres"
+            ]
+          }
+        }
+      ]
     },
     "EcosystemTag": {
       "type": "string",

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -94,16 +94,42 @@
         }
       },
       "additionalProperties": false,
-      "not": {
-        "properties": {
-          "postgres": {
-            "const": false
+      "allOf": [
+        {
+          "not": {
+            "properties": {
+              "postgres": {
+                "const": false
+              }
+            },
+            "required": [
+              "postgres"
+            ]
           }
         },
-        "required": [
-          "postgres"
-        ]
-      }
+        {
+          "if": {
+            "properties": {
+              "clickhouse": {
+                "const": true
+              }
+            },
+            "required": [
+              "clickhouse"
+            ]
+          },
+          "then": {
+            "properties": {
+              "postgres": {
+                "const": true
+              }
+            },
+            "required": [
+              "postgres"
+            ]
+          }
+        }
+      ]
     },
     "EcosystemTag": {
       "type": "string",


### PR DESCRIPTION
## Summary
This PR updates the storage configuration validation to require users to explicitly enable Postgres when using ClickHouse, rather than silently defaulting Postgres to true. This prevents accidental misconfiguration and makes the constraint more explicit in both the JSON schema and runtime validation.

## Key Changes

- **Schema validation updates**: Modified JSON schemas in `evm.schema.json`, `fuel.schema.json`, and `svm.schema.json` to add a conditional constraint: when `clickhouse: true` is set, `postgres: true` must be explicitly specified.

- **Runtime validation logic**: Updated `Storage::resolve()` in `system_config.rs` to change the default behavior:
  - When ClickHouse is omitted or false: Postgres defaults to true (existing behavior)
  - When ClickHouse is true: Postgres no longer defaults to true; it must be explicitly set, otherwise validation fails

- **Schema generation**: Updated `StorageConfig::json_schema()` in `human_config.rs` to generate the new conditional validation rules and improved the documentation comment explaining the constraints.

- **Test coverage**: Added a new test case verifying that `clickhouse: true` with `postgres: None` properly rejects the configuration with the expected error message.

## Implementation Details

The validation now uses JSON Schema's `allOf` with an `if-then` conditional to enforce that ClickHouse cannot be used as a single storage backend. This makes the constraint explicit at the schema level and prevents silent defaults from masking configuration errors.

https://claude.ai/code/session_01H5QGp11aPcxzecUg6Rwiwr