### PR TITLE
Extract filter parsing logic to EntityFilter module

### DIFF
--- a/packages/envio/src/UserContext.res
+++ b/packages/envio/src/UserContext.res
@@ -1,5 +1,3 @@
-let codegenHelpMessage = EntityFilter.codegenHelpMessage
-
 type contextParams = {
   item: Internal.item,
   checkpointId: Internal.checkpointId,
@@ -78,9 +76,8 @@ type entityContextParams = {
 let getWhereHandler = (params: entityContextParams, filter: dict<dict<unknown>>) => {
   let entityConfig = params.entityConfig
 
-  filter
-  ->EntityFilter.parseOrThrow(~entityName=entityConfig.name, ~table=entityConfig.table)
-  ->Array.map(filter =>
+  @inline
+  let loadWithFilter = filter =>
     LoadLayer.loadByFilter(
       ~loadManager=params.loadManager,
       ~persistence=params.persistence,
@@ -90,9 +87,18 @@ let getWhereHandler = (params: entityContextParams, filter: dict<dict<unknown>>)
       ~item=params.item,
       ~filter,
     )
-  )
-  ->Promise.all
-  ->Promise.thenResolve(results => results->Array.flat)
+
+  switch filter->EntityFilter.parseGetWhereOrThrow(
+    ~entityName=entityConfig.name,
+    ~table=entityConfig.table,
+  ) {
+  | [filter] => loadWithFilter(filter)
+  | filters =>
+    filters
+    ->Array.map(loadWithFilter)
+    ->Promise.all
+    ->Promise.thenResolve(results => results->Array.flat)
+  }
 }
 
 let noopSet = (_entity: Internal.entity) => ()
@@ -284,7 +290,7 @@ let handlerTraps: Utils.Proxy.traps<contextParams> = {
         ->(Utils.magic: entityContextParams => unknown)
       | None =>
         JsError.throwWithMessage(
-          `Invalid context access by '${prop}' property. ${codegenHelpMessage}`,
+          `Invalid context access by '${prop}' property. ${EntityFilter.codegenHelpMessage}`,
         )
       }
     }
@@ -353,7 +359,7 @@ let contractRegisterChainTraps: Utils.Proxy.traps<contractRegisterParams> = {
         {"add": addFn}->(Utils.magic: {"add": Address.t => unit} => unknown)
       } else {
         JsError.throwWithMessage(
-          `Invalid contract name '${prop}' on context.chain. ${codegenHelpMessage}`,
+          `Invalid contract name '${prop}' on context.chain. ${EntityFilter.codegenHelpMessage}`,
         )
       }
     }
@@ -376,7 +382,7 @@ let contractRegisterTraps: Utils.Proxy.traps<contractRegisterParams> = {
       ->(Utils.magic: contractRegisterParams => unknown)
     | _ =>
       JsError.throwWithMessage(
-        `Invalid context access by '${prop}' property. Use context.chain.ContractName.add(address) to register contracts. ${codegenHelpMessage}`,
+        `Invalid context access by '${prop}' property. Use context.chain.ContractName.add(address) to register contracts. ${EntityFilter.codegenHelpMessage}`,
       )
     }
   },

--- a/packages/envio/src/UserContext.res
+++ b/packages/envio/src/UserContext.res
@@ -92,10 +92,10 @@ let getWhereHandler = (params: entityContextParams, filter: dict<dict<unknown>>)
     ~entityName=entityConfig.name,
     ~table=entityConfig.table,
   ) {
-  | [filter] => loadWithFilter(filter)
+  | [single] => loadWithFilter(single)
   | filters =>
     filters
-    ->Array.map(loadWithFilter)
+    ->Array.map(filter => loadWithFilter(filter))
     ->Promise.all
     ->Promise.thenResolve(results => results->Array.flat)
   }

--- a/packages/envio/src/UserContext.res
+++ b/packages/envio/src/UserContext.res
@@ -1,4 +1,4 @@
-let codegenHelpMessage = `Rerun 'pnpm dev' to update generated code after schema.graphql changes.`
+let codegenHelpMessage = EntityFilter.codegenHelpMessage
 
 type contextParams = {
   item: Internal.item,
@@ -75,112 +75,12 @@ type entityContextParams = {
   entityConfig: Internal.entityConfig,
 }
 
-let getUndefinedOrNullName = (value: 'a) =>
-  if value === %raw(`undefined`) {
-    Some("undefined")
-  } else if value === %raw(`null`) {
-    Some("null")
-  } else {
-    None
-  }
-
-// Nullish values would otherwise turn into a "= NULL" query
-// silently matching nothing.
-let throwUnsupportedGetWhereValue = (~valueName, ~entityName, ~filterDisplay, ~hint="") =>
-  JsError.throwWithMessage(
-    `Invalid ${valueName} value passed to context.${entityName}.getWhere(${filterDisplay}). Filtering by null or undefined values is not supported in getWhere.${hint}`,
-  )
-
 let getWhereHandler = (params: entityContextParams, filter: dict<dict<unknown>>) => {
   let entityConfig = params.entityConfig
-  let filterKeys = filter->Dict.keysToArray
 
-  if filterKeys->Array.length === 0 {
-    JsError.throwWithMessage(
-      `Empty filter passed to context.${entityConfig.name}.getWhere(). Please provide a filter like { fieldName: { _eq: value } }.`,
-    )
-  }
-  if filterKeys->Array.length > 1 {
-    JsError.throwWithMessage(
-      `Multiple filter fields passed to context.${entityConfig.name}.getWhere(). Currently only one filter field per call is supported. Received fields: ${filterKeys->Array.joinUnsafe(
-          ", ",
-        )}.`,
-    )
-  }
-
-  let apiFieldName = filterKeys->Array.getUnsafe(0)
-  let operatorObj = filter->Dict.getUnsafe(apiFieldName)
-
-  switch operatorObj->getUndefinedOrNullName {
-  | Some(valueName) =>
-    throwUnsupportedGetWhereValue(
-      ~valueName,
-      ~entityName=entityConfig.name,
-      ~filterDisplay=`{ ${apiFieldName}: ${valueName} }`,
-      ~hint=` Please provide an operator like { _eq: value }.`,
-    )
-  | None => ()
-  }
-
-  let operatorKeys = operatorObj->Dict.keysToArray
-
-  if operatorKeys->Array.length === 0 {
-    JsError.throwWithMessage(
-      `Empty operator passed to context.${entityConfig.name}.getWhere({ ${apiFieldName}: {} }). Please provide an operator like { _eq: value }, { _gt: value }, { _lt: value }, { _gte: value }, { _lte: value }, or { _in: [values] }.`,
-    )
-  }
-  if operatorKeys->Array.length > 1 {
-    JsError.throwWithMessage(
-      `Multiple operators passed to context.${entityConfig.name}.getWhere({ ${apiFieldName}: ... }). Currently only one operator per filter field is supported. Received operators: ${operatorKeys->Array.joinUnsafe(
-          ", ",
-        )}.`,
-    )
-  }
-
-  let operatorKey = operatorKeys->Array.getUnsafe(0)
-
-  let throwInvalidOperator = () =>
-    JsError.throwWithMessage(
-      `Invalid operator "${operatorKey}" in context.${entityConfig.name}.getWhere({ ${apiFieldName}: { ${operatorKey}: ... } }). Valid operators are _eq, _gt, _lt, _gte, _lte, _in.`,
-    )
-
-  // Validate the operator and the field before the value, so a typoed
-  // operator or field gets the more specific error even when the value
-  // is also nullish
-  switch operatorKey {
-  | "_eq" | "_gt" | "_lt" | "_gte" | "_lte" | "_in" => ()
-  | _ => throwInvalidOperator()
-  }
-
-  switch entityConfig.table->Table.getFieldByApiName(apiFieldName) {
-  | None =>
-    JsError.throwWithMessage(
-      `Invalid field "${apiFieldName}" in context.${entityConfig.name}.getWhere(). The field doesn't exist. ${codegenHelpMessage}`,
-    )
-  | Some(DerivedFrom(_)) =>
-    JsError.throwWithMessage(
-      `The field "${apiFieldName}" on entity "${entityConfig.name}" is a derived field and cannot be used in getWhere(). Use the source entity's indexed field instead.`,
-    )
-  | Some(Field({isIndex: false, linkedEntity: None})) =>
-    JsError.throwWithMessage(
-      `The field "${apiFieldName}" on entity "${entityConfig.name}" does not have an index. To use it in getWhere(), add the @index directive in your schema.graphql:\n\n  ${apiFieldName}: ... @index\n\nThen run 'pnpm envio codegen' to regenerate.`,
-    )
-  | Some(Field(_)) => ()
-  }
-
-  let fieldValue = operatorObj->Dict.getUnsafe(operatorKey)
-  switch fieldValue->getUndefinedOrNullName {
-  | Some(valueName) =>
-    throwUnsupportedGetWhereValue(
-      ~valueName,
-      ~entityName=entityConfig.name,
-      ~filterDisplay=`{ ${apiFieldName}: { ${operatorKey}: ${valueName} } }`,
-    )
-  | None => ()
-  }
-
-  @inline
-  let loadWithFilter = filter =>
+  filter
+  ->EntityFilter.parseOrThrow(~entityName=entityConfig.name, ~table=entityConfig.table)
+  ->Array.map(filter =>
     LoadLayer.loadByFilter(
       ~loadManager=params.loadManager,
       ~persistence=params.persistence,
@@ -190,54 +90,9 @@ let getWhereHandler = (params: entityContextParams, filter: dict<dict<unknown>>)
       ~item=params.item,
       ~filter,
     )
-
-  if operatorKey === "_in" {
-    let fieldValues = fieldValue->(Utils.magic: unknown => array<unknown>)
-
-    // Load each value as a separate Eq filter to memoize
-    // them in memory on the per-value level.
-    // A nullish value throws mid-map and leaves the loads of earlier
-    // values running unawaited, which is fine since the whole
-    // getWhere call rejects
-    fieldValues
-    ->Array.mapWithIndex((fieldValue, index) => {
-      switch fieldValue->getUndefinedOrNullName {
-      | Some(valueName) =>
-        throwUnsupportedGetWhereValue(
-          ~valueName,
-          ~entityName=entityConfig.name,
-          ~filterDisplay=`{ ${apiFieldName}: { _in: [...] } }`,
-          ~hint=` The ${valueName} value is at index ${index->Int.toString} of the _in array.`,
-        )
-      | None => ()
-      }
-      loadWithFilter(EntityFilter.Eq({fieldName: apiFieldName, fieldValue}))
-    })
-    ->Promise.all
-    ->Promise.thenResolve(results => results->Array.flat)
-  } else if operatorKey === "_gte" || operatorKey === "_lte" {
-    // _gte and _lte are composed from Eq + Gt/Lt
-    let rangeFilter =
-      operatorKey === "_gte"
-        ? EntityFilter.Gt({fieldName: apiFieldName, fieldValue})
-        : EntityFilter.Lt({fieldName: apiFieldName, fieldValue})
-
-    [
-      loadWithFilter(EntityFilter.Eq({fieldName: apiFieldName, fieldValue})),
-      loadWithFilter(rangeFilter),
-    ]
-    ->Promise.all
-    ->Promise.thenResolve(results => results->Array.flat)
-  } else {
-    let filter = switch operatorKey {
-    | "_eq" => EntityFilter.Eq({fieldName: apiFieldName, fieldValue})
-    | "_gt" => EntityFilter.Gt({fieldName: apiFieldName, fieldValue})
-    | "_lt" => EntityFilter.Lt({fieldName: apiFieldName, fieldValue})
-    | _ => throwInvalidOperator()
-    }
-
-    loadWithFilter(filter)
-  }
+  )
+  ->Promise.all
+  ->Promise.thenResolve(results => results->Array.flat)
 }
 
 let noopSet = (_entity: Internal.entity) => ()

--- a/packages/envio/src/db/EntityFilter.res
+++ b/packages/envio/src/db/EntityFilter.res
@@ -101,7 +101,9 @@ let throwUnsupportedGetWhereValue = (~valueName, ~entityName, ~filterDisplay, ~h
 // Each returned filter should be loaded separately and the results flattened:
 // _in maps to one Eq per value so loads memoize on the per-value level,
 // and _gte/_lte are composed from Eq + Gt/Lt
-let parseOrThrow = (filter: dict<dict<unknown>>, ~entityName, ~table: Table.table): array<t> => {
+let parseGetWhereOrThrow = (filter: dict<dict<unknown>>, ~entityName, ~table: Table.table): array<
+  t,
+> => {
   let filterKeys = filter->Dict.keysToArray
 
   if filterKeys->Array.length === 0 {

--- a/packages/envio/src/db/EntityFilter.res
+++ b/packages/envio/src/db/EntityFilter.res
@@ -133,6 +133,14 @@ let parseGetWhereOrThrow = (filter: dict<dict<unknown>>, ~entityName, ~table: Ta
   | None => ()
   }
 
+  // A primitive operator value wouldn't throw on Dict.keysToArray, but report
+  // string indices or no keys as operators, so catch it with a real hint instead
+  if operatorObj->typeof !== #object || operatorObj->Array.isArray {
+    JsError.throwWithMessage(
+      `Invalid value passed to context.${entityName}.getWhere({ ${apiFieldName}: ... }). Please provide an operator like { _eq: value }.`,
+    )
+  }
+
   let operatorKeys = operatorObj->Dict.keysToArray
 
   if operatorKeys->Array.length === 0 {
@@ -191,6 +199,11 @@ let parseGetWhereOrThrow = (filter: dict<dict<unknown>>, ~entityName, ~table: Ta
   }
 
   if operatorKey === "_in" {
+    if !(fieldValue->Array.isArray) {
+      JsError.throwWithMessage(
+        `Invalid value passed to context.${entityName}.getWhere({ ${apiFieldName}: { _in: ... } }). The _in operator expects an array of values.`,
+      )
+    }
     let fieldValues = fieldValue->(Utils.magic: unknown => array<unknown>)
 
     fieldValues->Array.mapWithIndex((fieldValue, index) => {

--- a/packages/envio/src/db/EntityFilter.res
+++ b/packages/envio/src/db/EntityFilter.res
@@ -80,6 +80,149 @@ let rec toString = (filter: t) =>
   | And({filters}) => `And(${filters->Array.map(toString)->Array.join(",")})`
   }
 
+let codegenHelpMessage = `Rerun 'pnpm dev' to update generated code after schema.graphql changes.`
+
+let getUndefinedOrNullName = (value: 'a) =>
+  if value === %raw(`undefined`) {
+    Some("undefined")
+  } else if value === %raw(`null`) {
+    Some("null")
+  } else {
+    None
+  }
+
+// Nullish values would otherwise turn into a "= NULL" query
+// silently matching nothing.
+let throwUnsupportedGetWhereValue = (~valueName, ~entityName, ~filterDisplay, ~hint="") =>
+  JsError.throwWithMessage(
+    `Invalid ${valueName} value passed to context.${entityName}.getWhere(${filterDisplay}). Filtering by null or undefined values is not supported in getWhere.${hint}`,
+  )
+
+// Each returned filter should be loaded separately and the results flattened:
+// _in maps to one Eq per value so loads memoize on the per-value level,
+// and _gte/_lte are composed from Eq + Gt/Lt
+let parseOrThrow = (filter: dict<dict<unknown>>, ~entityName, ~table: Table.table): array<t> => {
+  let filterKeys = filter->Dict.keysToArray
+
+  if filterKeys->Array.length === 0 {
+    JsError.throwWithMessage(
+      `Empty filter passed to context.${entityName}.getWhere(). Please provide a filter like { fieldName: { _eq: value } }.`,
+    )
+  }
+  if filterKeys->Array.length > 1 {
+    JsError.throwWithMessage(
+      `Multiple filter fields passed to context.${entityName}.getWhere(). Currently only one filter field per call is supported. Received fields: ${filterKeys->Array.joinUnsafe(
+          ", ",
+        )}.`,
+    )
+  }
+
+  let apiFieldName = filterKeys->Array.getUnsafe(0)
+  let operatorObj = filter->Dict.getUnsafe(apiFieldName)
+
+  switch operatorObj->getUndefinedOrNullName {
+  | Some(valueName) =>
+    throwUnsupportedGetWhereValue(
+      ~valueName,
+      ~entityName,
+      ~filterDisplay=`{ ${apiFieldName}: ${valueName} }`,
+      ~hint=` Please provide an operator like { _eq: value }.`,
+    )
+  | None => ()
+  }
+
+  let operatorKeys = operatorObj->Dict.keysToArray
+
+  if operatorKeys->Array.length === 0 {
+    JsError.throwWithMessage(
+      `Empty operator passed to context.${entityName}.getWhere({ ${apiFieldName}: {} }). Please provide an operator like { _eq: value }, { _gt: value }, { _lt: value }, { _gte: value }, { _lte: value }, or { _in: [values] }.`,
+    )
+  }
+  if operatorKeys->Array.length > 1 {
+    JsError.throwWithMessage(
+      `Multiple operators passed to context.${entityName}.getWhere({ ${apiFieldName}: ... }). Currently only one operator per filter field is supported. Received operators: ${operatorKeys->Array.joinUnsafe(
+          ", ",
+        )}.`,
+    )
+  }
+
+  let operatorKey = operatorKeys->Array.getUnsafe(0)
+
+  let throwInvalidOperator = () =>
+    JsError.throwWithMessage(
+      `Invalid operator "${operatorKey}" in context.${entityName}.getWhere({ ${apiFieldName}: { ${operatorKey}: ... } }). Valid operators are _eq, _gt, _lt, _gte, _lte, _in.`,
+    )
+
+  // Validate the operator and the field before the value, so a typoed
+  // operator or field gets the more specific error even when the value
+  // is also nullish
+  switch operatorKey {
+  | "_eq" | "_gt" | "_lt" | "_gte" | "_lte" | "_in" => ()
+  | _ => throwInvalidOperator()
+  }
+
+  switch table->Table.getFieldByApiName(apiFieldName) {
+  | None =>
+    JsError.throwWithMessage(
+      `Invalid field "${apiFieldName}" in context.${entityName}.getWhere(). The field doesn't exist. ${codegenHelpMessage}`,
+    )
+  | Some(DerivedFrom(_)) =>
+    JsError.throwWithMessage(
+      `The field "${apiFieldName}" on entity "${entityName}" is a derived field and cannot be used in getWhere(). Use the source entity's indexed field instead.`,
+    )
+  | Some(Field({isIndex: false, linkedEntity: None})) =>
+    JsError.throwWithMessage(
+      `The field "${apiFieldName}" on entity "${entityName}" does not have an index. To use it in getWhere(), add the @index directive in your schema.graphql:\n\n  ${apiFieldName}: ... @index\n\nThen run 'pnpm envio codegen' to regenerate.`,
+    )
+  | Some(Field(_)) => ()
+  }
+
+  let fieldValue = operatorObj->Dict.getUnsafe(operatorKey)
+  switch fieldValue->getUndefinedOrNullName {
+  | Some(valueName) =>
+    throwUnsupportedGetWhereValue(
+      ~valueName,
+      ~entityName,
+      ~filterDisplay=`{ ${apiFieldName}: { ${operatorKey}: ${valueName} } }`,
+    )
+  | None => ()
+  }
+
+  if operatorKey === "_in" {
+    let fieldValues = fieldValue->(Utils.magic: unknown => array<unknown>)
+
+    fieldValues->Array.mapWithIndex((fieldValue, index) => {
+      switch fieldValue->getUndefinedOrNullName {
+      | Some(valueName) =>
+        throwUnsupportedGetWhereValue(
+          ~valueName,
+          ~entityName,
+          ~filterDisplay=`{ ${apiFieldName}: { _in: [...] } }`,
+          ~hint=` The ${valueName} value is at index ${index->Int.toString} of the _in array.`,
+        )
+      | None => ()
+      }
+      Eq({fieldName: apiFieldName, fieldValue})
+    })
+  } else if operatorKey === "_gte" || operatorKey === "_lte" {
+    [
+      Eq({fieldName: apiFieldName, fieldValue}),
+      operatorKey === "_gte"
+        ? Gt({fieldName: apiFieldName, fieldValue})
+        : Lt({fieldName: apiFieldName, fieldValue}),
+    ]
+  } else {
+    [
+      switch operatorKey {
+      | "_eq" => Eq({fieldName: apiFieldName, fieldValue})
+      | "_gt" => Gt({fieldName: apiFieldName, fieldValue})
+      | "_lt" => Lt({fieldName: apiFieldName, fieldValue})
+      | _ => throwInvalidOperator()
+      },
+    ]
+  }
+}
+
 // A field missing on the entity reads as `undefined`, which matches the `None`
 // arm of `FieldValue.t` (`option<...>`), so nullable columns omitted on the
 // entity object are compared as null rather than crashing.

--- a/scenarios/test_codegen/test/EntityFilter_test.res
+++ b/scenarios/test_codegen/test/EntityFilter_test.res
@@ -26,6 +26,90 @@ describe("EntityFilter.toOperationKey", () => {
   })
 })
 
+describe("EntityFilter.parseGetWhereOrThrow", () => {
+  let table = Table.mkTable(
+    "users",
+    ~fields=[
+      Table.mkField("id", String, ~isPrimaryKey=true, ~fieldSchema=S.string),
+      Table.mkField("score", Int32, ~isIndex=true, ~fieldSchema=S.int),
+      Table.mkField("name", String, ~fieldSchema=S.string),
+      Table.mkField("owner", Entity({name: "Owner"}), ~linkedEntity="Owner", ~fieldSchema=S.string),
+      Table.mkDerivedFromField("tokens", ~derivedFromEntity="Token", ~derivedFromField="owner"),
+    ],
+  )
+
+  // The filter comes from user-land JS, so test inputs are raw objects
+  let parse = (filter: 'a) =>
+    filter
+    ->(Utils.magic: 'a => dict<dict<unknown>>)
+    ->EntityFilter.parseGetWhereOrThrow(~entityName="User", ~table)
+
+  let v = (value: int) => value->(Utils.magic: int => unknown)
+
+  it("Parses every operator into the filters to load", t => {
+    t.expect([
+      parse(%raw(`{score: {_eq: 1}}`)),
+      parse(%raw(`{score: {_gt: 1}}`)),
+      parse(%raw(`{score: {_lt: 1}}`)),
+      parse(%raw(`{score: {_gte: 1}}`)),
+      parse(%raw(`{score: {_lte: 1}}`)),
+      parse(%raw(`{score: {_in: [1, 2]}}`)),
+      parse(%raw(`{score: {_in: []}}`)),
+      // Unindexed linked entity fields are allowed via the _id api name
+      parse(%raw(`{owner_id: {_eq: 1}}`)),
+    ]).toEqual([
+      [Eq({fieldName: "score", fieldValue: v(1)})],
+      [Gt({fieldName: "score", fieldValue: v(1)})],
+      [Lt({fieldName: "score", fieldValue: v(1)})],
+      [Eq({fieldName: "score", fieldValue: v(1)}), Gt({fieldName: "score", fieldValue: v(1)})],
+      [Eq({fieldName: "score", fieldValue: v(1)}), Lt({fieldName: "score", fieldValue: v(1)})],
+      [Eq({fieldName: "score", fieldValue: v(1)}), Eq({fieldName: "score", fieldValue: v(2)})],
+      [],
+      [Eq({fieldName: "owner_id", fieldValue: v(1)})],
+    ])
+  })
+
+  it("Throws a user friendly error for every invalid filter", t => {
+    let getError = (filter: 'a) =>
+      try {
+        let _ = parse(filter)
+        "Expected parseGetWhereOrThrow to throw"
+      } catch {
+      | JsExn(e) => e->JsExn.message->Option.getOr("(no message)")
+      }
+
+    t.expect([
+      getError(%raw(`{}`)),
+      getError(%raw(`{score: {_eq: 1}, name: {_eq: "a"}}`)),
+      getError(%raw(`{score: undefined}`)),
+      getError(%raw(`{score: null}`)),
+      getError(%raw(`{score: {}}`)),
+      getError(%raw(`{score: {_eq: 1, _gt: 2}}`)),
+      getError(%raw(`{score: {_foo: 1}}`)),
+      getError(%raw(`{nonExistingField: {_eq: 1}}`)),
+      getError(%raw(`{tokens: {_eq: 1}}`)),
+      getError(%raw(`{name: {_eq: "a"}}`)),
+      getError(%raw(`{score: {_eq: undefined}}`)),
+      getError(%raw(`{score: {_eq: null}}`)),
+      getError(%raw(`{score: {_in: [1, undefined]}}`)),
+    ]).toEqual([
+      `Empty filter passed to context.User.getWhere(). Please provide a filter like { fieldName: { _eq: value } }.`,
+      `Multiple filter fields passed to context.User.getWhere(). Currently only one filter field per call is supported. Received fields: score, name.`,
+      `Invalid undefined value passed to context.User.getWhere({ score: undefined }). Filtering by null or undefined values is not supported in getWhere. Please provide an operator like { _eq: value }.`,
+      `Invalid null value passed to context.User.getWhere({ score: null }). Filtering by null or undefined values is not supported in getWhere. Please provide an operator like { _eq: value }.`,
+      `Empty operator passed to context.User.getWhere({ score: {} }). Please provide an operator like { _eq: value }, { _gt: value }, { _lt: value }, { _gte: value }, { _lte: value }, or { _in: [values] }.`,
+      `Multiple operators passed to context.User.getWhere({ score: ... }). Currently only one operator per filter field is supported. Received operators: _eq, _gt.`,
+      `Invalid operator "_foo" in context.User.getWhere({ score: { _foo: ... } }). Valid operators are _eq, _gt, _lt, _gte, _lte, _in.`,
+      `Invalid field "nonExistingField" in context.User.getWhere(). The field doesn't exist. Rerun 'pnpm dev' to update generated code after schema.graphql changes.`,
+      `The field "tokens" on entity "User" is a derived field and cannot be used in getWhere(). Use the source entity's indexed field instead.`,
+      `The field "name" on entity "User" does not have an index. To use it in getWhere(), add the @index directive in your schema.graphql:\n\n  name: ... @index\n\nThen run 'pnpm envio codegen' to regenerate.`,
+      `Invalid undefined value passed to context.User.getWhere({ score: { _eq: undefined } }). Filtering by null or undefined values is not supported in getWhere.`,
+      `Invalid null value passed to context.User.getWhere({ score: { _eq: null } }). Filtering by null or undefined values is not supported in getWhere.`,
+      `Invalid undefined value passed to context.User.getWhere({ score: { _in: [...] } }). Filtering by null or undefined values is not supported in getWhere. The undefined value is at index 1 of the _in array.`,
+    ])
+  })
+})
+
 describe("EntityFilter.mapValues", () => {
   it("Maps scalar values one by one and In values as a whole array", t => {
     let calls = []

--- a/scenarios/test_codegen/test/EntityFilter_test.res
+++ b/scenarios/test_codegen/test/EntityFilter_test.res
@@ -83,6 +83,9 @@ describe("EntityFilter.parseGetWhereOrThrow", () => {
       getError(%raw(`{score: {_eq: 1}, name: {_eq: "a"}}`)),
       getError(%raw(`{score: undefined}`)),
       getError(%raw(`{score: null}`)),
+      getError(%raw(`{score: 5}`)),
+      getError(%raw(`{score: "abc"}`)),
+      getError(%raw(`{score: [1]}`)),
       getError(%raw(`{score: {}}`)),
       getError(%raw(`{score: {_eq: 1, _gt: 2}}`)),
       getError(%raw(`{score: {_foo: 1}}`)),
@@ -92,11 +95,15 @@ describe("EntityFilter.parseGetWhereOrThrow", () => {
       getError(%raw(`{score: {_eq: undefined}}`)),
       getError(%raw(`{score: {_eq: null}}`)),
       getError(%raw(`{score: {_in: [1, undefined]}}`)),
+      getError(%raw(`{score: {_in: 5}}`)),
     ]).toEqual([
       `Empty filter passed to context.User.getWhere(). Please provide a filter like { fieldName: { _eq: value } }.`,
       `Multiple filter fields passed to context.User.getWhere(). Currently only one filter field per call is supported. Received fields: score, name.`,
       `Invalid undefined value passed to context.User.getWhere({ score: undefined }). Filtering by null or undefined values is not supported in getWhere. Please provide an operator like { _eq: value }.`,
       `Invalid null value passed to context.User.getWhere({ score: null }). Filtering by null or undefined values is not supported in getWhere. Please provide an operator like { _eq: value }.`,
+      `Invalid value passed to context.User.getWhere({ score: ... }). Please provide an operator like { _eq: value }.`,
+      `Invalid value passed to context.User.getWhere({ score: ... }). Please provide an operator like { _eq: value }.`,
+      `Invalid value passed to context.User.getWhere({ score: ... }). Please provide an operator like { _eq: value }.`,
       `Empty operator passed to context.User.getWhere({ score: {} }). Please provide an operator like { _eq: value }, { _gt: value }, { _lt: value }, { _gte: value }, { _lte: value }, or { _in: [values] }.`,
       `Multiple operators passed to context.User.getWhere({ score: ... }). Currently only one operator per filter field is supported. Received operators: _eq, _gt.`,
       `Invalid operator "_foo" in context.User.getWhere({ score: { _foo: ... } }). Valid operators are _eq, _gt, _lt, _gte, _lte, _in.`,
@@ -106,6 +113,7 @@ describe("EntityFilter.parseGetWhereOrThrow", () => {
       `Invalid undefined value passed to context.User.getWhere({ score: { _eq: undefined } }). Filtering by null or undefined values is not supported in getWhere.`,
       `Invalid null value passed to context.User.getWhere({ score: { _eq: null } }). Filtering by null or undefined values is not supported in getWhere.`,
       `Invalid undefined value passed to context.User.getWhere({ score: { _in: [...] } }). Filtering by null or undefined values is not supported in getWhere. The undefined value is at index 1 of the _in array.`,
+      `Invalid value passed to context.User.getWhere({ score: { _in: ... } }). The _in operator expects an array of values.`,
     ])
   })
 })

--- a/scenarios/test_codegen/test/WriteRead_test.res
+++ b/scenarios/test_codegen/test/WriteRead_test.res
@@ -463,7 +463,7 @@ breaking precicion on big values. https://github.com/enviodev/hyperindex/issues/
     ).toBe(1)
   })
 
-  Async.it("getWhere throws a user friendly error for undefined filter values", async t => {
+  Async.it("getWhere throws a user friendly error for an invalid filter", async t => {
     let sourceMock = MockIndexer.Source.make(~chain=#1337, [#getHeightOrThrow, #getItemsOrThrow])
     let indexerMock = await MockIndexer.Indexer.make(
       ~chains=[{chain: #1337, sourceConfig: Config.CustomSources([sourceMock.source])}],
@@ -474,55 +474,28 @@ breaking precicion on big values. https://github.com/enviodev/hyperindex/issues/
     await Utils.delay(0)
     await Utils.delay(0)
 
-    let errors = ref([])
+    let error = ref("")
 
     sourceMock.resolveGetItemsOrThrow([
       {
         blockNumber: 50,
         logIndex: 1,
         handler: async ({context}) => {
-          let expectGetWhereError = (
-            getWhere: unit => promise<array<Indexer.Entities.Token.t>>,
-          ) =>
+          error := (
             try {
-              let _ = getWhere()
+              let _ = await context.\"Token".getWhere(%raw(`{tokenId: undefined}`))
               "Expected getWhere to throw"
             } catch {
             | JsExn(e) => e->JsExn.message->Option.getOr("(no message)")
             }
-
-          errors := [
-            expectGetWhereError(() => context.\"Token".getWhere(%raw(`{tokenId: undefined}`))),
-            expectGetWhereError(() => context.\"Token".getWhere(%raw(`{tokenId: null}`))),
-            expectGetWhereError(
-              () => context.\"Token".getWhere(%raw(`{tokenId: {_eq: undefined}}`)),
-            ),
-            expectGetWhereError(() => context.\"Token".getWhere(%raw(`{tokenId: {_eq: null}}`))),
-            expectGetWhereError(
-              () => context.\"Token".getWhere(%raw(`{tokenId: {_in: [1n, undefined]}}`)),
-            ),
-            // A typoed operator or field gets its specific error
-            // even when the value is also nullish
-            expectGetWhereError(
-              () => context.\"Token".getWhere(%raw(`{tokenId: {_foo: undefined}}`)),
-            ),
-            expectGetWhereError(
-              () => context.\"Token".getWhere(%raw(`{nonExistingField: {_eq: undefined}}`)),
-            ),
-          ]
+          )
         },
       },
     ])
     await indexerMock.getBatchWritePromise()
 
-    t.expect(errors.contents).toEqual([
+    t.expect(error.contents).toEqual(
       `Invalid undefined value passed to context.Token.getWhere({ tokenId: undefined }). Filtering by null or undefined values is not supported in getWhere. Please provide an operator like { _eq: value }.`,
-      `Invalid null value passed to context.Token.getWhere({ tokenId: null }). Filtering by null or undefined values is not supported in getWhere. Please provide an operator like { _eq: value }.`,
-      `Invalid undefined value passed to context.Token.getWhere({ tokenId: { _eq: undefined } }). Filtering by null or undefined values is not supported in getWhere.`,
-      `Invalid null value passed to context.Token.getWhere({ tokenId: { _eq: null } }). Filtering by null or undefined values is not supported in getWhere.`,
-      `Invalid undefined value passed to context.Token.getWhere({ tokenId: { _in: [...] } }). Filtering by null or undefined values is not supported in getWhere. The undefined value is at index 1 of the _in array.`,
-      `Invalid operator "_foo" in context.Token.getWhere({ tokenId: { _foo: ... } }). Valid operators are _eq, _gt, _lt, _gte, _lte, _in.`,
-      `Invalid field "nonExistingField" in context.Token.getWhere(). The field doesn't exist. Rerun 'pnpm dev' to update generated code after schema.graphql changes.`,
-    ])
+    )
   })
 })


### PR DESCRIPTION
## Summary
Refactored filter validation and parsing logic from `UserContext.getWhereHandler` into a new `EntityFilter.parseOrThrow` function, improving code organization and reusability.

## Changes
- Moved filter parsing, validation, and transformation logic from `UserContext.res` to `EntityFilter.res`
- Created `EntityFilter.parseOrThrow` function that validates filter structure, operators, and field existence, then returns an array of normalized filter objects
- Moved helper functions (`getUndefinedOrNullName`, `throwUnsupportedGetWhereValue`) and `codegenHelpMessage` to `EntityFilter.res`
- Simplified `UserContext.getWhereHandler` to use the new `parseOrThrow` function and focus on loading logic
- The `parseOrThrow` function returns an array of filters to support operators like `_in` (multiple Eq filters) and `_gte`/`_lte` (Eq + comparison filter pairs)

## Implementation Details
- Filter parsing now happens in a dedicated module, making it easier to test and reuse
- The function validates in the correct order: filter structure → operator validity → field existence → value nullability
- Error messages remain unchanged to maintain API compatibility
- The array return type enables proper memoization of individual values in `_in` operations and composition of range operators

https://claude.ai/code/session_01Aq2ZnKNyVJa8nopPdM7d6o