### PR TITLE
Use ClickHouse defaults matching out-of-the-box setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "subenum",
+ "tar",
  "tempdir",
  "thiserror 1.0.69",
  "tokio",
@@ -1210,6 +1211,16 @@ checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -3429,6 +3440,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4273,6 +4295,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -49,6 +49,7 @@ convert_case = "0.6.0"
 dotenvy = { git = "https://github.com/enviodev/dotenvy", rev = "e2da110668572cf2d67178f192eb1fc285224040" }
 bollard = "0.20"
 futures-util = "0.3"
+tar = "0.4"
 napi = { version = "=3.8.5", features = ["napi10", "async", "serde-json"] }
 napi-derive = "=3.5.4"
 

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -23,22 +23,21 @@ const CLICKHOUSE_IMAGE: &str = "clickhouse/clickhouse-server:26.2.15.4";
 const CONFIG_HASH_LABEL: &str = "dev.envio.config-hash";
 const SOCKET_TIMEOUT: u64 = 120;
 
-/// Override file mounted over /etc/clickhouse-server/users.d/. The 26.x
-/// image ships its own default-user.xml that locks down the `default`
-/// user with a non-empty password element, so an empty-password Basic
-/// Auth request from the indexer or the Playground fails. Bind-mounting
-/// this content as the entire users.d/ directory hides the image's file
-/// and gives us a pristine no-password default user.
-const CH_NO_PASSWORD_USER_XML: &str = r#"<clickhouse>
+/// Replacement for `/etc/clickhouse-server/users.d/default-user.xml`. The
+/// 26.x image ships a users.d/ override that restricts the `default` user
+/// to loopback only (`::1`, `127.0.0.1`), so requests through the Docker
+/// bridge gateway get rejected as IP_NOT_ALLOWED (surfaced confusingly as
+/// "password is incorrect"). The base users.xml already configures
+/// `default` with `<no_password/>` and the other defaults; we only need to
+/// broaden `<networks>` to any IP via `replace="replace"`. Injected with
+/// docker cp into the created-but-not-started container so the image's
+/// own users.d/default-user.xml gets overwritten before ClickHouse boots.
+const CH_DEFAULT_USER_OVERRIDE_XML: &str = r#"<clickhouse>
     <users>
-        <default replace="replace">
-            <no_password/>
-            <networks>
+        <default>
+            <networks replace="replace">
                 <ip>::/0</ip>
             </networks>
-            <profile>default</profile>
-            <quota>default</quota>
-            <access_management>1</access_management>
         </default>
     </users>
 </clickhouse>
@@ -95,17 +94,48 @@ fn socket_path_from_uri(uri: &str) -> &str {
     uri.strip_prefix("unix://").unwrap_or(uri)
 }
 
-/// Write the no-password override file under `<project>/.envio/` and
-/// return the directory to bind-mount at /etc/clickhouse-server/users.d
-/// in the container. Idempotent — overwriting is fine since ClickHouse
-/// hot-reloads users.d/ files.
-fn ensure_clickhouse_users_override_dir(project_root: &Path) -> anyhow::Result<PathBuf> {
-    let dir = project_root.join(".envio").join("clickhouse-users.d");
-    std::fs::create_dir_all(&dir).with_context(|| format!("Failed to create {}", dir.display()))?;
-    let file = dir.join("default-user.xml");
-    std::fs::write(&file, CH_NO_PASSWORD_USER_XML)
-        .with_context(|| format!("Failed to write {}", file.display()))?;
-    Ok(dir)
+/// Build an in-memory tar archive containing the single override file
+/// `default-user.xml`. Suitable for uploading to a container's
+/// `/etc/clickhouse-server/users.d/` directory via Docker's
+/// `PUT /containers/.../archive` endpoint, which extracts the tar there.
+fn build_clickhouse_users_override_tar() -> anyhow::Result<Vec<u8>> {
+    let mut header = tar::Header::new_gnu();
+    let bytes = CH_DEFAULT_USER_OVERRIDE_XML.as_bytes();
+    header
+        .set_path("default-user.xml")
+        .context("Invalid tar entry path")?;
+    header.set_size(bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+
+    let mut builder = tar::Builder::new(Vec::new());
+    builder
+        .append(&header, bytes)
+        .context("Failed appending override entry to tar")?;
+    builder.into_inner().context("Failed finalizing tar")
+}
+
+/// Inject the `default-user.xml` override into the given (created, not
+/// yet started) ClickHouse container. Targets the image's own override
+/// path so ClickHouse picks ours up on its first config load.
+async fn inject_clickhouse_users_override(
+    docker: &Docker,
+    container_name: &str,
+) -> anyhow::Result<()> {
+    let tar_bytes = build_clickhouse_users_override_tar()?;
+    let options = bollard::query_parameters::UploadToContainerOptionsBuilder::default()
+        .path("/etc/clickhouse-server/users.d")
+        .build();
+    docker
+        .upload_to_container(
+            container_name,
+            Some(options),
+            bollard::body_full(tar_bytes.into()),
+        )
+        .await
+        .with_context(|| {
+            format!("Failed to inject users.d override into container {container_name}")
+        })
 }
 
 /// Try connecting to a Docker-compatible socket, returning the client and a
@@ -348,6 +378,10 @@ impl EnvConfig {
 
     fn ch_config_hash(&self) -> String {
         let mut h = Sha256::new();
+        // Bump the version marker when the container creation shape
+        // changes (e.g. injected files, mounts) so stale containers from
+        // older CLI versions get recreated even when env values match.
+        h.update(b"v2");
         h.update(&self.ch_user);
         h.update(&self.ch_password);
         h.update(&self.ch_database);
@@ -693,6 +727,59 @@ async fn ensure_container(
         .create_container(Some(options), create_body)
         .await
         .with_context(|| format!("Failed creating container {name}"))?;
+
+    if let Err(e) = start_container(docker, name, host_port).await {
+        stop_and_remove(docker, name).await;
+        return Err(e);
+    }
+
+    println!("Started {name}");
+    Ok(true)
+}
+
+/// Like `ensure_container` but injects the ClickHouse users.d override
+/// into the container layer between create and start when
+/// `inject_default_user_override` is true. Mirrors the drift / reuse
+/// branches of `ensure_container`; the override only ships on a
+/// freshly-created container (existing ones already have it from their
+/// own first create, and reusing it costs nothing).
+async fn ensure_container_with_post_create(
+    docker: &Docker,
+    name: &str,
+    config_hash: &str,
+    host_port: u16,
+    create_body: ContainerCreateBody,
+    inject_default_user_override: bool,
+) -> anyhow::Result<bool> {
+    if container_exists(docker, name).await {
+        let existing_hash = get_container_config_hash(docker, name).await;
+        let drift = existing_hash.as_deref() != Some(config_hash);
+
+        if drift {
+            println!("Configuration changed for {name}, recreating...");
+            stop_and_remove(docker, name).await;
+        } else if is_container_running(docker, name).await {
+            return Ok(false);
+        } else {
+            start_container(docker, name, host_port).await?;
+            println!("Started {name}");
+            return Ok(false);
+        }
+    }
+
+    let options = CreateContainerOptionsBuilder::new().name(name).build();
+
+    docker
+        .create_container(Some(options), create_body)
+        .await
+        .with_context(|| format!("Failed creating container {name}"))?;
+
+    if inject_default_user_override {
+        if let Err(e) = inject_clickhouse_users_override(docker, name).await {
+            stop_and_remove(docker, name).await;
+            return Err(e);
+        }
+    }
 
     if let Err(e) = start_container(docker, name, host_port).await {
         stop_and_remove(docker, name).await;
@@ -1058,39 +1145,23 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             map
         };
 
-        // The 26.x image ships its own /etc/clickhouse-server/users.d/
-        // default-user.xml that requires a password — so even with no
-        // CLICKHOUSE_USER/PASSWORD env vars set the Playground and the
-        // indexer can't auth as `default` over Basic Auth with an empty
-        // password. When the user hasn't customized any ClickHouse env
-        // vars, bind-mount our own users.d/ directory over the image's
-        // one so a pristine `<no_password/>` default user wins.
-        let use_pristine_default =
+        // The 26.x image ships a /etc/clickhouse-server/users.d/
+        // default-user.xml that restricts `default` to loopback only,
+        // which our indexer and the Playground can't reach through the
+        // Docker bridge gateway. When the user hasn't customized any
+        // ClickHouse env vars, inject our own users.d/default-user.xml
+        // (broadens the network rule) into the container after creation
+        // but before start. Custom user/password/database setups go
+        // through the entrypoint untouched.
+        let use_dev_default_user =
             env.ch_user == "default" && env.ch_password.is_empty() && env.ch_database == "default";
-
-        let mut ch_mounts = vec![Mount {
-            target: Some("/var/lib/clickhouse".to_string()),
-            source: Some(CH_VOLUME.to_string()),
-            typ: Some(MountTypeEnum::VOLUME),
-            ..Default::default()
-        }];
-        if use_pristine_default {
-            let dir = ensure_clickhouse_users_override_dir(opts.project_root)?;
-            ch_mounts.push(Mount {
-                target: Some("/etc/clickhouse-server/users.d".to_string()),
-                source: Some(dir.to_string_lossy().to_string()),
-                typ: Some(MountTypeEnum::BIND),
-                read_only: Some(true),
-                ..Default::default()
-            });
-        }
 
         let ch_body = ContainerCreateBody {
             image: Some(CLICKHOUSE_IMAGE.to_string()),
             labels: Some(make_labels(&ch_hash)),
-            // Only forward env vars that diverge from the image's own
-            // defaults; when at defaults the override file above takes
-            // over and the entrypoint should leave user setup alone.
+            // Only forward env vars the user actually customized. When at
+            // image defaults the entrypoint leaves user setup alone and
+            // our injected override takes care of network rules.
             env: {
                 let mut vars = Vec::new();
                 if env.ch_user != "default" {
@@ -1106,7 +1177,12 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             },
             host_config: Some(HostConfig {
                 port_bindings: Some(ch_port_bindings),
-                mounts: Some(ch_mounts),
+                mounts: Some(vec![Mount {
+                    target: Some("/var/lib/clickhouse".to_string()),
+                    source: Some(CH_VOLUME.to_string()),
+                    typ: Some(MountTypeEnum::VOLUME),
+                    ..Default::default()
+                }]),
                 restart_policy: Some(RestartPolicy {
                     name: Some(RestartPolicyNameEnum::ALWAYS),
                     ..Default::default()
@@ -1117,7 +1193,15 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             ..Default::default()
         };
 
-        ensure_container(&docker, CH_CONTAINER, &ch_hash, url.port, ch_body).await?;
+        ensure_container_with_post_create(
+            &docker,
+            CH_CONTAINER,
+            &ch_hash,
+            url.port,
+            ch_body,
+            use_dev_default_user,
+        )
+        .await?;
         Ok(())
     };
 
@@ -1382,6 +1466,31 @@ mod tests {
             ch_password: "".into(),
             ch_database: "default".into(),
         }
+    }
+
+    #[test]
+    fn users_override_tar_round_trips_to_default_user_xml() {
+        let bytes = build_clickhouse_users_override_tar().expect("build tar");
+        let mut archive = tar::Archive::new(std::io::Cursor::new(&bytes));
+        let entries: Vec<(String, String)> = archive
+            .entries()
+            .expect("read entries")
+            .map(|e| {
+                let mut e = e.expect("entry");
+                let path = e.path().expect("entry path").to_string_lossy().into_owned();
+                let mut content = String::new();
+                std::io::Read::read_to_string(&mut e, &mut content).expect("read content");
+                (path, content)
+            })
+            .collect();
+        assert_eq!(
+            entries,
+            vec![(
+                "default-user.xml".to_string(),
+                CH_DEFAULT_USER_OVERRIDE_XML.to_string(),
+            )],
+            "tar should contain exactly the override XML at default-user.xml"
+        );
     }
 
     #[test]

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -244,9 +244,14 @@ impl EnvConfig {
             hasura_enable_console: var("HASURA_GRAPHQL_ENABLE_CONSOLE", "true"),
             hasura_admin_secret: var("HASURA_GRAPHQL_ADMIN_SECRET", "testing"),
             ch_host: var_opt("ENVIO_CLICKHOUSE_HOST"),
+            // `envio dev` defaults to the out-of-the-box ClickHouse setup:
+            // the pre-existing `default` user with no password and the
+            // pre-existing `default` database, so opening the Playground
+            // requires no credentials. `envio start` reads these same vars
+            // but has no defaults and requires the user to set them.
             ch_user: var("ENVIO_CLICKHOUSE_USERNAME", "default"),
-            ch_password: var("ENVIO_CLICKHOUSE_PASSWORD", "testing"),
-            ch_database: var("ENVIO_CLICKHOUSE_DATABASE", "envio_indexer"),
+            ch_password: var("ENVIO_CLICKHOUSE_PASSWORD", ""),
+            ch_database: var("ENVIO_CLICKHOUSE_DATABASE", "default"),
         }
     }
 
@@ -1240,8 +1245,8 @@ mod tests {
             hasura_admin_secret: "testing".into(),
             ch_host: None,
             ch_user: "default".into(),
-            ch_password: "testing".into(),
-            ch_database: "envio_indexer".into(),
+            ch_password: "".into(),
+            ch_database: "default".into(),
         }
     }
 

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -1188,13 +1188,67 @@ pub async fn down() -> anyhow::Result<()> {
 
     // 404 = network already gone (e.g. `up()` short-circuited when all
     // services were reachable externally, so `ensure_network` never ran).
-    // Treat it as success — mirrors the 409 tolerance in `ensure_network`.
+    // 403 = network still has active endpoints — typically a stray
+    // container (test harness, manual `docker run`, ...) that we don't own.
+    // Force-disconnect everything attached first so the second remove
+    // attempt succeeds; if it still doesn't, treat it as a warning rather
+    // than a hard failure since the volumes (the only state the user
+    // really wants nuked) have already been removed by this point.
     async fn remove_network_tolerant(docker: &Docker, name: &str) -> anyhow::Result<()> {
+        match docker.remove_network(name).await {
+            Ok(_) => return Ok(()),
+            Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 404, ..
+            }) => return Ok(()),
+            Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 403, ..
+            }) => {}
+            Err(e) => return Err(e).with_context(|| format!("Failed to remove network {name}")),
+        }
+
+        let inspect = match docker
+            .inspect_network(
+                name,
+                None::<bollard::query_parameters::InspectNetworkOptions>,
+            )
+            .await
+        {
+            Ok(n) => n,
+            Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 404, ..
+            }) => return Ok(()),
+            Err(e) => return Err(e).with_context(|| format!("Failed to inspect network {name}")),
+        };
+
+        if let Some(containers) = inspect.containers {
+            for container_id in containers.keys() {
+                let _ = docker
+                    .disconnect_network(
+                        name,
+                        bollard::models::NetworkDisconnectRequest {
+                            container: container_id.clone(),
+                            force: Some(true),
+                        },
+                    )
+                    .await;
+            }
+        }
+
         match docker.remove_network(name).await {
             Ok(_) => Ok(()),
             Err(bollard::errors::Error::DockerResponseServerError {
                 status_code: 404, ..
             }) => Ok(()),
+            Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 403, ..
+            }) => {
+                eprintln!(
+                    "Warning: network {name} still has active endpoints after \
+                     force-disconnect; leaving it in place. Inspect with \
+                     `docker network inspect {name}` to see what's attached."
+                );
+                Ok(())
+            }
             Err(e) => Err(e).with_context(|| format!("Failed to remove network {name}")),
         }
     }

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -23,6 +23,27 @@ const CLICKHOUSE_IMAGE: &str = "clickhouse/clickhouse-server:26.2.15.4";
 const CONFIG_HASH_LABEL: &str = "dev.envio.config-hash";
 const SOCKET_TIMEOUT: u64 = 120;
 
+/// Override file mounted over /etc/clickhouse-server/users.d/. The 26.x
+/// image ships its own default-user.xml that locks down the `default`
+/// user with a non-empty password element, so an empty-password Basic
+/// Auth request from the indexer or the Playground fails. Bind-mounting
+/// this content as the entire users.d/ directory hides the image's file
+/// and gives us a pristine no-password default user.
+const CH_NO_PASSWORD_USER_XML: &str = r#"<clickhouse>
+    <users>
+        <default replace="replace">
+            <no_password/>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+            <access_management>1</access_management>
+        </default>
+    </users>
+</clickhouse>
+"#;
+
 const PG_CONTAINER: &str = "envio-postgres";
 const HASURA_CONTAINER: &str = "envio-hasura";
 const CH_CONTAINER: &str = "envio-clickhouse";
@@ -72,6 +93,19 @@ fn podman_socket_candidates() -> Vec<PathBuf> {
 /// Strip `unix://` prefix from a URI to get a filesystem path.
 fn socket_path_from_uri(uri: &str) -> &str {
     uri.strip_prefix("unix://").unwrap_or(uri)
+}
+
+/// Write the no-password override file under `<project>/.envio/` and
+/// return the directory to bind-mount at /etc/clickhouse-server/users.d
+/// in the container. Idempotent — overwriting is fine since ClickHouse
+/// hot-reloads users.d/ files.
+fn ensure_clickhouse_users_override_dir(project_root: &Path) -> anyhow::Result<PathBuf> {
+    let dir = project_root.join(".envio").join("clickhouse-users.d");
+    std::fs::create_dir_all(&dir).with_context(|| format!("Failed to create {}", dir.display()))?;
+    let file = dir.join("default-user.xml");
+    std::fs::write(&file, CH_NO_PASSWORD_USER_XML)
+        .with_context(|| format!("Failed to write {}", file.display()))?;
+    Ok(dir)
 }
 
 /// Try connecting to a Docker-compatible socket, returning the client and a
@@ -1024,18 +1058,39 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             map
         };
 
+        // The 26.x image ships its own /etc/clickhouse-server/users.d/
+        // default-user.xml that requires a password — so even with no
+        // CLICKHOUSE_USER/PASSWORD env vars set the Playground and the
+        // indexer can't auth as `default` over Basic Auth with an empty
+        // password. When the user hasn't customized any ClickHouse env
+        // vars, bind-mount our own users.d/ directory over the image's
+        // one so a pristine `<no_password/>` default user wins.
+        let use_pristine_default =
+            env.ch_user == "default" && env.ch_password.is_empty() && env.ch_database == "default";
+
+        let mut ch_mounts = vec![Mount {
+            target: Some("/var/lib/clickhouse".to_string()),
+            source: Some(CH_VOLUME.to_string()),
+            typ: Some(MountTypeEnum::VOLUME),
+            ..Default::default()
+        }];
+        if use_pristine_default {
+            let dir = ensure_clickhouse_users_override_dir(opts.project_root)?;
+            ch_mounts.push(Mount {
+                target: Some("/etc/clickhouse-server/users.d".to_string()),
+                source: Some(dir.to_string_lossy().to_string()),
+                typ: Some(MountTypeEnum::BIND),
+                read_only: Some(true),
+                ..Default::default()
+            });
+        }
+
         let ch_body = ContainerCreateBody {
             image: Some(CLICKHOUSE_IMAGE.to_string()),
             labels: Some(make_labels(&ch_hash)),
-            // Only forward env vars that differ from the image's own
-            // defaults. The 26.x entrypoint writes
-            // `/etc/clickhouse-server/users.d/default-user.xml` whenever
-            // CLICKHOUSE_USER or CLICKHOUSE_PASSWORD is set at all,
-            // replacing the pristine `default` user (`<no_password/>`)
-            // with one whose `<password></password>` override doesn't
-            // match empty-password basic auth. Skipping the vars when
-            // they're at their out-of-the-box values keeps the image's
-            // own setup intact so the Playground opens auth-free.
+            // Only forward env vars that diverge from the image's own
+            // defaults; when at defaults the override file above takes
+            // over and the entrypoint should leave user setup alone.
             env: {
                 let mut vars = Vec::new();
                 if env.ch_user != "default" {
@@ -1051,12 +1106,7 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
             },
             host_config: Some(HostConfig {
                 port_bindings: Some(ch_port_bindings),
-                mounts: Some(vec![Mount {
-                    target: Some("/var/lib/clickhouse".to_string()),
-                    source: Some(CH_VOLUME.to_string()),
-                    typ: Some(MountTypeEnum::VOLUME),
-                    ..Default::default()
-                }]),
+                mounts: Some(ch_mounts),
                 restart_policy: Some(RestartPolicy {
                     name: Some(RestartPolicyNameEnum::ALWAYS),
                     ..Default::default()

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -1027,11 +1027,28 @@ pub async fn up(opts: UpOptions<'_>) -> anyhow::Result<UpResult> {
         let ch_body = ContainerCreateBody {
             image: Some(CLICKHOUSE_IMAGE.to_string()),
             labels: Some(make_labels(&ch_hash)),
-            env: Some(vec![
-                format!("CLICKHOUSE_USER={}", env.ch_user),
-                format!("CLICKHOUSE_PASSWORD={}", env.ch_password),
-                format!("CLICKHOUSE_DB={}", env.ch_database),
-            ]),
+            // Only forward env vars that differ from the image's own
+            // defaults. The 26.x entrypoint writes
+            // `/etc/clickhouse-server/users.d/default-user.xml` whenever
+            // CLICKHOUSE_USER or CLICKHOUSE_PASSWORD is set at all,
+            // replacing the pristine `default` user (`<no_password/>`)
+            // with one whose `<password></password>` override doesn't
+            // match empty-password basic auth. Skipping the vars when
+            // they're at their out-of-the-box values keeps the image's
+            // own setup intact so the Playground opens auth-free.
+            env: {
+                let mut vars = Vec::new();
+                if env.ch_user != "default" {
+                    vars.push(format!("CLICKHOUSE_USER={}", env.ch_user));
+                }
+                if !env.ch_password.is_empty() {
+                    vars.push(format!("CLICKHOUSE_PASSWORD={}", env.ch_password));
+                }
+                if env.ch_database != "default" {
+                    vars.push(format!("CLICKHOUSE_DB={}", env.ch_database));
+                }
+                Some(vars)
+            },
             host_config: Some(HostConfig {
                 port_bindings: Some(ch_port_bindings),
                 mounts: Some(vec![Mount {

--- a/packages/cli/src/docker_env.rs
+++ b/packages/cli/src/docker_env.rs
@@ -1220,8 +1220,21 @@ pub async fn down() -> anyhow::Result<()> {
             Err(e) => return Err(e).with_context(|| format!("Failed to inspect network {name}")),
         };
 
+        // Only force-disconnect endpoints we can prove are ours via the
+        // CONFIG_HASH_LABEL — by this point our own containers have already
+        // been removed by stop_and_remove(), so anything left is either a
+        // stale Envio container from an aborted previous run, or someone
+        // else's container that happens to share this network. Touching the
+        // latter would be hostile (breaking a parallel dev session, etc.);
+        // leaving it attached drops us into the warning path below.
         if let Some(containers) = inspect.containers {
             for container_id in containers.keys() {
+                let is_envio_owned = get_container_config_hash(docker, container_id)
+                    .await
+                    .is_some();
+                if !is_envio_owned {
+                    continue;
+                }
                 let _ = docker
                     .disconnect_network(
                         name,

--- a/packages/e2e-tests/src/dependency-tests/install.test.ts
+++ b/packages/e2e-tests/src/dependency-tests/install.test.ts
@@ -167,10 +167,14 @@ describe("Isolated dependency e2e", () => {
           ENVIO_TUI: "false",
           ENVIO_API_TOKEN: process.env.ENVIO_API_TOKEN ?? "",
           // e2e_test config.yaml declares `storage.clickhouse: true`, so
-          // PgStorage validates these env vars at indexer start.
+          // PgStorage validates these env vars at indexer start. The
+          // database must match what `test:e2e` wrote to in the prior job
+          // step, otherwise resume from the persisted Postgres checkpoint
+          // finds no corresponding ClickHouse row.
           ENVIO_CLICKHOUSE_HOST: config.clickhouseUrl,
           ENVIO_CLICKHOUSE_USERNAME: config.clickhouseUsername,
           ENVIO_CLICKHOUSE_PASSWORD: config.clickhousePassword,
+          ENVIO_CLICKHOUSE_DATABASE: "envio_indexer",
           // Fresh start (after the SQL reset above): handler check uses
           // the config endBlock as the source of truth.
           E2E_EXPECTED_END_BLOCK: "10861774",

--- a/packages/e2e-tests/src/e2e/e2e.test.ts
+++ b/packages/e2e-tests/src/e2e/e2e.test.ts
@@ -64,6 +64,7 @@ describe("E2E: Indexer with GraphQL and ClickHouse sink", () => {
         ENVIO_CLICKHOUSE_HOST: config.clickhouseUrl,
         ENVIO_CLICKHOUSE_USERNAME: config.clickhouseUsername,
         ENVIO_CLICKHOUSE_PASSWORD: config.clickhousePassword,
+        ENVIO_CLICKHOUSE_DATABASE: CH_DATABASE,
         // First run: no DB state yet, fallback returns the config endBlock
         E2E_EXPECTED_END_BLOCK: "10861774",
         // Flush chain metadata immediately (no throttle) so isReady
@@ -441,6 +442,7 @@ describe("E2E: Indexer with GraphQL and ClickHouse sink", () => {
           ENVIO_CLICKHOUSE_HOST: config.clickhouseUrl,
           ENVIO_CLICKHOUSE_USERNAME: config.clickhouseUsername,
           ENVIO_CLICKHOUSE_PASSWORD: config.clickhousePassword,
+          ENVIO_CLICKHOUSE_DATABASE: CH_DATABASE,
           E2E_EXPECTED_END_BLOCK: String(patchedEndBlock),
         },
       });

--- a/packages/envio/src/Env.res
+++ b/packages/envio/src/Env.res
@@ -134,11 +134,17 @@ module ClickHouse = {
       const v = process.env[k];
       return v === undefined || v === "" ? undefined : v;
     }`)
+    // Empty password is a valid, passwordless ClickHouse user — distinguish
+    // "unset" (None) from "set but empty" (Some("")).
+    let readAllowEmpty: string => option<string> = %raw(`(k) => {
+      const v = process.env[k];
+      return v === undefined ? undefined : v;
+    }`)
   )
   let host = () => read("ENVIO_CLICKHOUSE_HOST")
   let database = () => read("ENVIO_CLICKHOUSE_DATABASE")
   let username = () => read("ENVIO_CLICKHOUSE_USERNAME")
-  let password = () => read("ENVIO_CLICKHOUSE_PASSWORD")
+  let password = () => readAllowEmpty("ENVIO_CLICKHOUSE_PASSWORD")
   let replicated = () =>
     switch read("ENVIO_CLICKHOUSE_REPLICATED") {
     | None => false

--- a/packages/envio/src/Env.res
+++ b/packages/envio/src/Env.res
@@ -136,10 +136,7 @@ module ClickHouse = {
     }`)
     // Empty password is a valid, passwordless ClickHouse user — distinguish
     // "unset" (None) from "set but empty" (Some("")).
-    let readAllowEmpty: string => option<string> = %raw(`(k) => {
-      const v = process.env[k];
-      return v === undefined ? undefined : v;
-    }`)
+    let readAllowEmpty: string => option<string> = %raw(`(k) => process.env[k]`)
   )
   let host = () => read("ENVIO_CLICKHOUSE_HOST")
   let database = () => read("ENVIO_CLICKHOUSE_DATABASE")

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1724,6 +1724,7 @@ let makeStorageFromEnv = (
         let host = Env.ClickHouse.host()
         let username = Env.ClickHouse.username()
         let password = Env.ClickHouse.password()
+        let database = Env.ClickHouse.database()
         let missing = []
         let checkEnv = (opt, name) =>
           switch opt {
@@ -1733,6 +1734,7 @@ let makeStorageFromEnv = (
         host->checkEnv("ENVIO_CLICKHOUSE_HOST")
         username->checkEnv("ENVIO_CLICKHOUSE_USERNAME")
         password->checkEnv("ENVIO_CLICKHOUSE_PASSWORD")
+        database->checkEnv("ENVIO_CLICKHOUSE_DATABASE")
         if missing->Array.length > 0 {
           JsError.throwWithMessage(
             `ClickHouse storage is enabled but required env vars are not set: ${missing->Array.joinUnsafe(
@@ -1743,7 +1745,7 @@ let makeStorageFromEnv = (
         Some(
           Sink.makeClickHouse(
             ~host=host->Option.getUnsafe,
-            ~database=Env.ClickHouse.database(),
+            ~database=database->Option.getUnsafe,
             ~username=username->Option.getUnsafe,
             ~password=password->Option.getUnsafe,
           ),

--- a/packages/envio/src/Sink.res
+++ b/packages/envio/src/Sink.res
@@ -19,13 +19,8 @@ let makeClickHouse = (~host, ~database, ~username, ~password): t => {
     password,
   })
 
-  // Don't assign it to client immediately,
-  // since it will fail if the database doesn't exist
-  // Call USE database instead
-  let database = switch database {
-  | Some(database) => database
-  | None => "envio_indexer"
-  }
+  // Don't pass database to the client; it would fail if the database doesn't
+  // exist yet. Each query qualifies the name explicitly or runs USE first.
 
   let cache = Utils.WeakMap.make()
 

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -464,10 +464,10 @@ let initialize = async (
       ),
     )->Utils.Promise.ignoreValue
 
-    Logging.trace("ClickHouse sink initialization completed successfully")
+    Logging.trace("ClickHouse storage initialization completed successfully")
   } catch {
   | exn => {
-      Logging.errorWithExn(exn, "Failed to initialize ClickHouse sink")
+      Logging.errorWithExn(exn, "Failed to initialize ClickHouse storage")
       JsError.throwWithMessage("ClickHouse initialization failed")
     }
   }
@@ -483,7 +483,7 @@ let resume = async (client, ~database: string, ~checkpointId: Internal.checkpoin
     | exn =>
       Logging.errorWithExn(
         exn,
-        `ClickHouse sink database "${database}" not found. Please run 'envio start -r' to reinitialize the indexer (it'll also drop Postgres database).`,
+        `ClickHouse storage database "${database}" not found. Please run 'envio start -r' to reinitialize the indexer (it'll also drop Postgres database).`,
       )
       JsError.throwWithMessage("ClickHouse resume failed")
     }
@@ -511,7 +511,7 @@ let resume = async (client, ~database: string, ~checkpointId: Internal.checkpoin
   } catch {
   | Persistence.StorageError(_) as exn => throw(exn)
   | exn => {
-      Logging.errorWithExn(exn, "Failed to resume ClickHouse sink")
+      Logging.errorWithExn(exn, "Failed to resume ClickHouse storage")
       JsError.throwWithMessage("ClickHouse resume failed")
     }
   }

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -943,7 +943,7 @@ describe("PgStorage.makeStorageFromEnv ClickHouse env var validation", () => {
         message,
         ~message="Should throw a helpful error naming every missing env var at once",
       ).toBe(
-        "ClickHouse storage is enabled but required env vars are not set: ENVIO_CLICKHOUSE_HOST, ENVIO_CLICKHOUSE_USERNAME, ENVIO_CLICKHOUSE_PASSWORD. Please set them, disable clickhouse in the `storage` config, or run `envio dev` for a pre-configured local ClickHouse.",
+        "ClickHouse storage is enabled but required env vars are not set: ENVIO_CLICKHOUSE_HOST, ENVIO_CLICKHOUSE_USERNAME, ENVIO_CLICKHOUSE_PASSWORD, ENVIO_CLICKHOUSE_DATABASE. Please set them, disable clickhouse in the `storage` config, or run `envio dev` for a pre-configured local ClickHouse.",
       )
     },
   )


### PR DESCRIPTION
Changes ClickHouse configuration defaults to match the out-of-the-box ClickHouse setup, eliminating the need for credentials in local development while requiring explicit configuration in production.

## Summary

Updates default ClickHouse credentials and database name to use the pre-existing `default` user (with no password) and `default` database that come with a fresh ClickHouse installation. This allows `envio dev` to work without additional setup, while `envio start` continues to require explicit environment variable configuration.

## Key Changes

- **CLI defaults** (`docker_env.rs`): Changed `ch_password` default from `"testing"` to `""` (empty string) and `ch_database` default from `"envio_indexer"` to `"default"`
- **Password handling** (`Env.res`): Added `readAllowEmpty` function to distinguish between unset environment variables (`None`) and explicitly set empty passwords (`Some("")`), allowing passwordless ClickHouse users
- **Database validation** (`PgStorage.res`): Added `ENVIO_CLICKHOUSE_DATABASE` to required environment variable validation for `envio start`, ensuring users explicitly configure the database when not using defaults
- **Sink initialization** (`Sink.res`): Clarified that database is not passed to the client constructor; each query qualifies the name explicitly or runs `USE` first
- **E2E tests**: Added explicit `ENVIO_CLICKHOUSE_DATABASE` environment variable to test configurations
- **Test expectations**: Updated error message to include `ENVIO_CLICKHOUSE_DATABASE` in the list of required variables

## Implementation Details

The distinction between "unset" (`None`) and "set but empty" (`Some("")`) for the password is critical: ClickHouse supports passwordless users, so an empty string is a valid credential value that must be preserved and not conflated with an unset environment variable.

https://claude.ai/code/session_017sHyqsHsXQ7D3ZrxP5wcev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ClickHouse defaults updated: password defaults to empty and database defaults to "default"
  * Environment reader now distinguishes unset vs explicitly empty ClickHouse password
  * Startup/resume now validate and explicitly use the ClickHouse database value
  * Local teardown improved: network removal force-disconnects attached containers when necessary

* **Tests**
  * E2E and unit tests updated to set/expect the shared ClickHouse database

* **Chores**
  * Initialization/resume messages clarified to use "storage" terminology

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1205)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->