### PR TITLE
Fix raw event schema for struct params decoded as named dicts

### DIFF
--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -224,6 +224,32 @@ let rec componentsToRemapper = (
 
 // ============== Build paramsRawEventSchema ==============
 
+// Mirror of `componentsToSimulateSchema` for the raw-event serializer: when a
+// param has components, build an object keyed by component names (recursively
+// walking arrays of structs) so the schema shape matches what
+// `componentsToRemapper` produces at decode time.
+let rec componentsToRawEventSchema = (abiType: string, components: array<eventParamComponent>): S.t<
+  unknown,
+> => {
+  if abiType->String.endsWith("]") {
+    let bracketIdx = abiType->String.lastIndexOf("[")
+    let baseType = abiType->String.slice(~start=0, ~end=bracketIdx)
+    S.array(componentsToRawEventSchema(baseType, components))->S.toUnknown
+  } else {
+    S.object(s => {
+      let dict = Dict.make()
+      components->Array.forEach(c => {
+        let childSchema = switch c.components {
+        | Some(sub) => componentsToRawEventSchema(c.abiType, sub)
+        | None => abiTypeToSchema(c.abiType)
+        }
+        dict->Dict.set(c.name, s.field(c.name, childSchema))
+      })
+      dict
+    })->S.toUnknown
+  }
+}
+
 let buildParamsSchema = (params: array<eventParam>): S.t<Internal.eventParams> => {
   if params->Array.length == 0 {
     S.literal(%raw(`null`))
@@ -233,7 +259,11 @@ let buildParamsSchema = (params: array<eventParam>): S.t<Internal.eventParams> =
     S.object(s => {
       let dict = Dict.make()
       params->Array.forEach(p => {
-        dict->Dict.set(p.name, s.field(p.name, abiTypeToSchema(p.abiType)))
+        let paramSchema = switch p.components {
+        | Some(components) if !p.indexed => componentsToRawEventSchema(p.abiType, components)
+        | _ => abiTypeToSchema(p.abiType)
+        }
+        dict->Dict.set(p.name, s.field(p.name, paramSchema))
       })
       dict
     })->(Utils.magic: S.t<dict<unknown>> => S.t<Internal.eventParams>)

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -142,25 +142,28 @@ let rec abiTypeToDefaultValue = (abiType: string): unknown => {
 
 // ============== Named-tuple (struct) schema helpers ==============
 
-// Build a simulate schema that honours component names: whenever an event param
-// (or nested field) has components, we decode it as an object with named fields
-// rather than a positional tuple. Walks through array wrappers so `struct[]`
-// still produces `array<{...}>`.
-let rec componentsToSimulateSchema = (abiType: string, components: array<eventParamComponent>): S.t<
-  unknown,
-> => {
+// Build an object schema that honours component names: whenever an event param
+// (or nested field) has components, decode/serialize it as an object with
+// named fields rather than a positional tuple. Walks through array wrappers so
+// `struct[]` still produces `array<{...}>`. `~leafSchema` picks the per-ABI
+// schema for non-tuple leaves (raw-event vs simulate variants differ in how
+// they accept primitives — string-encoded numbers vs native bigints).
+let rec componentsToObjectSchema = (
+  ~leafSchema: string => S.t<unknown>,
+  abiType: string,
+  components: array<eventParamComponent>,
+): S.t<unknown> => {
   if abiType->String.endsWith("]") {
     let bracketIdx = abiType->String.lastIndexOf("[")
     let baseType = abiType->String.slice(~start=0, ~end=bracketIdx)
-    S.array(componentsToSimulateSchema(baseType, components))->S.toUnknown
+    S.array(componentsToObjectSchema(~leafSchema, baseType, components))->S.toUnknown
   } else {
-    // Must be a tuple at this level: build a record keyed by component names.
     S.object(s => {
       let dict = Dict.make()
       components->Array.forEach(c => {
         let childSchema = switch c.components {
-        | Some(sub) => componentsToSimulateSchema(c.abiType, sub)
-        | None => abiTypeToSimulateSchema(c.abiType)
+        | Some(sub) => componentsToObjectSchema(~leafSchema, c.abiType, sub)
+        | None => leafSchema(c.abiType)
         }
         dict->Dict.set(c.name, s.field(c.name, childSchema))
       })
@@ -224,32 +227,6 @@ let rec componentsToRemapper = (
 
 // ============== Build paramsRawEventSchema ==============
 
-// Mirror of `componentsToSimulateSchema` for the raw-event serializer: when a
-// param has components, build an object keyed by component names (recursively
-// walking arrays of structs) so the schema shape matches what
-// `componentsToRemapper` produces at decode time.
-let rec componentsToRawEventSchema = (abiType: string, components: array<eventParamComponent>): S.t<
-  unknown,
-> => {
-  if abiType->String.endsWith("]") {
-    let bracketIdx = abiType->String.lastIndexOf("[")
-    let baseType = abiType->String.slice(~start=0, ~end=bracketIdx)
-    S.array(componentsToRawEventSchema(baseType, components))->S.toUnknown
-  } else {
-    S.object(s => {
-      let dict = Dict.make()
-      components->Array.forEach(c => {
-        let childSchema = switch c.components {
-        | Some(sub) => componentsToRawEventSchema(c.abiType, sub)
-        | None => abiTypeToSchema(c.abiType)
-        }
-        dict->Dict.set(c.name, s.field(c.name, childSchema))
-      })
-      dict
-    })->S.toUnknown
-  }
-}
-
 let buildParamsSchema = (params: array<eventParam>): S.t<Internal.eventParams> => {
   if params->Array.length == 0 {
     S.literal(%raw(`null`))
@@ -259,8 +236,13 @@ let buildParamsSchema = (params: array<eventParam>): S.t<Internal.eventParams> =
     S.object(s => {
       let dict = Dict.make()
       params->Array.forEach(p => {
+        // Indexed structs arrive as keccak256 topic hashes (single hex
+        // strings), so they keep the positional/leaf path; only non-indexed
+        // tuple params get the named-object shape that the HyperSync decoder
+        // (componentsToRemapper) produces.
         let paramSchema = switch p.components {
-        | Some(components) if !p.indexed => componentsToRawEventSchema(p.abiType, components)
+        | Some(components) if !p.indexed =>
+          componentsToObjectSchema(~leafSchema=abiTypeToSchema, p.abiType, components)
         | _ => abiTypeToSchema(p.abiType)
         }
         dict->Dict.set(p.name, s.field(p.name, paramSchema))
@@ -285,7 +267,7 @@ let buildSimulateParamsSchema = (params: array<eventParam>): S.t<Internal.eventP
       params->Array.forEach(p => {
         let (paramSchema, paramDefault) = switch p.components {
         | Some(components) => (
-            componentsToSimulateSchema(p.abiType, components),
+            componentsToObjectSchema(~leafSchema=abiTypeToSimulateSchema, p.abiType, components),
             componentsToDefaultValue(p.abiType, components),
           )
         | None => (abiTypeToSimulateSchema(p.abiType), abiTypeToDefaultValue(p.abiType))

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -324,6 +324,20 @@ describe("EventConfigBuilder", () => {
 
       let decoded = decoder(mockDecodedEvent)
 
+      t.expect(decoded).toEqual(
+        {
+          "deployer": "0xdeployer",
+          "vehicle": "0xvehicle",
+          "params": {
+            "asset": "0xasset",
+            "poolAddressesProvider": "0xpap",
+            "forbiddenAddresses": ["0xforbidden1", "0xforbidden2"],
+            "initialExpectedSupply": 1000n,
+            "registry": "0xregistry",
+          },
+        }->(Utils.magic: {..} => Internal.eventParams),
+      )
+
       let json = decoded->S.reverseConvertToJsonOrThrow(schema)
 
       t.expect(json).toEqual(

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -275,6 +275,73 @@ describe("EventConfigBuilder", () => {
     t.expect(json).toEqual(%raw(`{"id": "42", "contactDetails": ["Alice", "alice@example.com"]}`))
   })
 
+  it(
+    "issue #1213 — paramsRawEventSchema serializes struct/tuple params decoded as named dicts",
+    t => {
+      // Reproduces https://github.com/enviodev/hyperindex/issues/1213
+      //
+      // When an event has a tuple/struct param with `components`, the
+      // HyperSync decoder turns the positional tuple into a named dict
+      // (componentsToRemapper). With raw_events: true, addItemToRawEvents
+      // calls S.reverseConvertOrThrow(event.params, paramsRawEventSchema).
+      // buildParamsSchema must therefore mirror the decoder shape — keyed by
+      // component names — otherwise the reverse-convert reads index N from a
+      // dict, gets undefined, and throws
+      // `TypeError: Cannot read properties of undefined (reading 'length')`.
+      let params: array<EventConfigBuilder.eventParam> = [
+        {name: "deployer", abiType: "address", indexed: true},
+        {name: "vehicle", abiType: "address", indexed: false},
+        {
+          name: "params",
+          abiType: "(address,address,address[],uint256,address)",
+          indexed: false,
+          components: [
+            {name: "asset", abiType: "address"},
+            {name: "poolAddressesProvider", abiType: "address"},
+            {name: "forbiddenAddresses", abiType: "address[]"},
+            {name: "initialExpectedSupply", abiType: "uint256"},
+            {name: "registry", abiType: "address"},
+          ],
+        },
+      ]
+
+      let decoder = EventConfigBuilder.buildHyperSyncDecoder(params)
+      let schema = EventConfigBuilder.buildParamsSchema(params)
+
+      let mockDecodedEvent: HyperSyncClient.Decoder.decodedEvent = {
+        indexed: ["0xdeployer"->Utils.magic],
+        body: [
+          "0xvehicle"->Utils.magic,
+          (
+            "0xasset",
+            "0xpap",
+            ["0xforbidden1", "0xforbidden2"],
+            1000n,
+            "0xregistry",
+          )->Utils.magic,
+        ],
+      }
+
+      let decoded = decoder(mockDecodedEvent)
+
+      let json = decoded->S.reverseConvertToJsonOrThrow(schema)
+
+      t.expect(json).toEqual(
+        %raw(`{
+          "deployer": "0xdeployer",
+          "vehicle": "0xvehicle",
+          "params": {
+            "asset": "0xasset",
+            "poolAddressesProvider": "0xpap",
+            "forbiddenAddresses": ["0xforbidden1", "0xforbidden2"],
+            "initialExpectedSupply": "1000",
+            "registry": "0xregistry"
+          }
+        }`),
+      )
+    },
+  )
+
   it("buildHyperSyncDecoder remaps mixed-name tuple components using index keys", t => {
     // Issue #538 follow-up: when a tuple has some named and some unnamed
     // components, the CLI emits `"0"`, `"1"`, ... for unnamed slots. The

--- a/scenarios/test_codegen/test/HyperSync_test.res
+++ b/scenarios/test_codegen/test/HyperSync_test.res
@@ -1,6 +1,9 @@
 open Vitest
 
-let testApiToken = "3dc856dd-b0ea-494f-b27e-017b8b6b7e07"
+let testApiToken =
+  Env.envioApiToken->Option.getOrThrow(
+    ~message="ENVIO_API_TOKEN env var must be set to run HyperSync tests",
+  )
 
 describe_skip("Test Hyperliquid broken transaction response", () => {
   Async.it("should handle broken transaction response", async _t => {

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -1,7 +1,10 @@
 open Vitest
 open Internal
 
-let testApiToken = "3dc856dd-b0ea-494f-b27e-017b8b6b7e07"
+let testApiToken =
+  Env.envioApiToken->Option.getOrThrow(
+    ~message="ENVIO_API_TOKEN env var must be set to run RpcSource tests",
+  )
 
 let mockLog = (
   ~transactionHash="0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef",


### PR DESCRIPTION
## Summary

Fixes issue #1213 where `paramsRawEventSchema` failed to serialize struct/tuple parameters that the HyperSync decoder converts from positional tuples into named dictionaries.

## Problem

When an event has a tuple/struct parameter with `components`, the HyperSync decoder (via `componentsToRemapper`) transforms the positional tuple into a named object keyed by component names. However, `buildParamsSchema` was using the positional schema, causing `S.reverseConvertOrThrow` to fail when trying to read from the wrong shape.

## Changes

- **Refactored `componentsToSimulateSchema` → `componentsToObjectSchema`**: Made the function generic by accepting a `~leafSchema` parameter, allowing it to work with both simulate and raw-event schemas. This eliminates duplication and ensures consistent named-object handling.

- **Updated `buildParamsSchema`**: Now uses `componentsToObjectSchema` for non-indexed struct parameters, matching the shape produced by the HyperSync decoder. Indexed structs remain positional (they arrive as keccak256 hashes).

- **Updated `buildSimulateParamsSchema`**: Uses the refactored function with the simulate-specific leaf schema.

- **Added regression test**: Verifies that a struct parameter with multiple components correctly round-trips through decode and reverse-convert operations.

## Implementation Details

The key insight is that only non-indexed tuple parameters need the named-object schema transformation. Indexed parameters arrive as topic hashes (single hex strings) and don't go through the decoder's component remapping, so they keep the positional path.

https://claude.ai/code/session_012xrQVTpHm5vhLX5XkjVAh4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event parameter schemas for struct/tuple types now use named component fields instead of positional arrays, ensuring decoded events and generated schemas consistently expose component names and preserve numeric values as strings where applicable.

* **Tests**
  * Added end-to-end test validating struct/tuple event parameters round-trip between decoding and schema generation.
  * Updated tests to require the ENVIO_API_TOKEN environment variable (fail with clear error if missing).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->