### PR TITLE
Make ClickHouse env vars read lazily instead of at module load

### DIFF
--- a/packages/envio/src/Env.res
+++ b/packages/envio/src/Env.res
@@ -123,11 +123,22 @@ module Db = {
 
 // Required env vars are validated lazily in PgStorage when the user
 // opts into ClickHouse via `storage.clickhouse: true` in config.yaml.
+//
+// Reads run at call time instead of module load. `envio dev` injects these
+// vars into `process.env` after booting its ClickHouse container, and that
+// happens strictly after this module has already been evaluated — caching
+// at module load would lock in `None` and defeat the injection.
 module ClickHouse = {
-  let host = envSafe->EnvSafe.get("ENVIO_CLICKHOUSE_HOST", S.option(S.string))
-  let database = envSafe->EnvSafe.get("ENVIO_CLICKHOUSE_DATABASE", S.option(S.string))
-  let username = envSafe->EnvSafe.get("ENVIO_CLICKHOUSE_USERNAME", S.option(S.string))
-  let password = envSafe->EnvSafe.get("ENVIO_CLICKHOUSE_PASSWORD", S.option(S.string))
+  %%private(
+    let read: string => option<string> = %raw(`(k) => {
+      const v = process.env[k];
+      return v === undefined || v === "" ? undefined : v;
+    }`)
+  )
+  let host = () => read("ENVIO_CLICKHOUSE_HOST")
+  let database = () => read("ENVIO_CLICKHOUSE_DATABASE")
+  let username = () => read("ENVIO_CLICKHOUSE_USERNAME")
+  let password = () => read("ENVIO_CLICKHOUSE_PASSWORD")
 }
 
 module Hasura = {

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1686,15 +1686,18 @@ let makeStorageFromEnv = (
       // Postgres storage. Required env vars are validated here only when
       // the user opts in via `storage.clickhouse: true` in config.yaml.
       if config.storage.clickhouse {
+        let host = Env.ClickHouse.host()
+        let username = Env.ClickHouse.username()
+        let password = Env.ClickHouse.password()
         let missing = []
         let checkEnv = (opt, name) =>
           switch opt {
           | Some(_) => ()
           | None => missing->Array.push(name)->ignore
           }
-        Env.ClickHouse.host->checkEnv("ENVIO_CLICKHOUSE_HOST")
-        Env.ClickHouse.username->checkEnv("ENVIO_CLICKHOUSE_USERNAME")
-        Env.ClickHouse.password->checkEnv("ENVIO_CLICKHOUSE_PASSWORD")
+        host->checkEnv("ENVIO_CLICKHOUSE_HOST")
+        username->checkEnv("ENVIO_CLICKHOUSE_USERNAME")
+        password->checkEnv("ENVIO_CLICKHOUSE_PASSWORD")
         if missing->Array.length > 0 {
           JsError.throwWithMessage(
             `ClickHouse storage is enabled but required env vars are not set: ${missing->Array.joinUnsafe(
@@ -1704,10 +1707,10 @@ let makeStorageFromEnv = (
         }
         Some(
           Sink.makeClickHouse(
-            ~host=Env.ClickHouse.host->Option.getUnsafe,
-            ~database=Env.ClickHouse.database,
-            ~username=Env.ClickHouse.username->Option.getUnsafe,
-            ~password=Env.ClickHouse.password->Option.getUnsafe,
+            ~host=host->Option.getUnsafe,
+            ~database=Env.ClickHouse.database(),
+            ~username=username->Option.getUnsafe,
+            ~password=password->Option.getUnsafe,
           ),
         )
       } else {

--- a/packages/envio/src/tui/Tui.res
+++ b/packages/envio/src/tui/Tui.res
@@ -237,7 +237,7 @@ module App = {
       } else {
         React.null
       }}
-      {switch (state.ctx.config.storage.clickhouse, Env.ClickHouse.host) {
+      {switch (state.ctx.config.storage.clickhouse, Env.ClickHouse.host()) {
       | (true, Some(host)) =>
         <Box flexDirection={Row}>
           <Text> {"ClickHouse: "->React.string} </Text>

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -960,4 +960,40 @@ describe("PgStorage.makeStorageFromEnv ClickHouse env var validation", () => {
       t.expect(true, ~message="Expected no throw when clickhouse is disabled").toBe(true)
     },
   )
+
+  // `envio dev` applies ENVIO_CLICKHOUSE_* vars via Bin.applyEnv, which runs
+  // AFTER Env.res has been imported. If Env.ClickHouse cached reads at module
+  // load, those late writes would be invisible and validation would still
+  // throw. This test simulates that timing by writing the vars to process.env
+  // right before calling makeStorageFromEnv.
+  Async.it(
+    "Picks up ENVIO_CLICKHOUSE_* vars set after Env.res has been loaded",
+    async t => {
+      let setEnvVar: (string, string) => unit = %raw(`(k, v) => { process.env[k] = v; }`)
+      let unsetEnvVar: string => unit = %raw(`(k) => { delete process.env[k]; }`)
+      setEnvVar("ENVIO_CLICKHOUSE_HOST", "http://localhost:8123")
+      setEnvVar("ENVIO_CLICKHOUSE_USERNAME", "default")
+      setEnvVar("ENVIO_CLICKHOUSE_PASSWORD", "testing")
+      setEnvVar("ENVIO_CLICKHOUSE_DATABASE", "envio_sink")
+      let config = {
+        ...MockIndexer.config,
+        storage: ({postgres: true, clickhouse: true}: Config.storage),
+      }
+      let result = try {
+        let _ = PgStorage.makeStorageFromEnv(~config)
+        Ok()
+      } catch {
+      | JsExn(e) => Error(e->JsExn.message->Option.getOr(""))
+      | _ => Error("non-JsExn")
+      }
+      unsetEnvVar("ENVIO_CLICKHOUSE_HOST")
+      unsetEnvVar("ENVIO_CLICKHOUSE_USERNAME")
+      unsetEnvVar("ENVIO_CLICKHOUSE_PASSWORD")
+      unsetEnvVar("ENVIO_CLICKHOUSE_DATABASE")
+      t.expect(
+        result,
+        ~message="Should read ClickHouse env vars lazily so envio dev's late injection works",
+      ).toEqual(Ok())
+    },
+  )
 })


### PR DESCRIPTION
## Summary
Changed ClickHouse environment variable reads from eager evaluation at module load time to lazy evaluation at call time. This ensures that environment variables injected after module initialization (such as by `envio dev` after booting its ClickHouse container) are properly picked up.

## Key Changes
- **Env.res**: Converted `ClickHouse` module fields from cached values to functions that read from `process.env` at call time
  - Replaced direct `EnvSafe.get()` calls with a raw JavaScript `read()` function that checks `process.env` dynamically
  - Changed `host`, `database`, `username`, and `password` from values to functions returning `option<string>`

- **PgStorage.res**: Updated all ClickHouse environment variable accesses to call the new functions
  - Added local variable bindings for required fields before validation
  - Updated validation and sink creation to use the function call results

- **Tui.res**: Updated ClickHouse host status display to call the function

## Implementation Details
The core issue was that `envio dev` injects ClickHouse credentials into `process.env` after the Env module has already been evaluated. By caching reads at module load, those late injections would be invisible and validation would fail. The solution uses a raw JavaScript function to read directly from `process.env` at call time, ensuring late-injected variables are always visible.

A new test case validates this behavior by simulating the timing scenario where environment variables are set after module load but before `makeStorageFromEnv` is called.

https://claude.ai/code/session_01AipTzv6PjBP3pcUMfsqw8M