### PR TITLE
Fix crash when setting entity with omitted nullable FK after getWhere

### DIFF
--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -71,7 +71,6 @@ module Entity = {
     fieldNameIndices: make(~hash=TableIndices.Index.getFieldName),
   }
 
-  exception UndefinedKey(string)
   let updateIndices = (
     self: t<'entity>,
     ~entity: 'entity,
@@ -83,8 +82,7 @@ module Entity = {
       let fieldValue =
         entity
         ->(Utils.magic: 'entity => dict<TableIndices.FieldValue.t>)
-        ->Dict.get(fieldName)
-        ->Option.getUnsafe
+        ->Dict.getUnsafe(fieldName)
       if !(index->TableIndices.Index.evaluate(~fieldName, ~fieldValue)) {
         entityIndices->Utils.Set.delete(index)->ignore
       }
@@ -93,27 +91,25 @@ module Entity = {
     self.fieldNameIndices.dict
     ->Dict.keysToArray
     ->Array.forEach(fieldName => {
-      switch (
-        entity->(Utils.magic: 'entity => dict<TableIndices.FieldValue.t>)->Dict.get(fieldName),
-        self.fieldNameIndices.dict->Dict.get(fieldName),
-      ) {
-      | (Some(fieldValue), Some(indices)) =>
-        indices
-        ->values
-        ->Array.forEach(((index, relatedEntityIds)) => {
-          if index->TableIndices.Index.evaluate(~fieldName, ~fieldValue) {
-            //Add entity id to indices and add index to entity indicies
-            relatedEntityIds->Utils.Set.add(getEntityIdUnsafe(entity))->ignore
-            entityIndices->Utils.Set.add(index)->ignore
-          } else {
-            relatedEntityIds->Utils.Set.delete(getEntityIdUnsafe(entity))->ignore
-          }
-        })
-      | _ =>
-        UndefinedKey(fieldName)->ErrorHandling.mkLogAndRaise(
-          ~msg="Expected field name to exist on the referenced index and the provided entity",
-        )
-      }
+      let indices = self.fieldNameIndices.dict->Dict.getUnsafe(fieldName)
+      // A missing key reads as `undefined`, which matches the `None` arm of
+      // `FieldValue.t` (`option<...>`). Mirror `addEmptyIndex` so nullable
+      // FK columns that were omitted on the set entity don't crash.
+      let fieldValue =
+        entity
+        ->(Utils.magic: 'entity => dict<TableIndices.FieldValue.t>)
+        ->Dict.getUnsafe(fieldName)
+      indices
+      ->values
+      ->Array.forEach(((index, relatedEntityIds)) => {
+        if index->TableIndices.Index.evaluate(~fieldName, ~fieldValue) {
+          //Add entity id to indices and add index to entity indicies
+          relatedEntityIds->Utils.Set.add(getEntityIdUnsafe(entity))->ignore
+          entityIndices->Utils.Set.add(index)->ignore
+        } else {
+          relatedEntityIds->Utils.Set.delete(getEntityIdUnsafe(entity))->ignore
+        }
+      })
     })
   }
 

--- a/scenarios/test_codegen/src/handlers/EventHandlers.ts
+++ b/scenarios/test_codegen/src/handlers/EventHandlers.ts
@@ -807,6 +807,27 @@ indexer.onEvent({ contract: "Gravatar", event: "FactoryEvent" }, async ({ event,
       });
       break;
     }
+
+    // getWhere on a nullable linkedEntity column registers an InMemoryTable
+    // index for that field. A subsequent set whose entity omits the FK key
+    // (the common shape for nullable relations) used to crash inside
+    // updateIndices with `UndefinedKey("gravatar_id")`.
+    case "getWhereThenSetNullableFk": {
+      await context.User.getWhere({
+        gravatar_id: { _eq: "non-existent-gravatar" },
+      });
+      context.User.set({
+        id: "user-with-null-gravatar",
+        address: "0x1111111111111111111111111111111111111111",
+        updatesCountOnUserForTesting: 0,
+        gravatar_id: undefined,
+        accountType: "USER",
+      });
+      context.CustomSelectionTestPass.set({
+        id: "getWhereThenSetNullableFk:ok",
+      });
+      break;
+    }
   }
 });
 

--- a/scenarios/test_codegen/test/EventHandler.test.ts
+++ b/scenarios/test_codegen/test/EventHandler.test.ts
@@ -648,6 +648,51 @@ describe("Use Envio test framework to test event handlers", () => {
     });
   });
 
+  // Regression: a `getWhere` on a nullable linkedEntity column (db column
+  // `<field>_id`) registers an in-memory index keyed by that column name.
+  // The next `set` of an entity whose JS object simply omits the FK (the
+  // natural shape for `nullableField === undefined`) used to throw
+  // `UndefinedKey("gravatar_id")` deep inside InMemoryTable.updateIndices.
+  // PgStorage stores the column as NULL, so the bug only surfaced for
+  // handlers that mix the two operations on the same entity table.
+  it("getWhere followed by set with omitted nullable FK does not crash", async () => {
+    const indexer = createTestIndexer();
+
+    const result = await indexer.process({
+      chains: {
+        1337: {
+          startBlock: 1,
+          endBlock: 100,
+          simulate: [
+            {
+              contract: "Gravatar",
+              event: "FactoryEvent",
+              params: {
+                contract: "0x1234567890123456789012345678901234567890",
+                testCase: "getWhereThenSetNullableFk",
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    assert.deepEqual(result.changes[0]?.User, {
+      sets: [
+        {
+          id: "user-with-null-gravatar",
+          address: "0x1111111111111111111111111111111111111111",
+          updatesCountOnUserForTesting: 0,
+          gravatar_id: undefined,
+          accountType: "USER",
+        },
+      ],
+    });
+    assert.deepEqual(result.changes[0]?.CustomSelectionTestPass, {
+      sets: [{ id: "getWhereThenSetNullableFk:ok" }],
+    });
+  });
+
   it("Throws when contract registered with invalid address", async () => {
     const indexer = createTestIndexer();
 


### PR DESCRIPTION
## Summary
Fixes a regression where calling `getWhere` on a nullable linked entity column followed by `set` on an entity that omits the foreign key would crash with `UndefinedKey` inside `InMemoryTable.updateIndices`.

## Root Cause
When `getWhere` is called on a nullable FK column (e.g., `gravatar_id`), it registers an in-memory index keyed by that field name. When a subsequent `set` operation provides an entity object that omits the FK key (the natural shape for `nullableField === undefined`), the code attempted to access the missing field with `Option.getUnsafe`, causing a crash. PgStorage handles this correctly by storing NULL, so the bug only surfaced when mixing both operations on the same entity table.

## Key Changes
- **InMemoryTable.res**: Removed the `UndefinedKey` exception and changed field access from `Dict.get(...)->Option.getUnsafe` to `Dict.getUnsafe(...)`. This allows missing keys to naturally read as `undefined`, which correctly matches the `None` arm of the `FieldValue.t` option type, mirroring the behavior of `addEmptyIndex`.
- **EventHandlers.ts**: Added test case `getWhereThenSetNullableFk` that reproduces the regression scenario.
- **EventHandler.test.ts**: Added regression test verifying that the handler completes successfully and produces expected entity changes.

## Implementation Details
The fix treats missing dictionary keys as `undefined` rather than throwing an exception. This is semantically correct because nullable FK columns that are omitted from the entity object should be treated the same as explicitly set to `undefined`, allowing the index evaluation logic to handle them properly.

https://claude.ai/code/session_01EGs1UWHZJ1xvP2wo9uiRbA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when performing query and update operations on entities with nullable foreign key fields that are omitted or undefined.

* **Tests**
  * Added regression test coverage for nullable foreign key field operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1208)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->