### PR TITLE
Improve incompatible schema change error message formatting

### DIFF
--- a/packages/cli/src/executor/dev.rs
+++ b/packages/cli/src/executor/dev.rs
@@ -107,11 +107,15 @@ pub async fn run_dev(project_paths: ParsedProjectPaths, restart: bool) -> Result
                 .map(|f| f.to_string())
                 .collect::<Vec<_>>()
                 .join(", ");
+            let revert_action = format!("Undo your {fields} changes");
+            let restart_action = "envio dev -r";
+            let width = revert_action.len().max(restart_action.len());
             return Err(anyhow!(
-                "Incompatible change detected in {fields}. To continue:\n\
+                "Your changes to {fields} are incompatible with the existing indexer data. \
+                 Pick one:\n\
                  \n  \
-                 1. Revert the change    # keep indexing with the existing state\n  \
-                 2. envio dev -r         # clear the database and re-index from scratch"
+                 1. {revert_action:<width$}    # resume indexing where it left off\n  \
+                 2. {restart_action:<width$}    # wipe the database and re-index from scratch"
             ));
         }
     }

--- a/packages/cli/src/executor/dev.rs
+++ b/packages/cli/src/executor/dev.rs
@@ -108,9 +108,10 @@ pub async fn run_dev(project_paths: ParsedProjectPaths, restart: bool) -> Result
                 .collect::<Vec<_>>()
                 .join(", ");
             return Err(anyhow!(
-                "Incompatible change detected in {fields}. Reverse the changes to continue \
-                 indexing with the existing state, or run `envio dev -r` to clear the database \
-                 and re-index from scratch."
+                "Incompatible change detected in {fields}. To continue:\n\
+                 \n  \
+                 1. Revert the change    # keep indexing with the existing state\n  \
+                 2. envio dev -r         # clear the database and re-index from scratch"
             ));
         }
     }


### PR DESCRIPTION
## Summary
Enhanced the error message displayed when incompatible changes are detected in indexed fields during development. The message now provides clearer, more actionable guidance with better formatting.

## Key Changes
- Restructured error message to present two distinct options with numbered formatting
- Added dynamic width calculation to align action descriptions for improved readability
- Changed messaging from imperative ("Reverse the changes") to more user-friendly language ("Your changes are incompatible")
- Clarified the consequences of each action with inline comments:
  - Option 1: Undo changes to resume indexing from current state
  - Option 2: Run `envio dev -r` to wipe database and re-index from scratch

## Implementation Details
- Introduced `revert_action` and `restart_action` string variables to enable consistent formatting
- Used `width` calculation (`revert_action.len().max(restart_action.len())`) to left-align both options at the same column width
- Improved visual hierarchy with numbered list format and inline explanatory comments

https://claude.ai/code/session_01T2ZRMnh9cmxejN39PEFduP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when incompatible changes are detected during development, now presenting two clear options: undo recent changes to resume indexing, or use `envio dev -r` to wipe and re-index the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->