### PR TITLE
ci: install capnproto on Rust-building workflows

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -32,6 +32,14 @@ jobs:
         with:
           targets: ${{ matrix.job.target }}
 
+      - name: Install capnproto (Linux)
+        if: ${{ matrix.job.platform == 'linux' }}
+        run: sudo apt-get update -y && sudo apt-get install -y capnproto libcapnp-dev
+
+      - name: Install capnproto (macOS)
+        if: ${{ matrix.job.platform == 'darwin' }}
+        run: brew install capnp
+
       - uses: ./.github/actions/cargo-cache
         with:
           cache-suffix: ${{ matrix.job.target }}

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install capnproto (Linux)
         if: ${{ matrix.job.platform == 'linux' }}
-        run: sudo apt-get update -y && sudo apt-get install -y capnproto libcapnp-dev
+        run: sudo apt-get update -y && sudo apt-get install -y capnproto
 
       - name: Install capnproto (macOS)
         if: ${{ matrix.job.platform == 'darwin' }}

--- a/.github/workflows/build_and_verify.yml
+++ b/.github/workflows/build_and_verify.yml
@@ -67,7 +67,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install capnproto
-        run: sudo apt-get update -y && sudo apt-get install -y capnproto libcapnp-dev
+        run: sudo apt-get update -y && sudo apt-get install -y capnproto
 
       - uses: ./.github/actions/cargo-cache
 
@@ -134,7 +134,7 @@ jobs:
           components: clippy
 
       - name: Install capnproto
-        run: sudo apt-get update -y && sudo apt-get install -y capnproto libcapnp-dev
+        run: sudo apt-get update -y && sudo apt-get install -y capnproto
 
       - uses: ./.github/actions/cargo-cache
 
@@ -160,7 +160,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install capnproto
-        run: sudo apt-get update -y && sudo apt-get install -y capnproto libcapnp-dev
+        run: sudo apt-get update -y && sudo apt-get install -y capnproto
 
       - uses: ./.github/actions/cargo-cache
 

--- a/.github/workflows/build_and_verify.yml
+++ b/.github/workflows/build_and_verify.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install capnproto
+        run: sudo apt-get update -y && sudo apt-get install -y capnproto libcapnp-dev
+
       - uses: ./.github/actions/cargo-cache
 
       - uses: pnpm/action-setup@v5
@@ -130,6 +133,9 @@ jobs:
         with:
           components: clippy
 
+      - name: Install capnproto
+        run: sudo apt-get update -y && sudo apt-get install -y capnproto libcapnp-dev
+
       - uses: ./.github/actions/cargo-cache
 
       - name: Clippy
@@ -152,6 +158,9 @@ jobs:
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Install capnproto
+        run: sudo apt-get update -y && sudo apt-get install -y capnproto libcapnp-dev
 
       - uses: ./.github/actions/cargo-cache
 


### PR DESCRIPTION
Closing — original blocker PR #1203 is being closed in favor of pivoting to HyperSync (which doesn't need `capnp` at build time). This infra change becomes unnecessary unless we resume the HyperFuel work.

If/when we resume HyperFuel, the upstream fix (enviodev/hyperfuel-client-rust#8) is the right long-term solution; this workflow change would only be needed as a stopgap if that doesn't land first.