### PR TITLE
Add per-backend `default` flag for entity storage fallback

### DIFF
--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -100,7 +100,7 @@ pub struct StorageConfig {
     pub clickhouse: Option<StorageBackendConfig>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum StorageBackendConfig {
     Enabled(bool),
@@ -115,6 +115,43 @@ pub struct StorageBackendOptions {
     pub default: Option<bool>,
 }
 
+// Hand-rolled instead of #[serde(untagged)]: the untagged derive swallows
+// errors from inside the variants, so a typo like `{defautl: true}` would
+// surface as "data did not match any variant" instead of the precise
+// unknown-field error from StorageBackendOptions.
+impl<'de> Deserialize<'de> for StorageBackendConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct BackendVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for BackendVisitor {
+            type Value = StorageBackendConfig;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a boolean or an options object like `{default: true}`")
+            }
+
+            fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Self::Value, E> {
+                Ok(StorageBackendConfig::Enabled(v))
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                StorageBackendOptions::deserialize(serde::de::value::MapAccessDeserializer::new(
+                    map,
+                ))
+                .map(StorageBackendConfig::Options)
+            }
+        }
+
+        deserializer.deserialize_any(BackendVisitor)
+    }
+}
+
 impl StorageBackendConfig {
     pub fn is_enabled(&self) -> bool {
         match self {
@@ -123,7 +160,7 @@ impl StorageBackendConfig {
         }
     }
 
-    pub fn default(&self) -> Option<bool> {
+    pub fn entity_default(&self) -> Option<bool> {
         match self {
             Self::Enabled(_) => None,
             Self::Options(options) => options.default,
@@ -141,60 +178,55 @@ impl JsonSchema for StorageConfig {
     }
 
     fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        let backend = |description: &str, default_description: &str| {
+            serde_json::json!({
+                "description": description,
+                "anyOf": [
+                    { "type": ["boolean", "null"] },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "default": {
+                                "description": default_description,
+                                "type": ["boolean", "null"]
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                ]
+            })
+        };
+        // Matches a backend in any of its enabled spellings (the object
+        // form implies enabled).
+        let enabled = serde_json::json!({
+            "anyOf": [{ "const": true }, { "type": "object" }]
+        });
         json_schema!({
             "type": "object",
             "properties": {
-                "postgres": {
-                    "description": "Whether to use Postgres as a storage backend (default: true). \
-                                    Accepts a boolean or an options object (the object form \
-                                    implies the backend is enabled).",
-                    "anyOf": [
-                        { "type": ["boolean", "null"] },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "default": {
-                                    "description": "Whether entities without an @storage \
-                                                    directive are stored in this backend \
-                                                    (default: true when Postgres is the only \
-                                                    enabled backend, false otherwise).",
-                                    "type": ["boolean", "null"]
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    ]
-                },
-                "clickhouse": {
-                    "description": "Whether to additionally sync the indexed data to ClickHouse. \
-                                    Requires Postgres to be enabled (default: false). Accepts a \
-                                    boolean or an options object (the object form implies the \
-                                    backend is enabled).",
-                    "anyOf": [
-                        { "type": ["boolean", "null"] },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "default": {
-                                    "description": "Whether entities without an @storage \
-                                                    directive are stored in this backend \
-                                                    (default: false).",
-                                    "type": ["boolean", "null"]
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    ]
-                }
+                "postgres": (backend(
+                    "Whether to use Postgres as a storage backend (default: true). Accepts a \
+                     boolean or an options object (the object form implies the backend is \
+                     enabled).",
+                    "Whether entities without an @storage directive are stored in this backend \
+                     (default: true when Postgres is the only enabled backend, false otherwise)."
+                )),
+                "clickhouse": (backend(
+                    "Whether to additionally sync the indexed data to ClickHouse. Requires \
+                     Postgres to be enabled (default: false). Accepts a boolean or an options \
+                     object (the object form implies the backend is enabled).",
+                    "Whether entities without an @storage directive are stored in this backend \
+                     (default: false)."
+                ))
             },
             "additionalProperties": false,
             // Storage::resolve rejects two shapes:
             //   1. `postgres: false` (with any clickhouse value) — either
             //      fails as "ClickHouse not supported as a single storage
             //      yet" or resolves to all-backends-disabled.
-            //   2. ClickHouse enabled (true or object form) without an
-            //      explicitly enabled postgres — the user must opt in to
-            //      Postgres alongside ClickHouse.
+            //   2. ClickHouse enabled without an explicitly enabled
+            //      postgres — the user must opt in to Postgres alongside
+            //      ClickHouse.
             "allOf": [
                 {
                     "not": {
@@ -207,17 +239,13 @@ impl JsonSchema for StorageConfig {
                 {
                     "if": {
                         "properties": {
-                            "clickhouse": {
-                                "anyOf": [{ "const": true }, { "type": "object" }]
-                            }
+                            "clickhouse": (enabled.clone())
                         },
                         "required": ["clickhouse"]
                     },
                     "then": {
                         "properties": {
-                            "postgres": {
-                                "anyOf": [{ "const": true }, { "type": "object" }]
-                            }
+                            "postgres": (enabled)
                         },
                         "required": ["postgres"]
                     }
@@ -1399,11 +1427,6 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
                 })),
             }
         );
-        let clickhouse = de.clickhouse.unwrap();
-        assert_eq!(
-            (clickhouse.is_enabled(), clickhouse.default()),
-            (true, Some(true))
-        );
 
         // Empty object form implies enabled with no default override
         let yaml = "postgres: {}\n";
@@ -1418,11 +1441,22 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
             }
         );
 
-        // Unknown field in the options object should fail
+        // A typo inside the options object surfaces the precise
+        // unknown-field error, not a generic match-no-variant one
         let yaml = "clickhouse:\n  defautl: true\n";
         let err = serde_yaml::from_str::<StorageConfig>(yaml).unwrap_err();
         assert!(
-            err.to_string().contains("untagged enum"),
+            err.to_string()
+                .contains("unknown field `defautl`, expected `default`"),
+            "Unexpected error: {err}"
+        );
+
+        // A value of the wrong type names the accepted shapes
+        let yaml = "clickhouse: enabled\n";
+        let err = serde_yaml::from_str::<StorageConfig>(yaml).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("expected a boolean or an options object like `{default: true}`"),
             "Unexpected error: {err}"
         );
     }

--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -85,7 +85,9 @@ pub struct BaseConfig {
         description = "Configuration for the storage backends the indexer writes to. Defaults to \
                        `postgres: true` when omitted. ClickHouse requires Postgres to be enabled \
                        (it is not supported as a single storage yet), and at least one backend \
-                       must be enabled."
+                       must be enabled. Each backend accepts a boolean or an options object with \
+                       `default` controlling whether entities without an @storage directive are \
+                       stored in it."
     )]
     pub storage: Option<StorageConfig>,
 }
@@ -94,9 +96,40 @@ pub struct BaseConfig {
 #[serde(deny_unknown_fields)]
 pub struct StorageConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postgres: Option<bool>,
+    pub postgres: Option<StorageBackendConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub clickhouse: Option<bool>,
+    pub clickhouse: Option<StorageBackendConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(untagged)]
+pub enum StorageBackendConfig {
+    Enabled(bool),
+    // The object form implies the backend is enabled.
+    Options(StorageBackendOptions),
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct StorageBackendOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<bool>,
+}
+
+impl StorageBackendConfig {
+    pub fn is_enabled(&self) -> bool {
+        match self {
+            Self::Enabled(enabled) => *enabled,
+            Self::Options(_) => true,
+        }
+    }
+
+    pub fn default(&self) -> Option<bool> {
+        match self {
+            Self::Enabled(_) => None,
+            Self::Options(options) => options.default,
+        }
+    }
 }
 
 // Hand-rolled JsonSchema so the generated YAML/JSON schema encodes the same
@@ -113,13 +146,45 @@ impl JsonSchema for StorageConfig {
             "type": "object",
             "properties": {
                 "postgres": {
-                    "description": "Whether to use Postgres as a storage backend (default: true).",
-                    "type": ["boolean", "null"]
+                    "description": "Whether to use Postgres as a storage backend (default: true). \
+                                    Accepts a boolean or an options object (the object form \
+                                    implies the backend is enabled).",
+                    "anyOf": [
+                        { "type": ["boolean", "null"] },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "default": {
+                                    "description": "Whether entities without an @storage \
+                                                    directive are stored in this backend \
+                                                    (default: true for postgres).",
+                                    "type": ["boolean", "null"]
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    ]
                 },
                 "clickhouse": {
                     "description": "Whether to additionally sync the indexed data to ClickHouse. \
-                                    Requires Postgres to be enabled (default: false).",
-                    "type": ["boolean", "null"]
+                                    Requires Postgres to be enabled (default: false). Accepts a \
+                                    boolean or an options object (the object form implies the \
+                                    backend is enabled).",
+                    "anyOf": [
+                        { "type": ["boolean", "null"] },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "default": {
+                                    "description": "Whether entities without an @storage \
+                                                    directive are stored in this backend \
+                                                    (default: false for clickhouse).",
+                                    "type": ["boolean", "null"]
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    ]
                 }
             },
             "additionalProperties": false,
@@ -127,8 +192,9 @@ impl JsonSchema for StorageConfig {
             //   1. `postgres: false` (with any clickhouse value) — either
             //      fails as "ClickHouse not supported as a single storage
             //      yet" or resolves to all-backends-disabled.
-            //   2. `clickhouse: true` without an explicit `postgres: true` —
-            //      the user must opt in to Postgres alongside ClickHouse.
+            //   2. ClickHouse enabled (true or object form) without an
+            //      explicitly enabled postgres — the user must opt in to
+            //      Postgres alongside ClickHouse.
             "allOf": [
                 {
                     "not": {
@@ -141,13 +207,17 @@ impl JsonSchema for StorageConfig {
                 {
                     "if": {
                         "properties": {
-                            "clickhouse": { "const": true }
+                            "clickhouse": {
+                                "anyOf": [{ "const": true }, { "type": "object" }]
+                            }
                         },
                         "required": ["clickhouse"]
                     },
                     "then": {
                         "properties": {
-                            "postgres": { "const": true }
+                            "postgres": {
+                                "anyOf": [{ "const": true }, { "type": "object" }]
+                            }
                         },
                         "required": ["postgres"]
                     }
@@ -1281,7 +1351,7 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
 
     #[test]
     fn deserialize_storage_config() {
-        use super::StorageConfig;
+        use super::{StorageBackendConfig, StorageConfig};
 
         // Both fields present
         let yaml = "postgres: true\nclickhouse: true\n";
@@ -1289,8 +1359,8 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
         assert_eq!(
             de,
             StorageConfig {
-                postgres: Some(true),
-                clickhouse: Some(true),
+                postgres: Some(StorageBackendConfig::Enabled(true)),
+                clickhouse: Some(StorageBackendConfig::Enabled(true)),
             }
         );
 
@@ -1301,7 +1371,7 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
             de,
             StorageConfig {
                 postgres: None,
-                clickhouse: Some(true),
+                clickhouse: Some(StorageBackendConfig::Enabled(true)),
             }
         );
 
@@ -1315,13 +1385,57 @@ address: ["0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"]
     }
 
     #[test]
+    fn deserialize_storage_backend_options() {
+        use super::{StorageBackendConfig, StorageBackendOptions, StorageConfig};
+
+        let yaml = "postgres: true\nclickhouse:\n  default: true\n";
+        let de: StorageConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            de,
+            StorageConfig {
+                postgres: Some(StorageBackendConfig::Enabled(true)),
+                clickhouse: Some(StorageBackendConfig::Options(StorageBackendOptions {
+                    default: Some(true),
+                })),
+            }
+        );
+        let clickhouse = de.clickhouse.unwrap();
+        assert_eq!(
+            (clickhouse.is_enabled(), clickhouse.default()),
+            (true, Some(true))
+        );
+
+        // Empty object form implies enabled with no default override
+        let yaml = "postgres: {}\n";
+        let de: StorageConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            de,
+            StorageConfig {
+                postgres: Some(StorageBackendConfig::Options(StorageBackendOptions {
+                    default: None,
+                })),
+                clickhouse: None,
+            }
+        );
+
+        // Unknown field in the options object should fail
+        let yaml = "clickhouse:\n  defautl: true\n";
+        let err = serde_yaml::from_str::<StorageConfig>(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("untagged enum"),
+            "Unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn deserialize_evm_config_with_storage() {
         use super::evm::HumanConfig as EvmConfig;
         let yaml = r#"
 name: storage-test
 storage:
   postgres: true
-  clickhouse: true
+  clickhouse:
+    default: true
 chains:
   - id: 1
     start_block: 0
@@ -1330,8 +1444,12 @@ chains:
         assert_eq!(
             cfg.base.storage,
             Some(super::StorageConfig {
-                postgres: Some(true),
-                clickhouse: Some(true),
+                postgres: Some(super::StorageBackendConfig::Enabled(true)),
+                clickhouse: Some(super::StorageBackendConfig::Options(
+                    super::StorageBackendOptions {
+                        default: Some(true),
+                    }
+                )),
             })
         );
     }

--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -82,13 +82,11 @@ pub struct BaseConfig {
     pub full_batch_size: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(
-        description = "Configuration for the storage backends the indexer writes to. Defaults to \
-                       `postgres: true` when omitted. ClickHouse requires Postgres to be enabled \
-                       (it is not supported as a single storage yet), and at least one backend \
-                       must be enabled. Each backend accepts a boolean or an options object with \
-                       `default` controlling whether entities without an @storage directive are \
-                       stored in it. A single enabled backend is implicitly the default; with \
-                       multiple backends none is, unless opted in via `default: true`."
+        description = "Storage backends the indexer writes data to. Defaults to Postgres when \
+                       omitted. Set `clickhouse: true` to additionally sync the indexed data to \
+                       ClickHouse. Mark a backend with `default: true` to store entities that \
+                       don't have an @storage directive in the schema, e.g. `clickhouse: \
+                       {default: true}`."
     )]
     pub storage: Option<StorageConfig>,
 }

--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -87,7 +87,8 @@ pub struct BaseConfig {
                        (it is not supported as a single storage yet), and at least one backend \
                        must be enabled. Each backend accepts a boolean or an options object with \
                        `default` controlling whether entities without an @storage directive are \
-                       stored in it."
+                       stored in it. A single enabled backend is implicitly the default; with \
+                       multiple backends none is, unless opted in via `default: true`."
     )]
     pub storage: Option<StorageConfig>,
 }
@@ -157,7 +158,8 @@ impl JsonSchema for StorageConfig {
                                 "default": {
                                     "description": "Whether entities without an @storage \
                                                     directive are stored in this backend \
-                                                    (default: true for postgres).",
+                                                    (default: true when Postgres is the only \
+                                                    enabled backend, false otherwise).",
                                     "type": ["boolean", "null"]
                                 }
                             },
@@ -178,7 +180,7 @@ impl JsonSchema for StorageConfig {
                                 "default": {
                                     "description": "Whether entities without an @storage \
                                                     directive are stored in this backend \
-                                                    (default: false for clickhouse).",
+                                                    (default: false).",
                                     "type": ["boolean", "null"]
                                 }
                             },

--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -53,6 +53,14 @@ struct StorageConfig {
     postgres: bool,
     #[serde(skip_serializing_if = "is_false")]
     clickhouse: bool,
+    // Skipped when matching the implied values (postgres: true,
+    // clickhouse: false) so configs not using per-backend `default`
+    // keep emitting byte-identical JSON — an added key would trip the
+    // persisted-config diff for every existing project.
+    #[serde(skip_serializing_if = "is_true")]
+    postgres_default: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    clickhouse_default: bool,
 }
 
 impl From<&system_config::Storage> for StorageConfig {
@@ -60,6 +68,8 @@ impl From<&system_config::Storage> for StorageConfig {
         Self {
             postgres: s.postgres,
             clickhouse: s.clickhouse,
+            postgres_default: s.postgres_default,
+            clickhouse_default: s.clickhouse_default,
         }
     }
 }

--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -53,14 +53,6 @@ struct StorageConfig {
     postgres: bool,
     #[serde(skip_serializing_if = "is_false")]
     clickhouse: bool,
-    // Skipped when matching the implied values (postgres: true,
-    // clickhouse: false) so configs not using per-backend `default`
-    // keep emitting byte-identical JSON — an added key would trip the
-    // persisted-config diff for every existing project.
-    #[serde(skip_serializing_if = "is_true")]
-    postgres_default: bool,
-    #[serde(skip_serializing_if = "is_false")]
-    clickhouse_default: bool,
 }
 
 impl From<&system_config::Storage> for StorageConfig {
@@ -68,8 +60,6 @@ impl From<&system_config::Storage> for StorageConfig {
         Self {
             postgres: s.postgres,
             clickhouse: s.clickhouse,
-            postgres_default: s.postgres_default,
-            clickhouse_default: s.clickhouse_default,
         }
     }
 }
@@ -79,9 +69,11 @@ impl From<&system_config::Storage> for StorageConfig {
 struct EntityJson {
     name: String,
     // Mirrors the user's `@storage(...)` directive verbatim: only the args
-    // they wrote are emitted, and the whole field is omitted when the
-    // directive is absent. Resolution against the global storage happens
-    // on the ReScript side.
+    // they wrote are emitted. Without a directive the entity gets the
+    // backends marked `default` in config.yaml — stamped here, except when
+    // they coincide with the enabled backends: then the field is omitted
+    // and the ReScript side falls back to the global storage, keeping the
+    // JSON byte-identical for projects predating per-backend `default`.
     #[serde(skip_serializing_if = "Option::is_none")]
     storage: Option<EntityStorageJson>,
     properties: Vec<PropertyJson>,
@@ -618,8 +610,18 @@ impl SystemConfig {
                         postgres: entity.postgres,
                         clickhouse: entity.clickhouse,
                     })
-                } else {
+                } else if (cfg.storage.postgres_default, cfg.storage.clickhouse_default)
+                    == (cfg.storage.postgres, cfg.storage.clickhouse)
+                {
                     None
+                } else {
+                    // Emitted in the same shape a positive @storage directive
+                    // would produce, so switching an entity between the
+                    // directive and a config-level default doesn't diff.
+                    Some(EntityStorageJson {
+                        postgres: cfg.storage.postgres_default.then_some(true),
+                        clickhouse: cfg.storage.clickhouse_default.then_some(true),
+                    })
                 };
 
                 Ok(EntityJson {

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -475,10 +475,12 @@ impl Storage {
         }
         let postgres_default = postgres
             && postgres_config
-                .and_then(|c| c.default())
+                .and_then(|c| c.entity_default())
                 .unwrap_or(!clickhouse);
-        let clickhouse_default =
-            clickhouse && clickhouse_config.and_then(|c| c.default()).unwrap_or(false);
+        let clickhouse_default = clickhouse
+            && clickhouse_config
+                .and_then(|c| c.entity_default())
+                .unwrap_or(false);
         Ok(Self {
             postgres,
             clickhouse,
@@ -513,7 +515,7 @@ pub fn validate_entity_storage(storage: &Storage, schema: &Schema) -> anyhow::Re
             return Err(anyhow!(
                 "Schema validation failed:\n\
                  \n\
-                 Entities without a storage (no @storage directive, and no storage backend has `default: true` in config.yaml):\n\
+                 Entities with no storage backend (no @storage directive, and no backend is marked `default: true` in config.yaml):\n\
                  {listed}\n\
                  \n\
                  Fixes:\n  \
@@ -2773,13 +2775,19 @@ mod test {
             }
         }
 
-        fn storage(
-            (postgres, postgres_default): (bool, bool),
-            (clickhouse, clickhouse_default): (bool, bool),
-        ) -> Storage {
+        fn postgres_only() -> Storage {
             Storage {
-                postgres,
-                clickhouse,
+                postgres: true,
+                clickhouse: false,
+                postgres_default: true,
+                clickhouse_default: false,
+            }
+        }
+
+        fn multi(postgres_default: bool, clickhouse_default: bool) -> Storage {
+            Storage {
+                postgres: true,
+                clickhouse: true,
                 postgres_default,
                 clickhouse_default,
             }
@@ -2788,25 +2796,20 @@ mod test {
         #[test]
         fn single_storage_no_directive_ok() {
             let schema = make_schema(vec![entity("Transfer", None, None)]);
-            assert!(
-                validate_entity_storage(&storage((true, true), (false, false)), &schema).is_ok()
-            );
+            assert!(validate_entity_storage(&postgres_only(), &schema).is_ok());
         }
 
         #[test]
         fn single_storage_matching_directive_ok() {
             let schema = make_schema(vec![entity("Transfer", Some(true), None)]);
-            assert!(
-                validate_entity_storage(&storage((true, true), (false, false)), &schema).is_ok()
-            );
+            assert!(validate_entity_storage(&postgres_only(), &schema).is_ok());
         }
 
         #[test]
         fn single_storage_entity_targets_disabled_backend_e1() {
             // Global: postgres only. Entity wants clickhouse → E1.
             let schema = make_schema(vec![entity("Snapshot", Some(true), Some(true))]);
-            let err = validate_entity_storage(&storage((true, true), (false, false)), &schema)
-                .unwrap_err();
+            let err = validate_entity_storage(&postgres_only(), &schema).unwrap_err();
             assert_eq!(
                 err.to_string(),
                 "Schema validation failed:\n\
@@ -2826,9 +2829,7 @@ mod test {
                 entity("Snapshot", None, Some(true)),
                 entity("Audit", Some(true), Some(true)),
             ]);
-            assert!(
-                validate_entity_storage(&storage((true, true), (true, false)), &schema).is_ok()
-            );
+            assert!(validate_entity_storage(&multi(false, false), &schema).is_ok());
         }
 
         #[test]
@@ -2837,12 +2838,8 @@ mod test {
                 entity("Transfer", None, None),
                 entity("Snapshot", None, Some(true)),
             ]);
-            assert!(
-                validate_entity_storage(&storage((true, true), (true, false)), &schema).is_ok()
-            );
-            assert!(
-                validate_entity_storage(&storage((true, false), (true, true)), &schema).is_ok()
-            );
+            assert!(validate_entity_storage(&multi(true, false), &schema).is_ok());
+            assert!(validate_entity_storage(&multi(false, true), &schema).is_ok());
         }
 
         #[test]
@@ -2852,13 +2849,12 @@ mod test {
                 entity("Approval", None, None),
                 entity("DailySnapshot", None, Some(true)),
             ]);
-            let err = validate_entity_storage(&storage((true, false), (true, false)), &schema)
-                .unwrap_err();
+            let err = validate_entity_storage(&multi(false, false), &schema).unwrap_err();
             assert_eq!(
                 err.to_string(),
                 "Schema validation failed:\n\
                  \n\
-                 Entities without a storage (no @storage directive, and no storage backend has `default: true` in config.yaml):\n  \
+                 Entities with no storage backend (no @storage directive, and no backend is marked `default: true` in config.yaml):\n  \
                  - Approval\n  \
                  - Transfer\n\
                  \n\
@@ -2881,8 +2877,7 @@ mod test {
                 entity("Apple", None, None),
                 entity("Mango", None, None),
             ]);
-            let err = validate_entity_storage(&storage((true, false), (true, false)), &schema)
-                .unwrap_err();
+            let err = validate_entity_storage(&multi(false, false), &schema).unwrap_err();
             assert!(
                 err.to_string().contains("- Apple\n  - Mango\n  - Zebra"),
                 "Entities not listed alphabetically. Got:\n{err}"

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -443,7 +443,8 @@ pub struct Storage {
     pub postgres: bool,
     pub clickhouse: bool,
     // Whether entities without an @storage directive are stored in the
-    // backend. Resolved here so downstream consumers never re-derive it.
+    // backend. A single enabled backend is implicitly the default; with
+    // multiple backends none is, unless opted in via `default: true`.
     pub postgres_default: bool,
     pub clickhouse_default: bool,
 }
@@ -472,8 +473,10 @@ impl Storage {
                  default)."
             ));
         }
-        let postgres_default =
-            postgres && postgres_config.and_then(|c| c.default()).unwrap_or(true);
+        let postgres_default = postgres
+            && postgres_config
+                .and_then(|c| c.default())
+                .unwrap_or(!clickhouse);
         let clickhouse_default =
             clickhouse && clickhouse_config.and_then(|c| c.default()).unwrap_or(false);
         Ok(Self {
@@ -2631,7 +2634,8 @@ mod test {
             }
         );
 
-        // Both enabled -> ok, clickhouse is not an entity default
+        // Both enabled -> ok; with multiple backends none is an implicit
+        // entity default
         assert_eq!(
             super::Storage::resolve(Some(&StorageConfig {
                 postgres: enabled(true),
@@ -2641,13 +2645,13 @@ mod test {
             super::Storage {
                 postgres: true,
                 clickhouse: true,
-                postgres_default: true,
+                postgres_default: false,
                 clickhouse_default: false,
             }
         );
 
-        // Object form implies enabled; `default: true` makes clickhouse an
-        // entity default alongside postgres
+        // Object form implies enabled; `default: true` opts clickhouse in
+        // as an entity default
         assert_eq!(
             super::Storage::resolve(Some(&StorageConfig {
                 postgres: enabled(true),
@@ -2657,23 +2661,39 @@ mod test {
             super::Storage {
                 postgres: true,
                 clickhouse: true,
-                postgres_default: true,
+                postgres_default: false,
                 clickhouse_default: true,
             }
         );
 
-        // Postgres can opt out of being the entity default
+        // Both backends can be entity defaults when opted in explicitly
         assert_eq!(
             super::Storage::resolve(Some(&StorageConfig {
-                postgres: options(Some(false)),
+                postgres: options(Some(true)),
                 clickhouse: options(Some(true)),
             }))
             .unwrap(),
             super::Storage {
                 postgres: true,
                 clickhouse: true,
-                postgres_default: false,
+                postgres_default: true,
                 clickhouse_default: true,
+            }
+        );
+
+        // Postgres as a single storage can opt out of being the entity
+        // default (entities then must carry @storage)
+        assert_eq!(
+            super::Storage::resolve(Some(&StorageConfig {
+                postgres: options(Some(false)),
+                clickhouse: None,
+            }))
+            .unwrap(),
+            super::Storage {
+                postgres: true,
+                clickhouse: false,
+                postgres_default: false,
+                clickhouse_default: false,
             }
         );
 

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -442,22 +442,23 @@ pub struct SystemConfig {
 pub struct Storage {
     pub postgres: bool,
     pub clickhouse: bool,
+    // Whether entities without an @storage directive are stored in the
+    // backend. Resolved here so downstream consumers never re-derive it.
+    pub postgres_default: bool,
+    pub clickhouse_default: bool,
 }
 
 impl Storage {
     pub fn resolve(config: Option<&human_config::StorageConfig>) -> Result<Self> {
-        let (postgres, clickhouse) = match config {
-            // Default: only Postgres enabled
-            None => (true, false),
-            Some(s) => {
-                let clickhouse = s.clickhouse.unwrap_or(false);
-                // When clickhouse is enabled, postgres must be set explicitly
-                // so that the validation below catches a clickhouse-only config
-                // instead of silently defaulting postgres to true.
-                let postgres = s.postgres.unwrap_or(!clickhouse);
-                (postgres, clickhouse)
-            }
+        let (postgres_config, clickhouse_config) = match config {
+            None => (None, None),
+            Some(s) => (s.postgres.as_ref(), s.clickhouse.as_ref()),
         };
+        let clickhouse = clickhouse_config.is_some_and(|c| c.is_enabled());
+        // When clickhouse is enabled, postgres must be set explicitly
+        // so that the validation below catches a clickhouse-only config
+        // instead of silently defaulting postgres to true.
+        let postgres = postgres_config.map_or(!clickhouse, |c| c.is_enabled());
         if clickhouse && !postgres {
             return Err(anyhow!(
                 "ClickHouse is not supported as a single storage yet. Please enable Postgres \
@@ -471,56 +472,56 @@ impl Storage {
                  default)."
             ));
         }
+        let postgres_default =
+            postgres && postgres_config.and_then(|c| c.default()).unwrap_or(true);
+        let clickhouse_default =
+            clickhouse && clickhouse_config.and_then(|c| c.default()).unwrap_or(false);
         Ok(Self {
             postgres,
             clickhouse,
+            postgres_default,
+            clickhouse_default,
         })
-    }
-
-    pub fn is_multi(&self) -> bool {
-        self.postgres && self.clickhouse
     }
 }
 
 /// Check per-entity `@storage` directives against the resolved global storage.
 /// Malformed directives are raised earlier, during schema parsing.
-//
-// With two backends, the two failure modes are mutually exclusive: multi-storage
-// mode means both backends are on (so an entity can never target a disabled one),
-// and single-storage mode is exempt from the must-declare rule. If a third
-// backend lands the two checks could fire together — flag that here so a future
-// reader sees the simplification's premise.
 pub fn validate_entity_storage(storage: &Storage, schema: &Schema) -> anyhow::Result<()> {
     let mut entities: Vec<&Entity> = schema.entities.values().collect();
     entities.sort_by(|a, b| a.name.cmp(&b.name));
 
-    if storage.is_multi() {
+    // Entities without @storage fall back to the backends marked `default`
+    // in config.yaml. When no backend is a default, such entities would end
+    // up with no storage at all.
+    if !storage.postgres_default && !storage.clickhouse_default {
         let missing: Vec<&str> = entities
             .iter()
             .filter(|e| !e.has_storage_directive())
             .map(|e| e.name.as_str())
             .collect();
-        if missing.is_empty() {
-            return Ok(());
+        if !missing.is_empty() {
+            let example = missing[0];
+            let listed = missing
+                .iter()
+                .map(|n| format!("  - {n}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            return Err(anyhow!(
+                "Schema validation failed:\n\
+                 \n\
+                 Entities without a storage (no @storage directive, and no storage backend has `default: true` in config.yaml):\n\
+                 {listed}\n\
+                 \n\
+                 Fixes:\n  \
+                 - Set `default: true` on a backend under `storage:` in config.yaml to include these entities automatically. Example:\n      \
+                 storage:\n        \
+                 postgres:\n          \
+                 default: true\n  \
+                 - Or add @storage(postgres: true) and/or @storage(clickhouse: true) to the entities listed above. Example:\n      \
+                 type {example} @storage(postgres: true) {{ ... }}"
+            ));
         }
-        let example = missing[0];
-        let listed = missing
-            .iter()
-            .map(|n| format!("  - {n}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        return Err(anyhow!(
-            "Schema validation failed:\n\
-             \n\
-             Entities missing the @storage directive (multi-storage mode requires it):\n\
-             {listed}\n\
-             \n\
-             Fixes:\n  \
-             - Add @storage(postgres: true) and/or @storage(clickhouse: true) to the entities listed above. Example:\n      \
-             type {example} @storage(postgres: true) {{ ... }}\n      \
-             type {example} @storage(clickhouse: true) {{ ... }}\n      \
-             type {example} @storage(postgres: true, clickhouse: true) {{ ... }}"
-        ));
     }
 
     let unsupported: Vec<(&str, &'static str)> = entities
@@ -2595,14 +2596,23 @@ mod test {
 
     #[test]
     fn test_storage_resolve() {
-        use super::human_config::StorageConfig;
+        use super::human_config::{StorageBackendConfig, StorageBackendOptions, StorageConfig};
 
-        // Default (None) -> postgres only
+        let enabled = |b: bool| Some(StorageBackendConfig::Enabled(b));
+        let options = |default: Option<bool>| {
+            Some(StorageBackendConfig::Options(StorageBackendOptions {
+                default,
+            }))
+        };
+
+        // Default (None) -> postgres only, postgres is the entity default
         assert_eq!(
             super::Storage::resolve(None).unwrap(),
             super::Storage {
                 postgres: true,
-                clickhouse: false
+                clickhouse: false,
+                postgres_default: true,
+                clickhouse_default: false,
             }
         );
 
@@ -2615,27 +2625,62 @@ mod test {
             .unwrap(),
             super::Storage {
                 postgres: true,
-                clickhouse: false
+                clickhouse: false,
+                postgres_default: true,
+                clickhouse_default: false,
             }
         );
 
-        // Both enabled -> ok
+        // Both enabled -> ok, clickhouse is not an entity default
         assert_eq!(
             super::Storage::resolve(Some(&StorageConfig {
-                postgres: Some(true),
-                clickhouse: Some(true),
+                postgres: enabled(true),
+                clickhouse: enabled(true),
             }))
             .unwrap(),
             super::Storage {
                 postgres: true,
-                clickhouse: true
+                clickhouse: true,
+                postgres_default: true,
+                clickhouse_default: false,
+            }
+        );
+
+        // Object form implies enabled; `default: true` makes clickhouse an
+        // entity default alongside postgres
+        assert_eq!(
+            super::Storage::resolve(Some(&StorageConfig {
+                postgres: enabled(true),
+                clickhouse: options(Some(true)),
+            }))
+            .unwrap(),
+            super::Storage {
+                postgres: true,
+                clickhouse: true,
+                postgres_default: true,
+                clickhouse_default: true,
+            }
+        );
+
+        // Postgres can opt out of being the entity default
+        assert_eq!(
+            super::Storage::resolve(Some(&StorageConfig {
+                postgres: options(Some(false)),
+                clickhouse: options(Some(true)),
+            }))
+            .unwrap(),
+            super::Storage {
+                postgres: true,
+                clickhouse: true,
+                postgres_default: false,
+                clickhouse_default: true,
             }
         );
 
         // ClickHouse without Postgres -> user-friendly error
         let err = super::Storage::resolve(Some(&StorageConfig {
-            postgres: Some(false),
-            clickhouse: Some(true),
+            postgres: enabled(false),
+            clickhouse: enabled(true),
         }))
         .unwrap_err();
         assert!(
@@ -2648,7 +2693,7 @@ mod test {
         // opt in to Postgres explicitly rather than relying on the default.
         let err = super::Storage::resolve(Some(&StorageConfig {
             postgres: None,
-            clickhouse: Some(true),
+            clickhouse: options(Some(true)),
         }))
         .unwrap_err();
         assert!(
@@ -2659,8 +2704,8 @@ mod test {
 
         // All storages disabled -> user-friendly error
         let err = super::Storage::resolve(Some(&StorageConfig {
-            postgres: Some(false),
-            clickhouse: Some(false),
+            postgres: enabled(false),
+            clickhouse: enabled(false),
         }))
         .unwrap_err();
         assert!(
@@ -2671,7 +2716,7 @@ mod test {
 
         // postgres explicitly false with clickhouse omitted -> same error
         let err = super::Storage::resolve(Some(&StorageConfig {
-            postgres: Some(false),
+            postgres: enabled(false),
             clickhouse: None,
         }))
         .unwrap_err();
@@ -2708,35 +2753,40 @@ mod test {
             }
         }
 
+        fn storage(
+            (postgres, postgres_default): (bool, bool),
+            (clickhouse, clickhouse_default): (bool, bool),
+        ) -> Storage {
+            Storage {
+                postgres,
+                clickhouse,
+                postgres_default,
+                clickhouse_default,
+            }
+        }
+
         #[test]
         fn single_storage_no_directive_ok() {
             let schema = make_schema(vec![entity("Transfer", None, None)]);
-            let storage = Storage {
-                postgres: true,
-                clickhouse: false,
-            };
-            assert!(validate_entity_storage(&storage, &schema).is_ok());
+            assert!(
+                validate_entity_storage(&storage((true, true), (false, false)), &schema).is_ok()
+            );
         }
 
         #[test]
         fn single_storage_matching_directive_ok() {
             let schema = make_schema(vec![entity("Transfer", Some(true), None)]);
-            let storage = Storage {
-                postgres: true,
-                clickhouse: false,
-            };
-            assert!(validate_entity_storage(&storage, &schema).is_ok());
+            assert!(
+                validate_entity_storage(&storage((true, true), (false, false)), &schema).is_ok()
+            );
         }
 
         #[test]
         fn single_storage_entity_targets_disabled_backend_e1() {
             // Global: postgres only. Entity wants clickhouse → E1.
             let schema = make_schema(vec![entity("Snapshot", Some(true), Some(true))]);
-            let storage = Storage {
-                postgres: true,
-                clickhouse: false,
-            };
-            let err = validate_entity_storage(&storage, &schema).unwrap_err();
+            let err = validate_entity_storage(&storage((true, true), (false, false)), &schema)
+                .unwrap_err();
             assert_eq!(
                 err.to_string(),
                 "Schema validation failed:\n\
@@ -2756,39 +2806,49 @@ mod test {
                 entity("Snapshot", None, Some(true)),
                 entity("Audit", Some(true), Some(true)),
             ]);
-            let storage = Storage {
-                postgres: true,
-                clickhouse: true,
-            };
-            assert!(validate_entity_storage(&storage, &schema).is_ok());
+            assert!(
+                validate_entity_storage(&storage((true, true), (true, false)), &schema).is_ok()
+            );
         }
 
         #[test]
-        fn multi_storage_missing_directives_e2() {
+        fn multi_storage_no_directive_falls_back_to_defaults_ok() {
+            let schema = make_schema(vec![
+                entity("Transfer", None, None),
+                entity("Snapshot", None, Some(true)),
+            ]);
+            assert!(
+                validate_entity_storage(&storage((true, true), (true, false)), &schema).is_ok()
+            );
+            assert!(
+                validate_entity_storage(&storage((true, false), (true, true)), &schema).is_ok()
+            );
+        }
+
+        #[test]
+        fn no_default_storage_and_missing_directives_e2() {
             let schema = make_schema(vec![
                 entity("Transfer", None, None),
                 entity("Approval", None, None),
-                entity("DailySnapshot", None, None),
+                entity("DailySnapshot", None, Some(true)),
             ]);
-            let storage = Storage {
-                postgres: true,
-                clickhouse: true,
-            };
-            let err = validate_entity_storage(&storage, &schema).unwrap_err();
+            let err = validate_entity_storage(&storage((true, false), (true, false)), &schema)
+                .unwrap_err();
             assert_eq!(
                 err.to_string(),
                 "Schema validation failed:\n\
                  \n\
-                 Entities missing the @storage directive (multi-storage mode requires it):\n  \
+                 Entities without a storage (no @storage directive, and no storage backend has `default: true` in config.yaml):\n  \
                  - Approval\n  \
-                 - DailySnapshot\n  \
                  - Transfer\n\
                  \n\
                  Fixes:\n  \
-                 - Add @storage(postgres: true) and/or @storage(clickhouse: true) to the entities listed above. Example:\n      \
-                 type Approval @storage(postgres: true) { ... }\n      \
-                 type Approval @storage(clickhouse: true) { ... }\n      \
-                 type Approval @storage(postgres: true, clickhouse: true) { ... }"
+                 - Set `default: true` on a backend under `storage:` in config.yaml to include these entities automatically. Example:\n      \
+                 storage:\n        \
+                 postgres:\n          \
+                 default: true\n  \
+                 - Or add @storage(postgres: true) and/or @storage(clickhouse: true) to the entities listed above. Example:\n      \
+                 type Approval @storage(postgres: true) { ... }"
             );
         }
 
@@ -2801,11 +2861,8 @@ mod test {
                 entity("Apple", None, None),
                 entity("Mango", None, None),
             ]);
-            let storage = Storage {
-                postgres: true,
-                clickhouse: true,
-            };
-            let err = validate_entity_storage(&storage, &schema).unwrap_err();
+            let err = validate_entity_storage(&storage((true, false), (true, false)), &schema)
+                .unwrap_err();
             assert!(
                 err.to_string().contains("- Apple\n  - Mango\n  - Zebra"),
                 "Entities not listed alphabetically. Got:\n{err}"

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -2767,6 +2767,36 @@ mod test {
         insta::assert_snapshot!(json);
     }
 
+    // When the backends marked `default` coincide with the enabled ones,
+    // the entity storage field must stay omitted (the runtime falls back to
+    // the global storage) — an added key would trip the persisted-config
+    // diff for projects predating per-backend `default`.
+    #[test]
+    fn internal_config_json_omits_entity_storage_matching_enabled_backends() {
+        let json = get_internal_config_json_helper("config-multi-storage-defaults.yaml");
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let entity_storages: Vec<(&str, Option<serde_json::Value>)> = parsed["entities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| (e["name"].as_str().unwrap(), e.get("storage").cloned()))
+            .collect();
+        assert_eq!(
+            entity_storages,
+            vec![
+                (
+                    "EmptyEntity",
+                    Some(serde_json::json!({"postgres": true, "clickhouse": true}))
+                ),
+                (
+                    "RelatedEntity",
+                    Some(serde_json::json!({"postgres": true, "clickhouse": true}))
+                ),
+                ("UnannotatedEntity", None),
+            ]
+        );
+    }
+
     #[test]
     fn envio_types_dts_generated_for_evm() {
         let project_template = get_project_template_helper("config1.yaml");

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_with_all_options.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_with_all_options.snap
@@ -13,8 +13,7 @@ expression: json
   "rawEvents": true,
   "storage": {
     "postgres": true,
-    "clickhouse": true,
-    "clickhouseDefault": true
+    "clickhouse": true
   },
   "evm": {
     "chains": {
@@ -190,6 +189,9 @@ expression: json
     },
     {
       "name": "UnannotatedEntity",
+      "storage": {
+        "clickhouse": true
+      },
       "properties": [
         {
           "name": "id",

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_with_all_options.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_with_all_options.snap
@@ -1,6 +1,5 @@
 ---
 source: packages/cli/src/hbs_templating/codegen_templates.rs
-assertion_line: 2767
 expression: json
 ---
 {
@@ -14,7 +13,8 @@ expression: json
   "rawEvents": true,
   "storage": {
     "postgres": true,
-    "clickhouse": true
+    "clickhouse": true,
+    "clickhouseDefault": true
   },
   "evm": {
     "chains": {
@@ -184,6 +184,15 @@ expression: json
         },
         {
           "name": "name",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "UnannotatedEntity",
+      "properties": [
+        {
+          "name": "id",
           "type": "string"
         }
       ]

--- a/packages/cli/test/configs/config-multi-storage-defaults.yaml
+++ b/packages/cli/test/configs/config-multi-storage-defaults.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../envio/evm.schema.json
+name: multi-storage-defaults
+schema: ../schemas/schema-with-multi-storage.graphql
+storage:
+  postgres:
+    default: true
+  clickhouse:
+    default: true
+chains:
+  - id: 1
+    start_block: 0
+    contracts: []

--- a/packages/cli/test/configs/config-with-all-options.yaml
+++ b/packages/cli/test/configs/config-with-all-options.yaml
@@ -9,7 +9,8 @@ save_full_history: true
 raw_events: true
 storage:
   postgres: true
-  clickhouse: true
+  clickhouse:
+    default: true
 field_selection:
   transaction_fields:
     - hash

--- a/packages/cli/test/schemas/schema-with-multi-storage.graphql
+++ b/packages/cli/test/schemas/schema-with-multi-storage.graphql
@@ -20,3 +20,7 @@ type EmptyEntity @storage(postgres: true, clickhouse: true) {
   tags: [String!]!
   optionalTags: [String!]
 }
+
+type UnannotatedEntity {
+  id: ID!
+}

--- a/packages/envio/evm.schema.json
+++ b/packages/envio/evm.schema.json
@@ -39,7 +39,7 @@
       "minimum": 0
     },
     "storage": {
-      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled.",
+      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it.",
       "anyOf": [
         {
           "$ref": "#/$defs/StorageConfig"
@@ -131,17 +131,51 @@
       "type": "object",
       "properties": {
         "postgres": {
-          "description": "Whether to use Postgres as a storage backend (default: true).",
-          "type": [
-            "boolean",
-            "null"
+          "description": "Whether to use Postgres as a storage backend (default: true). Accepts a boolean or an options object (the object form implies the backend is enabled).",
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "default": {
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: true for postgres).",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
           ]
         },
         "clickhouse": {
-          "description": "Whether to additionally sync the indexed data to ClickHouse. Requires Postgres to be enabled (default: false).",
-          "type": [
-            "boolean",
-            "null"
+          "description": "Whether to additionally sync the indexed data to ClickHouse. Requires Postgres to be enabled (default: false). Accepts a boolean or an options object (the object form implies the backend is enabled).",
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "default": {
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: false for clickhouse).",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
           ]
         }
       },
@@ -163,7 +197,14 @@
           "if": {
             "properties": {
               "clickhouse": {
-                "const": true
+                "anyOf": [
+                  {
+                    "const": true
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
               }
             },
             "required": [
@@ -173,7 +214,14 @@
           "then": {
             "properties": {
               "postgres": {
-                "const": true
+                "anyOf": [
+                  {
+                    "const": true
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
               }
             },
             "required": [

--- a/packages/envio/evm.schema.json
+++ b/packages/envio/evm.schema.json
@@ -39,7 +39,7 @@
       "minimum": 0
     },
     "storage": {
-      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it. A single enabled backend is implicitly the default; with multiple backends none is, unless opted in via `default: true`.",
+      "description": "Storage backends the indexer writes data to. Defaults to Postgres when omitted. Set `clickhouse: true` to additionally sync the indexed data to ClickHouse. Mark a backend with `default: true` to store entities that don't have an @storage directive in the schema, e.g. `clickhouse: {default: true}`.",
       "anyOf": [
         {
           "$ref": "#/$defs/StorageConfig"

--- a/packages/envio/evm.schema.json
+++ b/packages/envio/evm.schema.json
@@ -39,7 +39,7 @@
       "minimum": 0
     },
     "storage": {
-      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it.",
+      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it. A single enabled backend is implicitly the default; with multiple backends none is, unless opted in via `default: true`.",
       "anyOf": [
         {
           "$ref": "#/$defs/StorageConfig"
@@ -143,7 +143,7 @@
               "type": "object",
               "properties": {
                 "default": {
-                  "description": "Whether entities without an @storage directive are stored in this backend (default: true for postgres).",
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: true when Postgres is the only enabled backend, false otherwise).",
                   "type": [
                     "boolean",
                     "null"
@@ -167,7 +167,7 @@
               "type": "object",
               "properties": {
                 "default": {
-                  "description": "Whether entities without an @storage directive are stored in this backend (default: false for clickhouse).",
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: false).",
                   "type": [
                     "boolean",
                     "null"

--- a/packages/envio/fuel.schema.json
+++ b/packages/envio/fuel.schema.json
@@ -39,7 +39,7 @@
       "minimum": 0
     },
     "storage": {
-      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it.",
+      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it. A single enabled backend is implicitly the default; with multiple backends none is, unless opted in via `default: true`.",
       "anyOf": [
         {
           "$ref": "#/$defs/StorageConfig"
@@ -101,7 +101,7 @@
               "type": "object",
               "properties": {
                 "default": {
-                  "description": "Whether entities without an @storage directive are stored in this backend (default: true for postgres).",
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: true when Postgres is the only enabled backend, false otherwise).",
                   "type": [
                     "boolean",
                     "null"
@@ -125,7 +125,7 @@
               "type": "object",
               "properties": {
                 "default": {
-                  "description": "Whether entities without an @storage directive are stored in this backend (default: false for clickhouse).",
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: false).",
                   "type": [
                     "boolean",
                     "null"

--- a/packages/envio/fuel.schema.json
+++ b/packages/envio/fuel.schema.json
@@ -39,7 +39,7 @@
       "minimum": 0
     },
     "storage": {
-      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it. A single enabled backend is implicitly the default; with multiple backends none is, unless opted in via `default: true`.",
+      "description": "Storage backends the indexer writes data to. Defaults to Postgres when omitted. Set `clickhouse: true` to additionally sync the indexed data to ClickHouse. Mark a backend with `default: true` to store entities that don't have an @storage directive in the schema, e.g. `clickhouse: {default: true}`.",
       "anyOf": [
         {
           "$ref": "#/$defs/StorageConfig"

--- a/packages/envio/fuel.schema.json
+++ b/packages/envio/fuel.schema.json
@@ -39,7 +39,7 @@
       "minimum": 0
     },
     "storage": {
-      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled.",
+      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it.",
       "anyOf": [
         {
           "$ref": "#/$defs/StorageConfig"
@@ -89,17 +89,51 @@
       "type": "object",
       "properties": {
         "postgres": {
-          "description": "Whether to use Postgres as a storage backend (default: true).",
-          "type": [
-            "boolean",
-            "null"
+          "description": "Whether to use Postgres as a storage backend (default: true). Accepts a boolean or an options object (the object form implies the backend is enabled).",
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "default": {
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: true for postgres).",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
           ]
         },
         "clickhouse": {
-          "description": "Whether to additionally sync the indexed data to ClickHouse. Requires Postgres to be enabled (default: false).",
-          "type": [
-            "boolean",
-            "null"
+          "description": "Whether to additionally sync the indexed data to ClickHouse. Requires Postgres to be enabled (default: false). Accepts a boolean or an options object (the object form implies the backend is enabled).",
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "default": {
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: false for clickhouse).",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
           ]
         }
       },
@@ -121,7 +155,14 @@
           "if": {
             "properties": {
               "clickhouse": {
-                "const": true
+                "anyOf": [
+                  {
+                    "const": true
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
               }
             },
             "required": [
@@ -131,7 +172,14 @@
           "then": {
             "properties": {
               "postgres": {
-                "const": true
+                "anyOf": [
+                  {
+                    "const": true
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
               }
             },
             "required": [

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -353,7 +353,7 @@ let parseEnumsFromJson = (enumsJson: dict<array<string>>): array<Table.enumConfi
 let parseEntitiesFromJson = (
   entitiesJson: array<'entityJson>,
   ~enumConfigsByName: dict<Table.enumConfig<Table.enum>>,
-  ~globalStorage: storage,
+  ~storageDefaults: Internal.entityStorage,
 ): array<Internal.entityConfig> => {
   entitiesJson->Array.mapWithIndex((entityJson, index) => {
     let entityName = entityJson["name"]
@@ -434,10 +434,7 @@ let parseEntitiesFromJson = (
         postgres: s["postgres"]->Option.getOr(false),
         clickhouse: s["clickhouse"]->Option.getOr(false),
       }
-    | None => {
-        postgres: globalStorage.postgres,
-        clickhouse: globalStorage.clickhouse,
-      }
+    | None => storageDefaults
     }
 
     {
@@ -457,6 +454,8 @@ let publicConfigStorageSchema = S.schema(s =>
   {
     "postgres": s.matches(S.bool),
     "clickhouse": s.matches(S.option(S.bool)),
+    "postgresDefault": s.matches(S.option(S.bool)),
+    "clickhouseDefault": s.matches(S.option(S.bool)),
   }
 )
 
@@ -775,10 +774,18 @@ let fromPublic = (publicConfigJson: JSON.t) => {
     clickhouse: publicConfig["storage"]["clickhouse"]->Option.getOr(false),
   }
 
+  // The CLI omits the default flags from the JSON when they match the
+  // implied values (postgres: true, clickhouse: false), so `getOr` here
+  // must mirror those exact values.
+  let storageDefaults: Internal.entityStorage = {
+    postgres: publicConfig["storage"]["postgresDefault"]->Option.getOr(true),
+    clickhouse: publicConfig["storage"]["clickhouseDefault"]->Option.getOr(false),
+  }
+
   let userEntities =
     publicConfig["entities"]
     ->Option.getOr([])
-    ->parseEntitiesFromJson(~enumConfigsByName, ~globalStorage)
+    ->parseEntitiesFromJson(~enumConfigsByName, ~storageDefaults)
 
   let allEntities = userEntities->Array.concat([EnvioAddresses.entityConfig])
 

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -353,7 +353,7 @@ let parseEnumsFromJson = (enumsJson: dict<array<string>>): array<Table.enumConfi
 let parseEntitiesFromJson = (
   entitiesJson: array<'entityJson>,
   ~enumConfigsByName: dict<Table.enumConfig<Table.enum>>,
-  ~storageDefaults: Internal.entityStorage,
+  ~globalStorage: storage,
 ): array<Internal.entityConfig> => {
   entitiesJson->Array.mapWithIndex((entityJson, index) => {
     let entityName = entityJson["name"]
@@ -434,7 +434,10 @@ let parseEntitiesFromJson = (
         postgres: s["postgres"]->Option.getOr(false),
         clickhouse: s["clickhouse"]->Option.getOr(false),
       }
-    | None => storageDefaults
+    | None => {
+        postgres: globalStorage.postgres,
+        clickhouse: globalStorage.clickhouse,
+      }
     }
 
     {
@@ -454,8 +457,6 @@ let publicConfigStorageSchema = S.schema(s =>
   {
     "postgres": s.matches(S.bool),
     "clickhouse": s.matches(S.option(S.bool)),
-    "postgresDefault": s.matches(S.option(S.bool)),
-    "clickhouseDefault": s.matches(S.option(S.bool)),
   }
 )
 
@@ -774,18 +775,10 @@ let fromPublic = (publicConfigJson: JSON.t) => {
     clickhouse: publicConfig["storage"]["clickhouse"]->Option.getOr(false),
   }
 
-  // The CLI omits the default flags from the JSON when they match the
-  // implied values (postgres: true, clickhouse: false), so `getOr` here
-  // must mirror those exact values.
-  let storageDefaults: Internal.entityStorage = {
-    postgres: publicConfig["storage"]["postgresDefault"]->Option.getOr(true),
-    clickhouse: publicConfig["storage"]["clickhouseDefault"]->Option.getOr(false),
-  }
-
   let userEntities =
     publicConfig["entities"]
     ->Option.getOr([])
-    ->parseEntitiesFromJson(~enumConfigsByName, ~storageDefaults)
+    ->parseEntitiesFromJson(~enumConfigsByName, ~globalStorage)
 
   let allEntities = userEntities->Array.concat([EnvioAddresses.entityConfig])
 

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -39,7 +39,7 @@
       "minimum": 0
     },
     "storage": {
-      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it. A single enabled backend is implicitly the default; with multiple backends none is, unless opted in via `default: true`.",
+      "description": "Storage backends the indexer writes data to. Defaults to Postgres when omitted. Set `clickhouse: true` to additionally sync the indexed data to ClickHouse. Mark a backend with `default: true` to store entities that don't have an @storage directive in the schema, e.g. `clickhouse: {default: true}`.",
       "anyOf": [
         {
           "$ref": "#/$defs/StorageConfig"

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -39,7 +39,7 @@
       "minimum": 0
     },
     "storage": {
-      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled.",
+      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it.",
       "anyOf": [
         {
           "$ref": "#/$defs/StorageConfig"
@@ -72,17 +72,51 @@
       "type": "object",
       "properties": {
         "postgres": {
-          "description": "Whether to use Postgres as a storage backend (default: true).",
-          "type": [
-            "boolean",
-            "null"
+          "description": "Whether to use Postgres as a storage backend (default: true). Accepts a boolean or an options object (the object form implies the backend is enabled).",
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "default": {
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: true for postgres).",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
           ]
         },
         "clickhouse": {
-          "description": "Whether to additionally sync the indexed data to ClickHouse. Requires Postgres to be enabled (default: false).",
-          "type": [
-            "boolean",
-            "null"
+          "description": "Whether to additionally sync the indexed data to ClickHouse. Requires Postgres to be enabled (default: false). Accepts a boolean or an options object (the object form implies the backend is enabled).",
+          "anyOf": [
+            {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "default": {
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: false for clickhouse).",
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
           ]
         }
       },
@@ -104,7 +138,14 @@
           "if": {
             "properties": {
               "clickhouse": {
-                "const": true
+                "anyOf": [
+                  {
+                    "const": true
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
               }
             },
             "required": [
@@ -114,7 +155,14 @@
           "then": {
             "properties": {
               "postgres": {
-                "const": true
+                "anyOf": [
+                  {
+                    "const": true
+                  },
+                  {
+                    "type": "object"
+                  }
+                ]
               }
             },
             "required": [

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -39,7 +39,7 @@
       "minimum": 0
     },
     "storage": {
-      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it.",
+      "description": "Configuration for the storage backends the indexer writes to. Defaults to `postgres: true` when omitted. ClickHouse requires Postgres to be enabled (it is not supported as a single storage yet), and at least one backend must be enabled. Each backend accepts a boolean or an options object with `default` controlling whether entities without an @storage directive are stored in it. A single enabled backend is implicitly the default; with multiple backends none is, unless opted in via `default: true`.",
       "anyOf": [
         {
           "$ref": "#/$defs/StorageConfig"
@@ -84,7 +84,7 @@
               "type": "object",
               "properties": {
                 "default": {
-                  "description": "Whether entities without an @storage directive are stored in this backend (default: true for postgres).",
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: true when Postgres is the only enabled backend, false otherwise).",
                   "type": [
                     "boolean",
                     "null"
@@ -108,7 +108,7 @@
               "type": "object",
               "properties": {
                 "default": {
-                  "description": "Whether entities without an @storage directive are stored in this backend (default: false for clickhouse).",
+                  "description": "Whether entities without an @storage directive are stored in this backend (default: false).",
                   "type": [
                     "boolean",
                     "null"

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -377,6 +377,72 @@ describe("Config.fromPublic", () => {
     })
   })
 
+  it("resolves entity storage from global defaults when @storage is absent", t => {
+    let publicConfigJson: JSON.t = %raw(`{
+      "version": "0.0.1-dev",
+      "name": "test",
+      "storage": { "postgres": true, "clickhouse": true, "postgresDefault": false, "clickhouseDefault": true },
+      "evm": {
+        "chains": {
+          "ethereumMainnet": {
+            "id": 1,
+            "startBlock": 0,
+            "rpcs": [{ "url": "https://eth.com", "for": "sync" }]
+          }
+        },
+        "addressFormat": "checksum"
+      },
+      "enums": {},
+      "entities": [
+        {
+          "name": "User",
+          "properties": [{ "name": "id", "type": "string" }]
+        },
+        {
+          "name": "Snapshot",
+          "storage": { "postgres": true },
+          "properties": [{ "name": "id", "type": "string" }]
+        }
+      ]
+    }`)
+
+    let config = Config.fromPublic(publicConfigJson)
+    t.expect(config.userEntities->Array.map(e => (e.name, e.storage))).toEqual([
+      ("User", {Internal.postgres: false, clickhouse: true}),
+      ("Snapshot", {Internal.postgres: true, clickhouse: false}),
+    ])
+  })
+
+  it("entity storage defaults to postgres only when default flags are omitted", t => {
+    let publicConfigJson: JSON.t = %raw(`{
+      "version": "0.0.1-dev",
+      "name": "test",
+      "storage": { "postgres": true, "clickhouse": true },
+      "evm": {
+        "chains": {
+          "ethereumMainnet": {
+            "id": 1,
+            "startBlock": 0,
+            "rpcs": [{ "url": "https://eth.com", "for": "sync" }]
+          }
+        },
+        "addressFormat": "checksum"
+      },
+      "enums": {},
+      "entities": [
+        {
+          "name": "User",
+          "properties": [{ "name": "id", "type": "string" }]
+        }
+      ]
+    }`)
+
+    let config = Config.fromPublic(publicConfigJson)
+    t.expect(config.userEntities->Array.map(e => (e.name, e.storage))).toEqual([
+      ("User", {Internal.postgres: true, clickhouse: false}),
+    ])
+  })
+
   it("works with already-capitalized contract name", t => {
     let publicConfigJson: JSON.t = %raw(`{
       "version": "0.0.1-dev",

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -377,43 +377,7 @@ describe("Config.fromPublic", () => {
     })
   })
 
-  it("resolves entity storage from global defaults when @storage is absent", t => {
-    let publicConfigJson: JSON.t = %raw(`{
-      "version": "0.0.1-dev",
-      "name": "test",
-      "storage": { "postgres": true, "clickhouse": true, "postgresDefault": false, "clickhouseDefault": true },
-      "evm": {
-        "chains": {
-          "ethereumMainnet": {
-            "id": 1,
-            "startBlock": 0,
-            "rpcs": [{ "url": "https://eth.com", "for": "sync" }]
-          }
-        },
-        "addressFormat": "checksum"
-      },
-      "enums": {},
-      "entities": [
-        {
-          "name": "User",
-          "properties": [{ "name": "id", "type": "string" }]
-        },
-        {
-          "name": "Snapshot",
-          "storage": { "postgres": true },
-          "properties": [{ "name": "id", "type": "string" }]
-        }
-      ]
-    }`)
-
-    let config = Config.fromPublic(publicConfigJson)
-    t.expect(config.userEntities->Array.map(e => (e.name, e.storage))).toEqual([
-      ("User", {Internal.postgres: false, clickhouse: true}),
-      ("Snapshot", {Internal.postgres: true, clickhouse: false}),
-    ])
-  })
-
-  it("entity storage defaults to postgres only when default flags are omitted", t => {
+  it("resolves entity storage from the entity config, falling back to the global storage", t => {
     let publicConfigJson: JSON.t = %raw(`{
       "version": "0.0.1-dev",
       "name": "test",
@@ -433,13 +397,19 @@ describe("Config.fromPublic", () => {
         {
           "name": "User",
           "properties": [{ "name": "id", "type": "string" }]
+        },
+        {
+          "name": "Snapshot",
+          "storage": { "clickhouse": true },
+          "properties": [{ "name": "id", "type": "string" }]
         }
       ]
     }`)
 
     let config = Config.fromPublic(publicConfigJson)
     t.expect(config.userEntities->Array.map(e => (e.name, e.storage))).toEqual([
-      ("User", {Internal.postgres: true, clickhouse: false}),
+      ("User", {Internal.postgres: true, clickhouse: true}),
+      ("Snapshot", {Internal.postgres: false, clickhouse: true}),
     ])
   })
 


### PR DESCRIPTION
## Summary

Extends the storage configuration to support marking individual backends as the default for entities without an `@storage` directive. Previously, entities without explicit storage directives would implicitly use the only enabled backend (single-storage mode) or require directives in multi-storage mode. Now users can explicitly control which backends serve as defaults via a `default: true` flag.

## Key Changes

- **Storage config structure**: `StorageConfig` fields now accept `StorageBackendConfig` (boolean or options object) instead of plain booleans, allowing `postgres: {default: true}` syntax
  - Added `StorageBackendConfig` enum with `Enabled(bool)` and `Options(StorageBackendOptions)` variants
  - Hand-rolled `Deserialize` impl to provide precise error messages for typos in options objects
  
- **Storage resolution logic**: `Storage::resolve()` now computes `postgres_default` and `clickhouse_default` fields
  - Single enabled backend defaults to `true` unless explicitly opted out via `default: false`
  - Multiple enabled backends default to `false` unless explicitly opted in via `default: true`
  - Removed `is_multi()` helper; validation now checks if any backend is marked default
  
- **Entity storage validation**: `validate_entity_storage()` now allows entities without `@storage` directives when at least one backend is marked default
  - Error message updated to guide users toward setting `default: true` in config or adding `@storage` directives
  - Entities can fall back to any backend marked default, not just the single enabled one
  
- **Public config generation**: Entity storage field omitted when it matches the enabled backends (preserves JSON byte-compatibility for existing projects)

- **Schema and tests**: Updated JSON schemas, test fixtures, and validation tests to cover new configuration shapes and fallback behavior

## Notable Implementation Details

- `StorageBackendConfig` deserialization uses a custom visitor to distinguish between type errors ("expected boolean or object") and field errors ("unknown field `defautl`")
- Entity default resolution respects the implicit default behavior: Postgres defaults to true in single-storage mode, false in multi-storage unless opted in
- Test coverage includes all combinations: single storage, multi-storage with/without defaults, and error cases

https://claude.ai/code/session_01MqieEdSSbDF6D1o5r7NmVt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage backends can be specified as boolean or as an options object with a per-backend `default` override.

* **Improvements**
  * Improved entity storage inheritance and validation (omits per-entity storage when it matches defaults; ClickHouse requires Postgres).
  * Clearer, more precise validation error messages for malformed storage options.

* **Tests**
  * Expanded unit and integration tests covering new shapes, defaults, and error cases.

* **Documentation**
  * Updated JSON schemas and examples to reflect the new storage format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->