### PR TITLE
Add E2E test for context.log accessibility in effect handlers

### DIFF
--- a/packages/envio/src/UserContext.res
+++ b/packages/envio/src/UserContext.res
@@ -23,9 +23,10 @@ Utils.Object.defineProperty(
   effectContextPrototype,
   "log",
   {
-    get: () => {
+    // Wrap with toMethod so `this` binds to the EffectContext instance.
+    get: Utils.toMethod(() => {
       (paramsByThis->Utils.WeakMap.unsafeGet(%raw(`this`))).item->Logging.getUserLogger
-    },
+    }),
   },
 )
 %%raw(`
@@ -239,6 +240,7 @@ let entityTraps: Utils.Proxy.traps<entityContextParams> = {
       (filter => getWhereHandler(params, filter->(Utils.magic: unknown => dict<dict<unknown>>)))->(
         Utils.magic: (unknown => promise<array<Internal.entity>>) => unknown
       )
+
     | "getOrThrow" =>
       (
         (entityId, ~message=?) =>

--- a/packages/envio/src/Utils.res
+++ b/packages/envio/src/Utils.res
@@ -3,6 +3,11 @@
 external magic: 'a => 'b = "%identity"
 @val external floatToInt: float => int = "Math.trunc"
 
+// Force a function to compile to a regular `function` instead of an arrow,
+// so `this` binds to the call-site receiver (needed for prototype getters,
+// methods, etc).
+external toMethod: 'a => 'a = "%unsafe_to_method"
+
 @val external importPath: string => promise<unknown> = "import"
 
 @val

--- a/scenarios/test_codegen/test/E2E_test.res
+++ b/scenarios/test_codegen/test/E2E_test.res
@@ -649,6 +649,69 @@ describe("E2E tests", () => {
     ])
   })
 
+  // Reproduction for https://github.com/enviodev/hyperindex/issues/1173
+  // The effect context's `log` getter is compiled as an arrow function, so
+  // `this` is captured from the surrounding ESM module scope (undefined under
+  // strict mode) instead of the EffectContext instance. The lookup
+  // `paramsByThis.get(undefined)` returns undefined, and accessing `.item`
+  // throws `TypeError: Cannot read properties of undefined (reading 'item')`.
+  Async.it("context.log should be accessible from inside an effect handler", async t => {
+    let sourceMock = MockIndexer.Source.make(
+      [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+      ~chain=#1337,
+    )
+    let indexerMock = await MockIndexer.Indexer.make(
+      ~chains=[
+        {
+          chain: #1337,
+          sourceConfig: Config.CustomSources([sourceMock.source]),
+        },
+      ],
+    )
+    await Utils.delay(0)
+
+    let probeEffect = Envio.createEffect(
+      {
+        name: "logProbeEffect",
+        input: S.string,
+        output: S.string,
+        rateLimit: Disable,
+      },
+      async ({input, context}) => {
+        context.log.info("hello from effect")
+        input ++ "-output"
+      },
+    )
+
+    sourceMock.resolveGetHeightOrThrow(300)
+    await Utils.delay(0)
+    await Utils.delay(0)
+
+    let effectResult = ref(None)
+    let effectError = ref(None)
+    sourceMock.resolveGetItemsOrThrow(
+      [
+        {
+          blockNumber: 100,
+          logIndex: 0,
+          handler: async ({context}) => {
+            switch await context.effect(probeEffect, "test") {
+            | output => effectResult := Some(output)
+            | exception exn => effectError := Some(exn)
+            }
+          },
+        },
+      ],
+      ~latestFetchedBlockNumber=100,
+    )
+    await indexerMock.getBatchWritePromise()
+
+    t.expect(
+      (effectError.contents, effectResult.contents),
+      ~message="context.log access from inside an effect must not throw",
+    ).toEqual((None, Some("test-output")))
+  })
+
   Async.it(
     "Should attempt fallback source when primary source fails with missing params",
     async t => {


### PR DESCRIPTION
## Summary
This PR adds a regression test for issue #1173 to ensure that `context.log` is properly accessible from within effect handlers.

## Key Changes
- Added a new E2E test case that verifies `context.log.info()` can be called from inside an effect handler without throwing a `TypeError`
- The test reproduces the original issue where the effect context's `log` getter was compiled as an arrow function, causing `this` to be captured from the ESM module scope (undefined in strict mode) instead of the EffectContext instance
- The test validates that:
  - The effect handler can successfully call `context.log.info()`
  - The effect executes without errors
  - The effect returns the expected output

## Implementation Details
The test creates a mock indexer with a custom effect that attempts to log a message via `context.log.info()`. It then triggers the effect from within a handler and verifies that no exception is thrown and the effect completes successfully with the expected output.

https://claude.ai/code/session_01V8bGXBHmPMGU2LsAgd8aze

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test verifying effect handlers can log during event processing and return expected outputs without raising exceptions.

* **Bug Fixes**
  * Resolved a binding issue so logging from effect contexts works reliably during event handling, preventing intermittent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->