### PR TITLE
Support agentic mode in `envio init` with AI-readable prompts

### DIFF
--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -83,7 +83,7 @@ Initialize an indexer with one of the initialization options
 
   Possible values: `pnpm`, `npm`, `yarn`, `bun`
 
-* `--api-token <API_TOKEN>` — The hypersync API key to be initialized in your templates .env file. Falls back to the `ENVIO_API_TOKEN` environment variable, so agents that already have it in their session don't need to pass it explicitly
+* `--api-token <API_TOKEN>` — The hypersync API key to be initialized in your templates .env file. Falls back to the `ENVIO_API_TOKEN` environment variable
 
 
 

--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -83,7 +83,7 @@ Initialize an indexer with one of the initialization options
 
   Possible values: `pnpm`, `npm`, `yarn`, `bun`
 
-* `--api-token <API_TOKEN>` — The hypersync API key to be initialized in your templates .env file
+* `--api-token <API_TOKEN>` — The hypersync API key to be initialized in your templates .env file. Falls back to the `ENVIO_API_TOKEN` environment variable, so agents that already have it in their session don't need to pass it explicitly
 
 
 

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -168,8 +168,10 @@ pub struct InitArgs {
     #[clap(value_enum)]
     pub package_manager: Option<init_config::PackageManager>,
 
-    ///The hypersync API key to be initialized in your templates .env file
-    #[arg(global = true, long)]
+    ///The hypersync API key to be initialized in your templates .env file.
+    ///Falls back to the `ENVIO_API_TOKEN` environment variable, so agents
+    ///that already have it in their session don't need to pass it explicitly.
+    #[arg(global = true, long, env = "ENVIO_API_TOKEN")]
     pub api_token: Option<String>,
 }
 

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -169,8 +169,7 @@ pub struct InitArgs {
     pub package_manager: Option<init_config::PackageManager>,
 
     ///The hypersync API key to be initialized in your templates .env file.
-    ///Falls back to the `ENVIO_API_TOKEN` environment variable, so agents
-    ///that already have it in their session don't need to pass it explicitly.
+    ///Falls back to the `ENVIO_API_TOKEN` environment variable.
     #[arg(global = true, long, env = "ENVIO_API_TOKEN")]
     pub api_token: Option<String>,
 }

--- a/packages/cli/src/executor/init.rs
+++ b/packages/cli/src/executor/init.rs
@@ -46,7 +46,7 @@ pub async fn run_init_args(
     // `Logging.error`, which wraps the message in pino's JSON envelope and
     // buries the steps the agent needs to read.
     if init_args.init_commands.is_none() && is_agentic_init_mode(&AgenticEnv::from_process()) {
-        let prompt = agentic_init_prompt(std::env::var("ENVIO_API_TOKEN").is_ok());
+        let prompt = agentic_init_prompt(init_args.api_token.is_some());
         let mut stderr = std::io::stderr().lock();
         let _ = stderr.write_all(prompt.as_bytes());
         let _ = stderr.flush();

--- a/packages/cli/src/executor/init.rs
+++ b/packages/cli/src/executor/init.rs
@@ -438,7 +438,7 @@ fn agentic_init_prompt(has_api_token: bool) -> String {
         let _ = writeln!(
             out,
             "  {step}. ENVIO_API_TOKEN is not set. Ask the user to create one at \
-             https://envio.dev/app/api-tokens and export it before continuing."
+             https://envio.dev/app/api-tokens and provide it to the session before continuing."
         );
         step += 1;
     }
@@ -462,9 +462,7 @@ fn agentic_init_prompt(has_api_token: bool) -> String {
     out.push_str("         -b ${chainId} \\\n");
     out.push_str("         --single-contract \\\n");
     out.push_str("         --all-events \\\n");
-    out.push_str("         -l typescript \\\n");
-    out.push_str("         -d ${directory} \\\n");
-    out.push_str("         --api-token=$ENVIO_API_TOKEN\n");
+    out.push_str("         -d ${directory}\n");
     out.push('\n');
     out.push_str(
         "Then `cd ${directory}` and run `pnpm test`. Don't hand the project off yet — keep \

--- a/packages/cli/src/executor/init.rs
+++ b/packages/cli/src/executor/init.rs
@@ -388,12 +388,16 @@ fn next_steps_message(project_root: &Path, pm: init_config::PackageManager) -> S
 /// Inputs that decide whether `envio init` should print an agentic prompt
 /// instead of opening interactive selects. Pulled into a struct so tests can
 /// drive the logic without touching the real process env / TTY.
+///
+/// Mirrors the predicate `Envio.isNonInteractive` in
+/// `packages/envio/src/Envio.res` so a project picks up the same TUI/agent
+/// classification at init time as it will at runtime.
 struct AgenticEnv {
     envio_tui: Option<String>,
     stdout_is_tty: bool,
     claudecode: bool,
-    cursor: bool,
-    aider: bool,
+    ci: bool,
+    term: Option<String>,
 }
 
 impl AgenticEnv {
@@ -402,20 +406,21 @@ impl AgenticEnv {
             envio_tui: std::env::var("ENVIO_TUI").ok(),
             stdout_is_tty: std::io::stdout().is_terminal(),
             claudecode: std::env::var("CLAUDECODE").is_ok(),
-            cursor: std::env::var("CURSOR").is_ok(),
-            aider: std::env::var("AIDER").is_ok(),
+            ci: std::env::var("CI").is_ok(),
+            term: std::env::var("TERM").ok(),
         }
     }
 }
 
 fn is_agentic_init_mode(env: &AgenticEnv) -> bool {
-    // Explicit user override wins in either direction.
+    // ENVIO_TUI mirrors the runtime override in `Main.res`: an explicit value
+    // wins in either direction.
     match env.envio_tui.as_deref() {
         Some("true") | Some("1") => return false,
         Some("false") | Some("0") => return true,
         _ => {}
     }
-    !env.stdout_is_tty || env.claudecode || env.cursor || env.aider
+    !env.stdout_is_tty || env.claudecode || env.ci || env.term.as_deref() == Some("dumb")
 }
 
 fn agentic_init_prompt(has_api_token: bool) -> String {
@@ -423,9 +428,10 @@ fn agentic_init_prompt(has_api_token: bool) -> String {
 
     let mut out = String::new();
     out.push_str(
-        "Welcome to Envio agentic initialization. The goal is to set up an indexer to power \
-         the user's next Blockchain Backend.\n\n",
+        "Welcome to Envio Indexer! Let's set up an indexer that will become a reliable \
+         blockchain backend you trust, love, and own.\n\n",
     );
+    out.push_str("Leave the rest to your favorite agent:\n\n");
 
     let mut step = 1;
     if !has_api_token {
@@ -461,8 +467,9 @@ fn agentic_init_prompt(has_api_token: bool) -> String {
     out.push_str("         --api-token=$ENVIO_API_TOKEN\n");
     out.push('\n');
     out.push_str(
-        "After that command finishes, run the generated `pnpm test` to confirm the indexer \
-         compiles, then hand off the project directory to the user.\n",
+        "Then `cd ${directory}` and run `pnpm test`. Don't hand the project off yet — keep \
+         iterating on the indexer with a TDD loop (extend tests, run them, fix handlers) until \
+         the user's goal is met.\n",
     );
     out
 }
@@ -525,15 +532,15 @@ mod tests {
         envio_tui: Option<&str>,
         stdout_is_tty: bool,
         claudecode: bool,
-        cursor: bool,
-        aider: bool,
+        ci: bool,
+        term: Option<&str>,
     ) -> AgenticEnv {
         AgenticEnv {
             envio_tui: envio_tui.map(str::to_string),
             stdout_is_tty,
             claudecode,
-            cursor,
-            aider,
+            ci,
+            term: term.map(str::to_string),
         }
     }
 
@@ -542,31 +549,47 @@ mod tests {
         let cases = vec![
             (
                 "plain interactive tty",
-                env(None, true, false, false, false),
+                env(None, true, false, false, Some("xterm-256color")),
                 false,
             ),
-            ("piped stdout", env(None, false, false, false, false), true),
-            ("claudecode set", env(None, true, true, false, false), true),
-            ("cursor set", env(None, true, false, true, false), true),
-            ("aider set", env(None, true, false, false, true), true),
+            (
+                "piped stdout",
+                env(None, false, false, false, Some("xterm-256color")),
+                true,
+            ),
+            (
+                "claudecode set",
+                env(None, true, true, false, Some("xterm-256color")),
+                true,
+            ),
+            (
+                "ci set",
+                env(None, true, false, true, Some("xterm-256color")),
+                true,
+            ),
+            (
+                "term=dumb",
+                env(None, true, false, false, Some("dumb")),
+                true,
+            ),
             (
                 "envio_tui=false overrides tty",
-                env(Some("false"), true, false, false, false),
+                env(Some("false"), true, false, false, Some("xterm-256color")),
                 true,
             ),
             (
                 "envio_tui=true overrides agent",
-                env(Some("true"), false, true, false, false),
+                env(Some("true"), false, true, false, Some("dumb")),
                 false,
             ),
             (
                 "envio_tui=1 forces interactive",
-                env(Some("1"), false, true, false, false),
+                env(Some("1"), false, true, true, Some("dumb")),
                 false,
             ),
             (
                 "envio_tui=0 forces agentic",
-                env(Some("0"), true, false, false, false),
+                env(Some("0"), true, false, false, Some("xterm-256color")),
                 true,
             ),
         ];

--- a/packages/cli/src/executor/init.rs
+++ b/packages/cli/src/executor/init.rs
@@ -19,10 +19,15 @@ use crate::{
     template_dirs::TemplateDirs,
     utils::file_system,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
 use std::path::Path;
+
+/// Exit code used when `envio init` short-circuits with an agent prompt.
+/// Distinct from 1 (generic failure) so coding agents can tell "the user
+/// needs to take a follow-up step" from "the command actually failed".
+pub const AGENTIC_INIT_EXIT_CODE: i32 = 2;
 
 pub async fn run_init_args(
     init_args: InitArgs,
@@ -35,11 +40,17 @@ pub async fn run_init_args(
     // agent (or otherwise running non-interactively), short-circuit with an
     // agent-readable prompt instead of stalling on an `inquire` Select that
     // can't be answered.
+    //
+    // Writing straight to stderr + `process::exit` keeps the prompt pristine:
+    // routing it through `anyhow::bail!` would pass it through the JS host's
+    // `Logging.error`, which wraps the message in pino's JSON envelope and
+    // buries the steps the agent needs to read.
     if init_args.init_commands.is_none() && is_agentic_init_mode(&AgenticEnv::from_process()) {
-        return Err(anyhow!(
-            "{}",
-            agentic_init_prompt(std::env::var("ENVIO_API_TOKEN").is_ok())
-        ));
+        let prompt = agentic_init_prompt(std::env::var("ENVIO_API_TOKEN").is_ok());
+        let mut stderr = std::io::stderr().lock();
+        let _ = stderr.write_all(prompt.as_bytes());
+        let _ = stderr.flush();
+        std::process::exit(AGENTIC_INIT_EXIT_CODE);
     }
 
     //get_init_args_interactive opens an interactive cli for required args to be selected

--- a/packages/cli/src/executor/init.rs
+++ b/packages/cli/src/executor/init.rs
@@ -19,8 +19,9 @@ use crate::{
     template_dirs::TemplateDirs,
     utils::file_system,
 };
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 
+use std::io::IsTerminal;
 use std::path::Path;
 
 pub async fn run_init_args(
@@ -29,6 +30,18 @@ pub async fn run_init_args(
     envio_package_dir: Option<&str>,
 ) -> Result<()> {
     let template_dirs = TemplateDirs::new();
+
+    // When no subcommand is given and we detect we're being driven by an AI
+    // agent (or otherwise running non-interactively), short-circuit with an
+    // agent-readable prompt instead of stalling on an `inquire` Select that
+    // can't be answered.
+    if init_args.init_commands.is_none() && is_agentic_init_mode(&AgenticEnv::from_process()) {
+        return Err(anyhow!(
+            "{}",
+            agentic_init_prompt(std::env::var("ENVIO_API_TOKEN").is_ok())
+        ));
+    }
+
     //get_init_args_interactive opens an interactive cli for required args to be selected
     //if they haven't already been
     let init_config = prompt_missing_init_args(init_args, project_paths)
@@ -361,6 +374,88 @@ fn next_steps_message(project_root: &Path, pm: init_config::PackageManager) -> S
     out
 }
 
+/// Inputs that decide whether `envio init` should print an agentic prompt
+/// instead of opening interactive selects. Pulled into a struct so tests can
+/// drive the logic without touching the real process env / TTY.
+struct AgenticEnv {
+    envio_tui: Option<String>,
+    stdout_is_tty: bool,
+    claudecode: bool,
+    cursor: bool,
+    aider: bool,
+}
+
+impl AgenticEnv {
+    fn from_process() -> Self {
+        Self {
+            envio_tui: std::env::var("ENVIO_TUI").ok(),
+            stdout_is_tty: std::io::stdout().is_terminal(),
+            claudecode: std::env::var("CLAUDECODE").is_ok(),
+            cursor: std::env::var("CURSOR").is_ok(),
+            aider: std::env::var("AIDER").is_ok(),
+        }
+    }
+}
+
+fn is_agentic_init_mode(env: &AgenticEnv) -> bool {
+    // Explicit user override wins in either direction.
+    match env.envio_tui.as_deref() {
+        Some("true") | Some("1") => return false,
+        Some("false") | Some("0") => return true,
+        _ => {}
+    }
+    !env.stdout_is_tty || env.claudecode || env.cursor || env.aider
+}
+
+fn agentic_init_prompt(has_api_token: bool) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    out.push_str(
+        "Welcome to Envio agentic initialization. The goal is to set up an indexer to power \
+         the user's next Blockchain Backend.\n\n",
+    );
+
+    let mut step = 1;
+    if !has_api_token {
+        let _ = writeln!(
+            out,
+            "  {step}. ENVIO_API_TOKEN is not set. Ask the user to create one at \
+             https://envio.dev/app/api-tokens and export it before continuing."
+        );
+        step += 1;
+    }
+    let _ = writeln!(
+        out,
+        "  {step}. Prompt the user for the project intent if it is missing from context \
+         (what should the indexer track and surface?)."
+    );
+    step += 1;
+    let _ = writeln!(
+        out,
+        "  {step}. Determine the chain, contract, and addresses needed to produce that result. \
+         Use web search or block-explorer tool calls when the user hasn't supplied them."
+    );
+    step += 1;
+    let _ = writeln!(out, "  {step}. To continue, call:");
+    out.push('\n');
+    out.push_str("       pnpx envio init contract-import explorer \\\n");
+    out.push_str("         -n ${indexer-name} \\\n");
+    out.push_str("         -c ${address} \\\n");
+    out.push_str("         -b ${chainId} \\\n");
+    out.push_str("         --single-contract \\\n");
+    out.push_str("         --all-events \\\n");
+    out.push_str("         -l typescript \\\n");
+    out.push_str("         -d ${directory} \\\n");
+    out.push_str("         --api-token=$ENVIO_API_TOKEN\n");
+    out.push('\n');
+    out.push_str(
+        "After that command finishes, run the generated `pnpm test` to confirm the indexer \
+         compiles, then hand off the project directory to the user.\n",
+    );
+    out
+}
+
 /// Leave alphanumeric paths unquoted; single-quote anything containing chars
 /// the shell would interpret (spaces, `$`, backticks, `&`, `;`, etc.) so the
 /// printed `cd <path>` is safe to paste. Folder name validation rejects `'`,
@@ -413,5 +508,77 @@ mod tests {
     #[test]
     fn next_steps_in_current_dir_alias() {
         insta::assert_snapshot!(next_steps_message(Path::new("./"), PackageManager::Npm));
+    }
+
+    fn env(
+        envio_tui: Option<&str>,
+        stdout_is_tty: bool,
+        claudecode: bool,
+        cursor: bool,
+        aider: bool,
+    ) -> AgenticEnv {
+        AgenticEnv {
+            envio_tui: envio_tui.map(str::to_string),
+            stdout_is_tty,
+            claudecode,
+            cursor,
+            aider,
+        }
+    }
+
+    #[test]
+    fn agentic_mode_detection_matrix() {
+        let cases = vec![
+            (
+                "plain interactive tty",
+                env(None, true, false, false, false),
+                false,
+            ),
+            ("piped stdout", env(None, false, false, false, false), true),
+            ("claudecode set", env(None, true, true, false, false), true),
+            ("cursor set", env(None, true, false, true, false), true),
+            ("aider set", env(None, true, false, false, true), true),
+            (
+                "envio_tui=false overrides tty",
+                env(Some("false"), true, false, false, false),
+                true,
+            ),
+            (
+                "envio_tui=true overrides agent",
+                env(Some("true"), false, true, false, false),
+                false,
+            ),
+            (
+                "envio_tui=1 forces interactive",
+                env(Some("1"), false, true, false, false),
+                false,
+            ),
+            (
+                "envio_tui=0 forces agentic",
+                env(Some("0"), true, false, false, false),
+                true,
+            ),
+        ];
+
+        let report: String = cases
+            .into_iter()
+            .map(|(label, env, expected)| {
+                let got = is_agentic_init_mode(&env);
+                assert_eq!(got, expected, "case {label}");
+                format!("{label}: {got}")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        insta::assert_snapshot!(report);
+    }
+
+    #[test]
+    fn agentic_prompt_without_api_token() {
+        insta::assert_snapshot!(agentic_init_prompt(false));
+    }
+
+    #[test]
+    fn agentic_prompt_with_api_token() {
+        insta::assert_snapshot!(agentic_init_prompt(true));
     }
 }

--- a/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_mode_detection_matrix.snap
+++ b/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_mode_detection_matrix.snap
@@ -5,8 +5,8 @@ expression: report
 plain interactive tty: false
 piped stdout: true
 claudecode set: true
-cursor set: true
-aider set: true
+ci set: true
+term=dumb: true
 envio_tui=false overrides tty: true
 envio_tui=true overrides agent: false
 envio_tui=1 forces interactive: false

--- a/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_mode_detection_matrix.snap
+++ b/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_mode_detection_matrix.snap
@@ -1,0 +1,13 @@
+---
+source: packages/cli/src/executor/init.rs
+expression: report
+---
+plain interactive tty: false
+piped stdout: true
+claudecode set: true
+cursor set: true
+aider set: true
+envio_tui=false overrides tty: true
+envio_tui=true overrides agent: false
+envio_tui=1 forces interactive: false
+envio_tui=0 forces agentic: true

--- a/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_with_api_token.snap
+++ b/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_with_api_token.snap
@@ -1,0 +1,21 @@
+---
+source: packages/cli/src/executor/init.rs
+expression: agentic_init_prompt(true)
+---
+Welcome to Envio agentic initialization. The goal is to set up an indexer to power the user's next Blockchain Backend.
+
+  1. Prompt the user for the project intent if it is missing from context (what should the indexer track and surface?).
+  2. Determine the chain, contract, and addresses needed to produce that result. Use web search or block-explorer tool calls when the user hasn't supplied them.
+  3. To continue, call:
+
+       pnpx envio init contract-import explorer \
+         -n ${indexer-name} \
+         -c ${address} \
+         -b ${chainId} \
+         --single-contract \
+         --all-events \
+         -l typescript \
+         -d ${directory} \
+         --api-token=$ENVIO_API_TOKEN
+
+After that command finishes, run the generated `pnpm test` to confirm the indexer compiles, then hand off the project directory to the user.

--- a/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_with_api_token.snap
+++ b/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_with_api_token.snap
@@ -2,7 +2,9 @@
 source: packages/cli/src/executor/init.rs
 expression: agentic_init_prompt(true)
 ---
-Welcome to Envio agentic initialization. The goal is to set up an indexer to power the user's next Blockchain Backend.
+Welcome to Envio Indexer! Let's set up an indexer that will become a reliable blockchain backend you trust, love, and own.
+
+Leave the rest to your favorite agent:
 
   1. Prompt the user for the project intent if it is missing from context (what should the indexer track and surface?).
   2. Determine the chain, contract, and addresses needed to produce that result. Use web search or block-explorer tool calls when the user hasn't supplied them.
@@ -18,4 +20,4 @@ Welcome to Envio agentic initialization. The goal is to set up an indexer to pow
          -d ${directory} \
          --api-token=$ENVIO_API_TOKEN
 
-After that command finishes, run the generated `pnpm test` to confirm the indexer compiles, then hand off the project directory to the user.
+Then `cd ${directory}` and run `pnpm test`. Don't hand the project off yet — keep iterating on the indexer with a TDD loop (extend tests, run them, fix handlers) until the user's goal is met.

--- a/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_with_api_token.snap
+++ b/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_with_api_token.snap
@@ -16,8 +16,6 @@ Leave the rest to your favorite agent:
          -b ${chainId} \
          --single-contract \
          --all-events \
-         -l typescript \
-         -d ${directory} \
-         --api-token=$ENVIO_API_TOKEN
+         -d ${directory}
 
 Then `cd ${directory}` and run `pnpm test`. Don't hand the project off yet — keep iterating on the indexer with a TDD loop (extend tests, run them, fix handlers) until the user's goal is met.

--- a/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_without_api_token.snap
+++ b/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_without_api_token.snap
@@ -1,0 +1,22 @@
+---
+source: packages/cli/src/executor/init.rs
+expression: agentic_init_prompt(false)
+---
+Welcome to Envio agentic initialization. The goal is to set up an indexer to power the user's next Blockchain Backend.
+
+  1. ENVIO_API_TOKEN is not set. Ask the user to create one at https://envio.dev/app/api-tokens and export it before continuing.
+  2. Prompt the user for the project intent if it is missing from context (what should the indexer track and surface?).
+  3. Determine the chain, contract, and addresses needed to produce that result. Use web search or block-explorer tool calls when the user hasn't supplied them.
+  4. To continue, call:
+
+       pnpx envio init contract-import explorer \
+         -n ${indexer-name} \
+         -c ${address} \
+         -b ${chainId} \
+         --single-contract \
+         --all-events \
+         -l typescript \
+         -d ${directory} \
+         --api-token=$ENVIO_API_TOKEN
+
+After that command finishes, run the generated `pnpm test` to confirm the indexer compiles, then hand off the project directory to the user.

--- a/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_without_api_token.snap
+++ b/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_without_api_token.snap
@@ -2,7 +2,9 @@
 source: packages/cli/src/executor/init.rs
 expression: agentic_init_prompt(false)
 ---
-Welcome to Envio agentic initialization. The goal is to set up an indexer to power the user's next Blockchain Backend.
+Welcome to Envio Indexer! Let's set up an indexer that will become a reliable blockchain backend you trust, love, and own.
+
+Leave the rest to your favorite agent:
 
   1. ENVIO_API_TOKEN is not set. Ask the user to create one at https://envio.dev/app/api-tokens and export it before continuing.
   2. Prompt the user for the project intent if it is missing from context (what should the indexer track and surface?).
@@ -19,4 +21,4 @@ Welcome to Envio agentic initialization. The goal is to set up an indexer to pow
          -d ${directory} \
          --api-token=$ENVIO_API_TOKEN
 
-After that command finishes, run the generated `pnpm test` to confirm the indexer compiles, then hand off the project directory to the user.
+Then `cd ${directory}` and run `pnpm test`. Don't hand the project off yet — keep iterating on the indexer with a TDD loop (extend tests, run them, fix handlers) until the user's goal is met.

--- a/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_without_api_token.snap
+++ b/packages/cli/src/executor/snapshots/envio__executor__init__tests__agentic_prompt_without_api_token.snap
@@ -6,7 +6,7 @@ Welcome to Envio Indexer! Let's set up an indexer that will become a reliable bl
 
 Leave the rest to your favorite agent:
 
-  1. ENVIO_API_TOKEN is not set. Ask the user to create one at https://envio.dev/app/api-tokens and export it before continuing.
+  1. ENVIO_API_TOKEN is not set. Ask the user to create one at https://envio.dev/app/api-tokens and provide it to the session before continuing.
   2. Prompt the user for the project intent if it is missing from context (what should the indexer track and surface?).
   3. Determine the chain, contract, and addresses needed to produce that result. Use web search or block-explorer tool calls when the user hasn't supplied them.
   4. To continue, call:
@@ -17,8 +17,6 @@ Leave the rest to your favorite agent:
          -b ${chainId} \
          --single-contract \
          --all-events \
-         -l typescript \
-         -d ${directory} \
-         --api-token=$ENVIO_API_TOKEN
+         -d ${directory}
 
 Then `cd ${directory}` and run `pnpm test`. Don't hand the project off yet — keep iterating on the indexer with a TDD loop (extend tests, run them, fix handlers) until the user's goal is met.


### PR DESCRIPTION
## Summary

Adds detection and handling of non-interactive/agentic execution environments in `envio init`. When running without a subcommand in an agentic context (detected via TTY status, environment variables like `CLAUDECODE`/`CI`, or explicit `ENVIO_TUI` override), the command now exits with a distinct code and prints structured instructions for AI agents instead of stalling on interactive prompts.

## Key Changes

- **Agentic mode detection**: New `AgenticEnv` struct and `is_agentic_init_mode()` function that mirrors the runtime non-interactive predicate from `Envio.res`. Detects agentic contexts via:
  - Piped stdout (not a TTY)
  - `CLAUDECODE` or `CI` environment variables
  - `TERM=dumb`
  - Explicit `ENVIO_TUI` override (supports `true`/`false`, `1`/`0`)

- **Agent-readable prompt**: `agentic_init_prompt()` generates structured instructions for AI agents, including:
  - Conditional step for setting `ENVIO_API_TOKEN` if missing
  - Steps to gather project intent and determine chain/contract details
  - Ready-to-run `pnpx envio init` command with template variables
  - Guidance on iterating with TDD after setup

- **Early exit with distinct code**: When agentic mode is detected and no subcommand is provided, writes prompt directly to stderr and exits with code `2` (distinct from generic failure code `1`), allowing agents to distinguish "user action needed" from "command failed".

- **API token environment variable**: `--api-token` now falls back to `ENVIO_API_TOKEN` environment variable via clap's `env` attribute, enabling agents to pass credentials without CLI flags.

- **Comprehensive test coverage**: Added test matrix for mode detection logic and snapshot tests for both prompt variants (with/without API token).

## Implementation Details

- Prompt is written directly to stderr and flushed before exit to avoid being wrapped by the JS host's logging layer (which would bury the agent-readable instructions in JSON).
- `AgenticEnv` is a testable struct rather than reading process state directly, enabling thorough test coverage of the detection logic without mocking.
- Exit code `2` is documented as `AGENTIC_INIT_EXIT_CODE` for clarity and future reference.

https://claude.ai/code/session_01DET8bnkuZ1tCzvtpojBb3b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `envio init` now detects non-interactive/agentic environments, emits an agent-readable setup prompt to stderr, and exits with a dedicated exit code instead of opening interactive prompts.
  * The `--api-token <API_TOKEN>` option now falls back to the ENVIO_API_TOKEN environment variable.

* **Documentation**
  * Help text for `envio init` clarified to mention the environment-variable fallback for the API token.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->