### PR TITLE
Fix effect cache returning nested-option sentinel for None

### DIFF
--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -124,10 +124,19 @@ let getEffectInMemTable = (inMemoryStore: t, ~effect: Internal.effect) => {
   }
 }
 
-let getEffectOutput = (inMemTable: effectCacheInMemTable, key) =>
+let hasEffectOutput = (inMemTable: effectCacheInMemTable, key) =>
   switch inMemTable.dict->Utils.Dict.dangerouslyGetNonOption(key) {
-  | Some(Set({entity: output})) => Some(output)
-  | Some(Delete(_)) | None => None
+  | Some(Set(_)) => true
+  | Some(Delete(_)) | None => false
+  }
+
+// Returns the raw output. The output is itself an option for effects with an
+// optional output, so it must never be wrapped in another option here: Some(None)
+// is encoded as the nested-option sentinel and would leak to the handler.
+let getEffectOutputUnsafe = (inMemTable: effectCacheInMemTable, key): Internal.effectOutput =>
+  switch inMemTable.dict->Utils.Dict.dangerouslyGetNonOption(key) {
+  | Some(Set({entity: output})) => output
+  | Some(Delete(_)) | None => %raw(`undefined`)
   }
 
 // Records a handler output. Persisted on the next write only when shouldCache;

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -336,8 +336,8 @@ let loadEffect = (
     ~load,
     ~shouldGroup,
     ~hasher=args => args.cacheKey,
-    ~getUnsafeInMemory=hash => inMemTable->InMemoryStore.getEffectOutput(hash)->Option.getUnsafe,
-    ~hasInMemory=hash => inMemTable->InMemoryStore.getEffectOutput(hash)->Option.isSome,
+    ~getUnsafeInMemory=hash => inMemTable->InMemoryStore.getEffectOutputUnsafe(hash),
+    ~hasInMemory=hash => inMemTable->InMemoryStore.hasEffectOutput(hash),
     ~input=effectArgs,
   )
 }

--- a/scenarios/test_codegen/test/LoadLayer_test.res
+++ b/scenarios/test_codegen/test/LoadLayer_test.res
@@ -564,3 +564,59 @@ describe("LoadLayer", () => {
     },
   )
 })
+
+describe("LoadLayer effect cache", () => {
+  // Reproduces an envio v3.1.0-rc.x regression: an effect with an *optional*
+  // output that resolves to None leaks the ReScript nested-option sentinel
+  // `{ BS_PRIVATE_NESTED_SOME_NONE: 0 }` instead of JS `undefined`. The
+  // in-memory cache stores `option<output>` (here `option<option<bigint>>`)
+  // and the cache hit path returns it without unwrapping the outer option,
+  // so `Some(None)` reaches the handler. envio 3.0.2 returned `undefined`.
+  Async.it(
+    "Returns None (not the Some(None) sentinel) on a cache hit for an optional output that resolved to None",
+    async t => {
+      let storageMock = MockIndexer.Storage.make([#loadByIdsOrThrow])
+      let loadManager = LoadManager.make()
+      let inMemoryStore = MockIndexer.InMemoryStore.make()
+
+      let callCount = ref(0)
+      let effect =
+        Envio.createEffect(
+          {
+            name: "optionalOutputEffect",
+            input: S.string,
+            output: S.null(S.bigint),
+            rateLimit: Disable,
+            cache: false,
+          },
+          async _ => {
+            callCount := callCount.contents + 1
+            None
+          },
+        )->(Utils.magic: Envio.effect<string, option<bigint>> => Internal.effect)
+
+      let callEffect = () =>
+        LoadLayer.loadEffect(
+          ~loadManager,
+          ~persistence=storageMock->MockIndexer.Storage.toPersistence,
+          ~effect,
+          ~effectArgs={
+            input: "test"->(Utils.magic: string => Internal.effectInput),
+            context: {"cache": false}->(Utils.magic: {..} => Internal.effectContext),
+            cacheKey: "test",
+            checkpointId: 0n,
+          },
+          ~inMemoryStore,
+          ~shouldGroup=true,
+          ~item=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
+        )->(Utils.magic: promise<Internal.effectOutput> => promise<option<bigint>>)
+
+      // Cache miss: runs the handler and seeds the in-memory cache.
+      let first = await callEffect()
+      // Cache hit: served from the in-memory effect cache.
+      let second = await callEffect()
+
+      t.expect((callCount.contents, first, second)).toEqual((1, None, None))
+    },
+  )
+})


### PR DESCRIPTION
## Summary

Fixes a regression in envio v3.1.0-rc.x where effects with optional outputs that resolve to `None` would leak the ReScript nested-option sentinel `{ BS_PRIVATE_NESTED_SOME_NONE: 0 }` instead of `undefined` when served from the in-memory cache.

## Root Cause

The in-memory effect cache stores `option<output>` for all effects. When an effect with optional output (e.g., `option<bigint>`) returns `None`, the cache stores `Some(None)`. On cache hits, the code was wrapping this cached value in another `Option.getUnsafe`, which returned the raw `Some(None)` to the handler instead of unwrapping it to `None`/`undefined`.

## Key Changes

- **InMemoryStore.res**: Split `getEffectOutput` into two functions:
  - `hasEffectOutput`: Checks cache presence without wrapping the result
  - `getEffectOutputUnsafe`: Returns the raw cached output directly (never wrapped in `Option`), preventing the nested-option sentinel from leaking
  
- **LoadLayer.res**: Updated cache access to use the new functions, eliminating the extra `Option` wrapping that was causing the regression

- **LoadLayer_test.res**: Added regression test verifying that optional outputs resolving to `None` return `undefined` (not the sentinel) on cache hits

## Implementation Details

The fix ensures the cache hit path mirrors the cache miss path: both return the raw effect output without additional option wrapping. For effects with optional outputs, `None` is now correctly represented as `undefined` in both paths.

https://claude.ai/code/session_01QV6rPnY9qR7RubvyACNUdb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed in-memory effect output caching for optional types, addressing a regression in handling cached outputs.

* **Tests**
  * Added test suite to verify effect cache behavior with optional outputs and ensure handlers execute only once on cache hits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->