### PR TITLE
Simplify InMemoryTable by removing generic wrapper

### DIFF
--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -93,12 +93,7 @@ let addItemToRawEvents = (
     params,
   }
 
-  let eventIdStr = eventId->BigInt.toString
-
-  inMemoryStore.rawEvents->Dict.set(
-    EventUtils.getEventIdKeyString(~chainId, ~eventId=eventIdStr),
-    rawEvent,
-  )
+  inMemoryStore.rawEvents->Array.push(rawEvent)
 }
 
 exception ProcessingError({message: string, exn: exn, item: Internal.item})

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -95,7 +95,10 @@ let addItemToRawEvents = (
 
   let eventIdStr = eventId->BigInt.toString
 
-  inMemoryStore.rawEvents->InMemoryTable.set({chainId, eventId: eventIdStr}, rawEvent)
+  inMemoryStore.rawEvents->Dict.set(
+    EventUtils.getEventIdKeyString(~chainId, ~eventId=eventIdStr),
+    rawEvent,
+  )
 }
 
 exception ProcessingError({message: string, exn: exn, item: Internal.item})

--- a/packages/envio/src/EventUtils.res
+++ b/packages/envio/src/EventUtils.res
@@ -56,12 +56,3 @@ let packEventIndex = (~blockNumber, ~logIndex) => {
 // let packEventIndexFromRecord = (eventIndex: eventIndex) => {
 //   packEventIndex(~blockNumber=eventIndex.blockNumber, ~logIndex=eventIndex.logIndex)
 // }
-
-//Returns unique string id for an event using its chain id combined with event id
-//Used in IO for the key in the in mem rawEvents table
-let getEventIdKeyString = (~chainId: int, ~eventId: string) => {
-  let chainIdStr = chainId->Belt.Int.toString
-  let key = chainIdStr ++ "_" ++ eventId
-
-  key
-}

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -1,11 +1,3 @@
-type rawEventsKey = {
-  chainId: int,
-  eventId: string,
-}
-
-let hashRawEventsKey = (key: rawEventsKey) =>
-  EventUtils.getEventIdKeyString(~chainId=key.chainId, ~eventId=key.eventId)
-
 module EntityTables = {
   type t = dict<InMemoryTable.Entity.t>
   exception UndefinedEntity({entityName: string})
@@ -37,7 +29,7 @@ type effectCacheInMemTable = {
 
 type t = {
   allEntities: array<Internal.entityConfig>,
-  mutable rawEvents: InMemoryTable.t<rawEventsKey, InternalTable.RawEvents.t>,
+  mutable rawEvents: dict<InternalTable.RawEvents.t>,
   mutable entities: dict<InMemoryTable.Entity.t>,
   mutable effects: dict<effectCacheInMemTable>,
   mutable rollback: option<Persistence.rollback>,
@@ -46,7 +38,7 @@ type t = {
 
 let make = (~entities: array<Internal.entityConfig>): t => {
   allEntities: entities,
-  rawEvents: InMemoryTable.make(~hash=hashRawEventsKey),
+  rawEvents: Dict.make(),
   entities: EntityTables.make(entities),
   effects: Dict.make(),
   rollback: None,
@@ -113,7 +105,7 @@ let writeBatch = async (
     })
     await persistence.storage.writeBatch(
       ~batch,
-      ~rawEvents=inMemoryStore.rawEvents->InMemoryTable.values,
+      ~rawEvents=inMemoryStore.rawEvents->Dict.valuesToArray,
       ~rollback=inMemoryStore.rollback,
       ~isInReorgThreshold,
       ~config,
@@ -159,7 +151,7 @@ let writeBatch = async (
       },
     )
 
-    inMemoryStore.rawEvents = InMemoryTable.make(~hash=hashRawEventsKey)
+    inMemoryStore.rawEvents = Dict.make()
     inMemoryStore.effects = Dict.make()
     inMemoryStore.rollback = None
     inMemoryStore.committedCheckpointId = switch batch.checkpointIds->Utils.Array.last {
@@ -188,7 +180,7 @@ let prepareRollbackDiff = async (
   ~rollbackTargetCheckpointId,
   ~rollbackDiffCheckpointId,
 ) => {
-  inMemoryStore.rawEvents = InMemoryTable.make(~hash=hashRawEventsKey)
+  inMemoryStore.rawEvents = Dict.make()
   inMemoryStore.entities = EntityTables.make(inMemoryStore.allEntities)
   inMemoryStore.effects = Dict.make()
   inMemoryStore.rollback = Some({

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -29,7 +29,7 @@ type effectCacheInMemTable = {
 
 type t = {
   allEntities: array<Internal.entityConfig>,
-  mutable rawEvents: dict<InternalTable.RawEvents.t>,
+  mutable rawEvents: array<InternalTable.RawEvents.t>,
   mutable entities: dict<InMemoryTable.Entity.t>,
   mutable effects: dict<effectCacheInMemTable>,
   mutable rollback: option<Persistence.rollback>,
@@ -38,7 +38,7 @@ type t = {
 
 let make = (~entities: array<Internal.entityConfig>): t => {
   allEntities: entities,
-  rawEvents: Dict.make(),
+  rawEvents: [],
   entities: EntityTables.make(entities),
   effects: Dict.make(),
   rollback: None,
@@ -105,7 +105,7 @@ let writeBatch = async (
     })
     await persistence.storage.writeBatch(
       ~batch,
-      ~rawEvents=inMemoryStore.rawEvents->Dict.valuesToArray,
+      ~rawEvents=inMemoryStore.rawEvents,
       ~rollback=inMemoryStore.rollback,
       ~isInReorgThreshold,
       ~config,
@@ -151,7 +151,7 @@ let writeBatch = async (
       },
     )
 
-    inMemoryStore.rawEvents = Dict.make()
+    inMemoryStore.rawEvents = []
     inMemoryStore.effects = Dict.make()
     inMemoryStore.rollback = None
     inMemoryStore.committedCheckpointId = switch batch.checkpointIds->Utils.Array.last {
@@ -180,7 +180,7 @@ let prepareRollbackDiff = async (
   ~rollbackTargetCheckpointId,
   ~rollbackDiffCheckpointId,
 ) => {
-  inMemoryStore.rawEvents = Dict.make()
+  inMemoryStore.rawEvents = []
   inMemoryStore.entities = EntityTables.make(inMemoryStore.allEntities)
   inMemoryStore.effects = Dict.make()
   inMemoryStore.rollback = Some({

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -189,8 +189,7 @@ module Entity = {
       switch inMemTable.fieldNameIndices->Utils.Dict.dangerouslyGetNonOption(fieldName) {
       | None => false
       | Some(indicesSerializedToValue) => {
-          // Should match TableIndices.toString logic
-          let key = `${fieldName}:${(operator :> string)}:${fieldValueHash}`
+          let key = TableIndices.Index.toStringByParts(~fieldName, ~operator, ~fieldValueHash)
           indicesSerializedToValue->Utils.Dict.dangerouslyGetNonOption(key) !== None
         }
       }
@@ -203,8 +202,7 @@ module Entity = {
       | None =>
         JsError.throwWithMessage(`Unexpected error. Must have an index on field ${fieldName}`)
       | Some(indicesSerializedToValue) => {
-          // Should match TableIndices.toString logic
-          let key = `${fieldName}:${(operator :> string)}:${fieldValueHash}`
+          let key = TableIndices.Index.toStringByParts(~fieldName, ~operator, ~fieldValueHash)
           switch indicesSerializedToValue->Utils.Dict.dangerouslyGetNonOption(key) {
           | None =>
             JsError.throwWithMessage(

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -1,35 +1,10 @@
-type t<'key, 'val> = {
-  dict: dict<'val>,
-  hash: 'key => string,
-}
-
-let make = (~hash): t<'key, 'val> => {
-  dict: Dict.make(),
-  hash,
-}
-
-let set = (self: t<'key, 'val>, key, value) => self.dict->Dict.set(key->self.hash, value)
-
-let setByHash = (self: t<'key, 'val>, hash, value) => self.dict->Dict.set(hash, value)
-
-let hasByHash = (self: t<'key, 'val>, hash) => {
-  self.dict->Dict.has(hash)
-}
-
-let getUnsafeByHash = (self: t<'key, 'val>, hash) => {
-  self.dict->Dict.getUnsafe(hash)
-}
-
-let get = (self: t<'key, 'val>, key: 'key) =>
-  self.dict->Utils.Dict.dangerouslyGetNonOption(key->self.hash)
-
-let values = (self: t<'key, 'val>) => self.dict->Dict.valuesToArray
-
 module Entity = {
   type relatedEntityId = string
   type indexWithRelatedIds = (TableIndices.Index.t, Utils.Set.t<relatedEntityId>)
-  type indicesSerializedToValue = t<TableIndices.Index.t, indexWithRelatedIds>
-  type indexFieldNameToIndices = t<TableIndices.Index.t, indicesSerializedToValue>
+  // Keyed by TableIndices.Index.toString
+  type indicesSerializedToValue = dict<indexWithRelatedIds>
+  // Keyed by TableIndices.Index.getFieldName
+  type indexFieldNameToIndices = dict<indicesSerializedToValue>
 
   type entityIndices = Utils.Set.t<TableIndices.Index.t>
   type t = {
@@ -63,8 +38,8 @@ module Entity = {
     ~index,
     ~relatedEntityIds=Utils.Set.make(),
   ): indicesSerializedToValue => {
-    let empty = make(~hash=TableIndices.Index.toString)
-    empty->set(index, (index, relatedEntityIds))
+    let empty = Dict.make()
+    empty->Dict.set(index->TableIndices.Index.toString, (index, relatedEntityIds))
     empty
   }
 
@@ -72,7 +47,7 @@ module Entity = {
     latestEntityChangeById: Dict.make(),
     prevEntityChanges: [],
     indicesByEntityId: Dict.make(),
-    fieldNameIndices: make(~hash=TableIndices.Index.getFieldName),
+    fieldNameIndices: Dict.make(),
   }
 
   // Drops the per-batch index state and rollback history, but keeps the
@@ -101,10 +76,10 @@ module Entity = {
       })
     }
 
-    self.fieldNameIndices.dict
+    self.fieldNameIndices
     ->Dict.keysToArray
     ->Array.forEach(fieldName => {
-      let indices = self.fieldNameIndices.dict->Dict.getUnsafe(fieldName)
+      let indices = self.fieldNameIndices->Dict.getUnsafe(fieldName)
       // A missing key reads as `undefined`, which matches the `None` arm of
       // `FieldValue.t` (`option<...>`). Mirror `addEmptyIndex` so nullable
       // FK columns that were omitted on the set entity don't crash.
@@ -113,7 +88,7 @@ module Entity = {
         ->(Utils.magic: Internal.entity => dict<TableIndices.FieldValue.t>)
         ->Dict.getUnsafe(fieldName)
       indices
-      ->values
+      ->Dict.valuesToArray
       ->Array.forEach(((index, relatedEntityIds)) => {
         if index->TableIndices.Index.evaluate(~fieldName, ~fieldValue) {
           //Add entity id to indices and add index to entity indicies
@@ -132,8 +107,10 @@ module Entity = {
     | Some(entityIndices) =>
       entityIndices->Utils.Set.forEach(index => {
         switch self.fieldNameIndices
-        ->get(index)
-        ->Option.flatMap(get(_, index)) {
+        ->Utils.Dict.dangerouslyGetNonOption(index->TableIndices.Index.getFieldName)
+        ->Option.flatMap(indices =>
+          indices->Utils.Dict.dangerouslyGetNonOption(index->TableIndices.Index.toString)
+        ) {
         | Some((_index, relatedEntityIds)) =>
           let _wasRemoved = relatedEntityIds->Utils.Set.delete(entityId)
         | None => () //Unexpected index should exist if it is entityIndices
@@ -172,14 +149,14 @@ module Entity = {
     }
   }
 
-  let setRow = set
   let set = (inMemTable: t, ~committedCheckpointId, change: Change.t<Internal.entity>) => {
     let entityId = change->Change.getEntityId
     switch inMemTable.latestEntityChangeById->Utils.Dict.dangerouslyGetNonOption(entityId) {
     | Some(prev) =>
       let prevCheckpointId = prev->Change.getCheckpointId
       if (
-        prevCheckpointId > committedCheckpointId && prevCheckpointId < change->Change.getCheckpointId
+        prevCheckpointId > committedCheckpointId &&
+          prevCheckpointId < change->Change.getCheckpointId
       ) {
         inMemTable.prevEntityChanges->Array.push(prev)
       }
@@ -199,8 +176,6 @@ module Entity = {
     | Delete(_) => None
     }
 
-  let getRow = get
-
   /** It returns option<option<'entity>> where the first option means
   that the entity is not set to the in memory store,
   and the second option means that the entity doesn't esist/deleted.
@@ -213,12 +188,12 @@ module Entity = {
 
   let hasIndex = (inMemTable: t, ~fieldName, ~operator: TableIndices.Operator.t) =>
     fieldValueHash => {
-      switch inMemTable.fieldNameIndices.dict->Utils.Dict.dangerouslyGetNonOption(fieldName) {
+      switch inMemTable.fieldNameIndices->Utils.Dict.dangerouslyGetNonOption(fieldName) {
       | None => false
       | Some(indicesSerializedToValue) => {
           // Should match TableIndices.toString logic
           let key = `${fieldName}:${(operator :> string)}:${fieldValueHash}`
-          indicesSerializedToValue.dict->Utils.Dict.dangerouslyGetNonOption(key) !== None
+          indicesSerializedToValue->Utils.Dict.dangerouslyGetNonOption(key) !== None
         }
       }
     }
@@ -226,13 +201,13 @@ module Entity = {
   let getUnsafeOnIndex = (inMemTable: t, ~fieldName, ~operator: TableIndices.Operator.t) => {
     let getEntity = inMemTable->getUnsafe
     fieldValueHash => {
-      switch inMemTable.fieldNameIndices.dict->Utils.Dict.dangerouslyGetNonOption(fieldName) {
+      switch inMemTable.fieldNameIndices->Utils.Dict.dangerouslyGetNonOption(fieldName) {
       | None =>
         JsError.throwWithMessage(`Unexpected error. Must have an index on field ${fieldName}`)
       | Some(indicesSerializedToValue) => {
           // Should match TableIndices.toString logic
           let key = `${fieldName}:${(operator :> string)}:${fieldValueHash}`
-          switch indicesSerializedToValue.dict->Utils.Dict.dangerouslyGetNonOption(key) {
+          switch indicesSerializedToValue->Utils.Dict.dangerouslyGetNonOption(key) {
           | None =>
             JsError.throwWithMessage(
               `Unexpected error. Must have an index for the value ${fieldValueHash} on field ${fieldName}`,
@@ -274,35 +249,23 @@ module Entity = {
       | None => ()
       }
     })
-    switch inMemTable.fieldNameIndices->getRow(index) {
+    switch inMemTable.fieldNameIndices->Utils.Dict.dangerouslyGetNonOption(fieldName) {
     | None =>
-      inMemTable.fieldNameIndices->setRow(
-        index,
+      inMemTable.fieldNameIndices->Dict.set(
+        fieldName,
         makeIndicesSerializedToValue(~index, ~relatedEntityIds),
       )
     | Some(indicesSerializedToValue) =>
-      switch indicesSerializedToValue->getRow(index) {
-      | None => indicesSerializedToValue->setRow(index, (index, relatedEntityIds))
+      switch indicesSerializedToValue->Utils.Dict.dangerouslyGetNonOption(
+        index->TableIndices.Index.toString,
+      ) {
+      | None =>
+        indicesSerializedToValue->Dict.set(
+          index->TableIndices.Index.toString,
+          (index, relatedEntityIds),
+        )
       | Some(_) => () //Should not happen, this means the index already exists
       }
     }
   }
-
-  let addIdToIndex = (inMemTable: t, ~index, ~entityId) =>
-    switch inMemTable.fieldNameIndices->getRow(index) {
-    | None =>
-      inMemTable.fieldNameIndices->setRow(
-        index,
-        makeIndicesSerializedToValue(
-          ~index,
-          ~relatedEntityIds=Utils.Set.make()->Utils.Set.add(entityId),
-        ),
-      )
-    | Some(indicesSerializedToValue) =>
-      switch indicesSerializedToValue->getRow(index) {
-      | None =>
-        indicesSerializedToValue->setRow(index, (index, Utils.Set.make()->Utils.Set.add(entityId)))
-      | Some((_index, relatedEntityIds)) => relatedEntityIds->Utils.Set.add(entityId)->ignore
-      }
-    }
 }

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -87,9 +87,7 @@ module Entity = {
         entity
         ->(Utils.magic: Internal.entity => dict<TableIndices.FieldValue.t>)
         ->Dict.getUnsafe(fieldName)
-      indices
-      ->Dict.valuesToArray
-      ->Array.forEach(((index, relatedEntityIds)) => {
+      indices->Utils.Dict.forEach(((index, relatedEntityIds)) => {
         if index->TableIndices.Index.evaluate(~fieldName, ~fieldValue) {
           //Add entity id to indices and add index to entity indicies
           relatedEntityIds->Utils.Set.add(entityId)->ignore

--- a/packages/envio/src/TableIndices.res
+++ b/packages/envio/src/TableIndices.res
@@ -69,9 +69,14 @@ module SingleIndex = {
     operator,
   }
 
-  // Should much hashing logic in InMemoryTable
+  // Lookups against the in-memory index table reconstruct this key from raw
+  // (fieldName, operator, serialized value) parts, so this is the single
+  // source of truth for the key format.
+  let toStringByParts = (~fieldName, ~operator: Operator.t, ~fieldValueHash) =>
+    `${fieldName}:${(operator :> string)}:${fieldValueHash}`
+
   let toString = ({fieldName, fieldValue, operator}) =>
-    `${fieldName}:${(operator :> string)}:${fieldValue->FieldValue.toString}`
+    toStringByParts(~fieldName, ~operator, ~fieldValueHash=fieldValue->FieldValue.toString)
 
   let evaluate = (self: t, ~fieldName, ~fieldValue) =>
     self.fieldName === fieldName &&
@@ -100,6 +105,8 @@ module Index = {
     switch index {
     | Single(index) => index->SingleIndex.toString
     }
+
+  let toStringByParts = SingleIndex.toStringByParts
 
   let evaluate = (index: t, ~fieldName, ~fieldValue) =>
     switch index {


### PR DESCRIPTION
## Summary
Removes the generic `InMemoryTable.t` wrapper type and replaces all usages with direct `dict` operations. This simplifies the codebase by eliminating an unnecessary abstraction layer that only wrapped dictionary operations with a hash function.

## Key Changes
- **InMemoryTable.res**: Deleted the generic `t<'key, 'val>` type and all associated wrapper functions (`make`, `set`, `get`, `setByHash`, `hasByHash`, `getUnsafeByHash`, `values`)
- **Entity module**: Updated type definitions to use `dict` directly instead of `t<...>`:
  - `indicesSerializedToValue`: now `dict<indexWithRelatedIds>` (keyed by `TableIndices.Index.toString`)
  - `indexFieldNameToIndices`: now `dict<indicesSerializedToValue>` (keyed by `TableIndices.Index.getFieldName`)
- **Entity operations**: Replaced wrapper function calls with direct `Dict` operations and explicit hash key generation
- **InMemoryStore.res**: Simplified `rawEvents` storage from `InMemoryTable.t<rawEventsKey, InternalTable.RawEvents.t>` to `array<InternalTable.RawEvents.t>`, eliminating the need for the `hashRawEventsKey` function
- **EventUtils.res**: Removed unused `getEventIdKeyString` function
- **EventProcessing.res**: Updated to push raw events directly to array instead of using the wrapper's `set` method

## Implementation Details
- Hash key generation is now explicit at call sites (e.g., `index->TableIndices.Index.toString` for dictionary keys)
- The `rawEvents` field now uses a simple array instead of a keyed dictionary, as events are processed sequentially and don't require lookup by key
- All index lookups now use `Utils.Dict.dangerouslyGetNonOption` with explicit key generation

https://claude.ai/code/session_0189AsEpZmVSjhrox3K4PKEc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal event accumulation and storage for faster, more reliable event processing.
  * Reduced memory overhead and streamlined batching/rollback behavior to improve stability and throughput.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->