### PR TITLE
Support client-side filtering and comparison operators in --where

### DIFF
--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -402,9 +402,7 @@ Example — current archive height: `envio data knownHeight --chain=arbitrum-one
 ###### **Options:**
 
 * `--chain <CHAIN>` — Chain id (e.g. `8453`) or kebab-case name (e.g. `base`, `arbitrum-one`). Solana is not supported yet
-* `--where <WHERE_FILTER>` — Filter rows, as JSON5 (relaxed JSON: unquoted keys, single quotes, trailing commas, `//` comments). Group filters under `block`, `transaction`, and `log`. Match any field with a value, an array, or `_eq`/`_in`; compare numeric fields with `_gt`/`_gte`/`_lt`/`_lte`. Example:
-
-   --where='{ block:       { number: { _gte: 1000, _lte: 2000 } }, log:         { srcAddress: "0xa0b8..." }, transaction: { value: { _gt: 1000000000000000000 } }, }'
+* `--where <WHERE_FILTER>` — Filter rows (JSON5: unquoted keys, single quotes, trailing commas, `//` comments). Group fields under `block`, `transaction`, `log`. Match any field with a value, array, or `_eq`/`_in`; numeric fields also take `_gt`/`_gte`/`_lt`/`_lte`. Example: --where='{ block: { number: { _gte: 1000, _lte: 2000 } }, log: { srcAddress: "0xa0b8..." } }'
 
 
 

--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -402,9 +402,9 @@ Example — current archive height: `envio data knownHeight --chain=arbitrum-one
 ###### **Options:**
 
 * `--chain <CHAIN>` — Chain id (e.g. `8453`) or kebab-case name (e.g. `base`, `arbitrum-one`). Solana is not supported yet
-* `--where <WHERE_FILTER>` — Filter in indexer `where` form, as JSON5 — JSON-style braces with relaxed syntax: unquoted keys, single quotes, trailing commas, and `//` comments are all accepted. Example:
+* `--where <WHERE_FILTER>` — Filter in indexer `where` form, as JSON5 — JSON-style braces with relaxed syntax: unquoted keys, single quotes, trailing commas, and `//` comments are all accepted. Any field can be filtered. Fields Hypersync can filter (address, topics, from, to, sighash, ...) are pushed to the server; everything else — and all comparisons (`_gt`/`_gte`/`_lt`/`_lte`, numeric fields only) — is filtered client-side, so related rows in other sections may remain. Example:
 
-   --where='{ block: { number: { _gte: 1000, _lte: 2000 } }, log:   { srcAddress: "0xa0b8..." }, }'
+   --where='{ block:       { number: { _gte: 1000, _lte: 2000 } }, log:         { srcAddress: "0xa0b8..." }, transaction: { value: { _gt: 1000000000000000000 } }, }'
 
 
 

--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -402,7 +402,7 @@ Example — current archive height: `envio data knownHeight --chain=arbitrum-one
 ###### **Options:**
 
 * `--chain <CHAIN>` — Chain id (e.g. `8453`) or kebab-case name (e.g. `base`, `arbitrum-one`). Solana is not supported yet
-* `--where <WHERE_FILTER>` — Filter in indexer `where` form, as JSON5 — JSON-style braces with relaxed syntax: unquoted keys, single quotes, trailing commas, and `//` comments are all accepted. Any field can be filtered. Fields Hypersync can filter (address, topics, from, to, sighash, ...) are pushed to the server; everything else — and all comparisons (`_gt`/`_gte`/`_lt`/`_lte`, numeric fields only) — is filtered client-side, so related rows in other sections may remain. Example:
+* `--where <WHERE_FILTER>` — Filter rows, as JSON5 (relaxed JSON: unquoted keys, single quotes, trailing commas, `//` comments). Group filters under `block`, `transaction`, and `log`. Match any field with a value, an array, or `_eq`/`_in`; compare numeric fields with `_gt`/`_gte`/`_lt`/`_lte`. Example:
 
    --where='{ block:       { number: { _gte: 1000, _lte: 2000 } }, log:         { srcAddress: "0xa0b8..." }, transaction: { value: { _gt: 1000000000000000000 } }, }'
 

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -155,17 +155,11 @@ pub struct DataArgs {
     #[arg(long)]
     pub chain: String,
 
-    ///Filter rows, as JSON5 (relaxed JSON: unquoted keys, single quotes,
-    ///trailing commas, `//` comments). Group filters under `block`,
-    ///`transaction`, and `log`. Match any field with a value, an array, or
-    ///`_eq`/`_in`; compare numeric fields with `_gt`/`_gte`/`_lt`/`_lte`.
-    ///Example:
-    ///
-    ///  --where='{
-    ///    block:       { number: { _gte: 1000, _lte: 2000 } },
-    ///    log:         { srcAddress: "0xa0b8..." },
-    ///    transaction: { value: { _gt: 1000000000000000000 } },
-    ///  }'
+    ///Filter rows (JSON5: unquoted keys, single quotes, trailing commas,
+    ///`//` comments). Group fields under `block`, `transaction`, `log`.
+    ///Match any field with a value, array, or `_eq`/`_in`; numeric fields
+    ///also take `_gt`/`_gte`/`_lt`/`_lte`. Example:
+    ///--where='{ block: { number: { _gte: 1000, _lte: 2000 } }, log: { srcAddress: "0xa0b8..." } }'
     #[arg(long = "where")]
     pub where_filter: Option<String>,
 }

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -157,11 +157,16 @@ pub struct DataArgs {
 
     ///Filter in indexer `where` form, as JSON5 — JSON-style braces with
     ///relaxed syntax: unquoted keys, single quotes, trailing commas, and
-    ///`//` comments are all accepted. Example:
+    ///`//` comments are all accepted. Any field can be filtered. Fields
+    ///Hypersync can filter (address, topics, from, to, sighash, ...) are
+    ///pushed to the server; everything else — and all comparisons
+    ///(`_gt`/`_gte`/`_lt`/`_lte`, numeric fields only) — is filtered
+    ///client-side, so related rows in other sections may remain. Example:
     ///
     ///  --where='{
-    ///    block: { number: { _gte: 1000, _lte: 2000 } },
-    ///    log:   { srcAddress: "0xa0b8..." },
+    ///    block:       { number: { _gte: 1000, _lte: 2000 } },
+    ///    log:         { srcAddress: "0xa0b8..." },
+    ///    transaction: { value: { _gt: 1000000000000000000 } },
     ///  }'
     #[arg(long = "where")]
     pub where_filter: Option<String>,

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -155,13 +155,11 @@ pub struct DataArgs {
     #[arg(long)]
     pub chain: String,
 
-    ///Filter in indexer `where` form, as JSON5 — JSON-style braces with
-    ///relaxed syntax: unquoted keys, single quotes, trailing commas, and
-    ///`//` comments are all accepted. Any field can be filtered. Fields
-    ///Hypersync can filter (address, topics, from, to, sighash, ...) are
-    ///pushed to the server; everything else — and all comparisons
-    ///(`_gt`/`_gte`/`_lt`/`_lte`, numeric fields only) — is filtered
-    ///client-side, so related rows in other sections may remain. Example:
+    ///Filter rows, as JSON5 (relaxed JSON: unquoted keys, single quotes,
+    ///trailing commas, `//` comments). Group filters under `block`,
+    ///`transaction`, and `log`. Match any field with a value, an array, or
+    ///`_eq`/`_in`; compare numeric fields with `_gt`/`_gte`/`_lt`/`_lte`.
+    ///Example:
     ///
     ///  --where='{
     ///    block:       { number: { _gte: 1000, _lte: 2000 } },

--- a/packages/cli/src/data/client_filter.rs
+++ b/packages/cli/src/data/client_filter.rs
@@ -351,4 +351,79 @@ mod tests {
             Section::Log,
         );
     }
+
+    // End-to-end: parse a `--where` with several client-only filters, build an
+    // Arrow response, then mask + render. Exercises numeric range, `_in`, and a
+    // big-endian binary numeric comparison across two independent sections.
+    #[test]
+    fn advanced_client_filtering_end_to_end() {
+        use crate::data::field_selection::Selection;
+        use crate::data::toon::render_arrow_response;
+        use hypersync_client::{ArrowResponse, ArrowResponseData};
+
+        let selection = Selection::parse(&[
+            "log.blockNumber".into(),
+            "log.logIndex".into(),
+            "transaction.value".into(),
+        ])
+        .unwrap();
+
+        let filter = WhereFilter::parse(Some(
+            "{ log: { blockNumber: { _gte: 10, _lt: 20 }, logIndex: { _in: [0, 2] } }, \
+               transaction: { value: { _gt: 100 } } }",
+        ))
+        .unwrap();
+        assert_eq!(
+            (filter.server_filters.len(), filter.client_filters.len()),
+            (0, 3),
+        );
+
+        let log_schema = Schema::new(vec![
+            Field::new("block_number", DataType::UInt64, false),
+            Field::new("log_index", DataType::UInt64, false),
+        ]);
+        let logs = RecordBatch::try_new(
+            Arc::new(log_schema),
+            vec![
+                Arc::new(UInt64Array::from(vec![5u64, 10, 15, 15, 20, 19])),
+                Arc::new(UInt64Array::from(vec![0u64, 0, 1, 2, 2, 0])),
+            ],
+        )
+        .unwrap();
+
+        // `transaction.value` is a numeric field stored as big-endian bytes.
+        let value_bytes: Vec<Vec<u8>> = [50u64, 150, 100, 200]
+            .iter()
+            .map(|n| n.to_be_bytes().to_vec())
+            .collect();
+        let tx_schema = Schema::new(vec![Field::new("value", DataType::Binary, false)]);
+        let transactions = RecordBatch::try_new(
+            Arc::new(tx_schema),
+            vec![Arc::new(BinaryArray::from(
+                value_bytes.iter().map(|v| v.as_slice()).collect::<Vec<_>>(),
+            ))],
+        )
+        .unwrap();
+
+        let response = ArrowResponse {
+            archive_height: Some(1000),
+            next_block: 1000,
+            total_execution_time: 0,
+            data: ArrowResponseData {
+                logs: vec![logs],
+                transactions: vec![transactions],
+                ..Default::default()
+            },
+            rollback_guard: None,
+        };
+
+        let masks = compute_masks(&response, &filter.client_filters).unwrap();
+        let out = render_arrow_response(&selection, &response, &masks);
+
+        assert_eq!(
+            out,
+            "logs[3]{blockNumber,logIndex}:\n  10,0\n  15,2\n  19,0\n\
+             transactions[2]{value}:\n  150\n  200\n",
+        );
+    }
 }

--- a/packages/cli/src/data/client_filter.rs
+++ b/packages/cli/src/data/client_filter.rs
@@ -5,7 +5,7 @@ use hypersync_client::ArrowResponse;
 use ruint::aliases::U256;
 use serde_json::Value;
 
-use super::mapping::{ColumnFormat, Section};
+use super::mapping::{Section, ValueKind};
 use super::where_filter::{ClientFilter, CmpOp, Cond};
 
 /// Per-section keep masks, aligned with the row order produced when iterating a
@@ -51,7 +51,7 @@ pub fn compute_masks(response: &ArrowResponse, filters: &[ClientFilter]) -> Resu
 
 struct CompiledFilter {
     column: String,
-    fmt: ColumnFormat,
+    kind: ValueKind,
     conds: Vec<CompiledCond>,
 }
 
@@ -62,7 +62,7 @@ enum CompiledCond {
 
 impl CompiledFilter {
     fn compile(f: &ClientFilter) -> Result<Self> {
-        let fmt = f.field.column_format();
+        let kind = f.field.spec().value_kind;
         let label = format!(
             "{}.{}",
             f.field.section().as_indexer_str(),
@@ -74,7 +74,7 @@ impl CompiledFilter {
             .map(|cond| match cond {
                 Cond::In(vals) => Ok(CompiledCond::In(
                     vals.iter()
-                        .map(|v| filter_cell(v, fmt, &label))
+                        .map(|v| filter_cell(v, kind, &label))
                         .collect::<Result<Vec<_>>>()?,
                 )),
                 Cond::Cmp(op, v) => Ok(CompiledCond::Cmp(*op, filter_u256(v, &label)?)),
@@ -82,7 +82,7 @@ impl CompiledFilter {
             .collect::<Result<Vec<_>>>()?;
         Ok(Self {
             column: f.field.column_name(),
-            fmt,
+            kind,
             conds,
         })
     }
@@ -104,7 +104,7 @@ fn compute_section_mask(batches: &[RecordBatch], filters: &[CompiledFilter]) -> 
             .collect::<Result<Vec<_>>>()?;
         for row in 0..batch.num_rows() {
             let keep = filters.iter().zip(cols.iter()).all(|(f, col)| {
-                let cell = read_cell(*col, row, f.fmt);
+                let cell = read_cell(*col, row, f.kind);
                 cell_passes(&cell, &f.conds)
             });
             mask.push(keep);
@@ -121,7 +121,7 @@ enum Cell {
     Null,
 }
 
-fn read_cell(col: &dyn Array, row: usize, fmt: ColumnFormat) -> Cell {
+fn read_cell(col: &dyn Array, row: usize, kind: ValueKind) -> Cell {
     if col.is_null(row) {
         return Cell::Null;
     }
@@ -136,11 +136,9 @@ fn read_cell(col: &dyn Array, row: usize, fmt: ColumnFormat) -> Cell {
         DataType::Boolean => Cell::Bool(col.as_boolean().value(row)),
         DataType::Binary => {
             let bytes = col.as_binary::<i32>().value(row);
-            match fmt {
-                ColumnFormat::Decimal => {
-                    Cell::Num(U256::try_from_be_slice(bytes).unwrap_or_default())
-                }
-                ColumnFormat::Hex => Cell::Hex(faster_hex::hex_string(bytes)),
+            match kind {
+                ValueKind::Numeric => Cell::Num(U256::try_from_be_slice(bytes).unwrap_or_default()),
+                ValueKind::Hex | ValueKind::Bool => Cell::Hex(faster_hex::hex_string(bytes)),
             }
         }
         dt => unreachable!("unexpected arrow data type {dt:?} for envio data column"),
@@ -162,14 +160,20 @@ fn cell_passes(cell: &Cell, conds: &[CompiledCond]) -> bool {
     })
 }
 
-fn filter_cell(v: &Value, fmt: ColumnFormat, label: &str) -> Result<Cell> {
-    match fmt {
-        ColumnFormat::Decimal => Ok(Cell::Num(filter_u256(v, label)?)),
-        ColumnFormat::Hex => match v {
+fn filter_cell(v: &Value, kind: ValueKind, label: &str) -> Result<Cell> {
+    match kind {
+        ValueKind::Numeric => Ok(Cell::Num(filter_u256(v, label)?)),
+        ValueKind::Hex => match v {
             Value::String(s) => Ok(Cell::Hex(normalize_hex(s, label)?)),
-            Value::Bool(b) => Ok(Cell::Bool(*b)),
             other => bail!(
                 "Filter on `{label}` expects a hex string, got {}",
+                json_type(other),
+            ),
+        },
+        ValueKind::Bool => match v {
+            Value::Bool(b) => Ok(Cell::Bool(*b)),
+            other => bail!(
+                "Filter on `{label}` expects true or false, got {}",
                 json_type(other),
             ),
         },
@@ -312,7 +316,7 @@ mod tests {
         // `log.data` has no Hypersync builder, so it must route to client filters.
         let f = WhereFilter::parse(Some("{ log: { data: '0xabcd' } }")).unwrap();
         let routed = (
-            f.log_filters.len(),
+            f.server_filters.len(),
             f.client_filters.len(),
             f.client_filters[0].field.section(),
         );
@@ -322,16 +326,13 @@ mod tests {
     #[test]
     fn address_stays_server_side() {
         let f = WhereFilter::parse(Some("{ log: { srcAddress: '0xa0b8' } }")).unwrap();
-        assert_eq!((f.log_filters.len(), f.client_filters.len()), (1, 0));
+        assert_eq!((f.server_filters.len(), f.client_filters.len()), (1, 0));
     }
 
     #[test]
     fn comparison_on_numeric_field_is_client_side() {
         let f = WhereFilter::parse(Some("{ transaction: { value: { _gt: 1000 } } }")).unwrap();
-        assert_eq!(
-            (f.transaction_filters.len(), f.client_filters.len()),
-            (0, 1),
-        );
+        assert_eq!((f.server_filters.len(), f.client_filters.len()), (0, 1));
     }
 
     #[test]
@@ -339,7 +340,7 @@ mod tests {
         let err = WhereFilter::parse(Some("{ log: { srcAddress: { _gt: '0xa' } } }"))
             .unwrap_err()
             .to_string();
-        insta::assert_snapshot!(err, @"Comparison operators are not supported on hex field `log.srcAddress`. Use `_eq` or `_in`.");
+        insta::assert_snapshot!(err, @"Comparison operators are only supported on numeric fields; `log.srcAddress` is not numeric. Use `_eq` or `_in`.");
     }
 
     #[test]

--- a/packages/cli/src/data/client_filter.rs
+++ b/packages/cli/src/data/client_filter.rs
@@ -1,0 +1,353 @@
+use anyhow::{anyhow, bail, Result};
+use arrow::array::{Array, AsArray, RecordBatch};
+use arrow::datatypes::DataType;
+use hypersync_client::ArrowResponse;
+use ruint::aliases::U256;
+use serde_json::Value;
+
+use super::mapping::{ColumnFormat, Section};
+use super::where_filter::{ClientFilter, CmpOp, Cond};
+
+/// Per-section keep masks, aligned with the row order produced when iterating a
+/// section's record batches in order. `None` means the section has no client
+/// filters and every row is kept.
+#[derive(Default)]
+pub struct Masks {
+    pub block: Option<Vec<bool>>,
+    pub transaction: Option<Vec<bool>>,
+    pub log: Option<Vec<bool>>,
+}
+
+pub fn compute_masks(response: &ArrowResponse, filters: &[ClientFilter]) -> Result<Masks> {
+    let mut masks = Masks::default();
+    if filters.is_empty() {
+        return Ok(masks);
+    }
+
+    for section in [Section::Block, Section::Transaction, Section::Log] {
+        let compiled = filters
+            .iter()
+            .filter(|f| f.field.section() == section)
+            .map(CompiledFilter::compile)
+            .collect::<Result<Vec<_>>>()?;
+        if compiled.is_empty() {
+            continue;
+        }
+        let batches = match section {
+            Section::Block => &response.data.blocks,
+            Section::Transaction => &response.data.transactions,
+            Section::Log => &response.data.logs,
+        };
+        let mask = compute_section_mask(batches, &compiled)?;
+        match section {
+            Section::Block => masks.block = Some(mask),
+            Section::Transaction => masks.transaction = Some(mask),
+            Section::Log => masks.log = Some(mask),
+        }
+    }
+
+    Ok(masks)
+}
+
+struct CompiledFilter {
+    column: String,
+    fmt: ColumnFormat,
+    conds: Vec<CompiledCond>,
+}
+
+enum CompiledCond {
+    In(Vec<Cell>),
+    Cmp(CmpOp, U256),
+}
+
+impl CompiledFilter {
+    fn compile(f: &ClientFilter) -> Result<Self> {
+        let fmt = f.field.column_format();
+        let label = format!(
+            "{}.{}",
+            f.field.section().as_indexer_str(),
+            f.field.camel_name(),
+        );
+        let conds = f
+            .conds
+            .iter()
+            .map(|cond| match cond {
+                Cond::In(vals) => Ok(CompiledCond::In(
+                    vals.iter()
+                        .map(|v| filter_cell(v, fmt, &label))
+                        .collect::<Result<Vec<_>>>()?,
+                )),
+                Cond::Cmp(op, v) => Ok(CompiledCond::Cmp(*op, filter_u256(v, &label)?)),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            column: f.field.column_name(),
+            fmt,
+            conds,
+        })
+    }
+}
+
+fn compute_section_mask(batches: &[RecordBatch], filters: &[CompiledFilter]) -> Result<Vec<bool>> {
+    let mut mask = Vec::new();
+    for batch in batches {
+        let cols: Vec<&dyn Array> = filters
+            .iter()
+            .map(|f| {
+                batch
+                    .column_by_name(&f.column)
+                    .map(|c| c.as_ref())
+                    .ok_or_else(|| {
+                        anyhow!("filter column `{}` missing from query response", f.column)
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        for row in 0..batch.num_rows() {
+            let keep = filters.iter().zip(cols.iter()).all(|(f, col)| {
+                let cell = read_cell(*col, row, f.fmt);
+                cell_passes(&cell, &f.conds)
+            });
+            mask.push(keep);
+        }
+    }
+    Ok(mask)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Cell {
+    Num(U256),
+    Hex(String),
+    Bool(bool),
+    Null,
+}
+
+fn read_cell(col: &dyn Array, row: usize, fmt: ColumnFormat) -> Cell {
+    if col.is_null(row) {
+        return Cell::Null;
+    }
+    match col.data_type() {
+        DataType::UInt64 => Cell::Num(U256::from(
+            col.as_primitive::<arrow::datatypes::UInt64Type>()
+                .value(row),
+        )),
+        DataType::UInt8 => Cell::Num(U256::from(
+            col.as_primitive::<arrow::datatypes::UInt8Type>().value(row),
+        )),
+        DataType::Boolean => Cell::Bool(col.as_boolean().value(row)),
+        DataType::Binary => {
+            let bytes = col.as_binary::<i32>().value(row);
+            match fmt {
+                ColumnFormat::Decimal => {
+                    Cell::Num(U256::try_from_be_slice(bytes).unwrap_or_default())
+                }
+                ColumnFormat::Hex => Cell::Hex(faster_hex::hex_string(bytes)),
+            }
+        }
+        dt => unreachable!("unexpected arrow data type {dt:?} for envio data column"),
+    }
+}
+
+fn cell_passes(cell: &Cell, conds: &[CompiledCond]) -> bool {
+    conds.iter().all(|cond| match cond {
+        CompiledCond::In(vals) => vals.iter().any(|v| v == cell),
+        CompiledCond::Cmp(op, target) => match cell {
+            Cell::Num(n) => match op {
+                CmpOp::Gt => n > target,
+                CmpOp::Gte => n >= target,
+                CmpOp::Lt => n < target,
+                CmpOp::Lte => n <= target,
+            },
+            _ => false,
+        },
+    })
+}
+
+fn filter_cell(v: &Value, fmt: ColumnFormat, label: &str) -> Result<Cell> {
+    match fmt {
+        ColumnFormat::Decimal => Ok(Cell::Num(filter_u256(v, label)?)),
+        ColumnFormat::Hex => match v {
+            Value::String(s) => Ok(Cell::Hex(normalize_hex(s, label)?)),
+            Value::Bool(b) => Ok(Cell::Bool(*b)),
+            other => bail!(
+                "Filter on `{label}` expects a hex string, got {}",
+                json_type(other),
+            ),
+        },
+    }
+}
+
+fn filter_u256(v: &Value, label: &str) -> Result<U256> {
+    match v {
+        Value::Number(n) => match n.as_u64() {
+            Some(u) => Ok(U256::from(u)),
+            None => U256::from_str_radix(&n.to_string(), 10)
+                .map_err(|_| anyhow!("Filter on `{label}` expects an integer, got {n}")),
+        },
+        Value::String(s) => parse_u256_str(s)
+            .ok_or_else(|| anyhow!("Filter on `{label}` expects an integer, got \"{s}\"")),
+        other => bail!(
+            "Filter on `{label}` expects a number, got {}",
+            json_type(other),
+        ),
+    }
+}
+
+fn parse_u256_str(s: &str) -> Option<U256> {
+    let s = s.trim();
+    match s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        Some(hex) => U256::from_str_radix(hex, 16).ok(),
+        None => U256::from_str_radix(s, 10).ok(),
+    }
+}
+
+fn normalize_hex(s: &str, label: &str) -> Result<String> {
+    let t = s.trim();
+    let hex = t
+        .strip_prefix("0x")
+        .or_else(|| t.strip_prefix("0X"))
+        .unwrap_or(t);
+    if hex.is_empty() || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        bail!("Filter on `{label}` expects a hex string, got \"{s}\"");
+    }
+    Ok(hex.to_ascii_lowercase())
+}
+
+fn json_type(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::mapping::lookup;
+    use crate::data::where_filter::WhereFilter;
+    use arrow::array::{BinaryArray, RecordBatch, UInt64Array};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use pretty_assertions::assert_eq;
+    use std::sync::Arc;
+
+    fn client_filters(raw: &str) -> Vec<ClientFilter> {
+        WhereFilter::parse(Some(raw)).unwrap().client_filters
+    }
+
+    fn log_batch_value(values: &[u64]) -> RecordBatch {
+        let schema = Schema::new(vec![Field::new("block_number", DataType::UInt64, false)]);
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(UInt64Array::from(values.to_vec()))],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn numeric_range_mask() {
+        let filters = client_filters("{ log: { blockNumber: { _gte: 10, _lt: 20 } } }");
+        let batches = vec![log_batch_value(&[5, 10, 15, 19, 20, 25])];
+        let mask = compute_section_mask(
+            &batches,
+            &filters
+                .iter()
+                .map(CompiledFilter::compile)
+                .collect::<Result<Vec<_>>>()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(mask, vec![false, true, true, true, false, false]);
+    }
+
+    #[test]
+    fn numeric_in_mask() {
+        let filters = client_filters("{ transaction: { value: { _in: [100, 300] } } }");
+        let schema = Schema::new(vec![Field::new("value", DataType::UInt64, false)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(UInt64Array::from(vec![100u64, 200, 300, 400]))],
+        )
+        .unwrap();
+        let mask = compute_section_mask(
+            &[batch],
+            &filters
+                .iter()
+                .map(CompiledFilter::compile)
+                .collect::<Result<Vec<_>>>()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(mask, vec![true, false, true, false]);
+    }
+
+    #[test]
+    fn hex_eq_mask() {
+        let filters = client_filters("{ log: { data: '0xABCD' } }");
+        let schema = Schema::new(vec![Field::new("data", DataType::Binary, false)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(BinaryArray::from(vec![
+                [0xab, 0xcd].as_slice(),
+                [0x00, 0x01].as_slice(),
+            ]))],
+        )
+        .unwrap();
+        let mask = compute_section_mask(
+            &[batch],
+            &filters
+                .iter()
+                .map(CompiledFilter::compile)
+                .collect::<Result<Vec<_>>>()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(mask, vec![true, false]);
+    }
+
+    #[test]
+    fn data_field_is_client_side() {
+        // `log.data` has no Hypersync builder, so it must route to client filters.
+        let f = WhereFilter::parse(Some("{ log: { data: '0xabcd' } }")).unwrap();
+        let routed = (
+            f.log_filters.len(),
+            f.client_filters.len(),
+            f.client_filters[0].field.section(),
+        );
+        assert_eq!(routed, (0, 1, Section::Log));
+    }
+
+    #[test]
+    fn address_stays_server_side() {
+        let f = WhereFilter::parse(Some("{ log: { srcAddress: '0xa0b8' } }")).unwrap();
+        assert_eq!((f.log_filters.len(), f.client_filters.len()), (1, 0));
+    }
+
+    #[test]
+    fn comparison_on_numeric_field_is_client_side() {
+        let f = WhereFilter::parse(Some("{ transaction: { value: { _gt: 1000 } } }")).unwrap();
+        assert_eq!(
+            (f.transaction_filters.len(), f.client_filters.len()),
+            (0, 1),
+        );
+    }
+
+    #[test]
+    fn comparison_on_hex_field_is_rejected() {
+        let err = WhereFilter::parse(Some("{ log: { srcAddress: { _gt: '0xa' } } }"))
+            .unwrap_err()
+            .to_string();
+        insta::assert_snapshot!(err, @"Comparison operators are not supported on hex field `log.srcAddress`. Use `_eq` or `_in`.");
+    }
+
+    #[test]
+    fn lookup_is_used_for_section() {
+        // sanity: the helper used by classification resolves to the Log section.
+        assert_eq!(
+            lookup(Section::Log, "data").unwrap().section(),
+            Section::Log,
+        );
+    }
+}

--- a/packages/cli/src/data/field_selection.rs
+++ b/packages/cli/src/data/field_selection.rs
@@ -61,22 +61,31 @@ impl Selection {
         !self.columns.is_empty()
     }
 
-    pub fn build_net_field_selection(&self) -> NetFieldSelection {
+    /// Builds the Hypersync field selection, also requesting `extra` fields so
+    /// client-side filter fields are fetched even when not selected for output.
+    pub fn build_net_field_selection_with(&self, extra: &[TypedField]) -> NetFieldSelection {
         let mut fs = NetFieldSelection::default();
         for col in &self.columns {
-            match col.field {
-                TypedField::Block(f) => {
-                    fs.block.insert(f);
-                }
-                TypedField::Transaction(f) => {
-                    fs.transaction.insert(f);
-                }
-                TypedField::Log(f) => {
-                    fs.log.insert(f);
-                }
-            }
+            insert_field(&mut fs, col.field);
+        }
+        for field in extra {
+            insert_field(&mut fs, *field);
         }
         fs
+    }
+}
+
+fn insert_field(fs: &mut NetFieldSelection, field: TypedField) {
+    match field {
+        TypedField::Block(f) => {
+            fs.block.insert(f);
+        }
+        TypedField::Transaction(f) => {
+            fs.transaction.insert(f);
+        }
+        TypedField::Log(f) => {
+            fs.log.insert(f);
+        }
     }
 }
 

--- a/packages/cli/src/data/mapping.rs
+++ b/packages/cli/src/data/mapping.rs
@@ -3,10 +3,41 @@ use hypersync_client::net_types::{
 };
 use strum::IntoEnumIterator;
 
+/// How a field's value is parsed, compared, and rendered. Numeric fields are
+/// the only ones that support `_gt`/`_gte`/`_lt`/`_lte` comparisons.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ColumnFormat {
-    Decimal,
+pub enum ValueKind {
+    Numeric,
     Hex,
+    Bool,
+}
+
+/// The Hypersync builder a field maps to when pushed server-side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerFilter {
+    LogAddress,
+    LogTopic0,
+    LogTopic1,
+    LogTopic2,
+    LogTopic3,
+    TxFrom,
+    TxTo,
+    TxSighash,
+    TxHash,
+    TxContractAddress,
+    TxStatus,
+    TxType,
+    BlockHash,
+    BlockMiner,
+}
+
+/// Everything the `--where` pipeline needs to know about a field: how to match
+/// its name, how its values behave client-side, and whether it can be pushed
+/// server-side.
+pub struct FieldSpec {
+    pub aliases: &'static [&'static str],
+    pub value_kind: ValueKind,
+    pub server: Option<ServerFilter>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -54,29 +85,46 @@ impl TypedField {
         }
     }
 
-    /// Fields Hypersync can filter server-side via set-membership.
-    pub fn server_filterable(self) -> bool {
-        matches!(
-            self,
-            TypedField::Log(
-                LogField::Address
-                    | LogField::Topic0
-                    | LogField::Topic1
-                    | LogField::Topic2
-                    | LogField::Topic3,
-            ) | TypedField::Transaction(
-                TransactionField::From
-                    | TransactionField::To
-                    | TransactionField::Sighash
-                    | TransactionField::Hash
-                    | TransactionField::ContractAddress
-                    | TransactionField::Status
-                    | TransactionField::Type,
-            ) | TypedField::Block(BlockField::Hash | BlockField::Miner)
-        )
+    pub fn spec(self) -> FieldSpec {
+        FieldSpec {
+            aliases: self.aliases(),
+            value_kind: self.value_kind(),
+            server: self.server_filter(),
+        }
     }
 
-    pub fn column_format(self) -> ColumnFormat {
+    fn aliases(self) -> &'static [&'static str] {
+        match self {
+            TypedField::Log(LogField::Address) => &["srcAddress"],
+            _ => &[],
+        }
+    }
+
+    /// Which Hypersync builder this field maps to, or `None` if it can only be
+    /// filtered client-side. Single source of truth for server-side routing.
+    fn server_filter(self) -> Option<ServerFilter> {
+        use ServerFilter::*;
+        Some(match self {
+            TypedField::Log(LogField::Address) => LogAddress,
+            TypedField::Log(LogField::Topic0) => LogTopic0,
+            TypedField::Log(LogField::Topic1) => LogTopic1,
+            TypedField::Log(LogField::Topic2) => LogTopic2,
+            TypedField::Log(LogField::Topic3) => LogTopic3,
+            TypedField::Transaction(TransactionField::From) => TxFrom,
+            TypedField::Transaction(TransactionField::To) => TxTo,
+            TypedField::Transaction(TransactionField::Sighash) => TxSighash,
+            TypedField::Transaction(TransactionField::Hash) => TxHash,
+            TypedField::Transaction(TransactionField::ContractAddress) => TxContractAddress,
+            TypedField::Transaction(TransactionField::Status) => TxStatus,
+            TypedField::Transaction(TransactionField::Type) => TxType,
+            TypedField::Block(BlockField::Hash) => BlockHash,
+            TypedField::Block(BlockField::Miner) => BlockMiner,
+            _ => return None,
+        })
+    }
+
+    fn value_kind(self) -> ValueKind {
+        use ValueKind::{Bool, Hex, Numeric};
         match self {
             TypedField::Block(f) => match f {
                 BlockField::Number
@@ -91,7 +139,7 @@ impl TypedField {
                 | BlockField::BlobGasUsed
                 | BlockField::ExcessBlobGas
                 | BlockField::L1BlockNumber
-                | BlockField::SendCount => ColumnFormat::Decimal,
+                | BlockField::SendCount => Numeric,
                 BlockField::Hash
                 | BlockField::ParentHash
                 | BlockField::Sha3Uncles
@@ -106,7 +154,7 @@ impl TypedField {
                 | BlockField::ParentBeaconBlockRoot
                 | BlockField::WithdrawalsRoot
                 | BlockField::Withdrawals
-                | BlockField::SendRoot => ColumnFormat::Hex,
+                | BlockField::SendRoot => Hex,
             },
             TypedField::Transaction(f) => match f {
                 TransactionField::BlockNumber
@@ -141,7 +189,7 @@ impl TypedField {
                 | TransactionField::L1BaseFeeScalar
                 | TransactionField::L1BlobBaseFee
                 | TransactionField::L1BlobBaseFeeScalar
-                | TransactionField::L1BlockNumber => ColumnFormat::Decimal,
+                | TransactionField::L1BlockNumber => Numeric,
                 TransactionField::BlockHash
                 | TransactionField::Hash
                 | TransactionField::Input
@@ -154,21 +202,19 @@ impl TypedField {
                 | TransactionField::AuthorizationList
                 | TransactionField::BlobVersionedHashes
                 | TransactionField::Sighash
-                | TransactionField::SourceHash => ColumnFormat::Hex,
+                | TransactionField::SourceHash => Hex,
             },
             TypedField::Log(f) => match f {
-                LogField::BlockNumber | LogField::TransactionIndex | LogField::LogIndex => {
-                    ColumnFormat::Decimal
-                }
+                LogField::BlockNumber | LogField::TransactionIndex | LogField::LogIndex => Numeric,
+                LogField::Removed => Bool,
                 LogField::TransactionHash
                 | LogField::BlockHash
                 | LogField::Address
                 | LogField::Data
-                | LogField::Removed
                 | LogField::Topic0
                 | LogField::Topic1
                 | LogField::Topic2
-                | LogField::Topic3 => ColumnFormat::Hex,
+                | LogField::Topic3 => Hex,
             },
         }
     }
@@ -181,30 +227,20 @@ fn normalize(s: &str) -> String {
         .collect()
 }
 
-fn resolve_alias(section: Section, normalized: &str) -> Option<TypedField> {
-    match (section, normalized) {
-        (Section::Log, "srcaddress") => Some(TypedField::Log(LogField::Address)),
-        _ => None,
-    }
-}
-
 pub fn lookup(section: Section, user_input: &str) -> Option<TypedField> {
     let key = normalize(user_input);
-
-    if let Some(field) = resolve_alias(section, &key) {
-        return Some(field);
-    }
-
+    let matches = |field: TypedField| {
+        normalize(&field.column_name()) == key
+            || field.spec().aliases.iter().any(|a| normalize(a) == key)
+    };
     match section {
         Section::Block => BlockField::iter()
-            .find(|f| normalize(f.as_ref()) == key)
-            .map(TypedField::Block),
+            .map(TypedField::Block)
+            .find(|f| matches(*f)),
         Section::Transaction => TransactionField::iter()
-            .find(|f| normalize(f.as_ref()) == key)
-            .map(TypedField::Transaction),
-        Section::Log => LogField::iter()
-            .find(|f| normalize(f.as_ref()) == key)
-            .map(TypedField::Log),
+            .map(TypedField::Transaction)
+            .find(|f| matches(*f)),
+        Section::Log => LogField::iter().map(TypedField::Log).find(|f| matches(*f)),
     }
 }
 

--- a/packages/cli/src/data/mapping.rs
+++ b/packages/cli/src/data/mapping.rs
@@ -69,8 +69,10 @@ impl TypedField {
                     | TransactionField::To
                     | TransactionField::Sighash
                     | TransactionField::Hash
-                    | TransactionField::ContractAddress,
-            )
+                    | TransactionField::ContractAddress
+                    | TransactionField::Status
+                    | TransactionField::Type,
+            ) | TypedField::Block(BlockField::Hash | BlockField::Miner)
         )
     }
 

--- a/packages/cli/src/data/mapping.rs
+++ b/packages/cli/src/data/mapping.rs
@@ -46,6 +46,34 @@ impl TypedField {
         to_camel(&self.column_name())
     }
 
+    pub fn section(self) -> Section {
+        match self {
+            TypedField::Block(_) => Section::Block,
+            TypedField::Transaction(_) => Section::Transaction,
+            TypedField::Log(_) => Section::Log,
+        }
+    }
+
+    /// Fields Hypersync can filter server-side via set-membership.
+    pub fn server_filterable(self) -> bool {
+        matches!(
+            self,
+            TypedField::Log(
+                LogField::Address
+                    | LogField::Topic0
+                    | LogField::Topic1
+                    | LogField::Topic2
+                    | LogField::Topic3,
+            ) | TypedField::Transaction(
+                TransactionField::From
+                    | TransactionField::To
+                    | TransactionField::Sighash
+                    | TransactionField::Hash
+                    | TransactionField::ContractAddress,
+            )
+        )
+    }
+
     pub fn column_format(self) -> ColumnFormat {
         match self {
             TypedField::Block(f) => match f {

--- a/packages/cli/src/data/mod.rs
+++ b/packages/cli/src/data/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod chain;
+pub(crate) mod client_filter;
 pub(crate) mod field_selection;
 pub(crate) mod mapping;
 pub(crate) mod toon;

--- a/packages/cli/src/data/toon.rs
+++ b/packages/cli/src/data/toon.rs
@@ -6,7 +6,7 @@ use hypersync_client::ArrowResponse;
 
 use super::client_filter::Masks;
 use super::field_selection::{Column, Selection};
-use super::mapping::{ColumnFormat, Section};
+use super::mapping::{Section, ValueKind};
 
 pub fn render_table(name: &str, columns: &[impl AsRef<str>], rows: &[Vec<String>]) -> String {
     let mut out = String::new();
@@ -75,9 +75,8 @@ pub fn render_arrow_response(
         };
 
         let column_keys: Vec<String> = cols.iter().map(|c| c.field.column_name()).collect();
-        let column_formats: Vec<ColumnFormat> =
-            cols.iter().map(|c| c.field.column_format()).collect();
-        let rows = extract_rows(batches, &column_keys, &column_formats, mask);
+        let column_kinds: Vec<ValueKind> = cols.iter().map(|c| c.field.spec().value_kind).collect();
+        let rows = extract_rows(batches, &column_keys, &column_kinds, mask);
         out.push_str(&render_table(plural, &col_names, &rows));
     }
     out
@@ -86,7 +85,7 @@ pub fn render_arrow_response(
 fn extract_rows(
     batches: &[RecordBatch],
     column_keys: &[String],
-    column_formats: &[ColumnFormat],
+    column_kinds: &[ValueKind],
     mask: Option<&[bool]>,
 ) -> Vec<Vec<String>> {
     let mut rows = Vec::new();
@@ -103,9 +102,9 @@ fn extract_rows(
             }
             let row: Vec<String> = arrays
                 .iter()
-                .zip(column_formats.iter())
-                .map(|(arr, fmt)| match arr {
-                    Some(col) => cell_to_string(*col, row_idx, *fmt),
+                .zip(column_kinds.iter())
+                .map(|(arr, kind)| match arr {
+                    Some(col) => cell_to_string(*col, row_idx, *kind),
                     None => String::new(),
                 })
                 .collect();
@@ -116,7 +115,7 @@ fn extract_rows(
     rows
 }
 
-fn cell_to_string(col: &dyn Array, row: usize, fmt: ColumnFormat) -> String {
+fn cell_to_string(col: &dyn Array, row: usize, kind: ValueKind) -> String {
     if col.is_null(row) {
         return String::new();
     }
@@ -132,9 +131,9 @@ fn cell_to_string(col: &dyn Array, row: usize, fmt: ColumnFormat) -> String {
         DataType::Boolean => col.as_boolean().value(row).to_string(),
         DataType::Binary => {
             let bytes = col.as_binary::<i32>().value(row);
-            match fmt {
-                ColumnFormat::Decimal => binary_as_decimal(bytes),
-                ColumnFormat::Hex => format!("0x{}", faster_hex::hex_string(bytes)),
+            match kind {
+                ValueKind::Numeric => binary_as_decimal(bytes),
+                ValueKind::Hex | ValueKind::Bool => format!("0x{}", faster_hex::hex_string(bytes)),
             }
         }
         dt => unreachable!("unexpected arrow data type {dt:?} for envio data column"),
@@ -166,7 +165,7 @@ mod tests {
 
     #[test]
     fn empty_batches_render_zero_rows() {
-        let s = extract_rows(&[], &["number".to_string()], &[ColumnFormat::Decimal], None);
+        let s = extract_rows(&[], &["number".to_string()], &[ValueKind::Numeric], None);
         assert!(s.is_empty());
     }
 }

--- a/packages/cli/src/data/toon.rs
+++ b/packages/cli/src/data/toon.rs
@@ -4,6 +4,7 @@ use arrow::array::{Array, AsArray, RecordBatch};
 use arrow::datatypes::DataType;
 use hypersync_client::ArrowResponse;
 
+use super::client_filter::Masks;
 use super::field_selection::{Column, Selection};
 use super::mapping::{ColumnFormat, Section};
 
@@ -43,7 +44,11 @@ fn escape_cell(s: &str) -> String {
     format!("\"{escaped}\"")
 }
 
-pub fn render_arrow_response(selection: &Selection, response: &ArrowResponse) -> String {
+pub fn render_arrow_response(
+    selection: &Selection,
+    response: &ArrowResponse,
+    masks: &Masks,
+) -> String {
     let mut section_order: Vec<Section> = Vec::new();
     for col in &selection.columns {
         if !section_order.contains(&col.section) {
@@ -59,16 +64,20 @@ pub fn render_arrow_response(selection: &Selection, response: &ArrowResponse) ->
             .filter(|c| c.section == *section)
             .collect();
         let col_names: Vec<String> = cols.iter().map(|c| c.field.camel_name()).collect();
-        let (plural, batches) = match section {
-            Section::Block => ("blocks", &response.data.blocks),
-            Section::Transaction => ("transactions", &response.data.transactions),
-            Section::Log => ("logs", &response.data.logs),
+        let (plural, batches, mask) = match section {
+            Section::Block => ("blocks", &response.data.blocks, masks.block.as_deref()),
+            Section::Transaction => (
+                "transactions",
+                &response.data.transactions,
+                masks.transaction.as_deref(),
+            ),
+            Section::Log => ("logs", &response.data.logs, masks.log.as_deref()),
         };
 
         let column_keys: Vec<String> = cols.iter().map(|c| c.field.column_name()).collect();
         let column_formats: Vec<ColumnFormat> =
             cols.iter().map(|c| c.field.column_format()).collect();
-        let rows = extract_rows(batches, &column_keys, &column_formats);
+        let rows = extract_rows(batches, &column_keys, &column_formats, mask);
         out.push_str(&render_table(plural, &col_names, &rows));
     }
     out
@@ -78,14 +87,20 @@ fn extract_rows(
     batches: &[RecordBatch],
     column_keys: &[String],
     column_formats: &[ColumnFormat],
+    mask: Option<&[bool]>,
 ) -> Vec<Vec<String>> {
     let mut rows = Vec::new();
+    let mut row_offset = 0;
     for batch in batches {
         let arrays: Vec<Option<&dyn Array>> = column_keys
             .iter()
             .map(|key| batch.column_by_name(key).map(|c| c.as_ref()))
             .collect();
         for row_idx in 0..batch.num_rows() {
+            let keep = mask.is_none_or(|m| m[row_offset + row_idx]);
+            if !keep {
+                continue;
+            }
             let row: Vec<String> = arrays
                 .iter()
                 .zip(column_formats.iter())
@@ -96,6 +111,7 @@ fn extract_rows(
                 .collect();
             rows.push(row);
         }
+        row_offset += batch.num_rows();
     }
     rows
 }
@@ -150,7 +166,7 @@ mod tests {
 
     #[test]
     fn empty_batches_render_zero_rows() {
-        let s = extract_rows(&[], &["number".to_string()], &[ColumnFormat::Decimal]);
+        let s = extract_rows(&[], &["number".to_string()], &[ColumnFormat::Decimal], None);
         assert!(s.is_empty());
     }
 }

--- a/packages/cli/src/data/where_filter.rs
+++ b/packages/cli/src/data/where_filter.rs
@@ -3,12 +3,45 @@ use serde_json::Value;
 
 use hypersync_client::net_types::{FieldSelection, LogFilter, Query, TransactionFilter};
 
-use super::mapping::{self, Section, TypedField};
+use super::mapping::{self, ColumnFormat, Section, TypedField};
 
 #[derive(Debug, Clone)]
 pub struct FieldFilter {
     pub field: TypedField,
     pub values: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmpOp {
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+}
+
+impl CmpOp {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CmpOp::Gt => "_gt",
+            CmpOp::Gte => "_gte",
+            CmpOp::Lt => "_lt",
+            CmpOp::Lte => "_lte",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Cond {
+    In(Vec<Value>),
+    Cmp(CmpOp, Value),
+}
+
+/// A filter evaluated client-side because the field or operator can't be pushed
+/// to the Hypersync query. All conditions are AND'd together.
+#[derive(Debug, Clone)]
+pub struct ClientFilter {
+    pub field: TypedField,
+    pub conds: Vec<Cond>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -17,6 +50,7 @@ pub struct WhereFilter {
     pub to_block_exclusive: Option<u64>,
     pub log_filters: Vec<FieldFilter>,
     pub transaction_filters: Vec<FieldFilter>,
+    pub client_filters: Vec<ClientFilter>,
 }
 
 impl WhereFilter {
@@ -72,7 +106,15 @@ impl WhereFilter {
     }
 
     pub fn has_section_filters(&self) -> bool {
-        !self.log_filters.is_empty() || !self.transaction_filters.is_empty()
+        !self.log_filters.is_empty()
+            || !self.transaction_filters.is_empty()
+            || !self.client_filters.is_empty()
+    }
+
+    /// Fields referenced by client-side filters. These must be fetched even when
+    /// not part of the user's output selection so the predicate can be evaluated.
+    pub fn client_filter_fields(&self) -> Vec<TypedField> {
+        self.client_filters.iter().map(|f| f.field).collect()
     }
 
     pub fn build_net_query(&self, field_selection: FieldSelection) -> Result<Query> {
@@ -115,10 +157,7 @@ fn apply_log_filter(filter: LogFilter, f: &FieldFilter) -> Result<LogFilter> {
         LogField::Topic1 => (filter.and_topic1(refs), "invalid topic1"),
         LogField::Topic2 => (filter.and_topic2(refs), "invalid topic2"),
         LogField::Topic3 => (filter.and_topic3(refs), "invalid topic3"),
-        _ => bail!(
-            "Filtering on `log.{}` is not supported in --where.",
-            f.field.camel_name()
-        ),
+        _ => unreachable!("log_filters only holds server-filterable fields"),
     };
     filter.context(ctx)
 }
@@ -134,10 +173,12 @@ fn apply_tx_filter(filter: TransactionFilter, f: &FieldFilter) -> Result<Transac
         TransactionField::From => (filter.and_from(refs), "invalid from address"),
         TransactionField::To => (filter.and_to(refs), "invalid to address"),
         TransactionField::Sighash => (filter.and_sighash(refs), "invalid sighash"),
-        _ => bail!(
-            "Filtering on `transaction.{}` is not supported in --where.",
-            f.field.camel_name()
+        TransactionField::Hash => (filter.and_hash(refs), "invalid transaction hash"),
+        TransactionField::ContractAddress => (
+            filter.and_contract_address(refs),
+            "invalid contract address",
         ),
+        _ => unreachable!("transaction_filters only holds server-filterable fields"),
     };
     filter.context(ctx)
 }
@@ -182,20 +223,82 @@ fn apply_field(
         return apply_block_range(out, indexer_name, body);
     }
 
-    let dest = match section {
-        Section::Log => &mut out.log_filters,
-        Section::Transaction => &mut out.transaction_filters,
-        Section::Block => bail!(
-            "Filtering on `block.{indexer_name}` is not supported. Only `block.number` (with _gte/_lt/_lte/_gt) is a block filter.",
-        ),
-    };
+    let conds = parse_conditions(section, indexer_name, typed_field, body)?;
+    let has_cmp = conds.iter().any(|c| matches!(c, Cond::Cmp(..)));
 
-    let values = normalize_to_list(section, indexer_name, body)?;
-    dest.push(FieldFilter {
-        field: typed_field,
-        values,
-    });
+    if typed_field.server_filterable() && !has_cmp {
+        let values = conds
+            .into_iter()
+            .flat_map(|c| match c {
+                Cond::In(v) => v,
+                Cond::Cmp(..) => Vec::new(),
+            })
+            .collect();
+        let dest = match section {
+            Section::Log => &mut out.log_filters,
+            Section::Transaction => &mut out.transaction_filters,
+            Section::Block => unreachable!("no block field is server-filterable"),
+        };
+        dest.push(FieldFilter {
+            field: typed_field,
+            values,
+        });
+    } else {
+        out.client_filters.push(ClientFilter {
+            field: typed_field,
+            conds,
+        });
+    }
     Ok(())
+}
+
+fn parse_conditions(
+    section: Section,
+    name: &str,
+    field: TypedField,
+    body: Value,
+) -> Result<Vec<Cond>> {
+    let label = || format!("{}.{name}", section.as_indexer_str());
+    match body {
+        Value::String(_) | Value::Number(_) | Value::Bool(_) => Ok(vec![Cond::In(vec![body])]),
+        Value::Array(arr) => Ok(vec![Cond::In(arr)]),
+        Value::Object(map) => {
+            let mut conds = Vec::new();
+            for (k, v) in map {
+                let cond = match k.as_str() {
+                    "_eq" => Cond::In(vec![v]),
+                    "_in" => {
+                        let arr = v.as_array().ok_or_else(|| {
+                            anyhow!("`_in` on `{}` expects an array, got {}", label(), type_name(&v))
+                        })?;
+                        Cond::In(arr.clone())
+                    }
+                    "_gt" | "_gte" | "_lt" | "_lte" => {
+                        if field.column_format() == ColumnFormat::Hex {
+                            bail!(
+                                "Comparison operators are not supported on hex field `{}`. Use `_eq` or `_in`.",
+                                label(),
+                            );
+                        }
+                        let op = match k.as_str() {
+                            "_gt" => CmpOp::Gt,
+                            "_gte" => CmpOp::Gte,
+                            "_lt" => CmpOp::Lt,
+                            _ => CmpOp::Lte,
+                        };
+                        Cond::Cmp(op, v)
+                    }
+                    other => bail!(
+                        "Unsupported operator `{other}` on `{}`. Use a scalar, an array, `_eq`, `_in`, `_gt`, `_gte`, `_lt`, or `_lte`.",
+                        label(),
+                    ),
+                };
+                conds.push(cond);
+            }
+            Ok(conds)
+        }
+        Value::Null => bail!("`{}` cannot be null", label()),
+    }
 }
 
 fn apply_block_range(out: &mut WhereFilter, field_name: &str, body: Value) -> Result<()> {
@@ -241,34 +344,6 @@ fn value_to_u64(v: &Value) -> Result<u64> {
             .ok_or_else(|| anyhow!("Expected non-negative integer, got {n}")),
         Value::String(s) => s.parse::<u64>().context("Failed to parse integer"),
         _ => Err(anyhow!("Expected integer, got {}", type_name(v))),
-    }
-}
-
-fn normalize_to_list(section: Section, name: &str, body: Value) -> Result<Vec<Value>> {
-    let label = || format!("{}.{name}", section.as_indexer_str());
-    match body {
-        Value::String(_) | Value::Number(_) | Value::Bool(_) => Ok(vec![body]),
-        Value::Array(arr) => Ok(arr),
-        Value::Object(map) => {
-            let mut values = Vec::new();
-            for (k, v) in &map {
-                match k.as_str() {
-                    "_eq" => values.push(v.clone()),
-                    "_in" => {
-                        let arr = v.as_array().ok_or_else(|| {
-                            anyhow!("`_in` on `{}` expects an array, got {}", label(), type_name(v))
-                        })?;
-                        values.extend(arr.iter().cloned());
-                    }
-                    other => bail!(
-                        "Unsupported operator `{other}` on `{}`. Use a scalar, an array, `_eq`, or `_in`.",
-                        label(),
-                    ),
-                }
-            }
-            Ok(values)
-        }
-        Value::Null => bail!("`{}` cannot be null", label()),
     }
 }
 
@@ -345,6 +420,25 @@ mod tests {
     fn transaction_filters() {
         let f = pf("{ transaction: { from: '0xa0b8', sighash: '0xdead' } }");
         assert_eq!(f.transaction_filters.len(), 2);
+    }
+
+    #[test]
+    fn hash_and_contract_address_are_server_side() {
+        let f = pf("{ transaction: { hash: '0xa0b8', contractAddress: '0xdead' } }");
+        assert_eq!(
+            (f.transaction_filters.len(), f.client_filters.len()),
+            (2, 0),
+        );
+    }
+
+    #[test]
+    fn numeric_field_with_membership_is_client_side() {
+        // `transaction.gas` has no Hypersync builder → client-side even for `_in`.
+        let f = pf("{ transaction: { gas: [21000, 50000] } }");
+        assert_eq!(
+            (f.transaction_filters.len(), f.client_filters.len()),
+            (0, 1),
+        );
     }
 
     #[test]

--- a/packages/cli/src/data/where_filter.rs
+++ b/packages/cli/src/data/where_filter.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, bail, Context, Result};
 use serde_json::Value;
 
-use hypersync_client::net_types::{FieldSelection, LogFilter, Query, TransactionFilter};
+use hypersync_client::net_types::{
+    BlockFilter, FieldSelection, LogFilter, Query, TransactionFilter,
+};
 
 use super::mapping::{self, ColumnFormat, Section, TypedField};
 
@@ -50,6 +52,7 @@ pub struct WhereFilter {
     pub to_block_exclusive: Option<u64>,
     pub log_filters: Vec<FieldFilter>,
     pub transaction_filters: Vec<FieldFilter>,
+    pub block_filters: Vec<FieldFilter>,
     pub client_filters: Vec<ClientFilter>,
 }
 
@@ -108,6 +111,7 @@ impl WhereFilter {
     pub fn has_section_filters(&self) -> bool {
         !self.log_filters.is_empty()
             || !self.transaction_filters.is_empty()
+            || !self.block_filters.is_empty()
             || !self.client_filters.is_empty()
     }
 
@@ -140,6 +144,14 @@ impl WhereFilter {
             query = query.where_transactions(tf);
         }
 
+        if !self.block_filters.is_empty() {
+            let mut bf = BlockFilter::all();
+            for f in &self.block_filters {
+                bf = apply_block_filter(bf, f)?;
+            }
+            query = query.where_blocks(bf);
+        }
+
         Ok(query)
     }
 }
@@ -167,18 +179,44 @@ fn apply_tx_filter(filter: TransactionFilter, f: &FieldFilter) -> Result<Transac
     let TypedField::Transaction(tx_field) = f.field else {
         unreachable!("transaction_filters only holds Transaction fields")
     };
+    match tx_field {
+        TransactionField::Status => {
+            let [value] = f.values.as_slice() else {
+                bail!("`transaction.status` accepts a single value server-side.");
+            };
+            Ok(filter.and_status(value_to_u8(value)?))
+        }
+        TransactionField::Type => Ok(filter.and_type(values_to_u8(&f.values)?)),
+        _ => {
+            let owned = filter_values_as_strs(&f.values);
+            let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
+            let (filter, ctx) = match tx_field {
+                TransactionField::From => (filter.and_from(refs), "invalid from address"),
+                TransactionField::To => (filter.and_to(refs), "invalid to address"),
+                TransactionField::Sighash => (filter.and_sighash(refs), "invalid sighash"),
+                TransactionField::Hash => (filter.and_hash(refs), "invalid transaction hash"),
+                TransactionField::ContractAddress => (
+                    filter.and_contract_address(refs),
+                    "invalid contract address",
+                ),
+                _ => unreachable!("transaction_filters only holds server-filterable fields"),
+            };
+            filter.context(ctx)
+        }
+    }
+}
+
+fn apply_block_filter(filter: BlockFilter, f: &FieldFilter) -> Result<BlockFilter> {
+    use hypersync_client::net_types::block::BlockField;
+    let TypedField::Block(block_field) = f.field else {
+        unreachable!("block_filters only holds Block fields")
+    };
     let owned = filter_values_as_strs(&f.values);
     let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
-    let (filter, ctx) = match tx_field {
-        TransactionField::From => (filter.and_from(refs), "invalid from address"),
-        TransactionField::To => (filter.and_to(refs), "invalid to address"),
-        TransactionField::Sighash => (filter.and_sighash(refs), "invalid sighash"),
-        TransactionField::Hash => (filter.and_hash(refs), "invalid transaction hash"),
-        TransactionField::ContractAddress => (
-            filter.and_contract_address(refs),
-            "invalid contract address",
-        ),
-        _ => unreachable!("transaction_filters only holds server-filterable fields"),
+    let (filter, ctx) = match block_field {
+        BlockField::Hash => (filter.and_hash(refs), "invalid block hash"),
+        BlockField::Miner => (filter.and_miner(refs), "invalid miner address"),
+        _ => unreachable!("block_filters only holds server-filterable fields"),
     };
     filter.context(ctx)
 }
@@ -219,14 +257,28 @@ fn apply_field(
     body: Value,
 ) -> Result<()> {
     use hypersync_client::net_types::block::BlockField;
+    use hypersync_client::net_types::transaction::TransactionField;
     if matches!(typed_field, TypedField::Block(BlockField::Number)) {
         return apply_block_range(out, indexer_name, body);
     }
 
     let conds = parse_conditions(section, indexer_name, typed_field, body)?;
     let has_cmp = conds.iter().any(|c| matches!(c, Cond::Cmp(..)));
+    let membership: usize = conds
+        .iter()
+        .map(|c| match c {
+            Cond::In(v) => v.len(),
+            Cond::Cmp(..) => 0,
+        })
+        .sum();
+    // `transaction.status` maps to a single `u8` server-side, so a multi-value
+    // set must fall back to client-side filtering.
+    let status_multi = matches!(
+        typed_field,
+        TypedField::Transaction(TransactionField::Status)
+    ) && membership != 1;
 
-    if typed_field.server_filterable() && !has_cmp {
+    if typed_field.server_filterable() && !has_cmp && !status_multi {
         let values = conds
             .into_iter()
             .flat_map(|c| match c {
@@ -237,7 +289,7 @@ fn apply_field(
         let dest = match section {
             Section::Log => &mut out.log_filters,
             Section::Transaction => &mut out.transaction_filters,
-            Section::Block => unreachable!("no block field is server-filterable"),
+            Section::Block => &mut out.block_filters,
         };
         dest.push(FieldFilter {
             field: typed_field,
@@ -347,6 +399,31 @@ fn value_to_u64(v: &Value) -> Result<u64> {
     }
 }
 
+fn value_to_u8(v: &Value) -> Result<u8> {
+    match v {
+        Value::Number(n) => n
+            .as_u64()
+            .and_then(|x| u8::try_from(x).ok())
+            .ok_or_else(|| anyhow!("Expected an integer between 0 and 255, got {n}")),
+        Value::String(s) => {
+            let s = s.trim();
+            match s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+                Some(hex) => u8::from_str_radix(hex, 16),
+                None => s.parse::<u8>(),
+            }
+            .with_context(|| format!("Expected an integer between 0 and 255, got \"{s}\""))
+        }
+        _ => Err(anyhow!(
+            "Expected an integer between 0 and 255, got {}",
+            type_name(v)
+        )),
+    }
+}
+
+fn values_to_u8(values: &[Value]) -> Result<Vec<u8>> {
+    values.iter().map(value_to_u8).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -439,6 +516,53 @@ mod tests {
             (f.transaction_filters.len(), f.client_filters.len()),
             (0, 1),
         );
+    }
+
+    #[test]
+    fn status_and_type_are_server_side() {
+        let f = pf("{ transaction: { status: 1, type: [0, 2] } }");
+        let q = f.build_net_query(FieldSelection::default()).unwrap();
+        assert_eq!(
+            (
+                f.transaction_filters.len(),
+                f.client_filters.len(),
+                q.transactions.len(),
+            ),
+            (2, 0, 1),
+        );
+    }
+
+    #[test]
+    fn multi_value_status_falls_back_to_client() {
+        // `and_status` takes a single value, so a set must filter client-side.
+        let f = pf("{ transaction: { status: { _in: [0, 1] } } }");
+        assert_eq!(
+            (f.transaction_filters.len(), f.client_filters.len()),
+            (0, 1),
+        );
+    }
+
+    #[test]
+    fn block_hash_and_miner_are_server_side() {
+        let f = pf("{ block: { \
+             hash: '0x1111111111111111111111111111111111111111111111111111111111111111', \
+             miner: '0x2222222222222222222222222222222222222222' } }");
+        let q = f.build_net_query(FieldSelection::default()).unwrap();
+        assert_eq!(
+            (
+                f.block_filters.len(),
+                f.client_filters.len(),
+                q.blocks.len(),
+            ),
+            (2, 0, 1),
+        );
+    }
+
+    #[test]
+    fn other_block_field_is_client_side() {
+        // `block.timestamp` has no Hypersync builder → client-side.
+        let f = pf("{ block: { timestamp: { _gte: 1000 } } }");
+        assert_eq!((f.block_filters.len(), f.client_filters.len()), (0, 1));
     }
 
     #[test]

--- a/packages/cli/src/data/where_filter.rs
+++ b/packages/cli/src/data/where_filter.rs
@@ -5,7 +5,7 @@ use hypersync_client::net_types::{
     BlockFilter, FieldSelection, LogFilter, Query, TransactionFilter,
 };
 
-use super::mapping::{self, ColumnFormat, Section, TypedField};
+use super::mapping::{self, Section, ServerFilter, TypedField, ValueKind};
 
 #[derive(Debug, Clone)]
 pub struct FieldFilter {
@@ -50,9 +50,7 @@ pub struct ClientFilter {
 pub struct WhereFilter {
     pub from_block: Option<u64>,
     pub to_block_exclusive: Option<u64>,
-    pub log_filters: Vec<FieldFilter>,
-    pub transaction_filters: Vec<FieldFilter>,
-    pub block_filters: Vec<FieldFilter>,
+    pub server_filters: Vec<FieldFilter>,
     pub client_filters: Vec<ClientFilter>,
 }
 
@@ -109,10 +107,7 @@ impl WhereFilter {
     }
 
     pub fn has_section_filters(&self) -> bool {
-        !self.log_filters.is_empty()
-            || !self.transaction_filters.is_empty()
-            || !self.block_filters.is_empty()
-            || !self.client_filters.is_empty()
+        !self.server_filters.is_empty() || !self.client_filters.is_empty()
     }
 
     /// Fields referenced by client-side filters. These must be fetched even when
@@ -128,78 +123,87 @@ impl WhereFilter {
         }
         query.field_selection = field_selection;
 
-        if !self.log_filters.is_empty() {
-            let mut lf = LogFilter::all();
-            for f in &self.log_filters {
-                lf = apply_log_filter(lf, f)?;
+        let mut logs = LogFilter::all();
+        let mut transactions = TransactionFilter::all();
+        let mut blocks = BlockFilter::all();
+        let (mut has_log, mut has_tx, mut has_block) = (false, false, false);
+        for f in &self.server_filters {
+            match f.field.section() {
+                Section::Log => {
+                    logs = apply_log_filter(logs, f)?;
+                    has_log = true;
+                }
+                Section::Transaction => {
+                    transactions = apply_tx_filter(transactions, f)?;
+                    has_tx = true;
+                }
+                Section::Block => {
+                    blocks = apply_block_filter(blocks, f)?;
+                    has_block = true;
+                }
             }
-            query = query.where_logs(lf);
         }
-
-        if !self.transaction_filters.is_empty() {
-            let mut tf = TransactionFilter::all();
-            for f in &self.transaction_filters {
-                tf = apply_tx_filter(tf, f)?;
-            }
-            query = query.where_transactions(tf);
+        if has_log {
+            query = query.where_logs(logs);
         }
-
-        if !self.block_filters.is_empty() {
-            let mut bf = BlockFilter::all();
-            for f in &self.block_filters {
-                bf = apply_block_filter(bf, f)?;
-            }
-            query = query.where_blocks(bf);
+        if has_tx {
+            query = query.where_transactions(transactions);
+        }
+        if has_block {
+            query = query.where_blocks(blocks);
         }
 
         Ok(query)
     }
 }
 
+fn server_tag(field: TypedField) -> ServerFilter {
+    field
+        .spec()
+        .server
+        .expect("server_filters only holds server-filterable fields")
+}
+
+fn str_refs(values: &[String]) -> Vec<&str> {
+    values.iter().map(String::as_str).collect()
+}
+
 fn apply_log_filter(filter: LogFilter, f: &FieldFilter) -> Result<LogFilter> {
-    use hypersync_client::net_types::log::LogField;
-    let TypedField::Log(log_field) = f.field else {
-        unreachable!("log_filters only holds Log fields")
-    };
     let owned = filter_values_as_strs(&f.values);
-    let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
-    let (filter, ctx) = match log_field {
-        LogField::Address => (filter.and_address(refs), "invalid address"),
-        LogField::Topic0 => (filter.and_topic0(refs), "invalid topic0"),
-        LogField::Topic1 => (filter.and_topic1(refs), "invalid topic1"),
-        LogField::Topic2 => (filter.and_topic2(refs), "invalid topic2"),
-        LogField::Topic3 => (filter.and_topic3(refs), "invalid topic3"),
-        _ => unreachable!("log_filters only holds server-filterable fields"),
+    let refs = str_refs(&owned);
+    let (filter, ctx) = match server_tag(f.field) {
+        ServerFilter::LogAddress => (filter.and_address(refs), "invalid address"),
+        ServerFilter::LogTopic0 => (filter.and_topic0(refs), "invalid topic0"),
+        ServerFilter::LogTopic1 => (filter.and_topic1(refs), "invalid topic1"),
+        ServerFilter::LogTopic2 => (filter.and_topic2(refs), "invalid topic2"),
+        ServerFilter::LogTopic3 => (filter.and_topic3(refs), "invalid topic3"),
+        _ => unreachable!("non-log server tag in log section"),
     };
     filter.context(ctx)
 }
 
 fn apply_tx_filter(filter: TransactionFilter, f: &FieldFilter) -> Result<TransactionFilter> {
-    use hypersync_client::net_types::transaction::TransactionField;
-    let TypedField::Transaction(tx_field) = f.field else {
-        unreachable!("transaction_filters only holds Transaction fields")
-    };
-    match tx_field {
-        TransactionField::Status => {
+    match server_tag(f.field) {
+        ServerFilter::TxStatus => {
             let [value] = f.values.as_slice() else {
                 bail!("`transaction.status` accepts a single value server-side.");
             };
             Ok(filter.and_status(value_to_u8(value)?))
         }
-        TransactionField::Type => Ok(filter.and_type(values_to_u8(&f.values)?)),
-        _ => {
+        ServerFilter::TxType => Ok(filter.and_type(values_to_u8(&f.values)?)),
+        tag => {
             let owned = filter_values_as_strs(&f.values);
-            let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
-            let (filter, ctx) = match tx_field {
-                TransactionField::From => (filter.and_from(refs), "invalid from address"),
-                TransactionField::To => (filter.and_to(refs), "invalid to address"),
-                TransactionField::Sighash => (filter.and_sighash(refs), "invalid sighash"),
-                TransactionField::Hash => (filter.and_hash(refs), "invalid transaction hash"),
-                TransactionField::ContractAddress => (
+            let refs = str_refs(&owned);
+            let (filter, ctx) = match tag {
+                ServerFilter::TxFrom => (filter.and_from(refs), "invalid from address"),
+                ServerFilter::TxTo => (filter.and_to(refs), "invalid to address"),
+                ServerFilter::TxSighash => (filter.and_sighash(refs), "invalid sighash"),
+                ServerFilter::TxHash => (filter.and_hash(refs), "invalid transaction hash"),
+                ServerFilter::TxContractAddress => (
                     filter.and_contract_address(refs),
                     "invalid contract address",
                 ),
-                _ => unreachable!("transaction_filters only holds server-filterable fields"),
+                _ => unreachable!("non-transaction server tag in transaction section"),
             };
             filter.context(ctx)
         }
@@ -207,16 +211,12 @@ fn apply_tx_filter(filter: TransactionFilter, f: &FieldFilter) -> Result<Transac
 }
 
 fn apply_block_filter(filter: BlockFilter, f: &FieldFilter) -> Result<BlockFilter> {
-    use hypersync_client::net_types::block::BlockField;
-    let TypedField::Block(block_field) = f.field else {
-        unreachable!("block_filters only holds Block fields")
-    };
     let owned = filter_values_as_strs(&f.values);
-    let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
-    let (filter, ctx) = match block_field {
-        BlockField::Hash => (filter.and_hash(refs), "invalid block hash"),
-        BlockField::Miner => (filter.and_miner(refs), "invalid miner address"),
-        _ => unreachable!("block_filters only holds server-filterable fields"),
+    let refs = str_refs(&owned);
+    let (filter, ctx) = match server_tag(f.field) {
+        ServerFilter::BlockHash => (filter.and_hash(refs), "invalid block hash"),
+        ServerFilter::BlockMiner => (filter.and_miner(refs), "invalid miner address"),
+        _ => unreachable!("non-block server tag in block section"),
     };
     filter.context(ctx)
 }
@@ -257,7 +257,6 @@ fn apply_field(
     body: Value,
 ) -> Result<()> {
     use hypersync_client::net_types::block::BlockField;
-    use hypersync_client::net_types::transaction::TransactionField;
     if matches!(typed_field, TypedField::Block(BlockField::Number)) {
         return apply_block_range(out, indexer_name, body);
     }
@@ -273,12 +272,10 @@ fn apply_field(
         .sum();
     // `transaction.status` maps to a single `u8` server-side, so a multi-value
     // set must fall back to client-side filtering.
-    let status_multi = matches!(
-        typed_field,
-        TypedField::Transaction(TransactionField::Status)
-    ) && membership != 1;
+    let server = typed_field.spec().server;
+    let status_multi = server == Some(ServerFilter::TxStatus) && membership != 1;
 
-    if typed_field.server_filterable() && !has_cmp && !status_multi {
+    if server.is_some() && !has_cmp && !status_multi {
         let values = conds
             .into_iter()
             .flat_map(|c| match c {
@@ -286,12 +283,7 @@ fn apply_field(
                 Cond::Cmp(..) => Vec::new(),
             })
             .collect();
-        let dest = match section {
-            Section::Log => &mut out.log_filters,
-            Section::Transaction => &mut out.transaction_filters,
-            Section::Block => &mut out.block_filters,
-        };
-        dest.push(FieldFilter {
+        out.server_filters.push(FieldFilter {
             field: typed_field,
             values,
         });
@@ -326,9 +318,9 @@ fn parse_conditions(
                         Cond::In(arr.clone())
                     }
                     "_gt" | "_gte" | "_lt" | "_lte" => {
-                        if field.column_format() == ColumnFormat::Hex {
+                        if field.spec().value_kind != ValueKind::Numeric {
                             bail!(
-                                "Comparison operators are not supported on hex field `{}`. Use `_eq` or `_in`.",
+                                "Comparison operators are only supported on numeric fields; `{}` is not numeric. Use `_eq` or `_in`.",
                                 label(),
                             );
                         }
@@ -442,7 +434,10 @@ mod tests {
             (Some(1000), Some(2001))
         );
         assert_eq!(
-            (f.log_filters.len(), f.log_filters[0].field.camel_name()),
+            (
+                f.server_filters.len(),
+                f.server_filters[0].field.camel_name()
+            ),
             (1, "srcAddress".to_string())
         );
     }
@@ -496,26 +491,20 @@ mod tests {
     #[test]
     fn transaction_filters() {
         let f = pf("{ transaction: { from: '0xa0b8', sighash: '0xdead' } }");
-        assert_eq!(f.transaction_filters.len(), 2);
+        assert_eq!(f.server_filters.len(), 2);
     }
 
     #[test]
     fn hash_and_contract_address_are_server_side() {
         let f = pf("{ transaction: { hash: '0xa0b8', contractAddress: '0xdead' } }");
-        assert_eq!(
-            (f.transaction_filters.len(), f.client_filters.len()),
-            (2, 0),
-        );
+        assert_eq!((f.server_filters.len(), f.client_filters.len()), (2, 0));
     }
 
     #[test]
     fn numeric_field_with_membership_is_client_side() {
         // `transaction.gas` has no Hypersync builder → client-side even for `_in`.
         let f = pf("{ transaction: { gas: [21000, 50000] } }");
-        assert_eq!(
-            (f.transaction_filters.len(), f.client_filters.len()),
-            (0, 1),
-        );
+        assert_eq!((f.server_filters.len(), f.client_filters.len()), (0, 1));
     }
 
     #[test]
@@ -524,7 +513,7 @@ mod tests {
         let q = f.build_net_query(FieldSelection::default()).unwrap();
         assert_eq!(
             (
-                f.transaction_filters.len(),
+                f.server_filters.len(),
                 f.client_filters.len(),
                 q.transactions.len(),
             ),
@@ -536,10 +525,7 @@ mod tests {
     fn multi_value_status_falls_back_to_client() {
         // `and_status` takes a single value, so a set must filter client-side.
         let f = pf("{ transaction: { status: { _in: [0, 1] } } }");
-        assert_eq!(
-            (f.transaction_filters.len(), f.client_filters.len()),
-            (0, 1),
-        );
+        assert_eq!((f.server_filters.len(), f.client_filters.len()), (0, 1));
     }
 
     #[test]
@@ -550,7 +536,7 @@ mod tests {
         let q = f.build_net_query(FieldSelection::default()).unwrap();
         assert_eq!(
             (
-                f.block_filters.len(),
+                f.server_filters.len(),
                 f.client_filters.len(),
                 q.blocks.len(),
             ),
@@ -562,7 +548,7 @@ mod tests {
     fn other_block_field_is_client_side() {
         // `block.timestamp` has no Hypersync builder → client-side.
         let f = pf("{ block: { timestamp: { _gte: 1000 } } }");
-        assert_eq!((f.block_filters.len(), f.client_filters.len()), (0, 1));
+        assert_eq!((f.server_filters.len(), f.client_filters.len()), (0, 1));
     }
 
     #[test]
@@ -570,7 +556,7 @@ mod tests {
         let f = pf(
             "{ // comment\n  block: { number: { _gte: 100, } },\n  log: { srcAddress: '0xa', }, }",
         );
-        assert_eq!((f.from_block, f.log_filters.len()), (Some(100), 1));
+        assert_eq!((f.from_block, f.server_filters.len()), (Some(100), 1));
     }
 
     #[test]
@@ -582,7 +568,11 @@ mod tests {
     #[test]
     fn case_insensitive_where_fields() {
         let f = pf("{ log: { src_address: '0xa', TOPIC0: '0xb' } }");
-        let names: Vec<String> = f.log_filters.iter().map(|f| f.field.camel_name()).collect();
+        let names: Vec<String> = f
+            .server_filters
+            .iter()
+            .map(|f| f.field.camel_name())
+            .collect();
         assert_eq!(names, vec!["srcAddress", "topic0"]);
     }
 }

--- a/packages/cli/src/executor/data.rs
+++ b/packages/cli/src/executor/data.rs
@@ -5,9 +5,11 @@ use std::time::Duration;
 use crate::cli_args::clap_definitions::DataArgs;
 use crate::data::{
     chain::{self, Chain},
+    client_filter,
     field_selection::Selection,
+    mapping::Section,
     toon,
-    where_filter::WhereFilter,
+    where_filter::{ClientFilter, Cond, FieldFilter, WhereFilter},
 };
 
 enum PaginationState {
@@ -44,13 +46,15 @@ pub async fn run(args: DataArgs) -> Result<()> {
         bail!("No data fields requested. Pass at least one positional field.");
     }
 
-    let query = filter.build_net_query(selection.build_net_field_selection())?;
+    let field_selection = selection.build_net_field_selection_with(&filter.client_filter_fields());
+    let query = filter.build_net_query(field_selection)?;
     let response = client
         .get_arrow(&query)
         .await
         .context("Failed querying blockchain data")?;
 
-    let mut out = toon::render_arrow_response(&selection, &response);
+    let masks = client_filter::compute_masks(&response, &filter.client_filters)?;
+    let mut out = toon::render_arrow_response(&selection, &response, &masks);
 
     let archive_height = response.archive_height.unwrap_or(0);
 
@@ -119,7 +123,9 @@ fn build_client(chain: &Chain, token: &str) -> Result<hypersync_client::Client> 
 }
 
 fn render_where_hint(filter: &WhereFilter, next_block: u64) -> String {
-    let mut parts: Vec<String> = Vec::new();
+    let mut block: Vec<String> = Vec::new();
+    let mut transaction: Vec<String> = Vec::new();
+    let mut log: Vec<String> = Vec::new();
 
     let mut range = format!("number: {{ _gte: {next_block}");
     if let Some(end_excl) = filter.to_block_exclusive {
@@ -127,37 +133,60 @@ fn render_where_hint(filter: &WhereFilter, next_block: u64) -> String {
         range.push_str(&format!(", _lte: {lte}"));
     }
     range.push_str(" }");
-    parts.push(format!("block: {{ {range} }}"));
+    block.push(range);
 
-    if let Some(s) = section_part("log", &filter.log_filters) {
-        parts.push(s);
+    for f in &filter.log_filters {
+        log.push(render_server_field(f));
     }
-    if let Some(s) = section_part("transaction", &filter.transaction_filters) {
-        parts.push(s);
+    for f in &filter.transaction_filters {
+        transaction.push(render_server_field(f));
+    }
+    for c in &filter.client_filters {
+        let entry = render_client_field(c);
+        match c.field.section() {
+            Section::Block => block.push(entry),
+            Section::Transaction => transaction.push(entry),
+            Section::Log => log.push(entry),
+        }
     }
 
+    let parts: Vec<String> = [("block", block), ("transaction", transaction), ("log", log)]
+        .into_iter()
+        .filter(|(_, entries)| !entries.is_empty())
+        .map(|(name, entries)| format!("{name}: {{ {} }}", entries.join(", ")))
+        .collect();
     format!("{{ {} }}", parts.join(", "))
 }
 
-fn section_part(
-    section: &str,
-    filters: &[crate::data::where_filter::FieldFilter],
-) -> Option<String> {
-    if filters.is_empty() {
-        return None;
+fn render_server_field(f: &FieldFilter) -> String {
+    let v = if f.values.len() == 1 {
+        json_string(&f.values[0])
+    } else {
+        json_string(&Value::Array(f.values.clone()))
+    };
+    format!("{name}: {v}", name = f.field.camel_name())
+}
+
+fn render_client_field(c: &ClientFilter) -> String {
+    let name = c.field.camel_name();
+    if let [Cond::In(vals)] = c.conds.as_slice() {
+        let v = if vals.len() == 1 {
+            json_string(&vals[0])
+        } else {
+            json_string(&Value::Array(vals.clone()))
+        };
+        return format!("{name}: {v}");
     }
-    let body: Vec<String> = filters
+    let ops: Vec<String> = c
+        .conds
         .iter()
-        .map(|f| {
-            let v = if f.values.len() == 1 {
-                json_string(&f.values[0])
-            } else {
-                json_string(&Value::Array(f.values.clone()))
-            };
-            format!("{name}: {v}", name = f.field.camel_name())
+        .map(|cond| match cond {
+            Cond::In(vals) if vals.len() == 1 => format!("_eq: {}", json_string(&vals[0])),
+            Cond::In(vals) => format!("_in: {}", json_string(&Value::Array(vals.clone()))),
+            Cond::Cmp(op, v) => format!("{}: {}", op.as_str(), json_string(v)),
         })
         .collect();
-    Some(format!("{section}: {{ {} }}", body.join(", ")))
+    format!("{name}: {{ {} }}", ops.join(", "))
 }
 
 fn json_string(v: &Value) -> String {
@@ -185,4 +214,23 @@ fn missing_token_error() -> anyhow::Error {
          Set the ENVIO_API_TOKEN environment variable in your .env file.\n\
          Get a free API token at: https://envio.dev/app/api-tokens"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn hint_round_trips_server_and_client_filters() {
+        let filter = WhereFilter::parse(Some(
+            "{ block: { number: { _lte: 2000 } }, log: { srcAddress: '0xabc', data: '0xdead' }, transaction: { value: { _gt: 1000 } } }",
+        ))
+        .unwrap();
+        let hint = render_where_hint(&filter, 1500);
+        assert_eq!(
+            hint,
+            "{ block: { number: { _gte: 1500, _lte: 2000 } }, transaction: { value: { _gt: 1000 } }, log: { srcAddress: \"0xabc\", data: \"0xdead\" } }",
+        );
+    }
 }

--- a/packages/cli/src/executor/data.rs
+++ b/packages/cli/src/executor/data.rs
@@ -135,14 +135,13 @@ fn render_where_hint(filter: &WhereFilter, next_block: u64) -> String {
     range.push_str(" }");
     block.push(range);
 
-    for f in &filter.block_filters {
-        block.push(render_server_field(f));
-    }
-    for f in &filter.log_filters {
-        log.push(render_server_field(f));
-    }
-    for f in &filter.transaction_filters {
-        transaction.push(render_server_field(f));
+    for f in &filter.server_filters {
+        let entry = render_server_field(f);
+        match f.field.section() {
+            Section::Block => block.push(entry),
+            Section::Transaction => transaction.push(entry),
+            Section::Log => log.push(entry),
+        }
     }
     for c in &filter.client_filters {
         let entry = render_client_field(c);

--- a/packages/cli/src/executor/data.rs
+++ b/packages/cli/src/executor/data.rs
@@ -135,6 +135,9 @@ fn render_where_hint(filter: &WhereFilter, next_block: u64) -> String {
     range.push_str(" }");
     block.push(range);
 
+    for f in &filter.block_filters {
+        block.push(render_server_field(f));
+    }
     for f in &filter.log_filters {
         log.push(render_server_field(f));
     }
@@ -231,6 +234,19 @@ mod tests {
         assert_eq!(
             hint,
             "{ block: { number: { _gte: 1500, _lte: 2000 } }, transaction: { value: { _gt: 1000 } }, log: { srcAddress: \"0xabc\", data: \"0xdead\" } }",
+        );
+    }
+
+    #[test]
+    fn hint_includes_block_and_status_filters() {
+        let filter = WhereFilter::parse(Some(
+            "{ block: { miner: '0xbeef' }, transaction: { status: 1, type: [0, 2] } }",
+        ))
+        .unwrap();
+        let hint = render_where_hint(&filter, 100);
+        assert_eq!(
+            hint,
+            "{ block: { number: { _gte: 100 }, miner: \"0xbeef\" }, transaction: { status: 1, type: [0,2] } }",
         );
     }
 }

--- a/packages/cli/templates/static/shared/.claude/skills/envio-data/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/envio-data/SKILL.md
@@ -19,11 +19,11 @@ envio data <field>... --chain=<id|name> [--where='<json5>']
   Examples: `block.number`, `log.srcAddress`, `transaction.hash`.
   Case-insensitive — `gasLimit`, `gas_limit`, `GASLIMIT` all work.
 - **--chain**: numeric id (`8453`) or name (`base`, `arbitrum-one`).
-- **--where**: JSON5 with the indexer `where` syntax. Supported filters:
-  - `block.number` with range ops (`_gte`, `_gt`, `_lte`, `_lt`).
-  - `log.srcAddress`, `log.topic0..3` — scalar, array, `_eq`, or `_in`.
-  - `transaction.from`, `transaction.to`, `transaction.sighash` — same ops as log filters.
-  Other fields can be selected for output but cannot be filtered on.
+- **--where**: JSON5, grouping fields under `block`, `transaction`, `log`.
+  Any field can be filtered:
+  - Match with a scalar, an array, `_eq`, or `_in` (e.g. `log: { srcAddress: "0x..." }`).
+  - Compare numeric fields with `_gt`, `_gte`, `_lt`, `_lte` (e.g. `transaction: { value: { _gt: 1000000000000000000 } }`).
+  - Comparison ops are numeric-only; hex/bool fields take only `_eq`/`_in`.
 
 ## Examples
 
@@ -35,6 +35,17 @@ envio data block.number log.transactionHash \
   --where='{
     block: { number: { _gte: 0 } },
     log: { srcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" },
+  }'
+```
+
+Filter on any field, including numeric comparisons:
+
+```bash
+envio data transaction.hash transaction.value \
+  --chain=base \
+  --where='{
+    block: { number: { _gte: 1000000, _lt: 1000100 } },
+    transaction: { value: { _gt: 1000000000000000000 } },
   }'
 ```
 


### PR DESCRIPTION
## Summary

Extends the `--where` filter system to support client-side filtering and comparison operators (`_gt`, `_gte`, `_lt`, `_lte`). Previously, only server-side pushable filters were supported. This change introduces a two-tier filtering architecture: fields that can be pushed to Hypersync are sent server-side, while others are evaluated client-side after fetching the data.

## Key Changes

- **New `ClientFilter` type** (`where_filter.rs`): Represents filters evaluated client-side with support for membership tests (`_in`, `_eq`) and numeric comparisons (`_gt`, `_gte`, `_lt`, `_lte`).

- **Refactored filter routing** (`where_filter.rs`): 
  - Renamed `log_filters`/`transaction_filters` to `server_filters` for clarity
  - Added `client_filters` vector to hold client-side predicates
  - `parse_conditions()` now extracts operators and builds `Cond` enums instead of flattening to values
  - Filters are routed based on whether the field has a server-side builder and whether comparison operators are used

- **New `client_filter.rs` module**: Implements client-side mask computation
  - `compute_masks()` evaluates all client filters against Arrow record batches
  - Returns per-section boolean masks indicating which rows pass all predicates
  - Handles numeric comparisons, hex string matching, and boolean equality
  - Supports multi-value membership tests and range queries via AND'd conditions

- **Enhanced field metadata** (`mapping.rs`):
  - Renamed `ColumnFormat` to `ValueKind` (Numeric, Hex, Bool)
  - Added `ServerFilter` enum mapping fields to Hypersync builders
  - New `FieldSpec` struct centralizes field behavior (aliases, value kind, server routing)
  - `TypedField::spec()` provides single source of truth for field properties

- **Block filter support**: Extended `apply_block_filter()` to handle `block.hash` and `block.miner` server-side filters.

- **Transaction filter enhancements**: Added support for `transaction.status` and `transaction.type` with proper u8 conversion; multi-value status falls back to client-side.

- **Query building** (`field_selection.rs`): 
  - `build_net_field_selection_with()` now accepts extra fields needed by client filters
  - Ensures client-filter fields are fetched even when not in user's output selection

- **Rendering** (`executor/data.rs`, `toon.rs`):
  - Masks are computed and passed to `render_arrow_response()`
  - Rows filtered out by client predicates are excluded from output
  - `render_where_hint()` reconstructs filter syntax for pagination hints, handling both server and client filters

- **Tests**: Added comprehensive test coverage for numeric ranges, membership tests, hex matching, and filter routing logic.

## Notable Implementation Details

- Comparison operators are only allowed on numeric fields; attempting them on hex/bool fields raises an error.
- `transaction.status` with multiple values falls back to client-side since the Hypersync builder accepts only a single u8.
- Client filter fields are automatically included in the Hypersync query even if not selected for output, enabling predicate evaluation.
- Masks are aligned with record batch row order and applied during rendering to filter output rows.

https://claude.ai/code/session_01Jx7LRGzEGT2eMmV1P6QamA