### PR TITLE
Make config path root-relative in start command

### DIFF
--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -58,7 +58,7 @@ This document contains the help content for the `envio` command-line program.
 ###### **Options:**
 
 * `-d`, `--directory <DIRECTORY>` — The directory of the project. Defaults to current dir ("./")
-* `--config <CONFIG>` — The file in the project containing the configuration. It can also be set via the `ENVIO_CONFIG` environment variable
+* `--config <CONFIG>` — The config file path, resolved relative to --directory. It can also be set via the `ENVIO_CONFIG` environment variable
 
   Default value: `config.yaml`
 

--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -57,8 +57,8 @@ This document contains the help content for the `envio` command-line program.
 
 ###### **Options:**
 
-* `-d`, `--directory <DIRECTORY>` — The directory of the project. Defaults to current dir ("./"). The --config path is resolved relative to it
-* `--config <CONFIG>` — The config file path, resolved relative to the working directory. It can also be set via the `ENVIO_CONFIG` environment variable
+* `-d`, `--directory <DIRECTORY>` — The directory of the project. Defaults to current dir ("./")
+* `--config <CONFIG>` — The config file path, resolved relative to the project directory. It can also be set via the `ENVIO_CONFIG` environment variable
 
   Default value: `config.yaml`
 

--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -58,7 +58,7 @@ This document contains the help content for the `envio` command-line program.
 ###### **Options:**
 
 * `-d`, `--directory <DIRECTORY>` — The directory of the project. Defaults to current dir ("./")
-* `--config <CONFIG>` — The config file path, resolved relative to --directory (the current directory by default). It can also be set via the `ENVIO_CONFIG` environment variable
+* `--config <CONFIG>` — The config file path, resolved relative to --directory (the working directory by default). It can also be set via the `ENVIO_CONFIG` environment variable
 
   Default value: `config.yaml`
 

--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -58,7 +58,7 @@ This document contains the help content for the `envio` command-line program.
 ###### **Options:**
 
 * `-d`, `--directory <DIRECTORY>` — The directory of the project. Defaults to current dir ("./")
-* `--config <CONFIG>` — The config file path, resolved relative to --directory. It can also be set via the `ENVIO_CONFIG` environment variable
+* `--config <CONFIG>` — The config file path, resolved relative to --directory (the current directory by default). It can also be set via the `ENVIO_CONFIG` environment variable
 
   Default value: `config.yaml`
 

--- a/packages/cli/CommandLineHelp.md
+++ b/packages/cli/CommandLineHelp.md
@@ -57,8 +57,8 @@ This document contains the help content for the `envio` command-line program.
 
 ###### **Options:**
 
-* `-d`, `--directory <DIRECTORY>` — The directory of the project. Defaults to current dir ("./")
-* `--config <CONFIG>` — The config file path, resolved relative to --directory (the working directory by default). It can also be set via the `ENVIO_CONFIG` environment variable
+* `-d`, `--directory <DIRECTORY>` — The directory of the project. Defaults to current dir ("./"). The --config path is resolved relative to it
+* `--config <CONFIG>` — The config file path, resolved relative to the working directory. It can also be set via the `ENVIO_CONFIG` environment variable
 
   Default value: `config.yaml`
 

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -31,7 +31,7 @@ pub struct ProjectPaths {
     #[arg(global = true, short, long)]
     pub directory: Option<String>,
 
-    ///The config file path, resolved relative to --directory (the current directory by default). It can also be set via the `ENVIO_CONFIG` environment variable.
+    ///The config file path, resolved relative to --directory (the working directory by default). It can also be set via the `ENVIO_CONFIG` environment variable.
     #[arg(global = true, long, env = "ENVIO_CONFIG", default_value_t=String::from(DEFAULT_CONFIG_PATH))]
     pub config: String,
 }

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -27,11 +27,11 @@ impl CommandLineArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct ProjectPaths {
-    ///The directory of the project. Defaults to current dir ("./")
+    ///The directory of the project. Defaults to current dir ("./"). The --config path is resolved relative to it.
     #[arg(global = true, short, long)]
     pub directory: Option<String>,
 
-    ///The config file path, resolved relative to --directory (the working directory by default). It can also be set via the `ENVIO_CONFIG` environment variable.
+    ///The config file path, resolved relative to the working directory. It can also be set via the `ENVIO_CONFIG` environment variable.
     #[arg(global = true, long, env = "ENVIO_CONFIG", default_value_t=String::from(DEFAULT_CONFIG_PATH))]
     pub config: String,
 }

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -31,7 +31,7 @@ pub struct ProjectPaths {
     #[arg(global = true, short, long)]
     pub directory: Option<String>,
 
-    ///The file in the project containing the configuration. It can also be set via the `ENVIO_CONFIG` environment variable.
+    ///The config file path, resolved relative to --directory. It can also be set via the `ENVIO_CONFIG` environment variable.
     #[arg(global = true, long, env = "ENVIO_CONFIG", default_value_t=String::from(DEFAULT_CONFIG_PATH))]
     pub config: String,
 }

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -31,7 +31,7 @@ pub struct ProjectPaths {
     #[arg(global = true, short, long)]
     pub directory: Option<String>,
 
-    ///The config file path, resolved relative to --directory. It can also be set via the `ENVIO_CONFIG` environment variable.
+    ///The config file path, resolved relative to --directory (the current directory by default). It can also be set via the `ENVIO_CONFIG` environment variable.
     #[arg(global = true, long, env = "ENVIO_CONFIG", default_value_t=String::from(DEFAULT_CONFIG_PATH))]
     pub config: String,
 }

--- a/packages/cli/src/cli_args/clap_definitions.rs
+++ b/packages/cli/src/cli_args/clap_definitions.rs
@@ -27,11 +27,11 @@ impl CommandLineArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct ProjectPaths {
-    ///The directory of the project. Defaults to current dir ("./"). The --config path is resolved relative to it.
+    ///The directory of the project. Defaults to current dir ("./")
     #[arg(global = true, short, long)]
     pub directory: Option<String>,
 
-    ///The config file path, resolved relative to the working directory. It can also be set via the `ENVIO_CONFIG` environment variable.
+    ///The config file path, resolved relative to the project directory. It can also be set via the `ENVIO_CONFIG` environment variable.
     #[arg(global = true, long, env = "ENVIO_CONFIG", default_value_t=String::from(DEFAULT_CONFIG_PATH))]
     pub config: String,
 }

--- a/packages/cli/src/cli_args/snapshots/envio__cli_args__clap_definitions__test__envio_help_snapshot.snap
+++ b/packages/cli/src/cli_args/snapshots/envio__cli_args__clap_definitions__test__envio_help_snapshot.snap
@@ -18,7 +18,7 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-  -d, --directory <DIRECTORY>  The directory of the project. Defaults to current dir ("./")
-      --config <CONFIG>        The config file path, resolved relative to --directory (the working directory by default). It can also be set via the `ENVIO_CONFIG` environment variable [env: ENVIO_CONFIG=] [default: config.yaml]
+  -d, --directory <DIRECTORY>  The directory of the project. Defaults to current dir ("./"). The --config path is resolved relative to it
+      --config <CONFIG>        The config file path, resolved relative to the working directory. It can also be set via the `ENVIO_CONFIG` environment variable [env: ENVIO_CONFIG=] [default: config.yaml]
   -h, --help                   Print help
   -V, --version                Print version

--- a/packages/cli/src/cli_args/snapshots/envio__cli_args__clap_definitions__test__envio_help_snapshot.snap
+++ b/packages/cli/src/cli_args/snapshots/envio__cli_args__clap_definitions__test__envio_help_snapshot.snap
@@ -19,6 +19,6 @@ Commands:
 
 Options:
   -d, --directory <DIRECTORY>  The directory of the project. Defaults to current dir ("./")
-      --config <CONFIG>        The config file path, resolved relative to --directory (the current directory by default). It can also be set via the `ENVIO_CONFIG` environment variable [env: ENVIO_CONFIG=] [default: config.yaml]
+      --config <CONFIG>        The config file path, resolved relative to --directory (the working directory by default). It can also be set via the `ENVIO_CONFIG` environment variable [env: ENVIO_CONFIG=] [default: config.yaml]
   -h, --help                   Print help
   -V, --version                Print version

--- a/packages/cli/src/cli_args/snapshots/envio__cli_args__clap_definitions__test__envio_help_snapshot.snap
+++ b/packages/cli/src/cli_args/snapshots/envio__cli_args__clap_definitions__test__envio_help_snapshot.snap
@@ -18,7 +18,7 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-  -d, --directory <DIRECTORY>  The directory of the project. Defaults to current dir ("./"). The --config path is resolved relative to it
-      --config <CONFIG>        The config file path, resolved relative to the working directory. It can also be set via the `ENVIO_CONFIG` environment variable [env: ENVIO_CONFIG=] [default: config.yaml]
+  -d, --directory <DIRECTORY>  The directory of the project. Defaults to current dir ("./")
+      --config <CONFIG>        The config file path, resolved relative to the project directory. It can also be set via the `ENVIO_CONFIG` environment variable [env: ENVIO_CONFIG=] [default: config.yaml]
   -h, --help                   Print help
   -V, --version                Print version

--- a/packages/cli/src/cli_args/snapshots/envio__cli_args__clap_definitions__test__envio_help_snapshot.snap
+++ b/packages/cli/src/cli_args/snapshots/envio__cli_args__clap_definitions__test__envio_help_snapshot.snap
@@ -19,6 +19,6 @@ Commands:
 
 Options:
   -d, --directory <DIRECTORY>  The directory of the project. Defaults to current dir ("./")
-      --config <CONFIG>        The file in the project containing the configuration. It can also be set via the `ENVIO_CONFIG` environment variable [env: ENVIO_CONFIG=] [default: config.yaml]
+      --config <CONFIG>        The config file path, resolved relative to --directory. It can also be set via the `ENVIO_CONFIG` environment variable [env: ENVIO_CONFIG=] [default: config.yaml]
   -h, --help                   Print help
   -V, --version                Print version

--- a/packages/cli/src/cli_args/snapshots/envio__cli_args__clap_definitions__test__envio_help_snapshot.snap
+++ b/packages/cli/src/cli_args/snapshots/envio__cli_args__clap_definitions__test__envio_help_snapshot.snap
@@ -19,6 +19,6 @@ Commands:
 
 Options:
   -d, --directory <DIRECTORY>  The directory of the project. Defaults to current dir ("./")
-      --config <CONFIG>        The config file path, resolved relative to --directory. It can also be set via the `ENVIO_CONFIG` environment variable [env: ENVIO_CONFIG=] [default: config.yaml]
+      --config <CONFIG>        The config file path, resolved relative to --directory (the current directory by default). It can also be set via the `ENVIO_CONFIG` environment variable [env: ENVIO_CONFIG=] [default: config.yaml]
   -h, --help                   Print help
   -V, --version                Print version

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -1034,10 +1034,12 @@ impl SystemConfig {
     pub fn parse_from_project_files(project_paths: &ParsedProjectPaths) -> Result<Self> {
         let human_config_string =
             std::fs::read_to_string(&project_paths.config).context(format!(
-                "Failed to resolve config path {0}. Make sure you're in the correct \
-                 directory and that a config file with the name {0} exists. I can configure \
-                 another path by using the --config flag.",
+                "Failed to resolve config path {0} (--config {1} resolved relative to \
+                 --directory {2}). Make sure the file exists. Note that --config and \
+                 ENVIO_CONFIG are interpreted relative to --directory.",
                 &project_paths.config.to_str().unwrap_or("{unknown}"),
+                project_paths.config_relative_to_root().display(),
+                project_paths.project_root.display(),
             ))?;
 
         let mut env_state = EnvState::new(&project_paths.project_root);

--- a/packages/cli/src/executor/mod.rs
+++ b/packages/cli/src/executor/mod.rs
@@ -175,10 +175,8 @@ pub async fn execute(
 /// append extra env pairs (e.g. ClickHouse credentials from Docker for
 /// `envio dev`).
 ///
-/// `ENVIO_CONFIG` is exported relative to the project root: the runtime
-/// chdirs into `cwd` before reading it, and a CLI re-invocation joins it
-/// onto `--directory` again — a cwd-joined value would resolve to
-/// `<root>/<root>/config.yaml` in both cases.
+/// `ENVIO_CONFIG` is root-relative: consumers resolve it against
+/// `cwd` / `--directory`, so a cwd-joined value would double the prefix.
 pub fn build_start_command(
     config: &SystemConfig,
     reset: bool,

--- a/packages/cli/src/executor/mod.rs
+++ b/packages/cli/src/executor/mod.rs
@@ -174,6 +174,11 @@ pub async fn execute(
 /// `ENVIO_CONFIG` is always present in the returned `env`; callers may
 /// append extra env pairs (e.g. ClickHouse credentials from Docker for
 /// `envio dev`).
+///
+/// `ENVIO_CONFIG` is exported relative to the project root: the runtime
+/// chdirs into `cwd` before reading it, and a CLI re-invocation joins it
+/// onto `--directory` again — a cwd-joined value would resolve to
+/// `<root>/<root>/config.yaml` in both cases.
 pub fn build_start_command(
     config: &SystemConfig,
     reset: bool,
@@ -182,7 +187,7 @@ pub fn build_start_command(
 ) -> Result<Command> {
     let config_path = config
         .parsed_project_paths
-        .config
+        .config_relative_to_root()
         .to_string_lossy()
         .into_owned();
 

--- a/packages/cli/src/project_paths/mod.rs
+++ b/packages/cli/src/project_paths/mod.rs
@@ -58,6 +58,15 @@ impl ParsedProjectPaths {
         Self::new(project_root, DEFAULT_CONFIG_PATH)
     }
 
+    /// The config path expressed relative to the project root — the form
+    /// consumers need once the project root acts as cwd (the runtime chdirs
+    /// into it, and clap joins `ENVIO_CONFIG` onto `--directory` again).
+    pub fn config_relative_to_root(&self) -> PathBuf {
+        let normalized_root = path_utils::normalize_path(self.project_root.clone());
+        pathdiff::diff_paths(&self.config, &normalized_root)
+            .expect("config is validated to live under the project root")
+    }
+
     /// Path to the codegen-emitted `.envio/types.d.ts` file.
     pub fn envio_types_dts(&self) -> PathBuf {
         self.envio_dir.join(ENVIO_TYPES_FILE)
@@ -171,5 +180,36 @@ mod tests {
     #[test]
     fn check_default_does_not_panic() {
         ParsedProjectPaths::default();
+    }
+
+    #[test]
+    fn test_config_relative_to_root_round_trips_through_directory_join() {
+        let paths = ParsedProjectPaths::new("envio/analytics", "config.yaml").unwrap();
+        let relative = paths.config_relative_to_root();
+        let round_tripped =
+            ParsedProjectPaths::new("envio/analytics", relative.to_str().unwrap()).unwrap();
+        assert_eq!(
+            (relative, round_tripped),
+            (PathBuf::from("config.yaml"), paths)
+        );
+    }
+
+    #[test]
+    fn test_config_relative_to_root_with_default_root() {
+        let paths = ParsedProjectPaths::new("./", "configs/config.yaml").unwrap();
+        assert_eq!(
+            paths.config_relative_to_root(),
+            PathBuf::from("configs/config.yaml")
+        );
+    }
+
+    #[test]
+    fn test_config_relative_to_root_with_absolute_config() {
+        let paths =
+            ParsedProjectPaths::new("/repo/project", "/repo/project/configs/config.yaml").unwrap();
+        assert_eq!(
+            paths.config_relative_to_root(),
+            PathBuf::from("configs/config.yaml")
+        );
     }
 }

--- a/packages/cli/src/project_paths/mod.rs
+++ b/packages/cli/src/project_paths/mod.rs
@@ -58,9 +58,7 @@ impl ParsedProjectPaths {
         Self::new(project_root, DEFAULT_CONFIG_PATH)
     }
 
-    /// The config path expressed relative to the project root — the form
-    /// consumers need once the project root acts as cwd (the runtime chdirs
-    /// into it, and clap joins `ENVIO_CONFIG` onto `--directory` again).
+    /// The form consumers need when the project root acts as cwd.
     pub fn config_relative_to_root(&self) -> PathBuf {
         let normalized_root = path_utils::normalize_path(self.project_root.clone());
         pathdiff::diff_paths(&self.config, &normalized_root)


### PR DESCRIPTION
## Summary
Fixes a bug where the config path passed to the start command was absolute, causing double-prefixing when consumers resolved it against the working directory. The config path is now computed relative to the project root.

## Changes
- Add `config_relative_to_root()` method to `ParsedProjectPaths` that computes the config path relative to the project root using path normalization and diffing
- Update `build_start_command()` to use the new relative path method instead of the absolute config path
- Add documentation clarifying that `ENVIO_CONFIG` is root-relative and should be resolved against `cwd`/`--directory`
- Add three test cases covering:
  - Round-trip behavior through directory join
  - Relative paths with default root
  - Absolute paths with explicit root

https://claude.ai/code/session_014kgG3btfXFG5ujc6xzJja8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed config path handling so CLI --config and ENVIO_CONFIG are interpreted and resolved relative to the selected project directory; improved error reporting when resolution fails.

* **Documentation**
  * Clarified CLI help: --directory, --config, and ENVIO_CONFIG are documented as paths resolved relative to the chosen directory (defaults to current directory).

* **Tests**
  * Added tests validating config path round-tripping and resolution for relative and absolute inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->