### PR TITLE
Fail health check when HyperSync API has chains missing from enum

### DIFF
--- a/packages/cli/src/config_parsing/hypersync_endpoints.rs
+++ b/packages/cli/src/config_parsing/hypersync_endpoints.rs
@@ -40,6 +40,7 @@ mod test {
 #[cfg(feature = "integration_tests")]
 mod integration_tests {
     use super::{network_to_hypersync_url, HypersyncChain};
+    use crate::scripts::print_missing_networks::Diff;
     use strum::IntoEnumIterator;
 
     async fn fetch_hypersync_health(hypersync_endpoint: &str) -> anyhow::Result<bool> {
@@ -53,6 +54,20 @@ mod integration_tests {
 
     #[tokio::test]
     async fn all_supported_endpoints_are_healthy() {
+        // Iterating HypersyncChain::iter() alone only covers chains already in
+        // the enum, so chains added to the HyperSync API but missing from the
+        // enum slip through. Fail the test in that case before probing
+        // endpoints.
+        let diff = Diff::get()
+            .await
+            .expect("Failed to fetch chain diff from HyperSync API");
+        if !diff.missing_chains.is_empty() {
+            panic!(
+                "HyperSync API has chains absent from the Network enum:\n{}",
+                diff.missing_chains.join("\n")
+            );
+        }
+
         for network in HypersyncChain::iter() {
             let url = network_to_hypersync_url(&network);
             let mut last_err = None;


### PR DESCRIPTION
Previously the integration test iterated HypersyncChain::iter(), so chains added to the HyperSync API but absent from the Network enum passed silently. Fetch the diff up front and panic if any API chain is missing before probing endpoint health.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Hypersync endpoint configuration tests to validate support for all available chains, with explicit failure notifications for unsupported chains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->