### PR TITLE
Improve error logging during initialization failures

### DIFF
--- a/packages/envio/src/Bin.res
+++ b/packages/envio/src/Bin.res
@@ -76,7 +76,14 @@ let run = async args => {
     }
   } catch {
   | exn =>
-    exn->ErrorHandling.make(~msg="Failed at initialization")->ErrorHandling.log
+    // Log just the exception's own message — wrapping it in "Failed at
+    // initialization" and pino's err serializer buries the real cause under
+    // a nested `err: { type, message, stack, ... }` block.
+    let message = switch exn->JsExn.anyToExnInternal {
+    | JsExn(e) => e->JsExn.message->Option.getOr("Failed at initialization")
+    | _ => "Failed at initialization"
+    }
+    Logging.error(message)
     NodeJs.process->NodeJs.exitWithCode(Failure)
   }
 }

--- a/packages/envio/src/ErrorHandling.res
+++ b/packages/envio/src/ErrorHandling.res
@@ -5,10 +5,18 @@ let make = (exn, ~logger=Logging.getLogger(), ~msg=?) => {
 }
 
 let log = (self: t) => {
-  switch self {
-  | {exn, msg: Some(msg), logger} => logger->Logging.childErrorWithExn(exn->Utils.prettifyExn, msg)
-  | {exn, msg: None, logger} => logger->Logging.childError(exn->Utils.prettifyExn)
+  // Log as a single-line string so pino-pretty doesn't render the
+  // `err: { type, message, stack, ... }` block beneath the message.
+  let exnMessage = switch self.exn->JsExn.anyToExnInternal {
+  | JsExn(e) => e->JsExn.message->Option.getOr("")
+  | _ => ""
   }
+  let finalMsg = switch (self.msg, exnMessage) {
+  | (Some(msg), "") => msg
+  | (None, "") => "Unknown error"
+  | (_, exnMsg) => exnMsg
+  }
+  self.logger->Logging.childError(finalMsg)
 }
 
 let raiseExn = (self: t) => {

--- a/packages/envio/src/ErrorHandling.res
+++ b/packages/envio/src/ErrorHandling.res
@@ -5,18 +5,10 @@ let make = (exn, ~logger=Logging.getLogger(), ~msg=?) => {
 }
 
 let log = (self: t) => {
-  // Log as a single-line string so pino-pretty doesn't render the
-  // `err: { type, message, stack, ... }` block beneath the message.
-  let exnMessage = switch self.exn->JsExn.anyToExnInternal {
-  | JsExn(e) => e->JsExn.message->Option.getOr("")
-  | _ => ""
+  switch self {
+  | {exn, msg: Some(msg), logger} => logger->Logging.childErrorWithExn(exn->Utils.prettifyExn, msg)
+  | {exn, msg: None, logger} => logger->Logging.childError(exn->Utils.prettifyExn)
   }
-  let finalMsg = switch (self.msg, exnMessage) {
-  | (Some(msg), "") => msg
-  | (None, "") => "Unknown error"
-  | (_, exnMsg) => exnMsg
-  }
-  self.logger->Logging.childError(finalMsg)
 }
 
 let raiseExn = (self: t) => {


### PR DESCRIPTION
## Summary
Improved error message clarity when initialization fails by logging the exception's direct message instead of wrapping it in additional context that obscures the root cause.

## Key Changes
- Changed error handling in the initialization catch block to extract and log the exception's own message directly
- Replaced `ErrorHandling.make()` wrapper with direct `Logging.error()` call to avoid nested error serialization
- Added logic to extract the JavaScript exception message when available, falling back to a generic message if needed

## Implementation Details
- Uses `JsExn.anyToExnInternal` to safely convert the exception and extract its message
- Handles both JavaScript exceptions (extracting their message) and other exception types (using fallback message)
- This prevents pino's error serializer from burying the actual error cause under nested `err: { type, message, stack, ... }` blocks, making logs more readable and debugging easier

https://claude.ai/code/session_01EYj3DnyT47LxwD5UzVCjKj