### PR TITLE
Remove cargo-cache action from build-platforms workflow

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -32,10 +32,6 @@ jobs:
         with:
           targets: ${{ matrix.job.target }}
 
-      - uses: ./.github/actions/cargo-cache
-        with:
-          cache-suffix: ${{ matrix.job.target }}
-
       - name: Patch Cargo.toml version
         shell: bash
         run: sed -i.bak "s/^version = .*/version = \"${{ inputs.version }}\"/" packages/cli/Cargo.toml

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           targets: ${{ matrix.job.target }}
 
+      # No cargo cache here — this workflow produces published binaries,
+      # and a poisoned cache could inject tampered artifacts.
+
       - name: Patch Cargo.toml version
         shell: bash
         run: sed -i.bak "s/^version = .*/version = \"${{ inputs.version }}\"/" packages/cli/Cargo.toml


### PR DESCRIPTION
Removes the cargo-cache action step from the build-platforms CI workflow.

## Changes
- Removed the `./.github/actions/cargo-cache` action invocation that was caching Cargo artifacts per target platform

## Rationale
This simplifies the CI workflow by eliminating the per-target cargo caching step. This may reduce CI complexity or address issues with the caching strategy for multi-platform builds.

https://claude.ai/code/session_014sbg79Er1e6Mw2QTMeLuYE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform build workflow configuration to enhance build integrity and security practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->