### PR TITLE
Merge concurrent Eq/In filters into single In queries

### DIFF
--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -374,9 +374,46 @@ let loadByFilter = (
 
     let size = ref(0)
 
-    let _ = await filters
+    filters->Array.forEach(filter => inMemTable->InMemoryTable.Entity.addEmptyIndex(~filter))
+
+    // Filters in a group always share the operator and field name (both are
+    // encoded in the group key), so Eq and In batches collapse into a single
+    // In query. Loading a superset of rows is safe: every loaded entity is
+    // matched against all registered indices, not only the query's own filter.
+    let queries = if filters->Array.length === 1 {
+      filters
+    } else {
+      switch filters->Array.getUnsafe(0) {
+      | Eq({fieldName}) => [
+          EntityFilter.In({
+            fieldName,
+            fieldValue: filters->Array.filterMap(filter =>
+              switch filter {
+              | Eq({fieldValue}) => Some(fieldValue)
+              | _ => None
+              }
+            ),
+          }),
+        ]
+      | In({fieldName}) => [
+          EntityFilter.In({
+            fieldName,
+            fieldValue: filters
+            ->Array.map(filter =>
+              switch filter {
+              | In({fieldValue}) => fieldValue
+              | _ => []
+              }
+            )
+            ->Array.flat,
+          }),
+        ]
+      | Gt(_) | Lt(_) | And(_) => filters
+      }
+    }
+
+    let _ = await queries
     ->Array.map(async filter => {
-      inMemTable->InMemoryTable.Entity.addEmptyIndex(~filter)
       try {
         let entities =
           (await storage.loadOrThrow(~table=entityConfig.table, ~filter))->(

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -370,41 +370,10 @@ let loadByFilter = (
 
     filters->Array.forEach(filter => inMemTable->InMemoryTable.Entity.addEmptyIndex(~filter))
 
-    // Filters in a group always share the operator and field name (both are
-    // encoded in the group key), so Eq and In batches collapse into a single
-    // In query. Loading a superset of rows is safe: every loaded entity is
-    // matched against all registered indices, not only the query's own filter.
-    let queries = if filters->Array.length === 1 {
-      filters
-    } else {
-      switch filters->Array.getUnsafe(0) {
-      | Eq({fieldName}) => [
-          EntityFilter.In({
-            fieldName,
-            fieldValue: filters->Array.filterMap(filter =>
-              switch filter {
-              | Eq({fieldValue}) => Some(fieldValue)
-              | _ => None
-              }
-            ),
-          }),
-        ]
-      | In({fieldName}) => [
-          EntityFilter.In({
-            fieldName,
-            fieldValue: filters
-            ->Array.map(filter =>
-              switch filter {
-              | In({fieldValue}) => fieldValue
-              | _ => []
-              }
-            )
-            ->Array.flat,
-          }),
-        ]
-      | Gt(_) | Lt(_) | And(_) => filters
-      }
-    }
+    // Loading a superset of rows via a merged query is safe: every loaded
+    // entity is matched against all registered indices, not only the
+    // query's own filter.
+    let queries = filters->EntityFilter.merge
 
     let _ = await queries
     ->Array.map(async filter => {

--- a/packages/envio/src/db/EntityFilter.res
+++ b/packages/envio/src/db/EntityFilter.res
@@ -121,6 +121,43 @@ let toOperationKey = (filter: t, ~entityName) =>
   | And(_) => `${entityName}.getWhere({${filter->printOperationFilter(~paramsCount=ref(0))}})`
   }
 
+// Collapses filters sharing an operation key into fewer storage queries:
+// Eq and In batches merge into a single In on the field. Gt/Lt/And have
+// no lossless single-query form without an Or operator, so they stay as is.
+// Expects a homogeneous batch — filters with the same operation key.
+let merge = (filters: array<t>) =>
+  switch filters {
+  | [] | [_] => filters
+  | _ =>
+    switch filters->Array.getUnsafe(0) {
+    | Eq({fieldName}) => [
+        In({
+          fieldName,
+          fieldValue: filters->Array.filterMap(filter =>
+            switch filter {
+            | Eq({fieldValue}) => Some(fieldValue)
+            | _ => None
+            }
+          ),
+        }),
+      ]
+    | In({fieldName}) => [
+        In({
+          fieldName,
+          fieldValue: filters
+          ->Array.map(filter =>
+            switch filter {
+            | In({fieldValue}) => fieldValue
+            | _ => []
+            }
+          )
+          ->Array.flat,
+        }),
+      ]
+    | Gt(_) | Lt(_) | And(_) => filters
+    }
+  }
+
 // A field missing on the entity reads as `undefined`, which matches the `None`
 // arm of `FieldValue.t` (`option<...>`), so nullable columns omitted on the
 // entity object are compared as null rather than crashing.

--- a/scenarios/test_codegen/test/EntityFilter_test.res
+++ b/scenarios/test_codegen/test/EntityFilter_test.res
@@ -26,6 +26,39 @@ describe("EntityFilter.toOperationKey", () => {
   })
 })
 
+describe("EntityFilter.merge", () => {
+  it("Merges Eq and In batches into a single In, keeps the rest as is", t => {
+    let v = i => i->(Utils.magic: int => unknown)
+    t.expect(
+      (
+        [
+          EntityFilter.Eq({fieldName: "a", fieldValue: v(1)}),
+          EntityFilter.Eq({fieldName: "a", fieldValue: v(2)}),
+        ]->EntityFilter.merge,
+        [
+          EntityFilter.In({fieldName: "a", fieldValue: [v(1), v(2)]}),
+          EntityFilter.In({fieldName: "a", fieldValue: [v(3)]}),
+        ]->EntityFilter.merge,
+        [
+          EntityFilter.Gt({fieldName: "a", fieldValue: v(1)}),
+          EntityFilter.Gt({fieldName: "a", fieldValue: v(2)}),
+        ]->EntityFilter.merge,
+        [EntityFilter.Eq({fieldName: "a", fieldValue: v(1)})]->EntityFilter.merge,
+        []->EntityFilter.merge,
+      ),
+    ).toEqual((
+      [EntityFilter.In({fieldName: "a", fieldValue: [v(1), v(2)]})],
+      [EntityFilter.In({fieldName: "a", fieldValue: [v(1), v(2), v(3)]})],
+      [
+        EntityFilter.Gt({fieldName: "a", fieldValue: v(1)}),
+        EntityFilter.Gt({fieldName: "a", fieldValue: v(2)}),
+      ],
+      [EntityFilter.Eq({fieldName: "a", fieldValue: v(1)})],
+      [],
+    ))
+  })
+})
+
 describe("EntityFilter.mapValues", () => {
   it("Maps scalar values one by one and In values as a whole array", t => {
     let calls = []

--- a/scenarios/test_codegen/test/LoadLayer_test.res
+++ b/scenarios/test_codegen/test/LoadLayer_test.res
@@ -395,6 +395,135 @@ describe("LoadLayer", () => {
     )
   })
 
+  Async.it("Merges concurrent Eq filters on the same field into a single In query", async t => {
+    let storageMock = MockIndexer.Storage.make([#loadOrThrow])
+    let loadManager = LoadManager.make()
+
+    let user1: Indexer.Entities.User.t = {
+      id: "1",
+      accountType: USER,
+      address: "0x1",
+      gravatar_id: None,
+      updatesCountOnUserForTesting: 0,
+    }
+
+    let inMemoryStore = MockIndexer.InMemoryStore.make(
+      ~entities=[(MockIndexer.entityConfig(User), [user1])],
+    )
+
+    let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem
+    let getUsersWithAddress = fieldValue =>
+      LoadLayer.loadByFilter(
+        ~loadManager,
+        ~persistence=storageMock->MockIndexer.Storage.toPersistence,
+        ~entityConfig=MockIndexer.entityConfig(User),
+        ~inMemoryStore,
+        ~item,
+        ~filter=EntityFilter.Eq({
+          fieldName: "address",
+          fieldValue: fieldValue->(Utils.magic: string => unknown),
+        }),
+        ~shouldGroup=true,
+      )
+
+    let users = await Promise.all([getUsersWithAddress("0x1"), getUsersWithAddress("0x2")])
+
+    t.expect((users, storageMock.loadOrThrowCalls)).toEqual((
+      [[user1->(Utils.magic: Indexer.Entities.User.t => Internal.entity)], []],
+      [
+        {
+          "filter": EntityFilter.In({
+            fieldName: "address",
+            fieldValue: ["0x1", "0x2"]->(Utils.magic: array<string> => array<unknown>),
+          }),
+          "tableName": "User",
+        },
+      ],
+    ))
+  })
+
+  Async.it("Merges concurrent In filters on the same field into a single In query", async t => {
+    let storageMock = MockIndexer.Storage.make([#loadOrThrow])
+    let loadManager = LoadManager.make()
+    let inMemoryStore = MockIndexer.InMemoryStore.make()
+
+    let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem
+    let getUsersWithAddresses = fieldValues =>
+      LoadLayer.loadByFilter(
+        ~loadManager,
+        ~persistence=storageMock->MockIndexer.Storage.toPersistence,
+        ~entityConfig=MockIndexer.entityConfig(User),
+        ~inMemoryStore,
+        ~item,
+        ~filter=EntityFilter.In({
+          fieldName: "address",
+          fieldValue: fieldValues->(Utils.magic: array<string> => array<unknown>),
+        }),
+        ~shouldGroup=true,
+      )
+
+    let users = await Promise.all([
+      getUsersWithAddresses(["0x1", "0x2"]),
+      getUsersWithAddresses(["0x3"]),
+    ])
+
+    t.expect((users, storageMock.loadOrThrowCalls)).toEqual((
+      [[], []],
+      [
+        {
+          "filter": EntityFilter.In({
+            fieldName: "address",
+            fieldValue: ["0x1", "0x2", "0x3"]->(Utils.magic: array<string> => array<unknown>),
+          }),
+          "tableName": "User",
+        },
+      ],
+    ))
+  })
+
+  Async.it("Doesn't merge concurrent Gt filters", async t => {
+    let storageMock = MockIndexer.Storage.make([#loadOrThrow])
+    let loadManager = LoadManager.make()
+    let inMemoryStore = MockIndexer.InMemoryStore.make()
+
+    let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem
+    let getUsersWithUpdates = fieldValue =>
+      LoadLayer.loadByFilter(
+        ~loadManager,
+        ~persistence=storageMock->MockIndexer.Storage.toPersistence,
+        ~entityConfig=MockIndexer.entityConfig(User),
+        ~inMemoryStore,
+        ~item,
+        ~filter=EntityFilter.Gt({
+          fieldName: "updatesCountOnUserForTesting",
+          fieldValue: fieldValue->(Utils.magic: int => unknown),
+        }),
+        ~shouldGroup=true,
+      )
+
+    let users = await Promise.all([getUsersWithUpdates(0), getUsersWithUpdates(5)])
+
+    t.expect((users, storageMock.loadOrThrowCalls)).toEqual((
+      [[], []],
+      [
+        {
+          "filter": EntityFilter.Gt({
+            fieldName: "updatesCountOnUserForTesting",
+            fieldValue: 0->(Utils.magic: int => unknown),
+          }),
+          "tableName": "User",
+        },
+        {
+          "filter": EntityFilter.Gt({
+            fieldName: "updatesCountOnUserForTesting",
+            fieldValue: 5->(Utils.magic: int => unknown),
+          }),
+          "tableName": "User",
+        },
+      ],
+    ))
+  })
+
   Async.it("Gets entity from inMemoryStore by index if it exists", async t => {
     let storageMock = MockIndexer.Storage.make([#loadOrThrow])
     let loadManager = LoadManager.make()


### PR DESCRIPTION
Optimize database queries by merging concurrent filters on the same field into fewer storage calls.

## Summary
When multiple concurrent `loadByFilter` calls use `Eq` or `In` filters on the same field, they are now merged into a single `In` query. This reduces the number of database round-trips while maintaining correctness—loaded entities are matched against all registered indices, not just the merged query's filter.

## Changes
- **EntityFilter.res**: Added `merge` function that collapses homogeneous filter batches:
  - Multiple `Eq` filters on the same field → single `In` filter
  - Multiple `In` filters on the same field → single `In` filter with combined values
  - `Gt`/`Lt`/`And` filters remain unchanged (no lossless single-query form without `Or`)

- **LoadLayer.res**: Updated `loadByFilter` to:
  - Register all filters' indices before querying
  - Merge filters before executing storage queries
  - Execute merged queries instead of individual ones

- **Tests**: Added comprehensive test coverage:
  - `LoadLayer_test.res`: Three new async tests verifying merge behavior for `Eq`, `In`, and non-mergeable `Gt` filters
  - `EntityFilter_test.res`: Unit tests for the `merge` function with various filter combinations

https://claude.ai/code/session_01RPHfND7Ge1qS598LWPvfif

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized entity loading with automatic filter merging to reduce redundant database queries when multiple concurrent filter requests are issued.

* **Tests**
  * Added test coverage validating filter merging behavior for concurrent equality, inclusion, and comparison filter operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->