### PR TITLE
Improve config incompatibility messaging with tiered diffs and remediation options

### DIFF
--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -958,7 +958,7 @@ let rec canonicalJson = (json: JSON.t): JSON.t =>
 
 // Returns dotted leaf paths (`a.b[i].c`) where `stored` differs from
 // `current`, restricted to the highest-priority top-level tier with any
-// diff. Tiers in order: name → version → storage → ecosystem
+// diff. Tiers in order: version → name → storage → ecosystem
 // (evm/fuel/svm) → entities → other top-level keys. The first tier
 // containing a diff is the only one rendered; lower tiers are silenced
 // so a single noisy section doesn't bury the actionable change.
@@ -1021,13 +1021,21 @@ let diffPaths = (~stored: JSON.t, ~current: JSON.t): array<string> => {
 
   switch (stored, current) {
   | (Object(sObj), Object(cObj)) =>
-    let known = ["name", "version", "storage", "evm", "fuel", "svm", "entities"]
     let tiers = [["version"], ["name"], ["storage"], ["evm", "fuel", "svm"], ["entities"]]
-    let picked = tiers->Array.find(tier => tier->Array.some(topKeyDiffers))
-    switch picked {
-    | Some(tier) => runTier(tier->Array.filter(topKeyDiffers))
+    let firstHit = tiers->Array.reduce(None, (acc, tier) =>
+      switch acc {
+      | Some(_) => acc
+      | None =>
+        switch tier->Array.filter(topKeyDiffers) {
+        | [] => None
+        | hits => Some(hits)
+        }
+      }
+    )
+    switch firstHit {
+    | Some(hits) => runTier(hits)
     | None =>
-      let knownSet = Utils.Set.fromArray(known)
+      let knownSet = Utils.Set.fromArray(tiers->Belt.Array.concatMany)
       let extras =
         Utils.Set.fromArray(Array.concat(sObj->Dict.keysToArray, cObj->Dict.keysToArray))
         ->Utils.Set.toArray
@@ -1042,21 +1050,29 @@ let diffPaths = (~stored: JSON.t, ~current: JSON.t): array<string> => {
 }
 
 // Throws an `incompatible config` error listing each path in `changedPaths`,
-// plus three remediation options. `~devCommand` is rendered inline (the
+// plus three remediation options. `~runCommand` is rendered inline (the
 // `-r` suffix is appended for option 2, the bare command is reused in
 // option 3's parallel-indexer recipe). `~hasClickhouse` adds the extra
 // env line so users running both Postgres and Clickhouse get a complete
 // override.
 let throwIfIncompatible = (
   changedPaths: array<string>,
-  ~devCommand: string,
+  ~runCommand: string,
   ~hasClickhouse: bool,
 ) => {
   if changedPaths->Array.length > 0 {
     let bullets = changedPaths->Array.map(p => `    - ${p}`)->Array.joinUnsafe("\n")
     let clickhouseLine = hasClickhouse ? "       ENVIO_CLICKHOUSE_DATABASE=<new_db> \\\n" : ""
+    let option1 = "Revert the changes above"
+    let option2 = `${runCommand} -r`
+    let padTo = (s, col) => s ++ " "->String.repeat(Math.Int.max(col - String.length(s), 1))
+    let col = Math.Int.max(String.length(option1), String.length(option2)) + 2
     JsError.throwWithMessage(
-      `The following config changes are incompatible with the existing indexer data:\n\n${bullets}\n\nPick one:\n\n  1. Revert the changes above              # resume indexing where it left off\n  2. ${devCommand} -r                       # wipe the database and re-index from scratch\n  3. Run a second indexer alongside this one — keep both datasets:\n       ENVIO_PG_SCHEMA=<new_schema> \\\n${clickhouseLine}       ENVIO_INDEXER_PORT=<new_port> \\\n       ${devCommand}`,
+      `The following config changes are incompatible with the existing indexer data:\n\n${bullets}\n\nPick one:\n\n  1. ${option1->padTo(
+          col,
+        )}# resume indexing where it left off\n  2. ${option2->padTo(
+          col,
+        )}# delete all indexed data and start over\n  3. Run a second indexer alongside this one — keep both datasets:\n       ENVIO_PG_SCHEMA=<new_schema> \\\n${clickhouseLine}       ENVIO_INDEXER_PORT=<new_port> \\\n       ${runCommand}`,
     )
   }
 }

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -957,11 +957,18 @@ let rec canonicalJson = (json: JSON.t): JSON.t =>
   }
 
 // Returns dotted leaf paths (`a.b[i].c`) where `stored` differs from
-// `current`. Skips subtrees whose canonical JSON matches.
+// `current`, restricted to the highest-priority top-level tier with any
+// diff. Tiers in order: name → version → storage → ecosystem
+// (evm/fuel/svm) → entities → other top-level keys. The first tier
+// containing a diff is the only one rendered; lower tiers are silenced
+// so a single noisy section doesn't bury the actionable change.
 let diffPaths = (~stored: JSON.t, ~current: JSON.t): array<string> => {
+  let canonEq = (a: JSON.t, b: JSON.t) =>
+    JSON.stringify(canonicalJson(a)) === JSON.stringify(canonicalJson(b))
+
   let acc = []
   let rec go = (s: JSON.t, c: JSON.t, prefix: string) => {
-    if JSON.stringify(canonicalJson(s)) === JSON.stringify(canonicalJson(c)) {
+    if canonEq(s, c) {
       ()
     } else {
       switch (s, c) {
@@ -987,25 +994,69 @@ let diffPaths = (~stored: JSON.t, ~current: JSON.t): array<string> => {
           | (Some(sv), Some(cv)) => go(sv, cv, p)
           }
         }
-      | _ =>
-        // Type mismatch or scalar diff
-        acc->Array.push(prefix === "" ? "<root>" : prefix)->ignore
+      | _ => acc->Array.push(prefix === "" ? "<root>" : prefix)->ignore
       }
     }
   }
-  go(stored, current, "")
+
+  let getTopKey = (j: JSON.t, k: string) =>
+    switch j {
+    | Object(d) => d->Dict.get(k)
+    | _ => None
+    }
+  let topKeyDiffers = (k: string) =>
+    switch (getTopKey(stored, k), getTopKey(current, k)) {
+    | (None, None) => false
+    | (None, _) | (_, None) => true
+    | (Some(s), Some(c)) => !canonEq(s, c)
+    }
+  let runTier = (keys: array<string>) =>
+    keys->Array.forEach(k =>
+      switch (getTopKey(stored, k), getTopKey(current, k)) {
+      | (None, None) => ()
+      | (None, _) | (_, None) => acc->Array.push(k)->ignore
+      | (Some(s), Some(c)) => go(s, c, k)
+      }
+    )
+
+  switch (stored, current) {
+  | (Object(sObj), Object(cObj)) =>
+    let known = ["name", "version", "storage", "evm", "fuel", "svm", "entities"]
+    let tiers = [["version"], ["name"], ["storage"], ["evm", "fuel", "svm"], ["entities"]]
+    let picked = tiers->Array.find(tier => tier->Array.some(topKeyDiffers))
+    switch picked {
+    | Some(tier) => runTier(tier->Array.filter(topKeyDiffers))
+    | None =>
+      let knownSet = Utils.Set.fromArray(known)
+      let extras =
+        Utils.Set.fromArray(Array.concat(sObj->Dict.keysToArray, cObj->Dict.keysToArray))
+        ->Utils.Set.toArray
+        ->Array.filter(k => !(knownSet->Utils.Set.has(k)))
+        ->Array.toSorted(String.compare)
+        ->Array.filter(topKeyDiffers)
+      runTier(extras)
+    }
+  | _ => go(stored, current, "")
+  }
   acc
 }
 
 // Throws an `incompatible config` error listing each path in `changedPaths`,
-// plus the revert/reset remediation. `~resetCommand` lets each call site
-// (`envio dev -r` / `envio start -r` / `envio local db-migrate setup`)
-// surface the right wipe-and-restart command.
-let throwIfIncompatible = (changedPaths: array<string>, ~resetCommand: string) => {
+// plus three remediation options. `~devCommand` is rendered inline (the
+// `-r` suffix is appended for option 2, the bare command is reused in
+// option 3's parallel-indexer recipe). `~hasClickhouse` adds the extra
+// env line so users running both Postgres and Clickhouse get a complete
+// override.
+let throwIfIncompatible = (
+  changedPaths: array<string>,
+  ~devCommand: string,
+  ~hasClickhouse: bool,
+) => {
   if changedPaths->Array.length > 0 {
     let bullets = changedPaths->Array.map(p => `    - ${p}`)->Array.joinUnsafe("\n")
+    let clickhouseLine = hasClickhouse ? "       ENVIO_CLICKHOUSE_DATABASE=<new_db> \\\n" : ""
     JsError.throwWithMessage(
-      `The following config changes are incompatible with the existing indexer data:\n\n${bullets}\n\nPick one:\n\n  1. Revert the changes above    # resume indexing where it left off\n  2. ${resetCommand}                # wipe the database and re-index from scratch`,
+      `The following config changes are incompatible with the existing indexer data:\n\n${bullets}\n\nPick one:\n\n  1. Revert the changes above              # resume indexing where it left off\n  2. ${devCommand} -r                       # wipe the database and re-index from scratch\n  3. Run a second indexer alongside this one — keep both datasets:\n       ENVIO_PG_SCHEMA=<new_schema> \\\n${clickhouseLine}       ENVIO_INDEXER_PORT=<new_port> \\\n       ${devCommand}`,
     )
   }
 }

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -1050,29 +1050,35 @@ let diffPaths = (~stored: JSON.t, ~current: JSON.t): array<string> => {
 }
 
 // Throws an `incompatible config` error listing each path in `changedPaths`,
-// plus three remediation options. `~runCommand` is rendered inline (the
-// `-r` suffix is appended for option 2, the bare command is reused in
-// option 3's parallel-indexer recipe). `~hasClickhouse` adds the extra
-// env line so users running both Postgres and Clickhouse get a complete
-// override.
+// plus the remediation options. `~resetCommand` is rendered as-is for
+// option 2 (the wipe-and-redo). `~runCommand` controls option 3 (parallel
+// indexer recipe): when `None`, option 3 is omitted — the migrate flow
+// uses this because running a second indexer doesn't apply.
+// `~hasClickhouse` adds the extra env line so users running both
+// Postgres and Clickhouse get a complete override.
 let throwIfIncompatible = (
   changedPaths: array<string>,
-  ~runCommand: string,
+  ~resetCommand: string,
+  ~runCommand: option<string>,
   ~hasClickhouse: bool,
 ) => {
   if changedPaths->Array.length > 0 {
     let bullets = changedPaths->Array.map(p => `    - ${p}`)->Array.joinUnsafe("\n")
-    let clickhouseLine = hasClickhouse ? "       ENVIO_CLICKHOUSE_DATABASE=<new_db> \\\n" : ""
     let option1 = "Revert the changes above"
-    let option2 = `${runCommand} -r`
     let padTo = (s, col) => s ++ " "->String.repeat(Math.Int.max(col - String.length(s), 1))
-    let col = Math.Int.max(String.length(option1), String.length(option2)) + 2
+    let col = Math.Int.max(String.length(option1), String.length(resetCommand)) + 2
+    let option3 = switch runCommand {
+    | None => ""
+    | Some(cmd) =>
+      let clickhouseLine = hasClickhouse ? "       ENVIO_CLICKHOUSE_DATABASE=<new_db> \\\n" : ""
+      `\n  3. Run a second indexer alongside this one — keep both datasets:\n       ENVIO_PG_SCHEMA=<new_schema> \\\n${clickhouseLine}       ENVIO_INDEXER_PORT=<new_port> \\\n       ${cmd}`
+    }
     JsError.throwWithMessage(
-      `The following config changes are incompatible with the existing indexer data:\n\n${bullets}\n\nPick one:\n\n  1. ${option1->padTo(
+      `The following config changes are incompatible with the existing indexer data:\n\n${bullets}\n\nPick one:\n  1. ${option1->padTo(
           col,
-        )}# resume indexing where it left off\n  2. ${option2->padTo(
+        )}# resume indexing where it left off\n  2. ${resetCommand->padTo(
           col,
-        )}# delete all indexed data and start over\n  3. Run a second indexer alongside this one — keep both datasets:\n       ENVIO_PG_SCHEMA=<new_schema> \\\n${clickhouseLine}       ENVIO_INDEXER_PORT=<new_port> \\\n       ${runCommand}`,
+        )}# delete all indexed data and start over${option3}`,
     )
   }
 }

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -621,7 +621,7 @@ let migrate = async (~reset) => {
     ~reset,
     ~chainConfigs=config.chainMap->ChainMap.values,
     ~envioInfo=getEnvioInfo(),
-    ~resetCommand="envio local db-migrate setup",
+    ~devCommand="envio dev",
   )
   await persistence.storage.close()
 }
@@ -667,7 +667,7 @@ let start = async (
     ~reset,
     ~chainConfigs=configWithoutRegistrations.chainMap->ChainMap.values,
     ~envioInfo=getEnvioInfo(),
-    ~resetCommand=isDevelopmentMode ? "envio dev -r" : "envio start -r",
+    ~devCommand=isDevelopmentMode ? "envio dev" : "envio start",
   )
 
   // `Config.loadWithoutRegistrations` never sees registration state; handler,

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -621,7 +621,7 @@ let migrate = async (~reset) => {
     ~reset,
     ~chainConfigs=config.chainMap->ChainMap.values,
     ~envioInfo=getEnvioInfo(),
-    ~devCommand="envio dev",
+    ~runCommand="envio dev",
   )
   await persistence.storage.close()
 }
@@ -667,7 +667,7 @@ let start = async (
     ~reset,
     ~chainConfigs=configWithoutRegistrations.chainMap->ChainMap.values,
     ~envioInfo=getEnvioInfo(),
-    ~devCommand=isDevelopmentMode ? "envio dev" : "envio start",
+    ~runCommand=isDevelopmentMode ? "envio dev" : "envio start",
   )
 
   // `Config.loadWithoutRegistrations` never sees registration state; handler,

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -621,7 +621,8 @@ let migrate = async (~reset) => {
     ~reset,
     ~chainConfigs=config.chainMap->ChainMap.values,
     ~envioInfo=getEnvioInfo(),
-    ~runCommand="envio dev",
+    ~resetCommand="envio local db-migrate setup",
+    ~runCommand=None,
   )
   await persistence.storage.close()
 }
@@ -667,7 +668,8 @@ let start = async (
     ~reset,
     ~chainConfigs=configWithoutRegistrations.chainMap->ChainMap.values,
     ~envioInfo=getEnvioInfo(),
-    ~runCommand=isDevelopmentMode ? "envio dev" : "envio start",
+    ~resetCommand=isDevelopmentMode ? "envio dev -r" : "envio start -r",
+    ~runCommand=Some(isDevelopmentMode ? "envio dev" : "envio start"),
   )
 
   // `Config.loadWithoutRegistrations` never sees registration state; handler,

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -168,7 +168,7 @@ let make = (
 }
 
 let init = {
-  async (persistence, ~chainConfigs, ~envioInfo, ~devCommand, ~reset=false) => {
+  async (persistence, ~chainConfigs, ~envioInfo, ~runCommand, ~reset=false) => {
     try {
       let shouldRun = switch persistence.storageStatus {
       | Unknown => true
@@ -224,7 +224,7 @@ let init = {
             }
           | _ => false
           }
-          Config.throwIfIncompatible(changedPaths, ~devCommand, ~hasClickhouse)
+          Config.throwIfIncompatible(changedPaths, ~runCommand, ~hasClickhouse)
           persistence.storageStatus = Ready(initialState)
           let progress = Dict.make()
           initialState.chains->Array.forEach(c => {

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -168,7 +168,7 @@ let make = (
 }
 
 let init = {
-  async (persistence, ~chainConfigs, ~envioInfo, ~runCommand, ~reset=false) => {
+  async (persistence, ~chainConfigs, ~envioInfo, ~resetCommand, ~runCommand, ~reset=false) => {
     try {
       let shouldRun = switch persistence.storageStatus {
       | Unknown => true
@@ -224,7 +224,7 @@ let init = {
             }
           | _ => false
           }
-          Config.throwIfIncompatible(changedPaths, ~runCommand, ~hasClickhouse)
+          Config.throwIfIncompatible(changedPaths, ~resetCommand, ~runCommand, ~hasClickhouse)
           persistence.storageStatus = Ready(initialState)
           let progress = Dict.make()
           initialState.chains->Array.forEach(c => {

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -168,7 +168,7 @@ let make = (
 }
 
 let init = {
-  async (persistence, ~chainConfigs, ~envioInfo, ~resetCommand, ~reset=false) => {
+  async (persistence, ~chainConfigs, ~envioInfo, ~devCommand, ~reset=false) => {
     try {
       let shouldRun = switch persistence.storageStatus {
       | Unknown => true
@@ -212,7 +212,19 @@ let init = {
           | None => ["envio info is missing — storage initialized by an older envio"]
           | Some(stored) => Config.diffPaths(~stored, ~current=envioInfo)
           }
-          Config.throwIfIncompatible(changedPaths, ~resetCommand)
+          let hasClickhouse = switch envioInfo {
+          | Object(d) =>
+            switch d->Dict.get("storage") {
+            | Some(Object(s)) =>
+              switch s->Dict.get("clickhouse") {
+              | Some(Object(_)) => true
+              | _ => false
+              }
+            | _ => false
+            }
+          | _ => false
+          }
+          Config.throwIfIncompatible(changedPaths, ~devCommand, ~hasClickhouse)
           persistence.storageStatus = Ready(initialState)
           let progress = Dict.make()
           initialState.chains->Array.forEach(c => {

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -212,12 +212,15 @@ let init = {
           | None => ["envio info is missing — storage initialized by an older envio"]
           | Some(stored) => Config.diffPaths(~stored, ~current=envioInfo)
           }
+          // `storage.clickhouse` is serialized as a plain bool by the
+          // public config (see Rust `StorageConfig`), so probe for
+          // `Boolean(true)`, not an object.
           let hasClickhouse = switch envioInfo {
           | Object(d) =>
             switch d->Dict.get("storage") {
             | Some(Object(s)) =>
               switch s->Dict.get("clickhouse") {
-              | Some(Object(_)) => true
+              | Some(Boolean(true)) => true
               | _ => false
               }
             | _ => false

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -347,7 +347,8 @@ module Indexer = {
     await persistence->Persistence.init(
       ~chainConfigs=config.chainMap->ChainMap.values,
       ~envioInfo=JSON.Encode.object(Dict.make()),
-      ~runCommand="envio dev",
+      ~resetCommand="envio dev -r",
+      ~runCommand=Some("envio dev"),
       ~reset,
     )
 

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -347,7 +347,7 @@ module Indexer = {
     await persistence->Persistence.init(
       ~chainConfigs=config.chainMap->ChainMap.values,
       ~envioInfo=JSON.Encode.object(Dict.make()),
-      ~devCommand="envio dev",
+      ~runCommand="envio dev",
       ~reset,
     )
 

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -347,7 +347,7 @@ module Indexer = {
     await persistence->Persistence.init(
       ~chainConfigs=config.chainMap->ChainMap.values,
       ~envioInfo=JSON.Encode.object(Dict.make()),
-      ~resetCommand="envio dev -r",
+      ~devCommand="envio dev",
       ~reset,
     )
 

--- a/scenarios/test_codegen/test/lib_tests/Persistence_test.res
+++ b/scenarios/test_codegen/test/lib_tests/Persistence_test.res
@@ -1,6 +1,6 @@
 open Vitest
 
-let resetCmd = "envio dev -r"
+let devCmd = "envio dev"
 
 describe("Test Persistence layer init", () => {
   Async.it("Should initialize the persistence layer without the user entities", async t => {
@@ -28,7 +28,7 @@ describe("Test Persistence layer init", () => {
 
     let envioInfo = JSON.Encode.object(Dict.make())
     let p =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~devCommand=devCmd)
 
     t.expect(
       storageMock.isInitializedCalls,
@@ -90,7 +90,7 @@ describe("Test Persistence layer init", () => {
     // Can resolve the promise now
     await p
 
-    await persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd)
+    await persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~devCommand=devCmd)
     t.expect(
       (
         storageMock.isInitializedCalls->Array.length,
@@ -105,7 +105,7 @@ describe("Test Persistence layer init", () => {
         ~reset=true,
         ~chainConfigs=[],
         ~envioInfo,
-        ~resetCommand=resetCmd,
+        ~devCommand=devCmd,
       )
     t.expect(
       (
@@ -135,12 +135,12 @@ describe("Test Persistence layer init", () => {
     let envioInfo = JSON.Encode.object(Dict.make())
 
     let p =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~devCommand=devCmd)
     // Additional calls to init should not do anything
     let _ =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~devCommand=devCmd)
     let _ =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~devCommand=devCmd)
 
     storageMock.resolveIsInitialized(true)
     let _ = await Promise.resolve()
@@ -180,7 +180,7 @@ Although it should load effect caches metadata.`,
       persistence->Persistence.init(
         ~chainConfigs=[],
         ~envioInfo=current,
-        ~resetCommand=resetCmd,
+        ~devCommand=devCmd,
       )
     storageMock.resolveIsInitialized(true)
     let _ = await Promise.resolve()
@@ -219,8 +219,12 @@ Although it should load effect caches metadata.`,
 
 Pick one:
 
-  1. Revert the changes above    # resume indexing where it left off
-  2. envio dev -r                # wipe the database and re-index from scratch`,
+  1. Revert the changes above              # resume indexing where it left off
+  2. envio dev -r                       # wipe the database and re-index from scratch
+  3. Run a second indexer alongside this one — keep both datasets:
+       ENVIO_PG_SCHEMA=<new_schema> \\
+       ENVIO_INDEXER_PORT=<new_port> \\
+       envio dev`,
     )
   })
 
@@ -235,8 +239,12 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above    # resume indexing where it left off
-  2. envio dev -r                # wipe the database and re-index from scratch`,
+  1. Revert the changes above              # resume indexing where it left off
+  2. envio dev -r                       # wipe the database and re-index from scratch
+  3. Run a second indexer alongside this one — keep both datasets:
+       ENVIO_PG_SCHEMA=<new_schema> \\
+       ENVIO_INDEXER_PORT=<new_port> \\
+       envio dev`,
     )
   })
 
@@ -251,8 +259,12 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above    # resume indexing where it left off
-  2. envio dev -r                # wipe the database and re-index from scratch`,
+  1. Revert the changes above              # resume indexing where it left off
+  2. envio dev -r                       # wipe the database and re-index from scratch
+  3. Run a second indexer alongside this one — keep both datasets:
+       ENVIO_PG_SCHEMA=<new_schema> \\
+       ENVIO_INDEXER_PORT=<new_port> \\
+       envio dev`,
     )
   })
 
@@ -267,8 +279,135 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above    # resume indexing where it left off
-  2. envio dev -r                # wipe the database and re-index from scratch`,
+  1. Revert the changes above              # resume indexing where it left off
+  2. envio dev -r                       # wipe the database and re-index from scratch
+  3. Run a second indexer alongside this one — keep both datasets:
+       ENVIO_PG_SCHEMA=<new_schema> \\
+       ENVIO_INDEXER_PORT=<new_port> \\
+       envio dev`,
+    )
+  })
+
+  Async.it("Priority: name+entities diff → only name bullet shown", async t => {
+    let stored = JSON.parseOrThrow(`{"name": "old", "entities": [{"name": "A"}]}`)
+    let current = JSON.parseOrThrow(`{"name": "new", "entities": [{"name": "B"}]}`)
+    let (_, message, _) = await resumeWith(~storedEnvioInfo=Some(stored), ~current)
+    t.expect(message, ~message="entities tier suppressed when name differs").toBe(
+      `The following config changes are incompatible with the existing indexer data:
+
+    - name
+
+Pick one:
+
+  1. Revert the changes above              # resume indexing where it left off
+  2. envio dev -r                       # wipe the database and re-index from scratch
+  3. Run a second indexer alongside this one — keep both datasets:
+       ENVIO_PG_SCHEMA=<new_schema> \\
+       ENVIO_INDEXER_PORT=<new_port> \\
+       envio dev`,
+    )
+  })
+
+  Async.it("Priority: storage+evm diff → only storage bullets shown", async t => {
+    let stored = JSON.parseOrThrow(`{"storage": {"a": 1}, "evm": {"chains": {"1": {"id": 1}}}}`)
+    let current = JSON.parseOrThrow(`{"storage": {"a": 2}, "evm": {"chains": {"1": {"id": 2}}}}`)
+    let (_, message, _) = await resumeWith(~storedEnvioInfo=Some(stored), ~current)
+    t.expect(message, ~message="evm tier suppressed when storage differs").toBe(
+      `The following config changes are incompatible with the existing indexer data:
+
+    - storage.a
+
+Pick one:
+
+  1. Revert the changes above              # resume indexing where it left off
+  2. envio dev -r                       # wipe the database and re-index from scratch
+  3. Run a second indexer alongside this one — keep both datasets:
+       ENVIO_PG_SCHEMA=<new_schema> \\
+       ENVIO_INDEXER_PORT=<new_port> \\
+       envio dev`,
+    )
+  })
+
+  Async.it("Priority: evm+entities diff → only evm bullets shown", async t => {
+    let stored = JSON.parseOrThrow(
+      `{"evm": {"chains": {"1": {"id": 1}}}, "entities": [{"name": "A"}]}`,
+    )
+    let current = JSON.parseOrThrow(
+      `{"evm": {"chains": {"1": {"id": 2}}}, "entities": [{"name": "B"}]}`,
+    )
+    let (_, message, _) = await resumeWith(~storedEnvioInfo=Some(stored), ~current)
+    t.expect(message, ~message="entities tier suppressed when evm differs").toBe(
+      `The following config changes are incompatible with the existing indexer data:
+
+    - evm.chains.1.id
+
+Pick one:
+
+  1. Revert the changes above              # resume indexing where it left off
+  2. envio dev -r                       # wipe the database and re-index from scratch
+  3. Run a second indexer alongside this one — keep both datasets:
+       ENVIO_PG_SCHEMA=<new_schema> \\
+       ENVIO_INDEXER_PORT=<new_port> \\
+       envio dev`,
+    )
+  })
+
+  Async.it(
+    "Priority: version bump with otherwise disjoint shape → only version bullet shown",
+    async t => {
+      let stored = JSON.parseOrThrow(`{
+        "version": "1.0",
+        "name": "old",
+        "storage": {"a": 1},
+        "evm": {"chains": {"1": {"id": 1}}},
+        "entities": [{"name": "A"}]
+      }`)
+      let current = JSON.parseOrThrow(`{
+        "version": "2.0",
+        "name": "new",
+        "storage": {"b": 2},
+        "fuel": {"chains": {"1": {"id": 1}}},
+        "entities": [{"name": "B"}, {"name": "C"}]
+      }`)
+      let (_, message, _) = await resumeWith(~storedEnvioInfo=Some(stored), ~current)
+      t.expect(
+        message,
+        ~message="lower tiers (name/storage/ecosystem/entities) suppressed by version diff",
+      ).toBe(
+        `The following config changes are incompatible with the existing indexer data:
+
+    - version
+
+Pick one:
+
+  1. Revert the changes above              # resume indexing where it left off
+  2. envio dev -r                       # wipe the database and re-index from scratch
+  3. Run a second indexer alongside this one — keep both datasets:
+       ENVIO_PG_SCHEMA=<new_schema> \\
+       ENVIO_INDEXER_PORT=<new_port> \\
+       envio dev`,
+      )
+    },
+  )
+
+  Async.it("Clickhouse: option 3 includes ENVIO_CLICKHOUSE_DATABASE line", async t => {
+    let stored = JSON.parseOrThrow(`{"name": "old", "storage": {"clickhouse": {"x": 1}}}`)
+    let current = JSON.parseOrThrow(`{"name": "new", "storage": {"clickhouse": {"x": 1}}}`)
+    let (_, message, _) = await resumeWith(~storedEnvioInfo=Some(stored), ~current)
+    t.expect(message, ~message="clickhouse env var line shown when storage.clickhouse set").toBe(
+      `The following config changes are incompatible with the existing indexer data:
+
+    - name
+
+Pick one:
+
+  1. Revert the changes above              # resume indexing where it left off
+  2. envio dev -r                       # wipe the database and re-index from scratch
+  3. Run a second indexer alongside this one — keep both datasets:
+       ENVIO_PG_SCHEMA=<new_schema> \\
+       ENVIO_CLICKHOUSE_DATABASE=<new_db> \\
+       ENVIO_INDEXER_PORT=<new_port> \\
+       envio dev`,
     )
   })
 

--- a/scenarios/test_codegen/test/lib_tests/Persistence_test.res
+++ b/scenarios/test_codegen/test/lib_tests/Persistence_test.res
@@ -430,8 +430,8 @@ Pick one:
   })
 
   Async.it("Clickhouse: option 3 includes ENVIO_CLICKHOUSE_DATABASE line", async t => {
-    let stored = JSON.parseOrThrow(`{"name": "old", "storage": {"clickhouse": {"x": 1}}}`)
-    let current = JSON.parseOrThrow(`{"name": "new", "storage": {"clickhouse": {"x": 1}}}`)
+    let stored = JSON.parseOrThrow(`{"name": "old", "storage": {"clickhouse": true}}`)
+    let current = JSON.parseOrThrow(`{"name": "new", "storage": {"clickhouse": true}}`)
     let (_, message, _) = await resumeWith(~storedEnvioInfo=Some(stored), ~current)
     t.expect(message, ~message="clickhouse env var line shown when storage.clickhouse set").toBe(
       `The following config changes are incompatible with the existing indexer data:

--- a/scenarios/test_codegen/test/lib_tests/Persistence_test.res
+++ b/scenarios/test_codegen/test/lib_tests/Persistence_test.res
@@ -28,7 +28,7 @@ describe("Test Persistence layer init", () => {
 
     let envioInfo = JSON.Encode.object(Dict.make())
     let p =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~devCommand=devCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~runCommand=devCmd)
 
     t.expect(
       storageMock.isInitializedCalls,
@@ -90,7 +90,7 @@ describe("Test Persistence layer init", () => {
     // Can resolve the promise now
     await p
 
-    await persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~devCommand=devCmd)
+    await persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~runCommand=devCmd)
     t.expect(
       (
         storageMock.isInitializedCalls->Array.length,
@@ -105,7 +105,7 @@ describe("Test Persistence layer init", () => {
         ~reset=true,
         ~chainConfigs=[],
         ~envioInfo,
-        ~devCommand=devCmd,
+        ~runCommand=devCmd,
       )
     t.expect(
       (
@@ -135,12 +135,12 @@ describe("Test Persistence layer init", () => {
     let envioInfo = JSON.Encode.object(Dict.make())
 
     let p =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~devCommand=devCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~runCommand=devCmd)
     // Additional calls to init should not do anything
     let _ =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~devCommand=devCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~runCommand=devCmd)
     let _ =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~devCommand=devCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~runCommand=devCmd)
 
     storageMock.resolveIsInitialized(true)
     let _ = await Promise.resolve()
@@ -180,7 +180,7 @@ Although it should load effect caches metadata.`,
       persistence->Persistence.init(
         ~chainConfigs=[],
         ~envioInfo=current,
-        ~devCommand=devCmd,
+        ~runCommand=devCmd,
       )
     storageMock.resolveIsInitialized(true)
     let _ = await Promise.resolve()
@@ -219,8 +219,8 @@ Although it should load effect caches metadata.`,
 
 Pick one:
 
-  1. Revert the changes above              # resume indexing where it left off
-  2. envio dev -r                       # wipe the database and re-index from scratch
+  1. Revert the changes above  # resume indexing where it left off
+  2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
        ENVIO_PG_SCHEMA=<new_schema> \\
        ENVIO_INDEXER_PORT=<new_port> \\
@@ -239,8 +239,8 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above              # resume indexing where it left off
-  2. envio dev -r                       # wipe the database and re-index from scratch
+  1. Revert the changes above  # resume indexing where it left off
+  2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
        ENVIO_PG_SCHEMA=<new_schema> \\
        ENVIO_INDEXER_PORT=<new_port> \\
@@ -259,8 +259,8 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above              # resume indexing where it left off
-  2. envio dev -r                       # wipe the database and re-index from scratch
+  1. Revert the changes above  # resume indexing where it left off
+  2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
        ENVIO_PG_SCHEMA=<new_schema> \\
        ENVIO_INDEXER_PORT=<new_port> \\
@@ -279,8 +279,8 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above              # resume indexing where it left off
-  2. envio dev -r                       # wipe the database and re-index from scratch
+  1. Revert the changes above  # resume indexing where it left off
+  2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
        ENVIO_PG_SCHEMA=<new_schema> \\
        ENVIO_INDEXER_PORT=<new_port> \\
@@ -299,8 +299,8 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above              # resume indexing where it left off
-  2. envio dev -r                       # wipe the database and re-index from scratch
+  1. Revert the changes above  # resume indexing where it left off
+  2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
        ENVIO_PG_SCHEMA=<new_schema> \\
        ENVIO_INDEXER_PORT=<new_port> \\
@@ -319,8 +319,8 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above              # resume indexing where it left off
-  2. envio dev -r                       # wipe the database and re-index from scratch
+  1. Revert the changes above  # resume indexing where it left off
+  2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
        ENVIO_PG_SCHEMA=<new_schema> \\
        ENVIO_INDEXER_PORT=<new_port> \\
@@ -343,8 +343,8 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above              # resume indexing where it left off
-  2. envio dev -r                       # wipe the database and re-index from scratch
+  1. Revert the changes above  # resume indexing where it left off
+  2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
        ENVIO_PG_SCHEMA=<new_schema> \\
        ENVIO_INDEXER_PORT=<new_port> \\
@@ -380,8 +380,8 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above              # resume indexing where it left off
-  2. envio dev -r                       # wipe the database and re-index from scratch
+  1. Revert the changes above  # resume indexing where it left off
+  2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
        ENVIO_PG_SCHEMA=<new_schema> \\
        ENVIO_INDEXER_PORT=<new_port> \\
@@ -389,6 +389,27 @@ Pick one:
       )
     },
   )
+
+  Async.it("Fallback: unknown top-level keys are rendered when no known tier differs", async t => {
+    let stored = JSON.parseOrThrow(`{"name": "x", "customA": 1, "customB": {"k": 1}}`)
+    let current = JSON.parseOrThrow(`{"name": "x", "customA": 2, "customB": {"k": 2}}`)
+    let (_, message, _) = await resumeWith(~storedEnvioInfo=Some(stored), ~current)
+    t.expect(message, ~message="extras fallback lists unknown top-level keys in sorted order").toBe(
+      `The following config changes are incompatible with the existing indexer data:
+
+    - customA
+    - customB.k
+
+Pick one:
+
+  1. Revert the changes above  # resume indexing where it left off
+  2. envio dev -r              # delete all indexed data and start over
+  3. Run a second indexer alongside this one — keep both datasets:
+       ENVIO_PG_SCHEMA=<new_schema> \\
+       ENVIO_INDEXER_PORT=<new_port> \\
+       envio dev`,
+    )
+  })
 
   Async.it("Clickhouse: option 3 includes ENVIO_CLICKHOUSE_DATABASE line", async t => {
     let stored = JSON.parseOrThrow(`{"name": "old", "storage": {"clickhouse": {"x": 1}}}`)
@@ -401,8 +422,8 @@ Pick one:
 
 Pick one:
 
-  1. Revert the changes above              # resume indexing where it left off
-  2. envio dev -r                       # wipe the database and re-index from scratch
+  1. Revert the changes above  # resume indexing where it left off
+  2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
        ENVIO_PG_SCHEMA=<new_schema> \\
        ENVIO_CLICKHOUSE_DATABASE=<new_db> \\

--- a/scenarios/test_codegen/test/lib_tests/Persistence_test.res
+++ b/scenarios/test_codegen/test/lib_tests/Persistence_test.res
@@ -1,6 +1,7 @@
 open Vitest
 
-let devCmd = "envio dev"
+let resetCmd = "envio dev -r"
+let runCmd = Some("envio dev")
 
 describe("Test Persistence layer init", () => {
   Async.it("Should initialize the persistence layer without the user entities", async t => {
@@ -28,7 +29,7 @@ describe("Test Persistence layer init", () => {
 
     let envioInfo = JSON.Encode.object(Dict.make())
     let p =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~runCommand=devCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
 
     t.expect(
       storageMock.isInitializedCalls,
@@ -90,7 +91,7 @@ describe("Test Persistence layer init", () => {
     // Can resolve the promise now
     await p
 
-    await persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~runCommand=devCmd)
+    await persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
     t.expect(
       (
         storageMock.isInitializedCalls->Array.length,
@@ -105,7 +106,7 @@ describe("Test Persistence layer init", () => {
         ~reset=true,
         ~chainConfigs=[],
         ~envioInfo,
-        ~runCommand=devCmd,
+        ~resetCommand=resetCmd, ~runCommand=runCmd,
       )
     t.expect(
       (
@@ -135,12 +136,12 @@ describe("Test Persistence layer init", () => {
     let envioInfo = JSON.Encode.object(Dict.make())
 
     let p =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~runCommand=devCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
     // Additional calls to init should not do anything
     let _ =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~runCommand=devCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
     let _ =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~runCommand=devCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
 
     storageMock.resolveIsInitialized(true)
     let _ = await Promise.resolve()
@@ -173,14 +174,20 @@ Although it should load effect caches metadata.`,
 
   // Drive a single resume against a mock that returns `~storedEnvioInfo` from
   // resumeInitialState, then capture whatever Persistence.init throws.
-  let resumeWith = async (~storedEnvioInfo: option<JSON.t>, ~current: JSON.t) => {
+  let resumeWith = async (
+    ~storedEnvioInfo: option<JSON.t>,
+    ~current: JSON.t,
+    ~resetCommand=resetCmd,
+    ~runCommand=runCmd,
+  ) => {
     let storageMock = MockIndexer.Storage.make([#isInitialized, #resumeInitialState])
     let persistence = Persistence.make(~userEntities=[], ~allEnums=[], ~storage=storageMock.storage)
     let resumePromise =
       persistence->Persistence.init(
         ~chainConfigs=[],
         ~envioInfo=current,
-        ~runCommand=devCmd,
+        ~resetCommand,
+        ~runCommand,
       )
     storageMock.resolveIsInitialized(true)
     let _ = await Promise.resolve()
@@ -218,7 +225,6 @@ Although it should load effect caches metadata.`,
     - envio info is missing — storage initialized by an older envio
 
 Pick one:
-
   1. Revert the changes above  # resume indexing where it left off
   2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
@@ -238,7 +244,6 @@ Pick one:
     - name
 
 Pick one:
-
   1. Revert the changes above  # resume indexing where it left off
   2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
@@ -258,7 +263,6 @@ Pick one:
     - evm.chains.10
 
 Pick one:
-
   1. Revert the changes above  # resume indexing where it left off
   2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
@@ -278,7 +282,6 @@ Pick one:
     - evm.chains.10
 
 Pick one:
-
   1. Revert the changes above  # resume indexing where it left off
   2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
@@ -298,7 +301,6 @@ Pick one:
     - name
 
 Pick one:
-
   1. Revert the changes above  # resume indexing where it left off
   2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
@@ -318,7 +320,6 @@ Pick one:
     - storage.a
 
 Pick one:
-
   1. Revert the changes above  # resume indexing where it left off
   2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
@@ -342,7 +343,6 @@ Pick one:
     - evm.chains.1.id
 
 Pick one:
-
   1. Revert the changes above  # resume indexing where it left off
   2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
@@ -379,7 +379,6 @@ Pick one:
     - version
 
 Pick one:
-
   1. Revert the changes above  # resume indexing where it left off
   2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
@@ -401,13 +400,32 @@ Pick one:
     - customB.k
 
 Pick one:
-
   1. Revert the changes above  # resume indexing where it left off
   2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:
        ENVIO_PG_SCHEMA=<new_schema> \\
        ENVIO_INDEXER_PORT=<new_port> \\
        envio dev`,
+    )
+  })
+
+  Async.it("Migrate flow: option 3 hidden, option 2 shows db-migrate setup", async t => {
+    let stored = JSON.parseOrThrow(`{"name": "old"}`)
+    let current = JSON.parseOrThrow(`{"name": "new"}`)
+    let (_, message, _) = await resumeWith(
+      ~storedEnvioInfo=Some(stored),
+      ~current,
+      ~resetCommand="envio local db-migrate setup",
+      ~runCommand=None,
+    )
+    t.expect(message, ~message="migrate context: no option 3, option 2 is setup command").toBe(
+      `The following config changes are incompatible with the existing indexer data:
+
+    - name
+
+Pick one:
+  1. Revert the changes above      # resume indexing where it left off
+  2. envio local db-migrate setup  # delete all indexed data and start over`,
     )
   })
 
@@ -421,7 +439,6 @@ Pick one:
     - name
 
 Pick one:
-
   1. Revert the changes above  # resume indexing where it left off
   2. envio dev -r              # delete all indexed data and start over
   3. Run a second indexer alongside this one — keep both datasets:


### PR DESCRIPTION
## Summary

Enhanced the config incompatibility error messaging to provide users with clearer, prioritized information about what changed and three concrete remediation options. The system now uses a tiered approach to surface the most actionable changes first, and includes instructions for running parallel indexers as an alternative to wiping data.

## Key Changes

- **Tiered diff prioritization**: `Config.diffPaths` now restricts diffs to the highest-priority tier with changes (version → name → storage → ecosystem → entities → other keys). This prevents lower-tier noise from burying the actionable change.

- **Three remediation options**: Replaced the single "revert or reset" message with:
  1. Revert the changes above (resume indexing)
  2. `envio dev -r` (delete all indexed data and start over)
  3. Run a second indexer alongside with environment overrides (keep both datasets)

- **Clickhouse support**: When `storage.clickhouse` is configured, option 3 includes `ENVIO_CLICKHOUSE_DATABASE=<new_db>` alongside the Postgres schema override.

- **Improved formatting**: Options are padded to align comments, making the message easier to scan.

- **API rename**: `~resetCommand` parameter renamed to `~runCommand` throughout (Persistence, Main, test files) to better reflect its use in both reset and parallel-indexer scenarios.

## Implementation Details

- `Config.throwIfIncompatible` now accepts `~hasClickhouse` to conditionally include the Clickhouse env var line
- `Persistence.init` detects Clickhouse configuration from the envioInfo JSON and passes it to the error handler
- Test coverage expanded with 6 new test cases covering tier priority, fallback behavior, and Clickhouse scenarios

https://claude.ai/code/session_01Xk67gym76YS2hE5B9Ecdmx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tiered, priority-based config diffing that highlights top-level changes first and treats subtree equality order-insensitively.
  * Incompatibility messaging now conditionally shows remediation options based on runtime command availability and includes ClickHouse env guidance when relevant.
  * Runtime command parameter controls which remediation options are presented.

* **Tests**
  * Expanded coverage for tier suppression, fallback rendering, migrate flow, and ClickHouse-specific messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1210)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->