### PR TITLE
Move in-memory history to per-entity-table storage

### DIFF
--- a/packages/envio/src/Change.res
+++ b/packages/envio/src/Change.res
@@ -1,9 +1,14 @@
 @tag("type")
 type t<'entity> =
-  | @as("SET") Set({entityId: string, entity: 'entity, checkpointId: bigint})
-  | @as("DELETE") Delete({entityId: string, checkpointId: bigint})
+  | @as("SET") Set({entityId: string, entity: 'entity, checkpointId: bigint, isRollbackDiff?: bool})
+  | @as("DELETE") Delete({entityId: string, checkpointId: bigint, isRollbackDiff?: bool})
 
 @get
 external getEntityId: t<'entity> => string = "entityId"
 @get
 external getCheckpointId: t<'entity> => bigint = "checkpointId"
+@get
+external getIsRollbackDiffOpt: t<'entity> => option<bool> = "isRollbackDiff"
+
+let isRollbackDiff = (change: t<'entity>): bool =>
+  change->getIsRollbackDiffOpt->Belt.Option.getWithDefault(false)

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -107,7 +107,6 @@ let runEventHandlerOrThrow = async (
   ~inMemoryStore,
   ~loadManager,
   ~persistence,
-  ~shouldSaveHistory,
   ~chains: Internal.chains,
   ~config: Config.t,
 ) => {
@@ -123,7 +122,6 @@ let runEventHandlerOrThrow = async (
       inMemoryStore,
       loadManager,
       persistence,
-      shouldSaveHistory,
       isPreload: false,
       chains,
       config,
@@ -162,7 +160,6 @@ let runHandlerOrThrow = async (
   ~inMemoryStore,
   ~loadManager,
   ~ctx: Ctx.t,
-  ~shouldSaveHistory,
   ~chains: Internal.chains,
 ) => {
   switch item {
@@ -173,7 +170,6 @@ let runHandlerOrThrow = async (
         inMemoryStore,
         loadManager,
         persistence: ctx.persistence,
-        shouldSaveHistory,
         checkpointId,
         isPreload: false,
         chains,
@@ -207,7 +203,6 @@ let runHandlerOrThrow = async (
           ~inMemoryStore,
           ~loadManager,
           ~persistence=ctx.persistence,
-          ~shouldSaveHistory,
           ~chains,
           ~config=ctx.config,
         )
@@ -265,7 +260,6 @@ let preloadBatchOrThrow = async (
                   persistence,
                   checkpointId,
                   isPreload: true,
-                  shouldSaveHistory: false,
                   chains,
                   isResolved: false,
                   config,
@@ -300,7 +294,6 @@ let preloadBatchOrThrow = async (
                   persistence,
                   checkpointId,
                   isPreload: true,
-                  shouldSaveHistory: false,
                   chains,
                   isResolved: false,
                   config,
@@ -325,7 +318,6 @@ let runBatchHandlersOrThrow = async (
   ~inMemoryStore,
   ~loadManager,
   ~ctx,
-  ~shouldSaveHistory,
   ~chains: Internal.chains,
 ) => {
   let itemIdx = ref(0)
@@ -337,15 +329,7 @@ let runBatchHandlersOrThrow = async (
     for idx in 0 to checkpointEventsProcessed - 1 {
       let item = batch.items->Array.getUnsafe(itemIdx.contents + idx)
 
-      await runHandlerOrThrow(
-        item,
-        ~checkpointId,
-        ~inMemoryStore,
-        ~loadManager,
-        ~ctx,
-        ~shouldSaveHistory,
-        ~chains,
-      )
+      await runHandlerOrThrow(item, ~checkpointId, ~inMemoryStore, ~loadManager, ~ctx, ~chains)
     }
     itemIdx := itemIdx.contents + checkpointEventsProcessed
   }
@@ -414,13 +398,7 @@ let processEventBatch = async (
     let elapsedTimeAfterLoaders = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
 
     if batch.items->Utils.Array.notEmpty {
-      await batch->runBatchHandlersOrThrow(
-        ~inMemoryStore,
-        ~loadManager,
-        ~ctx,
-        ~shouldSaveHistory=ctx.config->Config.shouldSaveHistory(~isInReorgThreshold),
-        ~chains,
-      )
+      await batch->runBatchHandlersOrThrow(~inMemoryStore, ~loadManager, ~ctx, ~chains)
     }
 
     let elapsedTimeAfterProcessing = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -958,7 +958,6 @@ let injectedTaskReducer = (
         let progressedChainsById = batch.progressedChainsById
 
         let isInReorgThreshold = state.chainManager.isInReorgThreshold
-        let shouldSaveHistory = state.ctx.config->Config.shouldSaveHistory(~isInReorgThreshold)
 
         let isBelowReorgThreshold =
           !state.chainManager.isInReorgThreshold && state.ctx.config.shouldRollbackOnReorg
@@ -999,7 +998,7 @@ let injectedTaskReducer = (
           dispatchAction(UpdateQueues({progressedChainsById, shouldEnterReorgThreshold}))
 
           let inMemoryStore = state.ctx.inMemoryStore
-          inMemoryStore->InMemoryStore.setBatchDcs(~batch, ~shouldSaveHistory)
+          inMemoryStore->InMemoryStore.setBatchDcs(~batch)
 
           switch await EventProcessing.processEventBatch(
             ~batch,

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -181,8 +181,8 @@ let prepareRollbackDiff = async (
         Delete({
           entityId: data["id"],
           checkpointId: rollbackDiffCheckpointId,
+          isRollbackDiff: true,
         }),
-        ~containsRollbackDiffChange=true,
       )
     })
 
@@ -195,8 +195,8 @@ let prepareRollbackDiff = async (
           entityId: entity.id,
           checkpointId: rollbackDiffCheckpointId,
           entity,
+          isRollbackDiff: true,
         }),
-        ~containsRollbackDiffChange=true,
       )
     })
   })

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -96,14 +96,12 @@ let writeBatch = async (
     JsError.throwWithMessage(`Failed to access the indexer storage. The Persistence layer is not initialized.`)
   | Ready({cache}) =>
     let updatedEntities = persistence.allEntities->Belt.Array.keepMap(entityConfig => {
-      let updates =
-        inMemoryStore
-        ->getInMemTable(~entityConfig)
-        ->InMemoryTable.Entity.updates
+      let inMemTable = inMemoryStore->getInMemTable(~entityConfig)
+      let updates = inMemTable->InMemoryTable.Entity.updates
       if updates->Utils.Array.isEmpty {
         None
       } else {
-        Some(({entityConfig, updates}: Persistence.updatedEntity))
+        Some(({entityConfig, updates, history: inMemTable.history}: Persistence.updatedEntity))
       }
     })
     await persistence.storage.writeBatch(
@@ -184,7 +182,6 @@ let prepareRollbackDiff = async (
           entityId: data["id"],
           checkpointId: rollbackDiffCheckpointId,
         }),
-        ~shouldSaveHistory=false,
         ~containsRollbackDiffChange=true,
       )
     })
@@ -199,7 +196,6 @@ let prepareRollbackDiff = async (
           checkpointId: rollbackDiffCheckpointId,
           entity,
         }),
-        ~shouldSaveHistory=false,
         ~containsRollbackDiffChange=true,
       )
     })
@@ -212,7 +208,7 @@ let prepareRollbackDiff = async (
   }
 }
 
-let setBatchDcs = (inMemoryStore: t, ~batch: Batch.t, ~shouldSaveHistory) => {
+let setBatchDcs = (inMemoryStore: t, ~batch: Batch.t) => {
   let inMemTable =
     inMemoryStore->getInMemTable(~entityConfig=InternalTable.EnvioAddresses.entityConfig)
 
@@ -246,7 +242,6 @@ let setBatchDcs = (inMemoryStore: t, ~batch: Batch.t, ~shouldSaveHistory) => {
               checkpointId,
               entity: entity->InternalTable.EnvioAddresses.castToInternal,
             }),
-            ~shouldSaveHistory,
           )
         }
       }

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -39,6 +39,7 @@ module Entity = {
   type t = {
     table: t<string, entityWithIndices>,
     fieldNameIndices: indexFieldNameToIndices,
+    history: array<Change.t<Internal.entity>>,
   }
 
   // Helper to extract entity ID from any entity
@@ -73,6 +74,7 @@ module Entity = {
   let make = (): t => {
     table: make(~hash=str => str),
     fieldNameIndices: make(~hash=TableIndices.Index.getFieldName),
+    history: [],
   }
 
   let updateIndices = (self: t, ~entity: Internal.entity, ~row: entityWithIndices) => {
@@ -166,51 +168,47 @@ module Entity = {
   let set = (
     inMemTable: t,
     change: Change.t<Internal.entity>,
-    ~shouldSaveHistory,
     ~containsRollbackDiffChange=false,
   ) => {
-    //New entity row with only the latest update
-    @inline
-    let newStatus = () => Internal.Updated({
-      latestChange: change,
-      history: shouldSaveHistory
-        ? [change]
-        : Utils.Array.immutableEmpty->(
-            Utils.magic: array<unknown> => array<Change.t<Internal.entity>>
-          ),
-      containsRollbackDiffChange,
-    })
     let latest = switch change {
     | Set({entity}) => Some(entity)
     | Delete(_) => None
     }
 
-    let updatedEntityRecord: entityWithIndices = switch inMemTable.table->get(
-      change->Change.getEntityId,
-    ) {
-    | None => {latest, status: newStatus()}
-    | Some(prev) =>
-      switch prev.status {
-      | Loaded => {latest, status: newStatus(), entityIndices: ?prev.entityIndices}
-      | Updated(previous_values) =>
-        let newStatus = Internal.Updated({
-          latestChange: change,
-          history: switch shouldSaveHistory {
-          // This prevents two db actions in the same event on the same entity from being recorded to the history table.
-          | true
-            if previous_values.latestChange->Change.getCheckpointId ===
-              change->Change.getCheckpointId =>
-            previous_values.history->Utils.Array.setIndexImmutable(
-              previous_values.history->Array.length - 1,
-              change,
-            )
-          | true => [...previous_values.history, change]
-          | false => previous_values.history
-          },
-          containsRollbackDiffChange: previous_values.containsRollbackDiffChange,
-        })
-        {latest, status: newStatus, entityIndices: ?prev.entityIndices}
+    let prev = inMemTable.table->get(change->Change.getEntityId)
+
+    let historyIndex = if containsRollbackDiffChange {
+      // Rollback-diff replays are restorations from existing history;
+      // don't record them again in the in-memory history buffer.
+      -1
+    } else {
+      switch prev {
+      | Some({status: Updated(previous_values)})
+        if previous_values.historyIndex >= 0 &&
+          previous_values.latestChange->Change.getCheckpointId === change->Change.getCheckpointId =>
+        inMemTable.history->Array.setUnsafe(previous_values.historyIndex, change)
+        previous_values.historyIndex
+      | _ =>
+        inMemTable.history->Array.push(change)->ignore
+        inMemTable.history->Array.length - 1
       }
+    }
+
+    let containsRollbackDiffChange = switch prev {
+    | Some({status: Updated({containsRollbackDiffChange: prevFlag})}) =>
+      prevFlag || containsRollbackDiffChange
+    | _ => containsRollbackDiffChange
+    }
+
+    let newStatus = Internal.Updated({
+      latestChange: change,
+      containsRollbackDiffChange,
+      historyIndex,
+    })
+
+    let updatedEntityRecord: entityWithIndices = switch prev {
+    | None => {latest, status: newStatus}
+    | Some(prev) => {latest, status: newStatus, entityIndices: ?prev.entityIndices}
     }
 
     switch change {

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -165,11 +165,7 @@ module Entity = {
   }
 
   let setRow = set
-  let set = (
-    inMemTable: t,
-    change: Change.t<Internal.entity>,
-    ~containsRollbackDiffChange=false,
-  ) => {
+  let set = (inMemTable: t, change: Change.t<Internal.entity>) => {
     let latest = switch change {
     | Set({entity}) => Some(entity)
     | Delete(_) => None
@@ -177,7 +173,7 @@ module Entity = {
 
     let prev = inMemTable.table->get(change->Change.getEntityId)
 
-    let historyIndex = if containsRollbackDiffChange {
+    let historyIndex = if change->Change.isRollbackDiff {
       // Rollback-diff replays are restorations from existing history;
       // don't record them again in the in-memory history buffer.
       -1
@@ -194,15 +190,8 @@ module Entity = {
       }
     }
 
-    let containsRollbackDiffChange = switch prev {
-    | Some({status: Updated({containsRollbackDiffChange: prevFlag})}) =>
-      prevFlag || containsRollbackDiffChange
-    | _ => containsRollbackDiffChange
-    }
-
     let newStatus = Internal.Updated({
       latestChange: change,
-      containsRollbackDiffChange,
       historyIndex,
     })
 

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -596,14 +596,6 @@ type reorgCheckpoint = {
 
 type inMemoryStoreEntityUpdate = {
   latestChange: Change.t<entity>,
-  // In the event of a rollback, some entity updates may have been
-  // been affected by a rollback diff. If there was no rollback diff
-  // this will always be false.
-  // If there was a rollback diff, this will be false in the case of a
-  // new entity update (where entity affected is not present in the diff) b
-  // but true if the update is related to an entity that is
-  // currently present in the diff
-  containsRollbackDiffChange: bool,
   // Index of this row's most recent entry in the entity table's shared
   // history array. -1 when the row has no entry (e.g. only populated by
   // a rollback-diff replay).

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -596,7 +596,6 @@ type reorgCheckpoint = {
 
 type inMemoryStoreEntityUpdate = {
   latestChange: Change.t<entity>,
-  history: array<Change.t<entity>>,
   // In the event of a rollback, some entity updates may have been
   // been affected by a rollback diff. If there was no rollback diff
   // this will always be false.
@@ -605,6 +604,10 @@ type inMemoryStoreEntityUpdate = {
   // but true if the update is related to an entity that is
   // currently present in the diff
   containsRollbackDiffChange: bool,
+  // Index of this row's most recent entry in the entity table's shared
+  // history array. -1 when the row has no entry (e.g. only populated by
+  // a rollback-diff replay).
+  historyIndex: int,
 }
 
 @unboxed

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -51,6 +51,7 @@ type updatedEffectCache = {
 type updatedEntity = {
   entityConfig: Internal.entityConfig,
   updates: array<Internal.inMemoryStoreEntityUpdate>,
+  history: array<Change.t<Internal.entity>>,
 }
 
 type storage = {

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -745,7 +745,7 @@ let rec writeBatch = async (
       ~items=rawEvents,
     )
 
-    let setEntities = updatedEntities->Belt.Array.map(({entityConfig, updates}) => {
+    let setEntities = updatedEntities->Belt.Array.map(({entityConfig, updates, history}) => {
       let entitiesToSet = []
       let idsToDelete = []
 
@@ -773,24 +773,22 @@ let rec writeBatch = async (
             let batchDeleteEntityIds = []
 
             updates->Array.forEach(update => {
-              switch update {
-              | {history, containsRollbackDiffChange} =>
-                history->Array.forEach(
-                  (change: Change.t<'a>) => {
-                    if !containsRollbackDiffChange {
-                      backfillHistoryIds->Utils.Set.add(change->Change.getEntityId)->ignore
-                    }
-                    switch change {
-                    | Delete({entityId}) => {
-                        batchDeleteEntityIds->Belt.Array.push(entityId)->ignore
-                        batchDeleteCheckpointIds
-                        ->Belt.Array.push(change->Change.getCheckpointId)
-                        ->ignore
-                      }
-                    | Set(_) => batchSetUpdates->Array.push(change)->ignore
-                    }
-                  },
-                )
+              if !update.containsRollbackDiffChange {
+                backfillHistoryIds
+                ->Utils.Set.add(update.latestChange->Change.getEntityId)
+                ->ignore
+              }
+            })
+
+            history->Array.forEach((change: Change.t<'a>) => {
+              switch change {
+              | Delete({entityId}) => {
+                  batchDeleteEntityIds->Belt.Array.push(entityId)->ignore
+                  batchDeleteCheckpointIds
+                  ->Belt.Array.push(change->Change.getCheckpointId)
+                  ->ignore
+                }
+              | Set(_) => batchSetUpdates->Array.push(change)->ignore
               }
             })
 

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -773,7 +773,7 @@ let rec writeBatch = async (
             let batchDeleteEntityIds = []
 
             updates->Array.forEach(update => {
-              if !update.containsRollbackDiffChange {
+              if !(update.latestChange->Change.isRollbackDiff) {
                 backfillHistoryIds
                 ->Utils.Set.add(update.latestChange->Change.getEntityId)
                 ->ignore

--- a/packages/envio/src/Sink.res
+++ b/packages/envio/src/Sink.res
@@ -34,8 +34,8 @@ let makeClickHouse = (~host, ~database, ~username, ~password): t => {
     },
     writeBatch: async (~batch, ~updatedEntities) => {
       await Promise.all(
-        updatedEntities->Belt.Array.map(({entityConfig, updates}) => {
-          ClickHouse.setUpdatesOrThrow(client, ~cache, ~updates, ~entityConfig, ~database)
+        updatedEntities->Belt.Array.map(({entityConfig, history}) => {
+          ClickHouse.setUpdatesOrThrow(client, ~cache, ~history, ~entityConfig, ~database)
         }),
       )->Utils.Promise.ignoreValue
       await ClickHouse.setCheckpointsOrThrow(client, ~batch, ~database)

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -122,7 +122,7 @@ let handleWriteBatch = (
   // checkpointId -> entityName -> entityChange
   let changesByCheckpoint: dict<dict<entityChange>> = Dict.make()
 
-  updatedEntities->Array.forEach(({entityName, updates}) => {
+  updatedEntities->Array.forEach(({entityName, updates, history}) => {
     let entityDict = switch state.entities->Dict.get(entityName) {
     | Some(dict) => dict
     | None =>
@@ -132,68 +132,66 @@ let handleWriteBatch = (
     }
     let entityConfig = state.entityConfigs->Dict.getUnsafe(entityName)
 
-    updates->Array.forEach(update => {
-      // Helper to process a single change (Set or Delete)
-      let processChange = (change: TestIndexerProxyStorage.serializableChange) => {
-        switch change {
-        | Set({entityId, entity, checkpointId}) =>
-          // Parse entity immediately to store decoded values for proper comparisons
-          // (bigint/BigDecimal need actual values, not JSON strings)
-          let parsedEntity = entity->S.parseOrThrow(entityConfig.schema)
+    // Helper to process a single change (Set or Delete)
+    let processChange = (change: TestIndexerProxyStorage.serializableChange) => {
+      switch change {
+      | Set({entityId, entity, checkpointId}) =>
+        // Parse entity immediately to store decoded values for proper comparisons
+        // (bigint/BigDecimal need actual values, not JSON strings)
+        let parsedEntity = entity->S.parseOrThrow(entityConfig.schema)
 
-          // Update entities dict with parsed entity for load operations
-          entityDict->Dict.set(entityId, parsedEntity)
+        // Update entities dict with parsed entity for load operations
+        entityDict->Dict.set(entityId, parsedEntity)
 
-          // Track change by checkpoint
-          let checkpointKey = checkpointId->BigInt.toString
-          let entityChanges = switch changesByCheckpoint->Dict.get(checkpointKey) {
-          | Some(changes) => changes
-          | None =>
-            let changes = Dict.make()
-            changesByCheckpoint->Dict.set(checkpointKey, changes)
-            changes
-          }
-          let entityChange = switch entityChanges->Dict.get(entityName) {
-          | Some(change) => change
-          | None =>
-            let change = {sets: [], deleted: []}
-            entityChanges->Dict.set(entityName, change)
-            change
-          }
-          entityChange.sets->Array.push(parsedEntity->Utils.magic)->ignore
-
-        | Delete({entityId, checkpointId}) =>
-          // Update entities dict for load operations
-          Dict.delete(entityDict->Obj.magic, entityId)
-
-          // Track change by checkpoint
-          let checkpointKey = checkpointId->BigInt.toString
-          let entityChanges = switch changesByCheckpoint->Dict.get(checkpointKey) {
-          | Some(changes) => changes
-          | None =>
-            let changes = Dict.make()
-            changesByCheckpoint->Dict.set(checkpointKey, changes)
-            changes
-          }
-          let entityChange = switch entityChanges->Dict.get(entityName) {
-          | Some(change) => change
-          | None =>
-            let change = {sets: [], deleted: []}
-            entityChanges->Dict.set(entityName, change)
-            change
-          }
-          entityChange.deleted->Array.push(entityId)->ignore
+        // Track change by checkpoint
+        let checkpointKey = checkpointId->BigInt.toString
+        let entityChanges = switch changesByCheckpoint->Dict.get(checkpointKey) {
+        | Some(changes) => changes
+        | None =>
+          let changes = Dict.make()
+          changesByCheckpoint->Dict.set(checkpointKey, changes)
+          changes
         }
-      }
+        let entityChange = switch entityChanges->Dict.get(entityName) {
+        | Some(change) => change
+        | None =>
+          let change = {sets: [], deleted: []}
+          entityChanges->Dict.set(entityName, change)
+          change
+        }
+        entityChange.sets->Array.push(parsedEntity->Utils.magic)->ignore
 
-      // Iterate over all history entries (mirroring PgStorage.res behavior)
-      update.history->Array.forEach(processChange)
+      | Delete({entityId, checkpointId}) =>
+        // Update entities dict for load operations
+        Dict.delete(entityDict->Obj.magic, entityId)
 
-      // Also include latestChange if history is empty (fallback for backwards compatibility)
-      if update.history->Array.length === 0 {
-        processChange(update.latestChange)
+        // Track change by checkpoint
+        let checkpointKey = checkpointId->BigInt.toString
+        let entityChanges = switch changesByCheckpoint->Dict.get(checkpointKey) {
+        | Some(changes) => changes
+        | None =>
+          let changes = Dict.make()
+          changesByCheckpoint->Dict.set(checkpointKey, changes)
+          changes
+        }
+        let entityChange = switch entityChanges->Dict.get(entityName) {
+        | Some(change) => change
+        | None =>
+          let change = {sets: [], deleted: []}
+          entityChanges->Dict.set(entityName, change)
+          change
+        }
+        entityChange.deleted->Array.push(entityId)->ignore
       }
-    })
+    }
+
+    if history->Array.length > 0 {
+      history->Array.forEach(processChange)
+    } else {
+      // Fall back to latestChange for rollback-diff-only entities that
+      // don't contribute to the table-level history.
+      updates->Array.forEach(update => processChange(update.latestChange))
+    }
   })
 
   // Build combined checkpoint + entity changes objects

--- a/packages/envio/src/TestIndexerProxyStorage.res
+++ b/packages/envio/src/TestIndexerProxyStorage.res
@@ -9,13 +9,13 @@ type serializableChange =
 
 type serializableEntityUpdate = {
   latestChange: serializableChange,
-  history: array<serializableChange>,
   containsRollbackDiffChange: bool,
 }
 
 type serializableUpdatedEntity = {
   entityName: string,
   updates: array<serializableEntityUpdate>,
+  history: array<serializableChange>,
 }
 
 // Worker -> Main thread payloads
@@ -147,7 +147,7 @@ let makeStorage = (proxy: t): Persistence.storage => {
   ) => {
     // Encode entities to JSON for serialization across worker boundary
     let serializableEntities = updatedEntities->Array.map((
-      {entityConfig, updates}: Persistence.updatedEntity,
+      {entityConfig, updates, history}: Persistence.updatedEntity,
     ) => {
       let encodeChange = (change: Change.t<Internal.entity>): serializableChange => {
         switch change {
@@ -164,9 +164,9 @@ let makeStorage = (proxy: t): Persistence.storage => {
         entityName: entityConfig.name,
         updates: updates->Array.map(update => {
           latestChange: encodeChange(update.latestChange),
-          history: update.history->Array.map(encodeChange),
           containsRollbackDiffChange: update.containsRollbackDiffChange,
         }),
+        history: history->Array.map(encodeChange),
       }
     })
     let _ = await proxy->sendRequest(

--- a/packages/envio/src/TestIndexerProxyStorage.res
+++ b/packages/envio/src/TestIndexerProxyStorage.res
@@ -4,13 +4,10 @@ type requestId = int
 // Serializable change with entity as JSON (for worker thread messaging)
 @tag("type")
 type serializableChange =
-  | @as("SET") Set({entityId: string, entity: JSON.t, checkpointId: bigint})
-  | @as("DELETE") Delete({entityId: string, checkpointId: bigint})
+  | @as("SET") Set({entityId: string, entity: JSON.t, checkpointId: bigint, isRollbackDiff?: bool})
+  | @as("DELETE") Delete({entityId: string, checkpointId: bigint, isRollbackDiff?: bool})
 
-type serializableEntityUpdate = {
-  latestChange: serializableChange,
-  containsRollbackDiffChange: bool,
-}
+type serializableEntityUpdate = {latestChange: serializableChange}
 
 type serializableUpdatedEntity = {
   entityName: string,
@@ -150,21 +147,27 @@ let makeStorage = (proxy: t): Persistence.storage => {
       {entityConfig, updates, history}: Persistence.updatedEntity,
     ) => {
       let encodeChange = (change: Change.t<Internal.entity>): serializableChange => {
+        let isRollbackDiff = change->Change.isRollbackDiff
         switch change {
         | Set({entityId, entity, checkpointId}) =>
           Set({
             entityId,
             entity: entity->S.reverseConvertToJsonOrThrow(entityConfig.schema),
             checkpointId,
+            isRollbackDiff: ?(isRollbackDiff ? Some(true) : None),
           })
-        | Delete({entityId, checkpointId}) => Delete({entityId, checkpointId})
+        | Delete({entityId, checkpointId}) =>
+          Delete({
+            entityId,
+            checkpointId,
+            isRollbackDiff: ?(isRollbackDiff ? Some(true) : None),
+          })
         }
       }
       {
         entityName: entityConfig.name,
         updates: updates->Array.map(update => {
           latestChange: encodeChange(update.latestChange),
-          containsRollbackDiffChange: update.containsRollbackDiffChange,
         }),
         history: history->Array.map(encodeChange),
       }

--- a/packages/envio/src/UserContext.res
+++ b/packages/envio/src/UserContext.res
@@ -7,7 +7,6 @@ type contextParams = {
   loadManager: LoadManager.t,
   persistence: Persistence.t,
   isPreload: bool,
-  shouldSaveHistory: bool,
   chains: Internal.chains,
   config: Config.t,
   mutable isResolved: bool,
@@ -228,7 +227,6 @@ let entityTraps: Utils.Proxy.traps<entityContextParams> = {
               checkpointId: params.checkpointId,
               entity,
             }),
-            ~shouldSaveHistory=params.shouldSaveHistory,
           )
         }
 
@@ -333,7 +331,6 @@ let entityTraps: Utils.Proxy.traps<entityContextParams> = {
               entityId,
               checkpointId: params.checkpointId,
             }),
-            ~shouldSaveHistory=params.shouldSaveHistory,
           )
         }
       }->(Utils.magic: (string => unit) => unknown)
@@ -379,7 +376,6 @@ let handlerTraps: Utils.Proxy.traps<contextParams> = {
           inMemoryStore: params.inMemoryStore,
           loadManager: params.loadManager,
           persistence: params.persistence,
-          shouldSaveHistory: params.shouldSaveHistory,
           checkpointId: params.checkpointId,
           chains: params.chains,
           isResolved: params.isResolved,

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -239,11 +239,11 @@ type setUpdatesCache = {
 let setUpdatesOrThrow = async (
   client,
   ~cache: Utils.WeakMap.t<Internal.entityConfig, setUpdatesCache>,
-  ~updates: array<Internal.inMemoryStoreEntityUpdate>,
+  ~history: array<Change.t<Internal.entity>>,
   ~entityConfig: Internal.entityConfig,
   ~database: string,
 ) => {
-  if updates->Array.length === 0 {
+  if history->Array.length === 0 {
     ()
   } else {
     let {convertOrThrow, tableName} = switch cache->Utils.WeakMap.get(entityConfig) {
@@ -281,9 +281,7 @@ let setUpdatesOrThrow = async (
 
     try {
       // Convert entity updates to ClickHouse row format
-      let values = updates->Array.map(update => {
-        update.latestChange->convertOrThrow
-      })
+      let values = history->Array.map(convertOrThrow)
 
       await insertWithRetry(client, ~table=tableName, ~values, ~format="JSONEachRow")
     } catch {

--- a/scenarios/test_codegen/test/EventOrigin_test.res
+++ b/scenarios/test_codegen/test/EventOrigin_test.res
@@ -54,7 +54,6 @@ describe("Chains State", () => {
             ~config=Config.loadWithoutRegistrations(),
           ),
           inMemoryStore,
-          shouldSaveHistory: false,
           isPreload: false,
           checkpointId: 0n,
           chains,

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -17,7 +17,6 @@ module InMemoryStore = {
         checkpointId: 0n,
         entity,
       }),
-      ~shouldSaveHistory=config->Config.shouldSaveHistory(~isInReorgThreshold=false),
     )
   }
 

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -284,6 +284,22 @@ describe("E2E rollback tests", () => {
       ],
       [
         Set({
+          checkpointId: 0n,
+          entityId: "1",
+          entity: {
+            Indexer.Entities.SimpleEntity.id: "1",
+            value: "value-2",
+          },
+        }),
+        Set({
+          checkpointId: 0n,
+          entityId: "2",
+          entity: {
+            Indexer.Entities.SimpleEntity.id: "2",
+            value: "value-2",
+          },
+        }),
+        Set({
           checkpointId: firstHistoryCheckpointId->BigInt.add(3n),
           entityId: "1",
           entity: {
@@ -1698,6 +1714,14 @@ This might be wrong after we start exposing a block hash for progress block.`,
           },
         ],
         [
+          Set({
+            checkpointId: 0n,
+            entityId: "foo",
+            entity: {
+              Indexer.Entities.EntityWithBigDecimal.id: "foo",
+              bigDecimal: BigDecimal.fromFloat(0.),
+            },
+          }),
           Set({
             checkpointId: 10n,
             entityId: "foo",

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -156,18 +156,18 @@ describe("E2E rollback tests", () => {
           },
         }),
         Set({
-          checkpointId: firstHistoryCheckpointId->BigInt.add(1n),
-          entityId: "3",
-          entity: {
-            Indexer.Entities.SimpleEntity.id: "3",
-            value: "value-1",
-          },
-        }),
-        Set({
           checkpointId: firstHistoryCheckpointId,
           entityId: "4",
           entity: {
             Indexer.Entities.SimpleEntity.id: "4",
+            value: "value-1",
+          },
+        }),
+        Set({
+          checkpointId: firstHistoryCheckpointId->BigInt.add(1n),
+          entityId: "3",
+          entity: {
+            Indexer.Entities.SimpleEntity.id: "3",
             value: "value-1",
           },
         }),


### PR DESCRIPTION
## Summary

- Move the in-memory `history` array off `inMemoryStoreEntityUpdate` (per-row) and onto `InMemoryTable.Entity.t` (per entity table). Each row tracks its slot via `historyIndex` so a second write at the same checkpoint replaces in place — same dedup invariant as before, just keyed against a shared array.
- Drop the `shouldSaveHistory` gate at write time; history is always populated in memory. The flag is still respected at the Postgres flush (DB behavior unchanged) and removed from the context-param threading where it was no longer used.
- ClickHouse now writes the full table-level history, not just each row's `latestChange`, regardless of the flag.
- Rollback-diff replays skip the history buffer (`historyIndex = -1`) since they restore from existing history rows.

## Test plan

- [x] `pnpm rescript` clean in `packages/envio` and `scenarios/test_codegen`
- [x] `pnpm vitest run test/rollback/Rollback_test.res.mjs` — 15/15
- [x] `pnpm vitest run` for `E2E_test`, `WriteRead_test`, `lib_tests/EntityHistory_test`, `lib_tests/PgStorage_test`, `lib_tests/ClickHouse_test`, `EventOrigin_test` — 65 passed, 2 skipped
- [ ] Full suite

https://claude.ai/code/session_01Xo1n3gN3az2PSH81vVa3Va

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xo1n3gN3az2PSH81vVa3Va)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked entity history to use a shared per-entity history buffer referenced by index, removing the per-handler save-history flag and simplifying handler context.
  * Moved history to top-level batch updates, streamlining how sinks and persistence receive and persist history.

* **Bug Fixes**
  * Improved rollback replay correctness and checkpoint handling for history writes.

* **Tests**
  * Updated tests and mocks to match the new history and rollback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->