### PR TITLE
Pipeline batch SQL commits to run in parallel with next batch's CPU phase

### DIFF
--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -105,6 +105,7 @@ let runEventHandlerOrThrow = async (
   ~checkpointId,
   ~handler,
   ~inMemoryStore,
+  ~transit,
   ~loadManager,
   ~persistence,
   ~shouldSaveHistory,
@@ -121,6 +122,7 @@ let runEventHandlerOrThrow = async (
       item,
       checkpointId,
       inMemoryStore,
+      transit,
       loadManager,
       persistence,
       shouldSaveHistory,
@@ -160,6 +162,7 @@ let runHandlerOrThrow = async (
   item: Internal.item,
   ~checkpointId,
   ~inMemoryStore,
+  ~transit,
   ~loadManager,
   ~ctx: Ctx.t,
   ~shouldSaveHistory,
@@ -171,6 +174,7 @@ let runHandlerOrThrow = async (
       let contextParams: UserContext.contextParams = {
         item,
         inMemoryStore,
+        transit,
         loadManager,
         persistence: ctx.persistence,
         shouldSaveHistory,
@@ -205,6 +209,7 @@ let runHandlerOrThrow = async (
           ~handler,
           ~checkpointId,
           ~inMemoryStore,
+          ~transit,
           ~loadManager,
           ~persistence=ctx.persistence,
           ~shouldSaveHistory,
@@ -229,6 +234,7 @@ let preloadBatchOrThrow = async (
   ~persistence,
   ~config: Config.t,
   ~inMemoryStore,
+  ~transit,
   ~chains: Internal.chains,
 ) => {
   // On the first run of loaders, we don't care about the result,
@@ -261,6 +267,7 @@ let preloadBatchOrThrow = async (
                 context: UserContext.getHandlerContext({
                   item,
                   inMemoryStore,
+                  transit,
                   loadManager,
                   persistence,
                   checkpointId,
@@ -296,6 +303,7 @@ let preloadBatchOrThrow = async (
                 ~context=UserContext.getHandlerContext({
                   item,
                   inMemoryStore,
+                  transit,
                   loadManager,
                   persistence,
                   checkpointId,
@@ -323,6 +331,7 @@ let preloadBatchOrThrow = async (
 let runBatchHandlersOrThrow = async (
   batch: Batch.t,
   ~inMemoryStore,
+  ~transit,
   ~loadManager,
   ~ctx,
   ~shouldSaveHistory,
@@ -341,6 +350,7 @@ let runBatchHandlersOrThrow = async (
         item,
         ~checkpointId,
         ~inMemoryStore,
+        ~transit,
         ~loadManager,
         ~ctx,
         ~shouldSaveHistory,
@@ -374,9 +384,18 @@ type logPartitionInfo = {
   lastItemBlockNumber?: int,
 }
 
-let processEventBatch = async (
+type cpuPhaseResult = {
+  loaderDuration: float,
+  handlerDuration: float,
+}
+
+// Runs preload + handlers, but stops short of the SQL commit. Returns
+// the elapsed loader/handler durations so the caller can stitch metrics
+// after the deferred commit completes.
+let processEventBatchCpuOrThrow = async (
   ~batch: Batch.t,
   ~inMemoryStore: InMemoryStore.t,
+  ~transit: option<LoadLayer.transit>,
   ~isInReorgThreshold,
   ~loadManager,
   ~ctx: Ctx.t,
@@ -406,6 +425,7 @@ let processEventBatch = async (
         ~loadManager,
         ~persistence=ctx.persistence,
         ~inMemoryStore,
+        ~transit,
         ~chains,
         ~config=ctx.config,
       )
@@ -416,6 +436,7 @@ let processEventBatch = async (
     if batch.items->Utils.Array.notEmpty {
       await batch->runBatchHandlersOrThrow(
         ~inMemoryStore,
+        ~transit,
         ~loadManager,
         ~ctx,
         ~shouldSaveHistory=ctx.config->Config.shouldSaveHistory(~isInReorgThreshold),
@@ -425,34 +446,43 @@ let processEventBatch = async (
 
     let elapsedTimeAfterProcessing = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
 
-    try {
-      await ctx.persistence->Persistence.writeBatch(
-        ~batch,
-        ~config=ctx.config,
-        ~inMemoryStore,
-        ~isInReorgThreshold,
-      )
-
-      let elapsedTimeAfterDbWrite = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
-      let loaderDuration = elapsedTimeAfterLoaders
-      let handlerDuration = elapsedTimeAfterProcessing -. loaderDuration
-      let dbWriteDuration = elapsedTimeAfterDbWrite -. elapsedTimeAfterProcessing
-      registerProcessEventBatchMetrics(
-        ~logger,
-        ~loadDuration=loaderDuration,
-        ~handlerDuration,
-        ~dbWriteDuration,
-      )
-      Ok()
-    } catch {
-    | Persistence.StorageError({message, reason}) =>
-      reason->ErrorHandling.make(~msg=message, ~logger)->Error
-    | exn => exn->ErrorHandling.make(~msg="Failed writing batch to database", ~logger)->Error
-    }
+    Ok({
+      loaderDuration: elapsedTimeAfterLoaders,
+      handlerDuration: elapsedTimeAfterProcessing -. elapsedTimeAfterLoaders,
+    })
   } catch {
   | ProcessingError({message, exn, item}) =>
     exn
     ->ErrorHandling.make(~msg=message, ~logger=item->Logging.getItemLogger)
     ->Error
+  }
+}
+
+// Performs the SQL commit for a batch whose handlers already ran. Designed
+// to run in the background while the next batch's CPU phase starts.
+let commitBatchOrThrow = async (
+  ~batch: Batch.t,
+  ~inMemoryStore: InMemoryStore.t,
+  ~isInReorgThreshold,
+  ~persistence,
+  ~config,
+  ~cpuResult: cpuPhaseResult,
+) => {
+  let logger = Logging.getLogger()
+  let timeRef = Hrtime.makeTimer()
+  try {
+    await persistence->Persistence.writeBatch(~batch, ~config, ~inMemoryStore, ~isInReorgThreshold)
+    let dbWriteDuration = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
+    registerProcessEventBatchMetrics(
+      ~logger,
+      ~loadDuration=cpuResult.loaderDuration,
+      ~handlerDuration=cpuResult.handlerDuration,
+      ~dbWriteDuration,
+    )
+    Ok()
+  } catch {
+  | Persistence.StorageError({message, reason}) =>
+    reason->ErrorHandling.make(~msg=message, ~logger)->Error
+  | exn => exn->ErrorHandling.make(~msg="Failed writing batch to database", ~logger)->Error
   }
 }

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -37,6 +37,25 @@ module WriteThrottlers = {
   }
 }
 
+// Tracks the previous batch's SQL commit while the next batch's
+// CPU phase (decode + handlers + loaders) runs in parallel. The
+// next batch's LoadLayer consults `inMemoryStore` before hitting
+// Postgres so reads of entities still in-flight see the staged
+// writes. `commitPromise` resolves to Ok once the SQL transaction
+// has landed; the next batch must await it before starting its
+// own commit to keep SQL writes strictly ordered.
+type pendingCommit = {
+  inMemoryStore: InMemoryStore.t,
+  commitPromise: promise<result<unit, ErrorHandling.t>>,
+}
+
+// Stable holder for `pendingCommit`. Lives outside the spread-copied
+// record so mutations survive when actions return a fresh state via
+// `{...state, ...}`.
+type pipelineState = {
+  mutable pendingCommit: option<pendingCommit>,
+}
+
 type t = {
   ctx: Ctx.t,
   chainManager: ChainManager.t,
@@ -51,6 +70,7 @@ type t = {
   //Initialized as 0, increments, when rollbacks occur to invalidate
   //responses based on the wrong stateId
   id: int,
+  pipeline: pipelineState,
 }
 
 let make = (
@@ -72,6 +92,7 @@ let make = (
     keepProcessAlive: isDevelopmentMode || shouldUseTui,
     exitAfterFirstEventBlock,
     id: 0,
+    pipeline: {pendingCommit: None},
   }
 }
 
@@ -921,7 +942,17 @@ let injectedTaskReducer = (
           ~throttler=writeThrottlers.chainMetaData,
           ~persistence=state.ctx.persistence,
         )
-        dispatchAction(SuccessExit)
+        // The pipeline lets EventBatchProcessed fire while the last batch's
+        // SQL is still in flight. Drain it before exiting so the user's
+        // declared endblock state actually lands in Postgres.
+        switch state.pipeline.pendingCommit {
+        | Some({commitPromise}) =>
+          switch await commitPromise {
+          | Ok() => dispatchAction(SuccessExit)
+          | Error(errHandler) => dispatchAction(ErrorExit(errHandler))
+          }
+        | None => dispatchAction(SuccessExit)
+        }
       | ExitWithError(msg) =>
         dispatchAction(ErrorExit(ErrorHandling.make(JsError.throwWithMessage(msg))))
       | NoExit =>
@@ -1014,26 +1045,75 @@ let injectedTaskReducer = (
 
           inMemoryStore->InMemoryStore.setBatchDcs(~batch, ~shouldSaveHistory)
 
-          switch await EventProcessing.processEventBatch(
+          // Pipeline: run this batch's CPU phase (preload + handlers) in parallel
+          // with the previous batch's SQL commit. The transit handle exposes
+          // both the staged InMemoryStore (so loadById sees pending writes)
+          // and the commit promise (so loadByField can drain the write before
+          // querying the database). We don't pipeline during rollback — the
+          // diff store needs to be exclusively visible while we replay.
+          let transit: option<LoadLayer.transit> = switch (
+            rollbackInMemStore,
+            state.pipeline.pendingCommit,
+          ) {
+          | (None, Some({inMemoryStore: priorStore, commitPromise})) =>
+            Some({inMemoryStore: priorStore, commitPromise})
+          | _ => None
+          }
+
+          let cpuResult = switch await EventProcessing.processEventBatchCpuOrThrow(
             ~batch,
             ~inMemoryStore,
+            ~transit,
             ~isInReorgThreshold,
             ~loadManager=state.loadManager,
             ~ctx=state.ctx,
             ~chainFetchers=state.chainManager.chainFetchers,
           ) {
           | exception exn =>
-            //All casese should be handled/caught before this with better user messaging.
-            //This is just a safety in case something unexpected happens
             let errHandler =
               exn->ErrorHandling.make(
                 ~msg="A top level unexpected error occurred during processing",
               )
-            dispatchAction(ErrorExit(errHandler))
-          | res =>
-            switch res {
-            | Ok() => dispatchAction(EventBatchProcessed({batch: batch}))
-            | Error(errHandler) => dispatchAction(ErrorExit(errHandler))
+            Error(errHandler)
+          | res => res
+          }
+
+          switch cpuResult {
+          | Error(errHandler) => dispatchAction(ErrorExit(errHandler))
+          | Ok(cpuResult) => {
+              // Ordered commits: this batch's SQL must follow the prior one.
+              // If a prior commit is still in flight, await it now. If the
+              // prior commit failed, the indexer is shutting down — surface
+              // its error and skip queuing this batch.
+              let priorCommitOk = switch state.pipeline.pendingCommit {
+              | Some({commitPromise}) =>
+                switch await commitPromise {
+                | Ok() => true
+                | Error(errHandler) => {
+                    dispatchAction(ErrorExit(errHandler))
+                    false
+                  }
+                }
+              | None => true
+              }
+
+              if priorCommitOk {
+                // Fire this batch's SQL commit; track it so the next batch
+                // can both consult its entities (transit) and await it
+                // before kicking off its own commit.
+                let commitPromise = EventProcessing.commitBatchOrThrow(
+                  ~batch,
+                  ~inMemoryStore,
+                  ~isInReorgThreshold,
+                  ~persistence=state.ctx.persistence,
+                  ~config=state.ctx.config,
+                  ~cpuResult,
+                )
+
+                state.pipeline.pendingCommit = Some({inMemoryStore, commitPromise})
+
+                dispatchAction(EventBatchProcessed({batch: batch}))
+              }
             }
           }
         }
@@ -1060,168 +1140,186 @@ let injectedTaskReducer = (
       | {rollbackState: FoundReorgDepth(_), currentlyProcessingBatch: true} =>
         Logging.info("Waiting for batch to finish processing before executing rollback")
       | {rollbackState: FoundReorgDepth({chain: reorgChain, rollbackTargetBlockNumber})} =>
-        let startTime = Hrtime.makeTimer()
-
-        let chainFetcher = state.chainManager.chainFetchers->ChainMap.get(reorgChain)
-
-        let logger = Logging.createChildFrom(
-          ~logger=chainFetcher.logger,
-          ~params={
-            "action": "Rollback",
-            "reorgChain": reorgChain,
-            "targetBlockNumber": rollbackTargetBlockNumber,
-          },
-        )
-        logger->Logging.childInfo("Started rollback on reorg")
-        Prometheus.RollbackTargetBlockNumber.set(
-          ~blockNumber=rollbackTargetBlockNumber,
-          ~chain=reorgChain,
-        )
-
-        let reorgChainId = reorgChain->ChainMap.Chain.toChainId
-
-        let rollbackTargetCheckpointId = {
-          switch await state.ctx.persistence.storage.getRollbackTargetCheckpoint(
-            ~reorgChainId,
-            ~lastKnownValidBlockNumber=rollbackTargetBlockNumber,
-          ) {
-          | Some(checkpointId) => checkpointId
-          | None => 0n
+        // Rollback queries Postgres for the diff between the in-memory
+        // chain progress and the target checkpoint. With the pipeline,
+        // the most recent batch's CPU has finished but its SQL may
+        // still be in flight — running the rollback queries against
+        // a half-written DB would compute the wrong diff. Drain it.
+        let pendingOk = switch state.pipeline.pendingCommit {
+        | Some({commitPromise}) =>
+          switch await commitPromise {
+          | Ok() => true
+          | Error(errHandler) => {
+              dispatchAction(ErrorExit(errHandler))
+              false
+            }
           }
+        | None => true
         }
+        if pendingOk {
+          let startTime = Hrtime.makeTimer()
 
-        let eventsProcessedDiffByChain = Dict.make()
-        let newProgressBlockNumberPerChain = Dict.make()
-        let rollbackedProcessedEvents = ref(0.)
+          let chainFetcher = state.chainManager.chainFetchers->ChainMap.get(reorgChain)
 
-        {
-          let rollbackProgressDiff = await state.ctx.persistence.storage.getRollbackProgressDiff(
-            ~rollbackTargetCheckpointId,
+          let logger = Logging.createChildFrom(
+            ~logger=chainFetcher.logger,
+            ~params={
+              "action": "Rollback",
+              "reorgChain": reorgChain,
+              "targetBlockNumber": rollbackTargetBlockNumber,
+            },
           )
-          for idx in 0 to rollbackProgressDiff->Array.length - 1 {
-            let diff = rollbackProgressDiff->Array.getUnsafe(idx)
-            eventsProcessedDiffByChain->Utils.Dict.setByInt(
-              diff["chain_id"],
-              {
-                let eventsProcessedDiff =
-                  Float.fromString(diff["events_processed_diff"])->Option.getOrThrow
-                rollbackedProcessedEvents :=
-                  rollbackedProcessedEvents.contents +. eventsProcessedDiff
-                eventsProcessedDiff
-              },
-            )
-            newProgressBlockNumberPerChain->Utils.Dict.setByInt(
-              diff["chain_id"],
-              if rollbackTargetCheckpointId === 0n && diff["chain_id"] === reorgChainId {
-                Pervasives.min(diff["new_progress_block_number"], rollbackTargetBlockNumber)
-              } else {
-                diff["new_progress_block_number"]
-              },
-            )
+          logger->Logging.childInfo("Started rollback on reorg")
+          Prometheus.RollbackTargetBlockNumber.set(
+            ~blockNumber=rollbackTargetBlockNumber,
+            ~chain=reorgChain,
+          )
+
+          let reorgChainId = reorgChain->ChainMap.Chain.toChainId
+
+          let rollbackTargetCheckpointId = {
+            switch await state.ctx.persistence.storage.getRollbackTargetCheckpoint(
+              ~reorgChainId,
+              ~lastKnownValidBlockNumber=rollbackTargetBlockNumber,
+            ) {
+            | Some(checkpointId) => checkpointId
+            | None => 0n
+            }
           }
-        }
 
-        let chainFetchers = state.chainManager.chainFetchers->ChainMap.mapWithKey((chain, cf) => {
-          switch newProgressBlockNumberPerChain->Utils.Dict.dangerouslyGetByIntNonOption(
-            chain->ChainMap.Chain.toChainId,
-          ) {
-          | Some(newProgressBlockNumber) =>
-            let fetchState =
-              cf.fetchState->FetchState.rollback(~targetBlockNumber=newProgressBlockNumber)
-            let newTotalEventsProcessed =
-              cf.numEventsProcessed -.
-              eventsProcessedDiffByChain
-              ->Utils.Dict.dangerouslyGetByIntNonOption(chain->ChainMap.Chain.toChainId)
-              ->Option.getUnsafe
+          let eventsProcessedDiffByChain = Dict.make()
+          let newProgressBlockNumberPerChain = Dict.make()
+          let rollbackedProcessedEvents = ref(0.)
 
-            if cf.committedProgressBlockNumber !== newProgressBlockNumber {
-              Prometheus.ProgressBlockNumber.set(
-                ~blockNumber=newProgressBlockNumber,
-                ~chainId=chain->ChainMap.Chain.toChainId,
+          {
+            let rollbackProgressDiff = await state.ctx.persistence.storage.getRollbackProgressDiff(
+              ~rollbackTargetCheckpointId,
+            )
+            for idx in 0 to rollbackProgressDiff->Array.length - 1 {
+              let diff = rollbackProgressDiff->Array.getUnsafe(idx)
+              eventsProcessedDiffByChain->Utils.Dict.setByInt(
+                diff["chain_id"],
+                {
+                  let eventsProcessedDiff =
+                    Float.fromString(diff["events_processed_diff"])->Option.getOrThrow
+                  rollbackedProcessedEvents :=
+                    rollbackedProcessedEvents.contents +. eventsProcessedDiff
+                  eventsProcessedDiff
+                },
+              )
+              newProgressBlockNumberPerChain->Utils.Dict.setByInt(
+                diff["chain_id"],
+                if rollbackTargetCheckpointId === 0n && diff["chain_id"] === reorgChainId {
+                  Pervasives.min(diff["new_progress_block_number"], rollbackTargetBlockNumber)
+                } else {
+                  diff["new_progress_block_number"]
+                },
               )
             }
-            if cf.numEventsProcessed !== newTotalEventsProcessed {
-              Prometheus.ProgressEventsCount.set(
-                ~processedCount=newTotalEventsProcessed,
-                ~chainId=chain->ChainMap.Chain.toChainId,
-              )
-            }
+          }
 
-            {
-              ...cf,
-              reorgDetection: chain == reorgChain
-                ? cf.reorgDetection->ReorgDetection.rollbackToValidBlockNumber(
-                    ~blockNumber=rollbackTargetBlockNumber,
-                  )
-                : cf.reorgDetection,
-              safeCheckpointTracking: switch cf.safeCheckpointTracking {
-              | Some(safeCheckpointTracking) =>
-                Some(
-                  safeCheckpointTracking->SafeCheckpointTracking.rollback(
-                    ~targetBlockNumber=newProgressBlockNumber,
-                  ),
+          let chainFetchers = state.chainManager.chainFetchers->ChainMap.mapWithKey((chain, cf) => {
+            switch newProgressBlockNumberPerChain->Utils.Dict.dangerouslyGetByIntNonOption(
+              chain->ChainMap.Chain.toChainId,
+            ) {
+            | Some(newProgressBlockNumber) =>
+              let fetchState =
+                cf.fetchState->FetchState.rollback(~targetBlockNumber=newProgressBlockNumber)
+              let newTotalEventsProcessed =
+                cf.numEventsProcessed -.
+                eventsProcessedDiffByChain
+                ->Utils.Dict.dangerouslyGetByIntNonOption(chain->ChainMap.Chain.toChainId)
+                ->Option.getUnsafe
+
+              if cf.committedProgressBlockNumber !== newProgressBlockNumber {
+                Prometheus.ProgressBlockNumber.set(
+                  ~blockNumber=newProgressBlockNumber,
+                  ~chainId=chain->ChainMap.Chain.toChainId,
                 )
-              | None => None
-              },
-              fetchState,
-              committedProgressBlockNumber: newProgressBlockNumber,
-              numEventsProcessed: newTotalEventsProcessed,
-            }
+              }
+              if cf.numEventsProcessed !== newTotalEventsProcessed {
+                Prometheus.ProgressEventsCount.set(
+                  ~processedCount=newTotalEventsProcessed,
+                  ~chainId=chain->ChainMap.Chain.toChainId,
+                )
+              }
 
-          | None =>
-            // Even without a progress diff entry, the reorg chain must have its
-            // reorgDetection and fetchState rolled back. Otherwise the stale block hash
-            // stays in dataByBlockNumber and the same reorg is re-detected on the next
-            // fetch, causing an infinite reorg→rollback loop.
-            if chain == reorgChain {
               {
                 ...cf,
-                reorgDetection: cf.reorgDetection->ReorgDetection.rollbackToValidBlockNumber(
-                  ~blockNumber=rollbackTargetBlockNumber,
-                ),
-                fetchState: cf.fetchState->FetchState.rollback(
-                  ~targetBlockNumber=rollbackTargetBlockNumber,
-                ),
+                reorgDetection: chain == reorgChain
+                  ? cf.reorgDetection->ReorgDetection.rollbackToValidBlockNumber(
+                      ~blockNumber=rollbackTargetBlockNumber,
+                    )
+                  : cf.reorgDetection,
+                safeCheckpointTracking: switch cf.safeCheckpointTracking {
+                | Some(safeCheckpointTracking) =>
+                  Some(
+                    safeCheckpointTracking->SafeCheckpointTracking.rollback(
+                      ~targetBlockNumber=newProgressBlockNumber,
+                    ),
+                  )
+                | None => None
+                },
+                fetchState,
+                committedProgressBlockNumber: newProgressBlockNumber,
+                numEventsProcessed: newTotalEventsProcessed,
               }
-            } else {
-              cf
+
+            | None =>
+              // Even without a progress diff entry, the reorg chain must have its
+              // reorgDetection and fetchState rolled back. Otherwise the stale block hash
+              // stays in dataByBlockNumber and the same reorg is re-detected on the next
+              // fetch, causing an infinite reorg→rollback loop.
+              if chain == reorgChain {
+                {
+                  ...cf,
+                  reorgDetection: cf.reorgDetection->ReorgDetection.rollbackToValidBlockNumber(
+                    ~blockNumber=rollbackTargetBlockNumber,
+                  ),
+                  fetchState: cf.fetchState->FetchState.rollback(
+                    ~targetBlockNumber=rollbackTargetBlockNumber,
+                  ),
+                }
+              } else {
+                cf
+              }
             }
+          })
+
+          // Construct in Memory store with rollback diff
+          let diff = await state.ctx.persistence->Persistence.prepareRollbackDiff(
+            ~rollbackTargetCheckpointId,
+            ~rollbackDiffCheckpointId=state.chainManager.committedCheckpointId->BigInt.add(1n),
+          )
+
+          let chainManager = {
+            ...state.chainManager,
+            chainFetchers,
           }
-        })
 
-        // Construct in Memory store with rollback diff
-        let diff = await state.ctx.persistence->Persistence.prepareRollbackDiff(
-          ~rollbackTargetCheckpointId,
-          ~rollbackDiffCheckpointId=state.chainManager.committedCheckpointId->BigInt.add(1n),
-        )
+          logger->Logging.childTrace({
+            "msg": "Finished rollback on reorg",
+            "entityChanges": {
+              "deleted": diff["deletedEntities"],
+              "upserted": diff["setEntities"],
+            },
+            "rollbackedEvents": rollbackedProcessedEvents.contents,
+            "beforeCheckpointId": state.chainManager.committedCheckpointId,
+            "targetCheckpointId": rollbackTargetCheckpointId,
+          })
+          Prometheus.RollbackSuccess.increment(
+            ~timeSeconds=Hrtime.timeSince(startTime)->Hrtime.toSecondsFloat,
+            ~rollbackedProcessedEvents=rollbackedProcessedEvents.contents,
+          )
 
-        let chainManager = {
-          ...state.chainManager,
-          chainFetchers,
+          dispatchAction(
+            SetRollbackState({
+              diffInMemoryStore: diff["inMemStore"],
+              rollbackedChainManager: chainManager,
+              eventsProcessedDiffByChain,
+            }),
+          )
         }
-
-        logger->Logging.childTrace({
-          "msg": "Finished rollback on reorg",
-          "entityChanges": {
-            "deleted": diff["deletedEntities"],
-            "upserted": diff["setEntities"],
-          },
-          "rollbackedEvents": rollbackedProcessedEvents.contents,
-          "beforeCheckpointId": state.chainManager.committedCheckpointId,
-          "targetCheckpointId": rollbackTargetCheckpointId,
-        })
-        Prometheus.RollbackSuccess.increment(
-          ~timeSeconds=Hrtime.timeSince(startTime)->Hrtime.toSecondsFloat,
-          ~rollbackedProcessedEvents=rollbackedProcessedEvents.contents,
-        )
-
-        dispatchAction(
-          SetRollbackState({
-            diffInMemoryStore: diff["inMemStore"],
-            rollbackedChainManager: chainManager,
-            eventsProcessedDiffByChain,
-          }),
-        )
       }
     }
   }

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -1,14 +1,28 @@
+// The previous batch's writes whose SQL commit is still in flight.
+// Loaders consult `inMemoryStore` so they see staged entities instead
+// of pre-commit Postgres state. `commitPromise` lets callers that
+// query secondary indexes (loadByField) drain the write before
+// reading the database — the in-memory secondary index is not
+// reliable across batches.
+type transit = {
+  inMemoryStore: InMemoryStore.t,
+  commitPromise: promise<result<unit, ErrorHandling.t>>,
+}
+
 let loadById = (
   ~loadManager,
   ~persistence: Persistence.t,
   ~entityConfig: Internal.entityConfig,
   ~inMemoryStore,
+  ~transit: option<transit>=?,
   ~shouldGroup,
   ~item,
   ~entityId,
 ) => {
   let key = `${entityConfig.name}.get`
   let inMemTable = inMemoryStore->InMemoryStore.getInMemTable(~entityConfig)
+  let transitInMemTable =
+    transit->Belt.Option.map(({inMemoryStore: s}) => s->InMemoryStore.getInMemTable(~entityConfig))
 
   let load = async (idsToLoad, ~onError as _) => {
     let storage = persistence->Persistence.getInitializedStorageOrThrow
@@ -50,13 +64,37 @@ let loadById = (
     )
   }
 
+  // hasInMemory / getUnsafeInMemory check the active batch's table first
+  // and fall back to the transit table from the previous batch whose SQL
+  // commit is still in flight. Without the fallback, the next batch's
+  // loaders would query Postgres and miss writes from the prior batch.
+  let hasInMemory = switch transitInMemTable {
+  | Some(transit) =>
+    hash =>
+      inMemTable.table->InMemoryTable.hasByHash(hash) ||
+        transit.table->InMemoryTable.hasByHash(hash)
+  | None => hash => inMemTable.table->InMemoryTable.hasByHash(hash)
+  }
+  let getUnsafeInMemory = switch transitInMemTable {
+  | Some(transit) => {
+      let primary = inMemTable->InMemoryTable.Entity.getUnsafe
+      let secondary = transit->InMemoryTable.Entity.getUnsafe
+      key =>
+        switch inMemTable.table->InMemoryTable.hasByHash(key) {
+        | true => primary(key)
+        | false => secondary(key)
+        }
+    }
+  | None => inMemTable->InMemoryTable.Entity.getUnsafe
+  }
+
   loadManager->LoadManager.call(
     ~key,
     ~load,
     ~shouldGroup,
     ~hasher=LoadManager.noopHasher,
-    ~getUnsafeInMemory=inMemTable->InMemoryTable.Entity.getUnsafe,
-    ~hasInMemory=hash => inMemTable.table->InMemoryTable.hasByHash(hash),
+    ~getUnsafeInMemory,
+    ~hasInMemory,
     ~input=entityId,
   )
 }
@@ -346,6 +384,7 @@ let loadByField = (
   ~operator: TableIndices.Operator.t,
   ~entityConfig: Internal.entityConfig,
   ~inMemoryStore,
+  ~transit: option<transit>=?,
   ~fieldName,
   ~fieldValueSchema,
   ~shouldGroup,
@@ -361,6 +400,24 @@ let loadByField = (
   let inMemTable = inMemoryStore->InMemoryStore.getInMemTable(~entityConfig)
 
   let load = async (fieldValues: array<'fieldValue>, ~onError as _) => {
+    // Field queries hit the database, but the previous batch's writes
+    // may not have landed yet. Drain its commit before the SELECT or
+    // we'd return a stale set (missing entities the prior batch set
+    // and including ones it deleted). loadById can skip this because
+    // its lookup checks the transit in-memory table directly.
+    switch transit {
+    | Some({commitPromise}) =>
+      switch await commitPromise {
+      | Ok() => ()
+      | Error(errHandler) =>
+        errHandler.exn->ErrorHandling.mkLogAndRaise(
+          ~logger=item->Logging.getItemLogger,
+          ~msg="Previous batch commit failed; aborting field-load",
+        )
+      }
+    | None => ()
+    }
+
     let storage = persistence->Persistence.getInitializedStorageOrThrow
     let timerRef = Prometheus.StorageLoad.startOperation(~storage=storage.name, ~operation=key)
 

--- a/packages/envio/src/LoadLayer.resi
+++ b/packages/envio/src/LoadLayer.resi
@@ -1,8 +1,14 @@
+type transit = {
+  inMemoryStore: InMemoryStore.t,
+  commitPromise: promise<result<unit, ErrorHandling.t>>,
+}
+
 let loadById: (
   ~loadManager: LoadManager.t,
   ~persistence: Persistence.t,
   ~entityConfig: Internal.entityConfig,
   ~inMemoryStore: InMemoryStore.t,
+  ~transit: transit=?,
   ~shouldGroup: bool,
   ~item: Internal.item,
   ~entityId: string,
@@ -14,6 +20,7 @@ let loadByField: (
   ~operator: TableIndices.Operator.t,
   ~entityConfig: Internal.entityConfig,
   ~inMemoryStore: InMemoryStore.t,
+  ~transit: transit=?,
   ~fieldName: string,
   ~fieldValueSchema: RescriptSchema.S.t<'fieldValue>,
   ~shouldGroup: bool,

--- a/packages/envio/src/UserContext.res
+++ b/packages/envio/src/UserContext.res
@@ -4,6 +4,13 @@ type contextParams = {
   item: Internal.item,
   checkpointId: Internal.checkpointId,
   inMemoryStore: InMemoryStore.t,
+  // The previous batch whose SQL commit is still in flight. loadById
+  // checks the staged store as a fallback so it sees writes that
+  // haven't landed in Postgres yet; loadByField awaits the commit
+  // first because the in-memory secondary index doesn't carry
+  // across batches. None on the first batch or when pipelining is
+  // disabled (e.g. during rollback replay).
+  transit: option<LoadLayer.transit>,
   loadManager: LoadManager.t,
   persistence: Persistence.t,
   isPreload: bool,
@@ -143,6 +150,7 @@ let getWhereHandler = (params: entityContextParams, filter: dict<dict<unknown>>)
         ~fieldName=dbFieldName,
         ~fieldValueSchema=fieldSchema,
         ~inMemoryStore=params.inMemoryStore,
+        ~transit=?params.transit,
         ~shouldGroup=params.isPreload,
         ~item=params.item,
         ~fieldValue,
@@ -164,6 +172,7 @@ let getWhereHandler = (params: entityContextParams, filter: dict<dict<unknown>>)
         ~fieldName=dbFieldName,
         ~fieldValueSchema=fieldSchema,
         ~inMemoryStore=params.inMemoryStore,
+        ~transit=?params.transit,
         ~shouldGroup=params.isPreload,
         ~item=params.item,
         ~fieldValue,
@@ -193,6 +202,7 @@ let getWhereHandler = (params: entityContextParams, filter: dict<dict<unknown>>)
       ~fieldName=dbFieldName,
       ~fieldValueSchema=fieldSchema,
       ~inMemoryStore=params.inMemoryStore,
+      ~transit=?params.transit,
       ~shouldGroup=params.isPreload,
       ~item=params.item,
       ~fieldValue,
@@ -246,6 +256,7 @@ let entityTraps: Utils.Proxy.traps<entityContextParams> = {
               ~persistence=params.persistence,
               ~entityConfig=params.entityConfig,
               ~inMemoryStore=params.inMemoryStore,
+              ~transit=?params.transit,
               ~shouldGroup=params.isPreload,
               ~item=params.item,
               ~entityId,
@@ -277,6 +288,7 @@ let entityTraps: Utils.Proxy.traps<entityContextParams> = {
               ~persistence=params.persistence,
               ~entityConfig=params.entityConfig,
               ~inMemoryStore=params.inMemoryStore,
+              ~transit=?params.transit,
               ~shouldGroup=params.isPreload,
               ~item=params.item,
               ~entityId,
@@ -306,6 +318,7 @@ let entityTraps: Utils.Proxy.traps<entityContextParams> = {
               ~persistence=params.persistence,
               ~entityConfig=params.entityConfig,
               ~inMemoryStore=params.inMemoryStore,
+              ~transit=?params.transit,
               ~shouldGroup=params.isPreload,
               ~item=params.item,
               ~entityId=entity.id,
@@ -377,6 +390,7 @@ let handlerTraps: Utils.Proxy.traps<contextParams> = {
           item: params.item,
           isPreload: params.isPreload,
           inMemoryStore: params.inMemoryStore,
+          transit: params.transit,
           loadManager: params.loadManager,
           persistence: params.persistence,
           shouldSaveHistory: params.shouldSaveHistory,

--- a/scenarios/test_codegen/test/EventOrigin_test.res
+++ b/scenarios/test_codegen/test/EventOrigin_test.res
@@ -54,6 +54,7 @@ describe("Chains State", () => {
             ~config=Config.loadWithoutRegistrations(),
           ),
           inMemoryStore,
+          transit: None,
           shouldSaveHistory: false,
           isPreload: false,
           checkpointId: 0n,

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -379,6 +379,15 @@ module Indexer = {
           while before >= (gsManager->GlobalStateManager.getState).processedBatches {
             await Utils.delay(1)
           }
+          // The pipeline lets `processedBatches` tick once the CPU phase
+          // finishes, so the SQL commit may still be in flight. Tests
+          // expect the previous batch to be readable from Postgres by
+          // the time this resolves — drain the pending commit.
+          switch (gsManager->GlobalStateManager.getState).pipeline.pendingCommit {
+          | Some({commitPromise}) =>
+            let _ = await commitPromise
+          | None => ()
+          }
           // Skip extra microtasks for indexer to fire follow-up actions
           // (e.g. the NextQuery dispatch that schedules the next
           // getItemsOrThrow call). Without this, callers that immediately


### PR DESCRIPTION
## Summary

Implements batch processing pipelining to overlap the previous batch's SQL commit with the next batch's CPU phase (preload + handlers). This allows the indexer to hide database write latency and improve throughput.

## Key Changes

- **GlobalState**: Added `pipelineState` record with mutable `pendingCommit` field to track in-flight commits across state updates. The `pendingCommit` holds both the staged `InMemoryStore` (for loaders to see pending writes) and a promise that resolves when the SQL transaction lands.

- **EventProcessing**: Split batch processing into two phases:
  - `processEventBatchCpuOrThrow`: Runs preload + handlers, returns elapsed durations without committing
  - `commitBatchOrThrow`: Performs the deferred SQL commit, designed to run in the background

- **LoadLayer**: Added `transit` type to expose the previous batch's staged writes and commit promise. Updated `loadById` to check the transit in-memory table as a fallback so it sees entities from the prior batch before their SQL lands. Updated `loadByField` to await the transit commit promise before querying the database, since secondary indexes don't carry across batches.

- **UserContext**: Threaded `transit` through handler context so loaders can access staged writes from the previous batch.

- **Batch processing flow**: After handlers complete, fire the SQL commit as a background promise and immediately dispatch `EventBatchProcessed`. The next batch's CPU phase runs in parallel. Before the next batch's commit, await the prior commit to maintain strict SQL write ordering. Before rollback, drain any pending commit to ensure rollback queries see consistent state.

- **Exit handling**: Before `SuccessExit`, drain the final pending commit so declared endblock state actually lands in Postgres.

- **Test helpers**: Updated `MockIndexer` to drain pending commits when waiting for batch processing, ensuring tests see committed state.

## Notable Implementation Details

- The `pipelineState` lives outside the spread-copied state record so mutations survive `{...state, ...}` patterns.
- Pipelining is disabled during rollback replay (no transit passed) to keep the diff store exclusively visible.
- `loadById` checks transit as a fallback; `loadByField` must await the commit first because in-memory secondary indexes don't carry across batches.
- Metrics are stitched after the deferred commit completes using durations captured during the CPU phase.

https://claude.ai/code/session_01ENbBusRSerrzNiexfj5kWG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized batch processing pipeline by separating CPU execution and database commit phases for improved efficiency and reduced latency.
  * Enhanced concurrent batch operations to allow safe access to data from previous uncommitted batch writes.
  * Improved rollback handling to properly manage in-flight database operations and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1207)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->