### PR TITLE
Add internal onRollbackCommit callback API for rollback events

### DIFF
--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -1201,6 +1201,18 @@ export type IndexerFromConfig<Config extends IndexerConfigTypes = GlobalConfig> 
     readonly name: string;
     /** The indexer description from config.yaml. */
     readonly description: string | undefined;
+    /**
+     * Internal, unstable API that will be removed without notice. Registers a
+     * callback fired once per chain affected by a reorg rollback, after the
+     * rollback is durably written to the database. A throwing callback crashes
+     * the indexer through the same path as a failed write.
+     */
+    readonly "~internalAndWillBeRemovedSoon_onRollbackCommit": (
+      callback: (args: {
+        readonly chainId: number;
+        readonly rollbackToBlock: number;
+      }) => Promise<void>,
+    ) => void;
   } & SingleEcosystemChains<Config>
 >;
 

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -1155,12 +1155,11 @@ let injectedTaskReducer = (
         // computing the rollback diff against it.
         await state.ctx.inMemoryStore->InMemoryStore.flush
 
-        RollbackCommit.setPending(newProgressBlockNumberPerChain)
-
         let diff = await state.ctx.inMemoryStore->InMemoryStore.prepareRollbackDiff(
           ~persistence=state.ctx.persistence,
           ~rollbackTargetCheckpointId,
           ~rollbackDiffCheckpointId=state.ctx.inMemoryStore.committedCheckpointId->BigInt.add(1n),
+          ~progressBlockNumberByChainId=newProgressBlockNumberPerChain,
         )
 
         let chainManager = {

--- a/packages/envio/src/GlobalState.res
+++ b/packages/envio/src/GlobalState.res
@@ -1155,6 +1155,8 @@ let injectedTaskReducer = (
         // computing the rollback diff against it.
         await state.ctx.inMemoryStore->InMemoryStore.flush
 
+        RollbackCommit.setPending(newProgressBlockNumberPerChain)
+
         let diff = await state.ctx.inMemoryStore->InMemoryStore.prepareRollbackDiff(
           ~persistence=state.ctx.persistence,
           ~rollbackTargetCheckpointId,

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -359,6 +359,11 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
     )
 
     inMemoryStore.committedCheckpointId = upToCheckpointId
+
+    switch rollback {
+    | Some(_) => await RollbackCommit.fire()
+    | None => ()
+    }
   }
 }
 

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -361,8 +361,9 @@ let runOneWrite = async (inMemoryStore: t, ~persistence: Persistence.t, ~config)
     inMemoryStore.committedCheckpointId = upToCheckpointId
 
     switch rollback {
-    | Some(_) => await RollbackCommit.fire()
-    | None => ()
+    | Some({progressBlockNumberByChainId}) if RollbackCommit.callbacks->Utils.Array.notEmpty =>
+      await RollbackCommit.fire(~progressBlockNumberByChainId)
+    | _ => ()
     }
   }
 }
@@ -499,12 +500,14 @@ let prepareRollbackDiff = async (
   ~persistence: Persistence.t,
   ~rollbackTargetCheckpointId,
   ~rollbackDiffCheckpointId,
+  ~progressBlockNumberByChainId,
 ) => {
   inMemoryStore.entities = EntityTables.make(inMemoryStore.allEntities)
   inMemoryStore.effects = Dict.make()
   inMemoryStore.rollback = Some({
     targetCheckpointId: rollbackTargetCheckpointId,
     diffCheckpointId: rollbackDiffCheckpointId,
+    progressBlockNumberByChainId,
   })
 
   let deletedEntities = Dict.make()

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -312,6 +312,13 @@ let getGlobalIndexer = (): 'indexer => {
     )
   }
 
+  let onRollbackCommitFn = (callback: 'a) => {
+    HandlerRegister.throwIfFinishedRegistration(
+      ~methodName="~internalAndWillBeRemovedSoon_onRollbackCommit",
+    )
+    let _ = RollbackCommit.register(callback->(Utils.magic: 'a => RollbackCommit.callback))
+  }
+
   // Two-stage parse: first the ecosystem-specific outer schema unwraps the
   // wrapper (`block.number` / `block.height` / `slot`) and surfaces the
   // inner chunk as raw `unknown`; then the shared `blockRangeSchema`
@@ -453,8 +460,16 @@ let getGlobalIndexer = (): 'indexer => {
             "onEvent",
             "contractRegister",
             "onBlock",
+            "~internalAndWillBeRemovedSoon_onRollbackCommit",
           ]
-        | Svm => ["name", "description", "chainIds", "chains", "onSlot"]
+        | Svm => [
+            "name",
+            "description",
+            "chainIds",
+            "chains",
+            "onSlot",
+            "~internalAndWillBeRemovedSoon_onRollbackCommit",
+          ]
         }
         keysMemo := Some(keys)
         keys
@@ -477,6 +492,7 @@ let getGlobalIndexer = (): 'indexer => {
     | "onEvent" => onEventFn->Utils.magic
     | "contractRegister" => contractRegisterFn->Utils.magic
     | "onBlock" | "onSlot" => onBlockFn->Utils.magic
+    | "~internalAndWillBeRemovedSoon_onRollbackCommit" => onRollbackCommitFn->Utils.magic
     | _ =>
       JsError.throwWithMessage(
         `Field \`${prop}\` does not exist on \`indexer\`. Available fields: ${getKeys()->Array.join(

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -51,6 +51,9 @@ type updatedEffectCache = {
 type rollback = {
   targetCheckpointId: Internal.checkpointId,
   diffCheckpointId: Internal.checkpointId,
+  // Last valid block per chain affected by the rollback. Read by
+  // `RollbackCommit.fire` once the diff is durably written.
+  progressBlockNumberByChainId: dict<int>,
 }
 
 type updatedEntity = {

--- a/packages/envio/src/RollbackCommit.res
+++ b/packages/envio/src/RollbackCommit.res
@@ -1,16 +1,12 @@
 // Temporary, internal-only support for the unstable
 // `indexer.~internalAndWillBeRemovedSoon_onRollbackCommit` API. The whole
-// feature lives here plus three call sites: registration in `Main.res`, the
-// per-chain block snapshot in `GlobalState.res`, and the fire on a successful
-// rollback write in `InMemoryStore.res`. Delete those together with this module.
+// feature lives here plus two call sites: registration in `Main.res` and the
+// fire on a successful rollback write in `InMemoryStore.res`. Delete those
+// together with this module.
 type args = {chainId: int, rollbackToBlock: int}
 type callback = args => promise<unit>
 
 let callbacks: array<callback> = []
-
-// Last valid block per chain affected by the pending rollback. Set when the
-// rollback diff is staged, read by the write that flushes it.
-let pendingProgressBlockNumberByChainId: ref<dict<int>> = ref(Dict.make())
 
 let register = (callback: callback) => {
   callbacks->Array.push(callback)
@@ -21,14 +17,12 @@ let register = (callback: callback) => {
     }
 }
 
-let setPending = (progressBlockNumberByChainId: dict<int>) => {
-  pendingProgressBlockNumberByChainId := progressBlockNumberByChainId
-}
-
-// Fired after a rollback diff is durably written. A throwing callback bubbles to
-// the write loop's onError, crashing the indexer like a failed write.
-let fire = async () => {
-  let _ = await pendingProgressBlockNumberByChainId.contents
+// Fired after a rollback diff is durably written, once per affected chain.
+// `progressBlockNumberByChainId` is the last valid block per chain, taken from
+// the in-memory store's rollback object. A throwing callback bubbles to the
+// write loop's onError, crashing the indexer like a failed write.
+let fire = async (~progressBlockNumberByChainId: dict<int>) => {
+  let _ = await progressBlockNumberByChainId
   ->Dict.toArray
   ->Array.flatMap(((chainIdKey, rollbackToBlock)) => {
     let args = {chainId: chainIdKey->Int.fromString->Option.getUnsafe, rollbackToBlock}

--- a/packages/envio/src/RollbackCommit.res
+++ b/packages/envio/src/RollbackCommit.res
@@ -1,0 +1,38 @@
+// Temporary, internal-only support for the unstable
+// `indexer.~internalAndWillBeRemovedSoon_onRollbackCommit` API. The whole
+// feature lives here plus three call sites: registration in `Main.res`, the
+// per-chain block snapshot in `GlobalState.res`, and the fire on a successful
+// rollback write in `InMemoryStore.res`. Delete those together with this module.
+type args = {chainId: int, rollbackToBlock: int}
+type callback = args => promise<unit>
+
+let callbacks: array<callback> = []
+
+// Last valid block per chain affected by the pending rollback. Set when the
+// rollback diff is staged, read by the write that flushes it.
+let pendingProgressBlockNumberByChainId: ref<dict<int>> = ref(Dict.make())
+
+let register = (callback: callback) => {
+  callbacks->Array.push(callback)
+  () =>
+    switch callbacks->Array.indexOf(callback) {
+    | -1 => ()
+    | index => callbacks->Array.splice(~start=index, ~remove=1, ~insert=[])
+    }
+}
+
+let setPending = (progressBlockNumberByChainId: dict<int>) => {
+  pendingProgressBlockNumberByChainId := progressBlockNumberByChainId
+}
+
+// Fired after a rollback diff is durably written. A throwing callback bubbles to
+// the write loop's onError, crashing the indexer like a failed write.
+let fire = async () => {
+  let _ = await pendingProgressBlockNumberByChainId.contents
+  ->Dict.toArray
+  ->Array.flatMap(((chainIdKey, rollbackToBlock)) => {
+    let args = {chainId: chainIdKey->Int.fromString->Option.getUnsafe, rollbackToBlock}
+    callbacks->Array.map(callback => callback(args))
+  })
+  ->Promise.all
+}

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -424,6 +424,35 @@ describe("E2E rollback tests", () => {
     await testSingleChainRollback(~t, ~sourceMock, ~indexerMock)
   })
 
+  Async.it("Fires onRollbackCommit per affected chain after the rollback write", async t => {
+    let sourceMock = MockIndexer.Source.make(
+      [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+      ~chain=#1337,
+    )
+    let rollbackCommitCalls = []
+    let unregister = RollbackCommit.register(async (args: RollbackCommit.args) => {
+      rollbackCommitCalls->Array.push(args)
+    })
+    let indexerMock = await MockIndexer.Indexer.make(
+      ~chains=[
+        {
+          chain: #1337,
+          sourceConfig: Config.CustomSources([sourceMock.source]),
+        },
+      ],
+    )
+    await Utils.delay(0)
+
+    await MockIndexer.Helper.initialEnterReorgThreshold(~t, ~indexerMock, ~sourceMock)
+    await testSingleChainRollback(~t, ~sourceMock, ~indexerMock)
+    unregister()
+
+    t.expect(
+      rollbackCommitCalls,
+      ~message="Should fire once for the reorged chain with the last valid block",
+    ).toEqual([{RollbackCommit.chainId: 1337, rollbackToBlock: 100}])
+  })
+
   Async.it(
     "Stores checkpoints inside of the reorg threshold for batches without items",
     async t => {


### PR DESCRIPTION
## Summary

Adds an internal, unstable `~internalAndWillBeRemovedSoon_onRollbackCommit` API that allows indexers to register callbacks fired once per chain affected by a reorg rollback, after the rollback is durably written to the database.

## Key Changes

- **New `RollbackCommit` module** (`packages/envio/src/RollbackCommit.res`): Manages callback registration and firing for rollback commit events. Callbacks receive the chain ID and the last valid block number for that chain.

- **Integration in `InMemoryStore`**: After a rollback diff is durably written, `RollbackCommit.fire` is invoked with the progress block numbers per chain. Throwing callbacks bubble to the write loop's error handler, crashing the indexer like a failed write.

- **Registration in `Main`**: Exposes `onRollbackCommitFn` as a property on the indexer object, allowing users to register callbacks during the configuration phase. The method name is marked as internal and will be removed without notice.

- **Type definitions**: Updated `index.d.ts` to include the callback signature in the `IndexerFromConfig` type.

- **Persistence layer**: Extended the `rollback` type to carry `progressBlockNumberByChainId`, which is populated during rollback preparation in `GlobalState` and read by the callback firing logic.

- **Test coverage**: Added test verifying that the callback fires once per affected chain with correct arguments after a rollback write.

## Implementation Details

- Callbacks are stored in a module-level array and can be unregistered via a returned function.
- The `progressBlockNumberByChainId` dict is threaded through the rollback preparation pipeline to ensure the callback has access to the last valid block per chain.
- The feature is intentionally marked as temporary and internal; all three call sites (module definition, registration, and firing) should be deleted together when the API is removed.

https://claude.ai/code/session_01E1JiTmZ9APfXhzDvjEVgX7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added temporary internal API method to register callbacks for rollback completion events, with chainId and rollbackToBlock information provided to each callback.

* **Tests**
  * Added test coverage for rollback callback registration and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->