### PR TITLE
Support multiple fields and operators in getWhere filters, allow filtering by id

### DIFF
--- a/packages/cli/templates/static/shared/.claude/skills/indexer-handlers/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-handlers/SKILL.md
@@ -54,13 +54,15 @@ const list = await context.Entity.getWhere({ fieldName: { _lt: value } });
 const list = await context.Entity.getWhere({ fieldName: { _gte: value } });
 const list = await context.Entity.getWhere({ fieldName: { _lte: value } });
 const list = await context.Entity.getWhere({ fieldName: { _in: [value1, value2] } });
+const list = await context.Entity.getWhere({ fieldName: { _gte: min, _lte: max } });
+const list = await context.Entity.getWhere({ fieldA: { _eq: a }, fieldB: { _eq: b } });
 
 // Write
 context.Entity.set(entity);          // create or update (sync — no await)
 context.Entity.deleteUnsafe(id);     // delete (sync — no await)
 ```
 
-`getWhere` operators: `_eq`, `_gt`, `_lt`, `_gte`, `_lte`, `_in`. Only `@index` fields are queryable. See `indexer-schema` for @index syntax.
+`getWhere` operators: `_eq`, `_gt`, `_lt`, `_gte`, `_lte`, `_in`. Multiple fields and operators combine with AND semantics. Only `id` and `@index` fields are queryable. See `indexer-schema` for @index syntax.
 
 ### Context Properties
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexer-schema/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-schema/SKILL.md
@@ -96,7 +96,7 @@ type Trade @index(fields: ["poolId", ["date", "DESC"]]) {
 
 - Fields default to ASC; use `["field", "DESC"]` for descending
 - IDs and `@derivedFrom` fields are automatically indexed
-- Only `@index` fields are queryable via `context.Entity.getWhere()`
+- Only `id` and `@index` fields are queryable via `context.Entity.getWhere()`
 
 ## @config
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexer-troubleshooting/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-troubleshooting/SKILL.md
@@ -52,7 +52,7 @@ rpc:
 
 ## Common Runtime Errors
 
-**"field not indexed"** — `getWhere` only works on fields with `@index` in `schema.graphql`.
+**"field not indexed"** — `getWhere` only works on `id` and fields with `@index` in `schema.graphql`.
 
 **"entity is read-only"** — Entities from `context.Entity.get()` are frozen. Spread to update: `context.Entity.set({ ...entity, field: newValue })`.
 

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -107,7 +107,7 @@ export type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
 /**
  * Operator for filtering entity fields in getWhere queries.
- * Only fields with `@index` in the schema can be queried at runtime.
+ * Only `id` and fields with `@index` in the schema can be queried at runtime.
  */
 export type GetWhereOperator<T> = {
   /** Matches entities where the field equals the given value. */
@@ -128,7 +128,7 @@ export type GetWhereOperator<T> = {
  * Constructs a getWhere filter type from an entity type.
  * Each field can be filtered using {@link GetWhereOperator} (`_eq`, `_gt`, `_lt`, `_gte`, `_lte`, `_in`).
  *
- * Note: only fields with `@index` in the schema can be queried at runtime.
+ * Note: only `id` and fields with `@index` in the schema can be queried at runtime.
  * Attempting to filter on a non-indexed field will throw a descriptive error.
  */
 export type GetWhereFilter<E> = {

--- a/packages/envio/src/db/EntityFilter.res
+++ b/packages/envio/src/db/EntityFilter.res
@@ -100,7 +100,10 @@ let throwUnsupportedGetWhereValue = (~valueName, ~entityName, ~filterDisplay, ~h
 
 // Each returned filter should be loaded separately and the results flattened:
 // _in maps to one Eq per value so loads memoize on the per-value level,
-// and _gte/_lte are composed from Eq + Gt/Lt
+// and _gte/_lte are composed from Eq + Gt/Lt. Each field+operator pair
+// expands into a group of such alternatives, and multiple pairs combine
+// as a cross product of And filters — the groups stay disjoint, so the
+// flattened results contain no duplicates.
 let parseGetWhereOrThrow = (filter: dict<dict<unknown>>, ~entityName, ~table: Table.table): array<
   t,
 > => {
@@ -111,131 +114,133 @@ let parseGetWhereOrThrow = (filter: dict<dict<unknown>>, ~entityName, ~table: Ta
       `Empty filter passed to context.${entityName}.getWhere(). Please provide a filter like { fieldName: { _eq: value } }.`,
     )
   }
-  if filterKeys->Array.length > 1 {
-    JsError.throwWithMessage(
-      `Multiple filter fields passed to context.${entityName}.getWhere(). Currently only one filter field per call is supported. Received fields: ${filterKeys->Array.joinUnsafe(
-          ", ",
-        )}.`,
-    )
-  }
 
-  let apiFieldName = filterKeys->Array.getUnsafe(0)
-  let operatorObj = filter->Dict.getUnsafe(apiFieldName)
+  let filterGroups = filterKeys->Array.flatMap(apiFieldName => {
+    let operatorObj = filter->Dict.getUnsafe(apiFieldName)
 
-  switch operatorObj->getUndefinedOrNullName {
-  | Some(valueName) =>
-    throwUnsupportedGetWhereValue(
-      ~valueName,
-      ~entityName,
-      ~filterDisplay=`{ ${apiFieldName}: ${valueName} }`,
-      ~hint=` Please provide an operator like { _eq: value }.`,
-    )
-  | None => ()
-  }
+    switch operatorObj->getUndefinedOrNullName {
+    | Some(valueName) =>
+      throwUnsupportedGetWhereValue(
+        ~valueName,
+        ~entityName,
+        ~filterDisplay=`{ ${apiFieldName}: ${valueName} }`,
+        ~hint=` Please provide an operator like { _eq: value }.`,
+      )
+    | None => ()
+    }
 
-  // A primitive operator value wouldn't throw on Dict.keysToArray, but report
-  // string indices or no keys as operators, so catch it with a real hint instead
-  if operatorObj->typeof !== #object || operatorObj->Array.isArray {
-    JsError.throwWithMessage(
-      `Invalid value passed to context.${entityName}.getWhere({ ${apiFieldName}: ... }). Please provide an operator like { _eq: value }.`,
-    )
-  }
-
-  let operatorKeys = operatorObj->Dict.keysToArray
-
-  if operatorKeys->Array.length === 0 {
-    JsError.throwWithMessage(
-      `Empty operator passed to context.${entityName}.getWhere({ ${apiFieldName}: {} }). Please provide an operator like { _eq: value }, { _gt: value }, { _lt: value }, { _gte: value }, { _lte: value }, or { _in: [values] }.`,
-    )
-  }
-  if operatorKeys->Array.length > 1 {
-    JsError.throwWithMessage(
-      `Multiple operators passed to context.${entityName}.getWhere({ ${apiFieldName}: ... }). Currently only one operator per filter field is supported. Received operators: ${operatorKeys->Array.joinUnsafe(
-          ", ",
-        )}.`,
-    )
-  }
-
-  let operatorKey = operatorKeys->Array.getUnsafe(0)
-
-  let throwInvalidOperator = () =>
-    JsError.throwWithMessage(
-      `Invalid operator "${operatorKey}" in context.${entityName}.getWhere({ ${apiFieldName}: { ${operatorKey}: ... } }). Valid operators are _eq, _gt, _lt, _gte, _lte, _in.`,
-    )
-
-  // Validate the operator and the field before the value, so a typoed
-  // operator or field gets the more specific error even when the value
-  // is also nullish
-  switch operatorKey {
-  | "_eq" | "_gt" | "_lt" | "_gte" | "_lte" | "_in" => ()
-  | _ => throwInvalidOperator()
-  }
-
-  switch table->Table.getFieldByApiName(apiFieldName) {
-  | None =>
-    JsError.throwWithMessage(
-      `Invalid field "${apiFieldName}" in context.${entityName}.getWhere(). The field doesn't exist. ${codegenHelpMessage}`,
-    )
-  | Some(DerivedFrom(_)) =>
-    JsError.throwWithMessage(
-      `The field "${apiFieldName}" on entity "${entityName}" is a derived field and cannot be used in getWhere(). Use the source entity's indexed field instead.`,
-    )
-  | Some(Field({isIndex: false, linkedEntity: None})) =>
-    JsError.throwWithMessage(
-      `The field "${apiFieldName}" on entity "${entityName}" does not have an index. To use it in getWhere(), add the @index directive in your schema.graphql:\n\n  ${apiFieldName}: ... @index\n\nThen run 'pnpm envio codegen' to regenerate.`,
-    )
-  | Some(Field(_)) => ()
-  }
-
-  let fieldValue = operatorObj->Dict.getUnsafe(operatorKey)
-  switch fieldValue->getUndefinedOrNullName {
-  | Some(valueName) =>
-    throwUnsupportedGetWhereValue(
-      ~valueName,
-      ~entityName,
-      ~filterDisplay=`{ ${apiFieldName}: { ${operatorKey}: ${valueName} } }`,
-    )
-  | None => ()
-  }
-
-  if operatorKey === "_in" {
-    if !(fieldValue->Array.isArray) {
+    // A primitive operator value wouldn't throw on Dict.keysToArray, but report
+    // string indices or no keys as operators, so catch it with a real hint instead
+    if operatorObj->typeof !== #object || operatorObj->Array.isArray {
       JsError.throwWithMessage(
-        `Invalid value passed to context.${entityName}.getWhere({ ${apiFieldName}: { _in: ... } }). The _in operator expects an array of values.`,
+        `Invalid value passed to context.${entityName}.getWhere({ ${apiFieldName}: ... }). Please provide an operator like { _eq: value }.`,
       )
     }
-    let fieldValues = fieldValue->(Utils.magic: unknown => array<unknown>)
 
-    fieldValues->Array.mapWithIndex((fieldValue, index) => {
+    let operatorKeys = operatorObj->Dict.keysToArray
+
+    if operatorKeys->Array.length === 0 {
+      JsError.throwWithMessage(
+        `Empty operator passed to context.${entityName}.getWhere({ ${apiFieldName}: {} }). Please provide an operator like { _eq: value }, { _gt: value }, { _lt: value }, { _gte: value }, { _lte: value }, or { _in: [values] }.`,
+      )
+    }
+
+    let throwInvalidOperator = operatorKey =>
+      JsError.throwWithMessage(
+        `Invalid operator "${operatorKey}" in context.${entityName}.getWhere({ ${apiFieldName}: { ${operatorKey}: ... } }). Valid operators are _eq, _gt, _lt, _gte, _lte, _in.`,
+      )
+
+    // Validate the operators and the field before the values, so a typoed
+    // operator or field gets the more specific error even when the value
+    // is also nullish
+    operatorKeys->Array.forEach(operatorKey =>
+      switch operatorKey {
+      | "_eq" | "_gt" | "_lt" | "_gte" | "_lte" | "_in" => ()
+      | _ => throwInvalidOperator(operatorKey)
+      }
+    )
+
+    switch table->Table.getFieldByApiName(apiFieldName) {
+    | None =>
+      JsError.throwWithMessage(
+        `Invalid field "${apiFieldName}" in context.${entityName}.getWhere(). The field doesn't exist. ${codegenHelpMessage}`,
+      )
+    | Some(DerivedFrom(_)) =>
+      JsError.throwWithMessage(
+        `The field "${apiFieldName}" on entity "${entityName}" is a derived field and cannot be used in getWhere(). Use the source entity's indexed field instead.`,
+      )
+    | Some(Field({isPrimaryKey: false, isIndex: false, linkedEntity: None})) =>
+      JsError.throwWithMessage(
+        `The field "${apiFieldName}" on entity "${entityName}" does not have an index. To use it in getWhere(), add the @index directive in your schema.graphql:\n\n  ${apiFieldName}: ... @index\n\nThen run 'pnpm envio codegen' to regenerate.`,
+      )
+    | Some(Field(_)) => ()
+    }
+
+    operatorKeys->Array.map(operatorKey => {
+      let fieldValue = operatorObj->Dict.getUnsafe(operatorKey)
       switch fieldValue->getUndefinedOrNullName {
       | Some(valueName) =>
         throwUnsupportedGetWhereValue(
           ~valueName,
           ~entityName,
-          ~filterDisplay=`{ ${apiFieldName}: { _in: [...] } }`,
-          ~hint=` The ${valueName} value is at index ${index->Int.toString} of the _in array.`,
+          ~filterDisplay=`{ ${apiFieldName}: { ${operatorKey}: ${valueName} } }`,
         )
       | None => ()
       }
-      Eq({fieldName: apiFieldName, fieldValue})
-    })
-  } else if operatorKey === "_gte" || operatorKey === "_lte" {
-    [
-      Eq({fieldName: apiFieldName, fieldValue}),
-      operatorKey === "_gte"
-        ? Gt({fieldName: apiFieldName, fieldValue})
-        : Lt({fieldName: apiFieldName, fieldValue}),
-    ]
-  } else {
-    [
+
       switch operatorKey {
-      | "_eq" => Eq({fieldName: apiFieldName, fieldValue})
-      | "_gt" => Gt({fieldName: apiFieldName, fieldValue})
-      | "_lt" => Lt({fieldName: apiFieldName, fieldValue})
-      | _ => throwInvalidOperator()
-      },
-    ]
-  }
+      | "_in" => {
+          if !(fieldValue->Array.isArray) {
+            JsError.throwWithMessage(
+              `Invalid value passed to context.${entityName}.getWhere({ ${apiFieldName}: { _in: ... } }). The _in operator expects an array of values.`,
+            )
+          }
+          let fieldValues = fieldValue->(Utils.magic: unknown => array<unknown>)
+
+          fieldValues->Array.mapWithIndex(
+            (fieldValue, index) => {
+              switch fieldValue->getUndefinedOrNullName {
+              | Some(valueName) =>
+                throwUnsupportedGetWhereValue(
+                  ~valueName,
+                  ~entityName,
+                  ~filterDisplay=`{ ${apiFieldName}: { _in: [...] } }`,
+                  ~hint=` The ${valueName} value is at index ${index->Int.toString} of the _in array.`,
+                )
+              | None => ()
+              }
+              Eq({fieldName: apiFieldName, fieldValue})
+            },
+          )
+        }
+      | "_gte" => [
+          Eq({fieldName: apiFieldName, fieldValue}),
+          Gt({fieldName: apiFieldName, fieldValue}),
+        ]
+      | "_lte" => [
+          Eq({fieldName: apiFieldName, fieldValue}),
+          Lt({fieldName: apiFieldName, fieldValue}),
+        ]
+      | "_eq" => [Eq({fieldName: apiFieldName, fieldValue})]
+      | "_gt" => [Gt({fieldName: apiFieldName, fieldValue})]
+      | "_lt" => [Lt({fieldName: apiFieldName, fieldValue})]
+      | _ => throwInvalidOperator(operatorKey)
+      }
+    })
+  })
+
+  filterGroups
+  ->Array.reduce([[]], (combinations, group) =>
+    combinations->Array.flatMap(combination =>
+      group->Array.map(filter => combination->Array.concat([filter]))
+    )
+  )
+  ->Array.map(filters =>
+    switch filters {
+    | [filter] => filter
+    | _ => And({filters: filters})
+    }
+  )
 }
 
 let rec printOperationFilter = (filter: t, ~paramsCount: ref<int>) =>

--- a/scenarios/test_codegen/test/EntityFilter_test.res
+++ b/scenarios/test_codegen/test/EntityFilter_test.res
@@ -57,6 +57,8 @@ describe("EntityFilter.parseGetWhereOrThrow", () => {
       parse(%raw(`{score: {_in: []}}`)),
       // Unindexed linked entity fields are allowed via the _id api name
       parse(%raw(`{owner_id: {_eq: 1}}`)),
+      // Primary key fields are allowed without an explicit index
+      parse(%raw(`{id: {_eq: 1}}`)),
     ]).toEqual([
       [Eq({fieldName: "score", fieldValue: v(1)})],
       [Gt({fieldName: "score", fieldValue: v(1)})],
@@ -66,6 +68,63 @@ describe("EntityFilter.parseGetWhereOrThrow", () => {
       [Eq({fieldName: "score", fieldValue: v(1)}), Eq({fieldName: "score", fieldValue: v(2)})],
       [],
       [Eq({fieldName: "owner_id", fieldValue: v(1)})],
+      [Eq({fieldName: "id", fieldValue: v(1)})],
+    ])
+  })
+
+  it("Combines multiple operators and fields into a cross product of And filters", t => {
+    t.expect([
+      parse(%raw(`{score: {_gt: 1, _lt: 5}}`)),
+      parse(%raw(`{score: {_eq: 1}, owner_id: {_eq: 2}}`)),
+      parse(%raw(`{score: {_gte: 1}, owner_id: {_eq: 2}}`)),
+      parse(%raw(`{score: {_in: [1, 2]}, owner_id: {_eq: 3}}`)),
+      parse(%raw(`{score: {_in: []}, owner_id: {_eq: 3}}`)),
+    ]).toEqual([
+      [
+        And({
+          filters: [
+            Gt({fieldName: "score", fieldValue: v(1)}),
+            Lt({fieldName: "score", fieldValue: v(5)}),
+          ],
+        }),
+      ],
+      [
+        And({
+          filters: [
+            Eq({fieldName: "score", fieldValue: v(1)}),
+            Eq({fieldName: "owner_id", fieldValue: v(2)}),
+          ],
+        }),
+      ],
+      [
+        And({
+          filters: [
+            Eq({fieldName: "score", fieldValue: v(1)}),
+            Eq({fieldName: "owner_id", fieldValue: v(2)}),
+          ],
+        }),
+        And({
+          filters: [
+            Gt({fieldName: "score", fieldValue: v(1)}),
+            Eq({fieldName: "owner_id", fieldValue: v(2)}),
+          ],
+        }),
+      ],
+      [
+        And({
+          filters: [
+            Eq({fieldName: "score", fieldValue: v(1)}),
+            Eq({fieldName: "owner_id", fieldValue: v(3)}),
+          ],
+        }),
+        And({
+          filters: [
+            Eq({fieldName: "score", fieldValue: v(2)}),
+            Eq({fieldName: "owner_id", fieldValue: v(3)}),
+          ],
+        }),
+      ],
+      [],
     ])
   })
 
@@ -87,7 +146,6 @@ describe("EntityFilter.parseGetWhereOrThrow", () => {
       getError(%raw(`{score: "abc"}`)),
       getError(%raw(`{score: [1]}`)),
       getError(%raw(`{score: {}}`)),
-      getError(%raw(`{score: {_eq: 1, _gt: 2}}`)),
       getError(%raw(`{score: {_foo: 1}}`)),
       getError(%raw(`{nonExistingField: {_eq: 1}}`)),
       getError(%raw(`{tokens: {_eq: 1}}`)),
@@ -98,14 +156,13 @@ describe("EntityFilter.parseGetWhereOrThrow", () => {
       getError(%raw(`{score: {_in: 5}}`)),
     ]).toEqual([
       `Empty filter passed to context.User.getWhere(). Please provide a filter like { fieldName: { _eq: value } }.`,
-      `Multiple filter fields passed to context.User.getWhere(). Currently only one filter field per call is supported. Received fields: score, name.`,
+      `The field "name" on entity "User" does not have an index. To use it in getWhere(), add the @index directive in your schema.graphql:\n\n  name: ... @index\n\nThen run 'pnpm envio codegen' to regenerate.`,
       `Invalid undefined value passed to context.User.getWhere({ score: undefined }). Filtering by null or undefined values is not supported in getWhere. Please provide an operator like { _eq: value }.`,
       `Invalid null value passed to context.User.getWhere({ score: null }). Filtering by null or undefined values is not supported in getWhere. Please provide an operator like { _eq: value }.`,
       `Invalid value passed to context.User.getWhere({ score: ... }). Please provide an operator like { _eq: value }.`,
       `Invalid value passed to context.User.getWhere({ score: ... }). Please provide an operator like { _eq: value }.`,
       `Invalid value passed to context.User.getWhere({ score: ... }). Please provide an operator like { _eq: value }.`,
       `Empty operator passed to context.User.getWhere({ score: {} }). Please provide an operator like { _eq: value }, { _gt: value }, { _lt: value }, { _gte: value }, { _lte: value }, or { _in: [values] }.`,
-      `Multiple operators passed to context.User.getWhere({ score: ... }). Currently only one operator per filter field is supported. Received operators: _eq, _gt.`,
       `Invalid operator "_foo" in context.User.getWhere({ score: { _foo: ... } }). Valid operators are _eq, _gt, _lt, _gte, _lte, _in.`,
       `Invalid field "nonExistingField" in context.User.getWhere(). The field doesn't exist. Rerun 'pnpm dev' to update generated code after schema.graphql changes.`,
       `The field "tokens" on entity "User" is a derived field and cannot be used in getWhere(). Use the source entity's indexed field instead.`,


### PR DESCRIPTION
## Summary

- `context.Entity.getWhere()` now accepts multiple filter fields (`{ a: { _eq: x }, b: { _eq: y } }`) and multiple operators per field (`{ a: { _gt: min, _lt: max } }`), combined with AND semantics.
- Filtering by `id` is now allowed: primary-key fields pass the index validation since they're always backed by the PK index. The generated `getWhereFilter` types already included `id`, so only the runtime check changed.

## How it works

This is a parsing-only change in `EntityFilter.parseGetWhereOrThrow`. Each field+operator pair still expands into the same OR'd alternatives as before (`_in` → one `Eq` per value for per-value memoization, `_gte`/`_lte` → `Eq` + `Gt`/`Lt`), and multiple pairs now combine as a cross product of `And` filters. The groups stay disjoint, so the flattened results contain no duplicates.

Everything downstream — `PgStorage.makeFilterCondition`, `EntityFilter.matches`/`toOperationKey`/`mapValues`/`merge`, and the in-memory filter indices — already supported `And`, so no storage or load-layer changes were needed.

The previous "Multiple filter fields" and "Multiple operators" errors are removed; all other validation (nullish values, invalid operators, non-indexed/derived fields, non-array `_in`) is preserved per field.

Also updated the shipped skill docs and `index.d.ts` doc comments to reflect the new behavior.

## Testing

- New parse tests covering multi-operator, multi-field, `_gte`/`_in` cross products, empty `_in` short-circuit, and `id` filtering.
- Full `scenarios/test_codegen` suite: 626 passed, 5 skipped.

https://claude.ai/code/session_01ESuV2m7xR63bBfBCNFqefj

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESuV2m7xR63bBfBCNFqefj)_