### PR TITLE
Refactor InMemoryTable to use dict instead of custom table type

### DIFF
--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -13,7 +13,7 @@ let set = (self: t<'key, 'val>, key, value) => self.dict->Dict.set(key->self.has
 let setByHash = (self: t<'key, 'val>, hash, value) => self.dict->Dict.set(hash, value)
 
 let hasByHash = (self: t<'key, 'val>, hash) => {
-  self.dict->Utils.Dict.has(hash)
+  self.dict->Dict.has(hash)
 }
 
 let getUnsafeByHash = (self: t<'key, 'val>, hash) => {
@@ -265,7 +265,7 @@ module Entity = {
                 relatedEntityIds
                 ->Utils.Set.toArray
                 ->Array.filterMap(entityId => {
-                  switch inMemTable.entities->Utils.Dict.has(entityId) {
+                  switch inMemTable.entities->Dict.has(entityId) {
                   | true => getEntity(entityId)
                   | false => None
                   }

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -37,7 +37,7 @@ module Entity = {
     mutable entityIndices?: Utils.Set.t<TableIndices.Index.t>,
   }
   type t = {
-    dict: dict<entityWithIndices>,
+    entities: dict<entityWithIndices>,
     fieldNameIndices: indexFieldNameToIndices,
   }
 
@@ -71,7 +71,7 @@ module Entity = {
   }
 
   let make = (): t => {
-    dict: Dict.make(),
+    entities: Dict.make(),
     fieldNameIndices: make(~hash=TableIndices.Index.getFieldName),
   }
 
@@ -142,7 +142,7 @@ module Entity = {
   ) => {
     let shouldWriteEntity =
       allowOverWriteEntity ||
-      inMemTable.dict->Utils.Dict.dangerouslyGetNonOption(key)->Option.isNone
+      inMemTable.entities->Utils.Dict.dangerouslyGetNonOption(key)->Option.isNone
 
     //Only initialize a row in the case where it is none
     //or if allowOverWriteEntity is true (used for mockDb in test helpers)
@@ -158,7 +158,7 @@ module Entity = {
         inMemTable->updateIndices(~entity, ~row)
       | None => ()
       }
-      inMemTable.dict->Dict.set(key, row)
+      inMemTable.entities->Dict.set(key, row)
     }
   }
 
@@ -185,7 +185,7 @@ module Entity = {
     | Delete(_) => None
     }
 
-    let updatedEntityRecord: entityWithIndices = switch inMemTable.dict->Utils.Dict.dangerouslyGetNonOption(
+    let updatedEntityRecord: entityWithIndices = switch inMemTable.entities->Utils.Dict.dangerouslyGetNonOption(
       change->Change.getEntityId,
     ) {
     | None => {latest, status: newStatus()}
@@ -217,7 +217,7 @@ module Entity = {
     | Set({entity}) => inMemTable->updateIndices(~entity, ~row=updatedEntityRecord)
     | Delete({entityId}) => inMemTable->deleteEntityFromIndices(~entityId, ~row=updatedEntityRecord)
     }
-    inMemTable.dict->Dict.set(change->Change.getEntityId, updatedEntityRecord)
+    inMemTable.entities->Dict.set(change->Change.getEntityId, updatedEntityRecord)
   }
 
   let rowToEntity = row => row.latest
@@ -230,7 +230,7 @@ module Entity = {
   It's needed to prevent an additional round trips to the database for deleted entities. */
   let getUnsafe = (inMemTable: t) =>
     (key: string) =>
-      inMemTable.dict
+      inMemTable.entities
       ->Dict.getUnsafe(key)
       ->rowToEntity
 
@@ -265,7 +265,7 @@ module Entity = {
                 relatedEntityIds
                 ->Utils.Set.toArray
                 ->Array.filterMap(entityId => {
-                  switch inMemTable.dict->Utils.Dict.has(entityId) {
+                  switch inMemTable.entities->Utils.Dict.has(entityId) {
                   | true => getEntity(entityId)
                   | false => None
                   }
@@ -282,9 +282,7 @@ module Entity = {
     let fieldName = index->TableIndices.Index.getFieldName
     let relatedEntityIds = Utils.Set.make()
 
-    inMemTable.dict
-    ->Dict.valuesToArray
-    ->Array.forEach(row => {
+    inMemTable.entities->Utils.Dict.forEach(row => {
       switch row->rowToEntity {
       | Some(entity) =>
         let fieldValue =
@@ -331,19 +329,24 @@ module Entity = {
     }
 
   let updates = (inMemTable: t) => {
-    inMemTable.dict
-    ->Dict.valuesToArray
-    ->Array.filterMap(v =>
+    let acc = []
+    inMemTable.entities->Utils.Dict.forEach(v =>
       switch v.status {
-      | Updated(update) => Some(update)
-      | Loaded => None
+      | Updated(update) => acc->Array.push(update)
+      | Loaded => ()
       }
     )
+    acc
   }
 
   let values = (inMemTable: t) => {
-    inMemTable.dict
-    ->Dict.valuesToArray
-    ->Array.filterMap(rowToEntity)
+    let acc = []
+    inMemTable.entities->Utils.Dict.forEach(v =>
+      switch v->rowToEntity {
+      | Some(entity) => acc->Array.push(entity)
+      | None => ()
+      }
+    )
+    acc
   }
 }

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -37,7 +37,7 @@ module Entity = {
     mutable entityIndices?: Utils.Set.t<TableIndices.Index.t>,
   }
   type t = {
-    table: t<string, entityWithIndices>,
+    dict: dict<entityWithIndices>,
     fieldNameIndices: indexFieldNameToIndices,
   }
 
@@ -71,7 +71,7 @@ module Entity = {
   }
 
   let make = (): t => {
-    table: make(~hash=str => str),
+    dict: Dict.make(),
     fieldNameIndices: make(~hash=TableIndices.Index.getFieldName),
   }
 
@@ -142,7 +142,7 @@ module Entity = {
   ) => {
     let shouldWriteEntity =
       allowOverWriteEntity ||
-      inMemTable.table.dict->Dict.get(key->inMemTable.table.hash)->Option.isNone
+      inMemTable.dict->Utils.Dict.dangerouslyGetNonOption(key)->Option.isNone
 
     //Only initialize a row in the case where it is none
     //or if allowOverWriteEntity is true (used for mockDb in test helpers)
@@ -158,7 +158,7 @@ module Entity = {
         inMemTable->updateIndices(~entity, ~row)
       | None => ()
       }
-      inMemTable.table.dict->Dict.set(key->inMemTable.table.hash, row)
+      inMemTable.dict->Dict.set(key, row)
     }
   }
 
@@ -185,7 +185,7 @@ module Entity = {
     | Delete(_) => None
     }
 
-    let updatedEntityRecord: entityWithIndices = switch inMemTable.table->get(
+    let updatedEntityRecord: entityWithIndices = switch inMemTable.dict->Utils.Dict.dangerouslyGetNonOption(
       change->Change.getEntityId,
     ) {
     | None => {latest, status: newStatus()}
@@ -217,7 +217,7 @@ module Entity = {
     | Set({entity}) => inMemTable->updateIndices(~entity, ~row=updatedEntityRecord)
     | Delete({entityId}) => inMemTable->deleteEntityFromIndices(~entityId, ~row=updatedEntityRecord)
     }
-    inMemTable.table->setRow(change->Change.getEntityId, updatedEntityRecord)
+    inMemTable.dict->Dict.set(change->Change.getEntityId, updatedEntityRecord)
   }
 
   let rowToEntity = row => row.latest
@@ -230,7 +230,7 @@ module Entity = {
   It's needed to prevent an additional round trips to the database for deleted entities. */
   let getUnsafe = (inMemTable: t) =>
     (key: string) =>
-      inMemTable.table.dict
+      inMemTable.dict
       ->Dict.getUnsafe(key)
       ->rowToEntity
 
@@ -265,7 +265,7 @@ module Entity = {
                 relatedEntityIds
                 ->Utils.Set.toArray
                 ->Array.filterMap(entityId => {
-                  switch hasByHash(inMemTable.table, entityId) {
+                  switch inMemTable.dict->Utils.Dict.has(entityId) {
                   | true => getEntity(entityId)
                   | false => None
                   }
@@ -282,8 +282,8 @@ module Entity = {
     let fieldName = index->TableIndices.Index.getFieldName
     let relatedEntityIds = Utils.Set.make()
 
-    inMemTable.table
-    ->values
+    inMemTable.dict
+    ->Dict.valuesToArray
     ->Array.forEach(row => {
       switch row->rowToEntity {
       | Some(entity) =>
@@ -331,8 +331,8 @@ module Entity = {
     }
 
   let updates = (inMemTable: t) => {
-    inMemTable.table
-    ->values
+    inMemTable.dict
+    ->Dict.valuesToArray
     ->Array.filterMap(v =>
       switch v.status {
       | Updated(update) => Some(update)
@@ -342,8 +342,8 @@ module Entity = {
   }
 
   let values = (inMemTable: t) => {
-    inMemTable.table
-    ->values
+    inMemTable.dict
+    ->Dict.valuesToArray
     ->Array.filterMap(rowToEntity)
   }
 }

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -56,7 +56,7 @@ let loadById = (
     ~shouldGroup,
     ~hasher=LoadManager.noopHasher,
     ~getUnsafeInMemory=inMemTable->InMemoryTable.Entity.getUnsafe,
-    ~hasInMemory=hash => inMemTable.table->InMemoryTable.hasByHash(hash),
+    ~hasInMemory=hash => inMemTable.dict->Utils.Dict.has(hash),
     ~input=entityId,
   )
 }

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -56,7 +56,7 @@ let loadById = (
     ~shouldGroup,
     ~hasher=LoadManager.noopHasher,
     ~getUnsafeInMemory=inMemTable->InMemoryTable.Entity.getUnsafe,
-    ~hasInMemory=hash => inMemTable.entities->Utils.Dict.has(hash),
+    ~hasInMemory=hash => inMemTable.entities->Dict.has(hash),
     ~input=entityId,
   )
 }
@@ -253,7 +253,7 @@ let loadEffect = (
 
     if (
       switch persistence.storageStatus {
-      | Ready({cache}) => cache->Utils.Dict.has(effectName)
+      | Ready({cache}) => cache->Dict.has(effectName)
       | _ => false
       }
     ) {
@@ -335,7 +335,7 @@ let loadEffect = (
     ~shouldGroup,
     ~hasher=args => args.cacheKey,
     ~getUnsafeInMemory=hash => inMemTable.dict->Dict.getUnsafe(hash),
-    ~hasInMemory=hash => inMemTable.dict->Utils.Dict.has(hash),
+    ~hasInMemory=hash => inMemTable.dict->Dict.has(hash),
     ~input=effectArgs,
   )
 }

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -56,7 +56,7 @@ let loadById = (
     ~shouldGroup,
     ~hasher=LoadManager.noopHasher,
     ~getUnsafeInMemory=inMemTable->InMemoryTable.Entity.getUnsafe,
-    ~hasInMemory=hash => inMemTable.dict->Utils.Dict.has(hash),
+    ~hasInMemory=hash => inMemTable.entities->Utils.Dict.has(hash),
     ~input=entityId,
   )
 }

--- a/packages/envio/src/Utils.res
+++ b/packages/envio/src/Utils.res
@@ -114,8 +114,6 @@ module Dict = {
   @get_index
   external dangerouslyGetByIntNonOption: (dict<'a>, int) => option<'a> = ""
 
-  let has: (dict<'a>, string) => bool = %raw(`(dict, key) => key in dict`)
-
   let push = (dict, key, value) => {
     switch dict->dangerouslyGetNonOption(key) {
     | Some(arr) => arr->Array.push(value)

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -1079,7 +1079,7 @@ let make = (
     // We also don't care about it when we have a hard max block interval
     if (
       executedBlockInterval >= suggestedBlockInterval &&
-        !(mutSuggestedBlockIntervals->Utils.Dict.has(maxSuggestedBlockIntervalKey))
+        !(mutSuggestedBlockIntervals->Dict.has(maxSuggestedBlockIntervalKey))
     ) {
       // Increase batch size going forward, but do not increase past a configured maximum
       // See: https://en.wikipedia.org/wiki/Additive_increase/multiplicative_decrease


### PR DESCRIPTION
## Summary
Simplifies the `InMemoryTable.Entity` module by replacing the custom `table` type (a wrapped hash table) with ReScript's native `dict` type. This reduces unnecessary abstraction while maintaining the same functionality.

## Key Changes
- Changed `table: t<string, entityWithIndices>` field to `entities: dict<entityWithIndices>` in the `InMemoryTable.Entity.t` type
- Updated `make()` to initialize with `Dict.make()` instead of a custom hash table constructor
- Replaced all `table.dict->Dict.get()` calls with `entities->Utils.Dict.dangerouslyGetNonOption()` for unsafe access patterns
- Replaced `table->setRow()` calls with direct `Dict.set()` calls
- Replaced `table->values` iteration with `Utils.Dict.forEach()` for iterating over entity records
- Updated `LoadLayer.res` to use `entities->Utils.Dict.has()` instead of `table->InMemoryTable.hasByHash()`
- Refactored `updates()` and `values()` functions to use imperative accumulator pattern with `forEach` instead of functional `filterMap` on array conversions

## Notable Implementation Details
- The change eliminates the custom hash function wrapper that was previously used (`~hash=str => str`), simplifying the API surface
- Unsafe dict access patterns are now explicitly marked with `dangerouslyGetNonOption`, making the intent clearer
- The refactored `updates()` and `values()` functions now build results via mutation and accumulation rather than converting the entire dict to an array first, which is more efficient for large entity collections

https://claude.ai/code/session_01TjzN4UfPFgj7ksvdsAoPfb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data structure handling for improved performance and maintainability.
  * Streamlined entity storage and retrieval mechanisms.
  * Simplified utility helper functions for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->