### PR TITLE
Rename isLive to isRealtime across codebase

### DIFF
--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -542,7 +542,7 @@ pub mod evm {
                            historical sync, then automatically switch to this RPC once synced \
                            for lower latency."
         )]
-        Live,
+        Realtime,
     }
 
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]

--- a/packages/cli/src/config_parsing/public_config_json.rs
+++ b/packages/cli/src/config_parsing/public_config_json.rs
@@ -307,7 +307,7 @@ impl SystemConfig {
                                 source_for: match rpc.source_for {
                                     Some(For::Sync) => "sync",
                                     Some(For::Fallback) => "fallback",
-                                    Some(For::Live) => "live",
+                                    Some(For::Realtime) => "realtime",
                                     None => unreachable!(
                                         "source_for should be resolved by from_evm_network_config"
                                     ),

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -1312,8 +1312,8 @@ type indexerChain = {{
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether the chain has completed initial sync and is processing live events. */
-  isLive: bool,{contract_fields}
+  /** Whether all chains have completed initial sync and are processing real-time events. */
+  isRealtime: bool,{contract_fields}
 }}"#
         );
 

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -1312,7 +1312,7 @@ type indexerChain = {{
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether all chains have caught up to head and entered real-time indexing mode. */
+  /** Whether all chains have entered real-time indexing mode (caught up to head, or reached their configured endBlock for finite-range indexers). */
   isRealtime: bool,{contract_fields}
 }}"#
         );

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -1312,7 +1312,7 @@ type indexerChain = {{
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether all chains have completed initial sync and are processing real-time events. */
+  /** Whether all chains have caught up to head and entered real-time indexing mode. */
   isRealtime: bool,{contract_fields}
 }}"#
         );

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
@@ -335,7 +335,7 @@ type indexerChain = {
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether all chains have caught up to head and entered real-time indexing mode. */
+  /** Whether all chains have entered real-time indexing mode (caught up to head, or reached their configured endBlock for finite-range indexers). */
   isRealtime: bool,
   \"Contract1": indexerContract,
 }

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
@@ -335,7 +335,7 @@ type indexerChain = {
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether all chains have completed initial sync and are processing real-time events. */
+  /** Whether all chains have caught up to head and entered real-time indexing mode. */
   isRealtime: bool,
   \"Contract1": indexerContract,
 }

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
@@ -335,8 +335,8 @@ type indexerChain = {
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether the chain has completed initial sync and is processing live events. */
-  isLive: bool,
+  /** Whether all chains have completed initial sync and are processing real-time events. */
+  isRealtime: bool,
   \"Contract1": indexerContract,
 }
 

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
@@ -400,7 +400,7 @@ type indexerChain = {
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether all chains have completed initial sync and are processing real-time events. */
+  /** Whether all chains have caught up to head and entered real-time indexing mode. */
   isRealtime: bool,
   \"Contract1": indexerContract,
   \"Contract2": indexerContract,

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
@@ -400,8 +400,8 @@ type indexerChain = {
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether the chain has completed initial sync and is processing live events. */
-  isLive: bool,
+  /** Whether all chains have completed initial sync and are processing real-time events. */
+  isRealtime: bool,
   \"Contract1": indexerContract,
   \"Contract2": indexerContract,
 }

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
@@ -400,7 +400,7 @@ type indexerChain = {
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether all chains have caught up to head and entered real-time indexing mode. */
+  /** Whether all chains have entered real-time indexing mode (caught up to head, or reached their configured endBlock for finite-range indexers). */
   isRealtime: bool,
   \"Contract1": indexerContract,
   \"Contract2": indexerContract,

--- a/packages/cli/templates/dynamic/codegen/index.d.ts.hbs
+++ b/packages/cli/templates/dynamic/codegen/index.d.ts.hbs
@@ -220,9 +220,9 @@ export type HandlerContext = {
   /**
    * Chain state information for the current event's chain.
    * - id: the chain ID
-   * - isRealtime: true when all chains have completed initial sync and are processing
-   *               real-time events (unordered multichain). False during historical sync
-   *               on any chain.
+   * - isRealtime: true once all chains have caught up to head and entered real-time
+   *               indexing mode (unordered multichain). False while any chain is
+   *               still backfilling.
    */
   readonly chain: {
     readonly id: ChainId;

--- a/packages/cli/templates/dynamic/codegen/index.d.ts.hbs
+++ b/packages/cli/templates/dynamic/codegen/index.d.ts.hbs
@@ -220,12 +220,13 @@ export type HandlerContext = {
   /**
    * Chain state information for the current event's chain.
    * - id: the chain ID
-   * - isLive: true when the chain has completed initial sync and is processing live events,
-   *            false during historical synchronization
+   * - isRealtime: true when all chains have completed initial sync and are processing
+   *               real-time events (unordered multichain). False during historical sync
+   *               on any chain.
    */
   readonly chain: {
     readonly id: ChainId;
-    readonly isLive: boolean;
+    readonly isRealtime: boolean;
   };
   {{#each entities as | entity |}}
   readonly {{entity.name.original}}: {

--- a/packages/cli/templates/dynamic/codegen/index.d.ts.hbs
+++ b/packages/cli/templates/dynamic/codegen/index.d.ts.hbs
@@ -220,9 +220,9 @@ export type HandlerContext = {
   /**
    * Chain state information for the current event's chain.
    * - id: the chain ID
-   * - isRealtime: true once all chains have caught up to head and entered real-time
-   *               indexing mode (unordered multichain). False while any chain is
-   *               still backfilling.
+   * - isRealtime: true once all chains have caught up to head and entered
+   *               real-time indexing mode. False while any chain is still
+   *               backfilling.
    */
   readonly chain: {
     readonly id: ChainId;

--- a/packages/cli/templates/dynamic/codegen/index.d.ts.hbs
+++ b/packages/cli/templates/dynamic/codegen/index.d.ts.hbs
@@ -220,8 +220,9 @@ export type HandlerContext = {
   /**
    * Chain state information for the current event's chain.
    * - id: the chain ID
-   * - isRealtime: true once all chains have caught up to head and entered
-   *               real-time indexing mode. False while any chain is still
+   * - isRealtime: true once all chains have entered real-time indexing mode
+   *               (caught up to head, or reached their configured endBlock
+   *               for finite-range indexers). False while any chain is still
    *               backfilling.
    */
   readonly chain: {

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-handler-syntax/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-handler-syntax/SKILL.md
@@ -64,7 +64,7 @@ context.Entity.deleteUnsafe(id);     // delete (sync — no await)
 
 ```ts
 context.chain.id           // number — current chain ID
-context.chain.isRealtime   // boolean — true when ALL chains have caught up to head (unordered multichain)
+context.chain.isRealtime   // boolean — true when ALL chains have caught up to head
 context.isPreload      // boolean — true during preload phase
 context.log            // { debug, info, warn, error, errorWithExn }
 context.effect(fn, input)  // external call via Effect API (see indexing-external-calls)

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-handler-syntax/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-handler-syntax/SKILL.md
@@ -63,8 +63,8 @@ context.Entity.deleteUnsafe(id);     // delete (sync — no await)
 ### Context Properties
 
 ```ts
-context.chain.id       // number — current chain ID
-context.chain.isLive   // boolean — true when processing live blocks
+context.chain.id           // number — current chain ID
+context.chain.isRealtime   // boolean — true when ALL chains have caught up to head (unordered multichain)
 context.isPreload      // boolean — true during preload phase
 context.log            // { debug, info, warn, error, errorWithExn }
 context.effect(fn, input)  // external call via Effect API (see indexing-external-calls)
@@ -91,7 +91,7 @@ indexer.chainIds;                    // [1, 137]
 indexer.chains[1].id;                // 1
 indexer.chains[1].name;              // "ethereum"
 indexer.chains[1].startBlock;        // 0
-indexer.chains[1].isLive;            // false
+indexer.chains[1].isRealtime;        // false
 indexer.chains[1].MyContract.name;   // "MyContract"
 indexer.chains[1].MyContract.addresses; // ["0x..."]
 indexer.chains[1].MyContract.abi;    // [...]

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-multichain/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-multichain/SKILL.md
@@ -32,9 +32,9 @@ Contract.Event.handler(async ({ event, context }) => {
     137: { wrappedNative: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270" },
   }[chainId];
 
-  // context.chain.isLive is true when processing real-time blocks
-  if (context.chain.isLive) {
-    // Live-only logic
+  // context.chain.isRealtime is true once ALL chains finished backfill (unordered multichain)
+  if (context.chain.isRealtime) {
+    // Realtime-only logic
   }
 });
 ```

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-multichain/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-multichain/SKILL.md
@@ -32,7 +32,7 @@ Contract.Event.handler(async ({ event, context }) => {
     137: { wrappedNative: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270" },
   }[chainId];
 
-  // context.chain.isRealtime is true once ALL chains finished backfill (unordered multichain)
+  // context.chain.isRealtime is true once ALL chains have caught up to head
   if (context.chain.isRealtime) {
     // Realtime-only logic
   }

--- a/packages/cli/templates/static/shared/.claude/skills/indexing-performance/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexing-performance/SKILL.md
@@ -29,8 +29,8 @@ chains:
   - id: 1
     rpc:
       - url: ${ENVIO_RPC_URL}
-        for: sync                    # sync | live | fallback
-        ws: ${ENVIO_WS_URL}               # WebSocket for lower-latency live block detection
+        for: sync                    # sync | realtime | fallback
+        ws: ${ENVIO_WS_URL}               # WebSocket for lower-latency realtime block detection
         initial_block_interval: 5000 # Starting blocks per query
         backoff_multiplicative: 0.8  # Scale factor after RPC error (0.5-0.9)
         acceleration_additive: 1000  # Blocks added per successful query
@@ -45,11 +45,11 @@ chains:
 
 | Value | Description |
 |-------|-------------|
-| `sync` | RPC as main data source for both historical and live |
-| `live` | HyperSync for historical, switch to RPC for live (lower latency) |
+| `sync` | RPC as main data source for both historical and realtime |
+| `realtime` | HyperSync for historical, switch to RPC for realtime (lower latency) |
 | `fallback` | Backup when primary stalls (default when HyperSync available) |
 
-### WebSocket for Live Indexing
+### WebSocket for Realtime Indexing
 
 Add `ws:` for lower-latency new block detection via `eth_subscribe("newHeads")`:
 
@@ -57,7 +57,7 @@ Add `ws:` for lower-latency new block detection via `eth_subscribe("newHeads")`:
 rpc:
   - url: ${ENVIO_RPC_ENDPOINT}
     ws: ${ENVIO_WS_ENDPOINT}
-    for: live
+    for: realtime
 ```
 
 ## Database Indexes

--- a/packages/envio/evm.schema.json
+++ b/packages/envio/evm.schema.json
@@ -568,7 +568,7 @@
         {
           "description": "Use RPC for real-time indexing only. HyperSync will be used for historical sync, then automatically switch to this RPC once synced for lower latency.",
           "type": "string",
-          "const": "live"
+          "const": "realtime"
         }
       ]
     },

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -362,9 +362,7 @@ type EvmChain<
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether all chains have caught up to head and entered real-time indexing mode.
-   * For unordered multichain mode this flips once every chain has finished backfill;
-   * isolated multichain (per-chain semantics) is a future addition. */
+  /** Whether all chains have caught up to head and entered real-time indexing mode. */
   readonly isRealtime: boolean;
 } & {
   readonly [K in ContractName]: EvmContract<K>;
@@ -419,9 +417,7 @@ type FuelChain<
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether all chains have caught up to head and entered real-time indexing mode.
-   * For unordered multichain mode this flips once every chain has finished backfill;
-   * isolated multichain (per-chain semantics) is a future addition. */
+  /** Whether all chains have caught up to head and entered real-time indexing mode. */
   readonly isRealtime: boolean;
 } & {
   readonly [K in ContractName]: FuelContract<K>;
@@ -453,9 +449,7 @@ type SvmChain<Id extends number = number> = {
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether all chains have caught up to head and entered real-time indexing mode.
-   * For unordered multichain mode this flips once every chain has finished backfill;
-   * isolated multichain (per-chain semantics) is a future addition. */
+  /** Whether all chains have caught up to head and entered real-time indexing mode. */
   readonly isRealtime: boolean;
 };
 

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -362,8 +362,8 @@ type EvmChain<
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether all chains have completed initial sync and are processing real-time events.
-   * For unordered multichain mode this flips once every chain has caught up;
+  /** Whether all chains have caught up to head and entered real-time indexing mode.
+   * For unordered multichain mode this flips once every chain has finished backfill;
    * isolated multichain (per-chain semantics) is a future addition. */
   readonly isRealtime: boolean;
 } & {
@@ -419,8 +419,8 @@ type FuelChain<
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether all chains have completed initial sync and are processing real-time events.
-   * For unordered multichain mode this flips once every chain has caught up;
+  /** Whether all chains have caught up to head and entered real-time indexing mode.
+   * For unordered multichain mode this flips once every chain has finished backfill;
    * isolated multichain (per-chain semantics) is a future addition. */
   readonly isRealtime: boolean;
 } & {
@@ -453,8 +453,8 @@ type SvmChain<Id extends number = number> = {
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether all chains have completed initial sync and are processing real-time events.
-   * For unordered multichain mode this flips once every chain has caught up;
+  /** Whether all chains have caught up to head and entered real-time indexing mode.
+   * For unordered multichain mode this flips once every chain has finished backfill;
    * isolated multichain (per-chain semantics) is a future addition. */
   readonly isRealtime: boolean;
 };

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -362,8 +362,10 @@ type EvmChain<
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether the chain has completed initial sync and is processing live events. */
-  readonly isLive: boolean;
+  /** Whether all chains have completed initial sync and are processing real-time events.
+   * For unordered multichain mode this flips once every chain has caught up;
+   * isolated multichain (per-chain semantics) is a future addition. */
+  readonly isRealtime: boolean;
 } & {
   readonly [K in ContractName]: EvmContract<K>;
 };
@@ -417,8 +419,10 @@ type FuelChain<
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether the chain has completed initial sync and is processing live events. */
-  readonly isLive: boolean;
+  /** Whether all chains have completed initial sync and are processing real-time events.
+   * For unordered multichain mode this flips once every chain has caught up;
+   * isolated multichain (per-chain semantics) is a future addition. */
+  readonly isRealtime: boolean;
 } & {
   readonly [K in ContractName]: FuelContract<K>;
 };
@@ -449,8 +453,10 @@ type SvmChain<Id extends number = number> = {
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether the chain has completed initial sync and is processing live events. */
-  readonly isLive: boolean;
+  /** Whether all chains have completed initial sync and are processing real-time events.
+   * For unordered multichain mode this flips once every chain has caught up;
+   * isolated multichain (per-chain semantics) is a future addition. */
+  readonly isRealtime: boolean;
 };
 
 // ============== Indexer Type ==============
@@ -530,7 +536,7 @@ type BaseHandlerContext<Config extends IndexerConfigTypes, ChainId> = {
   /** Chain state for the current event's chain. */
   readonly chain: {
     readonly id: ChainId;
-    readonly isLive: boolean;
+    readonly isRealtime: boolean;
   };
 } & {
   readonly [K in keyof ConfigEntities<Config>]: EntityOperations<ConfigEntities<Config>[K]>;
@@ -568,8 +574,8 @@ type ContractRegistration = {
 };
 
 /** Context for contractRegister handlers. Chain object includes contract registration methods.
- * `isLive` is intentionally absent: contract registration runs during historical sync,
- * so the "live" distinction isn't meaningful and the runtime does not expose it. */
+ * `isRealtime` is intentionally absent: contract registration runs during historical sync,
+ * so the "realtime" distinction isn't meaningful and the runtime does not expose it. */
 export type EvmContractRegisterContext<Config extends IndexerConfigTypes> = Prettify<{
   readonly log: Logger;
   readonly chain: {
@@ -579,7 +585,7 @@ export type EvmContractRegisterContext<Config extends IndexerConfigTypes> = Pret
   };
 }>;
 
-/** Context for contractRegister handlers in Fuel ecosystem. `isLive` is intentionally
+/** Context for contractRegister handlers in Fuel ecosystem. `isRealtime` is intentionally
  * absent — see EvmContractRegisterContext. */
 export type FuelContractRegisterContext<Config extends IndexerConfigTypes> = Prettify<{
   readonly log: Logger;

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -362,7 +362,8 @@ type EvmChain<
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether all chains have caught up to head and entered real-time indexing mode. */
+  /** Whether all chains have entered real-time indexing mode (caught up to head,
+   * or reached their configured endBlock for finite-range indexers). */
   readonly isRealtime: boolean;
 } & {
   readonly [K in ContractName]: EvmContract<K>;
@@ -417,7 +418,8 @@ type FuelChain<
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether all chains have caught up to head and entered real-time indexing mode. */
+  /** Whether all chains have entered real-time indexing mode (caught up to head,
+   * or reached their configured endBlock for finite-range indexers). */
   readonly isRealtime: boolean;
 } & {
   readonly [K in ContractName]: FuelContract<K>;
@@ -449,7 +451,8 @@ type SvmChain<Id extends number = number> = {
   readonly startBlock: number;
   /** The block number indexing stops at (if configured). */
   readonly endBlock: number | undefined;
-  /** Whether all chains have caught up to head and entered real-time indexing mode. */
+  /** Whether all chains have entered real-time indexing mode (caught up to head,
+   * or reached their configured endBlock for finite-range indexers). */
   readonly isRealtime: boolean;
 };
 

--- a/packages/envio/src/ChainFetcher.res
+++ b/packages/envio/src/ChainFetcher.res
@@ -47,6 +47,7 @@ let make = (
   ~timestampCaughtUpToHeadOrEndblock,
   ~numEventsProcessed,
   ~isInReorgThreshold,
+  ~isRealtime,
   ~reorgCheckpoints: array<Internal.reorgCheckpoint>,
   ~maxReorgDepth,
   ~knownHeight=0,
@@ -243,7 +244,7 @@ let make = (
     sourceManager: SourceManager.make(
       ~sources,
       ~maxPartitionConcurrency=Env.maxPartitionConcurrency,
-      ~isRealtime=timestampCaughtUpToHeadOrEndblock->Option.isSome,
+      ~isRealtime,
     ),
     reorgDetection: ReorgDetection.make(
       ~chainReorgCheckpoints,
@@ -287,6 +288,7 @@ let makeFromConfig = (
     ~logger,
     ~indexingAddresses=configAddresses(chainConfig),
     ~isInReorgThreshold=false,
+    ~isRealtime=false,
     ~knownHeight,
   )
 }
@@ -299,6 +301,7 @@ let makeFromDbState = (
   ~resumedChainState: Persistence.initialChainState,
   ~reorgCheckpoints,
   ~isInReorgThreshold,
+  ~isRealtime,
   ~config,
   ~registrations,
   ~targetBufferSize,
@@ -332,6 +335,7 @@ let makeFromDbState = (
     ~logger,
     ~targetBufferSize,
     ~isInReorgThreshold,
+    ~isRealtime,
     ~knownHeight=resumedChainState.sourceBlockNumber,
   )
 }

--- a/packages/envio/src/ChainFetcher.res
+++ b/packages/envio/src/ChainFetcher.res
@@ -243,7 +243,7 @@ let make = (
     sourceManager: SourceManager.make(
       ~sources,
       ~maxPartitionConcurrency=Env.maxPartitionConcurrency,
-      ~isLive=timestampCaughtUpToHeadOrEndblock->Option.isSome,
+      ~isRealtime=timestampCaughtUpToHeadOrEndblock->Option.isSome,
     ),
     reorgDetection: ReorgDetection.make(
       ~chainReorgCheckpoints,

--- a/packages/envio/src/ChainManager.res
+++ b/packages/envio/src/ChainManager.res
@@ -57,9 +57,8 @@ let makeFromDbState = (
     Prometheus.EffectCacheCount.set(~count, ~effectName)
   })
 
-  // For unordered multichain, isRealtime is true only when every chain has
-  // previously caught up to head/endBlock. updateSyncTimeOnRestart wipes the
-  // saved timestamp so a restart re-enters backfill mode for all chains.
+  // updateSyncTimeOnRestart wipes the saved timestamp so a restart re-enters
+  // backfill mode for all chains.
   let isRealtime =
     !Env.updateSyncTimeOnRestart &&
     initialState.chains->Array.length > 0 &&
@@ -161,9 +160,7 @@ let isProgressAtHead = chainManager =>
 let isActivelyIndexing = chainManager =>
   chainManager.chainFetchers->ChainMap.values->Array.every(ChainFetcher.isActivelyIndexing)
 
-// True only once every chain has caught up to head/endBlock — the global
-// "real-time mode" signal for unordered multichain. Per-chain semantics for
-// isolated multichain are a future addition.
+// True only once every chain has caught up to head/endBlock.
 let isRealtime = chainManager =>
   chainManager.chainFetchers->ChainMap.values->Array.every(ChainFetcher.isReady)
 

--- a/packages/envio/src/ChainManager.res
+++ b/packages/envio/src/ChainManager.res
@@ -161,8 +161,12 @@ let isActivelyIndexing = chainManager =>
   chainManager.chainFetchers->ChainMap.values->Array.every(ChainFetcher.isActivelyIndexing)
 
 // True only once every chain has caught up to head/endBlock.
-let isRealtime = chainManager =>
-  chainManager.chainFetchers->ChainMap.values->Array.every(ChainFetcher.isReady)
+// Array.every is true on an empty array; guard against the no-fetchers case
+// to match ChainManager.makeFromDbState's startup requirement.
+let isRealtime = chainManager => {
+  let chainFetchers = chainManager.chainFetchers->ChainMap.values
+  chainFetchers->Array.length > 0 && chainFetchers->Array.every(ChainFetcher.isReady)
+}
 
 let getSafeCheckpointId = (chainManager: t) => {
   let chainFetchers = chainManager.chainFetchers->ChainMap.values

--- a/packages/envio/src/ChainManager.res
+++ b/packages/envio/src/ChainManager.res
@@ -57,6 +57,14 @@ let makeFromDbState = (
     Prometheus.EffectCacheCount.set(~count, ~effectName)
   })
 
+  // For unordered multichain, isRealtime is true only when every chain has
+  // previously caught up to head/endBlock. updateSyncTimeOnRestart wipes the
+  // saved timestamp so a restart re-enters backfill mode for all chains.
+  let isRealtime =
+    !Env.updateSyncTimeOnRestart &&
+    initialState.chains->Array.length > 0 &&
+    initialState.chains->Array.every(c => c.timestampCaughtUpToHeadOrEndblock->Option.isSome)
+
   let chainFetchersArr =
     initialState.chains->Array.map((resumedChainState: Persistence.initialChainState) => {
       let chain = Config.getChain(config, ~chainId=resumedChainState.id)
@@ -68,6 +76,7 @@ let makeFromDbState = (
           ~resumedChainState,
           ~reorgCheckpoints=initialState.reorgCheckpoints,
           ~isInReorgThreshold,
+          ~isRealtime,
           ~targetBufferSize,
           ~config,
           ~registrations,
@@ -151,6 +160,12 @@ let isProgressAtHead = chainManager =>
 
 let isActivelyIndexing = chainManager =>
   chainManager.chainFetchers->ChainMap.values->Array.every(ChainFetcher.isActivelyIndexing)
+
+// True only once every chain has caught up to head/endBlock — the global
+// "real-time mode" signal for unordered multichain. Per-chain semantics for
+// isolated multichain are a future addition.
+let isRealtime = chainManager =>
+  chainManager.chainFetchers->ChainMap.values->Array.every(ChainFetcher.isReady)
 
 let getSafeCheckpointId = (chainManager: t) => {
   let chainFetchers = chainManager.chainFetchers->ChainMap.values

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -152,9 +152,9 @@ module EnvioAddresses = {
   }->Internal.fromGenericEntityConfig
 }
 
-type rpcSourceFor = | @as("sync") Sync | @as("fallback") Fallback | @as("live") Live
+type rpcSourceFor = | @as("sync") Sync | @as("fallback") Fallback | @as("realtime") Realtime
 
-let rpcSourceForSchema = S.enum([Sync, Fallback, Live])
+let rpcSourceForSchema = S.enum([Sync, Fallback, Realtime])
 
 let rpcConfigSchema = S.schema(s =>
   {
@@ -616,7 +616,7 @@ let fromPublic = (publicConfigJson: JSON.t) => {
     switch sourceFor {
     | Sync => Source.Sync
     | Fallback => Source.Fallback
-    | Live => Source.Live
+    | Realtime => Source.Realtime
     }
   }
 

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -12,14 +12,13 @@ let computeChainsState = (chainFetchers: ChainMap.t<ChainFetcher.t>): Internal.c
   let isRealtime = chainFetchers->ChainMap.values->Array.every(cf => cf->ChainFetcher.isReady)
 
   chainFetchers
-  ->ChainMap.entries
-  ->Array.forEach(((chain, _chainFetcher)) => {
-    let chainId = chain->ChainMap.Chain.toChainId->Int.toString
-
+  ->ChainMap.keys
+  ->Array.forEach(chain => {
+    let chainId = chain->ChainMap.Chain.toChainId
     chains->Dict.set(
-      chainId,
+      chainId->Int.toString,
       {
-        Internal.id: chain->ChainMap.Chain.toChainId,
+        Internal.id: chainId,
         isRealtime,
       },
     )

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -7,17 +7,20 @@ let allChainsEventsProcessedToEndblock = (chainFetchers: ChainMap.t<ChainFetcher
 let computeChainsState = (chainFetchers: ChainMap.t<ChainFetcher.t>): Internal.chains => {
   let chains = Dict.make()
 
+  // For unordered multichain, isRealtime flips to true only after every chain
+  // has caught up. Isolated multichain (per-chain semantics) is a future addition.
+  let isRealtime = chainFetchers->ChainMap.values->Array.every(cf => cf->ChainFetcher.isReady)
+
   chainFetchers
   ->ChainMap.entries
-  ->Array.forEach(((chain, chainFetcher)) => {
+  ->Array.forEach(((chain, _chainFetcher)) => {
     let chainId = chain->ChainMap.Chain.toChainId->Int.toString
-    let isLive = chainFetcher->ChainFetcher.isReady
 
     chains->Dict.set(
       chainId,
       {
         Internal.id: chain->ChainMap.Chain.toChainId,
-        isLive,
+        isRealtime,
       },
     )
   })

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -7,8 +7,6 @@ let allChainsEventsProcessedToEndblock = (chainFetchers: ChainMap.t<ChainFetcher
 let computeChainsState = (chainFetchers: ChainMap.t<ChainFetcher.t>): Internal.chains => {
   let chains = Dict.make()
 
-  // For unordered multichain, isRealtime flips to true only after every chain
-  // has caught up. Isolated multichain (per-chain semantics) is a future addition.
   let isRealtime = chainFetchers->ChainMap.values->Array.every(cf => cf->ChainFetcher.isReady)
 
   chainFetchers

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -820,26 +820,21 @@ let checkAndFetchForChain = (
     let chainFetcher = state.chainManager.chainFetchers->ChainMap.get(chain)
     if !isPreparingRollback(state) {
       let {fetchState} = chainFetcher
+      let isRealtime = state.chainManager->ChainManager.isRealtime
 
-      // Reduce polling to 60s when this chain is caught up but waiting for other chains
+      // Reduce polling to 60s when this chain is caught up but other chains
+      // are still backfilling — i.e. this chain is ready but isRealtime=false.
       let reducedPolling = if state.ctx.config.shouldRollbackOnReorg {
         !state.chainManager.isInReorgThreshold &&
         fetchState->FetchState.isReadyToEnterReorgThreshold
       } else {
-        chainFetcher->ChainFetcher.isReady &&
-          state.chainManager.chainFetchers
-          ->ChainMap.values
-          ->Array.some(cf => !(cf->ChainFetcher.isReady))
+        chainFetcher->ChainFetcher.isReady && !isRealtime
       }
 
       await chainFetcher.sourceManager->SourceManager.fetchNext(
         ~fetchState,
         ~waitForNewBlock=(~knownHeight) =>
-          chainFetcher.sourceManager->waitForNewBlock(
-            ~knownHeight,
-            ~isRealtime=chainFetcher->ChainFetcher.isReady,
-            ~reducedPolling,
-          ),
+          chainFetcher.sourceManager->waitForNewBlock(~knownHeight, ~isRealtime, ~reducedPolling),
         ~onNewBlock=(~knownHeight) =>
           dispatchAction(FinishWaitingForNewBlock({chain, knownHeight})),
         ~executeQuery=async query => {
@@ -847,7 +842,7 @@ let checkAndFetchForChain = (
             let response = await chainFetcher.sourceManager->executeQuery(
               ~query,
               ~knownHeight=fetchState.knownHeight,
-              ~isRealtime=chainFetcher->ChainFetcher.isReady,
+              ~isRealtime,
             )
             dispatchAction(ValidatePartitionQueryResponse({chain, response, query}))
           } catch {

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -837,7 +837,7 @@ let checkAndFetchForChain = (
         ~waitForNewBlock=(~knownHeight) =>
           chainFetcher.sourceManager->waitForNewBlock(
             ~knownHeight,
-            ~isLive=chainFetcher->ChainFetcher.isReady,
+            ~isRealtime=chainFetcher->ChainFetcher.isReady,
             ~reducedPolling,
           ),
         ~onNewBlock=(~knownHeight) =>
@@ -847,7 +847,7 @@ let checkAndFetchForChain = (
             let response = await chainFetcher.sourceManager->executeQuery(
               ~query,
               ~knownHeight=fetchState.knownHeight,
-              ~isLive=chainFetcher->ChainFetcher.isReady,
+              ~isRealtime=chainFetcher->ChainFetcher.isReady,
             )
             dispatchAction(ValidatePartitionQueryResponse({chain, response, query}))
           } catch {

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -822,14 +822,14 @@ let checkAndFetchForChain = (
       let {fetchState} = chainFetcher
       let isRealtime = state.chainManager->ChainManager.isRealtime
 
-      // Reduce polling to 60s when this chain is caught up but other chains
-      // are still backfilling — i.e. this chain is ready but isRealtime=false.
-      let reducedPolling = if state.ctx.config.shouldRollbackOnReorg {
-        !state.chainManager.isInReorgThreshold &&
-        fetchState->FetchState.isReadyToEnterReorgThreshold
-      } else {
-        chainFetcher->ChainFetcher.isReady && !isRealtime
-      }
+      // Reduce polling when there's nothing useful to fetch right now:
+      //   - this chain has caught up but others are still backfilling, or
+      //   - we're about to enter the reorg threshold (rollback mode only).
+      let reducedPolling =
+        (chainFetcher->ChainFetcher.isReady && !isRealtime) ||
+          (state.ctx.config.shouldRollbackOnReorg &&
+          !state.chainManager.isInReorgThreshold &&
+          fetchState->FetchState.isReadyToEnterReorgThreshold)
 
       await chainFetcher.sourceManager->SourceManager.fetchNext(
         ~fetchState,

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -301,8 +301,8 @@ type entityHandlerContext<'entity> = {
 
 type chainInfo = {
   id: int,
-  // true when ALL chains have completed initial sync and are processing real-time events
-  // (for unordered multichain mode). False during historical synchronization on any chain.
+  // true once ALL chains have caught up to head and entered real-time indexing mode
+  // (for unordered multichain). False while any chain is still backfilling.
   isRealtime: bool,
 }
 

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -301,8 +301,8 @@ type entityHandlerContext<'entity> = {
 
 type chainInfo = {
   id: int,
-  // true once ALL chains have caught up to head and entered real-time indexing mode
-  // (for unordered multichain). False while any chain is still backfilling.
+  // True once every chain has caught up to head/endBlock and entered real-time
+  // indexing mode. False while any chain is still backfilling.
   isRealtime: bool,
 }
 

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -301,9 +301,9 @@ type entityHandlerContext<'entity> = {
 
 type chainInfo = {
   id: int,
-  // true when the chain has completed initial sync and is processing live events
-  // false during historical synchronization
-  isLive: bool,
+  // true when ALL chains have completed initial sync and are processing real-time events
+  // (for unordered multichain mode). False during historical synchronization on any chain.
+  isRealtime: bool,
 }
 
 type chains = dict<chainInfo>

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -150,10 +150,13 @@ let buildChainsObject = (~config: Config.t) => {
           switch globalGsManagerRef.contents {
           | Some(gsManager) =>
             (gsManager->GlobalStateManager.getState).chainManager->ChainManager.isRealtime
+          // Before the GlobalStateManager is available (eg during handler
+          // module load after resume), derive from persistence: every chain
+          // must have previously caught up to head or endBlock. Mirror the
+          // ChainManager.makeFromDbState path: updateSyncTimeOnRestart wipes
+          // the saved timestamps so a restart re-enters backfill.
+          | None if Env.updateSyncTimeOnRestart => false
           | None =>
-            // Before the GlobalStateManager is available (eg during handler
-            // module load after resume), derive from persistence: every
-            // chain must have previously caught up to head or endBlock.
             config.chainMap
             ->ChainMap.values
             ->Array.every(c =>

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -146,16 +146,13 @@ let buildChainsObject = (~config: Config.t) => {
       "isRealtime",
       {
         enumerable: true,
-        // For unordered multichain, isRealtime is true only when ALL chains
-        // have finished backfill. (Isolated multichain — separate per-chain
-        // logic — is a future addition.)
+        // For unordered multichain, isRealtime is true only once every chain
+        // has caught up to head/endBlock. (Isolated multichain — separate
+        // per-chain logic — is a future addition.)
         get: () => {
           switch globalGsManagerRef.contents {
           | Some(gsManager) =>
-            let state = gsManager->GlobalStateManager.getState
-            state.chainManager.chainFetchers
-            ->ChainMap.values
-            ->Array.every(cf => cf->ChainFetcher.isReady)
+            (gsManager->GlobalStateManager.getState).chainManager->ChainManager.isRealtime
           | None =>
             // Before the GlobalStateManager is available (eg during handler
             // module load after resume), derive from persistence: every

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -85,7 +85,7 @@ let globalGsManagerRef: ref<option<GlobalStateManager.t>> = ref(None)
 
 // Persistence is set by Main.start before handler modules load, so that
 // the exported indexer value can lazily expose DB state (startBlock,
-// endBlock, isLive, dynamic contract addresses) once it's ready.
+// endBlock, isRealtime, dynamic contract addresses) once it's ready.
 let globalPersistenceRef: ref<option<Persistence.t>> = ref(None)
 
 let getInitialChainState = (~chainId: int): option<Persistence.initialChainState> => {
@@ -143,25 +143,31 @@ let buildChainsObject = (~config: Config.t) => {
     )
     ->Utils.Object.definePropertyWithValue("name", {enumerable: true, value: chainConfig.name})
     ->Utils.Object.defineProperty(
-      "isLive",
+      "isRealtime",
       {
         enumerable: true,
+        // For unordered multichain, isRealtime is true only when ALL chains
+        // have finished backfill. (Isolated multichain — separate per-chain
+        // logic — is a future addition.)
         get: () => {
           switch globalGsManagerRef.contents {
           | Some(gsManager) =>
             let state = gsManager->GlobalStateManager.getState
-            let chain = ChainMap.Chain.makeUnsafe(~chainId=chainConfig.id)
-            let chainFetcher = state.chainManager.chainFetchers->ChainMap.get(chain)
-            chainFetcher->ChainFetcher.isReady
-          // Before the GlobalStateManager is available (eg during handler
-          // module load after resume), derive liveness from persistence:
-          // a chain is considered live when it previously caught up to head
-          // or endBlock (timestampCaughtUpToHeadOrEndblock is set).
+            state.chainManager.chainFetchers
+            ->ChainMap.values
+            ->Array.every(cf => cf->ChainFetcher.isReady)
           | None =>
-            switch getInitialChainState(~chainId=chainConfig.id) {
-            | Some(chainState) => chainState.timestampCaughtUpToHeadOrEndblock->Option.isSome
-            | None => false
-            }
+            // Before the GlobalStateManager is available (eg during handler
+            // module load after resume), derive from persistence: every
+            // chain must have previously caught up to head or endBlock.
+            config.chainMap
+            ->ChainMap.values
+            ->Array.every(c =>
+              switch getInitialChainState(~chainId=c.id) {
+              | Some(chainState) => chainState.timestampCaughtUpToHeadOrEndblock->Option.isSome
+              | None => false
+              }
+            )
           }
         },
       },

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -146,9 +146,6 @@ let buildChainsObject = (~config: Config.t) => {
       "isRealtime",
       {
         enumerable: true,
-        // For unordered multichain, isRealtime is true only once every chain
-        // has caught up to head/endBlock. (Isolated multichain — separate
-        // per-chain logic — is a future addition.)
         get: () => {
           switch globalGsManagerRef.contents {
           | Some(gsManager) =>

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -579,7 +579,7 @@ let makeCreateTestIndexer = (~config: Config.t, ~workerPath: string): (
         {enumerable: true, value: chainConfig.endBlock},
       )
       ->Utils.Object.definePropertyWithValue("name", {enumerable: true, value: chainConfig.name})
-      ->Utils.Object.definePropertyWithValue("isLive", {enumerable: true, value: false})
+      ->Utils.Object.definePropertyWithValue("isRealtime", {enumerable: true, value: false})
       ->ignore
 
       // Add contracts to chain object

--- a/packages/envio/src/sources/Source.res
+++ b/packages/envio/src/sources/Source.res
@@ -32,7 +32,7 @@ type getItemsError =
 
 exception GetItemsError(getItemsError)
 
-type sourceFor = Sync | Fallback | Live
+type sourceFor = Sync | Fallback | Realtime
 
 type t = {
   name: string,

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -22,7 +22,7 @@ type t = {
   mutable status: sourceManagerStatus,
   maxPartitionConcurrency: int,
   newBlockStallTimeout: int,
-  newBlockStallTimeoutLive: int,
+  newBlockStallTimeoutRealtime: int,
   stalledPollingInterval: int,
   reducedPollingInterval: int,
   getHeightRetryInterval: (~retry: int) => int,
@@ -31,7 +31,7 @@ type t = {
   // Should take into consideration partitions fetching for previous states (before rollback)
   mutable fetchingPartitionsCount: int,
   recoveryTimeout: float,
-  mutable hasLive: bool,
+  mutable hasRealtime: bool,
 }
 
 let getActiveSource = sourceManager => sourceManager.activeSource
@@ -39,16 +39,16 @@ let getActiveSource = sourceManager => sourceManager.activeSource
 type sourceRole = Primary | Secondary
 
 // Determines whether a source is Primary or Secondary given the current mode.
-// isLive=false (backfill): Sync=Primary, Fallback=Secondary, Live=ignored (None).
-// isLive=true with hasLive: Live=Primary, Sync+Fallback=Secondary.
-// isLive=true without hasLive: Sync=Primary, Fallback=Secondary.
-let getSourceRole = (~sourceFor: Source.sourceFor, ~isLive, ~hasLive) =>
-  switch (isLive, sourceFor) {
+// isRealtime=false (backfill): Sync=Primary, Fallback=Secondary, Realtime=ignored (None).
+// isRealtime=true with hasRealtime: Realtime=Primary, Sync+Fallback=Secondary.
+// isRealtime=true without hasRealtime: Sync=Primary, Fallback=Secondary.
+let getSourceRole = (~sourceFor: Source.sourceFor, ~isRealtime, ~hasRealtime) =>
+  switch (isRealtime, sourceFor) {
   | (false, Sync) => Some(Primary)
   | (false, Fallback) => Some(Secondary)
-  | (false, Live) => None
-  | (true, Live) => Some(Primary)
-  | (true, Sync) => hasLive ? Some(Secondary) : Some(Primary)
+  | (false, Realtime) => None
+  | (true, Realtime) => Some(Primary)
+  | (true, Sync) => hasRealtime ? Some(Secondary) : Some(Primary)
   | (true, Fallback) => Some(Secondary)
   }
 
@@ -70,9 +70,9 @@ let makeGetHeightRetryInterval = (
 let make = (
   ~sources: array<Source.t>,
   ~maxPartitionConcurrency,
-  ~isLive,
+  ~isRealtime,
   ~newBlockStallTimeout=60_000,
-  ~newBlockStallTimeoutLive=20_000,
+  ~newBlockStallTimeoutRealtime=20_000,
   ~stalledPollingInterval=5_000,
   ~reducedPollingInterval=60_000,
   ~recoveryTimeout=60_000.0,
@@ -82,9 +82,9 @@ let make = (
     ~maxRetryInterval=60_000,
   ),
 ) => {
-  let hasLive = sources->Array.some(s => s.sourceFor === Live)
+  let hasRealtime = sources->Array.some(s => s.sourceFor === Realtime)
   let initialActiveSource = switch sources->Array.find(source =>
-    getSourceRole(~sourceFor=source.sourceFor, ~isLive, ~hasLive) === Some(Primary)
+    getSourceRole(~sourceFor=source.sourceFor, ~isRealtime, ~hasRealtime) === Some(Primary)
   ) {
   | Some(source) => source
   | None =>
@@ -112,14 +112,14 @@ let make = (
     waitingForNewBlockStateId: None,
     fetchingPartitionsCount: 0,
     newBlockStallTimeout,
-    newBlockStallTimeoutLive,
+    newBlockStallTimeoutRealtime,
     stalledPollingInterval,
     reducedPollingInterval,
     getHeightRetryInterval,
     recoveryTimeout,
     statusStart: Hrtime.makeTimer(),
     status: Idle,
-    hasLive,
+    hasRealtime,
   }
 }
 
@@ -183,23 +183,22 @@ let fetchNext = async (
         ~chainId=sourceManager.activeSource.chain->ChainMap.Chain.toChainId,
       )
       sourceManager->trackNewStatus(~newStatus=Querieng)
-      let _ =
-        await queries
-        ->Array.map(q => {
-          let promise = q->executeQuery
-          let _ = promise->Promise.thenResolve(_ => {
-            sourceManager.fetchingPartitionsCount = sourceManager.fetchingPartitionsCount - 1
-            Prometheus.IndexingConcurrency.set(
-              ~concurrency=sourceManager.fetchingPartitionsCount,
-              ~chainId=sourceManager.activeSource.chain->ChainMap.Chain.toChainId,
-            )
-            if sourceManager.fetchingPartitionsCount === 0 {
-              sourceManager->trackNewStatus(~newStatus=Idle)
-            }
-          })
-          promise
+      let _ = await queries
+      ->Array.map(q => {
+        let promise = q->executeQuery
+        let _ = promise->Promise.thenResolve(_ => {
+          sourceManager.fetchingPartitionsCount = sourceManager.fetchingPartitionsCount - 1
+          Prometheus.IndexingConcurrency.set(
+            ~concurrency=sourceManager.fetchingPartitionsCount,
+            ~chainId=sourceManager.activeSource.chain->ChainMap.Chain.toChainId,
+          )
+          if sourceManager.fetchingPartitionsCount === 0 {
+            sourceManager->trackNewStatus(~newStatus=Idle)
+          }
         })
-        ->Promise.all
+        promise
+      })
+      ->Promise.all
     }
   }
 }
@@ -213,13 +212,13 @@ let disableSource = (sourceManager: t, sourceState: sourceState) => {
     | Some(unsubscribe) => unsubscribe()
     | None => ()
     }
-    if sourceState.source.sourceFor === Live {
-      // Only clear hasLive if no other non-disabled Live sources remain
-      let hasOtherLive =
+    if sourceState.source.sourceFor === Realtime {
+      // Only clear hasRealtime if no other non-disabled Realtime sources remain
+      let hasOtherRealtime =
         sourceManager.sourcesState->Array.some(s =>
-          s !== sourceState && !s.disabled && s.source.sourceFor === Live
+          s !== sourceState && !s.disabled && s.source.sourceFor === Realtime
         )
-      sourceManager.hasLive = hasOtherLive
+      sourceManager.hasRealtime = hasOtherRealtime
     }
     true
   } else {
@@ -232,7 +231,7 @@ let getSourceNewHeight = async (
   ~sourceState: sourceState,
   ~knownHeight,
   ~stallTimeout,
-  ~isLive,
+  ~isRealtime,
   ~status: ref<status>,
   ~logger,
   ~reducedPolling,
@@ -287,7 +286,7 @@ let getSourceNewHeight = async (
           // If createHeightSubscription is available and height hasn't changed,
           // create subscription instead of polling
           switch source.createHeightSubscription {
-          | Some(createSubscription) if isLive =>
+          | Some(createSubscription) if isRealtime =>
             let unsubscribe = createSubscription(~onHeight=newHeight => {
               sourceState.knownHeight = newHeight
               // Resolve all pending height resolvers
@@ -343,7 +342,7 @@ let compareByOldestFailure = (a: sourceState, b: sourceState) =>
   }
 
 // Priority: working primaries > working secondaries > all primaries.
-let getNextSources = (sourceManager, ~isLive, ~excludedSources=?) => {
+let getNextSources = (sourceManager, ~isRealtime, ~excludedSources=?) => {
   let now = Date.now()
   let workingPrimarySources = []
   let allPrimarySources = []
@@ -362,8 +361,8 @@ let getNextSources = (sourceManager, ~isLive, ~excludedSources=?) => {
         }
         switch getSourceRole(
           ~sourceFor=sourceState.source.sourceFor,
-          ~isLive,
-          ~hasLive=sourceManager.hasLive,
+          ~isRealtime,
+          ~hasRealtime=sourceManager.hasRealtime,
         ) {
         | Some(Primary) =>
           allPrimarySources->Array.push(sourceState)
@@ -389,8 +388,8 @@ let getNextSources = (sourceManager, ~isLive, ~excludedSources=?) => {
 
 // Single source selection from getNextSources.
 // Prefers activeSource if it's in the candidates. Fast path: check first item.
-let getNextSource = (sourceManager, ~isLive, ~excludedSources=?) => {
-  let sources = sourceManager->getNextSources(~isLive, ~excludedSources?)
+let getNextSource = (sourceManager, ~isRealtime, ~excludedSources=?) => {
+  let sources = sourceManager->getNextSources(~isRealtime, ~excludedSources?)
   switch sources->Array.get(0) {
   | None => None
   | Some(first) if first.source === sourceManager.activeSource => Some(first)
@@ -403,7 +402,7 @@ let getNextSource = (sourceManager, ~isLive, ~excludedSources=?) => {
 }
 
 // Polls for a block height greater than the given block number to ensure a new block is available for indexing.
-let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isLive, ~reducedPolling) => {
+let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isRealtime, ~reducedPolling) => {
   let {sourcesState} = sourceManager
 
   let logger = Logging.createChild(
@@ -421,7 +420,7 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isLive, ~reducedPo
     logger->Logging.childTrace("Initiating check for new blocks.")
   }
 
-  let mainSources = sourceManager->getNextSources(~isLive)
+  let mainSources = sourceManager->getNextSources(~isRealtime)
 
   let status = ref(Active)
 
@@ -429,8 +428,8 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isLive, ~reducedPo
   // to avoid spurious stall warnings while waiting for other chains to backfill
   let stallTimeout = if reducedPolling {
     sourceManager.reducedPollingInterval * 2
-  } else if isLive {
-    sourceManager.newBlockStallTimeoutLive
+  } else if isRealtime {
+    sourceManager.newBlockStallTimeoutRealtime
   } else {
     sourceManager.newBlockStallTimeout
   }
@@ -444,7 +443,7 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isLive, ~reducedPo
           ~sourceState,
           ~knownHeight,
           ~stallTimeout,
-          ~isLive,
+          ~isRealtime,
           ~status,
           ~logger,
           ~reducedPolling,
@@ -460,8 +459,8 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isLive, ~reducedPo
             !(mainSources->Array.includes(sourceState)) &&
             getSourceRole(
               ~sourceFor=sourceState.source.sourceFor,
-              ~isLive,
-              ~hasLive=sourceManager.hasLive,
+              ~isRealtime,
+              ~hasRealtime=sourceManager.hasRealtime,
             )->Option.isSome
           ) {
             fallbackSources->Array.push(sourceState)
@@ -494,7 +493,7 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isLive, ~reducedPo
                 ~sourceState,
                 ~knownHeight,
                 ~stallTimeout,
-                ~isLive,
+                ~isRealtime,
                 ~status,
                 ~logger,
                 ~reducedPolling,
@@ -521,7 +520,12 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isLive, ~reducedPo
   newBlockHeight
 }
 
-let executeQuery = async (sourceManager: t, ~query: FetchState.query, ~knownHeight, ~isLive) => {
+let executeQuery = async (
+  sourceManager: t,
+  ~query: FetchState.query,
+  ~knownHeight,
+  ~isRealtime,
+) => {
   let noSourcesError = "The indexer doesn't have data-sources which can continue fetching. Please, check the error logs or reach out to the Envio team."
 
   // Sources where the query is impossible — lazily allocated, excluded for the duration of this query
@@ -534,7 +538,7 @@ let executeQuery = async (sourceManager: t, ~query: FetchState.query, ~knownHeig
   while responseRef.contents->Option.isNone {
     // Select the best source at the start of every iteration
     let sourceState = switch sourceManager->getNextSource(
-      ~isLive,
+      ~isRealtime,
       ~excludedSources=?excludedSourcesRef.contents,
     ) {
     | Some(s) =>
@@ -670,7 +674,7 @@ let executeQuery = async (sourceManager: t, ~query: FetchState.query, ~knownHeig
           sourceState.lastFailedAt = Some(now)
           // Check if there's a working (recovered) source to switch to immediately
           let nextSource =
-            sourceManager->getNextSource(~isLive, ~excludedSources=?excludedSourcesRef.contents)
+            sourceManager->getNextSource(~isRealtime, ~excludedSources=?excludedSourcesRef.contents)
           let hasWorkingAlternative = switch nextSource {
           | Some(s) =>
             switch s.lastFailedAt {

--- a/packages/envio/src/sources/SourceManager.resi
+++ b/packages/envio/src/sources/SourceManager.resi
@@ -4,16 +4,16 @@ type sourceRole = Primary | Secondary
 
 let getSourceRole: (
   ~sourceFor: Source.sourceFor,
-  ~isLive: bool,
-  ~hasLive: bool,
+  ~isRealtime: bool,
+  ~hasRealtime: bool,
 ) => option<sourceRole>
 
 let make: (
   ~sources: array<Source.t>,
   ~maxPartitionConcurrency: int,
-  ~isLive: bool,
+  ~isRealtime: bool,
   ~newBlockStallTimeout: int=?,
-  ~newBlockStallTimeoutLive: int=?,
+  ~newBlockStallTimeoutRealtime: int=?,
   ~stalledPollingInterval: int=?,
   ~reducedPollingInterval: int=?,
   ~recoveryTimeout: float=?,
@@ -31,13 +31,18 @@ let fetchNext: (
   ~stateId: int,
 ) => promise<unit>
 
-let waitForNewBlock: (t, ~knownHeight: int, ~isLive: bool, ~reducedPolling: bool) => promise<int>
+let waitForNewBlock: (
+  t,
+  ~knownHeight: int,
+  ~isRealtime: bool,
+  ~reducedPolling: bool,
+) => promise<int>
 
 let executeQuery: (
   t,
   ~query: FetchState.query,
   ~knownHeight: int,
-  ~isLive: bool,
+  ~isRealtime: bool,
 ) => promise<Source.blockRangeFetchResponse>
 
 let makeGetHeightRetryInterval: (

--- a/scenarios/fuel_test/src/Indexer.res
+++ b/scenarios/fuel_test/src/Indexer.res
@@ -1099,8 +1099,8 @@ type indexerChain = {
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether the chain has completed initial sync and is processing live events. */
-  isLive: bool,
+  /** Whether all chains have completed initial sync and are processing real-time events. */
+  isRealtime: bool,
   \"AllEvents": indexerContract,
   \"Greeter": indexerContract,
 }

--- a/scenarios/test_codegen/src/Indexer.res
+++ b/scenarios/test_codegen/src/Indexer.res
@@ -1858,8 +1858,8 @@ type indexerChain = {
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether the chain has completed initial sync and is processing live events. */
-  isLive: bool,
+  /** Whether all chains have completed initial sync and are processing real-time events. */
+  isRealtime: bool,
   \"EventFiltersTest": indexerContract,
   \"Gravatar": indexerContract,
   \"NftFactory": indexerContract,

--- a/scenarios/test_codegen/src/Indexer.res
+++ b/scenarios/test_codegen/src/Indexer.res
@@ -1858,7 +1858,7 @@ type indexerChain = {
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether all chains have caught up to head and entered real-time indexing mode. */
+  /** Whether all chains have entered real-time indexing mode (caught up to head, or reached their configured endBlock for finite-range indexers). */
   isRealtime: bool,
   \"EventFiltersTest": indexerContract,
   \"Gravatar": indexerContract,

--- a/scenarios/test_codegen/src/Indexer.res
+++ b/scenarios/test_codegen/src/Indexer.res
@@ -1858,7 +1858,7 @@ type indexerChain = {
   startBlock: int,
   /** The block number to stop indexing at (if specified). */
   endBlock: option<int>,
-  /** Whether all chains have completed initial sync and are processing real-time events. */
+  /** Whether all chains have caught up to head and entered real-time indexing mode. */
   isRealtime: bool,
   \"EventFiltersTest": indexerContract,
   \"Gravatar": indexerContract,

--- a/scenarios/test_codegen/src/handlers/EventHandlers.res
+++ b/scenarios/test_codegen/src/handlers/EventHandlers.res
@@ -166,10 +166,10 @@ let lastEmptyEventChain: ref<option<Internal.chainInfo>> = ref(None)
 
 Indexer.indexer.onEvent({event: Indexer.Gravatar(EmptyEvent)}, async ({context}) => {
   // This handler tests that chain state is accessible in the context
-  // Chain will have isLive: false during sync and isLive: true during live indexing
+  // Chain will have isRealtime: false during sync and isRealtime: true once all chains caught up
   lastEmptyEventChain := Some(context.chain)
 
   // Log chain state for verification
-  let status = context.chain.isLive ? "ready (live)" : "syncing (historical)"
+  let status = context.chain.isRealtime ? "ready (realtime)" : "syncing (historical)"
   context.log.debug(`Chain ${context.chain.id->Belt.Int.toString} status: ${status}`)
 })

--- a/scenarios/test_codegen/src/handlers/EventHandlers.ts
+++ b/scenarios/test_codegen/src/handlers/EventHandlers.ts
@@ -161,7 +161,7 @@ indexer.onEvent({ contract: "Gravatar", event: "CustomSelection" }, async ({ eve
       typeof context.chain,
       {
         readonly id: EvmChainId;
-        readonly isLive: boolean;
+        readonly isRealtime: boolean;
       }
     >
   >(true);

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -110,7 +110,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       sourceManager: SourceManager.make(
         ~sources,
         ~maxPartitionConcurrency=Env.maxPartitionConcurrency,
-        ~isLive=false,
+        ~isRealtime=false,
       ),
       chainConfig,
       // This is quite a hack - but it works!

--- a/scenarios/test_codegen/test/E2E_test.res
+++ b/scenarios/test_codegen/test/E2E_test.res
@@ -1097,7 +1097,7 @@ describe("E2E tests", () => {
       let liveSource = MockIndexer.Source.make(
         [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
         ~chain=#1337,
-        ~sourceFor=Source.Live,
+        ~sourceFor=Source.Realtime,
       )
 
       let indexerMock = await MockIndexer.Indexer.make(
@@ -1145,7 +1145,7 @@ describe("E2E tests", () => {
       syncSource.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=300)
       await indexerMock.getBatchWritePromise()
 
-      // First waitForNewBlock runs with isLive=false (NextQuery fires before
+      // First waitForNewBlock runs with isRealtime=false (NextQuery fires before
       // EventBatchProcessed sets timestampCaughtUpToHeadOrEndblock).
       // Only Sync participates in height racing initially.
       t.expect(
@@ -1154,7 +1154,7 @@ describe("E2E tests", () => {
       ).toEqual(2)
       t.expect(
         liveSource.getHeightOrThrowCalls->Array.length,
-        ~message="Live source should NOT participate yet (isLive still false)",
+        ~message="Live source should NOT participate yet (isRealtime still false)",
       ).toEqual(0)
 
       // Resolve the first waitForNewBlock to advance to the next cycle
@@ -1170,7 +1170,7 @@ describe("E2E tests", () => {
       liveSource.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=301)
       await indexerMock.getBatchWritePromise()
 
-      // Now isLive=true (EventBatchProcessed has set timestampCaughtUpToHeadOrEndblock).
+      // Now isRealtime=true (EventBatchProcessed has set timestampCaughtUpToHeadOrEndblock).
       // Second waitForNewBlock: Live=Primary races, Sync=Secondary (not in main group).
       t.expect(
         syncSource.getHeightOrThrowCalls->Array.length,
@@ -1178,7 +1178,7 @@ describe("E2E tests", () => {
       ).toEqual(2)
       t.expect(
         liveSource.getHeightOrThrowCalls->Array.length,
-        ~message="Live source should now participate in height racing after isLive=true",
+        ~message="Live source should now participate in height racing after isRealtime=true",
       ).toEqual(1)
     },
   )

--- a/scenarios/test_codegen/test/EventHandler.test.ts
+++ b/scenarios/test_codegen/test/EventHandler.test.ts
@@ -79,28 +79,28 @@ describe("Use Envio test framework to test event handlers", () => {
             readonly startBlock: number;
             readonly endBlock: number | undefined;
             readonly name: string;
-            readonly isLive: boolean;
+            readonly isRealtime: boolean;
           } & ExpectedEvmContracts;
           readonly gnosis: {
             readonly id: 100;
             readonly startBlock: number;
             readonly endBlock: number | undefined;
             readonly name: string;
-            readonly isLive: boolean;
+            readonly isRealtime: boolean;
           } & ExpectedEvmContracts;
           readonly polygon: {
             readonly id: 137;
             readonly startBlock: number;
             readonly endBlock: number | undefined;
             readonly name: string;
-            readonly isLive: boolean;
+            readonly isRealtime: boolean;
           } & ExpectedEvmContracts;
           readonly "1337": {
             readonly id: 1337;
             readonly startBlock: number;
             readonly endBlock: number | undefined;
             readonly name: string;
-            readonly isLive: boolean;
+            readonly isRealtime: boolean;
           } & ExpectedEvmContracts;
         } & {
           readonly 1: {
@@ -108,33 +108,33 @@ describe("Use Envio test framework to test event handlers", () => {
             readonly startBlock: number;
             readonly endBlock: number | undefined;
             readonly name: string;
-            readonly isLive: boolean;
+            readonly isRealtime: boolean;
           } & ExpectedEvmContracts;
           readonly 100: {
             readonly id: 100;
             readonly startBlock: number;
             readonly endBlock: number | undefined;
             readonly name: string;
-            readonly isLive: boolean;
+            readonly isRealtime: boolean;
           } & ExpectedEvmContracts;
           readonly 137: {
             readonly id: 137;
             readonly startBlock: number;
             readonly endBlock: number | undefined;
             readonly name: string;
-            readonly isLive: boolean;
+            readonly isRealtime: boolean;
           } & ExpectedEvmContracts;
           readonly 1337: {
             readonly id: 1337;
             readonly startBlock: number;
             readonly endBlock: number | undefined;
             readonly name: string;
-            readonly isLive: boolean;
+            readonly isRealtime: boolean;
           } & ExpectedEvmContracts;
         }
       >
     >(true);
-    // Check that chain has the expected structure with name and isLive
+    // Check that chain has the expected structure with name and isRealtime
     expectType<
       TypeEqual<
         typeof indexer.chains.ethereumMainnet,
@@ -143,7 +143,7 @@ describe("Use Envio test framework to test event handlers", () => {
           readonly startBlock: number;
           readonly endBlock: number | undefined;
           readonly name: string;
-          readonly isLive: boolean;
+          readonly isRealtime: boolean;
         } & ExpectedEvmContracts
       >
     >(true);
@@ -184,7 +184,7 @@ describe("Use Envio test framework to test event handlers", () => {
     assert.deepEqual(indexer.chains[1].startBlock, 1);
     assert.deepEqual(indexer.chains[1].endBlock, undefined);
     assert.deepEqual(indexer.chains[1].name, "ethereumMainnet");
-    assert.deepEqual(indexer.chains[1].isLive, false);
+    assert.deepEqual(indexer.chains[1].isRealtime, false);
     assert.deepEqual(indexer.chains[1].Noop.addresses, [
       "0x0b2F78c5Bf6d9c12EE1225d5f374Aa91204580C3",
     ]);
@@ -197,7 +197,7 @@ describe("Use Envio test framework to test event handlers", () => {
       "startBlock",
       "endBlock",
       "name",
-      "isLive",
+      "isRealtime",
       "EventFiltersTest",
       "Gravatar",
       "NftFactory",
@@ -871,7 +871,7 @@ describe("Use Envio test framework to test event handlers", () => {
     assert.deepEqual(chain.name, "ethereumMainnet");
     assert.deepEqual(chain.startBlock, 1);
     assert.deepEqual(chain.endBlock, undefined);
-    assert.deepEqual(chain.isLive, false);
+    assert.deepEqual(chain.isRealtime, false);
 
     // Chain by name (non-enumerable alias)
     assert.deepEqual(testIndexer.chains[1], testIndexer.chains.ethereumMainnet);
@@ -1112,7 +1112,7 @@ describe("Use Envio test framework to test event handlers", () => {
 
     // Verify chain info types
     expectType<TypeEqual<typeof testIndexer.chainIds, readonly (1 | 100 | 137 | 1337)[]>>(true);
-    expectType<TypeEqual<typeof testIndexer.chains[1]["isLive"], boolean>>(true);
+    expectType<TypeEqual<typeof testIndexer.chains[1]["isRealtime"], boolean>>(true);
     expectType<TypeEqual<typeof testIndexer.chains[1]["id"], 1>>(true);
 
     const result = await testIndexer.process({
@@ -1589,7 +1589,7 @@ describe("onEvent / contractRegister types", () => {
 
   it("EvmOnEventContext has chain info and entity ops", () => {
     expectType<TypeEqual<EvmOnEventContext["chain"]["id"], EvmChainId>>(true);
-    expectType<TypeEqual<EvmOnEventContext["chain"]["isLive"], boolean>>(true);
+    expectType<TypeEqual<EvmOnEventContext["chain"]["isRealtime"], boolean>>(true);
     expectType<TypeEqual<EvmOnEventContext["isPreload"], boolean>>(true);
 
     // Entity ops are available on context

--- a/scenarios/test_codegen/test/EventOrigin_test.res
+++ b/scenarios/test_codegen/test/EventOrigin_test.res
@@ -3,18 +3,18 @@ open Vitest
 describe("Chains State", () => {
   describe("chainInfo type", () => {
     it(
-      "should have isLive field set to false",
+      "should have isRealtime field set to false",
       t => {
-        let chainInfo: Internal.chainInfo = {id: 1, isLive: false}
-        t.expect(chainInfo.isLive).toBe(false)
+        let chainInfo: Internal.chainInfo = {id: 1, isRealtime: false}
+        t.expect(chainInfo.isRealtime).toBe(false)
       },
     )
 
     it(
-      "should have isLive field set to true",
+      "should have isRealtime field set to true",
       t => {
-        let chainInfo: Internal.chainInfo = {id: 1, isLive: true}
-        t.expect(chainInfo.isLive).toBe(true)
+        let chainInfo: Internal.chainInfo = {id: 1, isRealtime: true}
+        t.expect(chainInfo.isRealtime).toBe(true)
       },
     )
   })
@@ -24,11 +24,11 @@ describe("Chains State", () => {
       "should support multiple chains with different states",
       t => {
         let chains: Internal.chains = Dict.make()
-        chains->Dict.set("1", {Internal.id: 1, isLive: false})
-        chains->Dict.set("2", {Internal.id: 2, isLive: true})
+        chains->Dict.set("1", {Internal.id: 1, isRealtime: false})
+        chains->Dict.set("2", {Internal.id: 2, isRealtime: true})
 
-        t.expect(chains->Dict.get("1")->Belt.Option.map(c => c.isLive)).toBe(Some(false))
-        t.expect(chains->Dict.get("2")->Belt.Option.map(c => c.isLive)).toBe(Some(true))
+        t.expect(chains->Dict.get("1")->Belt.Option.map(c => c.isRealtime)).toBe(Some(false))
+        t.expect(chains->Dict.get("2")->Belt.Option.map(c => c.isRealtime)).toBe(Some(true))
       },
     )
   })
@@ -45,7 +45,7 @@ describe("Chains State", () => {
         let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem
 
         let chains = Dict.make()
-        chains->Dict.set("1337", {Internal.id: 1337, isLive: false})
+        chains->Dict.set("1337", {Internal.id: 1337, isRealtime: false})
 
         let handlerContext = UserContext.getHandlerContext({
           item,
@@ -63,7 +63,7 @@ describe("Chains State", () => {
         })
 
         // Verify we can access current event's chain info
-        t.expect(handlerContext.chain.isLive).toBe(false)
+        t.expect(handlerContext.chain.isRealtime).toBe(false)
         t.expect(handlerContext.chain.id).toBe(1337)
       },
     )

--- a/scenarios/test_codegen/test/HandlerTypes_test.res
+++ b/scenarios/test_codegen/test/HandlerTypes_test.res
@@ -80,12 +80,12 @@ let _checkHandlerContext = (ctx: Indexer.handlerContext) => {
   let _: bool = ctx.isPreload
   let chainInfo: Internal.chainInfo = ctx.chain
   let _: int = chainInfo.id
-  let _: bool = chainInfo.isLive
+  let _: bool = chainInfo.isRealtime
   let _: Envio.logger = ctx.log
 }
 
 // 5. contractRegisterContext has chain.ContractName.add() registration.
-// Note: chain does NOT expose isLive — contract registration runs during sync
+// Note: chain does NOT expose isRealtime — contract registration runs during sync
 // so the "live" distinction isn't meaningful and the field was dropped.
 let _checkContractRegisterContext = (ctx: Indexer.contractRegisterContext) => {
   let chain: Indexer.contractRegisterChain = ctx.chain

--- a/scenarios/test_codegen/test/Indexer_test.res
+++ b/scenarios/test_codegen/test/Indexer_test.res
@@ -13,7 +13,7 @@ describe("Indexer.indexer", () => {
       startBlock: 1,
       endBlock: None,
       name: "1337",
-      isLive: false,
+      isRealtime: false,
       \"NftFactory": {
         name: "NftFactory",
         addresses: ["0xa2F6E6029638cCb484A2ccb6414499aD3e825CaC"->Address.unsafeFromString],

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -76,7 +76,7 @@ describe("SourceManager creation", () => {
   it("Successfully creates with a sync source", t => {
     let source = MockIndexer.Source.make([]).source
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[source],
       ~maxPartitionConcurrency=10,
     )
@@ -88,7 +88,7 @@ describe("SourceManager creation", () => {
     let sync0 = MockIndexer.Source.make([]).source
     let sync1 = MockIndexer.Source.make([]).source
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[fallback, sync0, sync1],
       ~maxPartitionConcurrency=10,
     )
@@ -96,10 +96,10 @@ describe("SourceManager creation", () => {
   })
 
   it("Prefers sync source over live source as initial active source", t => {
-    let live = MockIndexer.Source.make([], ~sourceFor=Live).source
+    let live = MockIndexer.Source.make([], ~sourceFor=Realtime).source
     let sync = MockIndexer.Source.make([]).source
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[live, sync],
       ~maxPartitionConcurrency=10,
     )
@@ -109,9 +109,9 @@ describe("SourceManager creation", () => {
 
   it("Prefers live source over sync source as initial active source in live mode", t => {
     let sync = MockIndexer.Source.make([]).source
-    let live = MockIndexer.Source.make([], ~sourceFor=Live).source
+    let live = MockIndexer.Source.make([], ~sourceFor=Realtime).source
     let sourceManager = SourceManager.make(
-      ~isLive=true,
+      ~isRealtime=true,
       ~sources=[sync, live],
       ~maxPartitionConcurrency=10,
     )
@@ -121,13 +121,13 @@ describe("SourceManager creation", () => {
   it("Fails to create without primary sources", t => {
     t.expect(
       () => {
-        SourceManager.make(~isLive=false, ~sources=[], ~maxPartitionConcurrency=10)
+        SourceManager.make(~isRealtime=false, ~sources=[], ~maxPartitionConcurrency=10)
       },
     ).toThrowError("Invalid configuration, no data-source for historical sync provided")
     t.expect(
       () => {
         SourceManager.make(
-          ~isLive=false,
+          ~isRealtime=false,
           ~sources=[MockIndexer.Source.make([], ~sourceFor=Fallback).source],
           ~maxPartitionConcurrency=10,
         )
@@ -137,43 +137,43 @@ describe("SourceManager creation", () => {
 })
 
 describe("SourceManager.getSourceRole", () => {
-  it("Backfill (isLive=false): Sync is Primary, Fallback is Secondary, Live is ignored", t => {
-    t.expect(SourceManager.getSourceRole(~sourceFor=Sync, ~isLive=false, ~hasLive=false)).toEqual(
+  it("Backfill (isRealtime=false): Sync is Primary, Fallback is Secondary, Live is ignored", t => {
+    t.expect(SourceManager.getSourceRole(~sourceFor=Sync, ~isRealtime=false, ~hasRealtime=false)).toEqual(
       Some(Primary),
     )
     t.expect(
-      SourceManager.getSourceRole(~sourceFor=Fallback, ~isLive=false, ~hasLive=false),
+      SourceManager.getSourceRole(~sourceFor=Fallback, ~isRealtime=false, ~hasRealtime=false),
     ).toEqual(Some(Secondary))
-    t.expect(SourceManager.getSourceRole(~sourceFor=Live, ~isLive=false, ~hasLive=false)).toEqual(
+    t.expect(SourceManager.getSourceRole(~sourceFor=Realtime, ~isRealtime=false, ~hasRealtime=false)).toEqual(
       None,
     )
-    // hasLive doesn't matter during backfill
-    t.expect(SourceManager.getSourceRole(~sourceFor=Sync, ~isLive=false, ~hasLive=true)).toEqual(
+    // hasRealtime doesn't matter during backfill
+    t.expect(SourceManager.getSourceRole(~sourceFor=Sync, ~isRealtime=false, ~hasRealtime=true)).toEqual(
       Some(Primary),
     )
-    t.expect(SourceManager.getSourceRole(~sourceFor=Live, ~isLive=false, ~hasLive=true)).toEqual(
+    t.expect(SourceManager.getSourceRole(~sourceFor=Realtime, ~isRealtime=false, ~hasRealtime=true)).toEqual(
       None,
     )
   })
 
   it("Live mode with Live source: Live is Primary, Sync+Fallback are Secondary", t => {
-    t.expect(SourceManager.getSourceRole(~sourceFor=Live, ~isLive=true, ~hasLive=true)).toEqual(
+    t.expect(SourceManager.getSourceRole(~sourceFor=Realtime, ~isRealtime=true, ~hasRealtime=true)).toEqual(
       Some(Primary),
     )
-    t.expect(SourceManager.getSourceRole(~sourceFor=Sync, ~isLive=true, ~hasLive=true)).toEqual(
+    t.expect(SourceManager.getSourceRole(~sourceFor=Sync, ~isRealtime=true, ~hasRealtime=true)).toEqual(
       Some(Secondary),
     )
-    t.expect(SourceManager.getSourceRole(~sourceFor=Fallback, ~isLive=true, ~hasLive=true)).toEqual(
+    t.expect(SourceManager.getSourceRole(~sourceFor=Fallback, ~isRealtime=true, ~hasRealtime=true)).toEqual(
       Some(Secondary),
     )
   })
 
   it("Live mode without Live source: Sync is Primary, Fallback is Secondary", t => {
-    t.expect(SourceManager.getSourceRole(~sourceFor=Sync, ~isLive=true, ~hasLive=false)).toEqual(
+    t.expect(SourceManager.getSourceRole(~sourceFor=Sync, ~isRealtime=true, ~hasRealtime=false)).toEqual(
       Some(Primary),
     )
     t.expect(
-      SourceManager.getSourceRole(~sourceFor=Fallback, ~isLive=true, ~hasLive=false),
+      SourceManager.getSourceRole(~sourceFor=Fallback, ~isRealtime=true, ~hasRealtime=false),
     ).toEqual(Some(Secondary))
   })
 })
@@ -193,20 +193,20 @@ describe("SourceManager source priority with Live sources", () => {
   }
 
   Async.it(
-    "During isLive=true with Live source: Live is primary, Sync+Fallback are secondary in waitForNewBlock",
+    "During isRealtime=true with Live source: Live is primary, Sync+Fallback are secondary in waitForNewBlock",
     async t => {
       let syncMock = MockIndexer.Source.make([#getHeightOrThrow])
-      let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Live)
+      let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Realtime)
       let fallbackMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Fallback)
-      let newBlockStallTimeoutLive = 5
+      let newBlockStallTimeoutRealtime = 5
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[syncMock.source, liveMock.source, fallbackMock.source],
         ~maxPartitionConcurrency=10,
-        ~newBlockStallTimeoutLive,
+        ~newBlockStallTimeoutRealtime,
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=100, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=100, ~reducedPolling=false)
 
       // Live is primary - should be called immediately
       t.expect(
@@ -231,26 +231,26 @@ describe("SourceManager source priority with Live sources", () => {
   )
 
   Async.it(
-    "During isLive=true with Live source: Sync and Fallback are used as secondary after timeout",
+    "During isRealtime=true with Live source: Sync and Fallback are used as secondary after timeout",
     async t => {
       let syncMock = MockIndexer.Source.make([#getHeightOrThrow])
-      let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Live)
+      let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Realtime)
       let fallbackMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Fallback)
-      let newBlockStallTimeoutLive = 5
+      let newBlockStallTimeoutRealtime = 5
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[syncMock.source, liveMock.source, fallbackMock.source],
         ~maxPartitionConcurrency=10,
-        ~newBlockStallTimeoutLive,
+        ~newBlockStallTimeoutRealtime,
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=100, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=100, ~reducedPolling=false)
 
       // Live doesn't find new block
       liveMock.resolveGetHeightOrThrow(100)
 
       // Wait for stall timeout
-      await Utils.delay(newBlockStallTimeoutLive)
+      await Utils.delay(newBlockStallTimeoutRealtime)
 
       // After timeout, Sync and Fallback should be called as secondaries
       t.expect(
@@ -270,27 +270,27 @@ describe("SourceManager source priority with Live sources", () => {
   )
 
   Async.it(
-    "During isLive=true with Live source: recovery from secondary goes to Live (not Sync)",
+    "During isRealtime=true with Live source: recovery from secondary goes to Live (not Sync)",
     async t => {
       let syncMock = MockIndexer.Source.make([#getHeightOrThrow, #getItemsOrThrow])
-      let liveMock = MockIndexer.Source.make([#getHeightOrThrow, #getItemsOrThrow], ~sourceFor=Live)
+      let liveMock = MockIndexer.Source.make([#getHeightOrThrow, #getItemsOrThrow], ~sourceFor=Realtime)
       let fallbackMock = MockIndexer.Source.make(
         [#getHeightOrThrow, #getItemsOrThrow],
         ~sourceFor=Fallback,
       )
-      let newBlockStallTimeoutLive = 0
+      let newBlockStallTimeoutRealtime = 0
       let sourceManager = SourceManager.make(
-        ~isLive=false,
-        ~newBlockStallTimeoutLive,
+        ~isRealtime=false,
+        ~newBlockStallTimeoutRealtime,
         ~sources=[syncMock.source, liveMock.source, fallbackMock.source],
         ~maxPartitionConcurrency=10,
       )
 
       {
-        // Switch to fallback via waitForNewBlock with isLive=true
+        // Switch to fallback via waitForNewBlock with isRealtime=true
 
-        let p = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=100, ~reducedPolling=false)
-        await Utils.delay(newBlockStallTimeoutLive)
+        let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=100, ~reducedPolling=false)
+        await Utils.delay(newBlockStallTimeoutRealtime)
         fallbackMock.resolveGetHeightOrThrow(101)
         t.expect(await p).toBe(101)
         t.expect(sourceManager->SourceManager.getActiveSource).toBe(fallbackMock.source)
@@ -298,12 +298,12 @@ describe("SourceManager source priority with Live sources", () => {
 
       {
         // Live never failed in executeQuery, recovery is immediate.
-        // With isLive=true, Live is Primary so recovery goes to Live, not Sync.
+        // With isRealtime=true, Live is Primary so recovery goes to Live, not Sync.
 
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=true,
+            ~isRealtime=true,
             ~knownHeight=100,
           )
         // The query goes to Live (recovered primary), not fallback
@@ -316,23 +316,23 @@ describe("SourceManager source priority with Live sources", () => {
 
       t.expect(
         sourceManager->SourceManager.getActiveSource,
-        ~message="Should recover to Live source (primary when isLive=true), not Sync",
+        ~message="Should recover to Live source (primary when isRealtime=true), not Sync",
       ).toBe(liveMock.source)
     },
   )
 
   Async.it(
-    "During isLive=true without Live source: Sync is primary, Fallback is secondary",
+    "During isRealtime=true without Live source: Sync is primary, Fallback is secondary",
     async t => {
       let syncMock = MockIndexer.Source.make([#getHeightOrThrow])
       let fallbackMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Fallback)
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[syncMock.source, fallbackMock.source],
         ~maxPartitionConcurrency=10,
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=0, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=0, ~reducedPolling=false)
 
       t.expect(
         syncMock.getHeightOrThrowCalls->Array.length,
@@ -459,7 +459,7 @@ describe("SourceManager fetchNext", () => {
     "Executes full partitions in any order when we didn't reach concurency limit",
     async t => {
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[source],
         ~maxPartitionConcurrency=10,
       )
@@ -529,7 +529,7 @@ describe("SourceManager fetchNext", () => {
     "Slices full partitions to the concurrency limit, takes the earliest queries first",
     async t => {
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[source],
         ~maxPartitionConcurrency=2,
       )
@@ -587,7 +587,7 @@ describe("SourceManager fetchNext", () => {
     "Skips full partitions at the chain last block and the ones at the mergeBlock",
     async t => {
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[source],
         ~maxPartitionConcurrency=10,
       )
@@ -623,7 +623,7 @@ describe("SourceManager fetchNext", () => {
 
   Async.it("Starts indexing from the initial state", async t => {
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[source],
       ~maxPartitionConcurrency=10,
     )
@@ -673,7 +673,7 @@ describe("SourceManager fetchNext", () => {
 
   Async.it("Waits for new block with knownHeight=0 even when all partitions are done", async t => {
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[source],
       ~maxPartitionConcurrency=10,
     )
@@ -704,7 +704,7 @@ describe("SourceManager fetchNext", () => {
 
   Async.it("Waits for new block when all partitions are at the knownHeight", async t => {
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[source],
       ~maxPartitionConcurrency=10,
     )
@@ -749,7 +749,7 @@ describe("SourceManager fetchNext", () => {
 
   Async.it("Restarts waiting for new block after a rollback", async t => {
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[source],
       ~maxPartitionConcurrency=10,
     )
@@ -810,7 +810,7 @@ describe("SourceManager fetchNext", () => {
 
   Async.it("Can add new partitions until the concurrency limit reached", async t => {
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[source],
       ~maxPartitionConcurrency=3,
     )
@@ -932,7 +932,7 @@ describe("SourceManager fetchNext", () => {
 
   Async.it("Should not query partitions that are at max queue size", async t => {
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[source],
       ~maxPartitionConcurrency=10,
     )
@@ -977,7 +977,7 @@ describe("SourceManager fetchNext", () => {
 
   Async.it("Sorts after all the filtering is applied", async t => {
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[source],
       ~maxPartitionConcurrency=1,
     )
@@ -1019,12 +1019,12 @@ describe("SourceManager wait for new blocks", () => {
         #getHeightOrThrow,
       ])
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[source],
         ~maxPartitionConcurrency=10,
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=0, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=0, ~reducedPolling=false)
 
       t.expect(getHeightOrThrowCalls->Array.length).toEqual(1)
       resolveGetHeightOrThrow(1)
@@ -1039,12 +1039,12 @@ describe("SourceManager wait for new blocks", () => {
       let mock0 = MockIndexer.Source.make([#getHeightOrThrow])
       let mock1 = MockIndexer.Source.make([#getHeightOrThrow])
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[mock0.source, mock1.source],
         ~maxPartitionConcurrency=10,
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=0, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=0, ~reducedPolling=false)
 
       t.expect(mock0.getHeightOrThrowCalls->Array.length).toEqual(1)
       t.expect(mock1.getHeightOrThrowCalls->Array.length).toEqual(1)
@@ -1071,16 +1071,16 @@ describe("SourceManager wait for new blocks", () => {
     },
   )
 
-  Async.it("Excludes live source from height fetch when isLive is false", async t => {
+  Async.it("Excludes live source from height fetch when isRealtime is false", async t => {
     let syncMock = MockIndexer.Source.make([#getHeightOrThrow])
-    let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Live)
+    let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Realtime)
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[syncMock.source, liveMock.source],
       ~maxPartitionConcurrency=10,
     )
 
-    let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=0, ~reducedPolling=false)
+    let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=0, ~reducedPolling=false)
 
     t.expect(
       syncMock.getHeightOrThrowCalls->Array.length,
@@ -1088,7 +1088,7 @@ describe("SourceManager wait for new blocks", () => {
     ).toEqual(1)
     t.expect(
       liveMock.getHeightOrThrowCalls->Array.length,
-      ~message="Should not call live source when isLive is false",
+      ~message="Should not call live source when isRealtime is false",
     ).toEqual(0)
 
     syncMock.resolveGetHeightOrThrow(1)
@@ -1099,15 +1099,15 @@ describe("SourceManager wait for new blocks", () => {
     ).toBe(syncMock.source)
   })
 
-  Async.it("Includes live source in height fetch when isLive is true", async t => {
+  Async.it("Includes live source in height fetch when isRealtime is true", async t => {
     let syncMock = MockIndexer.Source.make([#getHeightOrThrow])
-    let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Live)
+    let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Realtime)
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[syncMock.source, liveMock.source],
       ~maxPartitionConcurrency=10,
     )
-    let p = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=0, ~reducedPolling=false)
+    let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=0, ~reducedPolling=false)
 
     // With new priority logic: Live is Primary, Sync is Secondary when Live is present
     t.expect(
@@ -1116,7 +1116,7 @@ describe("SourceManager wait for new blocks", () => {
     ).toEqual(0)
     t.expect(
       liveMock.getHeightOrThrowCalls->Array.length,
-      ~message="Should call live source as primary when isLive is true",
+      ~message="Should call live source as primary when isRealtime is true",
     ).toEqual(1)
 
     liveMock.resolveGetHeightOrThrow(1)
@@ -1136,12 +1136,12 @@ describe("SourceManager wait for new blocks", () => {
       let mock0 = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval=pollingInterval0)
       let mock1 = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval=pollingInterval1)
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[mock0.source, mock1.source],
         ~maxPartitionConcurrency=10,
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=100, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=100, ~reducedPolling=false)
 
       let ((), ()) = await Promise.all2((
         (
@@ -1224,7 +1224,7 @@ describe("SourceManager wait for new blocks", () => {
       let mock0 = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval=pollingInterval0)
       let mock1 = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval=pollingInterval1)
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[mock0.source, mock1.source],
         ~maxPartitionConcurrency=10,
         ~getHeightRetryInterval=SourceManager.makeGetHeightRetryInterval(
@@ -1234,7 +1234,7 @@ describe("SourceManager wait for new blocks", () => {
         ),
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=100, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=100, ~reducedPolling=false)
 
       let ((), ()) = await Promise.all2((
         (
@@ -1362,14 +1362,14 @@ describe("SourceManager wait for new blocks", () => {
         ~pollingInterval,
       )
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[sync.source, fallback.source],
         ~maxPartitionConcurrency=10,
         ~newBlockStallTimeout,
         ~stalledPollingInterval,
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=100, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=100, ~reducedPolling=false)
 
       t.expect(sync.getHeightOrThrowCalls->Array.length).toEqual(1)
       t.expect(fallback.getHeightOrThrowCalls->Array.length).toEqual(0)
@@ -1441,7 +1441,7 @@ describe("SourceManager wait for new blocks", () => {
         ~message="Polling for fallback source should stop after successful response",
       ).toEqual(2)
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=101, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=101, ~reducedPolling=false)
 
       t.expect(
         sync.getHeightOrThrowCalls->Array.length,
@@ -1486,14 +1486,14 @@ describe("SourceManager wait for new blocks", () => {
       let sync = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval)
 
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[sync.source],
         ~maxPartitionConcurrency=10,
         ~newBlockStallTimeout,
         ~stalledPollingInterval,
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=100, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=100, ~reducedPolling=false)
 
       t.expect(sync.getHeightOrThrowCalls->Array.length).toEqual(1)
       sync.resolveGetHeightOrThrow(100)
@@ -1541,7 +1541,7 @@ describe("SourceManager wait for new blocks", () => {
       let sync = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval)
 
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[sync.source],
         ~maxPartitionConcurrency=10,
         ~stalledPollingInterval,
@@ -1549,7 +1549,7 @@ describe("SourceManager wait for new blocks", () => {
       )
 
       let p = sourceManager->SourceManager.waitForNewBlock(
-        ~isLive=false,
+        ~isRealtime=false,
         ~knownHeight=100,
         ~reducedPolling=true,
       )
@@ -1597,12 +1597,12 @@ describe("SourceManager.executeQuery", () => {
       #getItemsOrThrow,
     ])
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[source],
       ~maxPartitionConcurrency=10,
     )
     let p =
-      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isLive=false, ~knownHeight=100)
+      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isRealtime=false, ~knownHeight=100)
     t.expect(getItemsOrThrowCalls->Array.map(call => call.payload)).toEqual([
       {"fromBlock": 0, "toBlock": None, "retry": 0, "p": "0"},
     ])
@@ -1613,12 +1613,12 @@ describe("SourceManager.executeQuery", () => {
   Async.it("Rethrows unknown errors", async t => {
     let sourceMock = MockIndexer.Source.make([#getItemsOrThrow])
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[sourceMock.source],
       ~maxPartitionConcurrency=10,
     )
     let p =
-      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isLive=false, ~knownHeight=100)
+      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isRealtime=false, ~knownHeight=100)
     let error = {
       "message": "Something went wrong",
     }
@@ -1634,7 +1634,7 @@ describe("SourceManager.executeQuery", () => {
   Async.it("Immediately retries with the suggested toBlock", async t => {
     let sourceMock = MockIndexer.Source.make([#getItemsOrThrow])
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[
         sourceMock.source,
         // Added second source without mock to the test,
@@ -1644,7 +1644,7 @@ describe("SourceManager.executeQuery", () => {
       ~maxPartitionConcurrency=10,
     )
     let p =
-      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isLive=false, ~knownHeight=100)
+      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isRealtime=false, ~knownHeight=100)
     t.expect(
       sourceMock.getItemsOrThrowCalls->Array.length,
       ~message="Should call getItemsOrThrow",
@@ -1684,7 +1684,7 @@ describe("SourceManager.executeQuery", () => {
       let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
       let fallbackMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Fallback)
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[syncMock.source, fallbackMock.source],
         ~maxPartitionConcurrency=10,
       )
@@ -1693,7 +1693,7 @@ describe("SourceManager.executeQuery", () => {
       let p =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=false,
+          ~isRealtime=false,
           ~knownHeight=100,
         )
 
@@ -1801,7 +1801,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       )
       let newBlockStallTimeout = 0
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~newBlockStallTimeout,
         ~sources=[syncMock.source, fallbackMock.source],
         ~maxPartitionConcurrency=10,
@@ -1810,7 +1810,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       {
         // Switch active source to fallback via waitForNewBlock
 
-        let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=100, ~reducedPolling=false)
+        let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=100, ~reducedPolling=false)
         await Utils.delay(newBlockStallTimeout)
         fallbackMock.resolveGetHeightOrThrow(101)
         t.expect(await p).toBe(101)
@@ -1827,7 +1827,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=false,
+            ~isRealtime=false,
             ~knownHeight=100,
           )
         // Query goes to sync (recovered primary), not fallback
@@ -1855,7 +1855,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       )
       let recoveryTimeout = 5.0
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~recoveryTimeout,
         ~sources=[syncMock.source, fallbackMock.source],
         ~maxPartitionConcurrency=10,
@@ -1867,7 +1867,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=false,
+            ~isRealtime=false,
             ~knownHeight=100,
           )
         // Fail sync twice (retries 0, 1 don't switch), then on retry 2 it switches
@@ -1909,7 +1909,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=false,
+            ~isRealtime=false,
             ~knownHeight=100,
           )
         switch fallbackMock.getItemsOrThrowCalls {
@@ -1933,7 +1933,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=false,
+            ~isRealtime=false,
             ~knownHeight=100,
           )
         // Query goes to sync (recovered primary)
@@ -1955,7 +1955,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
     let recoveryTimeout = 0.0
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[syncMock.source],
       ~maxPartitionConcurrency=10,
       ~recoveryTimeout,
@@ -1966,7 +1966,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let p =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=false,
+          ~isRealtime=false,
           ~knownHeight=100,
         )
       switch syncMock.getItemsOrThrowCalls {
@@ -1985,10 +1985,10 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
   Async.it(
     "Does not attempt recovery when active source is already primary (live source)",
     async t => {
-      let liveMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Live)
+      let liveMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Realtime)
       let recoveryTimeout = 0.0
       let sourceManager = SourceManager.make(
-        ~isLive=true,
+        ~isRealtime=true,
         ~sources=[liveMock.source],
         ~maxPartitionConcurrency=10,
         ~recoveryTimeout,
@@ -1999,7 +1999,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=true,
+            ~isRealtime=true,
             ~knownHeight=100,
           )
         switch liveMock.getItemsOrThrowCalls {
@@ -2020,15 +2020,15 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     "When switching to secondary via waitForNewBlock in live mode, immediately recovers to live primary",
     async t => {
       let syncMock = MockIndexer.Source.make([#getHeightOrThrow])
-      let liveMock = MockIndexer.Source.make([#getHeightOrThrow, #getItemsOrThrow], ~sourceFor=Live)
+      let liveMock = MockIndexer.Source.make([#getHeightOrThrow, #getItemsOrThrow], ~sourceFor=Realtime)
       let fallbackMock = MockIndexer.Source.make(
         [#getHeightOrThrow, #getItemsOrThrow],
         ~sourceFor=Fallback,
       )
-      let newBlockStallTimeoutLive = 0
+      let newBlockStallTimeoutRealtime = 0
       let sourceManager = SourceManager.make(
-        ~isLive=false,
-        ~newBlockStallTimeoutLive,
+        ~isRealtime=false,
+        ~newBlockStallTimeoutRealtime,
         ~sources=[syncMock.source, liveMock.source, fallbackMock.source],
         ~maxPartitionConcurrency=10,
       )
@@ -2036,8 +2036,8 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       {
         // Switch activeSource to fallback via waitForNewBlock
 
-        let p = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=100, ~reducedPolling=false)
-        await Utils.delay(newBlockStallTimeoutLive)
+        let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=100, ~reducedPolling=false)
+        await Utils.delay(newBlockStallTimeoutRealtime)
         fallbackMock.resolveGetHeightOrThrow(101)
         t.expect(await p).toBe(101)
         t.expect(
@@ -2052,10 +2052,10 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=true,
+            ~isRealtime=true,
             ~knownHeight=100,
           )
-        // Query goes to live (primary when isLive=true), not fallback
+        // Query goes to live (primary when isRealtime=true), not fallback
         switch liveMock.getItemsOrThrowCalls {
         | [call] => call.resolve([])
         | _ => JsError.throwWithMessage("Expected one pending call to liveMock")
@@ -2077,7 +2077,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let fallbackMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Fallback)
       let recoveryTimeout = 5.0
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~recoveryTimeout,
         ~sources=[syncMock.source, fallbackMock.source],
         ~maxPartitionConcurrency=10,
@@ -2089,7 +2089,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=false,
+            ~isRealtime=false,
             ~knownHeight=100,
           )
         for idx in 0 to 2 {
@@ -2130,7 +2130,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=false,
+            ~isRealtime=false,
             ~knownHeight=100,
           )
         // Recovery switches to sync before query
@@ -2152,7 +2152,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=false,
+            ~isRealtime=false,
             ~knownHeight=101,
           )
         for idx in 0 to 2 {
@@ -2193,7 +2193,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         let p =
           sourceManager->SourceManager.executeQuery(
             ~query=mockQuery(),
-            ~isLive=false,
+            ~isRealtime=false,
             ~knownHeight=102,
           )
         switch syncMock.getItemsOrThrowCalls {
@@ -2211,24 +2211,24 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
   )
 
   Async.it(
-    "Disabling one of two Live sources keeps hasLive true, disabling both clears it",
+    "Disabling one of two Live sources keeps hasRealtime true, disabling both clears it",
     async t => {
       let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
-      let liveMock0 = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Live)
-      let liveMock1 = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Live)
+      let liveMock0 = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Realtime)
+      let liveMock1 = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Realtime)
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[syncMock.source, liveMock0.source, liveMock1.source],
         ~maxPartitionConcurrency=10,
       )
 
-      // In isLive=true mode with hasLive=true, Live sources are Primary.
+      // In isRealtime=true mode with hasRealtime=true, Live sources are Primary.
       // getNextSources picks liveMock0 (first primary).
       // Disable liveMock0 via UnsupportedSelection.
       let p1 =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=true,
+          ~isRealtime=true,
           ~knownHeight=100,
         )
       liveMock0.getItemsOrThrowCalls->Array.forEach(
@@ -2247,13 +2247,13 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let p2 =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=true,
+          ~isRealtime=true,
           ~knownHeight=100,
         )
       liveMock1.getItemsOrThrowCalls->Array.forEach(
         call => call.reject(Source.GetItemsError(UnsupportedSelection({message: "test disable"}))),
       )
-      // With both Live sources disabled, hasLive should be false.
+      // With both Live sources disabled, hasRealtime should be false.
       // Sync becomes Primary and should get the query.
       await Utils.delay(0)
       syncMock.getItemsOrThrowCalls->Array.forEach(call => call.resolve([]))
@@ -2270,7 +2270,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     let syncMock1 = MockIndexer.Source.make([#getHeightOrThrow, #getItemsOrThrow])
     let newBlockStallTimeout = 0
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~newBlockStallTimeout,
       ~sources=[syncMock0.source, syncMock1.source],
       ~maxPartitionConcurrency=10,
@@ -2279,7 +2279,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     {
       // Switch activeSource to syncMock1 via waitForNewBlock
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=100, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=100, ~reducedPolling=false)
       await Utils.delay(newBlockStallTimeout)
       syncMock1.resolveGetHeightOrThrow(101)
       t.expect(await p).toBe(101)
@@ -2296,7 +2296,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let p =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=false,
+          ~isRealtime=false,
           ~knownHeight=100,
         )
       switch syncMock1.getItemsOrThrowCalls {
@@ -2318,7 +2318,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let syncMock0 = MockIndexer.Source.make([#getItemsOrThrow])
       let syncMock1 = MockIndexer.Source.make([#getItemsOrThrow])
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[syncMock0.source, syncMock1.source],
         ~maxPartitionConcurrency=10,
       )
@@ -2326,7 +2326,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let p =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=false,
+          ~isRealtime=false,
           ~knownHeight=100,
         )
 
@@ -2366,7 +2366,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let p2 =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=false,
+          ~isRealtime=false,
           ~knownHeight=100,
         )
       switch syncMock1.getItemsOrThrowCalls {
@@ -2402,7 +2402,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let syncMock1 = MockIndexer.Source.make([#getItemsOrThrow])
       let syncMock2 = MockIndexer.Source.make([#getItemsOrThrow])
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[syncMock0.source, syncMock1.source, syncMock2.source],
         ~maxPartitionConcurrency=10,
       )
@@ -2410,7 +2410,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let p =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=false,
+          ~isRealtime=false,
           ~knownHeight=100,
         )
 
@@ -2465,7 +2465,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     let fallbackMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Fallback)
     let recoveryTimeout = 50.0
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[syncMock.source, fallbackMock.source],
       ~maxPartitionConcurrency=10,
       ~recoveryTimeout,
@@ -2473,7 +2473,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
 
     // Fail sync with WithBackoff enough times to trigger a switch (retries 0, 1, 2)
     let p1 =
-      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isLive=false, ~knownHeight=100)
+      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isRealtime=false, ~knownHeight=100)
     let withBackoff = Source.GetItemsError(
       FailedGettingItems({
         exn: %raw(`null`),
@@ -2515,7 +2515,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let p2 =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=false,
+          ~isRealtime=false,
           ~knownHeight=100,
         )
       switch fallbackMock.getItemsOrThrowCalls {
@@ -2533,7 +2533,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     await Utils.delay(recoveryTimeout->Float.toInt)
 
     let p3 =
-      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isLive=false, ~knownHeight=100)
+      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isRealtime=false, ~knownHeight=100)
     switch syncMock.getItemsOrThrowCalls {
     | [call] => call.resolve([])
     | _ => JsError.throwWithMessage("Expected sync to recover after timeout")
@@ -2550,13 +2550,13 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     let syncMock1 = MockIndexer.Source.make([#getItemsOrThrow])
     let fallbackMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Fallback)
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[syncMock0.source, syncMock1.source, fallbackMock.source],
       ~maxPartitionConcurrency=10,
     )
 
     let p =
-      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isLive=false, ~knownHeight=100)
+      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isRealtime=false, ~knownHeight=100)
 
     // Exclude syncMock0 via ImpossibleForTheQuery
     switch syncMock0.getItemsOrThrowCalls {
@@ -2607,13 +2607,13 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
   Async.it("WithBackoff with single source retries with delay, no crash", async t => {
     let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[syncMock.source],
       ~maxPartitionConcurrency=10,
     )
 
     let p =
-      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isLive=false, ~knownHeight=100)
+      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isRealtime=false, ~knownHeight=100)
     let withBackoff = Source.GetItemsError(
       FailedGettingItems({
         exn: %raw(`null`),
@@ -2651,7 +2651,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let syncMock0 = MockIndexer.Source.make([#getItemsOrThrow])
       let syncMock1 = MockIndexer.Source.make([#getItemsOrThrow])
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[syncMock0.source, syncMock1.source],
         ~maxPartitionConcurrency=10,
       )
@@ -2661,7 +2661,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let p0 =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=false,
+          ~isRealtime=false,
           ~knownHeight=100,
         )
       switch syncMock0.getItemsOrThrowCalls {
@@ -2694,7 +2694,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let p =
         sourceManager->SourceManager.executeQuery(
           ~query=mockQuery(),
-          ~isLive=false,
+          ~isRealtime=false,
           ~knownHeight=100,
         )
       switch syncMock1.getItemsOrThrowCalls {
@@ -2726,20 +2726,20 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     },
   )
 
-  Async.it("Disabling a Sync source does not affect hasLive", async t => {
+  Async.it("Disabling a Sync source does not affect hasRealtime", async t => {
     let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
-    let liveMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Live)
+    let liveMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Realtime)
     let fallbackMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Fallback)
     let sourceManager = SourceManager.make(
-      ~isLive=false,
+      ~isRealtime=false,
       ~sources=[syncMock.source, liveMock.source, fallbackMock.source],
       ~maxPartitionConcurrency=10,
     )
 
-    // In isLive=true mode, liveMock is Primary (hasLive=true).
-    // Disable sync via UnsupportedSelection — should NOT affect hasLive.
+    // In isRealtime=true mode, liveMock is Primary (hasRealtime=true).
+    // Disable sync via UnsupportedSelection — should NOT affect hasRealtime.
     let p1 =
-      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isLive=true, ~knownHeight=100)
+      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isRealtime=true, ~knownHeight=100)
     // liveMock is primary in live mode, gets query first
     switch liveMock.getItemsOrThrowCalls {
     | [call] => call.resolve([])
@@ -2749,7 +2749,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
 
     // Now disable sync via a backfill query where sync is primary
     let p2 =
-      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isLive=false, ~knownHeight=100)
+      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isRealtime=false, ~knownHeight=100)
     switch syncMock.getItemsOrThrowCalls {
     | [call] =>
       call.reject(Source.GetItemsError(UnsupportedSelection({message: "test disable sync"})))
@@ -2763,19 +2763,19 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     }
     let _ = await p2
 
-    // In isLive=true mode again, liveMock should still be Primary (hasLive unaffected by sync disable)
+    // In isRealtime=true mode again, liveMock should still be Primary (hasRealtime unaffected by sync disable)
     let p3 =
-      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isLive=true, ~knownHeight=100)
+      sourceManager->SourceManager.executeQuery(~query=mockQuery(), ~isRealtime=true, ~knownHeight=100)
     switch liveMock.getItemsOrThrowCalls {
     | [call] => call.resolve([])
     | _ =>
-      JsError.throwWithMessage("Expected liveMock to be primary in live mode (hasLive still true)")
+      JsError.throwWithMessage("Expected liveMock to be primary in live mode (hasRealtime still true)")
     }
     let _ = await p3
 
     t.expect(
       sourceManager->SourceManager.getActiveSource,
-      ~message="Live source should remain primary — disabling Sync doesn't affect hasLive",
+      ~message="Live source should remain primary — disabling Sync doesn't affect hasRealtime",
     ).toBe(liveMock.source)
   })
 })
@@ -2786,12 +2786,12 @@ describe("SourceManager height subscription", () => {
     async t => {
       let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
       let sourceManager = SourceManager.make(
-        ~isLive=true,
+        ~isRealtime=true,
         ~sources=[mock.source],
         ~maxPartitionConcurrency=10,
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=100, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=100, ~reducedPolling=false)
 
       // First call to getHeightOrThrow
       t.expect(mock.getHeightOrThrowCalls->Array.length).toEqual(1)
@@ -2816,20 +2816,20 @@ describe("SourceManager height subscription", () => {
   Async.it("Uses cached height from subscription if higher than knownHeight", async t => {
     let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
     let sourceManager = SourceManager.make(
-      ~isLive=true,
+      ~isRealtime=true,
       ~sources=[mock.source],
       ~maxPartitionConcurrency=10,
     )
 
     // First call - create subscription
-    let p1 = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=100, ~reducedPolling=false)
+    let p1 = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=100, ~reducedPolling=false)
     mock.resolveGetHeightOrThrow(100)
     await Utils.delay(0)
     mock.triggerHeightSubscription(105)
     t.expect(await p1).toEqual(105)
 
     // Second call - should use cached height immediately without calling getHeightOrThrow
-    let p2 = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=101, ~reducedPolling=false)
+    let p2 = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=101, ~reducedPolling=false)
     t.expect(
       mock.getHeightOrThrowCalls->Array.length,
       ~message="Should not call getHeightOrThrow again since subscription exists",
@@ -2842,20 +2842,20 @@ describe("SourceManager height subscription", () => {
     async t => {
       let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
       let sourceManager = SourceManager.make(
-        ~isLive=true,
+        ~isRealtime=true,
         ~sources=[mock.source],
         ~maxPartitionConcurrency=10,
       )
 
       // First call - create subscription and set initial height
-      let p1 = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=100, ~reducedPolling=false)
+      let p1 = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=100, ~reducedPolling=false)
       mock.resolveGetHeightOrThrow(100)
       await Utils.delay(0)
       mock.triggerHeightSubscription(101)
       t.expect(await p1).toEqual(101)
 
       // Second call with higher knownHeight - should wait for next subscription event
-      let p2 = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=101, ~reducedPolling=false)
+      let p2 = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=101, ~reducedPolling=false)
       t.expect(
         mock.getHeightOrThrowCalls->Array.length,
         ~message="Should not call getHeightOrThrow since subscription exists",
@@ -2874,12 +2874,12 @@ describe("SourceManager height subscription", () => {
       let pollingInterval = 1
       let mock = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval)
       let sourceManager = SourceManager.make(
-        ~isLive=false,
+        ~isRealtime=false,
         ~sources=[mock.source],
         ~maxPartitionConcurrency=10,
       )
 
-      let p = sourceManager->SourceManager.waitForNewBlock(~isLive=false, ~knownHeight=100, ~reducedPolling=false)
+      let p = sourceManager->SourceManager.waitForNewBlock(~isRealtime=false, ~knownHeight=100, ~reducedPolling=false)
 
       // Return same height - should trigger polling since no subscription available
       mock.resolveGetHeightOrThrow(100)
@@ -2901,21 +2901,21 @@ describe("SourceManager height subscription", () => {
       let stallTimeout = 20
       let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
       let sourceManager = SourceManager.make(
-        ~isLive=true,
+        ~isRealtime=true,
         ~sources=[mock.source],
         ~maxPartitionConcurrency=10,
-        ~newBlockStallTimeoutLive=stallTimeout,
+        ~newBlockStallTimeoutRealtime=stallTimeout,
       )
 
       // First call - create subscription
-      let p1 = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=100, ~reducedPolling=false)
+      let p1 = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=100, ~reducedPolling=false)
       mock.resolveGetHeightOrThrow(100)
       await Utils.delay(0)
       mock.triggerHeightSubscription(101)
       t.expect(await p1).toEqual(101)
 
       // Second call - subscription exists but won't deliver
-      let p2 = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=101, ~reducedPolling=false)
+      let p2 = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=101, ~reducedPolling=false)
 
       // Wait for stallTimeout/2 to trigger REST polling fallback
       await Utils.delay(stallTimeout / 2 + 5)
@@ -2935,20 +2935,20 @@ describe("SourceManager height subscription", () => {
   Async.it("Ignores subscription heights lower than or equal to knownHeight", async t => {
     let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
     let sourceManager = SourceManager.make(
-      ~isLive=true,
+      ~isRealtime=true,
       ~sources=[mock.source],
       ~maxPartitionConcurrency=10,
     )
 
     // First call - create subscription
-    let p1 = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=100, ~reducedPolling=false)
+    let p1 = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=100, ~reducedPolling=false)
     mock.resolveGetHeightOrThrow(100)
     await Utils.delay(0)
     mock.triggerHeightSubscription(101)
     t.expect(await p1).toEqual(101)
 
     // Second call with higher knownHeight
-    let p2 = sourceManager->SourceManager.waitForNewBlock(~isLive=true, ~knownHeight=105, ~reducedPolling=false)
+    let p2 = sourceManager->SourceManager.waitForNewBlock(~isRealtime=true, ~knownHeight=105, ~reducedPolling=false)
 
     // Trigger with lower heights - should be ignored
     mock.triggerHeightSubscription(102)


### PR DESCRIPTION
This PR renames the `isLive` parameter and property to `isRealtime` throughout the codebase to better reflect its actual semantics in multichain indexing scenarios.

## Summary
The `isLive` terminology was misleading in the context of unordered multichain indexing. The property doesn't indicate whether a single chain is processing live events, but rather whether **all chains** have caught up to head/endBlock and entered real-time indexing mode collectively. This rename clarifies the intended behavior.

## Key Changes

- **SourceManager**: Renamed `isLive` → `isRealtime` and `hasLive` → `hasRealtime` parameters and internal state
- **SourceManager.getSourceRole**: Updated function signature to use `isRealtime` and `hasRealtime`
- **Source.sourceFor**: Renamed enum variant `Live` → `Realtime`
- **ChainManager**: Added `isRealtime` parameter to track multichain real-time state; updated `computeChainsState` to compute `isRealtime` based on all chains being ready
- **ChainFetcher**: Added `isRealtime` parameter to constructor
- **GlobalState**: Updated to pass `isRealtime` to `waitForNewBlock` based on multichain readiness
- **Config**: Renamed RPC source type from `live` → `realtime` in configuration schema
- **Internal.chainInfo**: Renamed `isLive` → `isRealtime` with updated documentation clarifying multichain semantics
- **Type definitions**: Updated TypeScript definitions in `index.d.ts` and template files with clarified documentation
- **Tests**: Updated all test files to use new naming conventions and verify multichain behavior

## Notable Implementation Details

- For unordered multichain mode, `isRealtime` is `true` only when every chain has finished backfill and caught up to head/endBlock
- The `updateSyncTimeOnRestart` environment variable affects whether `isRealtime` state is preserved across restarts
- Documentation updates clarify that isolated multichain (per-chain semantics) is a future addition
- WebSocket subscriptions are only created when `isRealtime` is true, optimizing resource usage during backfill

https://claude.ai/code/session_0118Wh5Mk6ZQygM11brUmWKT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced “live” with “realtime” across configs, RPC values, runtime types and handler context properties; chain status now reflects a global "realtime" condition.

* **Documentation**
  * Updated guides, examples and API docs to use realtime wording and semantics.

* **Tests**
  * Updated tests and fixtures to assert and validate the new realtime naming and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->