### PR TITLE
Include storage config in `envio config view` output

### DIFF
--- a/packages/cli/src/config_parsing/mod.rs
+++ b/packages/cli/src/config_parsing/mod.rs
@@ -7,6 +7,6 @@ pub mod field_types;
 pub mod graph_migration;
 pub mod human_config;
 pub mod hypersync_endpoints;
-pub mod public_config_json;
+pub mod public_config;
 pub mod system_config;
 pub mod validation;

--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -51,10 +51,10 @@ pub(crate) struct PublicConfigJson<'a> {
 
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct StorageConfig {
-    pub(crate) postgres: bool,
+struct StorageConfig {
+    postgres: bool,
     #[serde(skip_serializing_if = "is_false")]
-    pub(crate) clickhouse: bool,
+    clickhouse: bool,
 }
 
 impl From<&system_config::Storage> for StorageConfig {
@@ -614,4 +614,19 @@ impl SystemConfig {
 
         Ok(serde_json::to_string_pretty(&config)? + "\n")
     }
+
+    pub fn to_view_json(&self) -> Result<String> {
+        let view = ConfigView {
+            version: system_config::VERSION,
+            storage: (&self.storage).into(),
+        };
+        Ok(serde_json::to_string_pretty(&view)?)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfigView<'a> {
+    version: &'a str,
+    storage: StorageConfig,
 }

--- a/packages/cli/src/config_parsing/public_config_json.rs
+++ b/packages/cli/src/config_parsing/public_config_json.rs
@@ -51,10 +51,19 @@ pub(crate) struct PublicConfigJson<'a> {
 
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-struct StorageConfig {
-    postgres: bool,
+pub(crate) struct StorageConfig {
+    pub(crate) postgres: bool,
     #[serde(skip_serializing_if = "is_false")]
-    clickhouse: bool,
+    pub(crate) clickhouse: bool,
+}
+
+impl From<&system_config::Storage> for StorageConfig {
+    fn from(s: &system_config::Storage) -> Self {
+        Self {
+            postgres: s.postgres,
+            clickhouse: s.clickhouse,
+        }
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -595,10 +604,7 @@ impl SystemConfig {
             rollback_on_reorg: cfg.rollback_on_reorg,
             save_full_history: cfg.save_full_history,
             raw_events: cfg.enable_raw_events,
-            storage: StorageConfig {
-                postgres: cfg.storage.postgres,
-                clickhouse: cfg.storage.clickhouse,
-            },
+            storage: (&cfg.storage).into(),
             evm,
             fuel,
             svm,

--- a/packages/cli/src/executor/config.rs
+++ b/packages/cli/src/executor/config.rs
@@ -1,32 +1,9 @@
-use crate::{
-    config_parsing::{
-        public_config_json::StorageConfig,
-        system_config::{SystemConfig, VERSION},
-    },
-    project_paths::ParsedProjectPaths,
-};
+use crate::{config_parsing::system_config::SystemConfig, project_paths::ParsedProjectPaths};
 use anyhow::{Context, Result};
-use serde::Serialize;
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ConfigView<'a> {
-    version: &'a str,
-    storage: StorageConfig,
-}
 
 pub fn run_view(parsed_project_paths: &ParsedProjectPaths) -> Result<()> {
     let config = SystemConfig::parse_from_project_files(parsed_project_paths)
         .context("Failed parsing config")?;
-
-    let payload = ConfigView {
-        version: VERSION,
-        storage: (&config.storage).into(),
-    };
-
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&payload).context("Failed serializing config view JSON")?
-    );
+    println!("{}", config.to_view_json()?);
     Ok(())
 }

--- a/packages/cli/src/executor/config.rs
+++ b/packages/cli/src/executor/config.rs
@@ -1,5 +1,8 @@
 use crate::{
-    config_parsing::system_config::{SystemConfig, VERSION},
+    config_parsing::{
+        public_config_json::StorageConfig,
+        system_config::{SystemConfig, VERSION},
+    },
     project_paths::ParsedProjectPaths,
 };
 use anyhow::{Context, Result};
@@ -7,17 +10,9 @@ use serde::Serialize;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct StorageView {
-    postgres: bool,
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    clickhouse: bool,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
 struct ConfigView<'a> {
     version: &'a str,
-    storage: StorageView,
+    storage: StorageConfig,
 }
 
 pub fn run_view(parsed_project_paths: &ParsedProjectPaths) -> Result<()> {
@@ -26,10 +21,7 @@ pub fn run_view(parsed_project_paths: &ParsedProjectPaths) -> Result<()> {
 
     let payload = ConfigView {
         version: VERSION,
-        storage: StorageView {
-            postgres: config.storage.postgres,
-            clickhouse: config.storage.clickhouse,
-        },
+        storage: (&config.storage).into(),
     };
 
     println!(

--- a/packages/cli/src/executor/config.rs
+++ b/packages/cli/src/executor/config.rs
@@ -1,8 +1,37 @@
-use crate::config_parsing::system_config::VERSION;
+use crate::{
+    config_parsing::system_config::{SystemConfig, VERSION},
+    project_paths::ParsedProjectPaths,
+};
 use anyhow::{Context, Result};
+use serde::Serialize;
 
-pub fn run_view() -> Result<()> {
-    let payload = serde_json::json!({ "version": VERSION });
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StorageView {
+    postgres: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    clickhouse: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfigView<'a> {
+    version: &'a str,
+    storage: StorageView,
+}
+
+pub fn run_view(parsed_project_paths: &ParsedProjectPaths) -> Result<()> {
+    let config = SystemConfig::parse_from_project_files(parsed_project_paths)
+        .context("Failed parsing config")?;
+
+    let payload = ConfigView {
+        version: VERSION,
+        storage: StorageView {
+            postgres: config.storage.postgres,
+            clickhouse: config.storage.clickhouse,
+        },
+    };
+
     println!(
         "{}",
         serde_json::to_string_pretty(&payload).context("Failed serializing config view JSON")?

--- a/packages/cli/src/executor/mod.rs
+++ b/packages/cli/src/executor/mod.rs
@@ -92,7 +92,7 @@ pub async fn execute(
         }
 
         CommandType::Config(ConfigSubcommand::View) => {
-            config::run_view()?;
+            config::run_view(&parsed_project_paths)?;
             Ok(None)
         }
 

--- a/scenarios/e2e_test/src/ConfigView.test.ts
+++ b/scenarios/e2e_test/src/ConfigView.test.ts
@@ -27,6 +27,10 @@ describe("envio config view", () => {
     }).toMatchInlineSnapshot(`
       {
         "parsed": {
+          "storage": {
+            "clickhouse": true,
+            "postgres": true,
+          },
           "version": "0.0.1-dev",
         },
         "signal": null,

--- a/scenarios/fuel_test/test/ConfigView.test.ts
+++ b/scenarios/fuel_test/test/ConfigView.test.ts
@@ -27,6 +27,9 @@ describe("envio config view", () => {
     }).toMatchInlineSnapshot(`
       {
         "parsed": {
+          "storage": {
+            "postgres": true,
+          },
           "version": "0.0.1-dev",
         },
         "signal": null,

--- a/scenarios/svm_test/test/ConfigView.test.ts
+++ b/scenarios/svm_test/test/ConfigView.test.ts
@@ -27,6 +27,9 @@ describe("envio config view", () => {
     }).toMatchInlineSnapshot(`
       {
         "parsed": {
+          "storage": {
+            "postgres": true,
+          },
           "version": "0.0.1-dev",
         },
         "signal": null,

--- a/scenarios/test_codegen/test/ConfigView.test.ts
+++ b/scenarios/test_codegen/test/ConfigView.test.ts
@@ -27,6 +27,9 @@ describe("envio config view", () => {
     }).toMatchInlineSnapshot(`
       {
         "parsed": {
+          "storage": {
+            "postgres": true,
+          },
           "version": "0.0.1-dev",
         },
         "signal": null,


### PR DESCRIPTION
## Summary
Extends the `envio config view` command to include storage configuration (postgres and clickhouse settings) in its output, making the command more informative about the project's storage setup.

## Key Changes
- Renamed `public_config_json.rs` to `public_config.rs` for clarity
- Added `From<&system_config::Storage>` trait implementation for `StorageConfig` to reduce boilerplate when converting storage configuration
- Introduced `ConfigView` struct to represent the output of `envio config view`, containing version and storage configuration
- Added `to_view_json()` method to `SystemConfig` to serialize the config view
- Updated `config::run_view()` to parse the full project configuration and output storage details alongside version information
- Updated all integration tests to expect storage configuration in the output

## Implementation Details
The `run_view` command now requires `ParsedProjectPaths` to load the full system configuration, allowing it to extract and display storage settings. The new `ConfigView` struct provides a focused output format containing only the version and storage information, keeping the output clean and relevant to users querying the config view.

https://claude.ai/code/session_01LBzbhgXrzscUYTfb5qRef4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `config view` command now displays storage configuration details in its output, showing the availability of PostgreSQL and ClickHouse.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1197)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->