### PR TITLE
envio init SVM Metaplex template + SVM TUI slot labels (Stage 5)

### DIFF
--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -179,7 +179,7 @@ Initialize Svm indexer from an example template
 
 * `-t`, `--template <TEMPLATE>` — Name of the template to be used in initialization
 
-  Possible values: `feature-block-handler`
+  Possible values: `metaplex-token-metadata`, `feature-block-handler`
 
 
 

--- a/packages/cli/src/cli_args/init_config.rs
+++ b/packages/cli/src/cli_args/init_config.rs
@@ -331,7 +331,9 @@ pub mod svm {
 
     #[derive(Clone, Debug, ValueEnum, Serialize, Deserialize, EnumIter, EnumString, Display)]
     pub enum Template {
-        #[strum(serialize = "Feature: Block Handler")]
+        #[strum(serialize = "Metaplex Token Metadata (instructions)")]
+        MetaplexTokenMetadata,
+        #[strum(serialize = "Feature: Block Handler (onSlot)")]
         FeatureBlockHandler,
     }
 

--- a/packages/cli/src/template_dirs.rs
+++ b/packages/cli/src/template_dirs.rs
@@ -36,6 +36,7 @@ impl Template for fuel::Template {
 impl Template for svm::Template {
     fn to_dir_name(&self) -> String {
         match self {
+            svm::Template::MetaplexTokenMetadata => "svm_metaplex",
             svm::Template::FeatureBlockHandler => "svmblock",
         }
         .to_string()

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/.env.example
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/.env.example
@@ -1,0 +1,1 @@
+ENVIO_MAINNET_RPC_URL=https://api.mainnet-beta.solana.com

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/.gitignore
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+.pnpm-store

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/README.md
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/README.md
@@ -1,0 +1,38 @@
+# Metaplex Token Metadata indexer
+
+A HyperIndex starter that streams Metaplex Token Metadata
+`CreateMetadataAccountV3` and `UpdateMetadataAccountV2` instructions off
+Solana mainnet via HyperSync, and writes one row per metadata PDA.
+
+## Quick start
+
+```bash
+pnpm install
+
+# Adjust config.yaml `start_block` to ~30k slots below current head:
+curl -s https://solana.hypersync.xyz/height
+
+pnpm envio local docker up    # Postgres + Hasura
+pnpm envio codegen
+pnpm envio start
+```
+
+Open the GraphQL playground at `http://localhost:8080` and query:
+
+```graphql
+{
+  TokenMetadataAccount(limit: 5, order_by: {lastUpdatedSlot: desc}) {
+    id mint updateAuthority updateCount lastUpdatedSlot
+  }
+  ProgramStats { id totalInstructions createCount updateCount }
+}
+```
+
+## What this teaches
+
+- Declaring a Solana program + its instructions in `config.yaml`
+  (`ecosystem: svm`, `programs[].instructions[]`).
+- Using `indexer.onInstruction({program, instruction}, handler)` to receive
+  positional accounts + raw instruction data.
+- Persisting per-instruction state to a typed entity (`TokenMetadataAccount`)
+  and a counter (`ProgramStats`).

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=./node_modules/envio/svm.schema.json
+name: solana-metaplex-token-metadata
+description: Indexes Metaplex Token Metadata creates and updates on Solana mainnet via HyperSync.
+ecosystem: svm
+chains:
+  - rpc: ${ENVIO_MAINNET_RPC_URL:-https://api.mainnet-beta.solana.com}
+    hypersync_config:
+      url: https://solana.hypersync.xyz
+    # Adjust just before first run: query the current height with
+    #   curl -s https://solana.hypersync.xyz/height
+    # and set this to ~30k slots below it for a quick backfill (~30s).
+    start_block: 417920000
+    programs:
+      - name: TokenMetadata
+        program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+        handler: ./src/handlers/TokenMetadataHandlers.ts
+        instructions:
+          - name: CreateMetadataAccountV3
+            discriminator: "0x21"
+            include_transaction: true
+          - name: UpdateMetadataAccountV2
+            discriminator: "0x0f"
+            include_transaction: true

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/schema.graphql
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/schema.graphql
@@ -1,0 +1,16 @@
+type TokenMetadataAccount {
+  id: ID!
+  mint: String!
+  updateAuthority: String
+  lastUpdatedSlot: Int!
+  updateCount: Int!
+  createdAtSlot: Int!
+  lastTxSignature: String
+}
+
+type ProgramStats {
+  id: ID!
+  totalInstructions: Int!
+  createCount: Int!
+  updateCount: Int!
+}

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/src/handlers/TokenMetadataHandlers.ts
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/src/handlers/TokenMetadataHandlers.ts
@@ -1,0 +1,104 @@
+/*
+ * Metaplex Token Metadata demo handler.
+ * See https://docs.envio.dev for a thorough guide on indexer features.
+ */
+import { indexer, type ProgramStats } from "envio";
+
+const STATS_ID = "metaplex-token-metadata";
+
+async function bumpStats(
+  context: {
+    ProgramStats: {
+      get: (id: string) => Promise<ProgramStats | undefined>;
+      set: (e: ProgramStats) => void;
+    };
+  },
+  kind: "create" | "update",
+) {
+  const prev = await context.ProgramStats.get(STATS_ID);
+  const next: ProgramStats =
+    prev === undefined
+      ? {
+          id: STATS_ID,
+          totalInstructions: 1,
+          createCount: kind === "create" ? 1 : 0,
+          updateCount: kind === "update" ? 1 : 0,
+        }
+      : {
+          ...prev,
+          totalInstructions: prev.totalInstructions + 1,
+          createCount: prev.createCount + (kind === "create" ? 1 : 0),
+          updateCount: prev.updateCount + (kind === "update" ? 1 : 0),
+        };
+  context.ProgramStats.set(next);
+}
+
+indexer.onInstruction(
+  { program: "TokenMetadata", instruction: "CreateMetadataAccountV3" },
+  async ({ event, context }) => {
+    const { accounts } = event.instruction;
+    // Token Metadata's CreateMetadataAccountV3 instruction layout (Metaplex):
+    //   0 = metadata account (PDA)
+    //   1 = mint
+    //   2 = mint authority
+    //   3 = payer
+    //   4 = update authority
+    const metadataPda = accounts[0];
+    if (metadataPda === undefined) return;
+    const mint = accounts[1] ?? "";
+    const updateAuthority = accounts[4];
+    const txSig = event.transaction?.signatures[0];
+
+    context.log.info(
+      `Create: slot=${event.slot} mint=${mint.slice(0, 8)}.. tx=${(txSig ?? "?").slice(0, 8)}..`,
+    );
+
+    context.TokenMetadataAccount.set({
+      id: metadataPda,
+      mint,
+      updateAuthority,
+      lastUpdatedSlot: event.slot,
+      updateCount: 0,
+      createdAtSlot: event.slot,
+      lastTxSignature: txSig,
+    });
+    await bumpStats(context, "create");
+  },
+);
+
+indexer.onInstruction(
+  { program: "TokenMetadata", instruction: "UpdateMetadataAccountV2" },
+  async ({ event, context }) => {
+    const { accounts } = event.instruction;
+    const metadataPda = accounts[0];
+    if (metadataPda === undefined) return;
+    const updateAuthority = accounts[1];
+    const txSig = event.transaction?.signatures[0];
+
+    context.log.info(
+      `Update: slot=${event.slot} metadata=${metadataPda.slice(0, 8)}.. tx=${(txSig ?? "?").slice(0, 8)}..`,
+    );
+
+    const existing = await context.TokenMetadataAccount.get(metadataPda);
+    if (existing) {
+      context.TokenMetadataAccount.set({
+        ...existing,
+        updateAuthority,
+        lastUpdatedSlot: event.slot,
+        updateCount: existing.updateCount + 1,
+        lastTxSignature: txSig,
+      });
+    } else {
+      context.TokenMetadataAccount.set({
+        id: metadataPda,
+        mint: "",
+        updateAuthority,
+        lastUpdatedSlot: event.slot,
+        updateCount: 1,
+        createdAtSlot: event.slot,
+        lastTxSignature: txSig,
+      });
+    }
+    await bumpStats(context, "update");
+  },
+);

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/tsconfig.json
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  /* For details: https://www.totaltypescript.com/tsconfig-cheat-sheet */
+  "compilerOptions": {
+    /* Base Options: */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    /* Strictness */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    /* For running Envio: */
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+
+    /* Code doesn't run in the DOM: */
+    "lib": ["es2022"],
+    "types": ["node"]
+  }
+}

--- a/packages/envio/src/tui/Tui.res
+++ b/packages/envio/src/tui/Tui.res
@@ -13,6 +13,7 @@ module ChainLine = {
     ~endBlock,
     ~poweredByHyperSync,
     ~eventsProcessed,
+    ~blockUnit: string,
   ) => {
     let chainsWidth = Pervasives.min(stdoutColumns - 2, 60)
     let headerWidth = maxChainIdLength + 10 // 10 for additional text
@@ -27,9 +28,10 @@ module ChainLine = {
       let toBlockStr = toBlock->TuiData.formatLocaleString
       let eventsStr = eventsProcessed->TuiData.formatFloatLocaleString
 
+      let endLabel = blockUnit === "Slots" ? " (End Slot)" : " (End Block)"
       let blocksText =
-        `Blocks: ${progressBlockStr} / ${toBlockStr}` ++
-        (endBlock->Option.isSome ? " (End Block)" : "") ++ `  `
+        `${blockUnit}: ${progressBlockStr} / ${toBlockStr}` ++
+        (endBlock->Option.isSome ? endLabel : "") ++ `  `
       let eventsText = `Events: ${eventsStr}`
 
       let fitsSameLine = blocksText->String.length + eventsText->String.length <= chainsWidth
@@ -210,6 +212,10 @@ module App = {
             poweredByHyperSync: (
               cf.sourceManager->SourceManager.getActiveSource
             ).poweredByHyperSync,
+            blockUnit: switch state.ctx.config.ecosystem.name {
+            | Svm => "Slots"
+            | Evm | Fuel => "Blocks"
+            },
           }: TuiData.chain
         )
       })
@@ -249,6 +255,7 @@ module App = {
           stdoutColumns={stdoutColumns}
           poweredByHyperSync={chainData.poweredByHyperSync}
           eventsProcessed={chainData.eventsProcessed}
+          blockUnit={chainData.blockUnit}
         />
       })
       ->React.array}

--- a/packages/envio/src/tui/components/TuiData.res
+++ b/packages/envio/src/tui/components/TuiData.res
@@ -30,6 +30,9 @@ type chain = {
   progress: progress,
   latestFetchedBlockNumber: int,
   knownHeight: int,
+  /** Localized unit noun for this chain's progress. `"Slots"` on SVM,
+   `"Blocks"` everywhere else. Drives the per-chain progress label. */
+  blockUnit: string,
 }
 
 let minOfOption: (int, option<int>) => int = (a: int, b: option<int>) => {


### PR DESCRIPTION
## Summary

Demo-ready ergonomics for the Solana ecosystem. Two pieces:

1. **`envio init` Metaplex template** — `envio init svm template --template metaplex-token-metadata --language typescript` scaffolds the working Metaplex Token Metadata indexer in one command. Verified end-to-end: scaffolds, codegen runs, `envio start` indexes against the live endpoint.
2. **SVM TUI slot labels** — the progress line now says `Slots: ...` and `(End Slot)` instead of `Blocks: ...` / `(End Block)` for SVM chains. Drives off `state.ctx.config.ecosystem.name`.

**Stacked on #1221.**

## Init usage

```bash
envio init svm template \
  --name metaplex-demo --directory ./demo \
  --template metaplex-token-metadata \
  --language typescript --package-manager pnpm
```

The scaffolded project ships with:
- `config.yaml` — Metaplex Token Metadata program, both Create+Update instructions, HyperSync URL pre-populated.
- `schema.graphql` — `TokenMetadataAccount` + `ProgramStats` entities.
- `src/handlers/TokenMetadataHandlers.ts` — two `indexer.onInstruction` registrations, `context.log.info` per matched instruction.
- `README.md` — Quick-start instructions including the `curl https://solana.hypersync.xyz/height` reminder for `start_block`.

## Changes

- `init_config::svm::Template`: adds `MetaplexTokenMetadata` (in addition to `FeatureBlockHandler`).
- `template_dirs::Template for svm::Template`: maps the new variant to `templates/static/svm_metaplex_template/`.
- `packages/cli/templates/static/svm_metaplex_template/typescript/` — new template tree.
- `CommandLineHelp.md` regenerated.
- `TuiData.chain` gains `blockUnit: string`.
- `Tui.res ChainLine` reads `blockUnit` to label the progress text per ecosystem.

## Test plan

- [x] `cargo test -p envio --lib` — **264 passed, 0 failed**. The `check_cli_help_md_is_up_to_date` test caught the doc drift; help regenerated.
- [x] `pnpm rescript` clean (envio + test_codegen).
- [x] **End-to-end init**: `envio init svm template --template metaplex-token-metadata --language typescript --package-manager pnpm --directory ./demo` produces a working project (config.yaml, schema.graphql, handlers.ts, README.md, package.json, tsconfig.json). pnpm install runs, codegen runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)