### PR TITLE
ci: announce releases to Discord

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -1,0 +1,25 @@
+name: Announce release to Discord
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    if: github.event.release.draft == false
+    steps:
+      - name: Post release to Discord
+        uses: SethCohen/github-releases-to-discord@24d166886aee4646d448c8a389ff9e1ebcab3682 # v1.20.0
+        with:
+          webhook_url: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          color: "5814783"
+          username: "HyperIndex Releases"
+          avatar_url: "https://avatars.githubusercontent.com/u/135992464?v=4"
+          footer_title: "HyperIndex"
+          footer_timestamp: "true"
+          reduce_headings: "true"
+          max_description: "4000"


### PR DESCRIPTION
Adds a workflow that posts a formatted embed to Discord whenever a GitHub release is published.

- Triggered by `release: published`
- Skips drafts; includes prereleases (alpha/rc)
- Action pinned to commit SHA
- Workflow runs with `contents: read` only
- Webhook URL comes from the `DISCORD_RELEASE_WEBHOOK` repo secret

To test without cutting a real release: temporarily add a `workflow_dispatch` trigger with `release_name`/`release_body`/`release_html_url` inputs, run once, then revert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Discord notifications for published releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1196)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->