### PR TITLE
SVM HyperSyncSolanaSource + indexer.onInstruction runtime (Stage 4 C2)

### DIFF
--- a/packages/envio/src/ChainFetcher.res
+++ b/packages/envio/src/ChainFetcher.res
@@ -233,7 +233,31 @@ let make = (
       ~lowercaseAddresses,
     )
   | Config.FuelSourceConfig({hypersync}) => [HyperFuelSource.make({chain, endpointUrl: hypersync})]
-  | Config.SvmSourceConfig({rpc}) => [Svm.makeRPCSource(~chain, ~rpc)]
+  | Config.SvmSourceConfig({hypersync, rpc}) =>
+    switch hypersync {
+    | None => [Svm.makeRPCSource(~chain, ~rpc)]
+    | Some(hypersyncUrl) =>
+      // HyperSync drives instruction sync; RPC remains the height oracle
+      // (Svm.makeRPCSource's `getFinalizedSlot` route) and the fallback.
+      let svmEventConfigs =
+        chainConfig.contracts
+        ->Array.flatMap(contract => contract.events)
+        ->(
+          Utils.magic: array<Internal.eventConfig> => array<Internal.svmInstructionEventConfig>
+        )
+      let apiToken = Env.envioApiToken
+      [
+        HyperSyncSolanaSource.make({
+          chain,
+          endpointUrl: hypersyncUrl,
+          apiToken,
+          eventConfigs: svmEventConfigs,
+          clientMaxRetries: Env.hyperSyncClientMaxRetries,
+          clientTimeoutMillis: Env.hyperSyncClientTimeoutMillis,
+        }),
+        Svm.makeRPCSource(~chain, ~rpc),
+      ]
+    }
   // For tests: use ready-to-use sources directly
   | Config.CustomSources(sources) => sources
   }

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -30,7 +30,7 @@ type evmRpcConfig = {
 type sourceConfig =
   | EvmSourceConfig({hypersync: option<string>, rpcs: array<evmRpcConfig>})
   | FuelSourceConfig({hypersync: string})
-  | SvmSourceConfig({rpc: string})
+  | SvmSourceConfig({hypersync: option<string>, rpc: string})
   // For tests: pass custom sources directly
   | CustomSources(array<Source.t>)
 
@@ -569,13 +569,20 @@ let fromPublic = (publicConfigJson: JSON.t) => {
   | None => ()
   }
 
-  // Build event configs for a contract from JSON event items
+  // Build event configs for a contract from JSON event items.
+  //
+  // `~addresses` is the chain-side address list. For SVM programs it's the
+  // single base58 program_id — wired onto each instruction's event config so
+  // the source can build `(programId, discriminator)`-keyed InstructionSelections.
+  // EVM and Fuel ignore it (the address lives in `ChainContract.addresses` and
+  // is looked up at dispatch time, not stamped on the event).
   let buildContractEvents = (
     ~contractName,
     ~events: option<array<_>>,
     ~abi,
     ~chainId: int,
     ~startBlock: option<int>,
+    ~addresses: array<string>,
   ) => {
     switch events {
     | None => []
@@ -607,10 +614,17 @@ let fromPublic = (publicConfigJson: JSON.t) => {
             )
           }
         | Ecosystem.Svm =>
-          // The real `programId` lives on the chain-side contract entry, not on
-          // the event item. Wiring it onto each instruction's event config (so
-          // the EventRouter can dispatch on `(programId, discriminator)`) is
-          // Stage 4 C2 work. C1 stamps a placeholder so the types line up.
+          let programId = switch addresses {
+          | [pid] => pid->SvmTypes.Pubkey.fromStringUnsafe
+          | [] =>
+            JsError.throwWithMessage(
+              `SVM program ${contractName} on chain ${chainId->Int.toString} is missing a program_id`,
+            )
+          | _ =>
+            JsError.throwWithMessage(
+              `SVM program ${contractName} on chain ${chainId->Int.toString} has multiple addresses; a program is uniquely identified by a single program_id`,
+            )
+          }
           let widenedEventItem =
             eventItem->(
               Utils.magic: _ => {
@@ -641,7 +655,7 @@ let fromPublic = (publicConfigJson: JSON.t) => {
           (EventConfigBuilder.buildSvmInstructionEventConfig(
             ~contractName,
             ~instructionName=eventName,
-            ~programId=""->SvmTypes.Pubkey.fromStringUnsafe,
+            ~programId,
             ~discriminator=svm["discriminator"],
             ~discriminatorByteLen=svm["discriminatorByteLen"],
             ~includeTransaction=svm["includeTransaction"],
@@ -712,11 +726,11 @@ let fromPublic = (publicConfigJson: JSON.t) => {
         ->Dict.toArray
         ->Array.map(((capitalizedName, contractData)) => {
           let chainContract = chainContracts->Dict.get(capitalizedName)
-          let addresses =
+          let rawAddresses =
             chainContract
             ->Option.flatMap(cc => cc["addresses"])
             ->Option.getOr([])
-            ->Array.map(parseAddress)
+          let addresses = rawAddresses->Array.map(parseAddress)
           let startBlock = chainContract->Option.flatMap(cc => cc["startBlock"])
 
           // Build event configs from JSON (field selections resolved inline)
@@ -730,6 +744,7 @@ let fromPublic = (publicConfigJson: JSON.t) => {
             ~abi=contractData["abi"],
             ~chainId,
             ~startBlock,
+            ~addresses=rawAddresses,
           )
 
           {
@@ -795,7 +810,11 @@ let fromPublic = (publicConfigJson: JSON.t) => {
         }
       | Ecosystem.Svm =>
         switch publicChainConfig["rpc"] {
-        | Some(rpc) => SvmSourceConfig({rpc: rpc})
+        | Some(rpc) =>
+          SvmSourceConfig({
+            hypersync: publicChainConfig["hypersync"],
+            rpc,
+          })
         | None => JsError.throwWithMessage(`Chain ${chainName} is missing rpc endpoint in config`)
         }
       }

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -298,6 +298,57 @@ let getGlobalIndexer = (): 'indexer => {
     )
   }
 
+  // SVM identity: `{program, instruction}` from TS or
+  // `{instruction: GADT{contract, _0}}` from ReScript. Same two-format dance
+  // as the EVM `parseIdentityConfig`, but reading the SVM-native field names.
+  let parseSvmIdentityConfig = (identityConfig: 'a) => {
+    let raw =
+      identityConfig->(
+        Utils.magic: 'a => {
+          "program": unknown,
+          "instruction": unknown,
+          "where": option<JSON.t>,
+        }
+      )
+    let (programName, instructionName) = if typeof(raw["program"]) === #string {
+      (
+        raw["program"]->(Utils.magic: unknown => string),
+        raw["instruction"]->(Utils.magic: unknown => string),
+      )
+    } else {
+      let inst =
+        raw["instruction"]->(Utils.magic: unknown => {"contract": string, "_0": string})
+      (inst["contract"], inst["_0"])
+    }
+    let where = raw["where"]
+    let eventOptions: option<Internal.eventOptions<_>> = switch where {
+    | None => None
+    | Some(_) =>
+      Some({
+        where: ?(where->(Utils.magic: option<JSON.t> => option<_>)),
+      })
+    }
+    (programName, instructionName, eventOptions)
+  }
+
+  // onInstruction: delegates to HandlerRegister.setHandler. The SVM analog of
+  // onEvent; the registration store keys on `(contractName, eventName)` which
+  // for SVM is `(programName, instructionName)`.
+  let onInstructionFn = (identityConfig: 'a, handler: 'b) => {
+    HandlerRegister.throwIfFinishedRegistration(~methodName="onInstruction")
+    let (programName, instructionName, eventOptions) = parseSvmIdentityConfig(identityConfig)
+    HandlerRegister.setHandler(
+      ~contractName=programName,
+      ~eventName=instructionName,
+      handler->(
+        Utils.magic: 'b => Internal.genericHandler<
+          Internal.genericHandlerArgs<Internal.event, Internal.handlerContext>,
+        >
+      ),
+      ~eventOptions,
+    )
+  }
+
   // contractRegister: delegates to HandlerRegister.setContractRegister
   let contractRegisterFn = (identityConfig: 'a, handler: 'b) => {
     HandlerRegister.throwIfFinishedRegistration(~methodName="contractRegister")
@@ -456,7 +507,7 @@ let getGlobalIndexer = (): 'indexer => {
             "contractRegister",
             "onBlock",
           ]
-        | Svm => ["name", "description", "chainIds", "chains", "onSlot"]
+        | Svm => ["name", "description", "chainIds", "chains", "onInstruction", "onSlot"]
         }
         keysMemo := Some(keys)
         keys
@@ -477,6 +528,7 @@ let getGlobalIndexer = (): 'indexer => {
         chains->(Utils.magic: {..} => unknown)
       }
     | "onEvent" => onEventFn->Utils.magic
+    | "onInstruction" => onInstructionFn->Utils.magic
     | "contractRegister" => contractRegisterFn->Utils.magic
     | "onBlock" | "onSlot" => onBlockFn->Utils.magic
     | _ =>

--- a/packages/envio/src/sources/EventRouter.res
+++ b/packages/envio/src/sources/EventRouter.res
@@ -116,3 +116,64 @@ let fromEvmEventModsOrThrow = (events: array<Internal.evmEventConfig>, ~chain): 
   })
   router
 }
+
+/** Dispatch key for SVM instructions. `None` matches any instruction in the
+ program (lowest priority). */
+let getSvmEventId = (~programId: SvmTypes.Pubkey.t, ~discriminator: option<string>) =>
+  switch discriminator {
+  | None => (programId->SvmTypes.Pubkey.toString) ++ "_none"
+  | Some(d) => (programId->SvmTypes.Pubkey.toString) ++ "_" ++ d
+  }
+
+/** Discriminator byte-lengths declared by a program, sorted descending. The
+ source uses this to probe `(programId, dN)` keys longest-first when routing
+ a returned instruction to a handler — matching the locked Q1 answer. */
+type svmProgramOrdering = {
+  programId: SvmTypes.Pubkey.t,
+  /** Byte lengths in descending order, deduplicated. Includes `0` only when
+   a handler is registered with no discriminator (program-wide match). */
+  byteLengthsDesc: array<int>,
+}
+
+let fromSvmEventConfigsOrThrow = (
+  events: array<Internal.svmInstructionEventConfig>,
+  ~chain,
+): (t<Internal.svmInstructionEventConfig>, array<svmProgramOrdering>) => {
+  let router = empty()
+  events->Belt.Array.forEach(config => {
+    router->addOrThrow(
+      config.id,
+      config,
+      ~contractName=config.contractName,
+      ~eventName=config.name,
+      ~chain,
+      ~isWildcard=config.isWildcard,
+    )
+  })
+
+  // Per-program list of declared discriminator byte lengths, sorted desc.
+  let byProgram: dict<Utils.Set.t<int>> = Dict.make()
+  events->Belt.Array.forEach(config => {
+    let key = config.programId->SvmTypes.Pubkey.toString
+    let set = switch byProgram->Utils.Dict.dangerouslyGetNonOption(key) {
+    | Some(s) => s
+    | None =>
+      let s = Utils.Set.make()
+      byProgram->Dict.set(key, s)
+      s
+    }
+    let _ = set->Utils.Set.add(config.discriminatorByteLen)
+  })
+  let ordering =
+    byProgram
+    ->Dict.toArray
+    ->Array.map(((programIdString, lens)) => {
+      let sorted = lens->Utils.Set.toArray->Array.toSorted((a, b) => (b - a)->Int.toFloat)
+      {
+        programId: programIdString->SvmTypes.Pubkey.fromStringUnsafe,
+        byteLengthsDesc: sorted,
+      }
+    })
+
+  (router, ordering)
+}

--- a/packages/envio/src/sources/HyperSyncSolanaSource.res
+++ b/packages/envio/src/sources/HyperSyncSolanaSource.res
@@ -1,0 +1,398 @@
+open Source
+
+exception EventRoutingFailed
+
+type options = {
+  chain: ChainMap.Chain.t,
+  endpointUrl: string,
+  apiToken: option<string>,
+  eventConfigs: array<Internal.svmInstructionEventConfig>,
+  clientMaxRetries: int,
+  clientTimeoutMillis: int,
+}
+
+// Build one HyperSync InstructionSelection per (programId, discriminator) pair.
+// Empty programId means the config carries no real program (placeholder), in
+// which case we skip — better to over-fetch nothing than ship a degenerate
+// query.
+let buildInstructionSelections = (
+  eventConfigs: array<Internal.svmInstructionEventConfig>,
+): array<HyperSyncSolanaClient.QueryTypes.instructionSelection> => {
+  eventConfigs->Belt.Array.keepMap(cfg => {
+    let programIdString = cfg.programId->SvmTypes.Pubkey.toString
+    if programIdString === "" {
+      None
+    } else {
+      // Each instruction owns exactly one dN field — the one matching its
+      // declared byte length. The server-side filter is `d{N} IN [..]`.
+      let (d1, d2, d4, d8) = switch (cfg.discriminator, cfg.discriminatorByteLen) {
+      | (Some(d), 1) => (Some([d]), None, None, None)
+      | (Some(d), 2) => (None, Some([d]), None, None)
+      | (Some(d), 4) => (None, None, Some([d]), None)
+      | (Some(d), 8) => (None, None, None, Some([d]))
+      | _ => (None, None, None, None)
+      }
+      let accountFilters = cfg.accountFilters
+      let a0 = accountFilters->Belt.Array.keepMap(f =>
+        f.position == 0 ? Some(f.values->SvmTypes.Pubkey.toStrings) : None
+      )->Belt.Array.get(0)
+      let a1 = accountFilters->Belt.Array.keepMap(f =>
+        f.position == 1 ? Some(f.values->SvmTypes.Pubkey.toStrings) : None
+      )->Belt.Array.get(0)
+      let a2 = accountFilters->Belt.Array.keepMap(f =>
+        f.position == 2 ? Some(f.values->SvmTypes.Pubkey.toStrings) : None
+      )->Belt.Array.get(0)
+      let a3 = accountFilters->Belt.Array.keepMap(f =>
+        f.position == 3 ? Some(f.values->SvmTypes.Pubkey.toStrings) : None
+      )->Belt.Array.get(0)
+      let a4 = accountFilters->Belt.Array.keepMap(f =>
+        f.position == 4 ? Some(f.values->SvmTypes.Pubkey.toStrings) : None
+      )->Belt.Array.get(0)
+      let a5 = accountFilters->Belt.Array.keepMap(f =>
+        f.position == 5 ? Some(f.values->SvmTypes.Pubkey.toStrings) : None
+      )->Belt.Array.get(0)
+      Some(
+        (
+          {
+            programId: [programIdString],
+            ?d1,
+            ?d2,
+            ?d4,
+            ?d8,
+            ?a0,
+            ?a1,
+            ?a2,
+            ?a3,
+            ?a4,
+            ?a5,
+            isInner: ?cfg.isInner,
+            includeTransaction: cfg.includeTransaction,
+            includeLogs: cfg.includeLogs,
+          }: HyperSyncSolanaClient.QueryTypes.instructionSelection
+        ),
+      )
+    }
+  })
+}
+
+// Synthesize a stable logIndex for an SVM instruction so the FetchState
+// ordering machinery (which compares by `(blockNumber, logIndex)`) sorts
+// instructions deterministically within a slot. The bit packing fits inside
+// JS's 53-bit safe-integer range: transactionIndex ≤ ~10k per slot,
+// instruction position ≤ 1000 per tx, depth ≤ ~10. Outer-only instructions
+// land at `tx * 65536`; inner ones append depth-weighted offsets.
+let synthLogIndex = (instr: HyperSyncSolanaClient.ResponseTypes.instruction) => {
+  let tx = instr.transactionIndex
+  let addrSum = instr.instructionAddress->Belt.Array.reduce(0, (acc, n) => acc * 1024 + n + 1)
+  tx * 65536 + addrSum
+}
+
+let serializeInstructionAddress = (addr: array<int>) =>
+  addr->Array.map(n => n->Int.toString)->Array.joinUnsafe(",")
+
+let toSvmInstruction = (
+  instr: HyperSyncSolanaClient.ResponseTypes.instruction,
+): Envio.svmInstruction => {
+  programId: instr.programId->SvmTypes.Pubkey.fromStringUnsafe,
+  data: instr.data,
+  accounts: instr.accounts->SvmTypes.Pubkey.fromStringsUnsafe,
+  instructionAddress: instr.instructionAddress,
+  isInner: instr.isInner,
+  d1: ?instr.d1,
+  d2: ?instr.d2,
+  d4: ?instr.d4,
+  d8: ?instr.d8,
+}
+
+let toSvmTransaction = (
+  tx: HyperSyncSolanaClient.ResponseTypes.transaction,
+): Envio.svmTransaction => {
+  signatures: tx.signatures,
+  accountKeys: tx.accountKeys->SvmTypes.Pubkey.fromStringsUnsafe,
+  feePayer: ?tx.feePayer->Option.map(SvmTypes.Pubkey.fromStringUnsafe),
+  success: ?tx.success,
+  err: ?tx.err,
+  // u64 lamports / compute units arrive as `int` over napi. Convert to
+  // `bigint` so the public type stays defensible even for pathological values.
+  fee: ?tx.fee->Option.map(BigInt.fromInt),
+  computeUnitsConsumed: ?tx.computeUnitsConsumed->Option.map(BigInt.fromInt),
+  recentBlockhash: ?tx.recentBlockhash,
+  version: ?tx.version,
+}
+
+// Probe the discriminator byte-length ordering longest-first. Stops at the
+// first router hit. Falls back to the `_none` key (program-wide handler) when
+// no discriminator-keyed handler matches.
+let probeRouter = (
+  router: EventRouter.t<Internal.svmInstructionEventConfig>,
+  programId: SvmTypes.Pubkey.t,
+  instr: HyperSyncSolanaClient.ResponseTypes.instruction,
+  byteLengthsDesc: array<int>,
+  ~contractAddress,
+  ~indexingAddresses,
+) => {
+  let probe = (dN: option<string>) => {
+    let tag = EventRouter.getSvmEventId(~programId, ~discriminator=dN)
+    router->EventRouter.get(
+      ~tag,
+      ~contractAddress,
+      ~blockNumber=instr.slot,
+      ~indexingAddresses,
+    )
+  }
+
+  let result = byteLengthsDesc->Belt.Array.reduce(None, (acc, len) =>
+    switch acc {
+    | Some(_) => acc
+    | None =>
+      let candidate = switch len {
+      | 8 => instr.d8
+      | 4 => instr.d4
+      | 2 => instr.d2
+      | 1 => instr.d1
+      | _ => None
+      }
+      switch candidate {
+      | Some(_) as d => probe(d)
+      | None => None
+      }
+    }
+  )
+
+  switch result {
+  | Some(_) as hit => hit
+  | None => probe(None) // program-wide fallback
+  }
+}
+
+let make = ({chain, endpointUrl, apiToken, eventConfigs, clientMaxRetries, clientTimeoutMillis}: options): t => {
+  let name = "HyperSyncSolana"
+  let chainId = chain->ChainMap.Chain.toChainId
+
+  let client = HyperSyncSolanaClient.make(
+    ~url=endpointUrl,
+    ~apiToken=?apiToken,
+    ~httpReqTimeoutMillis=clientTimeoutMillis,
+    ~maxNumRetries=clientMaxRetries,
+  )
+
+  let (eventRouter, programOrderings) =
+    EventRouter.fromSvmEventConfigsOrThrow(eventConfigs, ~chain)
+
+  // programId.toString -> sorted-desc byte lengths
+  let orderingByProgram = Dict.make()
+  programOrderings->Belt.Array.forEach(o =>
+    orderingByProgram->Dict.set(
+      o.programId->SvmTypes.Pubkey.toString,
+      o.byteLengthsDesc,
+    )
+  )
+
+  let getItemsOrThrow = async (
+    ~fromBlock,
+    ~toBlock,
+    ~addressesByContractName as _,
+    ~indexingAddresses,
+    ~knownHeight,
+    ~partitionId as _,
+    ~selection as _,
+    ~retry,
+    ~logger,
+  ) => {
+    let totalTimeRef = Hrtime.makeTimer()
+    let pageFetchRef = Hrtime.makeTimer()
+
+    let instructionSelections = buildInstructionSelections(eventConfigs)
+    let query: HyperSyncSolanaClient.query = {
+      fromSlot: fromBlock,
+      toSlot: ?toBlock,
+      instructions: instructionSelections,
+    }
+
+    Prometheus.SourceRequestCount.increment(
+      ~sourceName=name,
+      ~chainId,
+      ~method="getInstructions",
+    )
+
+    let resp = try await client.get(~query) catch {
+    | exn =>
+      throw(
+        Source.GetItemsError(
+          Source.FailedGettingItems({
+            exn,
+            attemptedToBlock: toBlock->Option.getOr(knownHeight),
+            retry: WithBackoff({
+              message: `Unexpected issue while fetching instructions from HyperSync Solana. Attempt a retry.`,
+              backoffMillis: switch retry {
+              | 0 => 500
+              | _ => 1000 * retry
+              },
+            }),
+          }),
+        ),
+      )
+    }
+    let pageFetchTime = pageFetchRef->Hrtime.timeSince->Hrtime.toSecondsFloat
+
+    let parsingRef = Hrtime.makeTimer()
+
+    // Per (slot, transaction_index) lookup for parent transactions.
+    let txByKey = Dict.make()
+    resp.data.transactions->Belt.Array.forEach(tx => {
+      let key =
+        tx.slot->Int.toString ++ ":" ++ tx.transactionIndex->Int.toString
+      txByKey->Dict.set(key, tx)
+    })
+
+    // Per (slot, transaction_index, instruction_address) lookup for logs
+    // scoped to a single instruction. `instructionAddress: None` logs are
+    // attached to no instruction (rare; usually only system messages).
+    let logsByKey = Dict.make()
+    resp.data.logs->Belt.Array.forEach(log => {
+      switch (log.transactionIndex, log.instructionAddress) {
+      | (Some(txIdx), Some(addr)) =>
+        let key =
+          log.slot->Int.toString ++
+          ":" ++
+          txIdx->Int.toString ++
+          ":" ++
+          serializeInstructionAddress(addr)
+        switch logsByKey->Dict.get(key) {
+        | Some(existing) => existing->Array.push(log)
+        | None => logsByKey->Dict.set(key, [log])
+        }
+      | _ => ()
+      }
+    })
+
+    let parsedQueueItems = []
+    resp.data.instructions->Belt.Array.forEach(instr => {
+      let programId = instr.programId->SvmTypes.Pubkey.fromStringUnsafe
+      let byteLengths =
+        orderingByProgram
+        ->Utils.Dict.dangerouslyGetNonOption(instr.programId)
+        ->Option.getOr([])
+
+      let contractAddress = instr.programId->Address.unsafeFromString
+      let maybeConfig = probeRouter(
+        eventRouter,
+        programId,
+        instr,
+        byteLengths,
+        ~contractAddress,
+        ~indexingAddresses,
+      )
+
+      switch maybeConfig {
+      | None => ()
+      | Some(eventConfig) =>
+        let txKey =
+          instr.slot->Int.toString ++ ":" ++ instr.transactionIndex->Int.toString
+        let maybeTx =
+          txByKey->Utils.Dict.dangerouslyGetNonOption(txKey)->Option.map(toSvmTransaction)
+        let logKey =
+          instr.slot->Int.toString ++
+          ":" ++
+          instr.transactionIndex->Int.toString ++
+          ":" ++
+          serializeInstructionAddress(instr.instructionAddress)
+        let maybeLogs =
+          logsByKey
+          ->Utils.Dict.dangerouslyGetNonOption(logKey)
+          ->Option.map(
+            logs =>
+              logs->Array.map((log): Envio.svmLog => {
+                kind: log.kind->Option.getOr(""),
+                message: log.message->Option.getOr(""),
+              }),
+          )
+
+        let payload: Envio.svmInstructionEvent = {
+          contractName: eventConfig.contractName,
+          eventName: eventConfig.name,
+          instruction: toSvmInstruction(instr),
+          transaction: eventConfig.includeTransaction ? maybeTx : None,
+          logs: eventConfig.includeLogs ? maybeLogs : None,
+          slot: instr.slot,
+          blockTime: None,
+        }
+
+        parsedQueueItems
+        ->Array.push(
+          Internal.Event({
+            eventConfig: (eventConfig :> Internal.eventConfig),
+            timestamp: 0,
+            chain,
+            blockNumber: instr.slot,
+            logIndex: synthLogIndex(instr),
+            event: payload->(
+              Utils.magic: Envio.svmInstructionEvent => Internal.event
+            ),
+          }),
+        )
+        ->ignore
+      }
+
+      let _ = logger
+    })
+
+    let parsingTimeElapsed = parsingRef->Hrtime.timeSince->Hrtime.toSecondsFloat
+    let heighestSlot = resp.nextSlot - 1
+
+    // C2 ships a no-op reorg guard for SVM: finalized commitment + extremely
+    // rare reorgs at finality. C3 wires the extra `queryBlockHash(slot)`
+    // route per the Q3 answer.
+    let reorgGuard: ReorgDetection.reorgGuard = {
+      rangeLastBlock: (
+        {
+          blockNumber: heighestSlot,
+          blockTimestamp: 0,
+          blockHash: "",
+        }: ReorgDetection.blockDataWithTimestamp
+      )->ReorgDetection.generalizeBlockDataWithTimestamp,
+      prevRangeLastBlock: None,
+    }
+
+    let totalTimeElapsed = totalTimeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
+
+    {
+      latestFetchedBlockTimestamp: 0,
+      parsedQueueItems,
+      latestFetchedBlockNumber: heighestSlot,
+      stats: {totalTimeElapsed, parsingTimeElapsed, pageFetchTime},
+      knownHeight,
+      reorgGuard,
+      fromBlockQueried: fromBlock,
+    }
+  }
+
+  {
+    name,
+    sourceFor: Sync,
+    chain,
+    pollingInterval: 1000,
+    poweredByHyperSync: true,
+    getBlockHashes: (~blockNumbers as _, ~logger as _) =>
+      // No-op reorg guard means callers never need block hashes for SVM. If a
+      // caller does ask, surface the limitation rather than fabricate empty
+      // data — C3 will replace this with a real lookup.
+      JsError.throwWithMessage(
+        "HyperSyncSolanaSource does not support getBlockHashes yet (reorg detection at finalized commitment is no-op in C2)",
+      ),
+    getHeightOrThrow: async () => {
+      let timer = Hrtime.makeTimer()
+      let h = await client.getHeight()
+      let seconds = timer->Hrtime.timeSince->Hrtime.toSecondsFloat
+      Prometheus.SourceRequestCount.increment(~sourceName=name, ~chainId, ~method="getHeight")
+      Prometheus.SourceRequestCount.addSeconds(
+        ~sourceName=name,
+        ~chainId,
+        ~method="getHeight",
+        ~seconds,
+      )
+      h
+    },
+    getItemsOrThrow,
+  }
+}

--- a/scenarios/test_codegen/test/EventRouter_svm_test.res
+++ b/scenarios/test_codegen/test/EventRouter_svm_test.res
@@ -1,0 +1,87 @@
+open Vitest
+
+let pubkey = SvmTypes.Pubkey.fromStringUnsafe
+
+describe("EventRouter SVM helpers", () => {
+  it("getSvmEventId builds discriminator-keyed tag and falls back to _none", t => {
+    let programId = pubkey("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s")
+    let actual = {
+      "withDiscriminator": EventRouter.getSvmEventId(
+        ~programId,
+        ~discriminator=Some("0x0f"),
+      ),
+      "withoutDiscriminator": EventRouter.getSvmEventId(
+        ~programId,
+        ~discriminator=None,
+      ),
+    }
+    t.expect(actual).toEqual({
+      "withDiscriminator": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s_0x0f",
+      "withoutDiscriminator": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s_none",
+    })
+  })
+
+  it("fromSvmEventConfigsOrThrow precomputes per-program discriminator-length ordering desc", t => {
+    let chain = ChainMap.Chain.makeUnsafe(~chainId=0)
+    let progA = pubkey("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s")
+    let progB = pubkey("11111111111111111111111111111111")
+    let mk = (
+      ~name,
+      ~contractName,
+      ~programId,
+      ~discriminator,
+      ~discriminatorByteLen,
+    ): Internal.svmInstructionEventConfig => {
+      id: discriminator->Option.getOr("none"),
+      name,
+      contractName,
+      isWildcard: false,
+      filterByAddresses: false,
+      dependsOnAddresses: true,
+      handler: None,
+      contractRegister: None,
+      paramsRawEventSchema: %raw(`null`),
+      simulateParamsSchema: %raw(`null`),
+      startBlock: None,
+      programId,
+      discriminator,
+      discriminatorByteLen,
+      includeTransaction: true,
+      includeLogs: false,
+      accountFilters: [],
+      isInner: None,
+    }
+    let configs = [
+      mk(
+        ~name="One",
+        ~contractName="ProgA",
+        ~programId=progA,
+        ~discriminator=Some("0x0f"),
+        ~discriminatorByteLen=1,
+      ),
+      mk(
+        ~name="Eight",
+        ~contractName="ProgA",
+        ~programId=progA,
+        ~discriminator=Some("0x0fffffffffffffff"),
+        ~discriminatorByteLen=8,
+      ),
+      mk(
+        ~name="Wide",
+        ~contractName="ProgB",
+        ~programId=progB,
+        ~discriminator=None,
+        ~discriminatorByteLen=0,
+      ),
+    ]
+    let (_router, ordering) = EventRouter.fromSvmEventConfigsOrThrow(configs, ~chain)
+    let byProgram =
+      ordering
+      ->Array.map(o => (o.programId->SvmTypes.Pubkey.toString, o.byteLengthsDesc))
+      ->Array.toSorted(((a, _), (b, _)) => String.compare(a, b))
+    t.expect(byProgram).toEqual([
+      ("11111111111111111111111111111111", [0]),
+      ("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s", [8, 1]),
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Makes the SVM ecosystem live. Programs/instructions declared in YAML now flow all the way through to the user-facing `indexer.onInstruction({program, instruction}, handler)` call.

**Stacked on #1217.** Merge after Stage 4 C1.

## What's in this PR

### Source layer — `packages/envio/src/sources/HyperSyncSolanaSource.res` (new, ~290 LOC)
- `Source.t` implementation. Builds one `InstructionSelection` per `(programId, discriminator)` from the chain's `Internal.svmInstructionEventConfig[]`. The matching `dN` field (d1/d2/d4/d8) carries the discriminator; `a0..a5` carry positional account filters; `isInner`, `includeTransaction`, `includeLogs` flow through.
- **Per-instruction log grouping** (Q2 answer). One pass builds a `(slot, tx_idx, instruction_address)` → logs map so each handler sees only the logs scoped to its instruction.
- **Longest-discriminator-prefix dispatch** (Q1 answer). The router precomputes a per-program byte-length ordering at construction time; runtime probes `d8` → `d4` → `d2` → `d1` → `none` in declared order, first hit wins.
- Synthesized `logIndex = tx_idx * 65536 + depth-weighted(instruction_address)` keeps `FetchState` ordering deterministic without touching its compare logic.
- **No-op reorg guard for C2.** Q3's `queryBlockHash(slot)` route is deferred — needs a new napi binding method.

### Routing helpers — `packages/envio/src/sources/EventRouter.res`
- `getSvmEventId(~programId, ~discriminator) → "<programId>_<hex>" | "<programId>_none"`.
- `fromSvmEventConfigsOrThrow` returns `(t<svmInstructionEventConfig>, array<svmProgramOrdering>)`. The ordering is per-program byte lengths sorted desc.

### Config + dispatch
- `Config.SvmSourceConfig` now `{hypersync: option<string>, rpc}`.
- `ChainFetcher.res` SVM arm: HyperSync primary when `hypersync` is set, RPC stays for `getFinalizedSlot` height; RPC-only path unchanged.
- `Config.res` `buildContractEvents` accepts `~addresses` and the SVM arm pulls `addresses[0]` as the real `SvmTypes.Pubkey.t` programId, replacing C1's placeholder.

### Public API — `Main.res`
- `indexer.onInstruction({program, instruction, where?}, handler)` registers via `HandlerRegister.setHandler` with `(contractName=program, eventName=instruction)`. Both TS-string and ReScript-GADT identity shapes parsed via the same two-format dance as `onEvent`.
- SVM indexer key list grows from `[name, description, chainIds, chains, onSlot]` to `[..., onInstruction, onSlot]`.

## Test plan

- [x] **264 cargo tests, 0 failed.** No regressions.
- [x] **Full ReScript builds clean**: 130 envio modules + 168 test_codegen modules.
- [x] New `scenarios/test_codegen/test/EventRouter_svm_test.res` — 2/2 passing:
  - `getSvmEventId` shape (with + without discriminator).
  - `fromSvmEventConfigsOrThrow` per-program ordering: ProgA with `0x0f` + `0x0fffffffffffffff` orders to `[8, 1]`; ProgB with no discriminator orders to `[0]`.
- [ ] Live Metaplex e2e vitest — deferred to C3.

## Deferred to C3

- Live Metaplex scenario (`scenarios/svm_token_metadata/`) — full end-to-end flow against `solana.hypersync.xyz`.
- Real reorg-guard block hashes: add a `queryBlockHash(slot)` route to `hypersync-client-solana` + napi binding, then to `HyperSyncSolanaClient.res`, then populate `reorgGuard.rangeLastBlock` properly.
- `index.d.ts` `OnInstruction` distributive-mapped types so TypeScript users get the fully-typed registration API (today they get `any` for the handler args).

🤖 Generated with [Claude Code](https://claude.com/claude-code)