### PR TITLE
Move committedCheckpointId from ChainManager to InMemoryStore

### DIFF
--- a/packages/envio/src/ChainManager.res
+++ b/packages/envio/src/ChainManager.res
@@ -135,7 +135,7 @@ let nextItemIsNone = (chainManager: t): bool => {
 
 let createBatch = (
   chainManager: t,
-  ~committedCheckpointId=Internal.initialCheckpointId,
+  ~committedCheckpointId,
   ~batchSizeTarget: int,
   ~isRollback: bool,
 ): Batch.t => {

--- a/packages/envio/src/ChainManager.res
+++ b/packages/envio/src/ChainManager.res
@@ -1,5 +1,4 @@
 type t = {
-  committedCheckpointId: bigint,
   chainFetchers: ChainMap.t<ChainFetcher.t>,
   isInReorgThreshold: bool,
   // True once every chain has caught up to head/endBlock. Monotonic during a run.
@@ -106,7 +105,6 @@ let makeFromDbState = (
   }
 
   {
-    committedCheckpointId: initialState.checkpointId,
     chainFetchers,
     isInReorgThreshold,
     isRealtime,
@@ -135,9 +133,14 @@ let nextItemIsNone = (chainManager: t): bool => {
   )
 }
 
-let createBatch = (chainManager: t, ~batchSizeTarget: int, ~isRollback: bool): Batch.t => {
+let createBatch = (
+  chainManager: t,
+  ~committedCheckpointId=Internal.initialCheckpointId,
+  ~batchSizeTarget: int,
+  ~isRollback: bool,
+): Batch.t => {
   Batch.make(
-    ~checkpointIdBeforeBatch=chainManager.committedCheckpointId->BigInt.add(
+    ~checkpointIdBeforeBatch=committedCheckpointId->BigInt.add(
       // Since for rollback we have a diff checkpoint id.
       // This is needed to currectly overwrite old state
       // in an append-only ClickHouse insert.

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -330,10 +330,6 @@ let updateProgressedChains = (chainManager: ChainManager.t, ~batch: Batch.t, ~ct
 
   {
     ...chainManager,
-    committedCheckpointId: switch batch.checkpointIds->Utils.Array.last {
-    | Some(checkpointId) => checkpointId
-    | None => chainManager.committedCheckpointId
-    },
     chainFetchers,
     isRealtime: chainManager.isRealtime || allChainsReady.contents,
   }
@@ -951,6 +947,7 @@ let injectedTaskReducer = (
 
         let batch =
           state.chainManager->ChainManager.createBatch(
+            ~committedCheckpointId=state.ctx.inMemoryStore.committedCheckpointId,
             ~batchSizeTarget=state.ctx.config.batchSize,
             ~isRollback=isRollbackBatch,
           )
@@ -1182,7 +1179,7 @@ let injectedTaskReducer = (
         let diff = await state.ctx.inMemoryStore->InMemoryStore.prepareRollbackDiff(
           ~persistence=state.ctx.persistence,
           ~rollbackTargetCheckpointId,
-          ~rollbackDiffCheckpointId=state.chainManager.committedCheckpointId->BigInt.add(1n),
+          ~rollbackDiffCheckpointId=state.ctx.inMemoryStore.committedCheckpointId->BigInt.add(1n),
         )
 
         let chainManager = {
@@ -1197,7 +1194,7 @@ let injectedTaskReducer = (
             "upserted": diff["setEntities"],
           },
           "rollbackedEvents": rollbackedProcessedEvents.contents,
-          "beforeCheckpointId": state.chainManager.committedCheckpointId,
+          "beforeCheckpointId": state.ctx.inMemoryStore.committedCheckpointId,
           "targetCheckpointId": rollbackTargetCheckpointId,
         })
         Prometheus.RollbackSuccess.increment(

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -44,13 +44,16 @@ type t = {
   mutable committedCheckpointId: Internal.checkpointId,
 }
 
-let make = (~entities: array<Internal.entityConfig>): t => {
+let make = (
+  ~entities: array<Internal.entityConfig>,
+  ~committedCheckpointId=Internal.initialCheckpointId,
+): t => {
   allEntities: entities,
   rawEvents: InMemoryTable.make(~hash=hashRawEventsKey),
   entities: EntityTables.make(entities),
   effects: Dict.make(),
   rollback: None,
-  committedCheckpointId: Internal.initialCheckpointId,
+  committedCheckpointId,
 }
 
 // Once the store holds this many entities across all tables, we drop them

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -690,7 +690,10 @@ let start = async (
     Ctx.registrations,
     config,
     persistence,
-    inMemoryStore: InMemoryStore.make(~entities=persistence.allEntities),
+    inMemoryStore: InMemoryStore.make(
+      ~entities=persistence.allEntities,
+      ~committedCheckpointId=(persistence->Persistence.getInitializedState).checkpointId,
+    ),
   }
 
   let envioVersion = Utils.EnvioPackage.value.version

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -129,7 +129,6 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
   (
     {
       ChainManager.chainFetchers,
-      committedCheckpointId: 0n,
       isInReorgThreshold: false,
       isRealtime: false,
     },

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -163,6 +163,7 @@ describe("ChainManager", () => {
         let rec testThatCreatedEventsAreOrderedCorrectly = (chainManager, lastEvent) => {
           let {items, totalBatchSize, progressedChainsById} = ChainManager.createBatch(
             chainManager,
+            ~committedCheckpointId=Internal.initialCheckpointId,
             ~batchSizeTarget=10000,
             ~isRollback=false,
           )


### PR DESCRIPTION
## Summary
Refactors checkpoint tracking by moving `committedCheckpointId` from `ChainManager` to `InMemoryStore`, where it logically belongs as part of the in-memory state. This simplifies the `ChainManager` type and makes checkpoint state management more cohesive.

## Key Changes
- Removed `committedCheckpointId` field from `ChainManager.t` type
- Updated `ChainManager.createBatch` to accept `committedCheckpointId` as a parameter instead of reading from the manager
- Moved checkpoint initialization to `InMemoryStore.make`, accepting it as an optional parameter defaulting to `Internal.initialCheckpointId`
- Updated `Main.res` to initialize `InMemoryStore` with the checkpoint ID from persisted state
- Removed checkpoint update logic from `GlobalState.updateProgressedChains` (no longer needed in ChainManager)
- Updated all call sites to pass `committedCheckpointId` from `state.ctx.inMemoryStore` instead of `state.chainManager`
- Updated test fixtures to remove the field from ChainManager construction

## Implementation Details
- `InMemoryStore.make` now accepts an optional `~committedCheckpointId` parameter, initialized from persisted state during startup
- `ChainManager.createBatch` now requires `committedCheckpointId` as an explicit parameter, making the dependency clear at call sites
- All references to checkpoint state now flow through `InMemoryStore`, centralizing state management

https://claude.ai/code/session_017aScst99c1b2ETxLY7fyTb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal checkpoint state management to improve system reliability and code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->