### PR TITLE
Track entity changes count to size in-memory store without scanning

### DIFF
--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -97,9 +97,9 @@ let writeBatch = async (
     let committedCheckpointId = inMemoryStore.committedCheckpointId
     let updatedEntities = persistence.allEntities->Belt.Array.keepMap(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
-      // Safe to mutate prevEntityChanges directly since the table gets a fresh
-      // one in the reset below.
-      let changes = table.prevEntityChanges
+      // Copy so prevEntityChanges keeps its real length for the reset below,
+      // which decrements changesCount by it.
+      let changes = table.prevEntityChanges->Array.copy
       table.latestEntityChangeById->Utils.Dict.forEach(change =>
         if change->Change.getCheckpointId > committedCheckpointId {
           changes->Array.push(change)

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -55,7 +55,7 @@ let make = (~entities: array<Internal.entityConfig>): t => {
 
 // Once the store holds this many entities across all tables, we drop them
 // after a batch write so it doesn't grow unbounded on long running indexers.
-let keepLatestChangesLimit = 50_000
+let keepLatestChangesLimit = 50_000.
 
 let getEffectInMemTable = (inMemoryStore: t, ~effect: Internal.effect) => {
   let key = effect.name
@@ -166,11 +166,10 @@ let writeBatch = async (
     | Some(checkpointId) => checkpointId
     | None => committedCheckpointId
     }
-    let totalLatestChanges = ref(0)
+    let totalLatestChanges = ref(0.)
     persistence.allEntities->Belt.Array.forEach(entityConfig => {
       totalLatestChanges :=
-        totalLatestChanges.contents +
-        (inMemoryStore->getInMemTable(~entityConfig)).latestEntityChangeById->Utils.Dict.size
+        totalLatestChanges.contents +. (inMemoryStore->getInMemTable(~entityConfig)).changesCount
     })
     let keepLatestChanges = totalLatestChanges.contents < keepLatestChangesLimit
     persistence.allEntities->Belt.Array.forEach(entityConfig => {

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -95,11 +95,23 @@ let writeBatch = async (
     JsError.throwWithMessage(`Failed to access the indexer storage. The Persistence layer is not initialized.`)
   | Ready({cache}) =>
     let committedCheckpointId = inMemoryStore.committedCheckpointId
+    // Decide before the keepMap below trims prevEntityChanges from changesCount,
+    // so the signal still reflects every change currently held in memory.
+    let keepLatestChanges = {
+      let totalChanges = ref(0.)
+      persistence.allEntities->Belt.Array.forEach(entityConfig => {
+        totalChanges :=
+          totalChanges.contents +. (inMemoryStore->getInMemTable(~entityConfig)).changesCount
+      })
+      totalChanges.contents < keepLatestChangesLimit
+    }
     let updatedEntities = persistence.allEntities->Belt.Array.keepMap(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
-      // Copy so prevEntityChanges keeps its real length for the reset below,
-      // which decrements changesCount by it.
-      let changes = table.prevEntityChanges->Array.copy
+
+      // The reset below drops prevEntityChanges and we reuse the array as the
+      // write buffer here, so drop it from the count before appending to it.
+      table.changesCount = table.changesCount -. table.prevEntityChanges->Array.length->Int.toFloat
+      let changes = table.prevEntityChanges
       table.latestEntityChangeById->Utils.Dict.forEach(change =>
         if change->Change.getCheckpointId > committedCheckpointId {
           changes->Array.push(change)
@@ -166,12 +178,6 @@ let writeBatch = async (
     | Some(checkpointId) => checkpointId
     | None => committedCheckpointId
     }
-    let totalLatestChanges = ref(0.)
-    persistence.allEntities->Belt.Array.forEach(entityConfig => {
-      totalLatestChanges :=
-        totalLatestChanges.contents +. (inMemoryStore->getInMemTable(~entityConfig)).changesCount
-    })
-    let keepLatestChanges = totalLatestChanges.contents < keepLatestChangesLimit
     persistence.allEntities->Belt.Array.forEach(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
       let resetTable = keepLatestChanges

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -3,7 +3,7 @@ module EntityTables = {
   exception UndefinedEntity({entityName: string})
   let make = (entities: array<Internal.entityConfig>): t => {
     let init = Dict.make()
-    entities->Belt.Array.forEach(entityConfig => {
+    entities->Array.forEach(entityConfig => {
       init->Dict.set((entityConfig.name :> string), InMemoryTable.Entity.make())
     })
     init
@@ -94,13 +94,13 @@ let writeBatch = async (
     // so the signal still reflects every change currently held in memory.
     let keepLatestChanges = {
       let totalChanges = ref(0.)
-      persistence.allEntities->Belt.Array.forEach(entityConfig => {
+      persistence.allEntities->Array.forEach(entityConfig => {
         totalChanges :=
           totalChanges.contents +. (inMemoryStore->getInMemTable(~entityConfig)).changesCount
       })
       totalChanges.contents < keepLatestChangesLimit
     }
-    let updatedEntities = persistence.allEntities->Belt.Array.keepMap(entityConfig => {
+    let updatedEntities = persistence.allEntities->Array.filterMap(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
 
       // The reset below drops prevEntityChanges and we reuse the array as the
@@ -133,17 +133,9 @@ let writeBatch = async (
           switch idsToStore {
           | [] => ()
           | ids =>
-            let items = Belt.Array.makeUninitializedUnsafe(ids->Belt.Array.length)
-            ids->Belt.Array.forEachWithIndex((index, id) => {
-              items->Array.setUnsafe(
-                index,
-                (
-                  {
-                    id,
-                    output: dict->Dict.getUnsafe(id),
-                  }: Internal.effectCacheItem
-                ),
-              )
+            let items = ids->Array.map((id): Internal.effectCacheItem => {
+              id,
+              output: dict->Dict.getUnsafe(id),
             })
             let effectName = effect.name
             let effectCacheRecord = switch cache->Utils.Dict.dangerouslyGetNonOption(effectName) {
@@ -173,7 +165,7 @@ let writeBatch = async (
     | Some(checkpointId) => checkpointId
     | None => committedCheckpointId
     }
-    persistence.allEntities->Belt.Array.forEach(entityConfig => {
+    persistence.allEntities->Array.forEach(entityConfig => {
       let table = inMemoryStore->getInMemTable(~entityConfig)
       let resetTable = keepLatestChanges
         ? table->InMemoryTable.Entity.resetButKeepLatestChanges
@@ -200,7 +192,7 @@ let prepareRollbackDiff = async (
   let setEntities = Dict.make()
 
   let _ = await persistence.allEntities
-  ->Belt.Array.map(async entityConfig => {
+  ->Array.map(async entityConfig => {
     let entityTable = inMemoryStore->getInMemTable(~entityConfig)
 
     let (removedIdsResult, restoredEntitiesResult) = await persistence.storage.getRollbackData(
@@ -221,7 +213,7 @@ let prepareRollbackDiff = async (
 
     let restoredEntities = restoredEntitiesResult->S.parseOrThrow(entityConfig.rowsSchema)
 
-    restoredEntities->Belt.Array.forEach((entity: Internal.entity) => {
+    restoredEntities->Array.forEach((entity: Internal.entity) => {
       setEntities->Utils.Dict.push(entityConfig.name, entity.id)
       entityTable->InMemoryTable.Entity.set(
         ~committedCheckpointId=inMemoryStore.committedCheckpointId,

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -147,20 +147,9 @@ module Entity = {
       })
     }
 
-  let initValue = (
-    inMemTable: t,
-    ~key: string,
-    ~entity: option<Internal.entity>,
-    // NOTE: This value is only set to true in the internals of the test framework to create the mockDb.
-    ~allowOverWriteEntity=false,
-  ) => {
-    let isNew =
-      inMemTable.latestEntityChangeById->Utils.Dict.dangerouslyGetNonOption(key)->Option.isNone
-    let shouldWriteEntity = allowOverWriteEntity || isNew
-
+  let initValue = (inMemTable: t, ~key: string, ~entity: option<Internal.entity>) => {
     //Only initialize a row in the case where it is none
-    //or if allowOverWriteEntity is true (used for mockDb in test helpers)
-    if shouldWriteEntity {
+    if inMemTable.latestEntityChangeById->Utils.Dict.dangerouslyGetNonOption(key)->Option.isNone {
       let change: Change.t<Internal.entity> = switch entity {
       | Some(entity) =>
         Set({entityId: key, entity, checkpointId: Internal.loadedFromDbCheckpointId})
@@ -173,9 +162,7 @@ module Entity = {
         inMemTable->updateIndices(~entity)
       | None => ()
       }
-      if isNew {
-        inMemTable.changesCount = inMemTable.changesCount +. 1.
-      }
+      inMemTable.changesCount = inMemTable.changesCount +. 1.
       inMemTable.latestEntityChangeById->Dict.set(key, change)
     }
   }

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -61,6 +61,7 @@ module Entity = {
   let resetButKeepLatestChanges = (self: t): t => {
     ...make(),
     latestEntityChangeById: self.latestEntityChangeById,
+    // writeBatch already mutated this to subtract the dropped prevEntityChanges.
     changesCount: self.changesCount,
   }
 

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -86,8 +86,7 @@ module Entity = {
   let resetButKeepLatestChanges = (self: t): t => {
     ...make(),
     latestEntityChangeById: self.latestEntityChangeById,
-    // prevEntityChanges is dropped, so only the retained latest changes count.
-    changesCount: self.changesCount -. self.prevEntityChanges->Array.length->Int.toFloat,
+    changesCount: self.changesCount,
   }
 
   let updateIndices = (self: t, ~entity: Internal.entity) => {

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -149,26 +149,6 @@ module Entity = {
       })
     }
 
-  let initValue = (inMemTable: t, ~key: string, ~entity: option<Internal.entity>) => {
-    //Only initialize a row in the case where it is none
-    if inMemTable.latestEntityChangeById->Utils.Dict.dangerouslyGetNonOption(key)->Option.isNone {
-      let change: Change.t<Internal.entity> = switch entity {
-      | Some(entity) =>
-        Set({entityId: key, entity, checkpointId: Internal.loadedFromDbCheckpointId})
-      | None => Delete({entityId: key, checkpointId: Internal.loadedFromDbCheckpointId})
-      }
-      switch entity {
-      | Some(entity) =>
-        //update table indices in the case where there
-        //is an already set entity
-        inMemTable->updateIndices(~entity)
-      | None => ()
-      }
-      inMemTable.changesCount = inMemTable.changesCount +. 1.
-      inMemTable.latestEntityChangeById->Dict.set(key, change)
-    }
-  }
-
   let setRow = set
   let set = (inMemTable: t, ~committedCheckpointId, change: Change.t<Internal.entity>) => {
     let entityId = change->Change.getEntityId
@@ -191,6 +171,23 @@ module Entity = {
     }
     inMemTable.latestEntityChangeById->Dict.set(entityId, change)
   }
+
+  // Only writes when the id isn't already present, so set always takes its
+  // None branch here (committedCheckpointId is never read).
+  let initValue = (
+    inMemTable: t,
+    ~committedCheckpointId,
+    ~key: string,
+    ~entity: option<Internal.entity>,
+  ) =>
+    if inMemTable.latestEntityChangeById->Utils.Dict.dangerouslyGetNonOption(key)->Option.isNone {
+      let change: Change.t<Internal.entity> = switch entity {
+      | Some(entity) =>
+        Set({entityId: key, entity, checkpointId: Internal.loadedFromDbCheckpointId})
+      | None => Delete({entityId: key, checkpointId: Internal.loadedFromDbCheckpointId})
+      }
+      inMemTable->set(~committedCheckpointId, change)
+    }
 
   let mapChangeToEntity = (change: Change.t<Internal.entity>) =>
     switch change {

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -34,6 +34,9 @@ module Entity = {
   type entityIndices = Utils.Set.t<TableIndices.Index.t>
   type t = {
     latestEntityChangeById: dict<Change.t<Internal.entity>>,
+    // Number of distinct ids in latestEntityChangeById, kept in sync manually
+    // so InMemoryStore can size the store without scanning every dict.
+    mutable changesCount: float,
     prevEntityChanges: array<Change.t<Internal.entity>>,
     indicesByEntityId: dict<entityIndices>,
     fieldNameIndices: indexFieldNameToIndices,
@@ -70,6 +73,7 @@ module Entity = {
 
   let make = (): t => {
     latestEntityChangeById: Dict.make(),
+    changesCount: 0.,
     prevEntityChanges: [],
     indicesByEntityId: Dict.make(),
     fieldNameIndices: make(~hash=TableIndices.Index.getFieldName),
@@ -81,6 +85,7 @@ module Entity = {
   let resetButKeepLatestChanges = (self: t): t => {
     ...make(),
     latestEntityChangeById: self.latestEntityChangeById,
+    changesCount: self.changesCount,
   }
 
   let updateIndices = (self: t, ~entity: Internal.entity) => {
@@ -149,9 +154,9 @@ module Entity = {
     // NOTE: This value is only set to true in the internals of the test framework to create the mockDb.
     ~allowOverWriteEntity=false,
   ) => {
-    let shouldWriteEntity =
-      allowOverWriteEntity ||
+    let isNew =
       inMemTable.latestEntityChangeById->Utils.Dict.dangerouslyGetNonOption(key)->Option.isNone
+    let shouldWriteEntity = allowOverWriteEntity || isNew
 
     //Only initialize a row in the case where it is none
     //or if allowOverWriteEntity is true (used for mockDb in test helpers)
@@ -168,6 +173,9 @@ module Entity = {
         inMemTable->updateIndices(~entity)
       | None => ()
       }
+      if isNew {
+        inMemTable.changesCount = inMemTable.changesCount +. 1.
+      }
       inMemTable.latestEntityChangeById->Dict.set(key, change)
     }
   }
@@ -179,11 +187,12 @@ module Entity = {
     | Some(prev) =>
       let prevCheckpointId = prev->Change.getCheckpointId
       if (
-        prevCheckpointId > committedCheckpointId && prevCheckpointId < change->Change.getCheckpointId
+        prevCheckpointId > committedCheckpointId &&
+          prevCheckpointId < change->Change.getCheckpointId
       ) {
         inMemTable.prevEntityChanges->Array.push(prev)
       }
-    | None => ()
+    | None => inMemTable.changesCount = inMemTable.changesCount +. 1.
     }
 
     switch change {

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -86,7 +86,8 @@ module Entity = {
   let resetButKeepLatestChanges = (self: t): t => {
     ...make(),
     latestEntityChangeById: self.latestEntityChangeById,
-    changesCount: self.changesCount,
+    // prevEntityChanges is dropped, so only the retained latest changes count.
+    changesCount: self.changesCount -. self.prevEntityChanges->Array.length->Int.toFloat,
   }
 
   let updateIndices = (self: t, ~entity: Internal.entity) => {

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -34,8 +34,9 @@ module Entity = {
   type entityIndices = Utils.Set.t<TableIndices.Index.t>
   type t = {
     latestEntityChangeById: dict<Change.t<Internal.entity>>,
-    // Number of distinct ids in latestEntityChangeById, kept in sync manually
-    // so InMemoryStore can size the store without scanning every dict.
+    // Counts every recorded change (new latest ids and pushes to
+    // prevEntityChanges), kept in sync manually so InMemoryStore can gauge the
+    // store size without scanning every dict.
     mutable changesCount: float,
     prevEntityChanges: array<Change.t<Internal.entity>>,
     indicesByEntityId: dict<entityIndices>,
@@ -178,6 +179,7 @@ module Entity = {
           prevCheckpointId < change->Change.getCheckpointId
       ) {
         inMemTable.prevEntityChanges->Array.push(prev)
+        inMemTable.changesCount = inMemTable.changesCount +. 1.
       }
     | None => inMemTable.changesCount = inMemTable.changesCount +. 1.
     }

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -36,7 +36,6 @@ let loadById = (
     }
     idsToLoad->Array.forEach(entityId => {
       inMemTable->InMemoryTable.Entity.initValue(
-        ~allowOverWriteEntity=false,
         ~key=entityId,
         ~entity=entitiesMap->Utils.Dict.dangerouslyGetNonOption(entityId),
       )
@@ -396,11 +395,7 @@ let loadByField = (
         )
 
         entities->Array.forEach(entity => {
-          inMemTable->InMemoryTable.Entity.initValue(
-            ~allowOverWriteEntity=false,
-            ~key=entity.id,
-            ~entity=Some(entity),
-          )
+          inMemTable->InMemoryTable.Entity.initValue(~key=entity.id, ~entity=Some(entity))
         })
 
         size := size.contents + entities->Array.length

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -36,6 +36,7 @@ let loadById = (
     }
     idsToLoad->Array.forEach(entityId => {
       inMemTable->InMemoryTable.Entity.initValue(
+        ~committedCheckpointId=inMemoryStore.committedCheckpointId,
         ~key=entityId,
         ~entity=entitiesMap->Utils.Dict.dangerouslyGetNonOption(entityId),
       )
@@ -395,7 +396,11 @@ let loadByField = (
         )
 
         entities->Array.forEach(entity => {
-          inMemTable->InMemoryTable.Entity.initValue(~key=entity.id, ~entity=Some(entity))
+          inMemTable->InMemoryTable.Entity.initValue(
+            ~committedCheckpointId=inMemoryStore.committedCheckpointId,
+            ~key=entity.id,
+            ~entity=Some(entity),
+          )
         })
 
         size := size.contents + entities->Array.length


### PR DESCRIPTION
## Summary

`InMemoryStore.writeBatch` decides whether to keep the latest entity changes for the next batch by comparing the total number of held changes against `keepLatestChangesLimit`. Previously it computed that total by calling `Dict.size` on every entity table's `latestEntityChangeById` each batch — an O(entities) scan across all tables.

This adds a maintained `changesCount: float` counter on `InMemoryTable.Entity.t` so the decision reads an O(1) value per table instead.

## How the counter stays accurate

`changesCount` tracks every change record currently held in a table, i.e. `latestEntityChangeById` size + `prevEntityChanges` length:

- **+1** when a new id is added to `latestEntityChangeById` (in `set`).
- **+1** when a prior change is pushed into `prevEntityChanges` (a repeated edit to the same entity within a batch — both records are held until the batch is written).
- **−(prevEntityChanges length)** when the batch is written, since the reset drops `prevEntityChanges`.

The keep/drop decision is computed *before* the write loop trims the count, so it still reflects everything held in memory; the trim then happens in place while `prevEntityChanges` is reused as the write buffer, so no array copy is needed.

## Incidental cleanups

- Removed the unused `~allowOverWriteEntity` parameter from `initValue` (no caller ever passed `true`).
- `initValue` now delegates to `set`, keeping all `changesCount` bookkeeping in one place.

## Testing

- `pnpm rescript` (envio + test_codegen) compiles clean.
- `pnpm vitest run` — LoadLayer, WriteRead, Indexer, Reorg, LoadLinkedEntities suites pass.

https://claude.ai/code/session_0135iEr2chYjT72ZDJXmkgbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0135iEr2chYjT72ZDJXmkgbZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-memory change tracking to accurately count changes across all entity tables, ensuring more reliable decisions on when to retain or reset stored changes during batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->