### PR TITLE
Persist all entity history changes to ClickHouse

### DIFF
--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -240,15 +240,16 @@ type setUpdatesCache = {
 // intermediate change must be persisted, not only the current value. Per
 // entity update, history holds the older changes in chronological order and
 // latestChange the most recent one.
-let collectChanges = (updates: array<Internal.inMemoryStoreEntityUpdate>): array<
-  Change.t<Internal.entity>,
-> => {
-  let changes = []
+let collectChanges = (
+  updates: array<Internal.inMemoryStoreEntityUpdate>,
+  ~convertOrThrow: Change.t<Internal.entity> => 'a,
+): array<'a> => {
+  let values = []
   updates->Belt.Array.forEach(update => {
-    update.history->Belt.Array.forEach(change => changes->Array.push(change)->ignore)
-    changes->Array.push(update.latestChange)->ignore
+    update.history->Belt.Array.forEach(change => values->Array.push(change->convertOrThrow)->ignore)
+    values->Array.push(update.latestChange->convertOrThrow)->ignore
   })
-  changes
+  values
 }
 
 let setUpdatesOrThrow = async (
@@ -295,7 +296,7 @@ let setUpdatesOrThrow = async (
     }
 
     try {
-      let values = updates->collectChanges->Array.map(convertOrThrow)
+      let values = updates->collectChanges(~convertOrThrow)
 
       await insertWithRetry(client, ~table=tableName, ~values, ~format="JSONEachRow")
     } catch {

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -35,8 +35,10 @@ type queryResult<'a>
 @send
 external query: (client, queryParams) => promise<queryResult<'a>> = "query"
 
+// The default `JSON` query format resolves to a `ResponseJSON` wrapper whose
+// rows live under `data`, not at the top level.
 @send
-external json: queryResult<'a> => promise<'a> = "json"
+external json: queryResult<'a> => promise<{"data": array<'a>}> = "json"
 
 let getClickHouseFieldType = (
   ~fieldType: Table.fieldType,
@@ -442,7 +444,7 @@ let initialize = async (
         let existingResult = await client->query({
           query: `SELECT engine FROM system.databases WHERE name = '${database}'`,
         })
-        let rows: array<{"engine": string}> = await existingResult->json
+        let rows = (await existingResult->json)["data"]
         switch rows->Array.get(0) {
         | Some(row) if row["engine"] !== expectedEngineName =>
           JsError.throwWithMessage(
@@ -501,7 +503,7 @@ let resume = async (client, ~database: string, ~checkpointId: Internal.checkpoin
     let tablesResult = await client->query({
       query: `SHOW TABLES FROM ${database} LIKE '${EntityHistory.historyTablePrefix}%'`,
     })
-    let tables: array<{"name": string}> = await tablesResult->json
+    let tables = (await tablesResult->json)["data"]
 
     // Delete rows with checkpoint IDs higher than the target for each history table
     await Promise.all(

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -76,13 +76,13 @@ let getClickHouseFieldType = (
   | Json => "String"
   | Date => "DateTime64(3, 'UTC')"
   | Enum({config}) => {
-      let variantsLength = config.variants->Belt.Array.length
+      let variantsLength = config.variants->Array.length
       // Theoretically we can store 256 variants in Enum8,
       // but it'd require to explicitly start with a negative index (probably)
       let enumType = variantsLength <= 127 ? "Enum8" : "Enum16"
       let enumValues =
         config.variants
-        ->Belt.Array.map(variant => {
+        ->Array.map(variant => {
           let variantStr = variant->(Utils.magic: 'a => string)
           `'${variantStr}'`
         })
@@ -105,7 +105,7 @@ let getClickHouseFieldType = (
 let makeClickHouseEntitySchema = (table: Table.table): S.t<Internal.entity> => {
   S.schema(s => {
     let dict = Dict.make()
-    table.fields->Belt.Array.forEach(field => {
+    table.fields->Array.forEach(field => {
       switch field {
       | Field(f) => {
           let fieldName = f->Table.getDbFieldName
@@ -203,11 +203,11 @@ let setCheckpointsOrThrow = async (client, ~batch: Batch.t, ~database: string) =
     for idx in 0 to checkpointsCount - 1 {
       checkpointRows
       ->Array.push((
-        batch.checkpointIds->Belt.Array.getUnsafe(idx)->BigInt.toString,
-        batch.checkpointChainIds->Belt.Array.getUnsafe(idx),
-        batch.checkpointBlockNumbers->Belt.Array.getUnsafe(idx),
-        batch.checkpointBlockHashes->Belt.Array.getUnsafe(idx),
-        batch.checkpointEventsProcessed->Belt.Array.getUnsafe(idx),
+        batch.checkpointIds->Array.getUnsafe(idx)->BigInt.toString,
+        batch.checkpointChainIds->Array.getUnsafe(idx),
+        batch.checkpointBlockNumbers->Array.getUnsafe(idx),
+        batch.checkpointBlockHashes->Array.getUnsafe(idx),
+        batch.checkpointEventsProcessed->Array.getUnsafe(idx),
       ))
       ->ignore
     }
@@ -234,22 +234,6 @@ let setCheckpointsOrThrow = async (client, ~batch: Batch.t, ~database: string) =
 type setUpdatesCache = {
   tableName: string,
   convertOrThrow: Change.t<Internal.entity> => JSON.t,
-}
-
-// The entity history table is the source of truth for ClickHouse, so every
-// intermediate change must be persisted, not only the current value. Per
-// entity update, history holds the older changes in chronological order and
-// latestChange the most recent one.
-let collectChanges = (
-  updates: array<Internal.inMemoryStoreEntityUpdate>,
-  ~convertOrThrow: Change.t<Internal.entity> => 'a,
-): array<'a> => {
-  let values = []
-  updates->Belt.Array.forEach(update => {
-    update.history->Belt.Array.forEach(change => values->Array.push(change->convertOrThrow)->ignore)
-    values->Array.push(update.latestChange->convertOrThrow)->ignore
-  })
-  values
 }
 
 let setUpdatesOrThrow = async (
@@ -296,7 +280,15 @@ let setUpdatesOrThrow = async (
     }
 
     try {
-      let values = updates->collectChanges(~convertOrThrow)
+      // The entity history table is the source of truth for ClickHouse, so every
+      // intermediate change must be persisted, not only the current value. Per
+      // entity update, history holds the older changes in chronological order
+      // and latestChange the most recent one.
+      let values = []
+      updates->Array.forEach(update => {
+        update.history->Array.forEach(change => values->Array.push(change->convertOrThrow))
+        values->Array.push(update.latestChange->convertOrThrow)
+      })
 
       await insertWithRetry(client, ~table=tableName, ~values, ~format="JSONEachRow")
     } catch {
@@ -318,7 +310,7 @@ let makeCreateHistoryTableQuery = (
   ~replicated: bool=false,
 ) => {
   let tableEngine = replicated ? "ReplicatedMergeTree" : "MergeTree()"
-  let fieldDefinitions = entityConfig.table.fields->Belt.Array.keepMap(field => {
+  let fieldDefinitions = entityConfig.table.fields->Array.filterMap(field => {
     switch field {
     | Field(field) =>
       Some({
@@ -402,7 +394,7 @@ let makeCreateViewQuery = (~entityConfig: Internal.entityConfig, ~database: stri
 
   let entityFields =
     entityConfig.table.fields
-    ->Belt.Array.keepMap(field => {
+    ->Array.filterMap(field => {
       switch field {
       | Field(field) => {
           let fieldName = field->Table.getDbFieldName
@@ -446,12 +438,12 @@ let initialize = async (
 
     switch databaseEngine {
     | Some(engineSpec) => {
-        let expectedEngineName = engineSpec->String.split("(")->Belt.Array.getUnsafe(0)->String.trim
+        let expectedEngineName = engineSpec->String.split("(")->Array.getUnsafe(0)->String.trim
         let existingResult = await client->query({
           query: `SELECT engine FROM system.databases WHERE name = '${database}'`,
         })
         let rows: array<{"engine": string}> = await existingResult->json
-        switch rows->Belt.Array.get(0) {
+        switch rows->Array.get(0) {
         | Some(row) if row["engine"] !== expectedEngineName =>
           JsError.throwWithMessage(
             `ClickHouse database "${database}" exists with engine "${row["engine"]}" but ENVIO_CLICKHOUSE_DATABASE_ENGINE specifies "${expectedEngineName}". Drop the database manually to change its engine.`,
@@ -469,14 +461,14 @@ let initialize = async (
     await client->exec({query: `USE ${database}`})
 
     await Promise.all(
-      entities->Belt.Array.map(entityConfig =>
+      entities->Array.map(entityConfig =>
         client->exec({query: makeCreateHistoryTableQuery(~entityConfig, ~database, ~replicated)})
       ),
     )->Utils.Promise.ignoreValue
     await client->exec({query: makeCreateCheckpointsTableQuery(~database, ~replicated)})
 
     await Promise.all(
-      entities->Belt.Array.map(entityConfig =>
+      entities->Array.map(entityConfig =>
         client->exec({query: makeCreateViewQuery(~entityConfig, ~database)})
       ),
     )->Utils.Promise.ignoreValue
@@ -513,7 +505,7 @@ let resume = async (client, ~database: string, ~checkpointId: Internal.checkpoin
 
     // Delete rows with checkpoint IDs higher than the target for each history table
     await Promise.all(
-      tables->Belt.Array.map(table => {
+      tables->Array.map(table => {
         let tableName = table["name"]
         client->exec({
           query: `ALTER TABLE ${database}.\`${tableName}\` DELETE WHERE \`${EntityHistory.checkpointIdFieldName}\` > ${checkpointId->BigInt.toString}`,

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -236,6 +236,21 @@ type setUpdatesCache = {
   convertOrThrow: Change.t<Internal.entity> => JSON.t,
 }
 
+// The entity history table is the source of truth for ClickHouse, so every
+// intermediate change must be persisted, not only the current value. Per
+// entity update, history holds the older changes in chronological order and
+// latestChange the most recent one.
+let collectChanges = (updates: array<Internal.inMemoryStoreEntityUpdate>): array<
+  Change.t<Internal.entity>,
+> => {
+  let changes = []
+  updates->Belt.Array.forEach(update => {
+    update.history->Belt.Array.forEach(change => changes->Array.push(change)->ignore)
+    changes->Array.push(update.latestChange)->ignore
+  })
+  changes
+}
+
 let setUpdatesOrThrow = async (
   client,
   ~cache: Utils.WeakMap.t<Internal.entityConfig, setUpdatesCache>,
@@ -280,10 +295,7 @@ let setUpdatesOrThrow = async (
     }
 
     try {
-      // Convert entity updates to ClickHouse row format
-      let values = updates->Array.map(update => {
-        update.latestChange->convertOrThrow
-      })
+      let values = updates->collectChanges->Array.map(convertOrThrow)
 
       await insertWithRetry(client, ~table=tableName, ~values, ~format="JSONEachRow")
     } catch {

--- a/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
@@ -163,34 +163,3 @@ WHERE \`envio_change\` = 'SET'`
     )
   })
 })
-
-describe("Test collectChanges", () => {
-  Async.it(
-    "Flattens every update into its history changes followed by the latest change",
-    async t => {
-      let entity = (id): Internal.entity =>
-        {"id": id}->(Utils.magic: {"id": string} => Internal.entity)
-      let set = (~id, ~checkpointId): Change.t<Internal.entity> =>
-        Change.Set({entityId: id, entity: entity(id), checkpointId: BigInt.fromInt(checkpointId)})
-      let delete = (~id, ~checkpointId): Change.t<Internal.entity> =>
-        Change.Delete({entityId: id, checkpointId: BigInt.fromInt(checkpointId)})
-
-      let aV1 = set(~id="a", ~checkpointId=1)
-      let aV2 = set(~id="a", ~checkpointId=2)
-      let aV3 = set(~id="a", ~checkpointId=3)
-      let bDelete = delete(~id="b", ~checkpointId=4)
-
-      let updates: array<Internal.inMemoryStoreEntityUpdate> = [
-        {latestChange: aV3, history: [aV1, aV2]},
-        {latestChange: bDelete, history: []},
-      ]
-
-      t.expect(
-        updates->ClickHouse.collectChanges(~convertOrThrow=change =>
-          change->Change.getCheckpointId->BigInt.toString
-        ),
-        ~message="Should convert all history changes in order, then the latest change",
-      ).toEqual(["1", "2", "3", "4"])
-    },
-  )
-})

--- a/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
@@ -163,3 +163,32 @@ WHERE \`envio_change\` = 'SET'`
     )
   })
 })
+
+describe("Test collectChanges", () => {
+  Async.it(
+    "Flattens every update into its history changes followed by the latest change",
+    async t => {
+      let entity = (id): Internal.entity =>
+        {"id": id}->(Utils.magic: {"id": string} => Internal.entity)
+      let set = (~id, ~checkpointId): Change.t<Internal.entity> =>
+        Change.Set({entityId: id, entity: entity(id), checkpointId: BigInt.fromInt(checkpointId)})
+      let delete = (~id, ~checkpointId): Change.t<Internal.entity> =>
+        Change.Delete({entityId: id, checkpointId: BigInt.fromInt(checkpointId)})
+
+      let aV1 = set(~id="a", ~checkpointId=1)
+      let aV2 = set(~id="a", ~checkpointId=2)
+      let aV3 = set(~id="a", ~checkpointId=3)
+      let bDelete = delete(~id="b", ~checkpointId=4)
+
+      let updates: array<Internal.inMemoryStoreEntityUpdate> = [
+        {latestChange: aV3, history: [aV1, aV2]},
+        {latestChange: bDelete, history: []},
+      ]
+
+      t.expect(
+        ClickHouse.collectChanges(updates),
+        ~message="Should write all history changes in order, then the latest change",
+      ).toEqual([aV1, aV2, aV3, bDelete])
+    },
+  )
+})

--- a/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
@@ -186,9 +186,11 @@ describe("Test collectChanges", () => {
       ]
 
       t.expect(
-        ClickHouse.collectChanges(updates),
-        ~message="Should write all history changes in order, then the latest change",
-      ).toEqual([aV1, aV2, aV3, bDelete])
+        updates->ClickHouse.collectChanges(~convertOrThrow=change =>
+          change->Change.getCheckpointId->BigInt.toString
+        ),
+        ~message="Should convert all history changes in order, then the latest change",
+      ).toEqual(["1", "2", "3", "4"])
     },
   )
 })


### PR DESCRIPTION
## Summary
Modified ClickHouse persistence to write all intermediate entity changes to the history table, not just the latest state. This ensures the entity history table remains the complete source of truth for all state transitions.

## Changes
- **Added `collectChanges` function** in `ClickHouse.res` that flattens entity updates by extracting all history changes in chronological order followed by the latest change
- **Updated `setUpdatesOrThrow`** to use `collectChanges` instead of only persisting `latestChange`, ensuring all intermediate states are written to ClickHouse
- **Added comprehensive test** in `ClickHouse_test.res` verifying that `collectChanges` correctly orders history changes before the latest change for multiple entities

## Implementation Details
The `collectChanges` function iterates through updates and builds a flat array where each entity's history changes are written first (in order), followed by its latest change. This preserves the complete audit trail of state transitions in ClickHouse while maintaining chronological ordering across all changes.

https://claude.ai/code/session_01UVSaigUffJJb1qS1AH1NYc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ClickHouse data persistence to store complete change history for each entity update, rather than only the latest changes. This ensures comprehensive historical data tracking is available in ClickHouse.

* **Tests**
  * Added test coverage to verify change history collection and ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperindex/pull/1257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->