### PR TITLE
Fix race condition in MockIndexer getItemsOrThrow resolution

### DIFF
--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -366,6 +366,12 @@ module Indexer = {
           while before >= (gsManager->GlobalStateManager.getState).processedBatches {
             await Utils.delay(1)
           }
+          // Skip an extra microtask for indexer to fire follow-up actions
+          // (e.g. the NextQuery dispatch that schedules the next
+          // getItemsOrThrow call). Without this, callers that immediately
+          // call resolveGetItemsOrThrow can race the dispatch and observe
+          // an empty calls array.
+          await Utils.delay(0)
           resolve()
         })
       },

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -366,11 +366,12 @@ module Indexer = {
           while before >= (gsManager->GlobalStateManager.getState).processedBatches {
             await Utils.delay(1)
           }
-          // Skip an extra microtask for indexer to fire follow-up actions
+          // Skip extra microtasks for indexer to fire follow-up actions
           // (e.g. the NextQuery dispatch that schedules the next
           // getItemsOrThrow call). Without this, callers that immediately
           // call resolveGetItemsOrThrow can race the dispatch and observe
           // an empty calls array.
+          await Utils.delay(0)
           await Utils.delay(0)
           resolve()
         })


### PR DESCRIPTION
## Summary
Add microtask delays to the MockIndexer's `getItemsOrThrow` resolution to prevent race conditions where callers immediately observe an empty calls array before follow-up actions are dispatched.

## Changes
- Added two `await Utils.delay(0)` calls before resolving the promise in `getItemsOrThrow`
- These delays allow the event loop to process pending microtasks, specifically the `NextQuery` dispatch that schedules the next `getItemsOrThrow` call
- Prevents callers from racing the dispatch and observing stale state

## Implementation Details
The fix uses two consecutive zero-delay microtasks to ensure sufficient event loop cycles for the indexer's follow-up actions to be scheduled before the promise resolves. This is a common pattern for handling asynchronous dispatch ordering in test scenarios.

https://claude.ai/code/session_018x4gnkTt9gMeDPFXSbeusn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of batch-processing tests by adding timing safeguards to avoid a race condition that could yield empty observations during async dispatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->