### PR TITLE
Add Etherlink, Katana, and Tempo networks

### DIFF
--- a/packages/cli/src/config_parsing/chain_helpers.rs
+++ b/packages/cli/src/config_parsing/chain_helpers.rs
@@ -155,6 +155,9 @@ pub enum Network {
     )]
     EthereumMainnet = 1,
 
+    #[subenum(HypersyncChain)]
+    Etherlink = 42793,
+
     #[subenum(NetworkWithExplorer)]
     Evmos = 9001,
 
@@ -212,6 +215,9 @@ pub enum Network {
 
     #[subenum(HypersyncChain)]
     Ink = 57073,
+
+    #[subenum(HypersyncChain)]
+    Katana = 747474,
 
     #[subenum(HypersyncChain, NetworkWithExplorer)]
     Kroma = 255,
@@ -398,6 +404,9 @@ pub enum Network {
     #[subenum(HypersyncChain)]
     Taraxa = 841,
 
+    #[subenum(HypersyncChain)]
+    Tempo = 4217,
+
     #[subenum(HypersyncChain, NetworkWithExplorer)]
     Unichain = 130,
 
@@ -501,6 +510,7 @@ impl Network {
             | Network::Darwinia
             | Network::Evmos
             | Network::EthereumMainnet
+            | Network::Etherlink
             | Network::Fantom
             | Network::FantomTestnet
             | Network::FhenixHelium
@@ -515,6 +525,7 @@ impl Network {
             | Network::Harmony
             | Network::Holesky
             | Network::IncoGentryTestnet
+            | Network::Katana
             | Network::Kroma
             | Network::Linea
             | Network::LineaSepolia
@@ -598,7 +609,8 @@ impl Network {
             | Network::Injective
             | Network::Megaeth
             | Network::SeiTestnet
-            | Network::StatusSepolia => None,
+            | Network::StatusSepolia
+            | Network::Tempo => None,
         }
     }
 }
@@ -650,7 +662,9 @@ impl HypersyncChain {
             }
 
             Linea | Berachain | Blast | Amoy | ZksyncEra | ArbitrumNova | Avalanche | Bsc
-            | Taraxa | Plasma | Lukso | CitreaTestnet | Injective | Citrea => Bronze,
+            | Taraxa | Plasma | Lukso | CitreaTestnet | Injective | Citrea | Katana | Etherlink => {
+                Bronze
+            }
 
             Curtis | PolygonZkevm | Abstract | Zora | Unichain | Aurora | Zeta | Manta | Kroma
             | Flare | Mantle | ShimmerEvm | Boba | Ink | Metall2 | SophonTestnet | BscTestnet
@@ -659,7 +673,7 @@ impl HypersyncChain {
             | Merlin | Mode | XdcTestnet | Morph | Harmony | Saakuru | Cyber | Superseed
             | Worldchain | Sophon | Fantom | Sepolia | Rsk | Chiliz | Lisk | Hyperliquid
             | Swell | Moonbeam | Plume | Scroll | Ab | ArcTestnet | SonicTestnet | SeiTestnet
-            | Hoodi | StatusSepolia => Stone,
+            | Hoodi | StatusSepolia | Tempo => Stone,
         }
     }
 


### PR DESCRIPTION
Adds three new HypersyncChain entries flagged by the print-missing-networks script: Etherlink (42793, Bronze), Katana (747474, Bronze), and Tempo (4217, Stone).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new blockchain networks: Etherlink (chain 42793), Katana (chain 747474), and Tempo (chain 4217). The CLI configuration now includes proper reorg depth behavior and network tier classifications for all three networks. These additions enable seamless integration and ensure optimal performance when working with these newly supported blockchain networks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->