### PR TITLE
Relax ReScript compiler warnings and remove unused variable

### DIFF
--- a/packages/envio/rescript.json
+++ b/packages/envio/rescript.json
@@ -18,6 +18,6 @@
   "dependencies": ["rescript-schema", "@rescript/react"],
   "compiler-flags": ["-open RescriptSchema"],
   "warnings": {
-    "error": "+3"
+    "error": "+a"
   }
 }

--- a/packages/envio/src/sources/HyperSyncSource.res
+++ b/packages/envio/src/sources/HyperSyncSource.res
@@ -227,7 +227,6 @@ Learn more or get a free API token at: https://envio.dev/app/api-tokens`)
     ~retry,
     ~logger,
   ) => {
-    let mkLogAndRaise = ErrorHandling.mkLogAndRaise(~logger, ...)
     let totalTimeRef = Hrtime.makeTimer()
 
     let selectionConfig = selection->getSelectionConfig


### PR DESCRIPTION
## Summary
Minor cleanup to improve compiler configuration and remove dead code in the HyperSyncSource module.

## Changes
- **rescript.json**: Changed compiler warning flag from `+3` to `+a` to enable all warnings instead of just warning 3, providing more comprehensive compiler feedback
- **HyperSyncSource.res**: Removed unused `mkLogAndRaise` variable binding that was never referenced in the function body

## Details
The `mkLogAndRaise` variable was created but never used, likely left over from a previous refactor. Removing it eliminates dead code and reduces cognitive overhead when reading the function.

https://claude.ai/code/session_01Drw9NeMUKU6WXuRj3jzgyD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compiler warning configuration settings.

* **Refactor**
  * Improved error handling code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->