### PR TITLE
Add test for NothingToQuery when buffer budget exhausted

### DIFF
--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1768,6 +1768,17 @@ describe("FetchState.getNextQuery & integration", () => {
     ->FetchState.updateKnownHeight(~knownHeight)
     ->FetchState.getNextQuery(~budget, ~chainPendingBudget=0.)
 
+  it("Returns NothingToQuery when the buffer budget is exhausted", t => {
+    // Same state queries Ready with a positive budget (see the test below), so a
+    // non-positive budget is the only reason nothing is queried here.
+    let fetchState = makeInitial()
+
+    t.expect(
+      (fetchState->getNextQuery(~budget=0), fetchState->getNextQuery(~budget=-5)),
+      ~message="Should skip fetching when there's no room left in the shared buffer pool",
+    ).toEqual((NothingToQuery, NothingToQuery))
+  })
+
   it("Emulate first indexer queries with a static event", t => {
     let fetchState = makeInitial()
 


### PR DESCRIPTION
## Summary
Add a test case to verify that `FetchState.getNextQuery` returns `NothingToQuery` when the buffer budget is exhausted or non-positive.

## Changes
- Added test "Returns NothingToQuery when the buffer budget is exhausted" to `FetchState_test.res`
- Test verifies that both zero and negative budgets result in `NothingToQuery` being returned
- Uses a single assertion to check both budget scenarios at once, following the convention of checking the whole value in one assert

## Details
The test documents the expected behavior that a non-positive budget is the only reason `getNextQuery` would return `NothingToQuery` for an initial fetch state, ensuring the shared buffer pool constraints are properly enforced.

https://claude.ai/code/session_01KcQaeMwie245tF3aa5Jkwk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for query handling behavior when system resources are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->