### PR TITLE
Add events per second metric to TUI display

### DIFF
--- a/packages/envio/src/tui/Tui.res
+++ b/packages/envio/src/tui/Tui.res
@@ -129,7 +129,6 @@ module GlobalEventsPerSecond = {
         <Text color={Secondary}>
           {`${Math.round(eps)->TuiData.formatFloatLocaleString}`->React.string}
         </Text>
-        <Text color={Gray}> {" (1m avg)"->React.string} </Text>
       </Text>
     | None => React.null
     }

--- a/packages/envio/src/tui/Tui.res
+++ b/packages/envio/src/tui/Tui.res
@@ -97,11 +97,8 @@ module GlobalEventsPerSecond = {
   let windowMs = 60_000.
 
   let computeEps = (samples: array<sample>) => {
-    let now = Date.now()
-    let cutoff = now -. windowMs
-    let inWindow = samples->Array.filter(s => s.time >= cutoff)
-    let len = inWindow->Array.length
-    switch (inWindow->Array.get(0), inWindow->Array.get(len - 1)) {
+    let len = samples->Array.length
+    switch (samples->Array.get(0), samples->Array.get(len - 1)) {
     | (Some(first), Some(last)) if last.time > first.time =>
       Some((last.events -. first.events) /. ((last.time -. first.time) /. 1000.))
     | _ => None

--- a/packages/envio/src/tui/Tui.res
+++ b/packages/envio/src/tui/Tui.res
@@ -91,6 +91,51 @@ module TotalEventsProcessed = {
   }
 }
 
+module GlobalEventsPerSecond = {
+  type sample = {time: float, events: float}
+
+  let windowMs = 60_000.
+
+  let computeEps = (samples: array<sample>) => {
+    let now = Date.now()
+    let cutoff = now -. windowMs
+    let inWindow = samples->Array.filter(s => s.time >= cutoff)
+    let len = inWindow->Array.length
+    switch (inWindow->Array.get(0), inWindow->Array.get(len - 1)) {
+    | (Some(first), Some(last)) if last.time > first.time =>
+      Some((last.events -. first.events) /. ((last.time -. first.time) /. 1000.))
+    | _ => None
+    }
+  }
+
+  @react.component
+  let make = (~totalEventsProcessed: float) => {
+    let (samples, setSamples) = React.useState((): array<sample> => [])
+
+    React.useEffect1(() => {
+      let now = Date.now()
+      let cutoff = now -. windowMs
+      setSamples(prev => {
+        let kept = prev->Array.filter(s => s.time >= cutoff)
+        kept->Array.concat([{time: now, events: totalEventsProcessed}])
+      })
+      None
+    }, [totalEventsProcessed])
+
+    switch computeEps(samples) {
+    | Some(eps) =>
+      <Text>
+        <Text bold=true> {"Events/sec: "->React.string} </Text>
+        <Text color={Secondary}>
+          {`${Math.round(eps)->TuiData.formatFloatLocaleString}`->React.string}
+        </Text>
+        <Text color={Gray}> {" (1m avg)"->React.string} </Text>
+      </Text>
+    | None => React.null
+    }
+  }
+}
+
 module App = {
   @react.component
   let make = (~getState) => {
@@ -215,6 +260,9 @@ module App = {
       })
       ->React.array}
       <TotalEventsProcessed totalEventsProcessed />
+      {SyncETA.isIndexerFullySynced(chains)
+        ? React.null
+        : <GlobalEventsPerSecond totalEventsProcessed />}
       <SyncETA chains indexerStartTime=state.indexerStartTime />
       <Newline />
       <Box flexDirection={Row}>

--- a/packages/envio/src/tui/Tui.res
+++ b/packages/envio/src/tui/Tui.res
@@ -78,20 +78,7 @@ module ChainLine = {
   }
 }
 
-module TotalEventsProcessed = {
-  @react.component
-  let make = (~totalEventsProcessed) => {
-    let label = "Total Events: "
-    <Text>
-      <Text bold=true> {label->React.string} </Text>
-      <Text color={Secondary}>
-        {`${totalEventsProcessed->TuiData.formatFloatLocaleString}`->React.string}
-      </Text>
-    </Text>
-  }
-}
-
-module GlobalEventsPerSecond = {
+module EventsPerSecond = {
   type sample = {time: float, events: float}
 
   let windowMs = 60_000.
@@ -105,8 +92,7 @@ module GlobalEventsPerSecond = {
     }
   }
 
-  @react.component
-  let make = (~totalEventsProcessed: float) => {
+  let use = (~totalEventsProcessed: float) => {
     let (samples, setSamples) = React.useState((): array<sample> => [])
 
     React.useEffect1(() => {
@@ -119,16 +105,26 @@ module GlobalEventsPerSecond = {
       None
     }, [totalEventsProcessed])
 
-    switch computeEps(samples) {
-    | Some(eps) =>
-      <Text>
-        <Text bold=true> {"Events/sec: "->React.string} </Text>
-        <Text color={Secondary}>
-          {`${Math.round(eps)->TuiData.formatFloatLocaleString}`->React.string}
-        </Text>
+    computeEps(samples)
+  }
+}
+
+module TotalEventsProcessed = {
+  @react.component
+  let make = (~totalEventsProcessed, ~eventsPerSecond: option<float>) => {
+    <Text>
+      <Text bold=true> {"Total Events: "->React.string} </Text>
+      <Text color={Secondary}>
+        {`${totalEventsProcessed->TuiData.formatFloatLocaleString}`->React.string}
       </Text>
-    | None => React.null
-    }
+      {switch eventsPerSecond {
+      | Some(eps) =>
+        <Text color={Gray}>
+          {` (${Math.round(eps)->TuiData.formatFloatLocaleString} events/sec)`->React.string}
+        </Text>
+      | None => React.null
+      }}
+    </Text>
   }
 }
 
@@ -229,6 +225,7 @@ module App = {
         acc
       }
     })
+    let eventsPerSecond = EventsPerSecond.use(~totalEventsProcessed)
 
     <Box flexDirection={Column}>
       <BigText
@@ -255,10 +252,10 @@ module App = {
         />
       })
       ->React.array}
-      <TotalEventsProcessed totalEventsProcessed />
-      {SyncETA.isIndexerFullySynced(chains)
-        ? React.null
-        : <GlobalEventsPerSecond totalEventsProcessed />}
+      <TotalEventsProcessed
+        totalEventsProcessed
+        eventsPerSecond={SyncETA.isIndexerFullySynced(chains) ? None : eventsPerSecond}
+      />
       <SyncETA chains indexerStartTime=state.indexerStartTime />
       <Newline />
       <Box flexDirection={Row}>


### PR DESCRIPTION
## Summary
Added real-time events per second (EPS) calculation and display to the terminal UI, showing the processing rate during indexing operations.

## Key Changes
- **New `EventsPerSecond` module**: Implements a sliding window algorithm that:
  - Maintains a 60-second window of event samples
  - Calculates EPS by comparing event deltas over time intervals
  - Uses React hooks to track samples and update on event count changes

- **Updated `TotalEventsProcessed` component**: 
  - Now accepts an optional `eventsPerSecond` parameter
  - Displays EPS in gray text alongside total event count when available
  - Only shows EPS during active syncing (hidden when indexer is fully synced)

- **Integration in `App` module**:
  - Calls `EventsPerSecond.use()` hook to compute the metric
  - Conditionally passes EPS to display component based on sync status

## Implementation Details
- The EPS calculation uses a sliding window approach, keeping only samples from the last 60 seconds
- EPS is rounded to nearest integer for display
- The metric is only shown during active indexing to avoid clutter when sync is complete
- Uses existing locale string formatting for consistency with other metrics

https://claude.ai/code/session_012aoqnAGRGG6oCbyPd2i9N5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time events-per-second (EPS) metric display to monitor processing throughput alongside total events processed, providing visibility into indexing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->