### PR TITLE
Fix same-signature event decoding across contracts with different param names

### DIFF
--- a/packages/cli/src/hypersync_source/decode.rs
+++ b/packages/cli/src/hypersync_source/decode.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use alloy_dyn_abi::DecodedEvent;
 use anyhow::{Context, Result};
 use hypersync_client::format::{Data, Hex, LogArgument};
 use hypersync_client::simple_types;
@@ -11,13 +12,58 @@ use crate::hypersync_source::{
     types::{sol_value_to_param, Event, EventParamsInput, Log, ParamMeta, ParamValue},
 };
 
-type MetaKey = ([u8; 32], u8);
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+struct MetaKey {
+    sighash: [u8; 32],
+    topic_count: u8,
+}
+
+impl MetaKey {
+    fn parse(sighash: &str, topic_count: i32) -> Result<Self> {
+        let bytes = LogArgument::decode_hex(sighash).context("decode sighash hex")?;
+        let topic_count: u8 = u8::try_from(topic_count).context("topic_count out of u8 range")?;
+        anyhow::ensure!(
+            (1..=4).contains(&topic_count),
+            "topic_count must be 1..=4, got {topic_count}",
+        );
+        Ok(Self {
+            sighash: **bytes,
+            topic_count,
+        })
+    }
+
+    fn from_topics(topics: &[Option<LogArgument>]) -> Result<Self> {
+        let topic0 = topics
+            .first()
+            .context("get topic0")?
+            .as_ref()
+            .context("topic0 is null")?;
+        let topic_count: u8 = topics
+            .iter()
+            .rposition(|t| t.is_some())
+            .map_or(0, |i| i + 1)
+            .try_into()
+            .context("topic_count overflow")?;
+        Ok(Self {
+            sighash: ***topic0,
+            topic_count,
+        })
+    }
+}
+
+/// One contract's naming for an event. Several contracts collapse to the same
+/// `MetaKey` when they emit the same-signature event; the positional decode is
+/// shared, the param names are not.
+struct EventVariant {
+    contract_name: String,
+    params: Vec<ParamMeta>,
+}
 
 #[derive(Clone)]
 pub(crate) struct DecoderCore {
     inner: Arc<hypersync_client::Decoder>,
     checksummed_addresses: bool,
-    param_meta: Arc<HashMap<MetaKey, Vec<ParamMeta>>>,
+    variants: Arc<HashMap<MetaKey, Vec<EventVariant>>>,
 }
 
 impl DecoderCore {
@@ -25,25 +71,32 @@ impl DecoderCore {
         event_params: Vec<EventParamsInput>,
         checksum_addresses: bool,
     ) -> Result<Self> {
-        let signatures: Vec<String> = event_params
-            .iter()
-            .map(|ep| reconstruct_signature(&ep.event_name, &ep.params))
-            .collect();
-
-        let inner = hypersync_client::Decoder::from_signatures(&signatures)
-            .context("create inner decoder")?;
-
-        let mut param_meta: HashMap<MetaKey, Vec<ParamMeta>> = HashMap::new();
+        let mut variants: HashMap<MetaKey, Vec<EventVariant>> = HashMap::new();
+        // The inner decoder matches purely on types + indexed layout, so one
+        // signature per `MetaKey` is enough — extra contracts sharing it only
+        // add naming variants, never a new decode.
+        let mut signatures: HashMap<MetaKey, String> = HashMap::new();
         for ep in event_params {
-            let key = parse_meta_key(&ep.sighash, ep.topic_count)
+            let key = MetaKey::parse(&ep.sighash, ep.topic_count)
                 .with_context(|| format!("parse meta key for {}", ep.event_name))?;
-            param_meta.insert(key, ep.params);
+            signatures
+                .entry(key)
+                .or_insert_with(|| reconstruct_signature(&ep.event_name, &ep.params));
+            variants.entry(key).or_default().push(EventVariant {
+                contract_name: ep.contract_name,
+                params: ep.params,
+            });
         }
+
+        let inner = hypersync_client::Decoder::from_signatures(
+            &signatures.into_values().collect::<Vec<_>>(),
+        )
+        .context("create inner decoder")?;
 
         Ok(Self {
             inner: Arc::new(inner),
             checksummed_addresses: checksum_addresses,
-            param_meta: Arc::new(param_meta),
+            variants: Arc::new(variants),
         })
     }
 
@@ -88,24 +141,36 @@ impl DecoderCore {
             None => return Ok(None),
         };
 
-        let topic_count: u8 = topics
-            .iter()
-            .rposition(|t| t.is_some())
-            .map_or(0, |i| i + 1)
-            .try_into()
-            .context("topic_count overflow")?;
-        let key: MetaKey = (***topic0, topic_count);
-
-        let params = match self.param_meta.get(&key) {
-            Some(p) => p,
+        let variants = match self.variants.get(&MetaKey::from_topics(topics)?) {
+            Some(v) => v,
             None => return Ok(None),
         };
 
-        let mut fields = Vec::with_capacity(params.len());
-        let mut indexed_idx = 0;
-        let mut body_idx = 0;
+        // Same log, one decode, named once per contract. JS routes by address
+        // and then picks `params[contractName]`, so two contracts that share a
+        // signature but name their params differently each get their own names.
+        let by_contract = variants
+            .iter()
+            .map(|variant| {
+                let fields = apply_names(&decoded, &variant.params, self.checksummed_addresses)?;
+                Ok((variant.contract_name.clone(), ParamValue::Obj(fields)))
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-        for param in params {
+        Ok(Some(ParamValue::Obj(by_contract)))
+    }
+}
+
+fn apply_names(
+    decoded: &DecodedEvent,
+    params: &[ParamMeta],
+    checksummed_addresses: bool,
+) -> Result<Vec<(String, ParamValue)>> {
+    let mut indexed_idx = 0;
+    let mut body_idx = 0;
+    params
+        .iter()
+        .map(|param| {
             let sol_value = if param.indexed {
                 let v = decoded
                     .indexed
@@ -123,27 +188,14 @@ impl DecoderCore {
                 body_idx += 1;
                 v
             };
-
             let value = sol_value_to_param(
                 sol_value,
                 param.components.as_deref(),
-                self.checksummed_addresses,
+                checksummed_addresses,
             );
-            fields.push((param.name.clone(), value));
-        }
-
-        Ok(Some(ParamValue::Obj(fields)))
-    }
-}
-
-fn parse_meta_key(sighash: &str, topic_count: i32) -> Result<MetaKey> {
-    let bytes = LogArgument::decode_hex(sighash).context("decode sighash hex")?;
-    let count: u8 = u8::try_from(topic_count).context("topic_count out of u8 range")?;
-    anyhow::ensure!(
-        (1..=4).contains(&count),
-        "topic_count must be 1..=4, got {count}",
-    );
-    Ok((**bytes, count))
+            Ok((param.name.clone(), value))
+        })
+        .collect()
 }
 
 fn reconstruct_signature(event_name: &str, params: &[ParamMeta]) -> String {
@@ -202,19 +254,19 @@ mod tests {
 
     #[test]
     fn parse_meta_key_rejects_zero_topics() {
-        let err = parse_meta_key(VALID_SIGHASH, 0).unwrap_err();
+        let err = MetaKey::parse(VALID_SIGHASH, 0).unwrap_err();
         assert!(format!("{err}").contains("topic_count must be 1..=4"));
     }
 
     #[test]
     fn parse_meta_key_rejects_five_topics() {
-        let err = parse_meta_key(VALID_SIGHASH, 5).unwrap_err();
+        let err = MetaKey::parse(VALID_SIGHASH, 5).unwrap_err();
         assert!(format!("{err}").contains("topic_count must be 1..=4"));
     }
 
     #[test]
     fn parse_meta_key_accepts_boundary_values() {
-        assert!(parse_meta_key(VALID_SIGHASH, 1).is_ok());
-        assert!(parse_meta_key(VALID_SIGHASH, 4).is_ok());
+        assert!(MetaKey::parse(VALID_SIGHASH, 1).is_ok());
+        assert!(MetaKey::parse(VALID_SIGHASH, 4).is_ok());
     }
 }

--- a/packages/cli/src/hypersync_source/decode.rs
+++ b/packages/cli/src/hypersync_source/decode.rs
@@ -72,9 +72,14 @@ impl DecoderCore {
         checksum_addresses: bool,
     ) -> Result<Self> {
         let mut variants: HashMap<MetaKey, Vec<EventVariant>> = HashMap::new();
-        // The inner decoder matches purely on types + indexed layout, so one
-        // signature per `MetaKey` is enough — extra contracts sharing it only
-        // add naming variants, never a new decode.
+        // The inner decoder is itself keyed by (topic0, topic count) — the same
+        // MetaKey — so it can hold only one decode per key. Contracts that share
+        // a key reuse that single positional decode and only layer on their own
+        // names, so we feed the inner decoder one signature per key. Two events
+        // sharing a MetaKey but indexing different params (same type list, same
+        // indexed count, different positions) can't be told apart at this layer
+        // regardless — `from_signatures` would collapse them too — so the first
+        // variant's layout wins; `apply_names` then keys names off each variant.
         let mut signatures: HashMap<MetaKey, String> = HashMap::new();
         for ep in event_params {
             let key = MetaKey::parse(&ep.sighash, ep.topic_count)

--- a/packages/cli/src/hypersync_source/types.rs
+++ b/packages/cli/src/hypersync_source/types.rs
@@ -472,6 +472,7 @@ pub struct EventParamsInput {
     pub sighash: String,
     pub topic_count: i32,
     pub event_name: String,
+    pub contract_name: String,
     pub params: Vec<ParamMeta>,
 }
 

--- a/packages/envio/src/sources/EvmChain.res
+++ b/packages/envio/src/sources/EvmChain.res
@@ -41,25 +41,18 @@ let getSyncConfig = (
 let collectEventParams = (contracts: array<Internal.evmContractConfig>): array<
   HyperSyncClient.Decoder.eventParamsInput,
 > => {
-  let seen = Dict.make()
   let result = []
   contracts->Array.forEach(contract => {
     contract.events->Array.forEach(event => {
-      let key = event.sighash ++ "_" ++ event.topicCount->Int.toString
-      switch seen->Dict.get(key) {
-      | Some(_) => ()
-      | None => {
-          seen->Dict.set(key, true)
-          result
-          ->Array.push({
-            HyperSyncClient.Decoder.sighash: event.sighash,
-            topicCount: event.topicCount,
-            eventName: event.name,
-            params: event.paramsMetadata,
-          })
-          ->ignore
-        }
-      }
+      result
+      ->Array.push({
+        HyperSyncClient.Decoder.sighash: event.sighash,
+        topicCount: event.topicCount,
+        eventName: event.name,
+        contractName: contract.name,
+        params: event.paramsMetadata,
+      })
+      ->ignore
     })
   })
   result

--- a/packages/envio/src/sources/HyperSyncClient.res
+++ b/packages/envio/src/sources/HyperSyncClient.res
@@ -322,11 +322,17 @@ module Decoder = {
     sighash: string,
     topicCount: int,
     eventName: string,
+    contractName: string,
     params: array<Internal.paramMeta>,
   }
 
+  // Decoded params keyed by contract name. Contracts that emit the same-signature
+  // event share one decode but get their own param names, so the caller picks the
+  // entry for the contract its router resolved the log to.
   type tWithParams = {
-    decodeLogs: array<ResponseTypes.event> => promise<array<Nullable.t<Internal.eventParams>>>,
+    decodeLogs: array<ResponseTypes.event> => promise<
+      array<Nullable.t<dict<Internal.eventParams>>>,
+    >,
   }
 
   @send
@@ -348,7 +354,7 @@ module EventItems = {
     topicCount: int,
     block: ResponseTypes.block,
     transaction: ResponseTypes.transaction,
-    params: Nullable.t<Internal.eventParams>,
+    params: Nullable.t<dict<Internal.eventParams>>,
   }
 
   type response = {

--- a/packages/envio/src/sources/HyperSyncSource.res
+++ b/packages/envio/src/sources/HyperSyncSource.res
@@ -351,26 +351,23 @@ Learn more or get a free API token at: https://envio.dev/app/api-tokens`)
           ~blockNumber=item.block.number->Belt.Option.getUnsafe,
         )
 
-      switch (maybeEventConfig, item.params) {
-      | (Some(eventConfig), Value(paramsByContractName)) =>
-        parsedQueueItems
-        ->Array.push(
-          makeEventBatchQueueItem(
-            item,
-            ~params=paramsByContractName->Dict.getUnsafe(eventConfig.contractName),
+      switch maybeEventConfig {
+      | None => () //ignore events that aren't registered
+      | Some(eventConfig) =>
+        switch item.params
+        ->Nullable.toOption
+        ->Option.flatMap(Dict.get(_, eventConfig.contractName)) {
+        | Some(params) =>
+          parsedQueueItems->Array.push(makeEventBatchQueueItem(item, ~params, ~eventConfig))->ignore
+        | None =>
+          handleDecodeFailure(
             ~eventConfig,
-          ),
-        )
-        ->ignore
-      | (Some(eventConfig), Null | Undefined) =>
-        handleDecodeFailure(
-          ~eventConfig,
-          ~logIndex=item.logIndex,
-          ~blockNumber=item.block.number->Belt.Option.getUnsafe,
-          ~chainId,
-          ~exn=UndefinedValue,
-        )
-      | (None, _) => () //ignore events that aren't registered
+            ~logIndex=item.logIndex,
+            ~blockNumber=item.block.number->Belt.Option.getUnsafe,
+            ~chainId,
+            ~exn=UndefinedValue,
+          )
+        }
       }
     })
 

--- a/packages/envio/src/sources/HyperSyncSource.res
+++ b/packages/envio/src/sources/HyperSyncSource.res
@@ -352,9 +352,15 @@ Learn more or get a free API token at: https://envio.dev/app/api-tokens`)
         )
 
       switch (maybeEventConfig, item.params) {
-      | (Some(eventConfig), Value(decoded)) =>
+      | (Some(eventConfig), Value(paramsByContractName)) =>
         parsedQueueItems
-        ->Array.push(makeEventBatchQueueItem(item, ~params=decoded, ~eventConfig))
+        ->Array.push(
+          makeEventBatchQueueItem(
+            item,
+            ~params=paramsByContractName->Dict.getUnsafe(eventConfig.contractName),
+            ~eventConfig,
+          ),
+        )
         ->ignore
       | (Some(eventConfig), Null | Undefined) =>
         handleDecodeFailure(

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -1115,7 +1115,7 @@ let make = (
     ->Array.zip(parsedEvents)
     ->Array.filterMap(((
       log: Rpc.GetLogs.log,
-      maybeDecodedEvent: Nullable.t<Internal.eventParams>,
+      maybeDecodedEvent: Nullable.t<dict<Internal.eventParams>>,
     )) => {
       let topic0 = log.topics[0]->Option.getOr("0x0")
       let routedAddress = if lowercaseAddresses {
@@ -1133,7 +1133,8 @@ let make = (
       | None => None
       | Some(eventConfig) =>
         switch maybeDecodedEvent {
-        | Value(decoded) =>
+        | Value(paramsByContractName) =>
+          let decoded = paramsByContractName->Dict.getUnsafe(eventConfig.contractName)
           Some(
             (
               async () => {

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -1132,9 +1132,10 @@ let make = (
       ) {
       | None => None
       | Some(eventConfig) =>
-        switch maybeDecodedEvent {
-        | Value(paramsByContractName) =>
-          let decoded = paramsByContractName->Dict.getUnsafe(eventConfig.contractName)
+        switch maybeDecodedEvent
+        ->Nullable.toOption
+        ->Option.flatMap(Dict.get(_, eventConfig.contractName)) {
+        | Some(decoded) =>
           Some(
             (
               async () => {
@@ -1177,7 +1178,7 @@ let make = (
               }
             )(),
           )
-        | Null | Undefined => None
+        | None => None
         }
       }
     })

--- a/scenarios/test_codegen/test/HyperSyncClient_test.res
+++ b/scenarios/test_codegen/test/HyperSyncClient_test.res
@@ -19,6 +19,7 @@ let transferEventParam: HyperSyncClient.Decoder.eventParamsInput = {
   sighash: transferSighash,
   topicCount: 3,
   eventName: "Transfer",
+  contractName: "ERC20",
   params: transferParams,
 }
 
@@ -76,8 +77,11 @@ describe("HyperSync client getEventItems (live)", () => {
       }),
       "everyParamsDecoded": res.items->Array.every(item =>
         switch item.params->Nullable.toOption {
-        | Some(p) =>
-          let obj = p->(Utils.magic: Internal.eventParams => {..})
+        | Some(paramsByContractName) =>
+          let obj =
+            paramsByContractName
+            ->Dict.getUnsafe("ERC20")
+            ->(Utils.magic: Internal.eventParams => {..})
           obj["from"]->typeof == #string &&
           obj["to"]->typeof == #string &&
           obj["value"]->typeof == #bigint
@@ -114,6 +118,7 @@ describe("HyperSync client getEventItems (live)", () => {
       sighash: "0x0000000000000000000000000000000000000000000000000000000000000001",
       topicCount: 1,
       eventName: "Unrelated",
+      contractName: "Unrelated",
       params: [],
     }
     let client = makeClient(~eventParams=[unrelatedEventParam])

--- a/scenarios/test_codegen/test/SourceBlockHashes_test.res
+++ b/scenarios/test_codegen/test/SourceBlockHashes_test.res
@@ -69,6 +69,7 @@ let pairCreatedEventParams: HyperSyncClient.Decoder.eventParamsInput = {
   sighash: pairCreatedTopic0,
   topicCount: 3,
   eventName: "PairCreated",
+  contractName: "UniswapV2Factory",
   params: pairCreatedAbi,
 }
 

--- a/scenarios/test_codegen/test/lib_tests/HyperSyncDecoder_test.res
+++ b/scenarios/test_codegen/test/lib_tests/HyperSyncDecoder_test.res
@@ -28,9 +28,15 @@ let decodeSingle = async (
     `event ${eventName}(${params->Array.map(p => p.indexed ? `${p.abiType} indexed` : p.abiType)->Array.joinUnsafe(", ")})`,
   )
   let topicCount = params->Array.reduce(1, (acc, p) => p.indexed ? acc + 1 : acc)
-  let decoder = HyperSyncClient.Decoder.fromParams([{sighash, topicCount, eventName, params}])
+  let decoder = HyperSyncClient.Decoder.fromParams([
+    {sighash, topicCount, eventName, contractName: "TestContract", params},
+  ])
   let decoded = await decoder.decodeLogs([event])
-  decoded[0]->Option.getUnsafe->Nullable.toOption->Option.getUnsafe
+  decoded[0]
+  ->Option.getUnsafe
+  ->Nullable.toOption
+  ->Option.getUnsafe
+  ->Dict.getUnsafe("TestContract")
 }
 
 let allIndexedLog = makeEvent(
@@ -58,6 +64,7 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
         sighash,
         topicCount: 4,
         eventName: "Transfer",
+        contractName: "TestContract",
         params: [
           {name: "from", abiType: "address", indexed: true},
           {name: "to", abiType: "address", indexed: true},
@@ -68,6 +75,7 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
         sighash,
         topicCount: 1,
         eventName: "Transfer",
+        contractName: "TestContract",
         params: [
           {name: "from", abiType: "address", indexed: false},
           {name: "to", abiType: "address", indexed: false},
@@ -78,8 +86,10 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
 
     let decoded = await decoder.decodeLogs([allIndexedLog, noneIndexedLog])
 
-    let paramsAll = decoded[0]->Option.getUnsafe->Nullable.toOption->Option.getUnsafe
-    let paramsNone = decoded[1]->Option.getUnsafe->Nullable.toOption->Option.getUnsafe
+    let pick = i =>
+      decoded[i]->Option.getUnsafe->Nullable.toOption->Option.getUnsafe->Dict.getUnsafe("TestContract")
+    let paramsAll = pick(0)
+    let paramsNone = pick(1)
 
     let expected = {"from": fromAddr, "to": toAddr, "value": value}->Utils.magic
     t.expect(paramsAll).toEqual(expected)
@@ -116,13 +126,19 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
         sighash: toEventSelector("event Empty()"),
         topicCount: 1,
         eventName: "Empty",
+        contractName: "TestContract",
         params: [],
       },
     ])
     let decoded = await decoder.decodeLogs([
       makeEvent(~topics=[toEventSelector("event Empty()")], ~data="0x"),
     ])
-    let result = decoded[0]->Option.getUnsafe->Nullable.toOption->Option.getUnsafe
+    let result =
+      decoded[0]
+      ->Option.getUnsafe
+      ->Nullable.toOption
+      ->Option.getUnsafe
+      ->Dict.getUnsafe("TestContract")
     t.expect(result).toEqual(%raw(`{}`))
   })
 

--- a/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
@@ -65,19 +65,24 @@ let transferLog = makeEvent(
 )
 
 describe("Same-signature event across contracts with different param names", () => {
-  Async.it("decodes TokenB's Transfer under TokenB's own param names", async t => {
+  Async.it("decodes the shared Transfer under each contract's own param names", async t => {
     // Full production path: collect the decoder inputs for both contracts,
-    // build the native decoder, decode a Transfer log emitted by TokenB.
+    // build the native decoder, decode the shared Transfer log. The decoder
+    // returns params keyed by contract name so each contract's router can pick
+    // its own names instead of the first-registered contract's.
     let allEventParams = EvmChain.collectEventParams([tokenA, tokenB])
     let decoder = HyperSyncClient.Decoder.fromParams(allEventParams)
 
     let decoded = await decoder.decodeLogs([transferLog])
-    let params = decoded[0]->Option.getUnsafe->Nullable.toOption->Option.getUnsafe
+    let paramsByContractName = decoded[0]->Option.getUnsafe->Nullable.toOption->Option.getUnsafe
 
-    // TokenB's handler reads `src`/`dst`/`wad`. `collectEventParams` dedupes by
-    // (sighash, topicCount) first-contract-wins, so only TokenA's metadata
-    // reaches the native decoder and TokenB's params decode as `from/to/value`,
-    // leaving the handler's reads undefined.
-    t.expect(params).toEqual({"src": fromAddr, "dst": toAddr, "wad": value}->Utils.magic)
+    t
+    .expect(paramsByContractName)
+    .toEqual(
+      {
+        "TokenA": {"from": fromAddr, "to": toAddr, "value": value},
+        "TokenB": {"src": fromAddr, "dst": toAddr, "wad": value},
+      }->Utils.magic,
+    )
   })
 })

--- a/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
@@ -1,0 +1,83 @@
+open Vitest
+
+@module("viem")
+external toEventSelector: string => string = "toEventSelector"
+
+@module("viem") external pad: string => string = "pad"
+
+@module("viem")
+external encodeAbiParameters: (JSON.t, JSON.t) => string = "encodeAbiParameters"
+
+// Two contracts emit the very same `Transfer(address indexed, address indexed,
+// uint256)` event but name the params differently (OpenZeppelin `from/to/value`
+// vs WETH `src/dst/wad`). Same sighash, same topicCount.
+let transferSighash = toEventSelector("event Transfer(address indexed, address indexed, uint256)")
+
+let makeContract = (~name, ~params): Internal.evmContractConfig => {
+  name,
+  abi: %raw(`[]`),
+  events: [
+    EventConfigBuilder.buildEvmEventConfig(
+      ~contractName=name,
+      ~eventName="Transfer",
+      ~sighash=transferSighash,
+      ~params,
+      ~isWildcard=false,
+      ~handler=None,
+      ~contractRegister=None,
+      ~eventFilters=None,
+      ~probeChainId=1,
+      ~onEventBlockFilterSchema=Evm.ecosystem.onEventBlockFilterSchema,
+    ),
+  ],
+}
+
+let tokenA = makeContract(
+  ~name="TokenA",
+  ~params=([
+    {name: "from", abiType: "address", indexed: true},
+    {name: "to", abiType: "address", indexed: true},
+    {name: "value", abiType: "uint256", indexed: false},
+  ]: array<Internal.paramMeta>),
+)
+
+let tokenB = makeContract(
+  ~name="TokenB",
+  ~params=([
+    {name: "src", abiType: "address", indexed: true},
+    {name: "dst", abiType: "address", indexed: true},
+    {name: "wad", abiType: "uint256", indexed: false},
+  ]: array<Internal.paramMeta>),
+)
+
+let makeEvent = (~topics: array<string>, ~data: string): HyperSyncClient.ResponseTypes.event =>
+  {"log": {"topics": topics, "data": data}}->(
+    Utils.magic: {..} => HyperSyncClient.ResponseTypes.event
+  )
+
+let fromAddr = "0x000000000000000000000000000000000000aaaa"
+let toAddr = "0x000000000000000000000000000000000000bbbb"
+let value = 42n
+
+let transferLog = makeEvent(
+  ~topics=[transferSighash, fromAddr->pad, toAddr->pad],
+  ~data=encodeAbiParameters(%raw(`[{"type":"uint256"}]`), %raw(`[42n]`)),
+)
+
+describe("Same-signature event across contracts with different param names", () => {
+  Async.it("decodes TokenB's Transfer under TokenB's own param names", async t => {
+    // Full production path: collect the decoder inputs for both contracts,
+    // build the native decoder, decode a Transfer log emitted by TokenB.
+    let allEventParams = EvmChain.collectEventParams([tokenA, tokenB])
+    let decoder = HyperSyncClient.Decoder.fromParams(allEventParams)
+
+    let decoded = await decoder.decodeLogs([transferLog])
+    let params = decoded[0]->Option.getUnsafe->Nullable.toOption->Option.getUnsafe
+
+    // TokenB's handler reads `src`/`dst`/`wad`. `collectEventParams` dedupes by
+    // (sighash, topicCount) first-contract-wins, so only TokenA's metadata
+    // reaches the native decoder and TokenB's params decode as `from/to/value`,
+    // leaving the handler's reads undefined.
+    t.expect(params).toEqual({"src": fromAddr, "dst": toAddr, "wad": value}->Utils.magic)
+  })
+})


### PR DESCRIPTION
## Problem

When two contracts emit the **same-signature** event but name its params differently (e.g. OpenZeppelin `Transfer(from, to, value)` vs WETH `Transfer(src, dst, wad)`), the second contract's handler reads `undefined` for its params.

`EvmChain.collectEventParams` built the native decoder's input by deduping on `(sighash, topicCount)`, first-contract-wins. Only the first contract's param metadata reached the decoder, so **every** matching log — including the second contract's — decoded under the first contract's names. The router still resolved the correct contract by address, but the params object already had the wrong keys baked in.

Worked on `3.0.0-alpha.20` (per-contract decoding via `convertHyperSyncEventArgs`); regressed in `3.1.0` (PR #1235) when naming moved into the native decoder keyed only by `(sighash, topicCount)`.

## Fix

The native decoder now returns params **keyed by contract name** (`paramsByContractName`):

- The expensive inner ABI decode stays **single** — keyed by signature, run once per log.
- Each contract sharing that signature re-applies **its own** names (including nested struct field names) over the shared positional values — cheap, and N=1 in the common case.
- `collectEventParams` no longer dedupes; it emits one entry per contract event with a `contractName`.
- After the router resolves a log to its contract by address, both `HyperSyncSource` and `RpcSource` pick `params[contractName]`.

No new dynamic state, no rollback coupling, no `indexingAddresses` plumbing — routing stays in JS, the decoder stays static.

### Rust cleanup
`param_meta: HashMap<MetaKey, Vec<ParamMeta>>` → `variants: HashMap<MetaKey, Vec<EventVariant>>` with a named `MetaKey` struct (both `parse` and `from_topics` constructors) and an extracted `apply_names` helper shared across variants.

## Tests

- New high-level reproduction `SameSignatureEventDecode_test.res` drives the full path (`collectEventParams` → native decoder) and asserts each contract decodes under its own names.
- Updated existing decoder/client tests for the by-contract shape.
- Rust unit tests, all 301 ReScript lib/source tests, `cargo fmt`, and `tsc --noEmit` pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MyjtCSDfE2XybnkeEa9q9y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event decoding now returns decoded parameters keyed by contract name so identically-signed events preserve each contract's own parameter names.
  * Event input now includes contract identity so per-contract parameter mappings are retained.

* **Behavior Change**
  * Event collection no longer deduplicates by signature/topic count; all matching event entries are preserved.

* **Tests**
  * Updated tests and fixtures to validate multi-contract decoding and the new contract-keyed decoding shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->