### PR TITLE
Support block-only selections and block.number set filters

### DIFF
--- a/packages/cli/src/data/client_filter.rs
+++ b/packages/cli/src/data/client_filter.rs
@@ -288,6 +288,27 @@ mod tests {
     }
 
     #[test]
+    fn block_number_in_mask() {
+        let filters = client_filters("{ block: { number: { _in: [10, 12] } } }");
+        let schema = Schema::new(vec![Field::new("number", DataType::UInt64, false)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(UInt64Array::from(vec![10u64, 11, 12]))],
+        )
+        .unwrap();
+        let mask = compute_section_mask(
+            &[batch],
+            &filters
+                .iter()
+                .map(CompiledFilter::compile)
+                .collect::<Result<Vec<_>>>()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(mask, vec![true, false, true]);
+    }
+
+    #[test]
     fn hex_eq_mask() {
         let filters = client_filters("{ log: { data: '0xABCD' } }");
         let schema = Schema::new(vec![Field::new("data", DataType::Binary, false)]);

--- a/packages/cli/src/data/where_filter.rs
+++ b/packages/cli/src/data/where_filter.rs
@@ -121,6 +121,11 @@ impl WhereFilter {
         if let Some(to) = self.to_block_exclusive {
             query = query.to_block_excl(to);
         }
+
+        let wants_log_fields = !field_selection.log.is_empty();
+        let wants_tx_fields = !field_selection.transaction.is_empty();
+        let wants_block_fields = !field_selection.block.is_empty();
+
         query.field_selection = field_selection;
 
         let mut logs = LogFilter::all();
@@ -143,14 +148,25 @@ impl WhereFilter {
                 }
             }
         }
-        if has_log {
+
+        // HyperSync returns only rows that match a selection, so request one for
+        // every entity the user wants data for. Without a filter the `all()`
+        // selection matches every row of that kind.
+        if has_log || wants_log_fields {
             query = query.where_logs(logs);
         }
-        if has_tx {
+        if has_tx || wants_tx_fields {
             query = query.where_transactions(transactions);
         }
         if has_block {
             query = query.where_blocks(blocks);
+        }
+
+        // Block headers are otherwise returned only for blocks joined to a
+        // matching log/transaction/block filter. When block fields are wanted but
+        // no filter scopes the blocks, ask the server for every block in the range.
+        if wants_block_fields && !has_log && !has_tx && !has_block {
+            query = query.include_all_blocks();
         }
 
         Ok(query)
@@ -453,6 +469,67 @@ mod tests {
         let f = WhereFilter::parse(None).unwrap();
         let q = f.build_net_query(FieldSelection::default()).unwrap();
         assert_eq!((q.from_block, q.to_block), (0, None));
+    }
+
+    #[test]
+    fn block_only_selection_requests_all_blocks() {
+        use hypersync_client::net_types::block::BlockField;
+        let mut fs = FieldSelection::default();
+        fs.block.insert(BlockField::Hash);
+        let q = WhereFilter::parse(None)
+            .unwrap()
+            .build_net_query(fs)
+            .unwrap();
+        assert_eq!(
+            (
+                q.include_all_blocks,
+                q.blocks.len(),
+                q.logs.len(),
+                q.transactions.len(),
+            ),
+            (true, 0, 0, 0),
+        );
+    }
+
+    #[test]
+    fn log_only_selection_requests_all_logs() {
+        use hypersync_client::net_types::log::LogField;
+        let mut fs = FieldSelection::default();
+        fs.log.insert(LogField::Data);
+        let q = WhereFilter::parse(None)
+            .unwrap()
+            .build_net_query(fs)
+            .unwrap();
+        assert_eq!(
+            (q.include_all_blocks, q.logs.len(), q.transactions.len()),
+            (false, 1, 0),
+        );
+    }
+
+    #[test]
+    fn transaction_only_selection_requests_all_transactions() {
+        use hypersync_client::net_types::transaction::TransactionField;
+        let mut fs = FieldSelection::default();
+        fs.transaction.insert(TransactionField::Hash);
+        let q = WhereFilter::parse(None)
+            .unwrap()
+            .build_net_query(fs)
+            .unwrap();
+        assert_eq!(
+            (q.include_all_blocks, q.transactions.len(), q.logs.len()),
+            (false, 1, 0),
+        );
+    }
+
+    #[test]
+    fn block_fields_scoped_by_log_filter_skip_all_blocks() {
+        use hypersync_client::net_types::block::BlockField;
+        let mut fs = FieldSelection::default();
+        fs.block.insert(BlockField::Hash);
+        let q = pf("{ log: { srcAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7' } }")
+            .build_net_query(fs)
+            .unwrap();
+        assert_eq!((q.include_all_blocks, q.logs.len()), (false, 1));
     }
 
     #[test]

--- a/packages/cli/src/data/where_filter.rs
+++ b/packages/cli/src/data/where_filter.rs
@@ -110,6 +110,14 @@ impl WhereFilter {
         !self.server_filters.is_empty() || !self.client_filters.is_empty()
     }
 
+    fn narrow_from(&mut self, n: u64) {
+        self.from_block = Some(self.from_block.map_or(n, |cur| cur.max(n)));
+    }
+
+    fn narrow_to_excl(&mut self, n: u64) {
+        self.to_block_exclusive = Some(self.to_block_exclusive.map_or(n, |cur| cur.min(n)));
+    }
+
     /// Fields referenced by client-side filters. These must be fetched even when
     /// not part of the user's output selection so the predicate can be evaluated.
     pub fn client_filter_fields(&self) -> Vec<TypedField> {
@@ -274,7 +282,7 @@ fn apply_field(
 ) -> Result<()> {
     use hypersync_client::net_types::block::BlockField;
     if matches!(typed_field, TypedField::Block(BlockField::Number)) {
-        return apply_block_range(out, indexer_name, body);
+        return apply_block_number(out, typed_field, body);
     }
 
     let conds = parse_conditions(section, indexer_name, typed_field, body)?;
@@ -361,39 +369,49 @@ fn parse_conditions(
     }
 }
 
-fn apply_block_range(out: &mut WhereFilter, field_name: &str, body: Value) -> Result<()> {
-    let map = match body {
-        Value::Object(m) => m,
-        _ => bail!("Expected operator object under `block.{field_name}` (e.g. `_gte: 1000`).",),
+/// `block.number` scopes the scan window rather than mapping to a row filter, so
+/// it desugars to `from_block`/`to_block`. A scalar or `_eq` pins a single block;
+/// an array or `_in` scans `[min, max]` and drops the rest with a client filter.
+fn apply_block_number(out: &mut WhereFilter, field: TypedField, body: Value) -> Result<()> {
+    let to_block = |v: &Value| {
+        value_to_u64(v)
+            .with_context(|| format!("`block.number` expects a non-negative integer, got {v}"))
     };
-
-    for (op, val) in map {
-        let n = value_to_u64(&val).with_context(|| {
-            format!(
-                "Operator `{op}` on `block.{field_name}` expects a non-negative integer, got {val}",
-            )
-        })?;
-        match op.as_str() {
-            "_gte" => {
-                out.from_block = Some(out.from_block.map_or(n, |cur| cur.max(n)));
+    for cond in parse_conditions(Section::Block, "number", field, body)? {
+        match cond {
+            Cond::Cmp(op, v) => {
+                let n = to_block(&v)?;
+                match op {
+                    CmpOp::Gte => out.narrow_from(n),
+                    CmpOp::Gt => out.narrow_from(n.saturating_add(1)),
+                    CmpOp::Lte => out.narrow_to_excl(n.saturating_add(1)),
+                    CmpOp::Lt => out.narrow_to_excl(n),
+                }
             }
-            "_gt" => {
-                let c = n.saturating_add(1);
-                out.from_block = Some(out.from_block.map_or(c, |cur| cur.max(c)));
+            Cond::In(vals) => {
+                let nums = vals.iter().map(to_block).collect::<Result<Vec<_>>>()?;
+                match (nums.iter().min(), nums.iter().max()) {
+                    (Some(&min), Some(&max)) => {
+                        out.narrow_from(min);
+                        out.narrow_to_excl(max.saturating_add(1));
+                        // A single value is already an exact range; only a set
+                        // needs the leftover blocks dropped client-side.
+                        if nums.len() > 1 {
+                            out.client_filters.push(ClientFilter {
+                                field,
+                                conds: vec![Cond::In(vals)],
+                            });
+                        }
+                    }
+                    // Empty `_in` matches no block; the client filter drops all rows.
+                    _ => out.client_filters.push(ClientFilter {
+                        field,
+                        conds: vec![Cond::In(vals)],
+                    }),
+                }
             }
-            "_lte" => {
-                let c = n.saturating_add(1);
-                out.to_block_exclusive = Some(out.to_block_exclusive.map_or(c, |cur| cur.min(c)));
-            }
-            "_lt" => {
-                out.to_block_exclusive = Some(out.to_block_exclusive.map_or(n, |cur| cur.min(n)));
-            }
-            other => bail!(
-                "Unsupported operator `{other}` on `block.{field_name}`. Use `_gte`, `_gt`, `_lte`, `_lt`.",
-            ),
         }
     }
-
     Ok(())
 }
 
@@ -462,6 +480,78 @@ mod tests {
     fn gt_and_lt_off_by_one() {
         let f = pf("{ block: { number: { _gt: 100, _lt: 200 } } }");
         assert_eq!((f.from_block, f.to_block_exclusive), (Some(101), Some(200)));
+    }
+
+    #[test]
+    fn block_number_eq_pins_single_block() {
+        let f = pf("{ block: { number: { _eq: 100 } } }");
+        assert_eq!(
+            (f.from_block, f.to_block_exclusive, f.client_filters.len()),
+            (Some(100), Some(101), 0),
+        );
+    }
+
+    #[test]
+    fn block_number_scalar_shorthand_pins_single_block() {
+        let f = pf("{ block: { number: 100 } }");
+        assert_eq!(
+            (f.from_block, f.to_block_exclusive, f.client_filters.len()),
+            (Some(100), Some(101), 0),
+        );
+    }
+
+    #[test]
+    fn block_number_in_scans_range_and_filters_rest_client_side() {
+        let f = pf("{ block: { number: { _in: [100, 50, 200] } } }");
+        assert_eq!(
+            (
+                f.from_block,
+                f.to_block_exclusive,
+                f.client_filters.len(),
+                f.client_filters[0].field.camel_name(),
+            ),
+            (Some(50), Some(201), 1, "number".to_string()),
+        );
+    }
+
+    #[test]
+    fn block_number_array_shorthand_matches_in() {
+        let f = pf("{ block: { number: [100, 50, 200] } }");
+        assert_eq!(
+            (f.from_block, f.to_block_exclusive, f.client_filters.len()),
+            (Some(50), Some(201), 1),
+        );
+    }
+
+    #[test]
+    fn block_number_single_element_in_needs_no_client_filter() {
+        let f = pf("{ block: { number: { _in: [42] } } }");
+        assert_eq!(
+            (f.from_block, f.to_block_exclusive, f.client_filters.len()),
+            (Some(42), Some(43), 0),
+        );
+    }
+
+    #[test]
+    fn block_number_in_builds_full_block_scan_over_range() {
+        use hypersync_client::net_types::block::BlockField;
+        let mut fs = FieldSelection::default();
+        fs.block.insert(BlockField::Number);
+        let q = pf("{ block: { number: { _in: [10, 12] } } }")
+            .build_net_query(fs)
+            .unwrap();
+        assert_eq!(
+            (q.from_block, q.to_block, q.include_all_blocks),
+            (10, Some(13), true),
+        );
+    }
+
+    #[test]
+    fn block_number_unsupported_operator_errors() {
+        let err = WhereFilter::parse(Some("{ block: { number: { _like: 5 } } }"))
+            .unwrap_err()
+            .to_string();
+        insta::assert_snapshot!(err, @"Unsupported operator `_like` on `block.number`. Use a scalar, an array, `_eq`, `_in`, `_gt`, `_gte`, `_lt`, or `_lte`.");
     }
 
     #[test]

--- a/packages/cli/src/executor/data.rs
+++ b/packages/cli/src/executor/data.rs
@@ -132,6 +132,14 @@ fn render_where_hint(filter: &WhereFilter, next_block: u64) -> String {
         let lte = end_excl.saturating_sub(1);
         range.push_str(&format!(", _lte: {lte}"));
     }
+    // A `block.number` set scans [min, max] and drops the rest client-side, so
+    // carry the set forward to keep filtering the same blocks across pages.
+    if let Some(set) = block_number_set(filter) {
+        range.push_str(&format!(
+            ", _in: {}",
+            json_string(&Value::Array(set.to_vec()))
+        ));
+    }
     range.push_str(" }");
     block.push(range);
 
@@ -144,6 +152,9 @@ fn render_where_hint(filter: &WhereFilter, next_block: u64) -> String {
         }
     }
     for c in &filter.client_filters {
+        if is_block_number(c) {
+            continue;
+        }
         let entry = render_client_field(c);
         match c.field.section() {
             Section::Block => block.push(entry),
@@ -158,6 +169,20 @@ fn render_where_hint(filter: &WhereFilter, next_block: u64) -> String {
         .map(|(name, entries)| format!("{name}: {{ {} }}", entries.join(", ")))
         .collect();
     format!("{{ {} }}", parts.join(", "))
+}
+
+fn is_block_number(c: &ClientFilter) -> bool {
+    c.field.section() == Section::Block && c.field.camel_name() == "number"
+}
+
+fn block_number_set(filter: &WhereFilter) -> Option<&[Value]> {
+    filter
+        .client_filters
+        .iter()
+        .find_map(|c| match c.conds.as_slice() {
+            [Cond::In(vals)] if is_block_number(c) => Some(vals.as_slice()),
+            _ => None,
+        })
 }
 
 fn render_server_field(f: &FieldFilter) -> String {
@@ -233,6 +258,17 @@ mod tests {
         assert_eq!(
             hint,
             "{ block: { number: { _gte: 1500, _lte: 2000 } }, transaction: { value: { _gt: 1000 } }, log: { srcAddress: \"0xabc\", data: \"0xdead\" } }",
+        );
+    }
+
+    #[test]
+    fn hint_folds_block_number_set_into_range() {
+        let filter =
+            WhereFilter::parse(Some("{ block: { number: { _in: [100, 50, 200] } } }")).unwrap();
+        let hint = render_where_hint(&filter, 120);
+        assert_eq!(
+            hint,
+            "{ block: { number: { _gte: 120, _lte: 200, _in: [100,50,200] } } }",
         );
     }
 

--- a/packages/cli/tests/data_integration.rs
+++ b/packages/cli/tests/data_integration.rs
@@ -137,7 +137,7 @@ fn block_only_selection_returns_block_data() {
         "block.number",
         "block.gasUsed",
         "--chain=1",
-        "--where={ block: { number: { _gte: 20000000, _lte: 20000000 } } }",
+        "--where={ block: { number: 20000000 } }",
     ]);
     assert!(out.ok, "envio data failed:\n{out}");
 

--- a/packages/cli/tests/data_integration.rs
+++ b/packages/cli/tests/data_integration.rs
@@ -124,6 +124,35 @@ logs[11]{srcAddress,logIndex}:
     assert_eq!(out.stderr_template(), "", "unexpected stderr:\n{out}");
 }
 
+/// Block-only selection with no log/transaction filter. HyperSync returns rows
+/// only for matching selections, so without `include_all_blocks` the response is
+/// empty — this guards the regression where `envio data block.<field>` returned
+/// nothing.
+#[test]
+fn block_only_selection_returns_block_data() {
+    if skip_without_token() {
+        return;
+    }
+    let out = envio_data(&[
+        "block.number",
+        "block.gasUsed",
+        "--chain=1",
+        "--where={ block: { number: { _gte: 20000000, _lte: 20000000 } } }",
+    ]);
+    assert!(out.ok, "envio data failed:\n{out}");
+
+    assert_eq!(
+        out.stdout,
+        "\
+blocks[1]{number,gasUsed}:
+  20000000,11089692
+",
+        "unexpected stdout:\n{out}",
+    );
+
+    assert_eq!(out.stderr_template(), "", "unexpected stderr:\n{out}");
+}
+
 /// Deterministic large range that hypersync cannot return in one batch.
 /// Verifies the executor prints the "next page" hint and echoes back the
 /// original chain input plus the unchanged upper bound.


### PR DESCRIPTION
## Summary

Fixes queries that select only block fields without log/transaction filters, and improves `block.number` filter handling to support set membership (`_in`) with client-side filtering.

## Key Changes

- **Block-only selections**: Added `include_all_blocks()` to HyperSync queries when block fields are selected but no log/transaction/block filters scope the results. Previously these queries returned empty results because HyperSync only returns rows matching a selection.

- **`block.number` refactoring**: Replaced custom operator parsing with reuse of the general `parse_conditions` infrastructure, enabling support for `_in` operator alongside existing comparison operators.

- **`block.number` set handling**: When `_in` is used with multiple values, the query scans `[min, max]` server-side and applies a client-side filter to drop unmatched blocks. Single-value sets skip the client filter (already exact). Empty sets are handled with a client filter that matches nothing.

- **Pagination support**: The `render_where_hint` function now preserves `block.number` sets across pages by including `_in` alongside the updated `_gte`/`_lte` range, ensuring consistent filtering across paginated results.

- **Helper methods**: Added `narrow_from()` and `narrow_to_excl()` to centralize block range narrowing logic.

## Notable Implementation Details

- `block.number` desugars to `from_block`/`to_block` parameters rather than row filters, so it's handled separately from other field filters.
- The `wants_log_fields`, `wants_tx_fields`, and `wants_block_fields` flags determine whether to request all rows of each kind when no explicit filter exists.
- Client-side `block.number` filters are excluded from the pagination hint since the set is already included in the `_in` operator.
- Tests verify single-block pins, range scans with client filtering, and the interaction with block field selection.

https://claude.ai/code/session_01QfhyYZWhpDLkzgFUhT2GgT