### PR TITLE
Add ON CLUSTER clause to ClickHouse DDL for replicated databases

### DIFF
--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -426,6 +426,10 @@ let initialize = async (
     | Some(engine) => ` ENGINE = ${engine}`
     | None => ""
     }
+    // Replicated database engine requires CREATE DATABASE to run on every
+    // replica; ON CLUSTER fans the DDL out via Keeper. The '{cluster}' macro
+    // resolves to each node's configured cluster name.
+    let onClusterClause = replicated ? ` ON CLUSTER '{cluster}'` : ""
 
     switch databaseEngine {
     | Some(engineSpec) => {
@@ -445,9 +449,9 @@ let initialize = async (
     | None => ()
     }
 
-    await client->exec({query: `TRUNCATE DATABASE IF EXISTS ${database}`})
+    await client->exec({query: `TRUNCATE DATABASE IF EXISTS ${database}${onClusterClause}`})
     await client->exec({
-      query: `CREATE DATABASE IF NOT EXISTS ${database}${databaseEngineClause}`,
+      query: `CREATE DATABASE IF NOT EXISTS ${database}${onClusterClause}${databaseEngineClause}`,
     })
     await client->exec({query: `USE ${database}`})
 


### PR DESCRIPTION
## Summary
Adds support for ClickHouse replicated database engines by including the `ON CLUSTER '{cluster}'` clause in DDL statements when a replicated engine is configured.

## Changes
- Introduce `onClusterClause` variable that conditionally adds `ON CLUSTER '{cluster}'` when `replicated` is true
- Apply the clause to both `TRUNCATE DATABASE` and `CREATE DATABASE` statements
- The `'{cluster}'` macro resolves to each node's configured cluster name, allowing DDL to fan out via Keeper to all replicas

## Implementation Details
The `ON CLUSTER` clause is necessary for replicated database engines in ClickHouse because DDL operations must execute on every replica. Without this clause, operations would only run on the current node, causing inconsistency across the cluster.

https://claude.ai/code/session_01MUsECHUzStHEWcY5LebVLa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for replicated ClickHouse environments. Storage initialization now automatically applies cluster configuration when replication is enabled, including updates to database management operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->