### PR TITLE
SVM handler dispatch plumbing (Stage 4 C1)

### DIFF
--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -44,7 +44,7 @@ pub(crate) struct PublicConfigJson<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     fuel: Option<FuelConfig<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    svm: Option<SvmConfig>,
+    svm: Option<SvmConfig<'a>>,
     enums: BTreeMap<String, Vec<String>>,
     entities: Vec<EntityJson>,
 }
@@ -154,8 +154,17 @@ struct FuelConfig<'a> {
 
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-struct SvmConfig {
+struct SvmConfig<'a> {
     chains: BTreeMap<String, ChainConfig>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    programs: BTreeMap<&'a str, ContractConfig>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct SvmAccountFilterJson {
+    position: u8,
+    values: Vec<String>,
 }
 
 #[derive(Serialize, Debug)]
@@ -284,6 +293,22 @@ struct ContractEventItem {
     block_fields: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     transaction_fields: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    svm: Option<SvmEventItem>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct SvmEventItem {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    discriminator: Option<String>,
+    discriminator_byte_len: u8,
+    include_transaction: bool,
+    include_logs: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    account_filters: Vec<SvmAccountFilterJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    is_inner: Option<bool>,
 }
 
 #[derive(Serialize, Debug)]
@@ -395,19 +420,25 @@ impl SystemConfig {
             cfg.contracts
                 .values()
                 .map(|contract| -> Result<(&str, ContractConfig)> {
-                    let abi_str = match &contract.abi {
-                        Abi::Evm(abi) => &abi.raw,
-                        Abi::Fuel(abi) => &abi.raw,
+                    let abi_raw = match &contract.abi {
+                        Abi::Evm(abi) => {
+                            let abi_value: serde_json::Value = serde_json::from_str(&abi.raw)?;
+                            let abi_compact = serde_json::to_string(&abi_value)?;
+                            serde_json::value::RawValue::from_string(abi_compact)?
+                        }
+                        Abi::Fuel(abi) => {
+                            let abi_value: serde_json::Value = serde_json::from_str(&abi.raw)?;
+                            let abi_compact = serde_json::to_string(&abi_value)?;
+                            serde_json::value::RawValue::from_string(abi_compact)?
+                        }
+                        Abi::Svm => serde_json::value::RawValue::from_string("null".into())?,
                     };
-                    let abi_value: serde_json::Value = serde_json::from_str(abi_str)?;
-                    let abi_compact = serde_json::to_string(&abi_value)?;
-                    let abi_raw = serde_json::value::RawValue::from_string(abi_compact)?;
 
                     let events: Vec<ContractEventItem> = contract
                         .events
                         .iter()
                         .map(|e| {
-                            let (params, kind) = match &e.kind {
+                            let (params, kind, svm) = match &e.kind {
                                 EventKind::Params(event_params) => {
                                     let params = event_params
                                         .iter()
@@ -427,7 +458,7 @@ impl SystemConfig {
                                             },
                                         })
                                         .collect();
-                                    (params, None)
+                                    (params, None, None)
                                 }
                                 EventKind::Fuel(fuel_kind) => {
                                     let kind_str = match fuel_kind {
@@ -437,7 +468,25 @@ impl SystemConfig {
                                         FuelEventKind::Transfer => "transfer",
                                         FuelEventKind::Call => "call",
                                     };
-                                    (vec![], Some(kind_str.to_string()))
+                                    (vec![], Some(kind_str.to_string()), None)
+                                }
+                                EventKind::Svm(svm_kind) => {
+                                    let svm_item = SvmEventItem {
+                                        discriminator: svm_kind.discriminator.clone(),
+                                        discriminator_byte_len: svm_kind.discriminator_byte_len,
+                                        include_transaction: svm_kind.include_transaction,
+                                        include_logs: svm_kind.include_logs,
+                                        account_filters: svm_kind
+                                            .account_filters
+                                            .iter()
+                                            .map(|af| SvmAccountFilterJson {
+                                                position: af.position,
+                                                values: af.values.clone(),
+                                            })
+                                            .collect(),
+                                        is_inner: svm_kind.is_inner,
+                                    };
+                                    (vec![], Some("svmInstruction".to_string()), Some(svm_item))
                                 }
                             };
                             ContractEventItem {
@@ -455,6 +504,7 @@ impl SystemConfig {
                                         .map(|f| f.name.clone())
                                         .collect()
                                 }),
+                                svm,
                             }
                         })
                         .collect();
@@ -497,7 +547,14 @@ impl SystemConfig {
                 None,
             ),
             Ecosystem::Fuel => (None, Some(FuelConfig { chains, contracts }), None),
-            Ecosystem::Svm => (None, None, Some(SvmConfig { chains })),
+            Ecosystem::Svm => (
+                None,
+                None,
+                Some(SvmConfig {
+                    chains,
+                    programs: contracts,
+                }),
+            ),
         };
 
         // Build multichain value

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -997,6 +997,62 @@ impl SystemConfig {
                             .map(|h| h.url.clone()),
                     };
 
+                    let mut chain_contracts = Vec::new();
+                    for program in network.programs.as_deref().unwrap_or(&[]) {
+                        let events = program
+                            .instructions
+                            .iter()
+                            .map(|instr| -> Result<Event> {
+                                let (normalized_discriminator, byte_len) =
+                                    match &instr.discriminator {
+                                        Some(d) => {
+                                            let hex = d.strip_prefix("0x").unwrap_or(d);
+                                            let byte_len = (hex.len() / 2) as u8;
+                                            (Some(format!("0x{hex}")), byte_len)
+                                        }
+                                        None => (None, 0u8),
+                                    };
+                                let svm_kind = SvmEventKind {
+                                    discriminator: normalized_discriminator.clone(),
+                                    discriminator_byte_len: byte_len,
+                                    include_transaction: instr.include_transaction.unwrap_or(true),
+                                    include_logs: instr.include_logs.unwrap_or(false),
+                                    account_filters: instr
+                                        .account_filters
+                                        .as_deref()
+                                        .unwrap_or(&[])
+                                        .iter()
+                                        .map(|af| SvmAccountFilter {
+                                            position: af.position,
+                                            values: af.values.clone(),
+                                        })
+                                        .collect(),
+                                    is_inner: instr.is_inner,
+                                };
+                                Ok(Event {
+                                    name: instr.name.clone(),
+                                    kind: EventKind::Svm(svm_kind),
+                                    sighash: normalized_discriminator.clone().unwrap_or_default(),
+                                    event_signature: String::new(),
+                                    field_selection: None,
+                                })
+                            })
+                            .collect::<Result<Vec<_>>>()?;
+
+                        let contract = Contract::new(
+                            program.name.clone(),
+                            program.handler.clone(),
+                            events,
+                            Abi::Svm,
+                        )?;
+                        contracts.insert(contract.name.clone(), contract.clone());
+                        chain_contracts.push(ChainContract {
+                            name: program.name.clone(),
+                            addresses: vec![program.program_id.clone()],
+                            start_block: None,
+                        });
+                    }
+
                     let chain = Chain {
                         id: 0, //network.id,
                         start_block: network.start_block,
@@ -1004,7 +1060,7 @@ impl SystemConfig {
                         max_reorg_depth: None,
                         block_lag: network.block_lag,
                         sync_source,
-                        contracts: vec![],
+                        contracts: chain_contracts,
                     };
 
                     unique_hashmap::try_insert(&mut chains, chain.id, chain)
@@ -1369,6 +1425,10 @@ impl EvmAbi {
 pub enum Abi {
     Evm(EvmAbi),
     Fuel(Box<FuelAbi>),
+    /// Solana doesn't ship an ABI artifact today. The variant keeps the
+    /// `Contract.abi` field uniform across ecosystems; future Borsh schemas
+    /// (per the Stage 7 roadmap) would attach here.
+    Svm,
 }
 
 impl Abi {
@@ -1376,6 +1436,7 @@ impl Abi {
         match self {
             Abi::Evm(abi) => abi.path.clone(),
             Abi::Fuel(abi) => Some(abi.path_buf.clone()),
+            Abi::Svm => None,
         }
     }
 
@@ -1438,9 +1499,32 @@ pub enum FuelEventKind {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct SvmAccountFilter {
+    pub position: u8,
+    pub values: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SvmEventKind {
+    /// Hex-encoded discriminator (`0x`-prefixed), or `None` to match every
+    /// instruction in the program.
+    pub discriminator: Option<String>,
+    /// Length of the decoded discriminator in bytes (0 / 1 / 2 / 4 / 8). The
+    /// router precomputes a per-program ordering on this so dispatch tries
+    /// longest first.
+    pub discriminator_byte_len: u8,
+    pub include_transaction: bool,
+    pub include_logs: bool,
+    pub account_filters: Vec<SvmAccountFilter>,
+    /// `None` matches both outer and inner (CPI-invoked) instructions.
+    pub is_inner: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum EventKind {
     Params(Vec<EventParam>),
     Fuel(FuelEventKind),
+    Svm(SvmEventKind),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -2122,6 +2206,7 @@ mod test {
         {
             super::Abi::Evm(abi) => abi.typed.clone(),
             super::Abi::Fuel(_) => panic!("Fuel abi should not be parsed"),
+            super::Abi::Svm => panic!("Svm abi should not be parsed"),
         };
 
         let expected_abi_string = r#"
@@ -2209,6 +2294,7 @@ mod test {
         {
             super::Abi::Evm(abi) => abi.typed.clone(),
             super::Abi::Fuel(_) => panic!("Fuel abi should not be parsed"),
+            super::Abi::Svm => panic!("Svm abi should not be parsed"),
         };
 
         let expected_abi_string = r#"
@@ -2727,6 +2813,75 @@ mod test {
                 err.to_string().contains("- Apple\n  - Mango\n  - Zebra"),
                 "Entities not listed alphabetically. Got:\n{err}"
             );
+        }
+    }
+
+    mod svm_translation {
+        use super::SystemConfig;
+        use crate::config_parsing::system_config::{Abi, DataSource, EventKind};
+        use crate::project_paths::ParsedProjectPaths;
+        use pretty_assertions::assert_eq;
+
+        /// End-to-end: the Metaplex YAML fixture deserializes, validates, and
+        /// translates into a single Contract whose two Events carry the
+        /// expected discriminator + flags. Guards Stage 3 + Stage 4 plumbing
+        /// from drifting out of sync.
+        #[test]
+        fn translates_metaplex_yaml_into_contract_events() {
+            let test_dir = format!("{}/test", env!("CARGO_MANIFEST_DIR"));
+            let project_paths =
+                ParsedProjectPaths::new(&test_dir, "configs/svm-metaplex-config.yaml")
+                    .expect("paths");
+            let config = SystemConfig::parse_from_project_files(&project_paths).expect("parse");
+
+            // Single chain, single program -> one contract with two events.
+            let contracts = config.contracts.values().collect::<Vec<_>>();
+            assert_eq!(contracts.len(), 1);
+            let token_metadata = contracts[0];
+            assert_eq!(token_metadata.name, "TokenMetadata");
+            assert!(matches!(token_metadata.abi, Abi::Svm));
+            assert_eq!(token_metadata.events.len(), 2);
+
+            let kinds: Vec<_> = token_metadata
+                .events
+                .iter()
+                .map(|e| match &e.kind {
+                    EventKind::Svm(k) => (
+                        e.name.as_str(),
+                        k.discriminator.as_deref(),
+                        k.discriminator_byte_len,
+                        k.include_transaction,
+                        k.include_logs,
+                        k.account_filters.len(),
+                    ),
+                    _ => panic!("expected Svm event kind, got {:?}", e.kind),
+                })
+                .collect();
+            assert_eq!(
+                kinds,
+                vec![
+                    ("CreateMetadataAccountV3", Some("0x21"), 1, true, false, 0),
+                    ("UpdateMetadataAccountV2", Some("0x0f"), 1, true, false, 1),
+                ],
+            );
+
+            // Chain data carries the program_id on the contract-side address,
+            // and the HyperSync URL flows through to the source config.
+            let chains = config.get_chains();
+            assert_eq!(chains.len(), 1);
+            let chain = chains[0];
+            assert_eq!(chain.contracts.len(), 1);
+            assert_eq!(
+                chain.contracts[0].addresses,
+                vec!["metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s".to_string()],
+            );
+            assert!(matches!(
+                &chain.sync_source,
+                DataSource::Svm {
+                    hypersync_endpoint_url: Some(url),
+                    ..
+                } if url == "https://solana.hypersync.xyz"
+            ));
         }
     }
 }

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -607,6 +607,34 @@ impl EventTemplate {
                     }
                 }
             }
+            EventKind::Svm(_) => Ok(Self::from_svm_instruction_event(
+                config_event,
+                contract_name,
+            )),
+        }
+    }
+
+    /// Per-instruction ReScript module for SVM. Minimal surface for C1: enough
+    /// shape so the GADT `eventIdentity<event, paramsConstructor, onEventWhere>`
+    /// machinery still type-checks. Concrete `indexer.onInstruction(...)`
+    /// registration arrives in C2 alongside dispatch.
+    fn from_svm_instruction_event(
+        config_event: &system_config::Event,
+        _contract_name: &CapitalizedOptions,
+    ) -> Self {
+        let event_name = config_event.name.capitalize();
+        let module_code = format!(
+            r#"
+let name = "{event_name}"
+let contractName = contractName
+type params = Envio.svmInstruction
+type paramsConstructor = unit
+type event = Envio.svmInstructionEvent
+type onEventWhere = Internal.noOnEventWhere"#
+        );
+        EventTemplate {
+            name: event_name,
+            module_code,
         }
     }
 }
@@ -653,6 +681,8 @@ impl ContractTemplate {
                     abi.path_relative_to_root, all_abi_type_declarations,
                 )
             }
+            // Solana programs ship no ABI artifact today.
+            Abi::Svm => String::new(),
         };
 
         Ok(ContractTemplate {
@@ -1397,6 +1427,11 @@ type indexer = {{
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
+  /** Register an instruction handler. */
+  onInstruction: 'event 'paramsConstructor 'where. (
+    onInstructionOptions<eventIdentity<'event, 'paramsConstructor, 'where>, 'where>,
+    Internal.genericHandler<Internal.genericHandlerArgs<'event, handlerContext>>,
+  ) => unit,
   /** Register a Slot Handler. Evaluates `where` once per configured chain at registration time. */
   onSlot: (
     Envio.onBlockOptions<indexerChain>,
@@ -1691,6 +1726,12 @@ module SingleOrMultiple: {{
 type onEventOptions<'eventIdentity, 'where> = {{
   event: 'eventIdentity,
   wildcard?: bool,
+  where?: 'where,
+}}
+
+/** Options for `indexer.onInstruction` (SVM). */
+type onInstructionOptions<'eventIdentity, 'where> = {{
+  instruction: 'eventIdentity,
   where?: 'where,
 }}
 

--- a/packages/cli/src/hbs_templating/contract_import_templates.rs
+++ b/packages/cli/src/hbs_templating/contract_import_templates.rs
@@ -593,6 +593,10 @@ impl Event {
         let params = match &event.kind {
             EventKind::Params(params) => params,
             EventKind::Fuel(_) => &empty_params,
+            // `contract_import` only drives the EVM/Fuel ABI-driven import flow.
+            // Solana programs declare instructions explicitly in the YAML — no
+            // params shape exists here.
+            EventKind::Svm(_) => &empty_params,
         };
 
         // Try to convert each parameter, collecting results and errors

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
@@ -182,6 +182,12 @@ type onEventOptions<'eventIdentity, 'where> = {
   where?: 'where,
 }
 
+/** Options for `indexer.onInstruction` (SVM). */
+type onInstructionOptions<'eventIdentity, 'where> = {
+  instruction: 'eventIdentity,
+  where?: 'where,
+}
+
 module Enums = {
   module Status = {
     type t =

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
@@ -182,6 +182,12 @@ type onEventOptions<'eventIdentity, 'where> = {
   where?: 'where,
 }
 
+/** Options for `indexer.onInstruction` (SVM). */
+type onInstructionOptions<'eventIdentity, 'where> = {
+  instruction: 'eventIdentity,
+  where?: 'where,
+}
+
 module Enums = {
 
 }

--- a/packages/cli/test/configs/svm-metaplex-config.yaml
+++ b/packages/cli/test/configs/svm-metaplex-config.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../../../envio/svm.schema.json
+name: Solana indexer
+ecosystem: svm
+chains:
+  - rpc: https://api.mainnet-beta.solana.com
+    hypersync_config:
+      url: https://solana.hypersync.xyz
+    start_block: 200000000
+    programs:
+      - name: TokenMetadata
+        program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+        instructions:
+          - name: CreateMetadataAccountV3
+            discriminator: "0x21"
+          - name: UpdateMetadataAccountV2
+            discriminator: "0x0f"
+            account_filters:
+              - position: 0
+                values:
+                  - metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+            include_transaction: true
+            include_logs: false

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -606,6 +606,53 @@ let fromPublic = (publicConfigJson: JSON.t) => {
               `Fuel event ${contractName}.${eventName} is missing "kind" in internal config`,
             )
           }
+        | Ecosystem.Svm =>
+          // The real `programId` lives on the chain-side contract entry, not on
+          // the event item. Wiring it onto each instruction's event config (so
+          // the EventRouter can dispatch on `(programId, discriminator)`) is
+          // Stage 4 C2 work. C1 stamps a placeholder so the types line up.
+          let widenedEventItem =
+            eventItem->(
+              Utils.magic: _ => {
+                "svm": option<{
+                  "discriminator": option<string>,
+                  "discriminatorByteLen": int,
+                  "includeTransaction": bool,
+                  "includeLogs": bool,
+                  "accountFilters": option<
+                    array<{"position": int, "values": array<string>}>,
+                  >,
+                  "isInner": option<bool>,
+                }>,
+              }
+            )
+          let svm = switch widenedEventItem["svm"] {
+          | Some(s) => s
+          | None =>
+            JsError.throwWithMessage(
+              `SVM instruction ${contractName}.${eventName} is missing the "svm" descriptor in internal config`,
+            )
+          }
+          let accountFilters =
+            (svm["accountFilters"]->Option.getOr([]))->Array.map(af => {
+              Internal.position: af["position"],
+              values: af["values"]->SvmTypes.Pubkey.fromStringsUnsafe,
+            })
+          (EventConfigBuilder.buildSvmInstructionEventConfig(
+            ~contractName,
+            ~instructionName=eventName,
+            ~programId=""->SvmTypes.Pubkey.fromStringUnsafe,
+            ~discriminator=svm["discriminator"],
+            ~discriminatorByteLen=svm["discriminatorByteLen"],
+            ~includeTransaction=svm["includeTransaction"],
+            ~includeLogs=svm["includeLogs"],
+            ~accountFilters,
+            ~isInner=svm["isInner"],
+            ~isWildcard=false,
+            ~handler=None,
+            ~contractRegister=None,
+            ~startBlock?,
+          ) :> Internal.eventConfig)
         | _ =>
           (EventConfigBuilder.buildEvmEventConfig(
             ~contractName,

--- a/packages/envio/src/Envio.res
+++ b/packages/envio/src/Envio.res
@@ -20,6 +20,62 @@ type svmOnSlotArgs<'context> = {
   context: 'context,
 }
 
+type svmInstruction = {
+  programId: SvmTypes.Pubkey.t,
+  /** Raw instruction bytes as `0x`-prefixed hex. */
+  data: string,
+  accounts: array<SvmTypes.Pubkey.t>,
+  /** Path through the call tree: `[outerIndex]` for top-level instructions,
+   appended child indices for inner CPI calls. */
+  instructionAddress: array<int>,
+  isInner: bool,
+  /** Discriminator prefixes pre-extracted by HyperSync. Each is `Some` only
+   when the underlying instruction is at least that long. */
+  d1?: string,
+  d2?: string,
+  d4?: string,
+  d8?: string,
+}
+
+type svmTransaction = {
+  signatures: array<string>,
+  feePayer?: SvmTypes.Pubkey.t,
+  success?: bool,
+  err?: string,
+  fee?: bigint,
+  computeUnitsConsumed?: bigint,
+  accountKeys: array<SvmTypes.Pubkey.t>,
+  recentBlockhash?: string,
+  version?: string,
+}
+
+type svmLog = {
+  kind: string,
+  message: string,
+}
+
+/** The per-instruction payload handlers receive on `.event`. Mirrors the
+ EVM `type event` shape inside generated per-event modules. */
+type svmInstructionEvent = {
+  contractName: string,
+  eventName: string,
+  instruction: svmInstruction,
+  /** Parent transaction. `None` when the per-instruction
+   `include_transaction` flag is `false`. */
+  transaction: option<svmTransaction>,
+  /** Program log entries scoped to this instruction. `None` when the
+   per-instruction `include_logs` flag is `false`. */
+  logs: option<array<svmLog>>,
+  slot: int,
+  blockTime: option<int>,
+}
+
+/** Arguments passed to handlers registered via `indexer.onInstruction`. */
+type svmOnInstructionArgs<'context> = {
+  event: svmInstructionEvent,
+  context: 'context,
+}
+
 // Internal-only type for the `indexer.onBlock` (and SVM `onSlot`) `where`
 // callback argument. The canonical TypeScript shape lives in
 // `packages/envio/index.d.ts`; the ReScript declaration here is free to

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -484,6 +484,50 @@ let buildEvmEventConfig = (
 
 // ============== Build Fuel event config ==============
 
+let buildSvmInstructionEventConfig = (
+  ~contractName: string,
+  ~instructionName: string,
+  ~programId: SvmTypes.Pubkey.t,
+  ~discriminator: option<string>,
+  ~discriminatorByteLen: int,
+  ~includeTransaction: bool,
+  ~includeLogs: bool,
+  ~accountFilters: array<Internal.svmAccountFilter>,
+  ~isInner: option<bool>,
+  ~isWildcard: bool,
+  ~handler: option<Internal.handler>,
+  ~contractRegister: option<Internal.contractRegister>,
+  ~startBlock: option<int>=?,
+): Internal.svmInstructionEventConfig => {
+  let paramsSchema =
+    S.json(~validate=false)
+    ->Utils.Schema.coerceToJsonPgType
+    ->(Utils.magic: S.t<JSON.t> => S.t<Internal.eventParams>)
+  {
+    id: switch discriminator {
+    | Some(d) => d
+    | None => "none"
+    },
+    name: instructionName,
+    contractName,
+    isWildcard,
+    handler,
+    contractRegister,
+    paramsRawEventSchema: paramsSchema,
+    simulateParamsSchema: paramsSchema,
+    filterByAddresses: false,
+    dependsOnAddresses: !isWildcard,
+    startBlock,
+    programId,
+    discriminator,
+    discriminatorByteLen,
+    includeTransaction,
+    includeLogs,
+    accountFilters,
+    isInner,
+  }
+}
+
 let buildFuelEventConfig = (
   ~contractName: string,
   ~eventName: string,

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -142,7 +142,18 @@ let applyRegistrations = (~config: Config.t): Config.t => {
               dependsOnAddresses: Internal.dependsOnAddresses(~isWildcard, ~filterByAddresses),
             } :> Internal.eventConfig)
           | Svm =>
-            JsError.throwWithMessage(`SVM does not support indexer.onEvent or indexer.contractRegister. Use indexer.onSlot for per-slot handlers.`)
+            let svmEv =
+              ev->(Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig)
+            ({
+              ...svmEv,
+              isWildcard,
+              handler,
+              contractRegister,
+              dependsOnAddresses: Internal.dependsOnAddresses(
+                ~isWildcard,
+                ~filterByAddresses=false,
+              ),
+            } :> Internal.eventConfig)
           }
         },
       )

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -422,6 +422,34 @@ type evmContractConfig = {
   events: array<evmEventConfig>,
 }
 
+type svmAccountFilter = {
+  position: int,
+  values: array<SvmTypes.Pubkey.t>,
+}
+
+type svmInstructionEventConfig = {
+  ...eventConfig,
+  /** Base58 Solana program id this instruction belongs to. */
+  programId: SvmTypes.Pubkey.t,
+  /** Hex-encoded discriminator. `None` matches every instruction in the program. */
+  discriminator: option<string>,
+  /** Length of the discriminator in bytes (0 / 1 / 2 / 4 / 8). Drives the
+   `dN` selector at query time and the dispatch-key precomputation in the
+   router. */
+  discriminatorByteLen: int,
+  includeTransaction: bool,
+  includeLogs: bool,
+  accountFilters: array<svmAccountFilter>,
+  /** `None` matches both outer and inner (CPI-invoked) instructions. */
+  isInner: option<bool>,
+}
+
+type svmProgramConfig = {
+  name: string,
+  programId: SvmTypes.Pubkey.t,
+  instructions: array<svmInstructionEventConfig>,
+}
+
 type indexingAddress = {
   address: Address.t,
   contractName: string,

--- a/packages/envio/src/SvmTypes.res
+++ b/packages/envio/src/SvmTypes.res
@@ -1,0 +1,9 @@
+module Pubkey = {
+  type t
+  let schema =
+    S.string->S.setName("SVM.Pubkey")->(Utils.magic: S.t<string> => S.t<t>)
+  external fromStringUnsafe: string => t = "%identity"
+  external fromStringsUnsafe: array<string> => array<t> = "%identity"
+  external toString: t => string = "%identity"
+  external toStrings: array<t> => array<string> = "%identity"
+}


### PR DESCRIPTION
## Summary

End-to-end plumbing from the Stage 3 YAML (`programs[].instructions[]`) through to a typed `Internal.svmInstructionEventConfig` runtime config. Handlers compile but the actual dispatch (`HyperSyncSolanaSource`, `ChainFetcher` wiring, `EventRouter`) lands in PR-C2.

**Stacked on #1216.** Merge after the Stage 3 config-schema PR.

## What's in this PR

### Rust
- `system_config::EventKind::Svm(SvmEventKind)` carries `discriminator`, `discriminator_byte_len`, `include_transaction`, `include_logs`, `account_filters`, `is_inner`. New `SvmAccountFilter`.
- `Abi::Svm` unit variant — Solana programs ship no ABI artifact today (Borsh schemas land per the Stage 7 roadmap).
- `system_config.rs` HumanConfig::Svm arm walks each program/instruction into a `Contract` with `Abi::Svm` and one `Event{kind: EventKind::Svm, sighash: discriminator}` per instruction. `ChainContract.addresses[0]` holds the base58 program_id.
- `public_config.rs` extends `ContractEventItem` with an optional `svm` descriptor and `SvmConfig` to carry `programs`. The runtime JSON now ships the SVM flags the ReScript layer needs.
- `codegen_templates.rs` new `EventTemplate::from_svm_instruction_event` emits a minimal per-instruction ReScript module (just `event` / `paramsConstructor` / `onEventWhere` aliases) — enough surface for the GADT to type-check.
- `contract_import_templates.rs` SVM arm yields empty params (the contract-import flow is EVM/Fuel-only).

### ReScript
- New `packages/envio/src/SvmTypes.res` with a thin `SvmTypes.Pubkey.t` newtype (per the Q4 review answer — treats Solana pubkeys distinctly from EVM `Address.t`).
- `Internal.svmInstructionEventConfig` mirrors `evm`/`fuelEventConfig`, carrying `programId` + `discriminator` + flags so the future router can dispatch by `(programId, discriminator)`.
- `Envio.res`: public `svmInstruction`, `svmTransaction`, `svmLog`, `svmInstructionEvent`, `svmOnInstructionArgs<'context>`. Mirrors EVM's `{event, context}` shape.
- `EventConfigBuilder.buildSvmInstructionEventConfig` is the runtime constructor; `Config.res` Svm arm calls it from `buildContractEvents`.
- `HandlerLoader.applyRegistrations` Svm arm replaces the previous throw with a Fuel-style pass-through.

## Deviation from the original roadmap (worth flagging)

The locked roadmap described a `TokenMetadata.UpdateMetadataAccountV2.handler(...)` user-facing API. Inspecting the actual EVM/Fuel codegen revealed they use `indexer.onEvent({contract, event}, handler)` instead. To genuinely mirror EVM, the C2 surface will be `indexer.onInstruction({program, instruction}, handler)`. The generated per-instruction ReScript modules expose the GADT-friendly type aliases now, so adding that method in C2 is additive.

## Out of scope (deferred to C2)

- `HyperSyncSolanaSource.res` (Source.t implementation, the actual dispatch).
- `ChainFetcher.res` wiring (HyperSync primary + RPC height fallback).
- `EventRouter.getSvmEventId` + per-program precomputed discriminator-length ordering.
- `indexer.onInstruction` registration surface on the generated indexer type.
- Wiring the real program_id onto each event config — currently stamped as a placeholder so types line up. The C2 work threads it from `ChainContract.addresses[0]` through `buildContractEvents` into `buildSvmInstructionEventConfig`.

## Test plan

- [x] `cargo test -p envio --lib` — **154 passed, 3 ignored, 0 failed**. One new test:
  - `config_parsing::system_config::test::svm_translation::translates_metaplex_yaml_into_contract_events` — feeds `test/configs/svm-metaplex-config.yaml` through `parse → validate → translate`, asserts (Program → Contract / Instruction → Event) shape, discriminator + flag round-trip, and program_id on `ChainContract.addresses[0]`.
- [x] `pnpm rescript` — 113 modules clean (SvmTypes added; Envio / Internal / EventConfigBuilder / HandlerLoader / Config extended).
- [x] `cargo check -p envio --lib`, `cargo fmt -p envio --check` (changed files clean).
- [ ] Full vitest suite — not run; no JS code path exercised yet (dispatch is C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)