### PR TITLE
Fix onBlock-only indexers getting stuck on resume

### DIFF
--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1674,7 +1674,7 @@ let make = (
   | None => ()
   }
 
-  {
+  let initialState = {
     optimizedPartitions,
     contractConfigs,
     chainId,
@@ -1689,6 +1689,16 @@ let make = (
     knownHeight,
     buffer: [],
     firstEventBlock,
+  }
+
+  // On resume, knownHeight is restored from the DB but the buffer starts empty.
+  // Without this, onBlock-only indexers (e.g. SVM onSlot) get stuck: getNextQuery
+  // returns NothingToQuery because there are no partitions to drive fetching,
+  // and no one calls updateInternal to populate the buffer.
+  if knownHeight > 0 && onBlockConfigs->Utils.Array.notEmpty {
+    initialState->updateInternal(~knownHeight)
+  } else {
+    initialState
   }
 }
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
@@ -32,7 +32,7 @@ let makeOnBlockConfig = (
   handler: Utils.magic("mock handler"),
 }
 
-let makeInitialWithOnBlock = (~startBlock=0, ~onBlockConfigs) => {
+let makeInitialWithOnBlock = (~startBlock=0, ~knownHeight=0, ~progressBlockNumber=?, ~onBlockConfigs) => {
   FetchState.make(
     ~eventConfigs=[baseEventConfig],
     ~addresses=[
@@ -48,7 +48,8 @@ let makeInitialWithOnBlock = (~startBlock=0, ~onBlockConfigs) => {
     ~targetBufferSize=5000,
     ~chainId,
     ~onBlockConfigs?,
-    ~knownHeight=0,
+    ~knownHeight,
+    ~progressBlockNumber?,
   )
 }
 
@@ -305,5 +306,56 @@ describe("FetchState onBlock functionality", () => {
       blockNumberLogIndexTuples,
       ~message="Should have correct block number and log index tuples",
     ).toEqual(expectedTuples)
+  })
+
+  it("should populate buffer on resume when knownHeight > progressBlockNumber (onBlock-only)", t => {
+    // Simulates SVM onSlot-only indexer: no event configs, no addresses, only onBlock handlers.
+    // On resume, knownHeight is restored from DB but the buffer starts empty.
+    let onBlockConfig = makeOnBlockConfig(~interval=1, ~startBlock=Some(100))
+    let fetchState = FetchState.make(
+      ~eventConfigs=[],
+      ~addresses=[],
+      ~startBlock=100,
+      ~endBlock=None,
+      ~maxAddrInPartition=3,
+      ~targetBufferSize=5000,
+      ~chainId,
+      ~onBlockConfigs=[onBlockConfig],
+      ~knownHeight=110,
+      ~progressBlockNumber=104,
+    )
+
+    t.expect(fetchState->FetchState.bufferSize).toBeGreaterThan(0)
+
+    let blockNumbers =
+      fetchState.buffer->Array.map(item => item->Internal.getItemBlockNumber)
+
+    t.expect(blockNumbers).toEqual([105, 106, 107, 108, 109, 110])
+  })
+
+  it("should not get stuck on resume for onBlock-only indexer", t => {
+    // Without the fix, getNextQuery returned NothingToQuery because:
+    // 1. headBlockNumber > 0 (not WaitingForNewBlock early return)
+    // 2. isOnBlockBehindTheHead=true -> shouldWaitForNewBlock=false
+    // 3. No partitions -> no queries
+    // Result: NothingToQuery -> fetcher does nothing -> stuck
+    let onBlockConfig = makeOnBlockConfig(~interval=1, ~startBlock=Some(100))
+    let fetchState = FetchState.make(
+      ~eventConfigs=[],
+      ~addresses=[],
+      ~startBlock=100,
+      ~endBlock=None,
+      ~maxAddrInPartition=3,
+      ~targetBufferSize=5000,
+      ~chainId,
+      ~onBlockConfigs=[onBlockConfig],
+      ~knownHeight=110,
+      ~progressBlockNumber=104,
+    )
+
+    // With the fix, the buffer is populated and onBlock pointer is caught up.
+    // getNextQuery should return WaitingForNewBlock, not NothingToQuery.
+    let nextQuery = fetchState->FetchState.getNextQuery(~concurrencyLimit=10)
+    t.expect(nextQuery).toEqual(FetchState.WaitingForNewBlock)
   })
 })


### PR DESCRIPTION
## Summary
Fixes a deadlock issue where onBlock-only indexers (e.g., SVM onSlot indexers) would get stuck after resuming from a checkpoint. The issue occurred because the buffer wasn't being populated when `knownHeight` was restored from the database.

## Key Changes
- **FetchState.res**: Modified the `make` function to call `updateInternal` during initialization when `knownHeight > 0` and onBlock configs exist. This ensures the buffer is populated on resume, allowing `getNextQuery` to return `WaitingForNewBlock` instead of `NothingToQuery`.

- **FetchState_onBlock_test.res**: 
  - Updated `makeInitialWithOnBlock` helper to accept `knownHeight` and `progressBlockNumber` as parameters instead of hardcoding them, enabling more flexible test scenarios.
  - Added two new test cases:
    - "should populate buffer on resume when knownHeight > progressBlockNumber (onBlock-only)" — verifies the buffer is populated with the correct block range on resume
    - "should not get stuck on resume for onBlock-only indexer" — verifies that `getNextQuery` returns the correct state instead of getting stuck

## Implementation Details
The fix addresses a specific scenario in onBlock-only indexers where:
1. No event configs or addresses exist (no partitions to drive fetching)
2. On resume, `knownHeight` is restored from the database but the buffer starts empty
3. Without the fix, `getNextQuery` would return `NothingToQuery` because there are no partitions and the onBlock pointer hasn't caught up to the head
4. The solution populates the buffer during initialization so the onBlock handler can progress normally

https://claude.ai/code/session_017fkJnxkYa4WxAsYFEN4axX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fetch-state resumption to properly populate state using block handlers when resuming from a previously saved height.

* **Tests**
  * Added new test cases validating resume behavior for block-handler-only indexers, ensuring correct buffer population and query responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->