### PR TITLE
Preserve committed entities across batches without rewriting history

### DIFF
--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -41,6 +41,7 @@ type t = {
   mutable entities: dict<InMemoryTable.Entity.t>,
   mutable effects: dict<effectCacheInMemTable>,
   mutable rollback: option<Persistence.rollback>,
+  mutable commitedCheckpointId: Internal.checkpointId,
 }
 
 let make = (~entities: array<Internal.entityConfig>): t => {
@@ -49,14 +50,12 @@ let make = (~entities: array<Internal.entityConfig>): t => {
   entities: EntityTables.make(entities),
   effects: Dict.make(),
   rollback: None,
+  commitedCheckpointId: Internal.loadedFromDbCheckpointId,
 }
 
-let clear = (self: t) => {
-  self.rawEvents = InMemoryTable.make(~hash=hashRawEventsKey)
-  self.entities = EntityTables.make(self.allEntities)
-  self.effects = Dict.make()
-  self.rollback = None
-}
+// Above this size we drop the entities kept in memory after a batch write,
+// so the store doesn't grow unbounded on long running indexers.
+let keepLatestChangesLimit = 50_000
 
 let getEffectInMemTable = (inMemoryStore: t, ~effect: Internal.effect) => {
   let key = effect.name
@@ -95,11 +94,12 @@ let writeBatch = async (
   | Initializing(_) =>
     JsError.throwWithMessage(`Failed to access the indexer storage. The Persistence layer is not initialized.`)
   | Ready({cache}) =>
+    let commitedCheckpointId = inMemoryStore.commitedCheckpointId
     let updatedEntities = persistence.allEntities->Belt.Array.keepMap(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
       let changes = table.prevEntityChanges->Belt.Array.copy
       table.latestEntityChangeById->Utils.Dict.forEach(change =>
-        if change->Change.getCheckpointId !== Internal.loadedFromDbCheckpointId {
+        if change->Change.getCheckpointId > commitedCheckpointId {
           changes->Array.push(change)
         }
       )
@@ -156,7 +156,22 @@ let writeBatch = async (
         acc
       },
     )
-    inMemoryStore->clear
+
+    inMemoryStore.rawEvents = InMemoryTable.make(~hash=hashRawEventsKey)
+    inMemoryStore.effects = Dict.make()
+    inMemoryStore.rollback = None
+    inMemoryStore.commitedCheckpointId = switch batch.checkpointIds->Utils.Array.last {
+    | Some(checkpointId) => checkpointId
+    | None => commitedCheckpointId
+    }
+    persistence.allEntities->Belt.Array.forEach(entityConfig => {
+      let table = inMemoryStore->getInMemTable(~entityConfig)
+      let resetTable =
+        table.latestEntityChangeById->Utils.Dict.size >= keepLatestChangesLimit
+          ? InMemoryTable.Entity.make()
+          : table->InMemoryTable.Entity.resetButKeepLatestChanges
+      inMemoryStore.entities->Dict.set((entityConfig.name :> string), resetTable)
+    })
   }
 
 let prepareRollbackDiff = async (
@@ -165,7 +180,9 @@ let prepareRollbackDiff = async (
   ~rollbackTargetCheckpointId,
   ~rollbackDiffCheckpointId,
 ) => {
-  inMemoryStore->clear
+  inMemoryStore.rawEvents = InMemoryTable.make(~hash=hashRawEventsKey)
+  inMemoryStore.entities = EntityTables.make(inMemoryStore.allEntities)
+  inMemoryStore.effects = Dict.make()
   inMemoryStore.rollback = Some({
     targetCheckpointId: rollbackTargetCheckpointId,
     diffCheckpointId: rollbackDiffCheckpointId,
@@ -186,6 +203,7 @@ let prepareRollbackDiff = async (
     removedIdsResult->Array.forEach(data => {
       deletedEntities->Utils.Dict.push(entityConfig.name, data["id"])
       entityTable->InMemoryTable.Entity.set(
+        ~commitedCheckpointId=inMemoryStore.commitedCheckpointId,
         Delete({
           entityId: data["id"],
           checkpointId: rollbackDiffCheckpointId,
@@ -198,6 +216,7 @@ let prepareRollbackDiff = async (
     restoredEntities->Belt.Array.forEach((entity: Internal.entity) => {
       setEntities->Utils.Dict.push(entityConfig.name, entity.id)
       entityTable->InMemoryTable.Entity.set(
+        ~commitedCheckpointId=inMemoryStore.commitedCheckpointId,
         Set({
           entityId: entity.id,
           checkpointId: rollbackDiffCheckpointId,
@@ -243,6 +262,7 @@ let setBatchDcs = (inMemoryStore: t, ~batch: Batch.t) => {
           }
 
           inMemTable->InMemoryTable.Entity.set(
+            ~commitedCheckpointId=inMemoryStore.commitedCheckpointId,
             Set({
               entityId: entity.id,
               checkpointId,

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -166,11 +166,13 @@ let writeBatch = async (
     | Some(checkpointId) => checkpointId
     | None => committedCheckpointId
     }
-    let totalLatestChanges =
-      persistence.allEntities->Belt.Array.reduce(0, (acc, entityConfig) =>
-        acc + (inMemoryStore->getInMemTable(~entityConfig)).latestEntityChangeById->Utils.Dict.size
-      )
-    let keepLatestChanges = totalLatestChanges < keepLatestChangesLimit
+    let totalLatestChanges = ref(0)
+    persistence.allEntities->Belt.Array.forEach(entityConfig => {
+      totalLatestChanges :=
+        totalLatestChanges.contents +
+        (inMemoryStore->getInMemTable(~entityConfig)).latestEntityChangeById->Utils.Dict.size
+    })
+    let keepLatestChanges = totalLatestChanges.contents < keepLatestChangesLimit
     persistence.allEntities->Belt.Array.forEach(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
       let resetTable = keepLatestChanges

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -97,7 +97,9 @@ let writeBatch = async (
     let commitedCheckpointId = inMemoryStore.commitedCheckpointId
     let updatedEntities = persistence.allEntities->Belt.Array.keepMap(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
-      let changes = table.prevEntityChanges->Belt.Array.copy
+      // Safe to mutate prevEntityChanges directly since the table gets a fresh
+      // one in the reset below.
+      let changes = table.prevEntityChanges
       table.latestEntityChangeById->Utils.Dict.forEach(change =>
         if change->Change.getCheckpointId > commitedCheckpointId {
           changes->Array.push(change)

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -41,7 +41,7 @@ type t = {
   mutable entities: dict<InMemoryTable.Entity.t>,
   mutable effects: dict<effectCacheInMemTable>,
   mutable rollback: option<Persistence.rollback>,
-  mutable commitedCheckpointId: Internal.checkpointId,
+  mutable committedCheckpointId: Internal.checkpointId,
 }
 
 let make = (~entities: array<Internal.entityConfig>): t => {
@@ -50,7 +50,7 @@ let make = (~entities: array<Internal.entityConfig>): t => {
   entities: EntityTables.make(entities),
   effects: Dict.make(),
   rollback: None,
-  commitedCheckpointId: Internal.initialCheckpointId,
+  committedCheckpointId: Internal.initialCheckpointId,
 }
 
 // Once the store holds this many entities across all tables, we drop them
@@ -94,14 +94,14 @@ let writeBatch = async (
   | Initializing(_) =>
     JsError.throwWithMessage(`Failed to access the indexer storage. The Persistence layer is not initialized.`)
   | Ready({cache}) =>
-    let commitedCheckpointId = inMemoryStore.commitedCheckpointId
+    let committedCheckpointId = inMemoryStore.committedCheckpointId
     let updatedEntities = persistence.allEntities->Belt.Array.keepMap(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
       // Safe to mutate prevEntityChanges directly since the table gets a fresh
       // one in the reset below.
       let changes = table.prevEntityChanges
       table.latestEntityChangeById->Utils.Dict.forEach(change =>
-        if change->Change.getCheckpointId > commitedCheckpointId {
+        if change->Change.getCheckpointId > committedCheckpointId {
           changes->Array.push(change)
         }
       )
@@ -162,17 +162,15 @@ let writeBatch = async (
     inMemoryStore.rawEvents = InMemoryTable.make(~hash=hashRawEventsKey)
     inMemoryStore.effects = Dict.make()
     inMemoryStore.rollback = None
-    inMemoryStore.commitedCheckpointId = switch batch.checkpointIds->Utils.Array.last {
+    inMemoryStore.committedCheckpointId = switch batch.checkpointIds->Utils.Array.last {
     | Some(checkpointId) => checkpointId
-    | None => commitedCheckpointId
+    | None => committedCheckpointId
     }
-    let totalLatestChanges = ref(0)
-    persistence.allEntities->Belt.Array.forEach(entityConfig => {
-      totalLatestChanges :=
-        totalLatestChanges.contents +
-        (inMemoryStore->getInMemTable(~entityConfig)).latestEntityChangeById->Utils.Dict.size
-    })
-    let keepLatestChanges = totalLatestChanges.contents < keepLatestChangesLimit
+    let totalLatestChanges =
+      persistence.allEntities->Belt.Array.reduce(0, (acc, entityConfig) =>
+        acc + (inMemoryStore->getInMemTable(~entityConfig)).latestEntityChangeById->Utils.Dict.size
+      )
+    let keepLatestChanges = totalLatestChanges < keepLatestChangesLimit
     persistence.allEntities->Belt.Array.forEach(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
       let resetTable = keepLatestChanges
@@ -211,7 +209,7 @@ let prepareRollbackDiff = async (
     removedIdsResult->Array.forEach(data => {
       deletedEntities->Utils.Dict.push(entityConfig.name, data["id"])
       entityTable->InMemoryTable.Entity.set(
-        ~commitedCheckpointId=inMemoryStore.commitedCheckpointId,
+        ~committedCheckpointId=inMemoryStore.committedCheckpointId,
         Delete({
           entityId: data["id"],
           checkpointId: rollbackDiffCheckpointId,
@@ -224,7 +222,7 @@ let prepareRollbackDiff = async (
     restoredEntities->Belt.Array.forEach((entity: Internal.entity) => {
       setEntities->Utils.Dict.push(entityConfig.name, entity.id)
       entityTable->InMemoryTable.Entity.set(
-        ~commitedCheckpointId=inMemoryStore.commitedCheckpointId,
+        ~committedCheckpointId=inMemoryStore.committedCheckpointId,
         Set({
           entityId: entity.id,
           checkpointId: rollbackDiffCheckpointId,
@@ -270,7 +268,7 @@ let setBatchDcs = (inMemoryStore: t, ~batch: Batch.t) => {
           }
 
           inMemTable->InMemoryTable.Entity.set(
-            ~commitedCheckpointId=inMemoryStore.commitedCheckpointId,
+            ~committedCheckpointId=inMemoryStore.committedCheckpointId,
             Set({
               entityId: entity.id,
               checkpointId,

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -53,8 +53,8 @@ let make = (~entities: array<Internal.entityConfig>): t => {
   commitedCheckpointId: Internal.loadedFromDbCheckpointId,
 }
 
-// Above this size we drop the entities kept in memory after a batch write,
-// so the store doesn't grow unbounded on long running indexers.
+// Once the store holds this many entities across all tables, we drop them
+// after a batch write so it doesn't grow unbounded on long running indexers.
 let keepLatestChangesLimit = 50_000
 
 let getEffectInMemTable = (inMemoryStore: t, ~effect: Internal.effect) => {
@@ -164,12 +164,18 @@ let writeBatch = async (
     | Some(checkpointId) => checkpointId
     | None => commitedCheckpointId
     }
+    let totalLatestChanges = ref(0)
+    persistence.allEntities->Belt.Array.forEach(entityConfig => {
+      totalLatestChanges :=
+        totalLatestChanges.contents +
+        (inMemoryStore->getInMemTable(~entityConfig)).latestEntityChangeById->Utils.Dict.size
+    })
+    let keepLatestChanges = totalLatestChanges.contents < keepLatestChangesLimit
     persistence.allEntities->Belt.Array.forEach(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
-      let resetTable =
-        table.latestEntityChangeById->Utils.Dict.size >= keepLatestChangesLimit
-          ? InMemoryTable.Entity.make()
-          : table->InMemoryTable.Entity.resetButKeepLatestChanges
+      let resetTable = keepLatestChanges
+        ? table->InMemoryTable.Entity.resetButKeepLatestChanges
+        : InMemoryTable.Entity.make()
       inMemoryStore.entities->Dict.set((entityConfig.name :> string), resetTable)
     })
   }

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -50,7 +50,7 @@ let make = (~entities: array<Internal.entityConfig>): t => {
   entities: EntityTables.make(entities),
   effects: Dict.make(),
   rollback: None,
-  commitedCheckpointId: Internal.loadedFromDbCheckpointId,
+  commitedCheckpointId: Internal.initialCheckpointId,
 }
 
 // Once the store holds this many entities across all tables, we drop them

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -173,13 +173,13 @@ module Entity = {
   }
 
   let setRow = set
-  let set = (inMemTable: t, ~commitedCheckpointId, change: Change.t<Internal.entity>) => {
+  let set = (inMemTable: t, ~committedCheckpointId, change: Change.t<Internal.entity>) => {
     let entityId = change->Change.getEntityId
     switch inMemTable.latestEntityChangeById->Utils.Dict.dangerouslyGetNonOption(entityId) {
     | Some(prev) =>
       let prevCheckpointId = prev->Change.getCheckpointId
       if (
-        prevCheckpointId > commitedCheckpointId && prevCheckpointId < change->Change.getCheckpointId
+        prevCheckpointId > committedCheckpointId && prevCheckpointId < change->Change.getCheckpointId
       ) {
         inMemTable.prevEntityChanges->Array.push(prev)
       }

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -75,6 +75,14 @@ module Entity = {
     fieldNameIndices: make(~hash=TableIndices.Index.getFieldName),
   }
 
+  // Drops the per-batch index state and rollback history, but keeps the
+  // already committed entities so the next batch can read them without
+  // hitting the database.
+  let resetButKeepLatestChanges = (self: t): t => {
+    ...make(),
+    latestEntityChangeById: self.latestEntityChangeById,
+  }
+
   let updateIndices = (self: t, ~entity: Internal.entity) => {
     let entityId = entity->getEntityIdUnsafe
     //Remove any invalid indices on entity
@@ -165,14 +173,13 @@ module Entity = {
   }
 
   let setRow = set
-  let set = (inMemTable: t, change: Change.t<Internal.entity>) => {
+  let set = (inMemTable: t, ~commitedCheckpointId, change: Change.t<Internal.entity>) => {
     let entityId = change->Change.getEntityId
     switch inMemTable.latestEntityChangeById->Utils.Dict.dangerouslyGetNonOption(entityId) {
     | Some(prev) =>
       let prevCheckpointId = prev->Change.getCheckpointId
       if (
-        prevCheckpointId !== Internal.loadedFromDbCheckpointId &&
-          prevCheckpointId < change->Change.getCheckpointId
+        prevCheckpointId > commitedCheckpointId && prevCheckpointId < change->Change.getCheckpointId
       ) {
         inMemTable.prevEntityChanges->Array.push(prev)
       }

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -586,6 +586,9 @@ type checkpointId = bigint
 // Assigned to changes loaded from the db, which never become history.
 let loadedFromDbCheckpointId: checkpointId = 0n
 
+// Committed checkpoint before any batch is written.
+let initialCheckpointId: checkpointId = 0n
+
 type reorgCheckpoint = {
   @as("id")
   checkpointId: bigint,

--- a/packages/envio/src/UserContext.res
+++ b/packages/envio/src/UserContext.res
@@ -222,7 +222,7 @@ let entityTraps: Utils.Proxy.traps<entityContextParams> = {
           params.inMemoryStore
           ->InMemoryStore.getInMemTable(~entityConfig=params.entityConfig)
           ->InMemoryTable.Entity.set(
-            ~commitedCheckpointId=params.inMemoryStore.commitedCheckpointId,
+            ~committedCheckpointId=params.inMemoryStore.committedCheckpointId,
             Set({
               entityId: entity.id,
               checkpointId: params.checkpointId,
@@ -328,7 +328,7 @@ let entityTraps: Utils.Proxy.traps<entityContextParams> = {
           params.inMemoryStore
           ->InMemoryStore.getInMemTable(~entityConfig=params.entityConfig)
           ->InMemoryTable.Entity.set(
-            ~commitedCheckpointId=params.inMemoryStore.commitedCheckpointId,
+            ~committedCheckpointId=params.inMemoryStore.committedCheckpointId,
             Delete({
               entityId,
               checkpointId: params.checkpointId,

--- a/packages/envio/src/UserContext.res
+++ b/packages/envio/src/UserContext.res
@@ -222,6 +222,7 @@ let entityTraps: Utils.Proxy.traps<entityContextParams> = {
           params.inMemoryStore
           ->InMemoryStore.getInMemTable(~entityConfig=params.entityConfig)
           ->InMemoryTable.Entity.set(
+            ~commitedCheckpointId=params.inMemoryStore.commitedCheckpointId,
             Set({
               entityId: entity.id,
               checkpointId: params.checkpointId,
@@ -327,6 +328,7 @@ let entityTraps: Utils.Proxy.traps<entityContextParams> = {
           params.inMemoryStore
           ->InMemoryStore.getInMemTable(~entityConfig=params.entityConfig)
           ->InMemoryTable.Entity.set(
+            ~commitedCheckpointId=params.inMemoryStore.commitedCheckpointId,
             Delete({
               entityId,
               checkpointId: params.checkpointId,

--- a/scenarios/test_codegen/test/WriteRead_test.res
+++ b/scenarios/test_codegen/test/WriteRead_test.res
@@ -178,6 +178,55 @@ breaking precicion on big values. https://github.com/enviodev/hyperindex/issues/
     })
   })
 
+  Async.it(
+    "Keeps committed entities across batches without rewriting their history",
+    async t => {
+      let sourceMock = MockIndexer.Source.make(~chain=#1337, [#getHeightOrThrow, #getItemsOrThrow])
+      let indexerMock = await MockIndexer.Indexer.make(
+        ~chains=[{chain: #1337, sourceConfig: Config.CustomSources([sourceMock.source])}],
+        ~saveFullHistory=true,
+      )
+      await Utils.delay(0)
+
+      sourceMock.resolveGetHeightOrThrow(300)
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      sourceMock.resolveGetItemsOrThrow([
+        {
+          blockNumber: 50,
+          logIndex: 1,
+          handler: async ({context}) => {
+            context.\"SimpleEntity".set({id: "untouched", value: "batch1"})
+            context.\"SimpleEntity".set({id: "updated", value: "batch1"})
+          },
+        },
+      ])
+      await indexerMock.getBatchWritePromise()
+
+      sourceMock.resolveGetItemsOrThrow([
+        {
+          blockNumber: 51,
+          logIndex: 1,
+          handler: async ({context}) => {
+            // "untouched" is carried over from the previous batch and read from
+            // the in-memory store without hitting the db.
+            let untouched = await context.\"SimpleEntity".get("untouched")
+            t.expect(untouched).toEqual(Some({id: "untouched", value: "batch1"}))
+            context.\"SimpleEntity".set({id: "updated", value: "batch2"})
+          },
+        },
+      ])
+      await indexerMock.getBatchWritePromise()
+
+      t.expect(await indexerMock.queryHistory(SimpleEntity)).toEqual([
+        Set({checkpointId: 1n, entityId: "untouched", entity: {id: "untouched", value: "batch1"}}),
+        Set({checkpointId: 1n, entityId: "updated", entity: {id: "updated", value: "batch1"}}),
+        Set({checkpointId: 3n, entityId: "updated", entity: {id: "updated", value: "batch2"}}),
+      ])
+    },
+  )
+
   Async.it("Test getWhere queries with eq and gt operators", async t => {
     let sourceMock = MockIndexer.Source.make(~chain=#1337, [#getHeightOrThrow, #getItemsOrThrow])
     let indexerMock = await MockIndexer.Indexer.make(

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -12,6 +12,7 @@ module InMemoryStore = {
     let inMemTable = inMemoryStore->InMemoryStore.getInMemTable(~entityConfig)
     let entity = entity->(Utils.magic: 'a => Internal.entity)
     inMemTable->InMemoryTable.Entity.set(
+      ~commitedCheckpointId=inMemoryStore.commitedCheckpointId,
       Set({
         entityId: (entity: Internal.entity).id,
         checkpointId: 0n,

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -12,7 +12,7 @@ module InMemoryStore = {
     let inMemTable = inMemoryStore->InMemoryStore.getInMemTable(~entityConfig)
     let entity = entity->(Utils.magic: 'a => Internal.entity)
     inMemTable->InMemoryTable.Entity.set(
-      ~commitedCheckpointId=inMemoryStore.commitedCheckpointId,
+      ~committedCheckpointId=inMemoryStore.committedCheckpointId,
       Set({
         entityId: (entity: Internal.entity).id,
         checkpointId: 0n,


### PR DESCRIPTION
## Summary
This change ensures that entities committed in previous batches are preserved in the in-memory store and can be read in subsequent batches without hitting the database, while maintaining correct history tracking.

## Key Changes
- **InMemoryStore**: Added `commitedCheckpointId` field to track the last committed checkpoint, replacing the previous approach of checking against `loadedFromDbCheckpointId`
- **Batch write logic**: Modified to selectively clear in-memory state while preserving committed entities:
  - Clears raw events, effects, and rollback state after each batch
  - Keeps `latestEntityChangeById` for entities below a size threshold (50,000 entities)
  - Updates `commitedCheckpointId` to the last checkpoint in the batch
- **InMemoryTable.Entity**: 
  - Added `resetButKeepLatestChanges()` to drop per-batch state while preserving committed entities
  - Updated `set()` to accept `commitedCheckpointId` parameter for accurate change tracking
- **Change detection**: Updated logic to compare checkpoint IDs against `commitedCheckpointId` instead of `loadedFromDbCheckpointId`, ensuring only uncommitted changes are written to the database
- **Test coverage**: Added comprehensive test verifying that entities from previous batches are read from memory and history is correctly maintained across batches

## Implementation Details
- When a batch completes, the store now keeps the latest entity changes in memory if the table size is below the limit, allowing subsequent batches to read them without database queries
- The `commitedCheckpointId` acts as a watermark to distinguish between committed changes (which should be preserved) and in-batch changes (which should be written)
- For large entity tables (≥50,000 entities), the store still clears the in-memory table to prevent unbounded memory growth on long-running indexers

https://claude.ai/code/session_01JRHFPTtYobx3WjahffvE1y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved in-memory checkpoint tracking so committed entity state is preserved across batch writes while retaining recent change history.

* **Bug Fixes**
  * Rollback and entity update flows refined to align in-memory state with committed checkpoints, preventing unintended history truncation.

* **Tests**
  * Added a test validating entity persistence and history ordering across sequential batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->