### PR TITLE
Auto-paginate sparse query results and preserve field name casing

### DIFF
--- a/packages/cli/src/data/field_selection.rs
+++ b/packages/cli/src/data/field_selection.rs
@@ -14,6 +14,9 @@ pub struct Selection {
 pub struct Column {
     pub section: Section,
     pub field: TypedField,
+    /// The field name exactly as the user typed it, used verbatim in the TOON
+    /// header so the output mirrors the request (e.g. `block.NUMBER` → `NUMBER`).
+    pub display_name: String,
 }
 
 impl Selection {
@@ -51,7 +54,11 @@ impl Selection {
                 anyhow!("Unknown field `{raw}`. Valid `{section_raw}.*` fields: {valid}.")
             })?;
 
-            sel.columns.push(Column { section, field });
+            sel.columns.push(Column {
+                section,
+                field,
+                display_name: field_raw.to_string(),
+            });
         }
 
         Ok(sel)

--- a/packages/cli/src/data/toon.rs
+++ b/packages/cli/src/data/toon.rs
@@ -44,11 +44,20 @@ fn escape_cell(s: &str) -> String {
     format!("\"{escaped}\"")
 }
 
-pub fn render_arrow_response(
+/// A section's rendered rows, kept separate from the final TOON string so pages
+/// can be accumulated before rendering a single table per section.
+pub struct SectionTable {
+    pub section: Section,
+    pub plural: &'static str,
+    pub col_names: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+pub fn collect_sections(
     selection: &Selection,
     response: &ArrowResponse,
     masks: &Masks,
-) -> String {
+) -> Vec<SectionTable> {
     let mut section_order: Vec<Section> = Vec::new();
     for col in &selection.columns {
         if !section_order.contains(&col.section) {
@@ -56,14 +65,14 @@ pub fn render_arrow_response(
         }
     }
 
-    let mut out = String::new();
+    let mut tables = Vec::new();
     for section in &section_order {
         let cols: Vec<&Column> = selection
             .columns
             .iter()
             .filter(|c| c.section == *section)
             .collect();
-        let col_names: Vec<String> = cols.iter().map(|c| c.field.camel_name()).collect();
+        let col_names: Vec<String> = cols.iter().map(|c| c.display_name.clone()).collect();
         let (plural, batches, mask) = match section {
             Section::Block => ("blocks", &response.data.blocks, masks.block.as_deref()),
             Section::Transaction => (
@@ -77,9 +86,31 @@ pub fn render_arrow_response(
         let column_keys: Vec<String> = cols.iter().map(|c| c.field.column_name()).collect();
         let column_kinds: Vec<ValueKind> = cols.iter().map(|c| c.field.spec().value_kind).collect();
         let rows = extract_rows(batches, &column_keys, &column_kinds, mask);
-        out.push_str(&render_table(plural, &col_names, &rows));
+        tables.push(SectionTable {
+            section: *section,
+            plural,
+            col_names,
+            rows,
+        });
+    }
+    tables
+}
+
+pub fn render_sections(tables: &[SectionTable]) -> String {
+    let mut out = String::new();
+    for table in tables {
+        out.push_str(&render_table(table.plural, &table.col_names, &table.rows));
     }
     out
+}
+
+#[cfg(test)]
+pub fn render_arrow_response(
+    selection: &Selection,
+    response: &ArrowResponse,
+    masks: &Masks,
+) -> String {
+    render_sections(&collect_sections(selection, response, masks))
 }
 
 fn extract_rows(
@@ -161,6 +192,43 @@ mod tests {
     fn quotes_cells_with_commas() {
         let s = render_table("t", &["a"], &[vec!["x,y".into()]]);
         assert_eq!(s, "t[1]{a}:\n  \"x,y\"\n");
+    }
+
+    #[test]
+    fn header_uses_field_name_as_typed() {
+        use super::super::client_filter::Masks;
+        use super::super::field_selection::Selection;
+        use arrow::array::UInt64Array;
+        use arrow::datatypes::{Field, Schema};
+        use hypersync_client::{ArrowResponse, ArrowResponseData};
+        use std::sync::Arc;
+
+        let selection = Selection::parse(&["block.hash".into(), "block.NUMBER".into()]).unwrap();
+        let schema = Schema::new(vec![
+            Field::new("hash", DataType::Binary, false),
+            Field::new("number", DataType::UInt64, false),
+        ]);
+        let blocks = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(arrow::array::BinaryArray::from(vec![[0xaa].as_slice()])),
+                Arc::new(UInt64Array::from(vec![100u64])),
+            ],
+        )
+        .unwrap();
+        let response = ArrowResponse {
+            archive_height: Some(100),
+            next_block: 100,
+            total_execution_time: 0,
+            data: ArrowResponseData {
+                blocks: vec![blocks],
+                ..Default::default()
+            },
+            rollback_guard: None,
+        };
+
+        let out = render_arrow_response(&selection, &response, &Masks::default());
+        assert_eq!(out, "blocks[1]{hash,NUMBER}:\n  0xaa,100\n");
     }
 
     #[test]

--- a/packages/cli/src/executor/data.rs
+++ b/packages/cli/src/executor/data.rs
@@ -18,12 +18,16 @@ enum PaginationState {
     MorePages,
 }
 
+/// Below this many rows a single page is too sparse to bother the user with a
+/// manual next-page command, so we fetch the following pages automatically.
+const AUTO_PAGINATE_MIN_ROWS: usize = 100;
+
 pub async fn run(args: DataArgs) -> Result<()> {
     let token = resolve_api_token().ok_or_else(missing_token_error)?;
 
     let chain = chain::resolve(&args.chain)?;
     let selection = Selection::parse(&args.fields)?;
-    let filter = WhereFilter::parse(args.where_filter.as_deref())?;
+    let mut filter = WhereFilter::parse(args.where_filter.as_deref())?;
     let client = build_client(&chain, &token)?;
 
     if selection.known_height
@@ -46,32 +50,47 @@ pub async fn run(args: DataArgs) -> Result<()> {
         bail!("No data fields requested. Pass at least one positional field.");
     }
 
-    let field_selection = selection.build_net_field_selection_with(&filter.client_filter_fields());
-    let query = filter.build_net_query(field_selection)?;
-    let response = client
-        .get_arrow(&query)
-        .await
-        .context("Failed querying blockchain data")?;
+    let extra_fields = filter.client_filter_fields();
+    let mut tables: Vec<toon::SectionTable> = Vec::new();
+    let mut total_rows = 0usize;
 
-    let masks = client_filter::compute_masks(&response, &filter.client_filters)?;
-    let mut out = toon::render_arrow_response(&selection, &response, &masks);
+    let (state, archive_height, next_block) = loop {
+        let field_selection = selection.build_net_field_selection_with(&extra_fields);
+        let query = filter.build_net_query(field_selection)?;
+        let response = client
+            .get_arrow(&query)
+            .await
+            .context("Failed querying blockchain data")?;
 
-    let archive_height = response.archive_height.unwrap_or(0);
+        let masks = client_filter::compute_masks(&response, &filter.client_filters)?;
+        for table in toon::collect_sections(&selection, &response, &masks) {
+            total_rows += table.rows.len();
+            merge_table(&mut tables, table);
+        }
 
+        let archive_height = response.archive_height.unwrap_or(0);
+        let next_block = response.next_block;
+
+        let state = if matches!(filter.to_block_exclusive, Some(end) if next_block >= end) {
+            PaginationState::RangeDone
+        } else if next_block >= archive_height {
+            PaginationState::ReachedHead
+        } else {
+            PaginationState::MorePages
+        };
+
+        if matches!(state, PaginationState::MorePages) && total_rows < AUTO_PAGINATE_MIN_ROWS {
+            filter.from_block = Some(next_block);
+            continue;
+        }
+        break (state, archive_height, next_block);
+    };
+
+    let mut out = toon::render_sections(&tables);
     if selection.known_height {
         out.push_str(&toon::render_height(archive_height));
     }
-
     print!("{out}");
-
-    let next_block = response.next_block;
-    let state = if matches!(filter.to_block_exclusive, Some(end) if next_block >= end) {
-        PaginationState::RangeDone
-    } else if next_block >= archive_height {
-        PaginationState::ReachedHead
-    } else {
-        PaginationState::MorePages
-    };
 
     match state {
         PaginationState::RangeDone => {}
@@ -94,6 +113,13 @@ pub async fn run(args: DataArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn merge_table(tables: &mut Vec<toon::SectionTable>, table: toon::SectionTable) {
+    match tables.iter_mut().find(|t| t.section == table.section) {
+        Some(existing) => existing.rows.extend(table.rows),
+        None => tables.push(table),
+    }
 }
 
 fn print_next_command(args: &DataArgs, chain: &Chain, filter: &WhereFilter, next_block: u64) {
@@ -127,21 +153,27 @@ fn render_where_hint(filter: &WhereFilter, next_block: u64) -> String {
     let mut transaction: Vec<String> = Vec::new();
     let mut log: Vec<String> = Vec::new();
 
-    let mut range = format!("number: {{ _gte: {next_block}");
-    if let Some(end_excl) = filter.to_block_exclusive {
-        let lte = end_excl.saturating_sub(1);
-        range.push_str(&format!(", _lte: {lte}"));
-    }
     // A `block.number` set scans [min, max] and drops the rest client-side, so
-    // carry the set forward to keep filtering the same blocks across pages.
+    // the next page only needs the values not yet covered by this response.
     if let Some(set) = block_number_set(filter) {
-        range.push_str(&format!(
-            ", _in: {}",
-            json_string(&Value::Array(set.to_vec()))
+        let remaining: Vec<Value> = set
+            .iter()
+            .filter(|v| value_as_u64(v).is_none_or(|n| n >= next_block))
+            .cloned()
+            .collect();
+        block.push(format!(
+            "number: {{ _in: {} }}",
+            json_string(&Value::Array(remaining))
         ));
+    } else {
+        let mut range = format!("number: {{ _gte: {next_block}");
+        if let Some(end_excl) = filter.to_block_exclusive {
+            let lte = end_excl.saturating_sub(1);
+            range.push_str(&format!(", _lte: {lte}"));
+        }
+        range.push_str(" }");
+        block.push(range);
     }
-    range.push_str(" }");
-    block.push(range);
 
     for f in &filter.server_filters {
         let entry = render_server_field(f);
@@ -220,6 +252,14 @@ fn json_string(v: &Value) -> String {
     serde_json::to_string(v).unwrap_or_else(|_| "<unprintable>".into())
 }
 
+fn value_as_u64(v: &Value) -> Option<u64> {
+    match v {
+        Value::Number(n) => n.as_u64(),
+        Value::String(s) => s.trim().parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
 fn resolve_api_token() -> Option<String> {
     let from_env = std::env::var("ENVIO_API_TOKEN").ok();
     let from_dotenv = || {
@@ -262,14 +302,11 @@ mod tests {
     }
 
     #[test]
-    fn hint_folds_block_number_set_into_range() {
+    fn hint_carries_only_unfetched_block_number_set() {
         let filter =
             WhereFilter::parse(Some("{ block: { number: { _in: [100, 50, 200] } } }")).unwrap();
         let hint = render_where_hint(&filter, 120);
-        assert_eq!(
-            hint,
-            "{ block: { number: { _gte: 120, _lte: 200, _in: [100,50,200] } } }",
-        );
+        assert_eq!(hint, "{ block: { number: { _in: [200] } } }");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Implements automatic pagination for sparse query results and preserves the exact casing of field names as typed by the user in output headers.

## Key Changes

- **Auto-pagination**: When a query returns fewer than 100 rows and more pages are available, automatically fetch subsequent pages without prompting the user. This improves UX for sparse datasets by presenting complete results in a single output.

- **Field name casing preservation**: Output headers now display field names exactly as the user typed them (e.g., `block.NUMBER` renders as `NUMBER` in the header), rather than normalizing to camelCase. This is tracked via a new `display_name` field in the `Column` struct.

- **Pagination state refactoring**: Moved pagination logic into a loop that accumulates results across multiple queries. Results are collected into `SectionTable` structures that are merged by section before final rendering, enabling multi-page result aggregation.

- **Block number set filtering**: When a block number set filter (`_in`) is present, the next page query now only includes block numbers not yet fetched, rather than repeating the entire set. This reduces redundant filtering and improves query efficiency.

- **Helper functions**: Added `merge_table()` to combine rows from the same section across pages, and `value_as_u64()` to parse block numbers from JSON values for filtering logic.

## Implementation Details

The core change separates data collection from rendering: `collect_sections()` now returns structured `SectionTable` objects instead of directly producing formatted output, allowing the pagination loop to accumulate results before calling `render_sections()` for final formatting. The `render_where_hint()` function was updated to intelligently handle block number sets by filtering out already-fetched blocks rather than blindly repeating the full set.

https://claude.ai/code/session_01WCbaRFCvUSbfMo6QJTFgiQ