### PR TITLE
Defer raw event creation and deep NUL stripping to batch write

### DIFF
--- a/packages/e2e-tests/src/e2e/e2e.test.ts
+++ b/packages/e2e-tests/src/e2e/e2e.test.ts
@@ -449,6 +449,52 @@ describe("E2E: Indexer with GraphQL and ClickHouse sink", () => {
     expect(Number(pgOnlyRows[0]?.[0])).toBe(transferCount);
   });
 
+  it("Postgres raw_events holds one row per indexed event with decoded data", async () => {
+    // config.yaml sets `raw_events: true`, so every processed event is
+    // mirrored into the internal raw_events table. There's one Transfer
+    // event per Transfer entity, so the counts must match.
+    const transferRows = await runPgSql(`SELECT count(*)::text FROM "Transfer"`);
+    const transferCount = Number(transferRows[0]?.[0]);
+    expect(transferCount).toBeGreaterThan(0);
+
+    const rawCountRows = await runPgSql(`SELECT count(*)::text FROM raw_events`);
+    expect(Number(rawCountRows[0]?.[0])).toBe(transferCount);
+
+    // Spot-check the first known event (chain 1, block 10861674, log index
+    // 23) against the deterministic decoded values from the smoke-test
+    // snapshot. Addresses are lower-cased to avoid checksum-casing churn.
+    const row = await runPgSql(`
+      SELECT
+        chain_id,
+        event_name,
+        contract_name,
+        block_number,
+        log_index,
+        lower(src_address),
+        transaction_fields->>'hash',
+        lower(params->>'from'),
+        lower(params->>'to'),
+        params->>'value'
+      FROM raw_events
+      WHERE block_number = 10861674 AND log_index = 23
+    `);
+
+    expect(row).toEqual([
+      [
+        "1",
+        "Transfer",
+        "ERC20",
+        "10861674",
+        "23",
+        "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+        "0x4b37d2f343608457ca3322accdab2811c707acf3eb07a40dd8d9567093ea5b82",
+        "0x0000000000000000000000000000000000000000",
+        "0x41653c7d61609d856f29355e404f310ec4142cfb",
+        "1000000000000000000000000000",
+      ],
+    ]);
+  });
+
   it("ClickHouse has tables for clickhouse-enabled entities only", async () => {
     const tables = await queryClickHouse<
       ClickHouseResult<{ name: string }>

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -25,77 +25,6 @@ let computeChainsState = (chainFetchers: ChainMap.t<ChainFetcher.t>): Internal.c
   chains
 }
 
-let convertFieldsToJson = (fields: option<dict<unknown>>) => {
-  switch fields {
-  | None => %raw(`{}`)
-  | Some(fields) =>
-    // Convert bigint fields to string. There are no fields with nested
-    // bigints, so iterating only the top level is safe.
-    fields
-    ->Utils.Dict.mapValues(value =>
-      typeof(value) === #bigint
-        ? value
-          ->(Utils.magic: unknown => bigint)
-          ->BigInt.toString
-          ->(Utils.magic: string => unknown)
-        : value
-    )
-    ->(Utils.magic: dict<unknown> => JSON.t)
-  }
-}
-
-let addItemToRawEvents = (
-  eventItem: Internal.eventItem,
-  ~inMemoryStore: InMemoryStore.t,
-  ~config: Config.t,
-) => {
-  let {event, eventConfig, chain, blockNumber, timestamp: blockTimestamp} = eventItem
-  let {block, transaction, params, logIndex, srcAddress} = event
-  let chainId = chain->ChainMap.Chain.toChainId
-  let eventId = EventUtils.packEventIndex(~logIndex, ~blockNumber)
-  let blockFields =
-    block
-    ->(Utils.magic: Internal.eventBlock => option<dict<unknown>>)
-    ->convertFieldsToJson
-  let transactionFields =
-    transaction
-    ->(Utils.magic: Internal.eventTransaction => option<dict<unknown>>)
-    ->convertFieldsToJson
-
-  blockFields->config.ecosystem.cleanUpRawEventFieldsInPlace
-
-  // Serialize to unknown, because serializing to Js.Json.t fails for Bytes Fuel type, since it has unknown schema
-  let params =
-    params
-    ->S.reverseConvertOrThrow(eventConfig.paramsRawEventSchema)
-    ->(Utils.magic: unknown => JSON.t)
-  let params = if params === %raw(`null`) {
-    // Should probably make the params field nullable
-    // But this is currently needed to make events
-    // with empty params work
-    %raw(`"null"`)
-  } else {
-    params
-  }
-
-  let rawEvent: InternalTable.RawEvents.t = {
-    chainId,
-    eventId,
-    eventName: eventConfig.name,
-    contractName: eventConfig.contractName,
-    blockNumber,
-    logIndex,
-    srcAddress,
-    blockHash: block->config.ecosystem.getId,
-    blockTimestamp,
-    blockFields,
-    transactionFields,
-    params,
-  }
-
-  inMemoryStore.rawEvents->Array.push(rawEvent)
-}
-
 exception ProcessingError({message: string, exn: exn, item: Internal.item})
 
 let runEventHandlerOrThrow = async (
@@ -192,26 +121,18 @@ let runHandlerOrThrow = async (
         }),
       )
     }
-  | Event({eventConfig}) => {
-      switch eventConfig.handler {
-      | Some(handler) =>
-        await item->runEventHandlerOrThrow(
-          ~handler,
-          ~checkpointId,
-          ~inMemoryStore,
-          ~loadManager,
-          ~persistence=ctx.persistence,
-          ~chains,
-          ~config=ctx.config,
-        )
-      | None => ()
-      }
-
-      if ctx.config.enableRawEvents {
-        item
-        ->Internal.castUnsafeEventItem
-        ->addItemToRawEvents(~inMemoryStore, ~config=ctx.config)
-      }
+  | Event({eventConfig}) => switch eventConfig.handler {
+    | Some(handler) =>
+      await item->runEventHandlerOrThrow(
+        ~handler,
+        ~checkpointId,
+        ~inMemoryStore,
+        ~loadManager,
+        ~persistence=ctx.persistence,
+        ~chains,
+        ~config=ctx.config,
+      )
+    | None => ()
     }
   }
 }

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -32,7 +32,6 @@ type effectCacheInMemTable = {
 
 type t = {
   allEntities: array<Internal.entityConfig>,
-  mutable rawEvents: array<InternalTable.RawEvents.t>,
   mutable entities: dict<InMemoryTable.Entity.t>,
   mutable effects: dict<effectCacheInMemTable>,
   mutable rollback: option<Persistence.rollback>,
@@ -83,7 +82,6 @@ let make = (
 
   {
     allEntities: entities,
-    rawEvents: [],
     entities: EntityTables.make(entities),
     effects: Dict.make(),
     rollback: None,
@@ -171,6 +169,7 @@ let drainBatchRun = (inMemoryStore: t): Batch.t => {
   let rest = []
   let progressedChainsById = Dict.make()
   let totalBatchSize = ref(0)
+  let items = []
   let checkpointIds = []
   let checkpointChainIds = []
   let checkpointBlockNumbers = []
@@ -183,6 +182,7 @@ let drainBatchRun = (inMemoryStore: t): Batch.t => {
         progressedChainsById->Dict.set(key, chainAfterBatch)
       )
       totalBatchSize := totalBatchSize.contents + batch.totalBatchSize
+      items->Array.pushMany(batch.items)
       checkpointIds->Array.pushMany(batch.checkpointIds)
       checkpointChainIds->Array.pushMany(batch.checkpointChainIds)
       checkpointBlockNumbers->Array.pushMany(batch.checkpointBlockNumbers)
@@ -196,7 +196,7 @@ let drainBatchRun = (inMemoryStore: t): Batch.t => {
 
   {
     totalBatchSize: totalBatchSize.contents,
-    items: [],
+    items,
     progressedChainsById,
     isInReorgThreshold,
     checkpointIds,
@@ -275,10 +275,6 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
     | None => committedCheckpointId
     }
 
-    // rawEvents and the effect cache aren't gated by isInReorgThreshold, so they're
-    // flushed in full rather than split at the run boundary.
-    let rawEvents = inMemoryStore.rawEvents
-    inMemoryStore.rawEvents = []
     let rollback = inMemoryStore.rollback
     inMemoryStore.rollback = None
 
@@ -296,7 +292,6 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
 
     await persistence.storage.writeBatch(
       ~batch,
-      ~rawEvents,
       ~rollback,
       ~isInReorgThreshold=batch.isInReorgThreshold,
       ~config,
@@ -429,7 +424,6 @@ let prepareRollbackDiff = async (
   ~rollbackTargetCheckpointId,
   ~rollbackDiffCheckpointId,
 ) => {
-  inMemoryStore.rawEvents = []
   inMemoryStore.entities = EntityTables.make(inMemoryStore.allEntities)
   inMemoryStore.effects = Dict.make()
   inMemoryStore.rollback = Some({

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -126,7 +126,6 @@ type storage = {
   // Write batch to storage
   writeBatch: (
     ~batch: Batch.t,
-    ~rawEvents: array<InternalTable.RawEvents.t>,
     ~rollback: option<rollback>,
     ~isInReorgThreshold: bool,
     ~config: Config.t,

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -450,26 +450,63 @@ let chunkArray = (arr: array<'a>, ~chunkSize) => {
   chunks
 }
 
-let removeInvalidUtf8InPlace = entities =>
-  entities->Array.forEach(item => {
-    let dict = item->(Utils.magic: 'a => dict<unknown>)
-    dict->Utils.Dict.forEachWithKey((value, key) => {
-      if value->typeof === #string {
-        let value = value->(Utils.magic: unknown => string)
+// Strips NUL bytes, recursing into nested objects/arrays so a NUL buried
+// inside a jsonb column (an event param object, a json entity field) is
+// removed too — Postgres rejects it in both text (0x00) and jsonb (22P05).
+let rec removeInvalidUtf8DeepInPlace = (value: unknown): unknown => {
+  if value->typeof === #string {
+    value
+    ->(Utils.magic: unknown => string)
+    ->Utils.String.replaceAll("\x00", "")
+    ->(Utils.magic: string => unknown)
+  } else if value->typeof === #object && value !== %raw(`null`) {
+    let dict = value->(Utils.magic: unknown => dict<unknown>)
+    dict->Utils.Dict.forEachWithKey((v, k) => dict->Dict.set(k, removeInvalidUtf8DeepInPlace(v)))
+    value
+  } else {
+    value
+  }
+}
 
-        dict->Dict.set(
-          key,
-          value
-          ->Utils.String.replaceAll("\x00", "")
-          ->(Utils.magic: string => unknown),
-        )
-      }
-    })
-  })
+let removeInvalidUtf8InPlace = items =>
+  items->Array.forEach(item =>
+    removeInvalidUtf8DeepInPlace(item->(Utils.magic: 'a => unknown))->ignore
+  )
 
 let pgErrorMessageSchema = S.object(s => s.field("message", S.string))
 
 exception PgEncodingError({table: Table.table})
+
+// Classifies a write failure, parking it in `specificError` so the
+// transaction can unwind and the outer handler can react. Both Postgres
+// encoding failures we recognize are NUL-related — `0x00` in a text column
+// and a NUL rejected by jsonb (22P05) — so they become a PgEncodingError
+// that triggers an escape-and-retry of the offending table, where deep NUL
+// stripping resolves them. We escape lazily on first failure to keep the
+// happy path free of per-item sanitization. The aborted-transaction cascade
+// is ignored so it never masks the original error.
+let classifyWriteError = (~specificError: ref<option<exn>>, ~table: Table.table, ~exn) => {
+  /* Note: Entity History doesn't return StorageError yet, and directly throws JsError */
+  let normalizedExn = switch exn {
+  | JsExn(_) => exn
+  | Persistence.StorageError({reason: exn}) => exn
+  | _ => exn
+  }->JsExn.anyToExnInternal
+
+  switch normalizedExn {
+  | JsExn(error) =>
+    switch error->S.parseOrThrow(pgErrorMessageSchema) {
+    | `current transaction is aborted, commands ignored until end of transaction block` => ()
+    | `invalid byte sequence for encoding "UTF8": 0x00`
+    | `unsupported Unicode escape sequence` =>
+      specificError.contents = Some(PgEncodingError({table: table}))
+    | _ => specificError.contents = Some(exn->Utils.prettifyExn)
+    | exception _ => ()
+    }
+  | S.Raised(_) => throw(normalizedExn) // But rethrow this one, since it's not a PG error
+  | _ => ()
+  }
+}
 
 // WeakMap for caching table batch set queries
 let setQueryCache = Utils.WeakMap.make()
@@ -801,28 +838,36 @@ let rec writeBatch = async (
     let specificError = ref(None)
 
     let rawEvents = if config.enableRawEvents {
-      batch.items->Belt.Array.keepMap(item =>
+      let rows = batch.items->Belt.Array.keepMap(item =>
         switch item {
         | Internal.Event(_) => Some(item->Internal.castUnsafeEventItem->makeRawEvent(~config))
         | Internal.Block(_) => None
         }
       )
+      switch escapeTables {
+      | Some(tables) if tables->Utils.Set.has(InternalTable.RawEvents.table) =>
+        rows->removeInvalidUtf8InPlace
+      | _ => ()
+      }
+      rows
     } else {
       []
     }
 
-    let setRawEvents = executeSet(
-      _,
-      ~dbFunction=(sql, items) => {
-        sql->setOrThrow(
-          ~items,
-          ~table=InternalTable.RawEvents.table,
-          ~itemSchema=InternalTable.RawEvents.schema,
-          ~pgSchema,
-        )
-      },
-      ~items=rawEvents,
-    )
+    let setRawEvents = async sql => {
+      try {
+        await sql->executeSet(~dbFunction=(sql, items) => {
+          sql->setOrThrow(
+            ~items,
+            ~table=InternalTable.RawEvents.table,
+            ~itemSchema=InternalTable.RawEvents.schema,
+            ~pgSchema,
+          )
+        }, ~items=rawEvents)
+      } catch {
+      | exn => classifyWriteError(~specificError, ~table=InternalTable.RawEvents.table, ~exn)
+      }
+    }
 
     let setEntities = updatedEntities->Belt.Array.map(({entityConfig, changes}) => {
       let entitiesToSet = []
@@ -962,42 +1007,11 @@ let rec writeBatch = async (
         // might throw PG error, earlier, than the handled error
         // from setOrThrow will be passed through.
         // This is needed for the utf8 encoding fix.
-        | exn => {
-            /* Note: Entity History doesn't return StorageError yet, and directly throws JsError */
-            let normalizedExn = switch exn {
-            | JsExn(_) => exn
-            | Persistence.StorageError({reason: exn}) => exn
-            | _ => exn
-            }->JsExn.anyToExnInternal
-
-            switch normalizedExn {
-            | JsExn(error) =>
-              // Workaround for https://github.com/enviodev/hyperindex/issues/446
-              // We do escaping only when we actually got an error writing for the first time.
-              // This is not perfect, but an optimization to avoid escaping for every single item.
-
-              switch error->S.parseOrThrow(pgErrorMessageSchema) {
-              | `current transaction is aborted, commands ignored until end of transaction block` => ()
-              | `invalid byte sequence for encoding "UTF8": 0x00` =>
-                // Since the transaction is aborted at this point,
-                // we can't simply retry the function with escaped items,
-                // so propagate the error, to restart the whole batch write.
-                // Also, pass the failing table, to escape only its items.
-                // TODO: Ideally all this should be done in the file,
-                // so it'll be easier to work on PG specific logic.
-                specificError.contents = Some(PgEncodingError({table: entityConfig.table}))
-              | _ => specificError.contents = Some(exn->Utils.prettifyExn)
-              | exception _ => ()
-              }
-            | S.Raised(_) => throw(normalizedExn) // But rethrow this one, since it's not a PG error
-            | _ => ()
-            }
-
-            // Improtant: Don't rethrow here, since it'll result in
-            // an unhandled rejected promise error.
-            // That's fine not to throw, since sql->Postgres.beginSql
-            // will fail anyways.
-          }
+        //
+        // Important: Don't rethrow here, since it'll result in an unhandled
+        // rejected promise error. That's fine not to throw, since
+        // sql->Postgres.beginSql will fail anyways.
+        | exn => classifyWriteError(~specificError, ~table=entityConfig.table, ~exn)
         }
       }
     })

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -712,10 +712,77 @@ let executeSet = (
   }
 }
 
+let convertFieldsToJson = (fields: option<dict<unknown>>) => {
+  switch fields {
+  | None => %raw(`{}`)
+  | Some(fields) =>
+    // Convert bigint fields to string. There are no fields with nested
+    // bigints, so iterating only the top level is safe.
+    fields
+    ->Utils.Dict.mapValues(value =>
+      typeof(value) === #bigint
+        ? value
+          ->(Utils.magic: unknown => bigint)
+          ->BigInt.toString
+          ->(Utils.magic: string => unknown)
+        : value
+    )
+    ->(Utils.magic: dict<unknown> => JSON.t)
+  }
+}
+
+let makeRawEvent = (
+  eventItem: Internal.eventItem,
+  ~config: Config.t,
+): InternalTable.RawEvents.t => {
+  let {event, eventConfig, chain, blockNumber, timestamp: blockTimestamp} = eventItem
+  let {block, transaction, params, logIndex, srcAddress} = event
+  let chainId = chain->ChainMap.Chain.toChainId
+  let eventId = EventUtils.packEventIndex(~logIndex, ~blockNumber)
+  let blockFields =
+    block
+    ->(Utils.magic: Internal.eventBlock => option<dict<unknown>>)
+    ->convertFieldsToJson
+  let transactionFields =
+    transaction
+    ->(Utils.magic: Internal.eventTransaction => option<dict<unknown>>)
+    ->convertFieldsToJson
+
+  blockFields->config.ecosystem.cleanUpRawEventFieldsInPlace
+
+  // Serialize to unknown, because serializing to Js.Json.t fails for Bytes Fuel type, since it has unknown schema
+  let params =
+    params
+    ->S.reverseConvertOrThrow(eventConfig.paramsRawEventSchema)
+    ->(Utils.magic: unknown => JSON.t)
+  let params = if params === %raw(`null`) {
+    // Should probably make the params field nullable
+    // But this is currently needed to make events
+    // with empty params work
+    %raw(`"null"`)
+  } else {
+    params
+  }
+
+  {
+    chainId,
+    eventId,
+    eventName: eventConfig.name,
+    contractName: eventConfig.contractName,
+    blockNumber,
+    logIndex,
+    srcAddress,
+    blockHash: block->config.ecosystem.getId,
+    blockTimestamp,
+    blockFields,
+    transactionFields,
+    params,
+  }
+}
+
 let rec writeBatch = async (
   sql,
   ~batch: Batch.t,
-  ~rawEvents,
   ~pgSchema,
   ~rollback: option<Persistence.rollback>,
   ~isInReorgThreshold,
@@ -732,6 +799,17 @@ let rec writeBatch = async (
     let shouldSaveHistory = config->Config.shouldSaveHistory(~isInReorgThreshold)
 
     let specificError = ref(None)
+
+    let rawEvents = if config.enableRawEvents {
+      batch.items->Belt.Array.keepMap(item =>
+        switch item {
+        | Internal.Event(_) => Some(item->Internal.castUnsafeEventItem->makeRawEvent(~config))
+        | Internal.Block(_) => None
+        }
+      )
+    } else {
+      []
+    }
 
     let setRawEvents = executeSet(
       _,
@@ -1047,7 +1125,6 @@ let rec writeBatch = async (
     await writeBatch(
       sql,
       ~escapeTables,
-      ~rawEvents,
       ~batch,
       ~pgSchema,
       ~rollback,
@@ -1643,7 +1720,6 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
 
   let writeBatchMethod = async (
     ~batch,
-    ~rawEvents,
     ~rollback,
     ~isInReorgThreshold,
     ~config,
@@ -1689,7 +1765,6 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
     await writeBatch(
       sql,
       ~batch,
-      ~rawEvents,
       ~pgSchema,
       ~rollback,
       ~isInReorgThreshold,

--- a/packages/envio/src/TestIndexerProxyStorage.res
+++ b/packages/envio/src/TestIndexerProxyStorage.res
@@ -131,7 +131,6 @@ let makeStorage = (proxy: t): Persistence.storage => {
   },
   writeBatch: async (
     ~batch,
-    ~rawEvents as _,
     ~rollback as _,
     ~isInReorgThreshold as _,
     ~config as _,

--- a/scenarios/e2e_test/config.yaml
+++ b/scenarios/e2e_test/config.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=../../packages/envio/evm.schema.json
 name: e2e_test
 description: E2E test indexer
+raw_events: true
 storage:
   postgres: true
   clickhouse: true

--- a/scenarios/test_codegen/test/ChainMeta_test.res
+++ b/scenarios/test_codegen/test/ChainMeta_test.res
@@ -37,7 +37,6 @@ let makeStore = () => {
     },
     writeBatch: (
       ~batch as _,
-      ~rawEvents as _,
       ~rollback as _,
       ~isInReorgThreshold as _,
       ~config as _,

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -217,7 +217,6 @@ module Storage = {
           JsError.throwWithMessage("Not implemented"),
         writeBatch: (
           ~batch as _,
-          ~rawEvents as _,
           ~rollback as _,
           ~isInReorgThreshold as _,
           ~config as _,

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -1002,3 +1002,51 @@ describe("PgStorage.makeStorageFromEnv ClickHouse env var validation", () => {
     },
   )
 })
+
+describe("PgStorage.makeRawEvent", () => {
+  Async.it(
+    "Derives a raw event row from a batch item, copying block hash before cleanup and stringifying bigint block fields",
+    async t => {
+      let srcAddress = "0x00000000000000000000000000000000000000ab"->(Utils.magic: string => Address.t)
+      let blockNumber = 5
+      let logIndex = 3
+
+      let event =
+        {
+          "block": %raw(`{"number": 5, "timestamp": 9999, "hash": "0xblockhash", "gasUsed": 99n, "miner": "0xminer"}`),
+          "transaction": %raw(`{"hash": "0xtxhash", "transactionIndex": 2}`),
+          "params": (),
+          "logIndex": logIndex,
+          "srcAddress": srcAddress,
+          "chainId": 137,
+          "contractName": "ERC20",
+          "eventName": "EventWithoutFields",
+        }->(Utils.magic: _ => Internal.event)
+
+      let eventItem =
+        Internal.Event({
+          eventConfig: (MockIndexer.evmEventConfig(~contractName="ERC20") :> Internal.eventConfig),
+          timestamp: 1234,
+          chain: ChainMap.Chain.makeUnsafe(~chainId=137),
+          blockNumber,
+          logIndex,
+          event,
+        })->Internal.castUnsafeEventItem
+
+      t.expect(eventItem->PgStorage.makeRawEvent(~config=MockIndexer.config)).toEqual({
+        chainId: 137,
+        eventId: EventUtils.packEventIndex(~logIndex, ~blockNumber),
+        eventName: "EventWithoutFields",
+        contractName: "ERC20",
+        blockNumber,
+        logIndex,
+        srcAddress,
+        blockHash: "0xblockhash",
+        blockTimestamp: 1234,
+        blockFields: %raw(`{"gasUsed": "99", "miner": "0xminer"}`),
+        transactionFields: %raw(`{"hash": "0xtxhash", "transactionIndex": 2}`),
+        params: %raw(`"null"`),
+      })
+    },
+  )
+})

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -1050,3 +1050,46 @@ describe("PgStorage.makeRawEvent", () => {
     },
   )
 })
+
+describe("PgStorage.removeInvalidUtf8InPlace", () => {
+  Async.it(
+    "Strips NUL bytes from raw event rows, including deep inside jsonb params and field selections",
+    async t => {
+      let rawEvent: InternalTable.RawEvents.t = {
+        chainId: 1,
+        eventId: 42n,
+        eventName: "Name\x00Changed",
+        contractName: "Resolver",
+        blockNumber: 5,
+        logIndex: 3,
+        srcAddress: "0x00000000000000000000000000000000000000ab"->(
+          Utils.magic: string => Address.t
+        ),
+        blockHash: "0xhash",
+        blockTimestamp: 100,
+        blockFields: %raw(`{"extraData": "0x00\x00ff"}`),
+        transactionFields: %raw(`{"hash": "0xtx"}`),
+        params: %raw(`{"node": "0xnode", "name": "Muscle-window.eth\x00tail", "labels": ["a\x00b", "c"]}`),
+      }
+
+      [rawEvent]->PgStorage.removeInvalidUtf8InPlace
+
+      t.expect(rawEvent).toEqual({
+        chainId: 1,
+        eventId: 42n,
+        eventName: "NameChanged",
+        contractName: "Resolver",
+        blockNumber: 5,
+        logIndex: 3,
+        srcAddress: "0x00000000000000000000000000000000000000ab"->(
+          Utils.magic: string => Address.t
+        ),
+        blockHash: "0xhash",
+        blockTimestamp: 100,
+        blockFields: %raw(`{"extraData": "0x00ff"}`),
+        transactionFields: %raw(`{"hash": "0xtx"}`),
+        params: %raw(`{"node": "0xnode", "name": "Muscle-window.ethtail", "labels": ["ab", "c"]}`),
+      })
+    },
+  )
+})


### PR DESCRIPTION
## Summary

Moves raw event creation from the event processing phase to the batch write phase, enabling lazy deep NUL byte stripping on first encoding failure. This defers per-item sanitization to the error path, keeping the happy path free of unnecessary processing.

## Key Changes

- **Raw event creation moved to `PgStorage`**: Extracted `makeRawEvent` function from `EventProcessing` to `PgStorage` where it's now called during batch write, not during event processing. This allows raw events to be created only when needed and to be sanitized together with entities on encoding errors.

- **Deep NUL stripping**: Replaced shallow `removeInvalidUtf8InPlace` with recursive `removeInvalidUtf8DeepInPlace` that strips NUL bytes from nested objects and arrays (e.g., inside jsonb params and field selections), not just top-level strings.

- **Unified error classification**: Extracted `classifyWriteError` function to handle both entity and raw event write failures consistently. Both Postgres encoding errors (0x00 in text, 22P05 in jsonb) now trigger `PgEncodingError` with the failing table, enabling escape-and-retry.

- **Lazy sanitization**: Raw events are only sanitized when `escapeTables` includes `RawEvents.table`, avoiding per-item processing in the happy path.

- **Removed `rawEvents` parameter**: Eliminated the `rawEvents` parameter from `writeBatch` and `writeBatchMethod` signatures since raw events are now derived from batch items internally.

- **Removed `InMemoryStore.rawEvents`**: Eliminated the in-memory accumulation of raw events during processing, reducing memory overhead.

- **Updated test coverage**: Added tests for `makeRawEvent` (verifying block hash copying and bigint stringification) and `removeInvalidUtf8InPlace` (verifying deep NUL stripping in nested structures).

## Implementation Details

- `makeRawEvent` mirrors the logic previously in `addItemToRawEvents`, converting block/transaction fields to JSON and handling null params.
- `removeInvalidUtf8DeepInPlace` recursively processes unknown values, handling strings, objects, and arrays while preserving non-object types.
- Error handling in `setRawEvents` now uses `classifyWriteError` to park encoding errors in `specificError`, allowing the transaction to unwind and retry with sanitized data.
- E2E test config enables `raw_events: true` and includes a spot-check query verifying raw event data matches decoded event values.

https://claude.ai/code/session_017ZnBvHguUrnVsqzrQeAQFM