### PR TITLE
Add `envio metrics runtime` subcommand

### DIFF
--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -377,7 +377,11 @@ Start the indexer. Runs codegen automatically before launching so the on-disk ty
 
 Fetch raw Prometheus metrics from the running indexer's /metrics endpoint
 
-**Usage:** `envio metrics`
+**Usage:** `envio metrics [OPTIONS]`
+
+###### **Options:**
+
+* `--runtime` — Fetch runtime metrics from the /metrics/runtime endpoint instead of /metrics
 
 
 

--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -29,6 +29,7 @@ This document contains the help content for the `envio` command-line program.
 * [`envio local db-migrate setup`↴](#envio-local-db-migrate-setup)
 * [`envio start`↴](#envio-start)
 * [`envio metrics`↴](#envio-metrics)
+* [`envio metrics runtime`↴](#envio-metrics-runtime)
 * [`envio skills`↴](#envio-skills)
 * [`envio skills update`↴](#envio-skills-update)
 * [`envio tools`↴](#envio-tools)
@@ -377,11 +378,19 @@ Start the indexer. Runs codegen automatically before launching so the on-disk ty
 
 Fetch raw Prometheus metrics from the running indexer's /metrics endpoint
 
-**Usage:** `envio metrics [OPTIONS]`
+**Usage:** `envio metrics [COMMAND]`
 
-###### **Options:**
+###### **Subcommands:**
 
-* `--runtime` — Fetch runtime metrics from the /metrics/runtime endpoint instead of /metrics
+* `runtime` — Fetch runtime metrics from the running indexer's /metrics/runtime endpoint
+
+
+
+## `envio metrics runtime`
+
+Fetch runtime metrics from the running indexer's /metrics/runtime endpoint
+
+**Usage:** `envio metrics runtime`
 
 
 

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -59,7 +59,7 @@ pub enum CommandType {
     Start(StartArgs),
 
     ///Fetch raw Prometheus metrics from the running indexer's /metrics endpoint
-    Metrics,
+    Metrics(MetricsArgs),
 
     ///Manage Envio-provided Claude Code skills under `.claude/skills/`
     #[command(subcommand)]
@@ -142,6 +142,13 @@ pub struct StartArgs {
     ///Clear your database and restart indexing from scratch
     #[arg(short = 'r', long, action)]
     pub restart: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct MetricsArgs {
+    ///Fetch runtime metrics from the /metrics/runtime endpoint instead of /metrics
+    #[arg(long, action)]
+    pub runtime: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -146,9 +146,14 @@ pub struct StartArgs {
 
 #[derive(Debug, Args)]
 pub struct MetricsArgs {
-    ///Fetch runtime metrics from the /metrics/runtime endpoint instead of /metrics
-    #[arg(long, action)]
-    pub runtime: bool,
+    #[command(subcommand)]
+    pub subcommand: Option<MetricsSubcommand>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum MetricsSubcommand {
+    ///Fetch runtime metrics from the running indexer's /metrics/runtime endpoint
+    Runtime,
 }
 
 #[derive(Debug, Subcommand)]

--- a/packages/cli/src/executor/metrics.rs
+++ b/packages/cli/src/executor/metrics.rs
@@ -13,9 +13,14 @@ fn resolve_port() -> Result<u16> {
     }
 }
 
-pub async fn run() -> Result<()> {
+pub async fn run(runtime: bool) -> Result<()> {
     let port = resolve_port()?;
-    let url = format!("http://127.0.0.1:{port}/metrics");
+    let path = if runtime {
+        "/metrics/runtime"
+    } else {
+        "/metrics"
+    };
+    let url = format!("http://127.0.0.1:{port}{path}");
 
     let client = reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)

--- a/packages/cli/src/executor/mod.rs
+++ b/packages/cli/src/executor/mod.rs
@@ -82,8 +82,8 @@ pub async fn execute(
             Ok(None)
         }
 
-        CommandType::Metrics => {
-            metrics::run().await?;
+        CommandType::Metrics(metrics_args) => {
+            metrics::run(metrics_args.runtime).await?;
             Ok(None)
         }
 

--- a/packages/cli/src/executor/mod.rs
+++ b/packages/cli/src/executor/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    clap_definitions::{ConfigSubcommand, JsonSchema, Script, SkillsSubcommand},
+    clap_definitions::{ConfigSubcommand, JsonSchema, MetricsSubcommand, Script, SkillsSubcommand},
     cli_args::clap_definitions::{CommandLineArgs, CommandType},
     commands,
     config_parsing::{human_config, system_config::SystemConfig},
@@ -83,7 +83,8 @@ pub async fn execute(
         }
 
         CommandType::Metrics(metrics_args) => {
-            metrics::run(metrics_args.runtime).await?;
+            let runtime = matches!(metrics_args.subcommand, Some(MetricsSubcommand::Runtime));
+            metrics::run(runtime).await?;
             Ok(None)
         }
 


### PR DESCRIPTION
## Summary
Adds a new `envio metrics runtime` subcommand to fetch runtime-specific metrics from the indexer's `/metrics/runtime` endpoint, while maintaining backward compatibility with the existing `envio metrics` command that fetches from `/metrics`.

## Changes
- **CLI argument definitions**: Converted `Metrics` command from a simple unit variant to `Metrics(MetricsArgs)` that accepts an optional subcommand
- **Metrics subcommand**: Added `MetricsSubcommand` enum with `Runtime` variant to support the new `runtime` subcommand
- **Metrics executor**: Updated `run()` function to accept a `runtime` boolean parameter that determines which endpoint to query (`/metrics/runtime` vs `/metrics`)
- **Command executor**: Modified metrics command handler to extract the subcommand and pass the runtime flag to the executor
- **Documentation**: Updated `CommandLineHelp.md` to reflect the new subcommand structure and usage

## Implementation Details
- The `runtime` flag is determined by checking if the subcommand matches `MetricsSubcommand::Runtime`
- The endpoint path is conditionally set based on the flag, maintaining a single code path for the HTTP request logic
- The change is backward compatible: calling `envio metrics` without a subcommand still works and queries the default `/metrics` endpoint

https://claude.ai/code/session_01FruGiMDrPPWC2wL3KjxFb4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `envio metrics runtime` subcommand to retrieve and display runtime-specific metrics from a dedicated endpoint.
  * Restructured metrics command to support subcommands, enabling organized access to different types of metrics data.

* **Documentation**
  * Updated CLI help documentation to reflect new `envio metrics runtime` subcommand and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->