### PR TITLE
Decouple batch processing from persistence writes

### DIFF
--- a/packages/envio/src/Batch.res
+++ b/packages/envio/src/Batch.res
@@ -23,6 +23,9 @@ type t = {
   totalBatchSize: int,
   items: array<Internal.item>,
   progressedChainsById: dict<chainAfterBatch>,
+  // Whether the batch was processed inside the reorg threshold. Drives whether
+  // history is saved, so writes are never merged across a change in this value.
+  isInReorgThreshold: bool,
   // Unnest-like checkpoint fields:
   checkpointIds: array<bigint>,
   checkpointChainIds: array<int>,
@@ -165,6 +168,7 @@ let prepareBatch = (
   ~checkpointIdBeforeBatch,
   ~chainsBeforeBatch: ChainMap.t<chainBeforeBatch>,
   ~batchSizeTarget,
+  ~isInReorgThreshold,
 ) => {
   let preparedFetchStates =
     chainsBeforeBatch
@@ -286,6 +290,7 @@ let prepareBatch = (
       ~batchSizePerChain=mutBatchSizePerChain,
       ~progressBlockNumberPerChain=mutProgressBlockNumberPerChain,
     ),
+    isInReorgThreshold,
     checkpointIds,
     checkpointChainIds,
     checkpointBlockNumbers,
@@ -298,8 +303,9 @@ let make = (
   ~checkpointIdBeforeBatch,
   ~chainsBeforeBatch: ChainMap.t<chainBeforeBatch>,
   ~batchSizeTarget,
+  ~isInReorgThreshold,
 ) => {
-  prepareBatch(~checkpointIdBeforeBatch, ~chainsBeforeBatch, ~batchSizeTarget)
+  prepareBatch(~checkpointIdBeforeBatch, ~chainsBeforeBatch, ~batchSizeTarget, ~isInReorgThreshold)
 }
 
 let findFirstEventBlockNumber = (batch: t, ~chainId) => {

--- a/packages/envio/src/ChainManager.res
+++ b/packages/envio/src/ChainManager.res
@@ -135,12 +135,12 @@ let nextItemIsNone = (chainManager: t): bool => {
 
 let createBatch = (
   chainManager: t,
-  ~committedCheckpointId,
+  ~processedCheckpointId,
   ~batchSizeTarget: int,
   ~isRollback: bool,
 ): Batch.t => {
   Batch.make(
-    ~checkpointIdBeforeBatch=committedCheckpointId->BigInt.add(
+    ~checkpointIdBeforeBatch=processedCheckpointId->BigInt.add(
       // Since for rollback we have a diff checkpoint id.
       // This is needed to currectly overwrite old state
       // in an append-only ClickHouse insert.

--- a/packages/envio/src/ChainManager.res
+++ b/packages/envio/src/ChainManager.res
@@ -140,6 +140,7 @@ let createBatch = (
   ~isRollback: bool,
 ): Batch.t => {
   Batch.make(
+    ~isInReorgThreshold=chainManager.isInReorgThreshold,
     ~checkpointIdBeforeBatch=processedCheckpointId->BigInt.add(
       // Since for rollback we have a diff checkpoint id.
       // This is needed to currectly overwrite old state

--- a/packages/envio/src/Env.res
+++ b/packages/envio/src/Env.res
@@ -209,8 +209,6 @@ module Configurable = {
 }
 
 module ThrottleWrites = {
-  let chainMetadataIntervalMillis =
-    envSafe->EnvSafe.get("ENVIO_THROTTLE_CHAIN_METADATA_INTERVAL_MILLIS", S.int, ~devFallback=500)
   let pruneStaleDataIntervalMillis =
     envSafe->EnvSafe.get(
       "ENVIO_THROTTLE_PRUNE_STALE_DATA_INTERVAL_MILLIS",

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -400,12 +400,7 @@ let processEventBatch = async (
 
     let elapsedTimeAfterProcessing = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
 
-    inMemoryStore->InMemoryStore.commitBatch(
-      ~persistence=ctx.persistence,
-      ~batch,
-      ~config=ctx.config,
-      ~isInReorgThreshold,
-    )
+    inMemoryStore->InMemoryStore.commitBatch(~batch, ~isInReorgThreshold)
 
     let loaderDuration = elapsedTimeAfterLoaders
     let handlerDuration = elapsedTimeAfterProcessing -. loaderDuration

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -353,7 +353,6 @@ type logPartitionInfo = {
 let processEventBatch = async (
   ~batch: Batch.t,
   ~inMemoryStore: InMemoryStore.t,
-  ~isInReorgThreshold,
   ~loadManager,
   ~ctx: Ctx.t,
   ~chainFetchers: ChainMap.t<ChainFetcher.t>,
@@ -400,7 +399,7 @@ let processEventBatch = async (
 
     let elapsedTimeAfterProcessing = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
 
-    inMemoryStore->InMemoryStore.commitBatch(~batch, ~isInReorgThreshold)
+    inMemoryStore->InMemoryStore.commitBatch(~batch)
 
     let loaderDuration = elapsedTimeAfterLoaders
     let handlerDuration = elapsedTimeAfterProcessing -. loaderDuration

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -383,6 +383,11 @@ let processEventBatch = async (
   try {
     let timeRef = Hrtime.makeTimer()
 
+    // Block until the in-memory store has capacity, so processing can't outrun
+    // the background persistence cycle by more than keepLatestChangesLimit.
+    // Also surfaces any error from a previous background write.
+    await inMemoryStore->InMemoryStore.awaitCapacity
+
     if batch.items->Utils.Array.notEmpty {
       await batch->preloadBatchOrThrow(
         ~loadManager,
@@ -401,34 +406,33 @@ let processEventBatch = async (
 
     let elapsedTimeAfterProcessing = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
 
-    try {
-      await inMemoryStore->InMemoryStore.writeBatch(
-        ~persistence=ctx.persistence,
-        ~batch,
-        ~config=ctx.config,
-        ~isInReorgThreshold,
-      )
+    // Hand the batch to the in-memory store and continue. The db write runs as a
+    // standalone cycle owned by the store, off the processing path.
+    inMemoryStore->InMemoryStore.commitBatch(
+      ~persistence=ctx.persistence,
+      ~batch,
+      ~config=ctx.config,
+      ~isInReorgThreshold,
+    )
 
-      let elapsedTimeAfterDbWrite = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
-      let loaderDuration = elapsedTimeAfterLoaders
-      let handlerDuration = elapsedTimeAfterProcessing -. loaderDuration
-      let dbWriteDuration = elapsedTimeAfterDbWrite -. elapsedTimeAfterProcessing
-      registerProcessEventBatchMetrics(
-        ~logger,
-        ~loadDuration=loaderDuration,
-        ~handlerDuration,
-        ~dbWriteDuration,
-      )
-      Ok()
-    } catch {
-    | Persistence.StorageError({message, reason}) =>
-      reason->ErrorHandling.make(~msg=message, ~logger)->Error
-    | exn => exn->ErrorHandling.make(~msg="Failed writing batch to database", ~logger)->Error
-    }
+    let elapsedTimeAfterDbWrite = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
+    let loaderDuration = elapsedTimeAfterLoaders
+    let handlerDuration = elapsedTimeAfterProcessing -. loaderDuration
+    let dbWriteDuration = elapsedTimeAfterDbWrite -. elapsedTimeAfterProcessing
+    registerProcessEventBatchMetrics(
+      ~logger,
+      ~loadDuration=loaderDuration,
+      ~handlerDuration,
+      ~dbWriteDuration,
+    )
+    Ok()
   } catch {
+  | Persistence.StorageError({message, reason}) =>
+    reason->ErrorHandling.make(~msg=message, ~logger)->Error
   | ProcessingError({message, exn, item}) =>
     exn
     ->ErrorHandling.make(~msg=message, ~logger=item->Logging.getItemLogger)
     ->Error
+  | exn => exn->ErrorHandling.make(~msg="Failed processing batch", ~logger)->Error
   }
 }

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -333,17 +333,11 @@ let runBatchHandlersOrThrow = async (
   }
 }
 
-let registerProcessEventBatchMetrics = (
-  ~logger,
-  ~loadDuration,
-  ~handlerDuration,
-  ~dbWriteDuration,
-) => {
+let registerProcessEventBatchMetrics = (~logger, ~loadDuration, ~handlerDuration) => {
   logger->Logging.childTrace({
     "msg": "Finished processing batch",
     "loader_time_elapsed": loadDuration,
     "handlers_time_elapsed": handlerDuration,
-    "write_time_elapsed": dbWriteDuration,
   })
 
   Prometheus.ProcessingBatch.registerMetrics(~loadDuration, ~handlerDuration)
@@ -381,12 +375,12 @@ let processEventBatch = async (
   })
 
   try {
-    let timeRef = Hrtime.makeTimer()
-
     // Block until the in-memory store has capacity, so processing can't outrun
     // the background persistence cycle by more than keepLatestChangesLimit.
     // Also surfaces any error from a previous background write.
     await inMemoryStore->InMemoryStore.awaitCapacity
+
+    let timeRef = Hrtime.makeTimer()
 
     if batch.items->Utils.Array.notEmpty {
       await batch->preloadBatchOrThrow(
@@ -406,8 +400,6 @@ let processEventBatch = async (
 
     let elapsedTimeAfterProcessing = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
 
-    // Hand the batch to the in-memory store and continue. The db write runs as a
-    // standalone cycle owned by the store, off the processing path.
     inMemoryStore->InMemoryStore.commitBatch(
       ~persistence=ctx.persistence,
       ~batch,
@@ -415,16 +407,9 @@ let processEventBatch = async (
       ~isInReorgThreshold,
     )
 
-    let elapsedTimeAfterDbWrite = timeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
     let loaderDuration = elapsedTimeAfterLoaders
     let handlerDuration = elapsedTimeAfterProcessing -. loaderDuration
-    let dbWriteDuration = elapsedTimeAfterDbWrite -. elapsedTimeAfterProcessing
-    registerProcessEventBatchMetrics(
-      ~logger,
-      ~loadDuration=loaderDuration,
-      ~handlerDuration,
-      ~dbWriteDuration,
-    )
+    registerProcessEventBatchMetrics(~logger, ~loadDuration=loaderDuration, ~handlerDuration)
     Ok()
   } catch {
   | Persistence.StorageError({message, reason}) =>

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -149,6 +149,7 @@ let updateChainMetadataTable = (
   cm: ChainManager.t,
   ~persistence: Persistence.t,
   ~throttler: Throttler.t,
+  ~inMemoryStore: InMemoryStore.t,
 ) => {
   let chainsData: dict<InternalTable.Chains.metaFields> = Dict.make()
 
@@ -168,7 +169,9 @@ let updateChainMetadataTable = (
 
   //Don't await this set, it can happen in its own time
   throttler->Throttler.schedule(() =>
-    persistence.storage.setChainMeta(chainsData)->Utils.Promise.ignoreValue
+    inMemoryStore->InMemoryStore.serializeDbWrite(() =>
+      persistence.storage.setChainMeta(chainsData)->Utils.Promise.ignoreValue
+    )
   )
 }
 
@@ -909,7 +912,9 @@ let injectedTaskReducer = (
           chainManager,
           ~throttler=writeThrottlers.chainMetaData,
           ~persistence=state.ctx.persistence,
+          ~inMemoryStore=state.ctx.inMemoryStore,
         )
+        await state.ctx.inMemoryStore->InMemoryStore.flush
         dispatchAction(SuccessExit)
       | ExitWithError(msg) =>
         dispatchAction(ErrorExit(ErrorHandling.make(JsError.throwWithMessage(msg))))
@@ -918,6 +923,7 @@ let injectedTaskReducer = (
           chainManager,
           ~throttler=writeThrottlers.chainMetaData,
           ~persistence=state.ctx.persistence,
+          ~inMemoryStore=state.ctx.inMemoryStore,
         )->ignore
       }
     | NextQuery(chainCheck) =>
@@ -947,7 +953,7 @@ let injectedTaskReducer = (
 
         let batch =
           state.chainManager->ChainManager.createBatch(
-            ~committedCheckpointId=state.ctx.inMemoryStore.committedCheckpointId,
+            ~processedCheckpointId=state.ctx.inMemoryStore.processedCheckpointId,
             ~batchSizeTarget=state.ctx.config.batchSize,
             ~isRollback=isRollbackBatch,
           )
@@ -986,7 +992,9 @@ let injectedTaskReducer = (
                 state.chainManager,
                 ~persistence=state.ctx.persistence,
                 ~throttler=state.writeThrottlers.chainMetaData,
+                ~inMemoryStore=state.ctx.inMemoryStore,
               )
+              await state.ctx.inMemoryStore->InMemoryStore.flush
               dispatchAction(SuccessExit)
             }
           }
@@ -1176,6 +1184,10 @@ let injectedTaskReducer = (
             }
           }
         })
+
+        // Let the background persistence cycle finish so committedCheckpointId
+        // reflects the db before we compute the rollback diff against it.
+        await state.ctx.inMemoryStore->InMemoryStore.drainForRollback
 
         let diff = await state.ctx.inMemoryStore->InMemoryStore.prepareRollbackDiff(
           ~persistence=state.ctx.persistence,

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -7,22 +7,8 @@ type rollbackState =
   | RollbackReady({eventsProcessedDiffByChain: dict<float>})
 
 module WriteThrottlers = {
-  type t = {
-    chainMetaData: Throttler.t,
-    pruneStaleEntityHistory: Throttler.t,
-  }
+  type t = {pruneStaleEntityHistory: Throttler.t}
   let make = (): t => {
-    let chainMetaData = {
-      let intervalMillis = Env.ThrottleWrites.chainMetadataIntervalMillis
-      let logger = Logging.createChild(
-        ~params={
-          "context": "Throttler for chain metadata writes",
-          "intervalMillis": intervalMillis,
-        },
-      )
-      Throttler.make(~intervalMillis, ~logger)
-    }
-
     let pruneStaleEntityHistory = {
       let intervalMillis = Env.ThrottleWrites.pruneStaleDataIntervalMillis
       let logger = Logging.createChild(
@@ -33,7 +19,7 @@ module WriteThrottlers = {
       )
       Throttler.make(~intervalMillis, ~logger)
     }
-    {chainMetaData, pruneStaleEntityHistory}
+    {pruneStaleEntityHistory: pruneStaleEntityHistory}
   }
 }
 
@@ -145,12 +131,7 @@ type task =
   | Rollback
   | PruneStaleEntityHistory
 
-let updateChainMetadataTable = (
-  cm: ChainManager.t,
-  ~persistence: Persistence.t,
-  ~throttler: Throttler.t,
-  ~inMemoryStore: InMemoryStore.t,
-) => {
+let updateChainMetadataTable = (cm: ChainManager.t, ~inMemoryStore: InMemoryStore.t) => {
   let chainsData: dict<InternalTable.Chains.metaFields> = Dict.make()
 
   cm.chainFetchers
@@ -167,14 +148,8 @@ let updateChainMetadataTable = (
     )
   })
 
-  // Don't await this set, it can happen in its own time. Route it through the
-  // store's serializer so it never overlaps a background batch write on the
-  // chains table.
-  throttler->Throttler.schedule(() =>
-    inMemoryStore->InMemoryStore.serializeDbWrite(() =>
-      persistence.storage.setChainMeta(chainsData)->Utils.Promise.ignoreValue
-    )
-  )
+  // Stage it; the persistence cycle folds the stale diff into the next batch write.
+  inMemoryStore->InMemoryStore.setChainMeta(chainsData)
 }
 
 /**
@@ -716,12 +691,18 @@ let actionReducer = (state: t, action: action) => {
           NoExit
         }
 
-    (
-      state,
+    // Once we've decided to exit, stop the processing loop. Persistence now
+    // happens off the processing path, so the exit flush is async - continuing
+    // to dispatch ProcessEventBatch would process further batches while it runs.
+    let tasks = switch shouldExit {
+    | ExitWithSuccess
+    | ExitWithError(_) => [UpdateChainMetaDataAndCheckForExit(shouldExit)]
+    | NoExit =>
       [UpdateChainMetaDataAndCheckForExit(shouldExit), ProcessEventBatch]->Array.concat(
         maybePruneEntityHistory,
-      ),
-    )
+      )
+    }
+    (state, tasks)
 
   | StartProcessingBatch => ({...state, currentlyProcessingBatch: true}, [])
   | StartFindingReorgDepth => ({...state, rollbackState: FindingReorgDepth}, [])
@@ -907,26 +888,15 @@ let injectedTaskReducer = (
       state.writeThrottlers.pruneStaleEntityHistory->Throttler.schedule(runPrune)
 
     | UpdateChainMetaDataAndCheckForExit(shouldExit) =>
-      let {chainManager, writeThrottlers} = state
+      let {chainManager} = state
       switch shouldExit {
       | ExitWithSuccess =>
-        updateChainMetadataTable(
-          chainManager,
-          ~throttler=writeThrottlers.chainMetaData,
-          ~persistence=state.ctx.persistence,
-          ~inMemoryStore=state.ctx.inMemoryStore,
-        )
+        updateChainMetadataTable(chainManager, ~inMemoryStore=state.ctx.inMemoryStore)
         await state.ctx.inMemoryStore->InMemoryStore.flush
         dispatchAction(SuccessExit)
       | ExitWithError(msg) =>
         dispatchAction(ErrorExit(ErrorHandling.make(JsError.throwWithMessage(msg))))
-      | NoExit =>
-        updateChainMetadataTable(
-          chainManager,
-          ~throttler=writeThrottlers.chainMetaData,
-          ~persistence=state.ctx.persistence,
-          ~inMemoryStore=state.ctx.inMemoryStore,
-        )->ignore
+      | NoExit => updateChainMetadataTable(chainManager, ~inMemoryStore=state.ctx.inMemoryStore)
       }
     | NextQuery(chainCheck) =>
       let fetchForChain = checkAndFetchForChain(
@@ -990,12 +960,7 @@ let injectedTaskReducer = (
           if EventProcessing.allChainsEventsProcessedToEndblock(state.chainManager.chainFetchers) {
             Logging.info("All chains are caught up to end blocks.")
             if !state.keepProcessAlive {
-              updateChainMetadataTable(
-                state.chainManager,
-                ~persistence=state.ctx.persistence,
-                ~throttler=state.writeThrottlers.chainMetaData,
-                ~inMemoryStore=state.ctx.inMemoryStore,
-              )
+              updateChainMetadataTable(state.chainManager, ~inMemoryStore=state.ctx.inMemoryStore)
               await state.ctx.inMemoryStore->InMemoryStore.flush
               dispatchAction(SuccessExit)
             }

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -7,22 +7,8 @@ type rollbackState =
   | RollbackReady({eventsProcessedDiffByChain: dict<float>})
 
 module WriteThrottlers = {
-  type t = {
-    chainMetaData: Throttler.t,
-    pruneStaleEntityHistory: Throttler.t,
-  }
+  type t = {pruneStaleEntityHistory: Throttler.t}
   let make = (): t => {
-    let chainMetaData = {
-      let intervalMillis = Env.ThrottleWrites.chainMetadataIntervalMillis
-      let logger = Logging.createChild(
-        ~params={
-          "context": "Throttler for chain metadata writes",
-          "intervalMillis": intervalMillis,
-        },
-      )
-      Throttler.make(~intervalMillis, ~logger)
-    }
-
     let pruneStaleEntityHistory = {
       let intervalMillis = Env.ThrottleWrites.pruneStaleDataIntervalMillis
       let logger = Logging.createChild(
@@ -33,7 +19,7 @@ module WriteThrottlers = {
       )
       Throttler.make(~intervalMillis, ~logger)
     }
-    {chainMetaData, pruneStaleEntityHistory}
+    {pruneStaleEntityHistory: pruneStaleEntityHistory}
   }
 }
 
@@ -148,7 +134,6 @@ type task =
 let updateChainMetadataTable = (
   cm: ChainManager.t,
   ~persistence: Persistence.t,
-  ~throttler: Throttler.t,
   ~inMemoryStore: InMemoryStore.t,
 ) => {
   let chainsData: dict<InternalTable.Chains.metaFields> = Dict.make()
@@ -167,12 +152,7 @@ let updateChainMetadataTable = (
     )
   })
 
-  //Don't await this set, it can happen in its own time
-  throttler->Throttler.schedule(() =>
-    inMemoryStore->InMemoryStore.serializeDbWrite(() =>
-      persistence.storage.setChainMeta(chainsData)->Utils.Promise.ignoreValue
-    )
-  )
+  inMemoryStore->InMemoryStore.setChainMeta(~persistence, chainsData)
 }
 
 /**
@@ -905,12 +885,11 @@ let injectedTaskReducer = (
       state.writeThrottlers.pruneStaleEntityHistory->Throttler.schedule(runPrune)
 
     | UpdateChainMetaDataAndCheckForExit(shouldExit) =>
-      let {chainManager, writeThrottlers} = state
+      let {chainManager} = state
       switch shouldExit {
       | ExitWithSuccess =>
         updateChainMetadataTable(
           chainManager,
-          ~throttler=writeThrottlers.chainMetaData,
           ~persistence=state.ctx.persistence,
           ~inMemoryStore=state.ctx.inMemoryStore,
         )
@@ -921,7 +900,6 @@ let injectedTaskReducer = (
       | NoExit =>
         updateChainMetadataTable(
           chainManager,
-          ~throttler=writeThrottlers.chainMetaData,
           ~persistence=state.ctx.persistence,
           ~inMemoryStore=state.ctx.inMemoryStore,
         )->ignore
@@ -991,7 +969,6 @@ let injectedTaskReducer = (
               updateChainMetadataTable(
                 state.chainManager,
                 ~persistence=state.ctx.persistence,
-                ~throttler=state.writeThrottlers.chainMetaData,
                 ~inMemoryStore=state.ctx.inMemoryStore,
               )
               await state.ctx.inMemoryStore->InMemoryStore.flush

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -7,8 +7,22 @@ type rollbackState =
   | RollbackReady({eventsProcessedDiffByChain: dict<float>})
 
 module WriteThrottlers = {
-  type t = {pruneStaleEntityHistory: Throttler.t}
+  type t = {
+    chainMetaData: Throttler.t,
+    pruneStaleEntityHistory: Throttler.t,
+  }
   let make = (): t => {
+    let chainMetaData = {
+      let intervalMillis = Env.ThrottleWrites.chainMetadataIntervalMillis
+      let logger = Logging.createChild(
+        ~params={
+          "context": "Throttler for chain metadata writes",
+          "intervalMillis": intervalMillis,
+        },
+      )
+      Throttler.make(~intervalMillis, ~logger)
+    }
+
     let pruneStaleEntityHistory = {
       let intervalMillis = Env.ThrottleWrites.pruneStaleDataIntervalMillis
       let logger = Logging.createChild(
@@ -19,7 +33,7 @@ module WriteThrottlers = {
       )
       Throttler.make(~intervalMillis, ~logger)
     }
-    {pruneStaleEntityHistory: pruneStaleEntityHistory}
+    {chainMetaData, pruneStaleEntityHistory}
   }
 }
 
@@ -134,6 +148,7 @@ type task =
 let updateChainMetadataTable = (
   cm: ChainManager.t,
   ~persistence: Persistence.t,
+  ~throttler: Throttler.t,
   ~inMemoryStore: InMemoryStore.t,
 ) => {
   let chainsData: dict<InternalTable.Chains.metaFields> = Dict.make()
@@ -152,7 +167,14 @@ let updateChainMetadataTable = (
     )
   })
 
-  inMemoryStore->InMemoryStore.setChainMeta(~persistence, chainsData)
+  // Don't await this set, it can happen in its own time. Route it through the
+  // store's serializer so it never overlaps a background batch write on the
+  // chains table.
+  throttler->Throttler.schedule(() =>
+    inMemoryStore->InMemoryStore.serializeDbWrite(() =>
+      persistence.storage.setChainMeta(chainsData)->Utils.Promise.ignoreValue
+    )
+  )
 }
 
 /**
@@ -885,11 +907,12 @@ let injectedTaskReducer = (
       state.writeThrottlers.pruneStaleEntityHistory->Throttler.schedule(runPrune)
 
     | UpdateChainMetaDataAndCheckForExit(shouldExit) =>
-      let {chainManager} = state
+      let {chainManager, writeThrottlers} = state
       switch shouldExit {
       | ExitWithSuccess =>
         updateChainMetadataTable(
           chainManager,
+          ~throttler=writeThrottlers.chainMetaData,
           ~persistence=state.ctx.persistence,
           ~inMemoryStore=state.ctx.inMemoryStore,
         )
@@ -900,6 +923,7 @@ let injectedTaskReducer = (
       | NoExit =>
         updateChainMetadataTable(
           chainManager,
+          ~throttler=writeThrottlers.chainMetaData,
           ~persistence=state.ctx.persistence,
           ~inMemoryStore=state.ctx.inMemoryStore,
         )->ignore
@@ -969,6 +993,7 @@ let injectedTaskReducer = (
               updateChainMetadataTable(
                 state.chainManager,
                 ~persistence=state.ctx.persistence,
+                ~throttler=state.writeThrottlers.chainMetaData,
                 ~inMemoryStore=state.ctx.inMemoryStore,
               )
               await state.ctx.inMemoryStore->InMemoryStore.flush
@@ -1164,7 +1189,7 @@ let injectedTaskReducer = (
 
         // Let the background persistence cycle finish so committedCheckpointId
         // reflects the db before we compute the rollback diff against it.
-        await state.ctx.inMemoryStore->InMemoryStore.drainForRollback
+        await state.ctx.inMemoryStore->InMemoryStore.flush
 
         let diff = await state.ctx.inMemoryStore->InMemoryStore.prepareRollbackDiff(
           ~persistence=state.ctx.persistence,

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -932,8 +932,6 @@ let injectedTaskReducer = (
 
         let progressedChainsById = batch.progressedChainsById
 
-        let isInReorgThreshold = state.chainManager.isInReorgThreshold
-
         let isBelowReorgThreshold =
           !state.chainManager.isInReorgThreshold && state.ctx.config.shouldRollbackOnReorg
         let shouldEnterReorgThreshold =
@@ -975,7 +973,6 @@ let injectedTaskReducer = (
           switch await EventProcessing.processEventBatch(
             ~batch,
             ~inMemoryStore,
-            ~isInReorgThreshold,
             ~loadManager=state.loadManager,
             ~ctx=state.ctx,
             ~chainFetchers=state.chainManager.chainFetchers,

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -59,6 +59,8 @@ type t = {
   // stale diff into the batch transaction, so it never races the batch write.
   mutable currentChainMeta: option<dict<InternalTable.Chains.metaFields>>,
   mutable committedChainMeta: option<dict<InternalTable.Chains.metaFields>>,
+  // Set by flush: persist stale metadata through the cycle even with no batch.
+  mutable shouldFlushChainMeta: bool,
 }
 
 let make = (
@@ -82,6 +84,7 @@ let make = (
   config,
   currentChainMeta: None,
   committedChainMeta: None,
+  shouldFlushChainMeta: false,
 }
 
 // The store may hold up to this many uncommitted changes before processing has
@@ -305,22 +308,41 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
   inMemoryStore.effects->Utils.Dict.forEach(inMemTable => inMemTable.pendingDict = Dict.make())
 }
 
+// True when the cycle has something to persist: a queued batch, or (when flush
+// asked for it) chain metadata that changed since the last write.
+let hasPendingWrite = (inMemoryStore: t) =>
+  inMemoryStore.processedBatches->Utils.Array.notEmpty ||
+    (inMemoryStore.shouldFlushChainMeta && inMemoryStore->staleChainMeta->Option.isSome)
+
 let runWriteLoop = async (inMemoryStore: t) => {
-  while (
-    inMemoryStore.processedBatches->Utils.Array.notEmpty &&
-      inMemoryStore.persistenceError->Option.isNone
-  ) {
+  while inMemoryStore->hasPendingWrite && inMemoryStore.persistenceError->Option.isNone {
     try {
-      await runOneWrite(
-        inMemoryStore,
-        ~persistence=inMemoryStore.persistence,
-        ~config=inMemoryStore.config,
-      )
+      if inMemoryStore.processedBatches->Utils.Array.notEmpty {
+        await runOneWrite(
+          inMemoryStore,
+          ~persistence=inMemoryStore.persistence,
+          ~config=inMemoryStore.config,
+        )
+      } else {
+        // Flush asked to persist chain metadata but there's no batch to carry
+        // it. Write it here, inside the single-writer cycle, so it never races a
+        // batch write.
+        switch inMemoryStore->staleChainMeta {
+        | Some(chainsData) =>
+          let snapshot = inMemoryStore.currentChainMeta
+          await inMemoryStore.persistence.storage.setChainMeta(
+            chainsData,
+          )->Utils.Promise.ignoreValue
+          inMemoryStore.committedChainMeta = snapshot
+        | None => ()
+        }
+      }
       inMemoryStore->wakeCommitWaiters
     } catch {
     | exn => inMemoryStore.persistenceError = Some(exn)
     }
   }
+  inMemoryStore.shouldFlushChainMeta = false
   inMemoryStore.writeFiber = None
   inMemoryStore->wakeCommitWaiters
 }
@@ -329,7 +351,7 @@ let kick = (inMemoryStore: t) =>
   if (
     inMemoryStore.writeFiber->Option.isNone &&
     inMemoryStore.persistenceError->Option.isNone &&
-    inMemoryStore.processedBatches->Utils.Array.notEmpty
+    inMemoryStore->hasPendingWrite
   ) {
     inMemoryStore.writeFiber = Some(runWriteLoop(inMemoryStore))
   }
@@ -375,17 +397,27 @@ let rec awaitCapacity = async (inMemoryStore: t) => {
   }
 }
 
-// Awaits until everything processed in memory is persisted to the db.
-let rec flush = async (inMemoryStore: t) => {
+// Awaits until everything processed in memory - including any stale chain
+// metadata - is persisted to the db. The metadata write goes through the cycle
+// (via shouldFlushChainMeta), which runWriteLoop clears once idle.
+let flush = async (inMemoryStore: t) => {
   switch inMemoryStore.persistenceError {
   | Some(exn) => throw(exn)
   | None => ()
   }
-  inMemoryStore->kick
-  switch inMemoryStore.writeFiber {
-  | Some(fiber) =>
-    await fiber
-    await inMemoryStore->flush
+  inMemoryStore.shouldFlushChainMeta = true
+  let rec drain = async () => {
+    inMemoryStore->kick
+    switch inMemoryStore.writeFiber {
+    | Some(fiber) =>
+      await fiber
+      await drain()
+    | None => ()
+    }
+  }
+  await drain()
+  switch inMemoryStore.persistenceError {
+  | Some(exn) => throw(exn)
   | None => ()
   }
 }

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -53,8 +53,8 @@ type t = {
   // Resolved after every commit so capacity/flush waiters can re-evaluate.
   mutable commitWaiters: array<unit => unit>,
   // Static for the store's lifetime - only the persistence cycle reads them.
-  persistence: option<Persistence.t>,
-  config: option<Config.t>,
+  persistence: Persistence.t,
+  config: Config.t,
   // Latest chain metadata and what was last persisted. The cycle folds the
   // stale diff into the batch transaction, so it never races the batch write.
   mutable currentChainMeta: option<dict<InternalTable.Chains.metaFields>>,
@@ -64,8 +64,8 @@ type t = {
 let make = (
   ~entities: array<Internal.entityConfig>,
   ~committedCheckpointId=Internal.initialCheckpointId,
-  ~persistence=?,
-  ~config=?,
+  ~persistence: Persistence.t,
+  ~config: Config.t,
 ): t => {
   allEntities: entities,
   rawEvents: [],
@@ -168,45 +168,51 @@ let waitForCommit = (inMemoryStore: t): promise<unit> =>
   })
 
 // Drains the leading run of processed batches that share isInReorgThreshold and
-// accumulates them into one persistence object. Batches past a change in
-// isInReorgThreshold stay queued for the next write, so a single write never
-// mixes history-saving modes. Mutates inMemoryStore.processedBatches.
+// accumulates them into one persistence object in a single pass. Batches past a
+// change in isInReorgThreshold stay queued for the next write, so a single write
+// never mixes history-saving modes. The caller (runOneWrite) only invokes this
+// when processedBatches is non-empty, so the first element is safe to read.
 let drainBatchRun = (inMemoryStore: t): Batch.t => {
   let all = inMemoryStore.processedBatches
   let isInReorgThreshold = (all->Array.getUnsafe(0)).isInReorgThreshold
-  let run = []
+
   let rest = []
+  let progressedChainsById = Dict.make()
+  let totalBatchSize = ref(0)
+  let checkpointIds = []
+  let checkpointChainIds = []
+  let checkpointBlockNumbers = []
+  let checkpointBlockHashes = []
+  let checkpointEventsProcessed = []
   all->Array.forEach(batch => {
+    // Once a batch lands in rest (the reorg-threshold boundary), every later one
+    // follows it, preserving order.
     if rest->Utils.Array.isEmpty && batch.isInReorgThreshold == isInReorgThreshold {
-      run->Array.push(batch)
+      batch.progressedChainsById->Utils.Dict.forEachWithKey((chainAfterBatch, key) =>
+        progressedChainsById->Dict.set(key, chainAfterBatch)
+      )
+      totalBatchSize := totalBatchSize.contents + batch.totalBatchSize
+      checkpointIds->Array.pushMany(batch.checkpointIds)
+      checkpointChainIds->Array.pushMany(batch.checkpointChainIds)
+      checkpointBlockNumbers->Array.pushMany(batch.checkpointBlockNumbers)
+      checkpointBlockHashes->Array.pushMany(batch.checkpointBlockHashes)
+      checkpointEventsProcessed->Array.pushMany(batch.checkpointEventsProcessed)
     } else {
       rest->Array.push(batch)
     }
   })
   inMemoryStore.processedBatches = rest
 
-  let progressedChainsById = Dict.make()
-  let totalBatchSize = ref(0)
-  run->Array.forEach(batch => {
-    batch.progressedChainsById->Utils.Dict.forEachWithKey((chainAfterBatch, key) =>
-      progressedChainsById->Dict.set(key, chainAfterBatch)
-    )
-    totalBatchSize := totalBatchSize.contents + batch.totalBatchSize
-  })
   {
     totalBatchSize: totalBatchSize.contents,
     items: [],
     progressedChainsById,
     isInReorgThreshold,
-    checkpointIds: run->Belt.Array.map(b => b.checkpointIds)->Belt.Array.concatMany,
-    checkpointChainIds: run->Belt.Array.map(b => b.checkpointChainIds)->Belt.Array.concatMany,
-    checkpointBlockNumbers: run
-    ->Belt.Array.map(b => b.checkpointBlockNumbers)
-    ->Belt.Array.concatMany,
-    checkpointBlockHashes: run->Belt.Array.map(b => b.checkpointBlockHashes)->Belt.Array.concatMany,
-    checkpointEventsProcessed: run
-    ->Belt.Array.map(b => b.checkpointEventsProcessed)
-    ->Belt.Array.concatMany,
+    checkpointIds,
+    checkpointChainIds,
+    checkpointBlockNumbers,
+    checkpointBlockHashes,
+    checkpointEventsProcessed,
   }
 }
 
@@ -300,20 +306,20 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
 }
 
 let runWriteLoop = async (inMemoryStore: t) => {
-  switch (inMemoryStore.persistence, inMemoryStore.config) {
-  | (Some(persistence), Some(config)) =>
-    while (
-      inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId &&
-        inMemoryStore.persistenceError->Option.isNone
-    ) {
-      try {
-        await runOneWrite(inMemoryStore, ~persistence, ~config)
-        inMemoryStore->wakeCommitWaiters
-      } catch {
-      | exn => inMemoryStore.persistenceError = Some(exn)
-      }
+  while (
+    inMemoryStore.processedBatches->Utils.Array.notEmpty &&
+      inMemoryStore.persistenceError->Option.isNone
+  ) {
+    try {
+      await runOneWrite(
+        inMemoryStore,
+        ~persistence=inMemoryStore.persistence,
+        ~config=inMemoryStore.config,
+      )
+      inMemoryStore->wakeCommitWaiters
+    } catch {
+    | exn => inMemoryStore.persistenceError = Some(exn)
     }
-  | _ => ()
   }
   inMemoryStore.writeFiber = None
   inMemoryStore->wakeCommitWaiters
@@ -323,7 +329,7 @@ let kick = (inMemoryStore: t) =>
   if (
     inMemoryStore.writeFiber->Option.isNone &&
     inMemoryStore.persistenceError->Option.isNone &&
-    inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId
+    inMemoryStore.processedBatches->Utils.Array.notEmpty
   ) {
     inMemoryStore.writeFiber = Some(runWriteLoop(inMemoryStore))
   }

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -28,7 +28,7 @@ type effectCacheInMemTable = {
   mutable dict: dict<Internal.effectOutput>,
   // Outputs of the in-flight write, kept readable until the write completes so
   // the cache stays warm without growing the live dict after a commit.
-  mutable pendingDict: option<dict<Internal.effectOutput>>,
+  mutable pendingDict: dict<Internal.effectOutput>,
   effect: Internal.effect,
 }
 
@@ -54,9 +54,9 @@ type t = {
   mutable persistence: option<Persistence.t>,
   mutable config: option<Config.t>,
   mutable isInReorgThreshold: bool,
-  // Tail of the serialized db-write queue. Keeps background batch writes and the
-  // throttled chain-metadata writes from touching the same rows concurrently.
-  mutable dbWriteTail: promise<unit>,
+  // Latest chain metadata to persist. Written by the cycle alongside batch
+  // writes so it never races them on the chains table.
+  mutable pendingChainMeta: option<dict<InternalTable.Chains.metaFields>>,
 }
 
 let make = (
@@ -77,7 +77,7 @@ let make = (
   persistence: None,
   config: None,
   isInReorgThreshold: false,
-  dbWriteTail: Promise.resolve(),
+  pendingChainMeta: None,
 }
 
 // The store may hold up to this many uncommitted changes before processing has
@@ -92,7 +92,7 @@ let getEffectInMemTable = (inMemoryStore: t, ~effect: Internal.effect) => {
     let table = {
       idsToStore: [],
       dict: Dict.make(),
-      pendingDict: None,
+      pendingDict: Dict.make(),
       invalidationsCount: 0,
       effect,
     }
@@ -105,11 +105,7 @@ let getEffectInMemTable = (inMemoryStore: t, ~effect: Internal.effect) => {
 let getEffectOutput = (inMemTable: effectCacheInMemTable, key) =>
   switch inMemTable.dict->Utils.Dict.dangerouslyGetNonOption(key) {
   | Some(_) as found => found
-  | None =>
-    switch inMemTable.pendingDict {
-    | Some(pending) => pending->Utils.Dict.dangerouslyGetNonOption(key)
-    | None => None
-    }
+  | None => inMemTable.pendingDict->Utils.Dict.dangerouslyGetNonOption(key)
   }
 
 let getInMemTable = (
@@ -127,15 +123,6 @@ let getChangesCount = (inMemoryStore: t) => {
     total := total.contents +. (inMemoryStore->getInMemTable(~entityConfig)).changesCount
   })
   total.contents
-}
-
-// Runs fn after any pending db write completes, blocking subsequent db writes
-// until it finishes, so writes to shared tables never overlap.
-let serializeDbWrite = (inMemoryStore: t, fn: unit => promise<'a>): promise<'a> => {
-  let run = inMemoryStore.dbWriteTail->Promise.then(_ => fn())
-  inMemoryStore.dbWriteTail =
-    run->Promise.then(_ => Promise.resolve())->Promise.catch(_ => Promise.resolve())
-  run
 }
 
 let wakeCommitWaiters = (inMemoryStore: t) => {
@@ -204,7 +191,7 @@ let snapshotEffects = (inMemoryStore: t, ~cache): array<Persistence.updatedEffec
       Prometheus.EffectCacheCount.set(~count=effectCacheRecord.count, ~effectName)
       acc->Array.push(({effect, items, shouldInitialize}: Persistence.updatedEffectCache))->ignore
     }
-    inMemTable.pendingDict = Some(dict)
+    inMemTable.pendingDict = dict
     inMemTable.dict = Dict.make()
     inMemTable.idsToStore = []
     inMemTable.invalidationsCount = 0
@@ -245,38 +232,50 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
   })
   let updatedEffectsCache = snapshotEffects(inMemoryStore, ~cache)
 
-  await inMemoryStore->serializeDbWrite(() =>
-    persistence.storage.writeBatch(
-      ~batch,
-      ~rawEvents,
-      ~rollback,
-      ~isInReorgThreshold=inMemoryStore.isInReorgThreshold,
-      ~config,
-      ~allEntities=persistence.allEntities,
-      ~updatedEntities,
-      ~updatedEffectsCache,
-    )
+  await persistence.storage.writeBatch(
+    ~batch,
+    ~rawEvents,
+    ~rollback,
+    ~isInReorgThreshold=inMemoryStore.isInReorgThreshold,
+    ~config,
+    ~allEntities=persistence.allEntities,
+    ~updatedEntities,
+    ~updatedEffectsCache,
   )
 
   inMemoryStore.committedCheckpointId = snapshotCheckpointId
-  inMemoryStore.effects->Utils.Dict.forEach(inMemTable => inMemTable.pendingDict = None)
+  inMemoryStore.effects->Utils.Dict.forEach(inMemTable => inMemTable.pendingDict = Dict.make())
 }
 
+// True while the cycle still has something to persist: a processed batch, or
+// fresh chain metadata.
+let hasPendingWrite = (inMemoryStore: t) =>
+  inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId ||
+    inMemoryStore.pendingChainMeta->Option.isSome
+
 let runWriteLoop = async (inMemoryStore: t) => {
-  switch (inMemoryStore.persistence, inMemoryStore.config) {
-  | (Some(persistence), Some(config)) =>
-    while (
-      inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId &&
-        inMemoryStore.persistenceError->Option.isNone
-    ) {
+  switch inMemoryStore.persistence {
+  | Some(persistence) =>
+    while inMemoryStore->hasPendingWrite && inMemoryStore.persistenceError->Option.isNone {
       try {
-        await runOneWrite(inMemoryStore, ~persistence, ~config)
+        switch inMemoryStore.config {
+        | Some(config)
+          if inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId =>
+          await runOneWrite(inMemoryStore, ~persistence, ~config)
+        | _ => ()
+        }
+        switch inMemoryStore.pendingChainMeta {
+        | Some(chainsData) =>
+          inMemoryStore.pendingChainMeta = None
+          await persistence.storage.setChainMeta(chainsData)->Utils.Promise.ignoreValue
+        | None => ()
+        }
         inMemoryStore->wakeCommitWaiters
       } catch {
       | exn => inMemoryStore.persistenceError = Some(exn)
       }
     }
-  | _ => ()
+  | None => ()
   }
   inMemoryStore.writeFiber = None
   inMemoryStore->wakeCommitWaiters
@@ -286,10 +285,22 @@ let kick = (inMemoryStore: t) =>
   if (
     inMemoryStore.writeFiber->Option.isNone &&
     inMemoryStore.persistenceError->Option.isNone &&
-    inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId
+    inMemoryStore->hasPendingWrite
   ) {
     inMemoryStore.writeFiber = Some(runWriteLoop(inMemoryStore))
   }
+
+// Queues the latest chain metadata for the cycle to persist alongside batch
+// writes, so it never races them on the chains table.
+let setChainMeta = (
+  inMemoryStore: t,
+  ~persistence: Persistence.t,
+  chainsData: dict<InternalTable.Chains.metaFields>,
+) => {
+  inMemoryStore.persistence = Some(persistence)
+  inMemoryStore.pendingChainMeta = Some(chainsData)
+  inMemoryStore->kick
+}
 
 // Records a processed batch in memory and triggers the background persistence
 // cycle. Returns immediately - the db write happens off the processing path.

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -360,8 +360,14 @@ let rec awaitCapacity = async (inMemoryStore: t) => {
         ~committedCheckpointId=inMemoryStore.committedCheckpointId,
       )
     )
-    if inMemoryStore->getChangesCount >= keepLatestChangesLimit {
-      // What's left is uncommitted, so wait for the cycle to persist more.
+
+    // What's left is uncommitted. Only wait if the cycle can actually free it by
+    // writing a queued batch - otherwise (e.g. a large rollback diff staged
+    // without a batch) waiting would deadlock, so let processing proceed instead.
+    if (
+      inMemoryStore->getChangesCount >= keepLatestChangesLimit &&
+        inMemoryStore.processedBatches->Utils.Array.notEmpty
+    ) {
       inMemoryStore->kick
       await inMemoryStore->waitForCommit
       await inMemoryStore->awaitCapacity

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -136,6 +136,22 @@ let getChangesCount = (inMemoryStore: t) => {
 let setChainMeta = (inMemoryStore: t, chainsData: dict<InternalTable.Chains.metaFields>) =>
   inMemoryStore.currentChainMeta = Some(chainsData)
 
+let chainMetaEqual = (a: InternalTable.Chains.metaFields, b: InternalTable.Chains.metaFields) => {
+  // Compare by timestamp, since structural equality on Date objects is unreliable.
+  let timestampEqual = switch (
+    a.timestampCaughtUpToHeadOrEndblock->Null.toOption,
+    b.timestampCaughtUpToHeadOrEndblock->Null.toOption,
+  ) {
+  | (None, None) => true
+  | (Some(x), Some(y)) => x->Date.getTime == y->Date.getTime
+  | _ => false
+  }
+  a.isHyperSync == b.isHyperSync &&
+  a.latestFetchedBlockNumber == b.latestFetchedBlockNumber &&
+  a.firstEventBlockNumber == b.firstEventBlockNumber &&
+  timestampEqual
+}
+
 // Per-chain metadata that changed since the last persisted write, or None when
 // nothing is stale.
 let staleChainMeta = (inMemoryStore: t): option<dict<InternalTable.Chains.metaFields>> =>
@@ -149,7 +165,7 @@ let staleChainMeta = (inMemoryStore: t): option<dict<InternalTable.Chains.metaFi
       | Some(committed) =>
         switch committed->Utils.Dict.dangerouslyGetNonOption(chainId) {
         | None => true
-        | Some(prev) => JSON.stringifyAny(meta) != JSON.stringifyAny(prev)
+        | Some(prev) => !chainMetaEqual(meta, prev)
         }
       }
       if changed {
@@ -374,25 +390,35 @@ let rec awaitCapacity = async (inMemoryStore: t) => {
   | Some(exn) => throw(exn)
   | None => ()
   }
-  if inMemoryStore->getChangesCount >= keepLatestChangesLimit {
+  let dropCommitted = (~keepLoadedFromDb) =>
     inMemoryStore.allEntities->Array.forEach(entityConfig =>
       inMemoryStore
       ->getInMemTable(~entityConfig)
       ->InMemoryTable.Entity.dropCommittedChanges(
         ~committedCheckpointId=inMemoryStore.committedCheckpointId,
+        ~keepLoadedFromDb,
       )
     )
 
-    // What's left is uncommitted. Only wait if the cycle can actually free it by
-    // writing a queued batch - otherwise (e.g. a large rollback diff staged
-    // without a batch) waiting would deadlock, so let processing proceed instead.
-    if (
-      inMemoryStore->getChangesCount >= keepLatestChangesLimit &&
-        inMemoryStore.processedBatches->Utils.Array.notEmpty
-    ) {
-      inMemoryStore->kick
-      await inMemoryStore->waitForCommit
-      await inMemoryStore->awaitCapacity
+  if inMemoryStore->getChangesCount >= keepLatestChangesLimit {
+    // First free committed changes but keep the ones loaded from the db, so
+    // reads still hit memory.
+    dropCommitted(~keepLoadedFromDb=true)
+    if inMemoryStore->getChangesCount >= keepLatestChangesLimit {
+      // Still over: drop the loaded-from-db changes too.
+      dropCommitted(~keepLoadedFromDb=false)
+
+      // What's left is uncommitted. Only wait if the cycle can free it by writing
+      // a queued batch - otherwise (e.g. a large rollback diff staged without a
+      // batch) waiting would deadlock, so let processing proceed instead.
+      if (
+        inMemoryStore->getChangesCount >= keepLatestChangesLimit &&
+          inMemoryStore.processedBatches->Utils.Array.notEmpty
+      ) {
+        inMemoryStore->kick
+        await inMemoryStore->waitForCommit
+        await inMemoryStore->awaitCapacity
+      }
     }
   }
 }

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -43,8 +43,9 @@ type t = {
   // Last checkpoint applied in memory (processing frontier). Runs ahead of
   // committedCheckpointId while the persistence cycle writes in the background.
   mutable processedCheckpointId: Internal.checkpointId,
-  // Per-batch checkpoint metadata accumulated since the last write started.
-  mutable pendingBatches: array<Batch.t>,
+  // Batches processed in memory but not yet written. The cycle drains them,
+  // splitting at any change in isInReorgThreshold so each write is consistent.
+  mutable processedBatches: array<Batch.t>,
   // The single in-flight write loop, None when idle. Strictly one at a time.
   mutable writeFiber: option<promise<unit>>,
   // A failed background write is surfaced at the next batch boundary / flush.
@@ -54,7 +55,6 @@ type t = {
   // Static for the store's lifetime - only the persistence cycle reads them.
   persistence: option<Persistence.t>,
   config: option<Config.t>,
-  mutable isInReorgThreshold: bool,
   // Latest chain metadata and what was last persisted. The cycle folds the
   // stale diff into the batch transaction, so it never races the batch write.
   mutable currentChainMeta: option<dict<InternalTable.Chains.metaFields>>,
@@ -74,13 +74,12 @@ let make = (
   rollback: None,
   committedCheckpointId,
   processedCheckpointId: committedCheckpointId,
-  pendingBatches: [],
+  processedBatches: [],
   writeFiber: None,
   persistenceError: None,
   commitWaiters: [],
   persistence,
   config,
-  isInReorgThreshold: false,
   currentChainMeta: None,
   committedChainMeta: None,
 }
@@ -168,10 +167,27 @@ let waitForCommit = (inMemoryStore: t): promise<unit> =>
     inMemoryStore.commitWaiters->Array.push(resolve)->ignore
   })
 
-let mergePendingBatches = (pendingBatches: array<Batch.t>): Batch.t => {
+// Drains the leading run of processed batches that share isInReorgThreshold and
+// accumulates them into one persistence object. Batches past a change in
+// isInReorgThreshold stay queued for the next write, so a single write never
+// mixes history-saving modes. Mutates inMemoryStore.processedBatches.
+let drainBatchRun = (inMemoryStore: t): Batch.t => {
+  let all = inMemoryStore.processedBatches
+  let isInReorgThreshold = (all->Array.getUnsafe(0)).isInReorgThreshold
+  let run = []
+  let rest = []
+  all->Array.forEach(batch => {
+    if rest->Utils.Array.isEmpty && batch.isInReorgThreshold == isInReorgThreshold {
+      run->Array.push(batch)
+    } else {
+      rest->Array.push(batch)
+    }
+  })
+  inMemoryStore.processedBatches = rest
+
   let progressedChainsById = Dict.make()
   let totalBatchSize = ref(0)
-  pendingBatches->Array.forEach(batch => {
+  run->Array.forEach(batch => {
     batch.progressedChainsById->Utils.Dict.forEachWithKey((chainAfterBatch, key) =>
       progressedChainsById->Dict.set(key, chainAfterBatch)
     )
@@ -181,17 +197,14 @@ let mergePendingBatches = (pendingBatches: array<Batch.t>): Batch.t => {
     totalBatchSize: totalBatchSize.contents,
     items: [],
     progressedChainsById,
-    checkpointIds: pendingBatches->Belt.Array.map(b => b.checkpointIds)->Belt.Array.concatMany,
-    checkpointChainIds: pendingBatches
-    ->Belt.Array.map(b => b.checkpointChainIds)
-    ->Belt.Array.concatMany,
-    checkpointBlockNumbers: pendingBatches
+    isInReorgThreshold,
+    checkpointIds: run->Belt.Array.map(b => b.checkpointIds)->Belt.Array.concatMany,
+    checkpointChainIds: run->Belt.Array.map(b => b.checkpointChainIds)->Belt.Array.concatMany,
+    checkpointBlockNumbers: run
     ->Belt.Array.map(b => b.checkpointBlockNumbers)
     ->Belt.Array.concatMany,
-    checkpointBlockHashes: pendingBatches
-    ->Belt.Array.map(b => b.checkpointBlockHashes)
-    ->Belt.Array.concatMany,
-    checkpointEventsProcessed: pendingBatches
+    checkpointBlockHashes: run->Belt.Array.map(b => b.checkpointBlockHashes)->Belt.Array.concatMany,
+    checkpointEventsProcessed: run
     ->Belt.Array.map(b => b.checkpointEventsProcessed)
     ->Belt.Array.concatMany,
   }
@@ -240,14 +253,16 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
   }
 
   let committedCheckpointId = inMemoryStore.committedCheckpointId
-  let pendingBatches = inMemoryStore.pendingBatches
-  inMemoryStore.pendingBatches = []
-  let batch = mergePendingBatches(pendingBatches)
-  let snapshotCheckpointId = switch batch.checkpointIds->Utils.Array.last {
+  let batch = inMemoryStore->drainBatchRun
+  // The run's last checkpoint - entity changes above it belong to later batches
+  // (a different isInReorgThreshold) and stay queued for the next write.
+  let upToCheckpointId = switch batch.checkpointIds->Utils.Array.last {
   | Some(checkpointId) => checkpointId
   | None => committedCheckpointId
   }
 
+  // rawEvents and the effect cache aren't gated by isInReorgThreshold, so they're
+  // flushed in full with this write rather than split at the run boundary.
   let rawEvents = inMemoryStore.rawEvents
   inMemoryStore.rawEvents = []
   let rollback = inMemoryStore.rollback
@@ -255,7 +270,8 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
 
   let updatedEntities = persistence.allEntities->Array.filterMap(entityConfig => {
     let table = inMemoryStore->getInMemTable(~entityConfig)
-    let changes = table->InMemoryTable.Entity.snapshotChanges(~committedCheckpointId)
+    let changes =
+      table->InMemoryTable.Entity.snapshotChanges(~committedCheckpointId, ~upToCheckpointId)
     if changes->Utils.Array.isEmpty {
       None
     } else {
@@ -270,7 +286,7 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
     ~batch,
     ~rawEvents,
     ~rollback,
-    ~isInReorgThreshold=inMemoryStore.isInReorgThreshold,
+    ~isInReorgThreshold=batch.isInReorgThreshold,
     ~config,
     ~allEntities=persistence.allEntities,
     ~updatedEntities,
@@ -278,7 +294,7 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
     ~chainMetaData,
   )
 
-  inMemoryStore.committedCheckpointId = snapshotCheckpointId
+  inMemoryStore.committedCheckpointId = upToCheckpointId
   inMemoryStore.committedChainMeta = chainMetaSnapshot
   inMemoryStore.effects->Utils.Dict.forEach(inMemTable => inMemTable.pendingDict = Dict.make())
 }
@@ -314,9 +330,8 @@ let kick = (inMemoryStore: t) =>
 
 // Records a processed batch in memory and triggers the background persistence
 // cycle. Returns immediately - the db write happens off the processing path.
-let commitBatch = (inMemoryStore: t, ~batch: Batch.t, ~isInReorgThreshold) => {
-  inMemoryStore.isInReorgThreshold = isInReorgThreshold
-  inMemoryStore.pendingBatches->Array.push(batch)->ignore
+let commitBatch = (inMemoryStore: t, ~batch: Batch.t) => {
+  inMemoryStore.processedBatches->Array.push(batch)->ignore
   switch batch.checkpointIds->Utils.Array.last {
   | Some(checkpointId) => inMemoryStore.processedCheckpointId = checkpointId
   | None => ()

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -54,9 +54,9 @@ type t = {
   mutable persistence: option<Persistence.t>,
   mutable config: option<Config.t>,
   mutable isInReorgThreshold: bool,
-  // Latest chain metadata to persist. Written by the cycle alongside batch
-  // writes so it never races them on the chains table.
-  mutable pendingChainMeta: option<dict<InternalTable.Chains.metaFields>>,
+  // Tail of the serialized db-write queue. Keeps the background batch writes and
+  // the throttled chain-metadata writes from touching the chains table at once.
+  mutable dbWriteTail: promise<unit>,
 }
 
 let make = (
@@ -77,7 +77,7 @@ let make = (
   persistence: None,
   config: None,
   isInReorgThreshold: false,
-  pendingChainMeta: None,
+  dbWriteTail: Promise.resolve(),
 }
 
 // The store may hold up to this many uncommitted changes before processing has
@@ -123,6 +123,15 @@ let getChangesCount = (inMemoryStore: t) => {
     total := total.contents +. (inMemoryStore->getInMemTable(~entityConfig)).changesCount
   })
   total.contents
+}
+
+// Runs fn after any pending db write completes, blocking subsequent db writes
+// until it finishes, so writes to shared tables never overlap.
+let serializeDbWrite = (inMemoryStore: t, fn: unit => promise<'a>): promise<'a> => {
+  let run = inMemoryStore.dbWriteTail->Promise.then(_ => fn())
+  inMemoryStore.dbWriteTail =
+    run->Promise.then(_ => Promise.resolve())->Promise.catch(_ => Promise.resolve())
+  run
 }
 
 let wakeCommitWaiters = (inMemoryStore: t) => {
@@ -232,50 +241,38 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
   })
   let updatedEffectsCache = snapshotEffects(inMemoryStore, ~cache)
 
-  await persistence.storage.writeBatch(
-    ~batch,
-    ~rawEvents,
-    ~rollback,
-    ~isInReorgThreshold=inMemoryStore.isInReorgThreshold,
-    ~config,
-    ~allEntities=persistence.allEntities,
-    ~updatedEntities,
-    ~updatedEffectsCache,
+  await inMemoryStore->serializeDbWrite(() =>
+    persistence.storage.writeBatch(
+      ~batch,
+      ~rawEvents,
+      ~rollback,
+      ~isInReorgThreshold=inMemoryStore.isInReorgThreshold,
+      ~config,
+      ~allEntities=persistence.allEntities,
+      ~updatedEntities,
+      ~updatedEffectsCache,
+    )
   )
 
   inMemoryStore.committedCheckpointId = snapshotCheckpointId
   inMemoryStore.effects->Utils.Dict.forEach(inMemTable => inMemTable.pendingDict = Dict.make())
 }
 
-// True while the cycle still has something to persist: a processed batch, or
-// fresh chain metadata.
-let hasPendingWrite = (inMemoryStore: t) =>
-  inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId ||
-    inMemoryStore.pendingChainMeta->Option.isSome
-
 let runWriteLoop = async (inMemoryStore: t) => {
-  switch inMemoryStore.persistence {
-  | Some(persistence) =>
-    while inMemoryStore->hasPendingWrite && inMemoryStore.persistenceError->Option.isNone {
+  switch (inMemoryStore.persistence, inMemoryStore.config) {
+  | (Some(persistence), Some(config)) =>
+    while (
+      inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId &&
+        inMemoryStore.persistenceError->Option.isNone
+    ) {
       try {
-        switch inMemoryStore.config {
-        | Some(config)
-          if inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId =>
-          await runOneWrite(inMemoryStore, ~persistence, ~config)
-        | _ => ()
-        }
-        switch inMemoryStore.pendingChainMeta {
-        | Some(chainsData) =>
-          inMemoryStore.pendingChainMeta = None
-          await persistence.storage.setChainMeta(chainsData)->Utils.Promise.ignoreValue
-        | None => ()
-        }
+        await runOneWrite(inMemoryStore, ~persistence, ~config)
         inMemoryStore->wakeCommitWaiters
       } catch {
       | exn => inMemoryStore.persistenceError = Some(exn)
       }
     }
-  | None => ()
+  | _ => ()
   }
   inMemoryStore.writeFiber = None
   inMemoryStore->wakeCommitWaiters
@@ -285,22 +282,10 @@ let kick = (inMemoryStore: t) =>
   if (
     inMemoryStore.writeFiber->Option.isNone &&
     inMemoryStore.persistenceError->Option.isNone &&
-    inMemoryStore->hasPendingWrite
+    inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId
   ) {
     inMemoryStore.writeFiber = Some(runWriteLoop(inMemoryStore))
   }
-
-// Queues the latest chain metadata for the cycle to persist alongside batch
-// writes, so it never races them on the chains table.
-let setChainMeta = (
-  inMemoryStore: t,
-  ~persistence: Persistence.t,
-  chainsData: dict<InternalTable.Chains.metaFields>,
-) => {
-  inMemoryStore.persistence = Some(persistence)
-  inMemoryStore.pendingChainMeta = Some(chainsData)
-  inMemoryStore->kick
-}
 
 // Records a processed batch in memory and triggers the background persistence
 // cycle. Returns immediately - the db write happens off the processing path.
@@ -357,22 +342,6 @@ let rec flush = async (inMemoryStore: t) => {
   | Some(fiber) =>
     await fiber
     await inMemoryStore->flush
-  | None => ()
-  }
-}
-
-// Before a rollback: let the in-flight write finish so committedCheckpointId
-// reflects the db, then reset the processing frontier to it. Uncommitted state
-// is discarded by prepareRollbackDiff and reprocessed from the committed point.
-let drainForRollback = async (inMemoryStore: t) => {
-  switch inMemoryStore.writeFiber {
-  | Some(fiber) => await fiber
-  | None => ()
-  }
-  inMemoryStore.pendingBatches = []
-  inMemoryStore.processedCheckpointId = inMemoryStore.committedCheckpointId
-  switch inMemoryStore.persistenceError {
-  | Some(exn) => throw(exn)
   | None => ()
   }
 }

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -51,17 +51,21 @@ type t = {
   mutable persistenceError: option<exn>,
   // Resolved after every commit so capacity/flush waiters can re-evaluate.
   mutable commitWaiters: array<unit => unit>,
-  mutable persistence: option<Persistence.t>,
-  mutable config: option<Config.t>,
+  // Static for the store's lifetime - only the persistence cycle reads them.
+  persistence: option<Persistence.t>,
+  config: option<Config.t>,
   mutable isInReorgThreshold: bool,
-  // Tail of the serialized db-write queue. Keeps the background batch writes and
-  // the throttled chain-metadata writes from touching the chains table at once.
-  mutable dbWriteTail: promise<unit>,
+  // Latest chain metadata and what was last persisted. The cycle folds the
+  // stale diff into the batch transaction, so it never races the batch write.
+  mutable currentChainMeta: option<dict<InternalTable.Chains.metaFields>>,
+  mutable committedChainMeta: option<dict<InternalTable.Chains.metaFields>>,
 }
 
 let make = (
   ~entities: array<Internal.entityConfig>,
   ~committedCheckpointId=Internal.initialCheckpointId,
+  ~persistence=?,
+  ~config=?,
 ): t => {
   allEntities: entities,
   rawEvents: [],
@@ -74,10 +78,11 @@ let make = (
   writeFiber: None,
   persistenceError: None,
   commitWaiters: [],
-  persistence: None,
-  config: None,
+  persistence,
+  config,
   isInReorgThreshold: false,
-  dbWriteTail: Promise.resolve(),
+  currentChainMeta: None,
+  committedChainMeta: None,
 }
 
 // The store may hold up to this many uncommitted changes before processing has
@@ -125,14 +130,32 @@ let getChangesCount = (inMemoryStore: t) => {
   total.contents
 }
 
-// Runs fn after any pending db write completes, blocking subsequent db writes
-// until it finishes, so writes to shared tables never overlap.
-let serializeDbWrite = (inMemoryStore: t, fn: unit => promise<'a>): promise<'a> => {
-  let run = inMemoryStore.dbWriteTail->Promise.then(_ => fn())
-  inMemoryStore.dbWriteTail =
-    run->Promise.then(_ => Promise.resolve())->Promise.catch(_ => Promise.resolve())
-  run
-}
+// Queues the latest chain metadata for the cycle to fold into the next write.
+let setChainMeta = (inMemoryStore: t, chainsData: dict<InternalTable.Chains.metaFields>) =>
+  inMemoryStore.currentChainMeta = Some(chainsData)
+
+// Per-chain metadata that changed since the last persisted write, or None when
+// nothing is stale.
+let staleChainMeta = (inMemoryStore: t): option<dict<InternalTable.Chains.metaFields>> =>
+  switch inMemoryStore.currentChainMeta {
+  | None => None
+  | Some(current) =>
+    let stale = Dict.make()
+    current->Utils.Dict.forEachWithKey((meta, chainId) => {
+      let changed = switch inMemoryStore.committedChainMeta {
+      | None => true
+      | Some(committed) =>
+        switch committed->Utils.Dict.dangerouslyGetNonOption(chainId) {
+        | None => true
+        | Some(prev) => JSON.stringifyAny(meta) != JSON.stringifyAny(prev)
+        }
+      }
+      if changed {
+        stale->Dict.set(chainId, meta)
+      }
+    })
+    stale->Dict.keysToArray->Utils.Array.notEmpty ? Some(stale) : None
+  }
 
 let wakeCommitWaiters = (inMemoryStore: t) => {
   let waiters = inMemoryStore.commitWaiters
@@ -240,21 +263,23 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
     }
   })
   let updatedEffectsCache = snapshotEffects(inMemoryStore, ~cache)
+  let chainMetaSnapshot = inMemoryStore.currentChainMeta
+  let chainMetaData = inMemoryStore->staleChainMeta
 
-  await inMemoryStore->serializeDbWrite(() =>
-    persistence.storage.writeBatch(
-      ~batch,
-      ~rawEvents,
-      ~rollback,
-      ~isInReorgThreshold=inMemoryStore.isInReorgThreshold,
-      ~config,
-      ~allEntities=persistence.allEntities,
-      ~updatedEntities,
-      ~updatedEffectsCache,
-    )
+  await persistence.storage.writeBatch(
+    ~batch,
+    ~rawEvents,
+    ~rollback,
+    ~isInReorgThreshold=inMemoryStore.isInReorgThreshold,
+    ~config,
+    ~allEntities=persistence.allEntities,
+    ~updatedEntities,
+    ~updatedEffectsCache,
+    ~chainMetaData,
   )
 
   inMemoryStore.committedCheckpointId = snapshotCheckpointId
+  inMemoryStore.committedChainMeta = chainMetaSnapshot
   inMemoryStore.effects->Utils.Dict.forEach(inMemTable => inMemTable.pendingDict = Dict.make())
 }
 
@@ -289,15 +314,7 @@ let kick = (inMemoryStore: t) =>
 
 // Records a processed batch in memory and triggers the background persistence
 // cycle. Returns immediately - the db write happens off the processing path.
-let commitBatch = (
-  inMemoryStore: t,
-  ~persistence: Persistence.t,
-  ~batch: Batch.t,
-  ~config,
-  ~isInReorgThreshold,
-) => {
-  inMemoryStore.persistence = Some(persistence)
-  inMemoryStore.config = Some(config)
+let commitBatch = (inMemoryStore: t, ~batch: Batch.t, ~isInReorgThreshold) => {
   inMemoryStore.isInReorgThreshold = isInReorgThreshold
   inMemoryStore.pendingBatches->Array.push(batch)->ignore
   switch batch.checkpointIds->Utils.Array.last {

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -21,9 +21,14 @@ module EntityTables = {
 }
 
 type effectCacheInMemTable = {
-  idsToStore: array<string>,
+  mutable idsToStore: array<string>,
   mutable invalidationsCount: int,
-  dict: dict<Internal.effectOutput>,
+  // Holds the effect outputs available for in-memory cache reads. Swapped into
+  // `pendingDict` while a write is in flight (see snapshotEffects).
+  mutable dict: dict<Internal.effectOutput>,
+  // Outputs of the in-flight write, kept readable until the write completes so
+  // the cache stays warm without growing the live dict after a commit.
+  mutable pendingDict: option<dict<Internal.effectOutput>>,
   effect: Internal.effect,
 }
 
@@ -33,7 +38,25 @@ type t = {
   mutable entities: dict<InMemoryTable.Entity.t>,
   mutable effects: dict<effectCacheInMemTable>,
   mutable rollback: option<Persistence.rollback>,
+  // Last checkpoint persisted to the db.
   mutable committedCheckpointId: Internal.checkpointId,
+  // Last checkpoint applied in memory (processing frontier). Runs ahead of
+  // committedCheckpointId while the persistence cycle writes in the background.
+  mutable processedCheckpointId: Internal.checkpointId,
+  // Per-batch checkpoint metadata accumulated since the last write started.
+  mutable pendingBatches: array<Batch.t>,
+  // The single in-flight write loop, None when idle. Strictly one at a time.
+  mutable writeFiber: option<promise<unit>>,
+  // A failed background write is surfaced at the next batch boundary / flush.
+  mutable persistenceError: option<exn>,
+  // Resolved after every commit so capacity/flush waiters can re-evaluate.
+  mutable commitWaiters: array<unit => unit>,
+  mutable persistence: option<Persistence.t>,
+  mutable config: option<Config.t>,
+  mutable isInReorgThreshold: bool,
+  // Tail of the serialized db-write queue. Keeps background batch writes and the
+  // throttled chain-metadata writes from touching the same rows concurrently.
+  mutable dbWriteTail: promise<unit>,
 }
 
 let make = (
@@ -46,10 +69,19 @@ let make = (
   effects: Dict.make(),
   rollback: None,
   committedCheckpointId,
+  processedCheckpointId: committedCheckpointId,
+  pendingBatches: [],
+  writeFiber: None,
+  persistenceError: None,
+  commitWaiters: [],
+  persistence: None,
+  config: None,
+  isInReorgThreshold: false,
+  dbWriteTail: Promise.resolve(),
 }
 
-// Once the store holds this many entities across all tables, we drop them
-// after a batch write so it doesn't grow unbounded on long running indexers.
+// The store may hold up to this many uncommitted changes before processing has
+// to wait for the persistence cycle to free capacity.
 let keepLatestChangesLimit = 50_000.
 
 let getEffectInMemTable = (inMemoryStore: t, ~effect: Internal.effect) => {
@@ -60,6 +92,7 @@ let getEffectInMemTable = (inMemoryStore: t, ~effect: Internal.effect) => {
     let table = {
       idsToStore: [],
       dict: Dict.make(),
+      pendingDict: None,
       invalidationsCount: 0,
       effect,
     }
@@ -67,6 +100,17 @@ let getEffectInMemTable = (inMemoryStore: t, ~effect: Internal.effect) => {
     table
   }
 }
+
+// Effect cache read that also consults the in-flight write's pending values.
+let getEffectOutput = (inMemTable: effectCacheInMemTable, key) =>
+  switch inMemTable.dict->Utils.Dict.dangerouslyGetNonOption(key) {
+  | Some(_) as found => found
+  | None =>
+    switch inMemTable.pendingDict {
+    | Some(pending) => pending->Utils.Dict.dangerouslyGetNonOption(key)
+    | None => None
+    }
+  }
 
 let getInMemTable = (
   inMemoryStore: t,
@@ -77,126 +121,250 @@ let getInMemTable = (
 
 let isRollingBack = (inMemoryStore: t) => inMemoryStore.rollback !== None
 
-let writeBatch = async (
-  inMemoryStore: t,
-  ~persistence: Persistence.t,
-  ~batch,
-  ~config,
-  ~isInReorgThreshold,
-) =>
-  switch persistence.storageStatus {
+let getChangesCount = (inMemoryStore: t) => {
+  let total = ref(0.)
+  inMemoryStore.allEntities->Array.forEach(entityConfig => {
+    total := total.contents +. (inMemoryStore->getInMemTable(~entityConfig)).changesCount
+  })
+  total.contents
+}
+
+// Runs fn after any pending db write completes, blocking subsequent db writes
+// until it finishes, so writes to shared tables never overlap.
+let serializeDbWrite = (inMemoryStore: t, fn: unit => promise<'a>): promise<'a> => {
+  let run = inMemoryStore.dbWriteTail->Promise.then(_ => fn())
+  inMemoryStore.dbWriteTail =
+    run->Promise.then(_ => Promise.resolve())->Promise.catch(_ => Promise.resolve())
+  run
+}
+
+let wakeCommitWaiters = (inMemoryStore: t) => {
+  let waiters = inMemoryStore.commitWaiters
+  inMemoryStore.commitWaiters = []
+  waiters->Array.forEach(resolve => resolve())
+}
+
+let waitForCommit = (inMemoryStore: t): promise<unit> =>
+  Promise.make((resolve, _) => {
+    inMemoryStore.commitWaiters->Array.push(resolve)->ignore
+  })
+
+let mergePendingBatches = (pendingBatches: array<Batch.t>): Batch.t => {
+  let progressedChainsById = Dict.make()
+  let totalBatchSize = ref(0)
+  pendingBatches->Array.forEach(batch => {
+    batch.progressedChainsById->Utils.Dict.forEachWithKey((chainAfterBatch, key) =>
+      progressedChainsById->Dict.set(key, chainAfterBatch)
+    )
+    totalBatchSize := totalBatchSize.contents + batch.totalBatchSize
+  })
+  {
+    totalBatchSize: totalBatchSize.contents,
+    items: [],
+    progressedChainsById,
+    checkpointIds: pendingBatches->Belt.Array.map(b => b.checkpointIds)->Belt.Array.concatMany,
+    checkpointChainIds: pendingBatches
+    ->Belt.Array.map(b => b.checkpointChainIds)
+    ->Belt.Array.concatMany,
+    checkpointBlockNumbers: pendingBatches
+    ->Belt.Array.map(b => b.checkpointBlockNumbers)
+    ->Belt.Array.concatMany,
+    checkpointBlockHashes: pendingBatches
+    ->Belt.Array.map(b => b.checkpointBlockHashes)
+    ->Belt.Array.concatMany,
+    checkpointEventsProcessed: pendingBatches
+    ->Belt.Array.map(b => b.checkpointEventsProcessed)
+    ->Belt.Array.concatMany,
+  }
+}
+
+// Captures the effects to persist, moving the live dict into pendingDict so its
+// values stay readable while the write runs, then starts a fresh live dict.
+let snapshotEffects = (inMemoryStore: t, ~cache): array<Persistence.updatedEffectCache> => {
+  let acc = []
+  inMemoryStore.effects->Utils.Dict.forEach(inMemTable => {
+    let {idsToStore, dict, effect, invalidationsCount} = inMemTable
+    switch idsToStore {
+    | [] => ()
+    | ids =>
+      let items = ids->Array.map((id): Internal.effectCacheItem => {
+        id,
+        output: dict->Dict.getUnsafe(id),
+      })
+      let effectName = effect.name
+      let effectCacheRecord = switch cache->Utils.Dict.dangerouslyGetNonOption(effectName) {
+      | Some(c) => c
+      | None =>
+        let c: Persistence.effectCacheRecord = {effectName, count: 0}
+        cache->Dict.set(effectName, c)
+        c
+      }
+      let shouldInitialize = effectCacheRecord.count === 0
+      effectCacheRecord.count = effectCacheRecord.count + items->Array.length - invalidationsCount
+      Prometheus.EffectCacheCount.set(~count=effectCacheRecord.count, ~effectName)
+      acc->Array.push(({effect, items, shouldInitialize}: Persistence.updatedEffectCache))->ignore
+    }
+    inMemTable.pendingDict = Some(dict)
+    inMemTable.dict = Dict.make()
+    inMemTable.idsToStore = []
+    inMemTable.invalidationsCount = 0
+  })
+  acc
+}
+
+let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config) => {
+  let cache = switch persistence.storageStatus {
   | Unknown
   | Initializing(_) =>
     JsError.throwWithMessage(`Failed to access the indexer storage. The Persistence layer is not initialized.`)
-  | Ready({cache}) =>
-    let committedCheckpointId = inMemoryStore.committedCheckpointId
-    // Decide before the keepMap below trims prevEntityChanges from changesCount,
-    // so the signal still reflects every change currently held in memory.
-    let keepLatestChanges = {
-      let totalChanges = ref(0.)
-      persistence.allEntities->Array.forEach(entityConfig => {
-        totalChanges :=
-          totalChanges.contents +. (inMemoryStore->getInMemTable(~entityConfig)).changesCount
-      })
-      totalChanges.contents < keepLatestChangesLimit
-    }
-    let updatedEntities = persistence.allEntities->Array.filterMap(entityConfig => {
-      let table = inMemoryStore->getInMemTable(~entityConfig)
+  | Ready({cache}) => cache
+  }
 
-      // The reset below drops prevEntityChanges and we reuse the array as the
-      // write buffer here, so drop it from the count before appending to it.
-      table.changesCount = table.changesCount -. table.prevEntityChanges->Array.length->Int.toFloat
-      let changes = table.prevEntityChanges
-      table.latestEntityChangeById->Utils.Dict.forEach(change =>
-        if change->Change.getCheckpointId > committedCheckpointId {
-          changes->Array.push(change)
-        }
-      )
-      if changes->Utils.Array.isEmpty {
-        None
-      } else {
-        Some(({entityConfig, changes}: Persistence.updatedEntity))
-      }
-    })
-    await persistence.storage.writeBatch(
+  let committedCheckpointId = inMemoryStore.committedCheckpointId
+  let pendingBatches = inMemoryStore.pendingBatches
+  inMemoryStore.pendingBatches = []
+  let batch = mergePendingBatches(pendingBatches)
+  let snapshotCheckpointId = switch batch.checkpointIds->Utils.Array.last {
+  | Some(checkpointId) => checkpointId
+  | None => committedCheckpointId
+  }
+
+  let rawEvents = inMemoryStore.rawEvents
+  inMemoryStore.rawEvents = []
+  let rollback = inMemoryStore.rollback
+  inMemoryStore.rollback = None
+
+  let updatedEntities = persistence.allEntities->Array.filterMap(entityConfig => {
+    let table = inMemoryStore->getInMemTable(~entityConfig)
+    let changes = table->InMemoryTable.Entity.snapshotChanges(~committedCheckpointId)
+    if changes->Utils.Array.isEmpty {
+      None
+    } else {
+      Some(({entityConfig, changes}: Persistence.updatedEntity))
+    }
+  })
+  let updatedEffectsCache = snapshotEffects(inMemoryStore, ~cache)
+
+  await inMemoryStore->serializeDbWrite(() =>
+    persistence.storage.writeBatch(
       ~batch,
-      ~rawEvents=inMemoryStore.rawEvents,
-      ~rollback=inMemoryStore.rollback,
-      ~isInReorgThreshold,
+      ~rawEvents,
+      ~rollback,
+      ~isInReorgThreshold=inMemoryStore.isInReorgThreshold,
       ~config,
       ~allEntities=persistence.allEntities,
       ~updatedEntities,
-      ~updatedEffectsCache={
-        let acc = []
-        inMemoryStore.effects->Utils.Dict.forEach(inMemTable => {
-          let {idsToStore, dict, effect, invalidationsCount} = inMemTable
-          switch idsToStore {
-          | [] => ()
-          | ids =>
-            let items = ids->Array.map((id): Internal.effectCacheItem => {
-              id,
-              output: dict->Dict.getUnsafe(id),
-            })
-            let effectName = effect.name
-            let effectCacheRecord = switch cache->Utils.Dict.dangerouslyGetNonOption(effectName) {
-            | Some(c) => c
-            | None =>
-              let c: Persistence.effectCacheRecord = {effectName, count: 0}
-              cache->Dict.set(effectName, c)
-              c
-            }
-            let shouldInitialize = effectCacheRecord.count === 0
-            effectCacheRecord.count =
-              effectCacheRecord.count + items->Array.length - invalidationsCount
-            Prometheus.EffectCacheCount.set(~count=effectCacheRecord.count, ~effectName)
-            acc
-            ->Array.push(({effect, items, shouldInitialize}: Persistence.updatedEffectCache))
-            ->ignore
-          }
-        })
-        acc
-      },
+      ~updatedEffectsCache,
     )
+  )
 
-    inMemoryStore.rawEvents = []
-    inMemoryStore.effects = Dict.make()
-    inMemoryStore.rollback = None
-    inMemoryStore.committedCheckpointId = switch batch.checkpointIds->Utils.Array.last {
-    | Some(checkpointId) => checkpointId
-    | None => committedCheckpointId
+  inMemoryStore.committedCheckpointId = snapshotCheckpointId
+  inMemoryStore.effects->Utils.Dict.forEach(inMemTable => inMemTable.pendingDict = None)
+}
+
+let runWriteLoop = async (inMemoryStore: t) => {
+  switch (inMemoryStore.persistence, inMemoryStore.config) {
+  | (Some(persistence), Some(config)) =>
+    while (
+      inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId &&
+        inMemoryStore.persistenceError->Option.isNone
+    ) {
+      try {
+        await runOneWrite(inMemoryStore, ~persistence, ~config)
+        inMemoryStore->wakeCommitWaiters
+      } catch {
+      | exn => inMemoryStore.persistenceError = Some(exn)
+      }
     }
-    if keepLatestChanges {
-      persistence.allEntities->Array.forEach(entityConfig => {
-        let table = inMemoryStore->getInMemTable(~entityConfig)
-        inMemoryStore.entities->Dict.set(
-          (entityConfig.name :> string),
-          table->InMemoryTable.Entity.resetButKeepLatestChanges,
-        )
-      })
-    } else {
-      // Over the limit: drop everything written in a batch and keep only the
-      // entities loaded from the db, so the next batch can still read them
-      // without hitting the database.
-      let loadedFromDbCount = ref(0.)
-      let resetTables = persistence.allEntities->Array.map(entityConfig => {
-        let resetTable =
-          inMemoryStore
-          ->getInMemTable(~entityConfig)
-          ->InMemoryTable.Entity.resetButKeepLoadedFromDbChanges
-        loadedFromDbCount := loadedFromDbCount.contents +. resetTable.changesCount
-        resetTable
-      })
-      // Even the loaded-from-db entities alone exceed the limit, so there's no
-      // point keeping them around - drop everything.
-      let dropEverything = loadedFromDbCount.contents >= keepLatestChangesLimit
-      persistence.allEntities->Array.forEachWithIndex((entityConfig, idx) => {
-        inMemoryStore.entities->Dict.set(
-          (entityConfig.name :> string),
-          dropEverything ? InMemoryTable.Entity.make() : resetTables->Array.getUnsafe(idx),
-        )
-      })
+  | _ => ()
+  }
+  inMemoryStore.writeFiber = None
+  inMemoryStore->wakeCommitWaiters
+}
+
+let kick = (inMemoryStore: t) =>
+  if (
+    inMemoryStore.writeFiber->Option.isNone &&
+    inMemoryStore.persistenceError->Option.isNone &&
+    inMemoryStore.processedCheckpointId > inMemoryStore.committedCheckpointId
+  ) {
+    inMemoryStore.writeFiber = Some(runWriteLoop(inMemoryStore))
+  }
+
+// Records a processed batch in memory and triggers the background persistence
+// cycle. Returns immediately - the db write happens off the processing path.
+let commitBatch = (
+  inMemoryStore: t,
+  ~persistence: Persistence.t,
+  ~batch: Batch.t,
+  ~config,
+  ~isInReorgThreshold,
+) => {
+  inMemoryStore.persistence = Some(persistence)
+  inMemoryStore.config = Some(config)
+  inMemoryStore.isInReorgThreshold = isInReorgThreshold
+  inMemoryStore.pendingBatches->Array.push(batch)->ignore
+  switch batch.checkpointIds->Utils.Array.last {
+  | Some(checkpointId) => inMemoryStore.processedCheckpointId = checkpointId
+  | None => ()
+  }
+  inMemoryStore->kick
+}
+
+// Blocks the next batch until the store holds fewer than keepLatestChangesLimit
+// changes, freeing committed changes first and awaiting commits as a last resort.
+let rec awaitCapacity = async (inMemoryStore: t) => {
+  switch inMemoryStore.persistenceError {
+  | Some(exn) => throw(exn)
+  | None => ()
+  }
+  if inMemoryStore->getChangesCount >= keepLatestChangesLimit {
+    inMemoryStore.allEntities->Array.forEach(entityConfig =>
+      inMemoryStore
+      ->getInMemTable(~entityConfig)
+      ->InMemoryTable.Entity.dropCommittedChanges(
+        ~committedCheckpointId=inMemoryStore.committedCheckpointId,
+      )
+    )
+    if inMemoryStore->getChangesCount >= keepLatestChangesLimit {
+      // What's left is uncommitted, so wait for the cycle to persist more.
+      inMemoryStore->kick
+      await inMemoryStore->waitForCommit
+      await inMemoryStore->awaitCapacity
     }
   }
+}
+
+// Awaits until everything processed in memory is persisted to the db.
+let rec flush = async (inMemoryStore: t) => {
+  switch inMemoryStore.persistenceError {
+  | Some(exn) => throw(exn)
+  | None => ()
+  }
+  inMemoryStore->kick
+  switch inMemoryStore.writeFiber {
+  | Some(fiber) =>
+    await fiber
+    await inMemoryStore->flush
+  | None => ()
+  }
+}
+
+// Before a rollback: let the in-flight write finish so committedCheckpointId
+// reflects the db, then reset the processing frontier to it. Uncommitted state
+// is discarded by prepareRollbackDiff and reprocessed from the committed point.
+let drainForRollback = async (inMemoryStore: t) => {
+  switch inMemoryStore.writeFiber {
+  | Some(fiber) => await fiber
+  | None => ()
+  }
+  inMemoryStore.pendingBatches = []
+  inMemoryStore.processedCheckpointId = inMemoryStore.committedCheckpointId
+  switch inMemoryStore.persistenceError {
+  | Some(exn) => throw(exn)
+  | None => ()
+  }
+}
 
 let prepareRollbackDiff = async (
   inMemoryStore: t,

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -13,9 +13,11 @@ module Entity = {
     // prevEntityChanges), kept in sync manually so InMemoryStore can gauge the
     // store size without scanning every dict.
     mutable changesCount: float,
-    prevEntityChanges: array<Change.t<Internal.entity>>,
-    indicesByEntityId: dict<entityIndices>,
-    fieldNameIndices: indexFieldNameToIndices,
+    // Swapped out wholesale when a write starts so processing can keep appending
+    // while the previous changes are persisted in the background.
+    mutable prevEntityChanges: array<Change.t<Internal.entity>>,
+    mutable indicesByEntityId: dict<entityIndices>,
+    mutable fieldNameIndices: indexFieldNameToIndices,
   }
 
   // Helper to extract entity ID from any entity
@@ -82,6 +84,39 @@ module Entity = {
       latestEntityChangeById,
       changesCount: keptCount.contents,
     }
+  }
+
+  // Pull out the changes that need to be persisted for checkpoints above
+  // committedCheckpointId. Reuses prevEntityChanges as the write buffer and
+  // installs a fresh one, so concurrent processing keeps accumulating into the
+  // table while these changes are written to the db in the background.
+  let snapshotChanges = (self: t, ~committedCheckpointId): array<Change.t<Internal.entity>> => {
+    let changes = self.prevEntityChanges
+    self.prevEntityChanges = []
+    self.changesCount = self.changesCount -. changes->Array.length->Int.toFloat
+    self.latestEntityChangeById->Utils.Dict.forEach(change =>
+      if change->Change.getCheckpointId > committedCheckpointId {
+        changes->Array.push(change)
+      }
+    )
+    changes
+  }
+
+  // Free memory held by changes already committed to the db: drop every latest
+  // entry at or below committedCheckpointId (re-readable from the db) and clear
+  // the per-batch indices so they get rebuilt on the next getWhere. Uncommitted
+  // changes (checkpointId > committedCheckpointId) must be kept.
+  let dropCommittedChanges = (self: t, ~committedCheckpointId) => {
+    let keysToDelete = []
+    self.latestEntityChangeById->Utils.Dict.forEachWithKey((change, key) =>
+      if !(change->Change.getCheckpointId > committedCheckpointId) {
+        keysToDelete->Array.push(key)
+      }
+    )
+    keysToDelete->Array.forEach(key => self.latestEntityChangeById->Utils.Dict.deleteInPlace(key))
+    self.changesCount = self.changesCount -. keysToDelete->Array.length->Int.toFloat
+    self.indicesByEntityId = Dict.make()
+    self.fieldNameIndices = Dict.make()
   }
 
   let updateIndices = (self: t, ~entity: Internal.entity) => {

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -57,35 +57,6 @@ module Entity = {
     fieldNameIndices: Dict.make(),
   }
 
-  // Drops the per-batch index state and rollback history, but keeps the
-  // already committed entities so the next batch can read them without
-  // hitting the database.
-  let resetButKeepLatestChanges = (self: t): t => {
-    ...make(),
-    latestEntityChangeById: self.latestEntityChangeById,
-    // writeBatch already mutated this to subtract the dropped prevEntityChanges.
-    changesCount: self.changesCount,
-  }
-
-  // Like resetButKeepLatestChanges, but only keeps entities loaded from the db
-  // (changes carrying loadedFromDbCheckpointId), dropping everything written in
-  // a batch. The kept count is exposed through the table's changesCount.
-  let resetButKeepLoadedFromDbChanges = (self: t): t => {
-    let latestEntityChangeById = Dict.make()
-    let keptCount = ref(0.)
-    self.latestEntityChangeById->Utils.Dict.forEachWithKey((change, key) =>
-      if change->Change.getCheckpointId === Internal.loadedFromDbCheckpointId {
-        latestEntityChangeById->Dict.set(key, change)
-        keptCount := keptCount.contents +. 1.
-      }
-    )
-    {
-      ...make(),
-      latestEntityChangeById,
-      changesCount: keptCount.contents,
-    }
-  }
-
   // Pull out the changes to persist for checkpoints in
   // (committedCheckpointId, upToCheckpointId]. Changes above upToCheckpointId
   // stay in the table for a later write (they belong to batches past a change in

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -84,19 +84,33 @@ module Entity = {
     changes
   }
 
-  // Free memory held by changes already committed to the db: drop every latest
-  // entry at or below committedCheckpointId (re-readable from the db) and clear
-  // the per-batch indices so they get rebuilt on the next getWhere. Uncommitted
-  // changes (checkpointId > committedCheckpointId) must be kept.
-  let dropCommittedChanges = (self: t, ~committedCheckpointId) => {
-    let keysToDelete = []
-    self.latestEntityChangeById->Utils.Dict.forEachWithKey((change, key) =>
-      if !(change->Change.getCheckpointId > committedCheckpointId) {
-        keysToDelete->Array.push(key)
+  // Free memory held by changes already committed to the db (re-readable from
+  // it): drop latest entries and history at or below committedCheckpointId, and
+  // clear the per-batch indices so they get rebuilt on the next getWhere.
+  // Uncommitted changes (checkpointId > committedCheckpointId) must be kept.
+  // With keepLoadedFromDb, entries loaded from the db are retained so reads stay
+  // in memory - dropped only on a second, more aggressive pass.
+  let dropCommittedChanges = (self: t, ~committedCheckpointId, ~keepLoadedFromDb) => {
+    // Safe to delete the current key during a for..in iteration.
+    self.latestEntityChangeById->Utils.Dict.forEachWithKey((change, key) => {
+      let checkpointId = change->Change.getCheckpointId
+      let isCommitted = !(checkpointId > committedCheckpointId)
+      let isLoadedFromDb = checkpointId === Internal.loadedFromDbCheckpointId
+      if isCommitted && !(keepLoadedFromDb && isLoadedFromDb) {
+        self.latestEntityChangeById->Utils.Dict.deleteInPlace(key)
+        self.changesCount = self.changesCount -. 1.
+      }
+    })
+    // History changes are never loaded-from-db, so drop every committed one.
+    let keptPrev = []
+    self.prevEntityChanges->Array.forEach(change =>
+      if change->Change.getCheckpointId > committedCheckpointId {
+        keptPrev->Array.push(change)
+      } else {
+        self.changesCount = self.changesCount -. 1.
       }
     )
-    keysToDelete->Array.forEach(key => self.latestEntityChangeById->Utils.Dict.deleteInPlace(key))
-    self.changesCount = self.changesCount -. keysToDelete->Array.length->Int.toFloat
+    self.prevEntityChanges = keptPrev
     self.indicesByEntityId = Dict.make()
     self.fieldNameIndices = Dict.make()
   }

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -86,19 +86,30 @@ module Entity = {
     }
   }
 
-  // Pull out the changes that need to be persisted for checkpoints above
-  // committedCheckpointId. Reuses prevEntityChanges as the write buffer and
-  // installs a fresh one, so concurrent processing keeps accumulating into the
-  // table while these changes are written to the db in the background.
-  let snapshotChanges = (self: t, ~committedCheckpointId): array<Change.t<Internal.entity>> => {
-    let changes = self.prevEntityChanges
-    self.prevEntityChanges = []
-    self.changesCount = self.changesCount -. changes->Array.length->Int.toFloat
-    self.latestEntityChangeById->Utils.Dict.forEach(change =>
-      if change->Change.getCheckpointId > committedCheckpointId {
+  // Pull out the changes to persist for checkpoints in
+  // (committedCheckpointId, upToCheckpointId]. Changes above upToCheckpointId
+  // stay in the table for a later write (they belong to batches past a change in
+  // isInReorgThreshold). Concurrent processing keeps accumulating meanwhile.
+  let snapshotChanges = (self: t, ~committedCheckpointId, ~upToCheckpointId): array<
+    Change.t<Internal.entity>,
+  > => {
+    let changes = []
+    let keptPrev = []
+    self.prevEntityChanges->Array.forEach(change =>
+      if change->Change.getCheckpointId > upToCheckpointId {
+        keptPrev->Array.push(change)
+      } else {
         changes->Array.push(change)
       }
     )
+    self.prevEntityChanges = keptPrev
+    self.changesCount = self.changesCount -. changes->Array.length->Int.toFloat
+    self.latestEntityChangeById->Utils.Dict.forEach(change => {
+      let checkpointId = change->Change.getCheckpointId
+      if checkpointId > committedCheckpointId && !(checkpointId > upToCheckpointId) {
+        changes->Array.push(change)
+      }
+    })
     changes
   }
 

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -334,8 +334,8 @@ let loadEffect = (
     ~load,
     ~shouldGroup,
     ~hasher=args => args.cacheKey,
-    ~getUnsafeInMemory=hash => inMemTable.dict->Dict.getUnsafe(hash),
-    ~hasInMemory=hash => inMemTable.dict->Dict.has(hash),
+    ~getUnsafeInMemory=hash => inMemTable->InMemoryStore.getEffectOutput(hash)->Option.getUnsafe,
+    ~hasInMemory=hash => inMemTable->InMemoryStore.getEffectOutput(hash)->Option.isSome,
     ~input=effectArgs,
   )
 }

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -693,6 +693,8 @@ let start = async (
     inMemoryStore: InMemoryStore.make(
       ~entities=persistence.allEntities,
       ~committedCheckpointId=(persistence->Persistence.getInitializedState).checkpointId,
+      ~persistence,
+      ~config,
     ),
   }
 

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -133,6 +133,9 @@ type storage = {
     ~allEntities: array<Internal.entityConfig>,
     ~updatedEffectsCache: array<updatedEffectCache>,
     ~updatedEntities: array<updatedEntity>,
+    // Chain metadata fields that went stale since the last write, persisted in
+    // the same transaction so they never race the batch write.
+    ~chainMetaData: option<dict<InternalTable.Chains.metaFields>>,
   ) => promise<unit>,
   // Release any long-lived resources (e.g. the postgres connection pool) so
   // short-lived CLI commands like `db-migrate setup` can exit cleanly.

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -725,6 +725,7 @@ let rec writeBatch = async (
   ~updatedEffectsCache,
   ~updatedEntities: array<Persistence.updatedEntity>,
   ~sinkPromise: option<promise<option<exn>>>,
+  ~chainMetaData: option<dict<InternalTable.Chains.metaFields>>,
   ~escapeTables=?,
 ) => {
   try {
@@ -975,6 +976,16 @@ let rec writeBatch = async (
             setRawEvents,
           ]->Belt.Array.concat(setEntities)
 
+          switch chainMetaData {
+          | Some(chainsData) =>
+            setOperations
+            ->Array.push(sql =>
+              sql->InternalTable.Chains.setMeta(~pgSchema, ~chainsData)->Utils.Promise.ignoreValue
+            )
+            ->ignore
+          | None => ()
+          }
+
           if shouldSaveHistory {
             setOperations->Belt.Array.push(sql =>
               sql->InternalTable.Checkpoints.insert(
@@ -1047,6 +1058,7 @@ let rec writeBatch = async (
       ~allEntities,
       ~updatedEntities,
       ~sinkPromise,
+      ~chainMetaData,
     )
   }
 }
@@ -1638,6 +1650,7 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
     ~allEntities,
     ~updatedEffectsCache,
     ~updatedEntities,
+    ~chainMetaData,
   ) => {
     let pgUpdates = []
     let chUpdates = []
@@ -1686,6 +1699,7 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
       ~updatedEffectsCache,
       ~updatedEntities=pgUpdates,
       ~sinkPromise,
+      ~chainMetaData,
     )
     Prometheus.StorageWrite.increment(
       ~storage="postgres",

--- a/packages/envio/src/TestIndexerProxyStorage.res
+++ b/packages/envio/src/TestIndexerProxyStorage.res
@@ -138,6 +138,7 @@ let makeStorage = (proxy: t): Persistence.storage => {
     ~allEntities as _,
     ~updatedEffectsCache as _,
     ~updatedEntities,
+    ~chainMetaData as _,
   ) => {
     // Encode entities to JSON for serialization across worker boundary
     let serializableEntities = updatedEntities->Array.map((

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -163,7 +163,7 @@ describe("ChainManager", () => {
         let rec testThatCreatedEventsAreOrderedCorrectly = (chainManager, lastEvent) => {
           let {items, totalBatchSize, progressedChainsById} = ChainManager.createBatch(
             chainManager,
-            ~committedCheckpointId=Internal.initialCheckpointId,
+            ~processedCheckpointId=Internal.initialCheckpointId,
             ~batchSizeTarget=10000,
             ~isRollback=false,
           )

--- a/scenarios/test_codegen/test/E2E_test.res
+++ b/scenarios/test_codegen/test/E2E_test.res
@@ -1060,41 +1060,40 @@ describe("E2E tests", () => {
       syncSource.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=300)
       await indexerMock.getBatchWritePromise()
 
-      // First waitForNewBlock runs with isRealtime=false (NextQuery fires before
-      // EventBatchProcessed sets timestampCaughtUpToHeadOrEndblock).
-      // Only Sync participates in height racing initially.
-      t.expect(
-        syncSource.getHeightOrThrowCalls->Array.length,
-        ~message="Sync source should be called for first waitForNewBlock",
-      ).toEqual(2)
+      // With the standalone persistence cycle, EventBatchProcessed marks the
+      // chain caught up before the first waitForNewBlock fires, so the height
+      // race is already in realtime mode: Live=Primary races, Sync=Secondary.
       t.expect(
         liveSource.getHeightOrThrowCalls->Array.length,
-        ~message="Live source should NOT participate yet (isRealtime still false)",
-      ).toEqual(0)
+        ~message="Live source should participate in the first waitForNewBlock (realtime)",
+      ).toEqual(1)
+      t.expect(
+        syncSource.getHeightOrThrowCalls->Array.length,
+        ~message="Sync source should stay at 1 (Secondary, not racing)",
+      ).toEqual(1)
 
-      // Resolve the first waitForNewBlock to advance to the next cycle
-      syncSource.resolveGetHeightOrThrow(301)
+      // Resolve the first waitForNewBlock via the Live (Primary) source
+      liveSource.resolveGetHeightOrThrow(301)
       await Utils.delay(0)
       await Utils.delay(0)
 
       // Resolve the items query for the new block
       t.expect(
         syncSource.getItemsOrThrowCalls->Array.length,
-        ~message="Even though the sync source resolves the rate, we are now in the live mode, so we attempt to query items from the live source now.",
+        ~message="We are in live mode, so we query items from the live source.",
       ).toEqual(0)
       liveSource.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=301)
       await indexerMock.getBatchWritePromise()
 
-      // Now isRealtime=true (EventBatchProcessed has set timestampCaughtUpToHeadOrEndblock).
-      // Second waitForNewBlock: Live=Primary races, Sync=Secondary (not in main group).
+      // Second waitForNewBlock: Live=Primary races again, Sync=Secondary (stays).
       t.expect(
         syncSource.getHeightOrThrowCalls->Array.length,
-        ~message="Sync source should stay at 2 (now Secondary, not racing)",
-      ).toEqual(2)
+        ~message="Sync source should stay at 1 (Secondary, not racing)",
+      ).toEqual(1)
       t.expect(
         liveSource.getHeightOrThrowCalls->Array.length,
-        ~message="Live source should now participate in height racing after isRealtime=true",
-      ).toEqual(1)
+        ~message="Live source should keep racing in realtime mode",
+      ).toEqual(2)
     },
   )
 

--- a/scenarios/test_codegen/test/EventOrigin_test.res
+++ b/scenarios/test_codegen/test/EventOrigin_test.res
@@ -39,7 +39,7 @@ describe("Chains State", () => {
       async t => {
         // This test verifies that the chain field is accessible
         // The actual integration test is in EventHandlers.res with the EmptyEvent handler
-        let inMemoryStore = InMemoryStore.make(~entities=(Config.loadWithoutRegistrations()).allEntities)
+        let inMemoryStore = MockIndexer.InMemoryStore.make()
         let loadManager = LoadManager.make()
 
         let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem

--- a/scenarios/test_codegen/test/LoadLayer_test.res
+++ b/scenarios/test_codegen/test/LoadLayer_test.res
@@ -3,7 +3,7 @@ open Vitest
 describe("LoadLayer", () => {
   Async.it("Trys to load non existing entity from db", async t => {
     let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
-    let inMemoryStore = InMemoryStore.make(~entities=(Config.loadWithoutRegistrations()).allEntities)
+    let inMemoryStore = MockIndexer.InMemoryStore.make()
     let loadManager = LoadManager.make()
 
     let getUser = entityId =>
@@ -31,7 +31,7 @@ describe("LoadLayer", () => {
   Async.it("Does two round trips to db when requesting non existing entity one by one", async t => {
     let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
     let loadManager = LoadManager.make()
-    let inMemoryStore = InMemoryStore.make(~entities=(Config.loadWithoutRegistrations()).allEntities)
+    let inMemoryStore = MockIndexer.InMemoryStore.make()
 
     let getUser = entityId =>
       LoadLayer.loadById(
@@ -66,7 +66,7 @@ describe("LoadLayer", () => {
     async t => {
       let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
       let loadManager = LoadManager.make()
-      let inMemoryStore = InMemoryStore.make(~entities=(Config.loadWithoutRegistrations()).allEntities)
+      let inMemoryStore = MockIndexer.InMemoryStore.make()
       let getUser = entityId =>
         LoadLayer.loadById(
           ~loadManager,

--- a/scenarios/test_codegen/test/WriteRead_test.res
+++ b/scenarios/test_codegen/test/WriteRead_test.res
@@ -227,33 +227,27 @@ breaking precicion on big values. https://github.com/enviodev/hyperindex/issues/
     },
   )
 
-  it(
-    "resetButKeepLoadedFromDbChanges keeps only entities loaded from the db, counted via changesCount",
-    t => {
-      let makeEntity = (id): Internal.entity =>
-        {"id": id}->(Utils.magic: {"id": string} => Internal.entity)
-      let committedCheckpointId = Internal.initialCheckpointId
+  it("dropCommittedChanges keeps only uncommitted changes (checkpointId > committed)", t => {
+    let makeEntity = (id): Internal.entity =>
+      {"id": id}->(Utils.magic: {"id": string} => Internal.entity)
 
-      let table = InMemoryTable.Entity.make()
-      table->InMemoryTable.Entity.initValue(
-        ~committedCheckpointId,
-        ~key="loaded-set",
-        ~entity=Some(makeEntity("loaded-set")),
-      )
-      table->InMemoryTable.Entity.initValue(~committedCheckpointId, ~key="loaded-deleted", ~entity=None)
+    let table = InMemoryTable.Entity.make()
+    let add = (id, checkpointId) =>
       table->InMemoryTable.Entity.set(
-        ~committedCheckpointId,
-        Set({entityId: "written", entity: makeEntity("written"), checkpointId: 5n}),
+        ~committedCheckpointId=Internal.initialCheckpointId,
+        Set({entityId: id, entity: makeEntity(id), checkpointId}),
       )
+    add("loaded", Internal.loadedFromDbCheckpointId)
+    add("committed", 5n)
+    add("uncommitted", 6n)
 
-      let resetTable = table->InMemoryTable.Entity.resetButKeepLoadedFromDbChanges
+    table->InMemoryTable.Entity.dropCommittedChanges(~committedCheckpointId=5n)
 
-      t.expect((
-        resetTable.changesCount,
-        resetTable.latestEntityChangeById->Dict.keysToArray->Array.toSorted(String.compare),
-      )).toEqual((2., ["loaded-deleted", "loaded-set"]))
-    },
-  )
+    t.expect((
+      table.changesCount,
+      table.latestEntityChangeById->Dict.keysToArray->Array.toSorted(String.compare),
+    )).toEqual((1., ["uncommitted"]))
+  })
 
   Async.it("Test getWhere queries with eq and gt operators", async t => {
     let sourceMock = MockIndexer.Source.make(~chain=#1337, [#getHeightOrThrow, #getItemsOrThrow])

--- a/scenarios/test_codegen/test/WriteRead_test.res
+++ b/scenarios/test_codegen/test/WriteRead_test.res
@@ -227,26 +227,41 @@ breaking precicion on big values. https://github.com/enviodev/hyperindex/issues/
     },
   )
 
-  it("dropCommittedChanges keeps only uncommitted changes (checkpointId > committed)", t => {
+  it("dropCommittedChanges drops committed changes, optionally keeping db-loaded ones", t => {
     let makeEntity = (id): Internal.entity =>
       {"id": id}->(Utils.magic: {"id": string} => Internal.entity)
 
-    let table = InMemoryTable.Entity.make()
-    let add = (id, checkpointId) =>
-      table->InMemoryTable.Entity.set(
-        ~committedCheckpointId=Internal.initialCheckpointId,
-        Set({entityId: id, entity: makeEntity(id), checkpointId}),
-      )
-    add("loaded", Internal.loadedFromDbCheckpointId)
-    add("committed", 5n)
-    add("uncommitted", 6n)
+    let makeTable = () => {
+      let table = InMemoryTable.Entity.make()
+      let add = (id, checkpointId) =>
+        table->InMemoryTable.Entity.set(
+          ~committedCheckpointId=Internal.initialCheckpointId,
+          Set({entityId: id, entity: makeEntity(id), checkpointId}),
+        )
+      add("loaded", Internal.loadedFromDbCheckpointId)
+      add("committed", 5n)
+      add("uncommitted", 6n)
+      table
+    }
+    let keys = table => table.InMemoryTable.Entity.latestEntityChangeById->Dict.keysToArray->Array.toSorted(String.compare)
 
-    table->InMemoryTable.Entity.dropCommittedChanges(~committedCheckpointId=5n)
+    // Keep db-loaded: only the committed (non-loaded) entry is dropped.
+    let kept = makeTable()
+    kept->InMemoryTable.Entity.dropCommittedChanges(~committedCheckpointId=5n, ~keepLoadedFromDb=true)
 
-    t.expect((
-      table.changesCount,
-      table.latestEntityChangeById->Dict.keysToArray->Array.toSorted(String.compare),
-    )).toEqual((1., ["uncommitted"]))
+    // Drop everything committed, leaving only uncommitted.
+    let dropped = makeTable()
+    dropped->InMemoryTable.Entity.dropCommittedChanges(
+      ~committedCheckpointId=5n,
+      ~keepLoadedFromDb=false,
+    )
+
+    t.expect((kept.changesCount, kept->keys, dropped.changesCount, dropped->keys)).toEqual((
+      2.,
+      ["loaded", "uncommitted"],
+      1.,
+      ["uncommitted"],
+    ))
   })
 
   Async.it("Test getWhere queries with eq and gt operators", async t => {

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -10,6 +10,18 @@ let entityConfig = (name: Indexer.Entities.name<_>): Internal.entityConfig =>
 // Keep a handle to the real module before the local shadow below.
 module RealInMemoryStore = InMemoryStore
 
+// In-memory-only test stores never run the persistence cycle, but the store
+// still requires a persistence/config; reuse one for all of them.
+let defaultPersistence = PgStorage.makePersistenceFromConfig(
+  ~config,
+  ~storage=PgStorage.makeStorageFromEnv(
+    ~config,
+    ~sql=PgStorage.makeClient(),
+    ~pgSchema=Env.Db.publicSchema,
+    ~isHasuraEnabled=false,
+  ),
+)
+
 module InMemoryStore = {
   let setEntity = (inMemoryStore, ~entityConfig: Internal.entityConfig, entity) => {
     let inMemTable = inMemoryStore->InMemoryStore.getInMemTable(~entityConfig)
@@ -25,7 +37,8 @@ module InMemoryStore = {
   }
 
   let make = (~entities=[]) => {
-    let inMemoryStore = InMemoryStore.make(~entities=config.allEntities)
+    let inMemoryStore =
+      RealInMemoryStore.make(~entities=config.allEntities, ~persistence=defaultPersistence, ~config)
     entities->Array.forEach(((entityConfig, items)) => {
       items->Array.forEach(entity => {
         inMemoryStore->setEntity(~entityConfig, entity)

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -204,6 +204,7 @@ module Storage = {
           ~allEntities as _,
           ~updatedEffectsCache as _,
           ~updatedEntities as _,
+          ~chainMetaData as _,
         ) => JsError.throwWithMessage("Not implemented"),
         close: () => Promise.resolve(),
       },
@@ -334,7 +335,7 @@ module Indexer = {
       Ctx.registrations,
       config,
       persistence,
-      inMemoryStore: InMemoryStore.make(),
+      inMemoryStore: RealInMemoryStore.make(~entities=config.allEntities, ~persistence, ~config),
     }
 
     let graphqlClient = Rest.client(`${Env.Hasura.url}/v1/graphql`)

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -7,6 +7,9 @@ let entityConfig = (name: Indexer.Entities.name<_>): Internal.entityConfig =>
   ->Dict.get(name->(Utils.magic: Indexer.Entities.name<_> => string))
   ->Option.getOrThrow
 
+// Keep a handle to the real module before the local shadow below.
+module RealInMemoryStore = InMemoryStore
+
 module InMemoryStore = {
   let setEntity = (inMemoryStore, ~entityConfig: Internal.entityConfig, entity) => {
     let inMemTable = inMemoryStore->InMemoryStore.getInMemTable(~entityConfig)
@@ -378,9 +381,34 @@ module Indexer = {
       getBatchWritePromise: () => {
         Utils.Promise.makeAsync(async (resolve, _reject) => {
           let before = (gsManager->GlobalStateManager.getState).processedBatches
-          while before >= (gsManager->GlobalStateManager.getState).processedBatches {
-            await Utils.delay(1)
+          // Wait until a new batch has been processed and fully written to the db
+          // by the standalone persistence cycle. During a reorg the awaited batch
+          // can be processed before this call (e.g. while the test awaits the
+          // rollback), so also stop once the indexer has fully settled.
+          let idleChecks = ref(0)
+          let rec wait = async () => {
+            await ctx.inMemoryStore->RealInMemoryStore.flush
+            let state = gsManager->GlobalStateManager.getState
+            let store = ctx.inMemoryStore
+            let isIdle =
+              !state.currentlyProcessingBatch &&
+              store.writeFiber->Option.isNone &&
+              store.committedCheckpointId == store.processedCheckpointId
+            if before < state.processedBatches {
+              ()
+            } else if isIdle && idleChecks.contents >= 5 {
+              ()
+            } else {
+              idleChecks := if isIdle {
+                idleChecks.contents + 1
+              } else {
+                0
+              }
+              await Utils.delay(1)
+              await wait()
+            }
           }
+          await wait()
           // Skip extra microtasks for indexer to fire follow-up actions
           // (e.g. the NextQuery dispatch that schedules the next
           // getItemsOrThrow call). Without this, callers that immediately
@@ -501,13 +529,16 @@ module Indexer = {
         | None => []
         }
       },
-      restart: () => {
+      restart: async () => {
+        // Ensure everything processed in memory is persisted before simulating
+        // a restart, otherwise the resumed indexer would lose uncommitted state.
+        await ctx.inMemoryStore->RealInMemoryStore.flush
         let state = gsManager->GlobalStateManager.getState
         gsManager->GlobalStateManager.setState({
           ...gsManager->GlobalStateManager.getState,
           id: state.id + 1,
         })
-        make(
+        await make(
           ~chains,
           ~enableHasura,
           ~enableRawEvents,


### PR DESCRIPTION
## Summary

Refactors the indexer's event processing pipeline to decouple batch processing from database writes. Instead of blocking on each batch write, the system now queues batches for asynchronous persistence while processing continues. This allows the processing frontier to advance ahead of the committed checkpoint, improving throughput and responsiveness.

## Key Changes

- **Standalone persistence cycle**: Introduced `runWriteLoop` that continuously drains pending batches in the background, decoupled from the event processing path. The main processing thread calls `commitBatch` (non-blocking) instead of `writeBatch` (blocking).

- **Dual checkpoint tracking**: Added `processedCheckpointId` (processing frontier) alongside `committedCheckpointId` (db state). Processing can now run ahead of persistence, bounded by `keepLatestChangesLimit` to prevent unbounded memory growth.

- **Capacity management**: New `awaitCapacity` function blocks the next batch only when in-memory changes exceed the limit. It first drops committed changes, then awaits the background cycle if uncommitted changes still exceed the limit.

- **Effect cache snapshots**: Refactored effect cache handling with `snapshotEffects` to swap the live dict into `pendingDict` while a write is in flight. This keeps cached values readable during the write without growing the live dict after commit.

- **Entity change snapshots**: Added `snapshotChanges` to extract changes for persistence while installing a fresh array for concurrent processing. Paired with `dropCommittedChanges` to free memory of persisted entries.

- **Serialized db writes**: New `serializeDbWrite` ensures background batch writes and throttled chain-metadata writes don't touch shared rows concurrently, using a promise chain (`dbWriteTail`) as a queue.

- **Commit waiters**: Added `commitWaiters` array and `waitForCommit` to allow capacity/flush waiters to re-evaluate after each commit completes.

- **Error propagation**: Persistence errors are captured in `persistenceError` and surfaced at batch boundaries or flush, preventing silent failures.

## Implementation Details

- The write loop checks `processedCheckpointId > committedCheckpointId` to decide whether to persist, allowing it to idle when caught up.
- `mergePendingBatches` combines queued batches into a single write, reducing db round-trips.
- The `getEffectOutput` helper consults both the live dict and pending dict during reads, ensuring the cache stays warm.
- Test helpers updated to wait for the standalone cycle to settle (checking `writeFiber`, `committedCheckpointId`, and `processedCheckpointId`).
- Chain metadata writes are serialized through the same `dbWriteTail` queue to avoid concurrent writes to shared tables.

https://claude.ai/code/session_01TuuFyaX6X8RzzDK2v6gfAt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async background batch persistence with serialized DB writes and chain metadata persisted alongside batches.

* **Bug Fixes**
  * Stronger backpressure and clearer persistence error surfacing.
  * Ensures in-memory state is flushed before exits, restarts, and rollbacks to avoid divergence.

* **Refactor**
  * Reworked in-memory buffering, commit coordination, checkpoint tracking, and effect-cache read semantics; batches now track reorg-threshold status.

* **Tests**
  * Updated tests to reflect new checkpoint, ordering, and flush behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->