### PR TITLE
Fix onBlock handlers without event handlers

### DIFF
--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1674,7 +1674,7 @@ let make = (
   | None => ()
   }
 
-  {
+  let initialState = {
     optimizedPartitions,
     contractConfigs,
     chainId,
@@ -1689,6 +1689,16 @@ let make = (
     knownHeight,
     buffer: [],
     firstEventBlock,
+  }
+
+  // On resume, knownHeight is restored from the DB but the buffer starts empty.
+  // Without this, onBlock-only indexers (e.g. SVM onSlot) get stuck: getNextQuery
+  // returns NothingToQuery because there are no partitions to drive fetching,
+  // and no one calls updateInternal to populate the buffer.
+  if knownHeight > 0 && onBlockConfigs->Utils.Array.notEmpty {
+    initialState->updateInternal(~knownHeight)
+  } else {
+    initialState
   }
 }
 

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -555,6 +555,63 @@ let blockItemLogIndex = 16777216
 
 let numAddresses = fetchState => fetchState.indexingAddresses->Utils.Dict.size
 
+// Appends Block items produced by the onBlock handlers for every block in
+// (fromBlock, maxBlockNumber] into mutItems and returns the new
+// latestOnBlockBlockNumber pointer. targetBufferSize bounds how many items
+// are generated at once to prevent OOM.
+let appendOnBlockItems = (
+  mutItems: array<Internal.item>,
+  ~onBlockConfigs: array<Internal.onBlockConfig>,
+  ~indexerStartBlock,
+  ~fromBlock,
+  ~maxBlockNumber,
+  ~targetBufferSize,
+) => {
+  let newItemsCounter = ref(0)
+  let latestOnBlockBlockNumber = ref(fromBlock)
+
+  // Simply iterate over every block
+  // could have a better algorithm to iterate over blocks in a more efficient way
+  // but raw loops are fast enough
+  while (
+    latestOnBlockBlockNumber.contents < maxBlockNumber &&
+      // Additional safeguard to prevent OOM
+      newItemsCounter.contents <= targetBufferSize
+  ) {
+    let blockNumber = latestOnBlockBlockNumber.contents + 1
+    latestOnBlockBlockNumber := blockNumber
+
+    for configIdx in 0 to onBlockConfigs->Array.length - 1 {
+      let onBlockConfig = onBlockConfigs->Array.getUnsafe(configIdx)
+
+      let handlerStartBlock = switch onBlockConfig.startBlock {
+      | Some(startBlock) => startBlock
+      | None => indexerStartBlock
+      }
+
+      if (
+        blockNumber >= handlerStartBlock &&
+        switch onBlockConfig.endBlock {
+        | Some(endBlock) => blockNumber <= endBlock
+        | None => true
+        } &&
+        (blockNumber - handlerStartBlock)->Pervasives.mod(onBlockConfig.interval) === 0
+      ) {
+        mutItems->Array.push(
+          Block({
+            onBlockConfig,
+            blockNumber,
+            logIndex: blockItemLogIndex + onBlockConfig.index,
+          }),
+        )
+        newItemsCounter := newItemsCounter.contents + 1
+      }
+    }
+  }
+
+  latestOnBlockBlockNumber.contents
+}
+
 /*
 Update fetchState, merge registers and recompute derived values.
 Runs partition optimization when partitions change.
@@ -597,49 +654,13 @@ let updateInternal = (
       }
       mutItemsRef := Some(mutItems)
 
-      let newItemsCounter = ref(0)
-      let latestOnBlockBlockNumber = ref(fetchState.latestOnBlockBlockNumber)
-
-      // Simply iterate over every block
-      // could have a better algorithm to iterate over blocks in a more efficient way
-      // but raw loops are fast enough
-      while (
-        latestOnBlockBlockNumber.contents < maxBlockNumber &&
-          // Additional safeguard to prevent OOM
-          newItemsCounter.contents <= fetchState.targetBufferSize
-      ) {
-        let blockNumber = latestOnBlockBlockNumber.contents + 1
-        latestOnBlockBlockNumber := blockNumber
-
-        for configIdx in 0 to onBlockConfigs->Array.length - 1 {
-          let onBlockConfig = onBlockConfigs->Array.getUnsafe(configIdx)
-
-          let handlerStartBlock = switch onBlockConfig.startBlock {
-          | Some(startBlock) => startBlock
-          | None => fetchState.startBlock
-          }
-
-          if (
-            blockNumber >= handlerStartBlock &&
-            switch onBlockConfig.endBlock {
-            | Some(endBlock) => blockNumber <= endBlock
-            | None => true
-            } &&
-            (blockNumber - handlerStartBlock)->Pervasives.mod(onBlockConfig.interval) === 0
-          ) {
-            mutItems->Array.push(
-              Block({
-                onBlockConfig,
-                blockNumber,
-                logIndex: blockItemLogIndex + onBlockConfig.index,
-              }),
-            )
-            newItemsCounter := newItemsCounter.contents + 1
-          }
-        }
-      }
-
-      latestOnBlockBlockNumber.contents
+      mutItems->appendOnBlockItems(
+        ~onBlockConfigs,
+        ~indexerStartBlock=fetchState.startBlock,
+        ~fromBlock=fetchState.latestOnBlockBlockNumber,
+        ~maxBlockNumber,
+        ~targetBufferSize=fetchState.targetBufferSize,
+      )
     }
   }
 
@@ -1661,45 +1682,58 @@ let make = (
     )
   }
 
-  let numAddresses = indexingAddresses->Utils.Dict.size
-  Prometheus.IndexingAddresses.set(~addressesCount=numAddresses, ~chainId)
-  Prometheus.IndexingPartitions.set(
-    ~partitionsCount=optimizedPartitions->OptimizedPartitions.count,
-    ~chainId,
-  )
-  Prometheus.IndexingBufferSize.set(~bufferSize=0, ~chainId)
-  Prometheus.IndexingBufferBlockNumber.set(~blockNumber=latestFetchedBlock.blockNumber, ~chainId)
-  switch endBlock {
-  | Some(endBlock) => Prometheus.IndexingEndBlock.set(~endBlock, ~chainId)
-  | None => ()
+  // On resume knownHeight is restored from the DB but the buffer starts empty.
+  // For onBlock-only indexers (e.g. SVM onSlot) there are no partitions to drive
+  // fetching, so without seeding the buffer here getNextQuery would return
+  // NothingToQuery and the indexer would get stuck.
+  let buffer = []
+  let latestOnBlockBlockNumber = if knownHeight > 0 && onBlockConfigs->Utils.Array.notEmpty {
+    let maxBlockNumber = switch optimizedPartitions->OptimizedPartitions.getLatestFullyFetchedBlock {
+    | None => knownHeight
+    | Some(latestFullyFetchedBlock) => latestFullyFetchedBlock.blockNumber
+    }
+    buffer->appendOnBlockItems(
+      ~onBlockConfigs,
+      ~indexerStartBlock=startBlock,
+      ~fromBlock=progressBlockNumber,
+      ~maxBlockNumber,
+      ~targetBufferSize,
+    )
+  } else {
+    progressBlockNumber
   }
 
-  let initialState = {
+  let fetchState = {
     optimizedPartitions,
     contractConfigs,
     chainId,
     startBlock,
     endBlock,
-    latestOnBlockBlockNumber: progressBlockNumber,
+    latestOnBlockBlockNumber,
     normalSelection,
     indexingAddresses,
     blockLag,
     onBlockConfigs,
     targetBufferSize,
     knownHeight,
-    buffer: [],
+    buffer,
     firstEventBlock,
   }
 
-  // On resume, knownHeight is restored from the DB but the buffer starts empty.
-  // Without this, onBlock-only indexers (e.g. SVM onSlot) get stuck: getNextQuery
-  // returns NothingToQuery because there are no partitions to drive fetching,
-  // and no one calls updateInternal to populate the buffer.
-  if knownHeight > 0 && onBlockConfigs->Utils.Array.notEmpty {
-    initialState->updateInternal(~knownHeight)
-  } else {
-    initialState
+  let numAddresses = indexingAddresses->Utils.Dict.size
+  Prometheus.IndexingAddresses.set(~addressesCount=numAddresses, ~chainId)
+  Prometheus.IndexingPartitions.set(
+    ~partitionsCount=optimizedPartitions->OptimizedPartitions.count,
+    ~chainId,
+  )
+  Prometheus.IndexingBufferSize.set(~bufferSize=buffer->Array.length, ~chainId)
+  Prometheus.IndexingBufferBlockNumber.set(~blockNumber=fetchState->bufferBlockNumber, ~chainId)
+  switch endBlock {
+  | Some(endBlock) => Prometheus.IndexingEndBlock.set(~endBlock, ~chainId)
+  | None => ()
   }
+
+  fetchState
 }
 
 let bufferSize = ({buffer}: t) => buffer->Array.length

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -560,7 +560,7 @@ let numAddresses = fetchState => fetchState.indexingAddresses->Utils.Dict.size
 // latestOnBlockBlockNumber pointer. targetBufferSize bounds how many items
 // are generated at once to prevent OOM.
 let appendOnBlockItems = (
-  mutItems: array<Internal.item>,
+  ~mutItems: array<Internal.item>,
   ~onBlockConfigs: array<Internal.onBlockConfig>,
   ~indexerStartBlock,
   ~fromBlock,
@@ -654,7 +654,8 @@ let updateInternal = (
       }
       mutItemsRef := Some(mutItems)
 
-      mutItems->appendOnBlockItems(
+      appendOnBlockItems(
+        ~mutItems,
         ~onBlockConfigs,
         ~indexerStartBlock=fetchState.startBlock,
         ~fromBlock=fetchState.latestOnBlockBlockNumber,
@@ -1692,7 +1693,8 @@ let make = (
     | None => knownHeight
     | Some(latestFullyFetchedBlock) => latestFullyFetchedBlock.blockNumber
     }
-    buffer->appendOnBlockItems(
+    appendOnBlockItems(
+      ~mutItems=buffer,
       ~onBlockConfigs,
       ~indexerStartBlock=startBlock,
       ~fromBlock=progressBlockNumber,

--- a/scenarios/svm_test/test/SlotResume_test.res
+++ b/scenarios/svm_test/test/SlotResume_test.res
@@ -1,0 +1,31 @@
+open Vitest
+
+// Regression: an onSlot-only indexer (no contracts, no event partitions) used
+// to get stuck after resuming from a checkpoint. On resume the buffer started
+// empty and nothing repopulated it, so getNextQuery never produced work and the
+// indexer never advanced past the resumed progress block.
+Async.it("onSlot-only indexer keeps progressing after a resume", async t => {
+  let indexer = Indexer.createTestIndexer()
+
+  // Initial run up to slot 9.
+  let _ = await indexer.process({
+    chains: {
+      \"0": {startBlock: 0, endBlock: Some(9)},
+    },
+  })
+
+  // Resume from slot 10 up to slot 19. Before the fix this run got stuck and
+  // produced no new SlotPing entities.
+  let _ = await indexer.process({
+    chains: {
+      \"0": {startBlock: 10, endBlock: Some(19)},
+    },
+  })
+
+  let slots =
+    (await indexer.\"SlotPing".getAll())
+    ->Array.map(ping => ping.slot)
+    ->Belt.SortArray.Int.stableSort
+
+  t.expect(slots).toEqual([0, 5, 10, 15])
+})

--- a/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
@@ -32,7 +32,7 @@ let makeOnBlockConfig = (
   handler: Utils.magic("mock handler"),
 }
 
-let makeInitialWithOnBlock = (~startBlock=0, ~knownHeight=0, ~progressBlockNumber=?, ~onBlockConfigs) => {
+let makeInitialWithOnBlock = (~startBlock=0, ~onBlockConfigs) => {
   FetchState.make(
     ~eventConfigs=[baseEventConfig],
     ~addresses=[
@@ -48,8 +48,7 @@ let makeInitialWithOnBlock = (~startBlock=0, ~knownHeight=0, ~progressBlockNumbe
     ~targetBufferSize=5000,
     ~chainId,
     ~onBlockConfigs?,
-    ~knownHeight,
-    ~progressBlockNumber?,
+    ~knownHeight=0,
   )
 }
 
@@ -306,56 +305,5 @@ describe("FetchState onBlock functionality", () => {
       blockNumberLogIndexTuples,
       ~message="Should have correct block number and log index tuples",
     ).toEqual(expectedTuples)
-  })
-
-  it("should populate buffer on resume when knownHeight > progressBlockNumber (onBlock-only)", t => {
-    // Simulates SVM onSlot-only indexer: no event configs, no addresses, only onBlock handlers.
-    // On resume, knownHeight is restored from DB but the buffer starts empty.
-    let onBlockConfig = makeOnBlockConfig(~interval=1, ~startBlock=Some(100))
-    let fetchState = FetchState.make(
-      ~eventConfigs=[],
-      ~addresses=[],
-      ~startBlock=100,
-      ~endBlock=None,
-      ~maxAddrInPartition=3,
-      ~targetBufferSize=5000,
-      ~chainId,
-      ~onBlockConfigs=[onBlockConfig],
-      ~knownHeight=110,
-      ~progressBlockNumber=104,
-    )
-
-    t.expect(fetchState->FetchState.bufferSize).toBeGreaterThan(0)
-
-    let blockNumbers =
-      fetchState.buffer->Array.map(item => item->Internal.getItemBlockNumber)
-
-    t.expect(blockNumbers).toEqual([105, 106, 107, 108, 109, 110])
-  })
-
-  it("should not get stuck on resume for onBlock-only indexer", t => {
-    // Without the fix, getNextQuery returned NothingToQuery because:
-    // 1. headBlockNumber > 0 (not WaitingForNewBlock early return)
-    // 2. isOnBlockBehindTheHead=true -> shouldWaitForNewBlock=false
-    // 3. No partitions -> no queries
-    // Result: NothingToQuery -> fetcher does nothing -> stuck
-    let onBlockConfig = makeOnBlockConfig(~interval=1, ~startBlock=Some(100))
-    let fetchState = FetchState.make(
-      ~eventConfigs=[],
-      ~addresses=[],
-      ~startBlock=100,
-      ~endBlock=None,
-      ~maxAddrInPartition=3,
-      ~targetBufferSize=5000,
-      ~chainId,
-      ~onBlockConfigs=[onBlockConfig],
-      ~knownHeight=110,
-      ~progressBlockNumber=104,
-    )
-
-    // With the fix, the buffer is populated and onBlock pointer is caught up.
-    // getNextQuery should return WaitingForNewBlock, not NothingToQuery.
-    let nextQuery = fetchState->FetchState.getNextQuery(~concurrencyLimit=10)
-    t.expect(nextQuery).toEqual(FetchState.WaitingForNewBlock)
   })
 })

--- a/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
@@ -32,7 +32,7 @@ let makeOnBlockConfig = (
   handler: Utils.magic("mock handler"),
 }
 
-let makeInitialWithOnBlock = (~startBlock=0, ~onBlockConfigs) => {
+let makeInitialWithOnBlock = (~startBlock=0, ~knownHeight=0, ~progressBlockNumber=?, ~onBlockConfigs) => {
   FetchState.make(
     ~eventConfigs=[baseEventConfig],
     ~addresses=[
@@ -48,7 +48,8 @@ let makeInitialWithOnBlock = (~startBlock=0, ~onBlockConfigs) => {
     ~targetBufferSize=5000,
     ~chainId,
     ~onBlockConfigs?,
-    ~knownHeight=0,
+    ~knownHeight,
+    ~progressBlockNumber?,
   )
 }
 
@@ -305,5 +306,56 @@ describe("FetchState onBlock functionality", () => {
       blockNumberLogIndexTuples,
       ~message="Should have correct block number and log index tuples",
     ).toEqual(expectedTuples)
+  })
+
+  it("should populate buffer on resume when knownHeight > progressBlockNumber (onBlock-only)", t => {
+    // Simulates SVM onSlot-only indexer: no event configs, no addresses, only onBlock handlers.
+    // On resume, knownHeight is restored from DB but the buffer starts empty.
+    let onBlockConfig = makeOnBlockConfig(~interval=1, ~startBlock=Some(100))
+    let fetchState = FetchState.make(
+      ~eventConfigs=[],
+      ~addresses=[],
+      ~startBlock=100,
+      ~endBlock=None,
+      ~maxAddrInPartition=3,
+      ~targetBufferSize=5000,
+      ~chainId,
+      ~onBlockConfigs=[onBlockConfig],
+      ~knownHeight=110,
+      ~progressBlockNumber=104,
+    )
+
+    t.expect(fetchState->FetchState.bufferSize).toBeGreaterThan(0)
+
+    let blockNumbers =
+      fetchState.buffer->Array.map(item => item->Internal.getItemBlockNumber)
+
+    t.expect(blockNumbers).toEqual([105, 106, 107, 108, 109, 110])
+  })
+
+  it("should not get stuck on resume for onBlock-only indexer", t => {
+    // Without the fix, getNextQuery returned NothingToQuery because:
+    // 1. headBlockNumber > 0 (not WaitingForNewBlock early return)
+    // 2. isOnBlockBehindTheHead=true -> shouldWaitForNewBlock=false
+    // 3. No partitions -> no queries
+    // Result: NothingToQuery -> fetcher does nothing -> stuck
+    let onBlockConfig = makeOnBlockConfig(~interval=1, ~startBlock=Some(100))
+    let fetchState = FetchState.make(
+      ~eventConfigs=[],
+      ~addresses=[],
+      ~startBlock=100,
+      ~endBlock=None,
+      ~maxAddrInPartition=3,
+      ~targetBufferSize=5000,
+      ~chainId,
+      ~onBlockConfigs=[onBlockConfig],
+      ~knownHeight=110,
+      ~progressBlockNumber=104,
+    )
+
+    // With the fix, the buffer is populated and onBlock pointer is caught up.
+    // getNextQuery should return WaitingForNewBlock, not NothingToQuery.
+    let nextQuery = fetchState->FetchState.getNextQuery(~concurrencyLimit=10)
+    t.expect(nextQuery).toEqual(FetchState.WaitingForNewBlock)
   })
 })


### PR DESCRIPTION
## Summary

Indexers that only have `onBlock` handlers and no event handlers (no contracts/addresses, so no fetch partitions) got stuck after resuming from a checkpoint. The clearest case is an SVM `onSlot`-only indexer.

On resume, `knownHeight` is restored from the DB but the buffer starts empty. With no partitions to drive fetching and nothing repopulating the buffer, `getNextQuery` returned `NothingToQuery` and the indexer never advanced past the resumed progress block.

## Fix

`FetchState.make` now seeds the buffer from the `onBlock` configs when resuming (`knownHeight > 0` with non-empty `onBlockConfigs`). The buffer-generation logic is extracted into a shared `appendOnBlockItems` function used by both `make` and `updateInternal`, so there's a single source of truth instead of an opaque `updateInternal` call during initialization.

## Tests

Added `scenarios/svm_test/test/SlotResume_test.res` — a MockIndexer regression test driving a real `onSlot`-only indexer through an initial run and a resume. It asserts the indexer keeps progressing across the resume (produces slots `[0, 5, 10, 15]`). Verified it fails (hangs/stuck) without the fix and passes with it.

https://claude.ai/code/session_01XEtRPxD9HMn4WUQKSyDaRt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of onBlock handlers when resuming from checkpoints, ensuring proper buffer initialization and preventing missed work items.
  * Enhanced memory safeguards for buffer management to prevent out-of-memory issues.

* **Tests**
  * Added regression test ensuring onSlot-only indexers continue progressing correctly after resuming from a checkpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->