### PR TITLE
Auto-detect non-interactive environments for TUI

### DIFF
--- a/packages/cli/templates/static/shared/.claude/skills/indexing-config/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-config/SKILL.md
@@ -124,6 +124,12 @@ Works in any string value in config. Set via `.env` file or shell environment.
 
 **IMPORTANT:** All environment variables MUST use the `ENVIO_` prefix (e.g., `ENVIO_RPC_URL`, not `RPC_URL`). The hosted service requires the `ENVIO_` prefix — variables without it will not be available at runtime.
 
+## Runtime Environment Variables
+
+Set on the indexer process (not interpolated into config.yaml):
+
+- `ENVIO_TUI` — `true` forces the terminal UI on, `false` forces it off. Unset (default) auto-disables under agents, CI, and non-TTY stdout, so plain `pnpm dev` produces line-buffered output suitable for log capture without manual intervention.
+
 ## YAML Validation
 
 Add at top of file for IDE schema validation:

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-handler-syntax/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-handler-syntax/SKILL.md
@@ -16,7 +16,7 @@ This is an ESM project (`"type": "module"` in package.json). Top-level `await` i
 
 1. After any change to `schema.graphql` or `config.yaml` → run `pnpm codegen`
 2. After any change to TypeScript files → run `pnpm tsc --noEmit`
-3. Once compilation succeeds → run `pnpm dev` to catch runtime errors (TUI auto-disables under agents)
+3. Once compilation succeeds → run `pnpm dev` to catch runtime errors
 
 ## Handler Registration
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-handler-syntax/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-handler-syntax/SKILL.md
@@ -16,7 +16,7 @@ This is an ESM project (`"type": "module"` in package.json). Top-level `await` i
 
 1. After any change to `schema.graphql` or `config.yaml` → run `pnpm codegen`
 2. After any change to TypeScript files → run `pnpm tsc --noEmit`
-3. Once compilation succeeds → run `TUI_OFF=true pnpm dev` to catch runtime errors
+3. Once compilation succeeds → run `pnpm dev` to catch runtime errors (TUI auto-disables under agents)
 
 ## Handler Registration
 

--- a/packages/cli/templates/static/shared/.claude/skills/subgraph-migration/references/step-by-step.md
+++ b/packages/cli/templates/static/shared/.claude/skills/subgraph-migration/references/step-by-step.md
@@ -15,8 +15,10 @@ Use the TDD flow: write a failing test, implement, verify the test passes.
 If tests aren't sufficient to catch a runtime issue, also run:
 
 ```bash
-TUI_OFF=true pnpm dev
+pnpm dev
 ```
+
+(TUI auto-disables under agents/CI; pass `TUI_OFF=false` to force it on.)
 
 **Why this is critical:**
 - TypeScript compilation (`tsc --noEmit`) only catches syntax and type errors
@@ -25,7 +27,7 @@ TUI_OFF=true pnpm dev
 
 **Runtime Testing Checklist:**
 - [ ] After every code change, run `pnpm test`
-- [ ] If needed, run `TUI_OFF=true pnpm dev` for ~30 seconds
+- [ ] If needed, run `pnpm dev` for ~30 seconds
 - [ ] Watch the output for any error messages or warnings
 - [ ] Stop the background process after confirming it runs without errors
 - [ ] Only proceed to the next step after confirming tests pass

--- a/packages/cli/templates/static/shared/.claude/skills/subgraph-migration/references/step-by-step.md
+++ b/packages/cli/templates/static/shared/.claude/skills/subgraph-migration/references/step-by-step.md
@@ -18,7 +18,7 @@ If tests aren't sufficient to catch a runtime issue, also run:
 pnpm dev
 ```
 
-(TUI auto-disables under agents/CI; pass `TUI_OFF=false` to force it on.)
+(TUI auto-disables under agents/CI; set `ENVIO_TUI=true` to force it on.)
 
 **Why this is critical:**
 - TypeScript compilation (`tsc --noEmit`) only catches syntax and type errors

--- a/packages/cli/templates/static/shared/.claude/skills/subgraph-migration/references/step-by-step.md
+++ b/packages/cli/templates/static/shared/.claude/skills/subgraph-migration/references/step-by-step.md
@@ -18,8 +18,6 @@ If tests aren't sufficient to catch a runtime issue, also run:
 pnpm dev
 ```
 
-(TUI auto-disables under agents/CI; set `ENVIO_TUI=true` to force it on.)
-
 **Why this is critical:**
 - TypeScript compilation (`tsc --noEmit`) only catches syntax and type errors
 - Runtime errors (database issues, missing entities, logic errors) only appear when running the indexer

--- a/packages/cli/templates/static/shared/AGENTS.md
+++ b/packages/cli/templates/static/shared/AGENTS.md
@@ -15,7 +15,7 @@ Blockchain event indexer built with [Envio HyperIndex](https://docs.envio.dev). 
 ```bash
 pnpm codegen          # Regenerate types from schema.graphql + config.yaml
 pnpm tsc --noEmit     # Type-check without emitting
-TUI_OFF=true pnpm dev # Run indexer (TUI_OFF for CI/AI-friendly output)
+pnpm dev             # Run indexer (TUI auto-disables for CI/AI/non-TTY output)
 pnpm test             # Run tests (Vitest)
 ```
 
@@ -25,7 +25,7 @@ pnpm test             # Run tests (Vitest)
 2. Run `pnpm codegen` (required after any schema/config change)
 3. Edit handlers in `src/handlers/`
 4. Run `pnpm tsc --noEmit` to type-check
-5. Run `TUI_OFF=true pnpm dev` to verify at runtime
+5. Run `pnpm dev` to verify at runtime (TUI auto-disables under agents/CI)
 
 ## Key Rules
 

--- a/packages/cli/templates/static/shared/AGENTS.md
+++ b/packages/cli/templates/static/shared/AGENTS.md
@@ -15,7 +15,7 @@ Blockchain event indexer built with [Envio HyperIndex](https://docs.envio.dev). 
 ```bash
 pnpm codegen          # Regenerate types from schema.graphql + config.yaml
 pnpm tsc --noEmit     # Type-check without emitting
-pnpm dev             # Run indexer (TUI auto-disables for CI/AI/non-TTY output)
+pnpm dev              # Run indexer
 pnpm test             # Run tests (Vitest)
 ```
 
@@ -25,7 +25,7 @@ pnpm test             # Run tests (Vitest)
 2. Run `pnpm codegen` (required after any schema/config change)
 3. Edit handlers in `src/handlers/`
 4. Run `pnpm tsc --noEmit` to type-check
-5. Run `pnpm dev` to verify at runtime (TUI auto-disables under agents/CI)
+5. Run `pnpm dev` to verify at runtime
 
 ## Key Rules
 

--- a/packages/cli/templates/static/shared/CLAUDE.md
+++ b/packages/cli/templates/static/shared/CLAUDE.md
@@ -10,7 +10,7 @@ See `AGENTS.md` for full project context, commands, and workflow.
 - Use Effect API (`createEffect` + `context.effect()`) for ALL external calls
 - Schema uses entity references (`collection: NftCollection!`); handlers use `_id` suffix (`collection_id: value`); never add `_id` to schema field names
 - Use pnpm, not npm
-- Run `pnpm dev` — TUI auto-disables for agents/CI/non-TTY; pass `TUI_OFF=false` to force it on
+- Run `pnpm dev` — TUI auto-disables for agents/CI/non-TTY; set `ENVIO_TUI=true` to force it on
 - **All environment variables MUST use the `ENVIO_` prefix** (e.g., `ENVIO_RPC_URL`, `ENVIO_API_KEY`). The hosted service only exposes variables with this prefix at runtime.
 
 ## Skills

--- a/packages/cli/templates/static/shared/CLAUDE.md
+++ b/packages/cli/templates/static/shared/CLAUDE.md
@@ -10,7 +10,7 @@ See `AGENTS.md` for full project context, commands, and workflow.
 - Use Effect API (`createEffect` + `context.effect()`) for ALL external calls
 - Schema uses entity references (`collection: NftCollection!`); handlers use `_id` suffix (`collection_id: value`); never add `_id` to schema field names
 - Use pnpm, not npm
-- Run `TUI_OFF=true pnpm dev` for AI-friendly indexer output
+- Run `pnpm dev` — TUI auto-disables for agents/CI/non-TTY; pass `TUI_OFF=false` to force it on
 - **All environment variables MUST use the `ENVIO_` prefix** (e.g., `ENVIO_RPC_URL`, `ENVIO_API_KEY`). The hosted service only exposes variables with this prefix at runtime.
 
 ## Skills

--- a/packages/cli/templates/static/shared/CLAUDE.md
+++ b/packages/cli/templates/static/shared/CLAUDE.md
@@ -10,7 +10,6 @@ See `AGENTS.md` for full project context, commands, and workflow.
 - Use Effect API (`createEffect` + `context.effect()`) for ALL external calls
 - Schema uses entity references (`collection: NftCollection!`); handlers use `_id` suffix (`collection_id: value`); never add `_id` to schema field names
 - Use pnpm, not npm
-- Run `pnpm dev` — TUI auto-disables for agents/CI/non-TTY; set `ENVIO_TUI=true` to force it on
 - **All environment variables MUST use the `ENVIO_` prefix** (e.g., `ENVIO_RPC_URL`, `ENVIO_API_KEY`). The hosted service only exposes variables with this prefix at runtime.
 
 ## Skills

--- a/packages/e2e-tests/src/dependency-tests/install.test.ts
+++ b/packages/e2e-tests/src/dependency-tests/install.test.ts
@@ -164,7 +164,7 @@ describe("Isolated dependency e2e", () => {
       indexerProcess = startBackground(config.envioCommand, [...config.envioArgs, "dev"], {
         cwd: projectDir,
         env: {
-          TUI_OFF: "true",
+          ENVIO_TUI: "false",
           ENVIO_API_TOKEN: process.env.ENVIO_API_TOKEN ?? "",
           // e2e_test config.yaml declares `storage.clickhouse: true`, so
           // PgStorage validates these env vars at indexer start.

--- a/packages/e2e-tests/src/e2e/e2e.test.ts
+++ b/packages/e2e-tests/src/e2e/e2e.test.ts
@@ -51,7 +51,7 @@ describe("E2E: Indexer with GraphQL and ClickHouse sink", () => {
     indexerProcess = startBackground(config.envioCommand, [...config.envioArgs, "dev"], {
       cwd: PROJECT_DIR,
       env: {
-        TUI_OFF: "true",
+        ENVIO_TUI: "false",
         ENVIO_API_TOKEN: process.env.ENVIO_API_TOKEN ?? "",
         ENVIO_CLICKHOUSE_HOST: config.clickhouseUrl,
         ENVIO_CLICKHOUSE_USERNAME: config.clickhouseUsername,
@@ -260,7 +260,7 @@ describe("E2E: Indexer with GraphQL and ClickHouse sink", () => {
       secondProcess = startBackground(config.envioCommand, [...config.envioArgs, "dev"], {
         cwd: PROJECT_DIR,
         env: {
-          TUI_OFF: "true",
+          ENVIO_TUI: "false",
           ENVIO_API_TOKEN: process.env.ENVIO_API_TOKEN ?? "",
           ENVIO_CLICKHOUSE_HOST: config.clickhouseUrl,
           ENVIO_CLICKHOUSE_USERNAME: config.clickhouseUsername,

--- a/packages/envio/src/Env.res
+++ b/packages/envio/src/Env.res
@@ -22,7 +22,7 @@ let serverPort =
     ~fallback=envSafe->EnvSafe.get("METRICS_PORT", S.int->S.port, ~fallback=9898),
   )
 
-let tuiOffEnvVar = envSafe->EnvSafe.get("TUI_OFF", S.bool, ~fallback=false)
+let tuiOffEnvVar = envSafe->EnvSafe.get("TUI_OFF", S.option(S.bool))
 
 let logLevelSchema = S.enum([
   #trace,

--- a/packages/envio/src/Env.res
+++ b/packages/envio/src/Env.res
@@ -22,7 +22,7 @@ let serverPort =
     ~fallback=envSafe->EnvSafe.get("METRICS_PORT", S.int->S.port, ~fallback=9898),
   )
 
-let tuiOffEnvVar = envSafe->EnvSafe.get("TUI_OFF", S.option(S.bool))
+let tuiEnvVar = envSafe->EnvSafe.get("ENVIO_TUI", S.option(S.bool))
 
 let logLevelSchema = S.enum([
   #trace,

--- a/packages/envio/src/Envio.res
+++ b/packages/envio/src/Envio.res
@@ -189,10 +189,10 @@ let isDevMode = () => NodeJs.Process.process.env->Dict.get("ENVIO_DEV_MODE") ===
 // stdout, CI, and coding agents. `CLAUDECODE` is set by Claude Code; `CI` is the
 // de-facto convention across CI providers; `TERM=dumb` is set by editors/tools
 // that emulate a terminal without ANSI support.
+@val external stdoutIsTty: option<bool> = "process.stdout.isTTY"
 let isNonInteractive = () => {
-  let stdoutIsTty: bool = %raw(`process.stdout.isTTY === true`)
   let env = NodeJs.Process.process.env
-  !stdoutIsTty ||
+  stdoutIsTty !== Some(true) ||
   env->Dict.get("CLAUDECODE")->Option.isSome ||
   env->Dict.get("CI")->Option.isSome ||
   env->Dict.get("TERM") === Some("dumb")

--- a/packages/envio/src/Envio.res
+++ b/packages/envio/src/Envio.res
@@ -185,6 +185,19 @@ type fuelSimulateItem = {
 // snapshot the pre-applyEnv value (undefined → false).
 let isDevMode = () => NodeJs.Process.process.env->Dict.get("ENVIO_DEV_MODE") === Some("true")
 
+// Detects contexts where a full-screen TUI is counter-productive: piped/redirected
+// stdout, CI, and coding agents. `CLAUDECODE` is set by Claude Code; `CI` is the
+// de-facto convention across CI providers; `TERM=dumb` is set by editors/tools
+// that emulate a terminal without ANSI support.
+let isNonInteractive = () => {
+  let stdoutIsTty: bool = %raw(`process.stdout.isTTY === true`)
+  let env = NodeJs.Process.process.env
+  !stdoutIsTty ||
+  env->Dict.get("CLAUDECODE")->Option.isSome ||
+  env->Dict.get("CI")->Option.isSome ||
+  env->Dict.get("TERM") === Some("dumb")
+}
+
 module TestHelpers = {
   module Addresses = {
     let mockAddresses =

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -631,7 +631,15 @@ let start = async (
   ~patchConfig: option<(Config.t, HandlerRegister.registrations) => Config.t>=?,
 ) => {
   let mainArgs: mainArgs = process->argv->Yargs.hideBin->Yargs.yargs->Yargs.argv
-  let shouldUseTui = !isTest && !(mainArgs.tuiOff->Belt.Option.getWithDefault(Env.tuiOffEnvVar))
+  let explicitTuiOff = switch mainArgs.tuiOff {
+  | Some(_) as v => v
+  | None => Env.tuiOffEnvVar
+  }
+  let shouldUseTui = switch (isTest, explicitTuiOff) {
+  | (true, _) => false
+  | (_, Some(tuiOff)) => !tuiOff
+  | (_, None) => !Envio.isNonInteractive()
+  }
   // isDevelopmentMode controls whether the indexer stays alive after all
   // chains finish (keepProcessAlive) and whether the console API is exposed.
   // Set by `envio dev` via the ENVIO_DEV_MODE env var; `envio start` leaves

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -631,13 +631,13 @@ let start = async (
   ~patchConfig: option<(Config.t, HandlerRegister.registrations) => Config.t>=?,
 ) => {
   let mainArgs: mainArgs = process->argv->Yargs.hideBin->Yargs.yargs->Yargs.argv
-  let explicitTuiOff = switch mainArgs.tuiOff {
-  | Some(_) as v => v
-  | None => Env.tuiOffEnvVar
+  let explicitTui = switch mainArgs.tuiOff {
+  | Some(off) => Some(!off)
+  | None => Env.tuiEnvVar
   }
-  let shouldUseTui = switch (isTest, explicitTuiOff) {
+  let shouldUseTui = switch (isTest, explicitTui) {
   | (true, _) => false
-  | (_, Some(tuiOff)) => !tuiOff
+  | (_, Some(tui)) => tui
   | (_, None) => !Envio.isNonInteractive()
   }
   // isDevelopmentMode controls whether the indexer stays alive after all


### PR DESCRIPTION
## Summary
Replace the `TUI_OFF` environment variable with intelligent auto-detection of non-interactive environments. The TUI now automatically disables itself when running in CI, under coding agents (Claude Code), with piped/redirected stdout, or in terminals without ANSI support, while remaining enabled for normal interactive development.

## Key Changes

- **Added `isNonInteractive()` detection** in `Envio.res` that checks for:
  - Non-TTY stdout (`process.stdout.isTTY !== true`)
  - Claude Code agent (`CLAUDECODE` env var)
  - CI environments (`CI` env var)
  - Dumb terminals (`TERM=dumb`)

- **Replaced `TUI_OFF` with `ENVIO_TUI`** in `Env.res`:
  - New variable is optional boolean (unset = auto-detect)
  - Follows the `ENVIO_` prefix convention
  - Allows explicit override when needed (`true` forces on, `false` forces off)

- **Updated TUI logic** in `Main.res`:
  - Respects explicit `--tuiOff` CLI flag
  - Falls back to `ENVIO_TUI` env var if set
  - Uses auto-detection (`!isNonInteractive()`) as final default
  - Test mode still disables TUI unconditionally

- **Updated documentation and examples**:
  - Removed `TUI_OFF=true` from all development instructions
  - Updated e2e tests to use `ENVIO_TUI=false` instead
  - Added `ENVIO_TUI` to runtime environment variables documentation
  - Simplified agent/CI guidance (no manual flag needed)

## Implementation Details

The auto-detection is conservative—it disables the TUI in any environment where line-buffered output is likely preferred (CI logs, agent output capture, piped streams). Users can still force the TUI on with `ENVIO_TUI=true` if needed, or off with `ENVIO_TUI=false` for explicit control.

https://claude.ai/code/session_01KimdRWf9wXtDXxrLN8uSki

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ENVIO_TUI` environment variable for explicit terminal UI control (`true`/`false`).
  * Auto-detects non-interactive environments (CI, agents, non-TTY output) to automatically disable the UI.

* **Documentation**
  * Updated runtime command examples and guides to reflect simplified environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->