### PR TITLE
Make InMemoryStore a per-indexer singleton

### DIFF
--- a/packages/envio/package.json
+++ b/packages/envio/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/enviodev/hyperindex.git"
   },
   "scripts": {
-    "build": "pnpx rescript",
+    "build": "rescript",
     "watch": "rescript watch"
   },
   "author": "envio contributors <about@envio.dev>",

--- a/packages/envio/package.json
+++ b/packages/envio/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/enviodev/hyperindex.git"
   },
   "scripts": {
+    "build": "pnpx rescript",
     "watch": "rescript watch"
   },
   "author": "envio contributors <about@envio.dev>",

--- a/packages/envio/src/Ctx.res
+++ b/packages/envio/src/Ctx.res
@@ -2,4 +2,5 @@ type t = {
   registrations: HandlerRegister.registrations,
   config: Config.t,
   persistence: Persistence.t,
+  inMemoryStore: InMemoryStore.t,
 }

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -999,13 +999,9 @@ let injectedTaskReducer = (
           dispatchAction(UpdateQueues({progressedChainsById, shouldEnterReorgThreshold}))
 
           let inMemoryStore = state.ctx.inMemoryStore
-          if !isRollbackBatch {
-            inMemoryStore->InMemoryStore.clear
-          }
-
           inMemoryStore->InMemoryStore.setBatchDcs(~batch, ~shouldSaveHistory)
 
-          switch await EventProcessing.processEventBatch(
+          let result = switch await EventProcessing.processEventBatch(
             ~batch,
             ~inMemoryStore,
             ~isInReorgThreshold,
@@ -1016,16 +1012,19 @@ let injectedTaskReducer = (
           | exception exn =>
             //All casese should be handled/caught before this with better user messaging.
             //This is just a safety in case something unexpected happens
-            let errHandler =
+            Error(
               exn->ErrorHandling.make(
                 ~msg="A top level unexpected error occurred during processing",
-              )
-            dispatchAction(ErrorExit(errHandler))
-          | res =>
-            switch res {
-            | Ok() => dispatchAction(EventBatchProcessed({batch: batch}))
-            | Error(errHandler) => dispatchAction(ErrorExit(errHandler))
-            }
+              ),
+            )
+          | res => res
+          }
+
+          inMemoryStore->InMemoryStore.clear
+
+          switch result {
+          | Ok() => dispatchAction(EventBatchProcessed({batch: batch}))
+          | Error(errHandler) => dispatchAction(ErrorExit(errHandler))
           }
         }
       }
@@ -1180,8 +1179,6 @@ let injectedTaskReducer = (
           }
         })
 
-        // Populate the singleton in-memory store with the rollback diff
-        state.ctx.inMemoryStore->InMemoryStore.clear
         let diff = await state.ctx.persistence->Persistence.prepareRollbackDiff(
           ~inMemoryStore=state.ctx.inMemoryStore,
           ~rollbackTargetCheckpointId,

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -670,6 +670,7 @@ let actionReducer = (state: t, action: action) => {
       ~chain,
     )
   | EventBatchProcessed({batch}) =>
+    state.ctx.inMemoryStore->InMemoryStore.clear
     let maybePruneEntityHistory =
       state.ctx.config->Config.shouldPruneHistory(
         ~isInReorgThreshold=state.chainManager.isInReorgThreshold,
@@ -1001,7 +1002,7 @@ let injectedTaskReducer = (
           let inMemoryStore = state.ctx.inMemoryStore
           inMemoryStore->InMemoryStore.setBatchDcs(~batch, ~shouldSaveHistory)
 
-          let result = switch await EventProcessing.processEventBatch(
+          switch await EventProcessing.processEventBatch(
             ~batch,
             ~inMemoryStore,
             ~isInReorgThreshold,
@@ -1012,19 +1013,16 @@ let injectedTaskReducer = (
           | exception exn =>
             //All casese should be handled/caught before this with better user messaging.
             //This is just a safety in case something unexpected happens
-            Error(
+            let errHandler =
               exn->ErrorHandling.make(
                 ~msg="A top level unexpected error occurred during processing",
-              ),
-            )
-          | res => res
-          }
-
-          inMemoryStore->InMemoryStore.clear
-
-          switch result {
-          | Ok() => dispatchAction(EventBatchProcessed({batch: batch}))
-          | Error(errHandler) => dispatchAction(ErrorExit(errHandler))
+              )
+            dispatchAction(ErrorExit(errHandler))
+          | res =>
+            switch res {
+            | Ok() => dispatchAction(EventBatchProcessed({batch: batch}))
+            | Error(errHandler) => dispatchAction(ErrorExit(errHandler))
+            }
           }
         }
       }

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -4,7 +4,7 @@ type rollbackState =
   | ReorgDetected({chain: chain, blockNumber: int})
   | FindingReorgDepth
   | FoundReorgDepth({chain: chain, rollbackTargetBlockNumber: int})
-  | RollbackReady({diffInMemoryStore: InMemoryStore.t, eventsProcessedDiffByChain: dict<float>})
+  | RollbackReady({eventsProcessedDiffByChain: dict<float>})
 
 module WriteThrottlers = {
   type t = {
@@ -132,7 +132,6 @@ type action =
   | SuccessExit
   | ErrorExit(ErrorHandling.t)
   | SetRollbackState({
-      diffInMemoryStore: InMemoryStore.t,
       rollbackedChainManager: ChainManager.t,
       eventsProcessedDiffByChain: dict<float>,
     })
@@ -764,12 +763,11 @@ let actionReducer = (state: t, action: action) => {
       },
       [NextQuery(CheckAllChains)],
     )
-  | SetRollbackState({diffInMemoryStore, rollbackedChainManager, eventsProcessedDiffByChain}) => (
+  | SetRollbackState({rollbackedChainManager, eventsProcessedDiffByChain}) => (
       {
         ...state,
         rollbackState: RollbackReady({
-          diffInMemoryStore,
-          eventsProcessedDiffByChain,
+          eventsProcessedDiffByChain: eventsProcessedDiffByChain,
         }),
         chainManager: rollbackedChainManager,
       },
@@ -946,17 +944,15 @@ let injectedTaskReducer = (
       }
     | ProcessEventBatch =>
       if !state.currentlyProcessingBatch && !isPreparingRollback(state) {
-        //In the case of a rollback, use the provided in memory store
-        //With rolled back values
-        let rollbackInMemStore = switch state.rollbackState {
-        | RollbackReady({diffInMemoryStore}) => Some(diffInMemoryStore)
-        | _ => None
+        let isRollbackBatch = switch state.rollbackState {
+        | RollbackReady(_) => true
+        | _ => false
         }
 
         let batch =
           state.chainManager->ChainManager.createBatch(
             ~batchSizeTarget=state.ctx.config.batchSize,
-            ~isRollback=rollbackInMemStore !== None,
+            ~isRollback=isRollbackBatch,
           )
 
         let progressedChainsById = batch.progressedChainsById
@@ -1002,10 +998,10 @@ let injectedTaskReducer = (
           dispatchAction(StartProcessingBatch)
           dispatchAction(UpdateQueues({progressedChainsById, shouldEnterReorgThreshold}))
 
-          let inMemoryStore =
-            rollbackInMemStore->Option.getOr(
-              InMemoryStore.make(~entities=state.ctx.persistence.allEntities),
-            )
+          let inMemoryStore = state.ctx.inMemoryStore
+          if !isRollbackBatch {
+            inMemoryStore->InMemoryStore.clear
+          }
 
           inMemoryStore->InMemoryStore.setBatchDcs(~batch, ~shouldSaveHistory)
 
@@ -1184,8 +1180,10 @@ let injectedTaskReducer = (
           }
         })
 
-        // Construct in Memory store with rollback diff
+        // Populate the singleton in-memory store with the rollback diff
+        state.ctx.inMemoryStore->InMemoryStore.clear
         let diff = await state.ctx.persistence->Persistence.prepareRollbackDiff(
+          ~inMemoryStore=state.ctx.inMemoryStore,
           ~rollbackTargetCheckpointId,
           ~rollbackDiffCheckpointId=state.chainManager.committedCheckpointId->BigInt.add(1n),
         )
@@ -1212,7 +1210,6 @@ let injectedTaskReducer = (
 
         dispatchAction(
           SetRollbackState({
-            diffInMemoryStore: diff["inMemStore"],
             rollbackedChainManager: chainManager,
             eventsProcessedDiffByChain,
           }),

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -47,20 +47,30 @@ type effectCacheInMemTable = {
 }
 
 type t = {
-  rawEvents: InMemoryTable.t<rawEventsKey, InternalTable.RawEvents.t>,
-  entities: dict<InMemoryTable.Entity.t<Internal.entity>>,
-  effects: dict<effectCacheInMemTable>,
-  rollbackTargetCheckpointId: option<Internal.checkpointId>,
+  allEntities: array<Internal.entityConfig>,
+  mutable rawEvents: InMemoryTable.t<rawEventsKey, InternalTable.RawEvents.t>,
+  mutable entities: dict<InMemoryTable.Entity.t<Internal.entity>>,
+  mutable effects: dict<effectCacheInMemTable>,
+  mutable rollbackTargetCheckpointId: option<Internal.checkpointId>,
 }
 
 let make = (~entities: array<Internal.entityConfig>, ~rollbackTargetCheckpointId=?): t => {
+  allEntities: entities,
   rawEvents: InMemoryTable.make(~hash=hashRawEventsKey),
   entities: EntityTables.make(entities),
   effects: Dict.make(),
   rollbackTargetCheckpointId,
 }
 
+let clear = (self: t) => {
+  self.rawEvents = InMemoryTable.make(~hash=hashRawEventsKey)
+  self.entities = EntityTables.make(self.allEntities)
+  self.effects = Dict.make()
+  self.rollbackTargetCheckpointId = None
+}
+
 let clone = (self: t) => {
+  allEntities: self.allEntities,
   rawEvents: self.rawEvents->InMemoryTable.clone,
   entities: self.entities->EntityTables.clone,
   effects: Dict.mapValues(self.effects, table => {

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -30,13 +30,6 @@ module EntityTables = {
       )
     }
   }
-
-  let clone = (self: t) => {
-    self
-    ->Dict.toArray
-    ->Belt.Array.map(((k, v)) => (k, v->InMemoryTable.Entity.clone))
-    ->Dict.fromArray
-  }
 }
 
 type effectCacheInMemTable = {
@@ -67,19 +60,6 @@ let clear = (self: t) => {
   self.entities = EntityTables.make(self.allEntities)
   self.effects = Dict.make()
   self.rollbackTargetCheckpointId = None
-}
-
-let clone = (self: t) => {
-  allEntities: self.allEntities,
-  rawEvents: self.rawEvents->InMemoryTable.clone,
-  entities: self.entities->EntityTables.clone,
-  effects: Dict.mapValues(self.effects, table => {
-    idsToStore: table.idsToStore->Array.copy,
-    invalidationsCount: table.invalidationsCount,
-    dict: table.dict->Utils.Dict.shallowCopy,
-    effect: table.effect,
-  }),
-  rollbackTargetCheckpointId: self.rollbackTargetCheckpointId,
 }
 
 let getEffectInMemTable = (inMemoryStore: t, ~effect: Internal.effect) => {

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -25,11 +25,6 @@ let get = (self: t<'key, 'val>, key: 'key) =>
 
 let values = (self: t<'key, 'val>) => self.dict->Dict.valuesToArray
 
-let clone = (self: t<'key, 'val>) => {
-  ...self,
-  dict: self.dict->Lodash.cloneDeep,
-}
-
 module Entity = {
   type relatedEntityId = string
   type indexWithRelatedIds = (TableIndices.Index.t, Utils.Set.t<relatedEntityId>)
@@ -347,16 +342,5 @@ module Entity = {
     inMemTable.table
     ->values
     ->Array.filterMap(rowToEntity)
-  }
-
-  let clone = ({table, fieldNameIndices}: t<'entity>) => {
-    table: table->clone,
-    fieldNameIndices: {
-      ...fieldNameIndices,
-      dict: fieldNameIndices.dict
-      ->Dict.toArray
-      ->Array.map(((k, v)) => (k, v->clone))
-      ->Dict.fromArray,
-    },
   }
 }

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -690,6 +690,7 @@ let start = async (
     Ctx.registrations,
     config,
     persistence,
+    inMemoryStore: InMemoryStore.make(~entities=persistence.allEntities),
   }
 
   let envioVersion = Utils.EnvioPackage.value.version

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -340,6 +340,7 @@ let prepareRollbackDiff = async (
   ~rollbackTargetCheckpointId,
   ~rollbackDiffCheckpointId,
 ) => {
+  inMemoryStore->InMemoryStore.clear
   inMemoryStore.rollbackTargetCheckpointId = Some(rollbackTargetCheckpointId)
 
   let deletedEntities = Dict.make()

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -336,20 +336,18 @@ let writeBatch = (
 
 let prepareRollbackDiff = async (
   persistence: t,
+  ~inMemoryStore: InMemoryStore.t,
   ~rollbackTargetCheckpointId,
   ~rollbackDiffCheckpointId,
 ) => {
-  let inMemStore = InMemoryStore.make(
-    ~entities=persistence.allEntities,
-    ~rollbackTargetCheckpointId,
-  )
+  inMemoryStore.rollbackTargetCheckpointId = Some(rollbackTargetCheckpointId)
 
   let deletedEntities = Dict.make()
   let setEntities = Dict.make()
 
   let _ = await persistence.allEntities
   ->Belt.Array.map(async entityConfig => {
-    let entityTable = inMemStore->InMemoryStore.getInMemTable(~entityConfig)
+    let entityTable = inMemoryStore->InMemoryStore.getInMemTable(~entityConfig)
 
     let (removedIdsResult, restoredEntitiesResult) = await persistence.storage.getRollbackData(
       ~entityConfig,
@@ -388,7 +386,6 @@ let prepareRollbackDiff = async (
   ->Promise.all
 
   {
-    "inMemStore": inMemStore,
     "deletedEntities": deletedEntities,
     "setEntities": setEntities,
   }

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -331,6 +331,7 @@ module Indexer = {
       Ctx.registrations,
       config,
       persistence,
+      inMemoryStore: InMemoryStore.make(),
     }
 
     let graphqlClient = Rest.client(`${Env.Hasura.url}/v1/graphql`)


### PR DESCRIPTION
## Summary

- `InMemoryStore.t` is now allocated once per indexer (on `Ctx.t`) instead of per batch. Top-level fields are `mutable`; `clear` reassigns each to a fresh empty value rather than rebuilding the record.
- Clearing runs in the `EventBatchProcessed` reducer, so the store is reset as part of finishing a batch.
- `Persistence.prepareRollbackDiff` now takes the singleton, clears it itself, and populates it in place — `RollbackReady` no longer carries a separate store reference.
- Dropped unused `clone` helpers on `InMemoryStore`, `EntityTables`, and `InMemoryTable` (only referenced each other).
- Added `build` script to `packages/envio/package.json`.

## Test plan

- [x] `pnpm build` in `packages/envio` (rescript compile clean)
- [x] `pnpx rescript` in `scenarios/test_codegen` (compile clean)
- [x] `vitest run` in `scenarios/test_codegen` — 550 passed, 3 skipped, 0 failed
- [ ] Manual smoke of a running indexer with reorg-triggered rollback

https://claude.ai/code/session_01CQJbze6rXVDt85XnX6Cd67

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQJbze6rXVDt85XnX6Cd67)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build script configuration.

* **Refactor**
  * Improved in-memory state management efficiency by replacing clone-based patterns with targeted state clearing and reuse.
  * Optimized rollback handling to streamline internal state tracking and reduce memory overhead.
  * Enhanced initialization of in-memory state from persisted data on startup.

* **Tests**
  * Updated test helper to reflect state management changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->