### PR TITLE
Support named tuple components in event signatures

### DIFF
--- a/packages/cli/src/config_parsing/abi_compat.rs
+++ b/packages/cli/src/config_parsing/abi_compat.rs
@@ -442,6 +442,38 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "reproduces issue #1206 — remove once fixed"]
+    fn test_parse_event_with_named_nested_tuple_from_issue_1206() {
+        // Reproduces https://github.com/enviodev/hyperindex/issues/1206.
+        // User reports that a custom event signature with a named tuple
+        // parameter fails codegen when no `abi_file_path` is provided.
+        let sig = "event ConsumeBoostVial(address from, uint256 playerId, (uint40 a, uint24 b, uint16 c, uint16 d, uint8 e) playerBoostInfo)";
+        let event = parse_event(sig).expect("custom event signature with named tuple should parse");
+        let tuple_field = event
+            .inputs
+            .iter()
+            .find(|p| p.name == "playerBoostInfo")
+            .expect("playerBoostInfo input");
+        let tuple_fields = match &tuple_field.kind {
+            AbiType::Tuple(fields) => fields,
+            other => panic!("expected Tuple, got {:?}", other),
+        };
+        assert_eq!(
+            tuple_fields
+                .iter()
+                .map(|f| (f.name.as_deref(), f.kind.clone()))
+                .collect::<Vec<_>>(),
+            vec![
+                (Some("a"), AbiType::Uint(40)),
+                (Some("b"), AbiType::Uint(24)),
+                (Some("c"), AbiType::Uint(16)),
+                (Some("d"), AbiType::Uint(16)),
+                (Some("e"), AbiType::Uint(8)),
+            ]
+        );
+    }
+
+    #[test]
     fn test_parse_param_type() {
         let uint_type = parse_param_type("uint256").unwrap();
         assert!(matches!(uint_type, DynSolType::Uint(256)));

--- a/packages/cli/src/config_parsing/abi_compat.rs
+++ b/packages/cli/src/config_parsing/abi_compat.rs
@@ -188,10 +188,266 @@ impl EventParam {
 /// Parse an event signature string (e.g., "event Transfer(address indexed from, address indexed to, uint256 value)")
 /// into an Event struct.
 pub fn parse_event(sig: &str) -> Result<Event> {
-    let alloy_event =
-        AlloyEvent::parse(sig).map_err(|e| anyhow!("Failed to parse event signature: {}", e))?;
+    let alloy_event = parse_event_signature_to_alloy(sig)?;
     Event::try_from_alloy(&alloy_event)
         .with_context(|| format!("Failed to convert event '{}'", alloy_event.name))
+}
+
+/// Parse a human-readable event signature into an `AlloyEvent`.
+///
+/// Tries alloy's built-in parser first. Falls back to a permissive parser that
+/// accepts named tuple components (e.g. `event E((uint a, uint b) data)`),
+/// which alloy's signature parser rejects. The fallback populates
+/// `components` so downstream selector and ABI consumers see the named fields.
+pub fn parse_event_signature_to_alloy(sig: &str) -> Result<AlloyEvent> {
+    match AlloyEvent::parse(sig) {
+        Ok(ev) => Ok(ev),
+        Err(alloy_err) => sig_parser::parse(sig).map_err(|e| {
+            anyhow!(
+                "Failed to parse event signature: {}\n(strict parser error: {})",
+                e,
+                alloy_err
+            )
+        }),
+    }
+}
+
+/// Permissive human-readable event signature parser.
+///
+/// Differences from `alloy_json_abi::Event::parse`:
+/// - Accepts component names inside tuple types: `(uint40 a, uint24 b)` is valid.
+/// - Otherwise mirrors alloy's syntax: optional `event` prefix, optional
+///   `indexed` per top-level param, optional trailing `anonymous`.
+mod sig_parser {
+    use super::{AlloyEvent, AlloyEventParam, AlloyParam};
+    use anyhow::{anyhow, bail, Context, Result};
+
+    pub fn parse(sig: &str) -> Result<AlloyEvent> {
+        let mut p = Cursor::new(sig);
+        p.skip_ws();
+        if p.try_keyword("event") {
+            p.skip_ws();
+        }
+        let name = p
+            .ident()
+            .ok_or_else(|| anyhow!("expected event name in '{}'", sig))?
+            .to_string();
+        p.skip_ws();
+        p.expect('(', sig)?;
+        let mut inputs = Vec::new();
+        p.skip_ws();
+        if !p.peek_is(')') {
+            loop {
+                inputs.push(parse_event_param(&mut p, sig)?);
+                p.skip_ws();
+                if p.peek_is(',') {
+                    p.bump();
+                    p.skip_ws();
+                    continue;
+                }
+                break;
+            }
+        }
+        p.expect(')', sig)?;
+        p.skip_ws();
+        let anonymous = p.try_keyword("anonymous");
+        p.skip_ws();
+        if !p.eof() {
+            bail!(
+                "unexpected trailing input '{}' in event signature '{}'",
+                p.rest(),
+                sig
+            );
+        }
+        Ok(AlloyEvent {
+            name,
+            inputs,
+            anonymous,
+        })
+    }
+
+    fn parse_event_param(p: &mut Cursor, sig: &str) -> Result<AlloyEventParam> {
+        p.skip_ws();
+        let (ty, components) = parse_type(p, sig)?;
+        p.skip_ws();
+        let indexed = p.try_keyword("indexed");
+        if indexed {
+            p.skip_ws();
+        }
+        let name = p.ident().unwrap_or("").to_string();
+        Ok(AlloyEventParam {
+            name,
+            ty,
+            indexed,
+            components,
+            internal_type: None,
+        })
+    }
+
+    fn parse_param(p: &mut Cursor, sig: &str) -> Result<AlloyParam> {
+        p.skip_ws();
+        let (ty, components) = parse_type(p, sig)?;
+        p.skip_ws();
+        let name = p.ident().unwrap_or("").to_string();
+        Ok(AlloyParam {
+            name,
+            ty,
+            components,
+            internal_type: None,
+        })
+    }
+
+    fn parse_type(p: &mut Cursor, sig: &str) -> Result<(String, Vec<AlloyParam>)> {
+        p.skip_ws();
+        let (mut base_ty, components) = if p.peek_is('(') {
+            p.bump();
+            let mut comps = Vec::new();
+            p.skip_ws();
+            if !p.peek_is(')') {
+                loop {
+                    comps.push(parse_param(p, sig)?);
+                    p.skip_ws();
+                    if p.peek_is(',') {
+                        p.bump();
+                        p.skip_ws();
+                        continue;
+                    }
+                    break;
+                }
+            }
+            p.expect(')', sig)?;
+            ("tuple".to_string(), comps)
+        } else {
+            let leaf = p
+                .ident()
+                .ok_or_else(|| anyhow!("expected type in event signature '{}'", sig))?
+                .to_string();
+            (leaf, Vec::new())
+        };
+        loop {
+            p.skip_ws();
+            if !p.peek_is('[') {
+                break;
+            }
+            p.bump();
+            p.skip_ws();
+            if p.peek_is(']') {
+                p.bump();
+                base_ty.push_str("[]");
+            } else {
+                let n = p
+                    .digits()
+                    .ok_or_else(|| anyhow!("expected array size or ']' in '{}'", sig))?;
+                let size: usize = n
+                    .parse()
+                    .with_context(|| format!("invalid array size '{}' in '{}'", n, sig))?;
+                p.skip_ws();
+                p.expect(']', sig)?;
+                base_ty.push('[');
+                base_ty.push_str(&size.to_string());
+                base_ty.push(']');
+            }
+        }
+        Ok((base_ty, components))
+    }
+
+    struct Cursor<'a> {
+        src: &'a str,
+        pos: usize,
+    }
+
+    impl<'a> Cursor<'a> {
+        fn new(src: &'a str) -> Self {
+            Self { src, pos: 0 }
+        }
+        fn rest(&self) -> &'a str {
+            &self.src[self.pos..]
+        }
+        fn eof(&self) -> bool {
+            self.pos >= self.src.len()
+        }
+        fn peek(&self) -> Option<char> {
+            self.rest().chars().next()
+        }
+        fn peek_is(&self, c: char) -> bool {
+            self.peek() == Some(c)
+        }
+        fn bump(&mut self) -> Option<char> {
+            let c = self.peek()?;
+            self.pos += c.len_utf8();
+            Some(c)
+        }
+        fn skip_ws(&mut self) {
+            while matches!(self.peek(), Some(c) if c.is_whitespace()) {
+                self.bump();
+            }
+        }
+        fn expect(&mut self, c: char, sig: &str) -> Result<()> {
+            match self.peek() {
+                Some(actual) if actual == c => {
+                    self.bump();
+                    Ok(())
+                }
+                Some(actual) => bail!(
+                    "expected '{}' but found '{}' in event signature '{}'",
+                    c,
+                    actual,
+                    sig
+                ),
+                None => bail!(
+                    "expected '{}' but reached end of event signature '{}'",
+                    c,
+                    sig
+                ),
+            }
+        }
+        fn ident(&mut self) -> Option<&'a str> {
+            let s = self.rest();
+            let mut iter = s.char_indices();
+            let (_, first) = iter.next()?;
+            if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+                return None;
+            }
+            let mut end = first.len_utf8();
+            for (_, c) in iter {
+                if c.is_ascii_alphanumeric() || c == '_' || c == '$' {
+                    end += c.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            let out = &s[..end];
+            self.pos += end;
+            Some(out)
+        }
+        fn try_keyword(&mut self, kw: &str) -> bool {
+            let mark = self.pos;
+            if let Some(id) = self.ident() {
+                if id == kw {
+                    return true;
+                }
+            }
+            self.pos = mark;
+            false
+        }
+        fn digits(&mut self) -> Option<&'a str> {
+            let s = self.rest();
+            let mut end = 0;
+            for c in s.chars() {
+                if c.is_ascii_digit() {
+                    end += c.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            if end == 0 {
+                return None;
+            }
+            let out = &s[..end];
+            self.pos += end;
+            Some(out)
+        }
+    }
 }
 
 /// An event with parsed parameters.
@@ -442,11 +698,12 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "reproduces issue #1206 — remove once fixed"]
     fn test_parse_event_with_named_nested_tuple_from_issue_1206() {
-        // Reproduces https://github.com/enviodev/hyperindex/issues/1206.
-        // User reports that a custom event signature with a named tuple
-        // parameter fails codegen when no `abi_file_path` is provided.
+        // Regression test for https://github.com/enviodev/hyperindex/issues/1206.
+        // Custom event signatures with named tuple components were rejected by
+        // alloy's signature parser, so codegen failed when no `abi_file_path`
+        // was provided. The fallback parser in `parse_event_signature_to_alloy`
+        // accepts these and propagates the field names.
         let sig = "event ConsumeBoostVial(address from, uint256 playerId, (uint40 a, uint24 b, uint16 c, uint16 d, uint8 e) playerBoostInfo)";
         let event = parse_event(sig).expect("custom event signature with named tuple should parse");
         let tuple_field = event
@@ -471,6 +728,33 @@ mod tests {
                 (Some("e"), AbiType::Uint(8)),
             ]
         );
+    }
+
+    #[test]
+    fn test_parse_event_with_named_tuple_array_and_indexed() {
+        // Mixed: tuple[] with named components, plus indexed scalar.
+        let sig = "event Trade((uint128 amount, uint16 fee)[] items, address indexed trader)";
+        let event = parse_event(sig).expect("named tuple[] should parse");
+        assert_eq!(event.name, "Trade");
+        assert_eq!(event.inputs.len(), 2);
+        match &event.inputs[0].kind {
+            AbiType::Array(inner) => match inner.as_ref() {
+                AbiType::Tuple(fields) => assert_eq!(
+                    fields
+                        .iter()
+                        .map(|f| (f.name.as_deref(), f.kind.clone()))
+                        .collect::<Vec<_>>(),
+                    vec![
+                        (Some("amount"), AbiType::Uint(128)),
+                        (Some("fee"), AbiType::Uint(16)),
+                    ]
+                ),
+                other => panic!("expected tuple inside array, got {:?}", other),
+            },
+            other => panic!("expected array, got {:?}", other),
+        }
+        assert_eq!(event.inputs[1].name, "trader");
+        assert!(event.inputs[1].indexed);
     }
 
     #[test]

--- a/packages/cli/src/config_parsing/abi_compat.rs
+++ b/packages/cli/src/config_parsing/abi_compat.rs
@@ -195,29 +195,19 @@ pub fn parse_event(sig: &str) -> Result<Event> {
 
 /// Parse a human-readable event signature into an `AlloyEvent`.
 ///
-/// Tries alloy's built-in parser first. Falls back to a permissive parser that
-/// accepts named tuple components (e.g. `event E((uint a, uint b) data)`),
-/// which alloy's signature parser rejects. The fallback populates
-/// `components` so downstream selector and ABI consumers see the named fields.
+/// Accepts component names inside tuple types (`event E((uint a, uint b) data)`),
+/// which alloy's own signature parser rejects. `components` are populated so
+/// downstream selector and ABI consumers see the named fields.
 pub fn parse_event_signature_to_alloy(sig: &str) -> Result<AlloyEvent> {
-    match AlloyEvent::parse(sig) {
-        Ok(ev) => Ok(ev),
-        Err(alloy_err) => sig_parser::parse(sig).map_err(|e| {
-            anyhow!(
-                "Failed to parse event signature: {}\n(strict parser error: {})",
-                e,
-                alloy_err
-            )
-        }),
-    }
+    sig_parser::parse(sig)
 }
 
-/// Permissive human-readable event signature parser.
+/// Human-readable event signature parser.
 ///
-/// Differences from `alloy_json_abi::Event::parse`:
-/// - Accepts component names inside tuple types: `(uint40 a, uint24 b)` is valid.
-/// - Otherwise mirrors alloy's syntax: optional `event` prefix, optional
-///   `indexed` per top-level param, optional trailing `anonymous`.
+/// Grammar: `[event] Name(param,*)[ anonymous]` where each param is
+/// `type [indexed] [name]` and `type` is either a leaf identifier, a tuple
+/// `(component,*)`, or any of those followed by array suffixes.
+/// Tuple components allow names; top-level params allow `indexed`.
 mod sig_parser {
     use super::{AlloyEvent, AlloyEventParam, AlloyParam};
     use anyhow::{anyhow, bail, Context, Result};

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -1489,7 +1489,7 @@ impl Event {
 
     fn get_abi_event(event_string: &str, opt_abi: &Option<EvmAbi>) -> Result<AlloyEvent> {
         let parse_event_sig = |sig: &str| -> Result<AlloyEvent> {
-            AlloyEvent::parse(sig).map_err(|err| {
+            crate::config_parsing::abi_compat::parse_event_signature_to_alloy(sig).map_err(|err| {
                 anyhow!(
                     "Unable to parse event signature {} due to the following error: {}. \
                      Please refer to our docs on how to correctly define a human readable ABI.",
@@ -2381,6 +2381,44 @@ mod test {
             parsed.selector().to_string(),
             expected.selector().to_string(),
             "Sighash should match regardless of formatting"
+        );
+    }
+
+    #[test]
+    fn parse_event_sig_with_named_tuple_components_issue_1206() {
+        // Regression for https://github.com/enviodev/hyperindex/issues/1206.
+        // A custom event signature whose tuple components are named must not
+        // require an ABI file. Selector should match the canonical tuple-only
+        // signature (component names stripped per ABI spec).
+        let event_string = "ConsumeBoostVial(address from, uint256 playerId, (uint40 a, uint24 b, uint16 c, uint16 d, uint8 e) playerBoostInfo)";
+        let parsed = Event::get_abi_event(event_string, &None).unwrap();
+
+        let canonical = "ConsumeBoostVial(address from, uint256 playerId, (uint40,uint24,uint16,uint16,uint8) playerBoostInfo)";
+        let canonical_parsed = Event::get_abi_event(canonical, &None).unwrap();
+
+        // Selector is computed from the canonical (unnamed) signature so the
+        // two forms must match.
+        assert_eq!(
+            parsed.selector().to_string(),
+            canonical_parsed.selector().to_string(),
+        );
+
+        // Component names must survive into our converted EventParam tree so
+        // codegen can emit named record fields.
+        let params = Event::convert_event_params(&parsed).unwrap();
+        let tuple_param = params
+            .iter()
+            .find(|p| p.name == "playerBoostInfo")
+            .expect("playerBoostInfo");
+        let names: Vec<Option<&str>> = match &tuple_param.kind {
+            crate::config_parsing::abi_compat::AbiType::Tuple(fields) => {
+                fields.iter().map(|f| f.name.as_deref()).collect()
+            }
+            other => panic!("expected Tuple, got {:?}", other),
+        };
+        assert_eq!(
+            names,
+            vec![Some("a"), Some("b"), Some("c"), Some("d"), Some("e")]
         );
     }
 


### PR DESCRIPTION
## Summary
Adds a custom event signature parser that accepts named tuple components, enabling event signatures like `event E((uint a, uint b) data)` to work without requiring an ABI file. Previously, alloy's signature parser rejected these, causing codegen to fail when no `abi_file_path` was provided.

## Key Changes
- Introduced `parse_event_signature_to_alloy()` function that delegates to a new `sig_parser` module
- Implemented custom recursive descent parser (`sig_parser`) that:
  - Parses event signatures with optional `event` keyword and `anonymous` modifier
  - Supports named tuple components in both top-level and nested contexts
  - Handles array suffixes (`[]`, `[N]`) on any type
  - Preserves component names in the resulting `AlloyEvent` for downstream codegen
- Updated `parse_event()` in `abi_compat.rs` to use the new parser
- Updated `Event::get_abi_event()` in `system_config.rs` to use the new parser as fallback
- Added regression tests verifying:
  - Named nested tuples parse correctly and preserve field names
  - Tuple arrays with named components work alongside indexed parameters
  - Event selector matches the canonical (unnamed) signature per ABI spec

## Implementation Details
The `sig_parser` module uses a `Cursor` struct for position tracking and implements:
- `parse()`: Entry point handling event keyword, name, parameters, and anonymous modifier
- `parse_event_param()`: Parses top-level parameters with optional `indexed` keyword
- `parse_param()`: Parses tuple component parameters (no `indexed` allowed)
- `parse_type()`: Recursively handles leaf types, tuples, and array suffixes
- Helper methods on `Cursor` for character/whitespace/identifier/digit parsing

Component names are preserved through `AlloyParam` and `AlloyEventParam` structures, allowing the ABI conversion pipeline to emit named record fields in codegen output.

https://claude.ai/code/session_017kSBtmRyLh7wPM89p29LXM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of event signatures containing named tuple components, resolving previous compatibility issues.
  * Improved error handling with clearer contextual messages for event signature parsing.

* **Tests**
  * Added regression tests for event signatures with named tuple types, including tuple arrays and indexed parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1211)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->