### PR TITLE
Unify fetch scheduling into single scheduleFetch callback

### DIFF
--- a/packages/envio/src/BatchProcessing.res
+++ b/packages/envio/src/BatchProcessing.res
@@ -11,11 +11,7 @@ let yieldTick = () => Promise.make((resolve, _) => NodeJs.setImmediate(() => res
 // re-kick it. `state.isProcessing` guarantees one instance. The loop
 // decides whether to keep going by inspecting state after each batch, rather than
 // from a return value of processNextBatch.
-let rec startProcessing = async (
-  state: IndexerState.t,
-  ~scheduleFetchAllChains,
-  ~scheduleRollback,
-) => {
+let rec startProcessing = async (state: IndexerState.t, ~scheduleFetch, ~scheduleRollback) => {
   if !(state->IndexerState.isProcessing) && !(state->IndexerState.isStopped) {
     state->IndexerState.beginProcessing
     // FIXME: Needed only for test determinism. The mocks resolve several fetch
@@ -37,7 +33,7 @@ let rec startProcessing = async (
       !(state->IndexerState.isResolvingReorg)
     ) {
       let processedBatchesBefore = state->IndexerState.processedBatchesCount
-      switch await processNextBatch(state, ~scheduleFetchAllChains) {
+      switch await processNextBatch(state, ~scheduleFetch) {
       | exception exn =>
         IndexerState.errorExit(state, exn->ErrorHandling.make(~msg=IndexerState.unexpectedErrorMsg))
       | () => hasMoreWork := state->IndexerState.processedBatchesCount > processedBatchesBefore
@@ -53,7 +49,7 @@ let rec startProcessing = async (
   }
 }
 
-and processNextBatch = async (state: IndexerState.t, ~scheduleFetchAllChains): unit => {
+and processNextBatch = async (state: IndexerState.t, ~scheduleFetch): unit => {
   // The reorg-threshold and queue updates below advance the chain states for the
   // next round, but the current batch is created and processed against the chain
   // states as they are now.
@@ -97,7 +93,7 @@ and processNextBatch = async (state: IndexerState.t, ~scheduleFetchAllChains): u
 
   if progressedChainsById->Utils.Dict.isEmpty {
     if shouldEnterReorgThreshold {
-      scheduleFetchAllChains()
+      scheduleFetch()
     }
 
     // When resuming from persisted state, all events may already be processed.
@@ -120,7 +116,7 @@ and processNextBatch = async (state: IndexerState.t, ~scheduleFetchAllChains): u
     // lands mid-batch commits only fetch-frontier fields (buffer, knownHeight),
     // while applyBatchProgress below commits only progress fields, so the two
     // concurrent writes are disjoint and neither clobbers the other.
-    scheduleFetchAllChains()
+    scheduleFetch()
 
     state->InMemoryStore.setBatchDcs(~batch)
 
@@ -156,7 +152,7 @@ and processNextBatch = async (state: IndexerState.t, ~scheduleFetchAllChains): u
           // parked during backfill is bound to the old source; bump the epoch to
           // invalidate it and kick a fresh fetch that parks on the realtime source.
           state->IndexerState.invalidateInflight
-          scheduleFetchAllChains()
+          scheduleFetch()
         }
 
         let allCaughtUp = EventProcessing.allChainsEventsProcessedToEndblock(

--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -90,7 +90,7 @@ let rec onQueryResponse = async (
   state: IndexerState.t,
   {chain, response, query}: partitionQueryResponse,
   ~stateId,
-  ~scheduleFetchChain,
+  ~scheduleFetch,
   ~scheduleProcessing,
   ~scheduleRollback,
 ) =>
@@ -208,7 +208,7 @@ let rec onQueryResponse = async (
             ~query,
           )
           ChainMetadata.stage(state)
-          scheduleFetchChain(chain)
+          scheduleFetch()
           scheduleProcessing()
         }
 
@@ -270,8 +270,7 @@ let finishWaitingForNewBlock = (
   ~chain,
   ~knownHeight,
   ~stateId,
-  ~scheduleFetchAllChains,
-  ~scheduleFetchChain,
+  ~scheduleFetch,
   ~scheduleProcessing,
 ) =>
   if state->IndexerState.isStale(~stateId) {
@@ -295,10 +294,8 @@ let finishWaitingForNewBlock = (
     // Kick processing in case there are block handlers to run.
     if shouldEnterReorgThreshold {
       IndexerState.enterReorgThreshold(state)
-      scheduleFetchAllChains()
-    } else {
-      scheduleFetchChain(chain)
     }
+    scheduleFetch()
     scheduleProcessing()
   }
 
@@ -306,8 +303,7 @@ let checkAndFetchForChain = async (
   state: IndexerState.t,
   chain,
   ~stateId,
-  ~scheduleFetchAllChains,
-  ~scheduleFetchChain,
+  ~scheduleFetch,
   ~scheduleProcessing,
   ~scheduleRollback,
 ) => {
@@ -334,8 +330,7 @@ let checkAndFetchForChain = async (
             ~chain,
             ~knownHeight,
             ~stateId,
-            ~scheduleFetchAllChains,
-            ~scheduleFetchChain,
+            ~scheduleFetch,
             ~scheduleProcessing,
           ),
         ~executeQuery=async query => {
@@ -352,7 +347,7 @@ let checkAndFetchForChain = async (
               state,
               {chain, response, query},
               ~stateId,
-              ~scheduleFetchChain,
+              ~scheduleFetch,
               ~scheduleProcessing,
               ~scheduleRollback,
             )
@@ -372,8 +367,7 @@ let checkAndFetchForChain = async (
 let checkAndFetchAllChains = async (
   state: IndexerState.t,
   ~stateId,
-  ~scheduleFetchAllChains,
-  ~scheduleFetchChain,
+  ~scheduleFetch,
   ~scheduleProcessing,
   ~scheduleRollback,
 ) => {
@@ -387,8 +381,7 @@ let checkAndFetchAllChains = async (
       state,
       ChainMap.Chain.makeUnsafe(~chainId=(cs->ChainState.chainConfig).id),
       ~stateId,
-      ~scheduleFetchAllChains,
-      ~scheduleFetchChain,
+      ~scheduleFetch,
       ~scheduleProcessing,
       ~scheduleRollback,
     )

--- a/packages/envio/src/IndexerLoop.res
+++ b/packages/envio/src/IndexerLoop.res
@@ -15,38 +15,23 @@ let launch = (state: IndexerState.t, work: unit => promise<unit>) =>
 // (fetch kicks process/rollback, which kick fetch again), so they're defined as
 // one `let rec` block and threaded into the operations as the only way back in.
 let start = (state: IndexerState.t) => {
-  let rec scheduleFetchAllChains = () =>
+  let rec scheduleFetch = () =>
     launch(state, () =>
       ChainFetching.checkAndFetchAllChains(
         state,
         ~stateId=state->IndexerState.epoch,
-        ~scheduleFetchAllChains,
-        ~scheduleFetchChain,
-        ~scheduleProcessing,
-        ~scheduleRollback,
-      )
-    )
-  and scheduleFetchChain = chain =>
-    launch(state, () =>
-      ChainFetching.checkAndFetchForChain(
-        state,
-        chain,
-        ~stateId=state->IndexerState.epoch,
-        ~scheduleFetchAllChains,
-        ~scheduleFetchChain,
+        ~scheduleFetch,
         ~scheduleProcessing,
         ~scheduleRollback,
       )
     )
   and scheduleProcessing = () =>
-    launch(state, () =>
-      BatchProcessing.startProcessing(state, ~scheduleFetchAllChains, ~scheduleRollback)
-    )
+    launch(state, () => BatchProcessing.startProcessing(state, ~scheduleFetch, ~scheduleRollback))
   and scheduleRollback = () =>
     launch(state, () =>
-      Rollback.rollback(state, ~scheduleFetchAllChains, ~scheduleProcessing, ~scheduleRollback)
+      Rollback.rollback(state, ~scheduleFetch, ~scheduleProcessing, ~scheduleRollback)
     )
 
-  scheduleFetchAllChains()
+  scheduleFetch()
   scheduleProcessing()
 }

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -40,7 +40,7 @@ let getLastKnownValidBlock = async (
 
 let rec rollback = async (
   state: IndexerState.t,
-  ~scheduleFetchAllChains,
+  ~scheduleFetch,
   ~scheduleProcessing,
   ~scheduleRollback,
 ) =>
@@ -78,7 +78,7 @@ let rec rollback = async (
         state,
         ~reorgChain,
         ~rollbackTargetBlockNumber,
-        ~scheduleFetchAllChains,
+        ~scheduleFetch,
         ~scheduleProcessing,
       )
     }
@@ -91,7 +91,7 @@ and executeRollback = async (
   state: IndexerState.t,
   ~reorgChain,
   ~rollbackTargetBlockNumber,
-  ~scheduleFetchAllChains,
+  ~scheduleFetch,
   ~scheduleProcessing,
 ) => {
   let startTime = Hrtime.makeTimer()
@@ -199,6 +199,6 @@ and executeRollback = async (
   )
 
   state->IndexerState.completeRollback(~eventsProcessedDiffByChain)
-  scheduleFetchAllChains()
+  scheduleFetch()
   scheduleProcessing()
 }

--- a/scenarios/test_codegen/test/lib_tests/IndexerLoop_test.res
+++ b/scenarios/test_codegen/test/lib_tests/IndexerLoop_test.res
@@ -70,7 +70,7 @@ describe("Indexer loop", () => {
   Async.it("startProcessing releases the flag once there is no work", async t => {
     let state = makeState()
 
-    await BatchProcessing.startProcessing(state, ~scheduleFetchAllChains=() => (), ~scheduleRollback=() => ())
+    await BatchProcessing.startProcessing(state, ~scheduleFetch=() => (), ~scheduleRollback=() => ())
 
     t.expect(
       state->IndexerState.isProcessing,
@@ -83,7 +83,7 @@ describe("Indexer loop", () => {
     // Simulate an in-flight loop instance.
     state->IndexerState.beginProcessing
 
-    await BatchProcessing.startProcessing(state, ~scheduleFetchAllChains=() => (), ~scheduleRollback=() => ())
+    await BatchProcessing.startProcessing(state, ~scheduleFetch=() => (), ~scheduleRollback=() => ())
 
     t.expect(
       state->IndexerState.isProcessing,


### PR DESCRIPTION
## Summary
Consolidates the dual-callback fetch scheduling pattern (`scheduleFetchAllChains` and `scheduleFetchChain`) into a single `scheduleFetch` callback throughout the indexer loop. This simplifies the scheduling interface and reduces parameter passing complexity.

## Key Changes
- **IndexerLoop.res**: Merged `scheduleFetchAllChains` and `scheduleFetchChain` into a single `scheduleFetch` callback that always fetches all chains
- **ChainFetching.res**: Updated `onQueryResponse`, `finishWaitingForNewBlock`, `checkAndFetchForChain`, and `checkAndFetchAllChains` to accept `~scheduleFetch` instead of separate chain-specific callbacks
- **BatchProcessing.res**: Simplified `startProcessing` and `processNextBatch` signatures to use `~scheduleFetch`
- **Rollback.res**: Updated `rollback` and `executeRollback` to use unified `~scheduleFetch` parameter
- **Tests**: Updated test calls in `IndexerLoop_test.res` to use the new callback signature

## Implementation Details
The refactoring removes the distinction between fetching a single chain and fetching all chains at the callback level. The decision of what to fetch is now made within the fetching logic itself (e.g., in `finishWaitingForNewBlock`, the reorg threshold check determines behavior, but both paths now call the same `scheduleFetch()` callback).

https://claude.ai/code/session_01UCJS8YGtJNyLCxYMPop51w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal scheduling architecture by consolidating multiple scheduling mechanisms into a unified effect across batch processing, blockchain data fetching, and reorg rollback handling.
  * Enhanced code consistency and maintainability throughout indexer loop orchestration while preserving all existing functionality and performance characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->