### PR TITLE
Add `envio config view` command to inspect indexer config

### DIFF
--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -31,6 +31,8 @@ This document contains the help content for the `envio` command-line program.
 * [`envio metrics`↴](#envio-metrics)
 * [`envio skills`↴](#envio-skills)
 * [`envio skills update`↴](#envio-skills-update)
+* [`envio config`↴](#envio-config)
+* [`envio config view`↴](#envio-config-view)
 
 ## `envio`
 
@@ -46,6 +48,7 @@ This document contains the help content for the `envio` command-line program.
 * `start` — Start the indexer. Runs codegen automatically before launching so the on-disk types stay in sync with `config.yaml` and `schema.graphql`
 * `metrics` — Fetch raw Prometheus metrics from the running indexer's /metrics endpoint
 * `skills` — Manage Envio-provided Claude Code skills under `.claude/skills/`
+* `config` — Inspect the indexer config
 
 ###### **Options:**
 
@@ -391,6 +394,26 @@ Manage Envio-provided Claude Code skills under `.claude/skills/`
 Re-extract every skill shipped by this CLI version, overwriting the matching directories under `<cwd>/.claude/skills/`. Skills not shipped by envio are left untouched
 
 **Usage:** `envio skills update`
+
+
+
+## `envio config`
+
+Inspect the indexer config
+
+**Usage:** `envio config <COMMAND>`
+
+###### **Subcommands:**
+
+* `view` — Print the resolved indexer config as JSON
+
+
+
+## `envio config view`
+
+Print the resolved indexer config as JSON
+
+**Usage:** `envio config view`
 
 
 

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -65,9 +65,19 @@ pub enum CommandType {
     #[command(subcommand)]
     Skills(SkillsSubcommand),
 
+    ///Inspect the indexer config
+    #[command(subcommand)]
+    Config(ConfigSubcommand),
+
     #[clap(hide = true)]
     #[command(subcommand)]
     Script(Script),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ConfigSubcommand {
+    ///Print the resolved indexer config as JSON
+    View,
 }
 
 #[derive(Debug, Subcommand)]

--- a/packages/cli/src/executor/config.rs
+++ b/packages/cli/src/executor/config.rs
@@ -1,0 +1,11 @@
+use crate::config_parsing::system_config::VERSION;
+use anyhow::{Context, Result};
+
+pub fn run_view() -> Result<()> {
+    let payload = serde_json::json!({ "version": VERSION });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&payload).context("Failed serializing config view JSON")?
+    );
+    Ok(())
+}

--- a/packages/cli/src/executor/mod.rs
+++ b/packages/cli/src/executor/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    clap_definitions::{JsonSchema, Script, SkillsSubcommand},
+    clap_definitions::{ConfigSubcommand, JsonSchema, Script, SkillsSubcommand},
     cli_args::clap_definitions::{CommandLineArgs, CommandType},
     commands,
     config_parsing::{human_config, system_config::SystemConfig},
@@ -9,6 +9,7 @@ use crate::{
 };
 
 mod codegen;
+mod config;
 mod dev;
 pub mod init;
 mod local;
@@ -87,6 +88,11 @@ pub async fn execute(
 
         CommandType::Skills(SkillsSubcommand::Update) => {
             skills::run_update(&parsed_project_paths)?;
+            Ok(None)
+        }
+
+        CommandType::Config(ConfigSubcommand::View) => {
+            config::run_view()?;
             Ok(None)
         }
 

--- a/scenarios/e2e_test/src/ConfigView.test.ts
+++ b/scenarios/e2e_test/src/ConfigView.test.ts
@@ -24,17 +24,14 @@ describe("envio config view", () => {
       status: result.status,
       signal: result.signal,
       parsed: JSON.parse(result.stdout),
-    }).toMatchInlineSnapshot(
-      { parsed: { version: expect.any(String) } },
-      `
+    }).toMatchInlineSnapshot(`
       {
         "parsed": {
-          "version": Any<String>,
+          "version": "0.0.1-dev",
         },
         "signal": null,
         "status": 0,
       }
-    `,
-    );
+    `);
   });
 });

--- a/scenarios/e2e_test/src/ConfigView.test.ts
+++ b/scenarios/e2e_test/src/ConfigView.test.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from "child_process";
+import path from "path";
+import { describe, it, expect } from "vitest";
+
+const ENVIO_BIN = path.resolve(
+  import.meta.dirname,
+  "../node_modules/envio/bin.mjs",
+);
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "..");
+
+describe("envio config view", () => {
+  it("prints the config as JSON", () => {
+    const result = spawnSync(
+      process.execPath,
+      [ENVIO_BIN, "config", "view"],
+      {
+        cwd: PROJECT_ROOT,
+        encoding: "utf-8",
+        timeout: 15_000,
+      },
+    );
+
+    expect({
+      status: result.status,
+      signal: result.signal,
+      parsed: JSON.parse(result.stdout),
+    }).toMatchInlineSnapshot(
+      { parsed: { version: expect.any(String) } },
+      `
+      {
+        "parsed": {
+          "version": Any<String>,
+        },
+        "signal": null,
+        "status": 0,
+      }
+    `,
+    );
+  });
+});

--- a/scenarios/fuel_test/test/ConfigView.test.ts
+++ b/scenarios/fuel_test/test/ConfigView.test.ts
@@ -24,17 +24,14 @@ describe("envio config view", () => {
       status: result.status,
       signal: result.signal,
       parsed: JSON.parse(result.stdout),
-    }).toMatchInlineSnapshot(
-      { parsed: { version: expect.any(String) } },
-      `
+    }).toMatchInlineSnapshot(`
       {
         "parsed": {
-          "version": Any<String>,
+          "version": "0.0.1-dev",
         },
         "signal": null,
         "status": 0,
       }
-    `,
-    );
+    `);
   });
 });

--- a/scenarios/fuel_test/test/ConfigView.test.ts
+++ b/scenarios/fuel_test/test/ConfigView.test.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from "child_process";
+import path from "path";
+import { describe, it, expect } from "vitest";
+
+const ENVIO_BIN = path.resolve(
+  import.meta.dirname,
+  "../node_modules/envio/bin.mjs",
+);
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "..");
+
+describe("envio config view", () => {
+  it("prints the config as JSON", () => {
+    const result = spawnSync(
+      process.execPath,
+      [ENVIO_BIN, "config", "view"],
+      {
+        cwd: PROJECT_ROOT,
+        encoding: "utf-8",
+        timeout: 15_000,
+      },
+    );
+
+    expect({
+      status: result.status,
+      signal: result.signal,
+      parsed: JSON.parse(result.stdout),
+    }).toMatchInlineSnapshot(
+      { parsed: { version: expect.any(String) } },
+      `
+      {
+        "parsed": {
+          "version": Any<String>,
+        },
+        "signal": null,
+        "status": 0,
+      }
+    `,
+    );
+  });
+});

--- a/scenarios/svm_test/test/ConfigView.test.ts
+++ b/scenarios/svm_test/test/ConfigView.test.ts
@@ -24,17 +24,14 @@ describe("envio config view", () => {
       status: result.status,
       signal: result.signal,
       parsed: JSON.parse(result.stdout),
-    }).toMatchInlineSnapshot(
-      { parsed: { version: expect.any(String) } },
-      `
+    }).toMatchInlineSnapshot(`
       {
         "parsed": {
-          "version": Any<String>,
+          "version": "0.0.1-dev",
         },
         "signal": null,
         "status": 0,
       }
-    `,
-    );
+    `);
   });
 });

--- a/scenarios/svm_test/test/ConfigView.test.ts
+++ b/scenarios/svm_test/test/ConfigView.test.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from "child_process";
+import path from "path";
+import { describe, it, expect } from "vitest";
+
+const ENVIO_BIN = path.resolve(
+  import.meta.dirname,
+  "../node_modules/envio/bin.mjs",
+);
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "..");
+
+describe("envio config view", () => {
+  it("prints the config as JSON", () => {
+    const result = spawnSync(
+      process.execPath,
+      [ENVIO_BIN, "config", "view"],
+      {
+        cwd: PROJECT_ROOT,
+        encoding: "utf-8",
+        timeout: 15_000,
+      },
+    );
+
+    expect({
+      status: result.status,
+      signal: result.signal,
+      parsed: JSON.parse(result.stdout),
+    }).toMatchInlineSnapshot(
+      { parsed: { version: expect.any(String) } },
+      `
+      {
+        "parsed": {
+          "version": Any<String>,
+        },
+        "signal": null,
+        "status": 0,
+      }
+    `,
+    );
+  });
+});

--- a/scenarios/test_codegen/test/ConfigView.test.ts
+++ b/scenarios/test_codegen/test/ConfigView.test.ts
@@ -24,17 +24,14 @@ describe("envio config view", () => {
       status: result.status,
       signal: result.signal,
       parsed: JSON.parse(result.stdout),
-    }).toMatchInlineSnapshot(
-      { parsed: { version: expect.any(String) } },
-      `
+    }).toMatchInlineSnapshot(`
       {
         "parsed": {
-          "version": Any<String>,
+          "version": "0.0.1-dev",
         },
         "signal": null,
         "status": 0,
       }
-    `,
-    );
+    `);
   });
 });

--- a/scenarios/test_codegen/test/ConfigView.test.ts
+++ b/scenarios/test_codegen/test/ConfigView.test.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from "child_process";
+import path from "path";
+import { describe, it, expect } from "vitest";
+
+const ENVIO_BIN = path.resolve(
+  import.meta.dirname,
+  "../node_modules/envio/bin.mjs",
+);
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "..");
+
+describe("envio config view", () => {
+  it("prints the config as JSON", () => {
+    const result = spawnSync(
+      process.execPath,
+      [ENVIO_BIN, "config", "view"],
+      {
+        cwd: PROJECT_ROOT,
+        encoding: "utf-8",
+        timeout: 15_000,
+      },
+    );
+
+    expect({
+      status: result.status,
+      signal: result.signal,
+      parsed: JSON.parse(result.stdout),
+    }).toMatchInlineSnapshot(
+      { parsed: { version: expect.any(String) } },
+      `
+      {
+        "parsed": {
+          "version": Any<String>,
+        },
+        "signal": null,
+        "status": 0,
+      }
+    `,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a new `envio config view` subcommand that prints the resolved indexer configuration as JSON output.

## Key Changes
- **New CLI command**: Added `envio config view` subcommand under a new `config` command group
  - Defined `ConfigSubcommand` enum with `View` variant in `clap_definitions.rs`
  - Added `Config` variant to `CommandType` enum
  
- **Implementation**: Created new `config.rs` executor module
  - `run_view()` function serializes and prints config as pretty-printed JSON
  - Currently outputs the CLI version from `VERSION` constant
  
- **Documentation**: Updated `CommandLineHelp.md` with help text for new commands
  - Added entries for `envio config` and `envio config view`
  - Documented as "Inspect the indexer config" and "Print the resolved indexer config as JSON"

- **Tests**: Added integration tests across all scenario projects
  - `ConfigView.test.ts` in `scenarios/e2e_test/src/`, `scenarios/fuel_test/test/`, `scenarios/svm_test/test/`, and `scenarios/test_codegen/test/`
  - Tests verify the command executes successfully and outputs valid JSON with version information

## Implementation Details
- The config view currently outputs a minimal JSON structure containing only the version field
- Tests use `spawnSync` to invoke the CLI and validate JSON output matches expected snapshot
- Command integrates into existing executor pattern with proper error handling via `anyhow::Result`

https://claude.ai/code/session_019JLjsDnAWDAnARbkKud3TA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `envio config view` command that displays the current indexer configuration in JSON format.

* **Tests**
  * Added comprehensive end-to-end test coverage for the new config view command across multiple test scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1193)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->