### PR TITLE
Make isRealtime a monotonic state field in ChainManager

### DIFF
--- a/packages/envio/src/ChainManager.res
+++ b/packages/envio/src/ChainManager.res
@@ -3,6 +3,8 @@ type t = {
   chainFetchers: ChainMap.t<ChainFetcher.t>,
   multichain: Config.multichain,
   isInReorgThreshold: bool,
+  // True once every chain has caught up to head/endBlock. Monotonic during a run.
+  isRealtime: bool,
 }
 
 // Check if progress is past the reorg threshold (safe block).
@@ -107,6 +109,7 @@ let makeFromDbState = (
     multichain: config.multichain,
     chainFetchers,
     isInReorgThreshold,
+    isRealtime,
   }
 }
 
@@ -160,13 +163,7 @@ let isProgressAtHead = chainManager =>
 let isActivelyIndexing = chainManager =>
   chainManager.chainFetchers->ChainMap.values->Array.every(ChainFetcher.isActivelyIndexing)
 
-// True only once every chain has caught up to head/endBlock.
-// Array.every is true on an empty array; guard against the no-fetchers case
-// to match ChainManager.makeFromDbState's startup requirement.
-let isRealtime = chainManager => {
-  let chainFetchers = chainManager.chainFetchers->ChainMap.values
-  chainFetchers->Array.length > 0 && chainFetchers->Array.every(ChainFetcher.isReady)
-}
+let isRealtime = chainManager => chainManager.isRealtime
 
 let getSafeCheckpointId = (chainManager: t) => {
   let chainFetchers = chainManager.chainFetchers->ChainMap.values

--- a/packages/envio/src/ChainManager.res
+++ b/packages/envio/src/ChainManager.res
@@ -163,8 +163,6 @@ let isProgressAtHead = chainManager =>
 let isActivelyIndexing = chainManager =>
   chainManager.chainFetchers->ChainMap.values->Array.every(ChainFetcher.isActivelyIndexing)
 
-let isRealtime = chainManager => chainManager.isRealtime
-
 let getSafeCheckpointId = (chainManager: t) => {
   let chainFetchers = chainManager.chainFetchers->ChainMap.values
 

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -182,7 +182,7 @@ let updateProgressedChains = (chainManager: ChainManager.t, ~batch: Batch.t, ~ct
 
   let allChainsAtHead = chainManager->ChainManager.isProgressAtHead
   //Update the timestampCaughtUpToHeadOrEndblock values
-  let allChainsReady = ref(true)
+  let allChainsReady = ref(chainManager.chainFetchers->ChainMap.values->Array.length > 0)
   let chainFetchers = chainManager.chainFetchers->ChainMap.map(prev => {
     let cf = prev
     let chain = ChainMap.Chain.makeUnsafe(~chainId=cf.chainConfig.id)
@@ -336,6 +336,7 @@ let updateProgressedChains = (chainManager: ChainManager.t, ~batch: Batch.t, ~ct
     | None => chainManager.committedCheckpointId
     },
     chainFetchers,
+    isRealtime: chainManager.isRealtime || allChainsReady.contents,
   }
 }
 

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -182,7 +182,7 @@ let updateProgressedChains = (chainManager: ChainManager.t, ~batch: Batch.t, ~ct
 
   let allChainsAtHead = chainManager->ChainManager.isProgressAtHead
   //Update the timestampCaughtUpToHeadOrEndblock values
-  let allChainsReady = ref(chainManager.chainFetchers->ChainMap.values->Array.length > 0)
+  let allChainsReady = ref(true)
   let chainFetchers = chainManager.chainFetchers->ChainMap.map(prev => {
     let cf = prev
     let chain = ChainMap.Chain.makeUnsafe(~chainId=cf.chainConfig.id)
@@ -821,7 +821,7 @@ let checkAndFetchForChain = (
     let chainFetcher = state.chainManager.chainFetchers->ChainMap.get(chain)
     if !isPreparingRollback(state) {
       let {fetchState} = chainFetcher
-      let isRealtime = state.chainManager->ChainManager.isRealtime
+      let isRealtime = state.chainManager.isRealtime
 
       // Reduce polling when there's nothing useful to fetch right now:
       //   - this chain has caught up but others are still backfilling, or

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -148,8 +148,7 @@ let buildChainsObject = (~config: Config.t) => {
         enumerable: true,
         get: () => {
           switch globalGsManagerRef.contents {
-          | Some(gsManager) =>
-            (gsManager->GlobalStateManager.getState).chainManager->ChainManager.isRealtime
+          | Some(gsManager) => (gsManager->GlobalStateManager.getState).chainManager.isRealtime
           // Before the GlobalStateManager is available (eg during handler
           // module load after resume), derive from persistence: every chain
           // must have previously caught up to head or endBlock. Mirror the

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -132,6 +132,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       multichain: Ordered,
       committedCheckpointId: 0n,
       isInReorgThreshold: false,
+      isRealtime: false,
     },
     numberOfMockEventsCreated.contents,
     allEvents,


### PR DESCRIPTION
## Summary
This PR refactors the `isRealtime` flag from a computed property into a persistent state field in `ChainManager`, making it monotonic (only transitions from false to true once during a run).

## Key Changes
- Added `isRealtime: bool` field to the `ChainManager.t` type with documentation noting its monotonic behavior
- Moved `isRealtime` calculation from a function that recomputes on every call to a state field that is initialized and updated during chain progress updates
- Updated `ChainManager.makeFromDbState` to initialize the `isRealtime` field based on whether all chain fetchers are ready
- Modified `GlobalState.updateProgressedChains` to update the `isRealtime` field monotonically (once true, stays true) when all chains become ready
- Updated test fixtures to include the new `isRealtime` field initialization

## Implementation Details
- The `isRealtime` field is initialized in `makeFromDbState` by checking if all chain fetchers are ready (with a guard against empty fetcher arrays)
- In `updateProgressedChains`, the field is updated using `chainManager.isRealtime || allChainsReady.contents`, ensuring it only transitions from false to true and never back
- This change improves efficiency by avoiding repeated computation of the realtime status and provides clearer semantics about when the indexer has caught up to the chain head

https://claude.ai/code/session_01K1R67dXjjqN3qDJWQonEEk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked realtime mode tracking so realtime status is stored and propagated as part of manager state instead of being recomputed per-fetcher.
* **Bug Fixes**
  * Ensure realtime flag is correctly carried through chain-progress updates and read consistently across the system.
* **Tests**
  * Updated tests to explicitly define realtime behavior for deterministic test setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->