### PR TITLE
Deduplicate blocks in HyperSync response, validate required fields

### DIFF
--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Once};
 
 use anyhow::{Context, Result};
@@ -117,14 +117,24 @@ impl EvmHypersyncClient {
             .clone()
             .unwrap_or_default();
 
-        // Join logs to their blocks/transactions ourselves rather than going
-        // through the client's event API. The strategies decide whether the
-        // join key can be lifted off the log (block.number / nothing) or needs
-        // the joined row fetched, and augment the field selection accordingly.
+        // Join logs to their blocks ourselves rather than going through the
+        // client's event API. The block strategy decides whether the join key
+        // can be lifted off the log (block.number) or needs the block fetched.
         let block_join = JoinStrategy::for_block(&requested_block_fields);
-        let transaction_join = JoinStrategy::for_transaction(&requested_transaction_fields);
         apply_block_join(&mut query.field_selection, block_join);
-        apply_transaction_join(&mut query.field_selection, transaction_join);
+        // Transactions are accumulated into the store keyed by
+        // (blockNumber, transactionIndex), so those keys must come back on each
+        // transaction row whenever any transaction field is requested.
+        if !requested_transaction_fields.is_empty() {
+            add_field(
+                &mut query.field_selection.transaction,
+                TransactionField::BlockNumber,
+            );
+            add_field(
+                &mut query.field_selection.transaction,
+                TransactionField::TransactionIndex,
+            );
+        }
 
         let query = query.try_into().context("parse query").map_err(map_err)?;
         let res = self
@@ -140,15 +150,14 @@ impl EvmHypersyncClient {
         };
 
         let transaction_store = TransactionStore::with_checksum(self.enable_checksum_addresses);
-        let items = tokio::task::block_in_place(|| {
-            convert_event_items(
+        let (items, blocks) = tokio::task::block_in_place(|| {
+            process_response(
                 response.data.blocks,
                 response.data.transactions,
                 response.data.logs,
                 &self.decoder,
                 self.enable_checksum_addresses,
                 block_join,
-                transaction_join,
                 &requested_block_fields,
                 &requested_transaction_fields,
                 &transaction_store,
@@ -168,6 +177,7 @@ impl EvmHypersyncClient {
                 .try_into()
                 .context("convert next_block")
                 .map_err(map_err)?,
+            blocks,
             items,
             rollback_guard: response
                 .rollback_guard
@@ -203,7 +213,9 @@ pub struct EventItem {
     pub src_address: String,
     pub topic0: String,
     pub topic_count: i64,
-    pub block: Block,
+    /// Block this log belongs to. The block itself is carried once, deduplicated,
+    /// in `EventItemsResponse.blocks` — the caller joins on this number.
+    pub block_number: i64,
     /// Key into the per-chain `TransactionStore` (paired with the block number);
     /// the transaction itself is materialised field-by-field on demand.
     pub transaction_index: i64,
@@ -217,6 +229,10 @@ pub struct EventItem {
 pub struct EventItemsResponse {
     pub archive_height: Option<i64>,
     pub next_block: i64,
+    /// The page's blocks, one per block number. Items reference them by
+    /// `block_number` instead of each carrying their own copy, so a block shared
+    /// by many logs crosses the napi boundary once.
+    pub blocks: Vec<Block>,
     pub items: Vec<EventItem>,
     pub rollback_guard: Option<RollbackGuard>,
 }
@@ -254,16 +270,16 @@ fn convert_response(
     })
 }
 
-/// How a log gets joined to its block (or transaction). Mirrors the client's
-/// internal event-join: when the only requested field is the join key itself
-/// (`block.number`) we lift it off the log instead of fetching the joined row.
+/// How a log gets joined to its block. Mirrors the client's internal
+/// event-join: when the only requested field is the join key itself
+/// (`block.number`) we lift it off the log instead of fetching the block.
 #[derive(Clone, Copy)]
 enum JoinStrategy {
-    /// No fields requested — the joined row is absent from the item.
+    /// No block fields requested — the page carries no blocks.
     NotSelected,
-    /// Only the join key is requested; synthesize it from the log.
+    /// Only `block.number` requested; synthesize the block from the log.
     OnlyLogJoinField,
-    /// Other fields requested; fetch the joined row and match it to the log.
+    /// Other fields requested; fetch the block and match it to the log by number.
     FullJoin,
 }
 
@@ -272,14 +288,6 @@ impl JoinStrategy {
         match fields {
             [] => Self::NotSelected,
             [BlockField::Number] => Self::OnlyLogJoinField,
-            _ => Self::FullJoin,
-        }
-    }
-
-    fn for_transaction(fields: &[TransactionField]) -> Self {
-        match fields {
-            [] => Self::NotSelected,
-            [TransactionField::Hash] => Self::OnlyLogJoinField,
             _ => Self::FullJoin,
         }
     }
@@ -308,39 +316,30 @@ fn apply_block_join(selection: &mut FieldSelection, strategy: JoinStrategy) {
     }
 }
 
-fn apply_transaction_join(selection: &mut FieldSelection, strategy: JoinStrategy) {
-    match strategy {
-        JoinStrategy::NotSelected => {}
-        JoinStrategy::OnlyLogJoinField => {
-            add_field(&mut selection.log, LogField::TransactionHash);
-            remove_field(&mut selection.transaction, TransactionField::Hash);
-        }
-        JoinStrategy::FullJoin => {
-            add_field(&mut selection.log, LogField::TransactionHash);
-            add_field(&mut selection.transaction, TransactionField::Hash);
-        }
+fn push_unique(missing: &mut Vec<String>, name: String) {
+    if !missing.contains(&name) {
+        missing.push(name);
     }
 }
 
-/// Joins logs to their blocks/transactions, validates the requested fields and
-/// decodes each log into an `EventItem`. Aborts on the first item that has a
-/// structural defect (server omitted a required field; raw bytes can't be
-/// decoded against the declared ABI).
+/// Builds the page's event items and its deduplicated blocks, accumulates the
+/// page's transactions into `transaction_store`, and checks that every requested
+/// block/transaction field came back. Returns `ConvertError::MissingFields`
+/// (surfaced as `ImpossibleForTheQuery` on the JS side) when the source omitted
+/// a requested non-nullable field or a joined row, and propagates genuine decode
+/// errors otherwise.
 #[allow(clippy::too_many_arguments)]
-fn convert_event_items(
+fn process_response(
     blocks: Vec<Vec<simple_types::Block>>,
     transactions: Vec<Vec<simple_types::Transaction>>,
     logs: Vec<Vec<simple_types::Log>>,
     decoder: &DecoderCore,
     should_checksum: bool,
     block_join: JoinStrategy,
-    transaction_join: JoinStrategy,
     requested_block_fields: &[BlockField],
     requested_transaction_fields: &[TransactionField],
     transaction_store: &TransactionStore,
-) -> std::result::Result<Vec<EventItem>, ConvertError> {
-    use hypersync_client::format::Hash;
-
+) -> std::result::Result<(Vec<EventItem>, Vec<Block>), ConvertError> {
     let blocks_by_number: HashMap<u64, Arc<simple_types::Block>> =
         if matches!(block_join, JoinStrategy::FullJoin) {
             blocks
@@ -352,106 +351,120 @@ fn convert_event_items(
             HashMap::new()
         };
 
-    let transactions_by_hash: HashMap<Hash, Arc<simple_types::Transaction>> =
-        if matches!(transaction_join, JoinStrategy::FullJoin) {
-            transactions
-                .into_iter()
-                .flatten()
-                .filter_map(|t| t.hash.clone().map(|hash| (hash, Arc::new(t))))
-                .collect()
-        } else {
-            HashMap::new()
-        };
+    let mut missing: Vec<String> = Vec::new();
+
+    // Accumulate transactions into the store keyed by (blockNumber, txIndex).
+    // Many logs share a transaction, so a per-log insert would redundantly
+    // re-store it; inserting each transaction once deduplicates by key.
+    let mut transaction_keys: HashSet<(u64, u32)> = HashSet::new();
+    if !requested_transaction_fields.is_empty() {
+        for tx in transactions.into_iter().flatten() {
+            for &field in requested_transaction_fields {
+                if let Some(name) = transaction_field_missing(&tx, field) {
+                    push_unique(&mut missing, format!("transaction.{}", name));
+                }
+            }
+            if let (Some(block_number), Some(transaction_index)) =
+                (tx.block_number, tx.transaction_index)
+            {
+                let block_number = u64::from(block_number);
+                let transaction_index = u64::from(transaction_index) as u32;
+                transaction_keys.insert((block_number, transaction_index));
+                transaction_store.insert_evm_raw(block_number, transaction_index, Arc::new(tx));
+            }
+        }
+    }
+
+    // Validate the requested block fields once per distinct block.
+    for block in blocks_by_number.values() {
+        for &field in requested_block_fields {
+            if let Some(name) = block_field_missing(block, field) {
+                push_unique(&mut missing, format!("block.{}", name));
+            }
+        }
+    }
+
+    // Coverage: every log must resolve to its block (when block fields were
+    // requested) and its transaction (when transaction fields were requested).
+    for log in logs.iter().flatten() {
+        if matches!(block_join, JoinStrategy::FullJoin) {
+            let present = log
+                .block_number
+                .is_some_and(|n| blocks_by_number.contains_key(&u64::from(n)));
+            if !present {
+                push_unique(&mut missing, "block".into());
+            }
+        }
+        if !requested_transaction_fields.is_empty() {
+            let present = match (log.block_number, log.transaction_index) {
+                (Some(bn), Some(ti)) => {
+                    transaction_keys.contains(&(u64::from(bn), u64::from(ti) as u32))
+                }
+                _ => false,
+            };
+            if !present {
+                push_unique(&mut missing, "transaction".into());
+            }
+        }
+    }
+
+    if !missing.is_empty() {
+        return Err(ConvertError::MissingFields(missing));
+    }
+
+    // Deduplicated blocks for the page; items reference them by number.
+    let out_blocks: Vec<Block> = match block_join {
+        JoinStrategy::NotSelected => Vec::new(),
+        JoinStrategy::FullJoin => {
+            let mut blocks = blocks_by_number
+                .values()
+                .map(|b| Block::from_simple(b, should_checksum))
+                .collect::<Result<Vec<_>>>()
+                .context("mapping blocks")?;
+            blocks.sort_by_key(|b| b.number);
+            blocks
+        }
+        JoinStrategy::OnlyLogJoinField => {
+            let mut seen: HashSet<u64> = HashSet::new();
+            let mut blocks = Vec::new();
+            for log in logs.iter().flatten() {
+                if let Some(number) = log.block_number {
+                    if seen.insert(u64::from(number)) {
+                        blocks.push(Block::from_simple(
+                            &simple_types::Block {
+                                number: Some(u64::from(number)),
+                                ..Default::default()
+                            },
+                            should_checksum,
+                        )?);
+                    }
+                }
+            }
+            blocks.sort_by_key(|b| b.number);
+            blocks
+        }
+    };
 
     let mut items = Vec::with_capacity(logs.iter().map(Vec::len).sum());
     for log in logs.into_iter().flatten() {
-        let block: Option<Arc<simple_types::Block>> = match block_join {
-            JoinStrategy::NotSelected => None,
-            JoinStrategy::OnlyLogJoinField => Some(Arc::new(simple_types::Block {
-                number: log.block_number.map(u64::from),
-                ..Default::default()
-            })),
-            JoinStrategy::FullJoin => log
-                .block_number
-                .and_then(|number| blocks_by_number.get(&u64::from(number)).cloned()),
-        };
-
-        let transaction: Option<Arc<simple_types::Transaction>> = match transaction_join {
-            JoinStrategy::NotSelected => None,
-            JoinStrategy::OnlyLogJoinField => Some(Arc::new(simple_types::Transaction {
-                hash: log.transaction_hash.clone(),
-                ..Default::default()
-            })),
-            JoinStrategy::FullJoin => log
-                .transaction_hash
-                .as_ref()
-                .and_then(|hash| transactions_by_hash.get(hash).cloned()),
-        };
-
-        let mut missing: Vec<String> = Vec::new();
-
-        match &block {
-            None if !requested_block_fields.is_empty() => missing.push("block".into()),
-            Some(block) => {
-                for &field in requested_block_fields {
-                    if let Some(name) = block_field_missing(block, field) {
-                        missing.push(format!("block.{}", name));
-                    }
-                }
-            }
-            None => {}
-        }
-
-        match &transaction {
-            None if !requested_transaction_fields.is_empty() => missing.push("transaction".into()),
-            Some(transaction) => {
-                for &field in requested_transaction_fields {
-                    if let Some(name) = transaction_field_missing(transaction, field) {
-                        missing.push(format!("transaction.{}", name));
-                    }
-                }
-            }
-            None => {}
-        }
-
-        if !missing.is_empty() {
-            return Err(ConvertError::MissingFields(missing));
-        }
-
-        // Propagate genuine decode errors (malformed bytes, ABI mismatch) up
-        // to the JS caller instead of silently coercing them into `None` —
-        // `None` is reserved for "topic0/count doesn't match a registered
-        // signature", which is the only outcome the wildcard event path
-        // expects to handle.
+        // Propagate genuine decode errors (malformed bytes, ABI mismatch) up to
+        // the JS caller instead of silently coercing them into `None` — `None`
+        // is reserved for "topic0/count doesn't match a registered signature".
         let params = decoder.decode_simple(&log).context("decode event params")?;
-
-        let item_block = block
-            .as_ref()
-            .map(|b| Block::from_simple(b, should_checksum))
-            .transpose()
-            .context("mapping block")?
-            .unwrap_or_default();
-
         let (log_index, src_address, topic0, topic_count, block_number, transaction_index) =
             flatten_log_for_js(&log, should_checksum).context("mapping log")?;
-
-        // Move the raw transaction into the store keyed by (block, txIndex). Its
-        // fields materialise on demand; logs sharing a tx collapse to one entry.
-        if let Some(tx) = transaction {
-            transaction_store.insert_evm_raw(block_number as u64, transaction_index as u32, tx);
-        }
-
         items.push(EventItem {
             log_index,
             src_address,
             topic0,
             topic_count,
-            block: item_block,
+            block_number,
             transaction_index,
             params,
         });
     }
-    Ok(items)
+
+    Ok((items, out_blocks))
 }
 
 fn flatten_log_for_js(
@@ -678,14 +691,13 @@ mod tests {
     fn missing_block_field_returns_typed_error() {
         // The server returned no block for the log but the user asked for
         // block.number/hash/timestamp.
-        let err = convert_event_items(
+        let err = process_response(
             vec![],
             vec![],
             vec![vec![simple_types::Log::default()]],
             &empty_decoder(),
             false,
             JoinStrategy::FullJoin,
-            JoinStrategy::NotSelected,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[],
             &TransactionStore::new(),
@@ -706,14 +718,13 @@ mod tests {
         block.number = Some(1);
         block.hash = Some(Default::default());
         // timestamp left None
-        let err = convert_event_items(
+        let err = process_response(
             vec![vec![block]],
             vec![],
             vec![vec![full_log(1)]],
             &empty_decoder(),
             false,
             JoinStrategy::FullJoin,
-            JoinStrategy::NotSelected,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[],
             &TransactionStore::new(),
@@ -738,14 +749,13 @@ mod tests {
         block.hash = Some(Default::default());
         block.timestamp = Some(Default::default());
         // base_fee_per_gas left None
-        let res = convert_event_items(
+        let (items, _blocks) = process_response(
             vec![vec![block]],
             vec![],
             vec![vec![full_log(1)]],
             &empty_decoder(),
             false,
             JoinStrategy::FullJoin,
-            JoinStrategy::NotSelected,
             &[
                 BlockField::Number,
                 BlockField::Hash,
@@ -756,7 +766,7 @@ mod tests {
             &TransactionStore::new(),
         )
         .expect("expected success when only nullable fields are absent");
-        assert_eq!(res.len(), 1);
+        assert_eq!(items.len(), 1);
     }
 
     #[test]
@@ -765,16 +775,18 @@ mod tests {
         block.number = Some(1);
         block.hash = Some(Default::default());
         block.timestamp = Some(Default::default());
-        // The log carries no transactionHash, so the synthesized join transaction
-        // has no hash and the requested transaction.hash is reported missing.
-        let err = convert_event_items(
+        // The transaction is keyed to the log by (blockNumber, txIndex) but is
+        // missing the requested hash, so transaction.hash is reported missing.
+        let mut tx = simple_types::Transaction::default();
+        tx.block_number = Some(1u64.into());
+        tx.transaction_index = Some(0u64.into());
+        let err = process_response(
             vec![vec![block]],
-            vec![],
+            vec![vec![tx]],
             vec![vec![full_log(1)]],
             &empty_decoder(),
             false,
             JoinStrategy::FullJoin,
-            JoinStrategy::OnlyLogJoinField,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[TransactionField::Hash],
             &TransactionStore::new(),
@@ -791,30 +803,56 @@ mod tests {
     }
 
     #[test]
+    fn missing_transaction_when_not_returned() {
+        // Transaction fields requested but the source returned no transaction for
+        // the log's (blockNumber, txIndex).
+        let mut block = simple_types::Block::default();
+        block.number = Some(1);
+        block.hash = Some(Default::default());
+        block.timestamp = Some(Default::default());
+        let err = process_response(
+            vec![vec![block]],
+            vec![],
+            vec![vec![full_log(1)]],
+            &empty_decoder(),
+            false,
+            JoinStrategy::FullJoin,
+            &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
+            &[TransactionField::Hash],
+            &TransactionStore::new(),
+        )
+        .err()
+        .expect("expected MissingFields error");
+
+        match err {
+            ConvertError::MissingFields(fields) => {
+                assert_eq!(fields, vec!["transaction".to_string()])
+            }
+            ConvertError::Other(e) => panic!("unexpected ConvertError::Other: {e:?}"),
+        }
+    }
+
+    #[test]
     fn full_join_matches_block_and_transaction() {
         // Block and transaction live in separate response arrays; the log is
-        // matched to its block by number and to its transaction by hash, and the
-        // transaction lands in the store keyed by (blockNumber, txIndex).
+        // matched to its block by number and the transaction lands in the store
+        // keyed by (blockNumber, txIndex). The page carries one deduplicated block.
         let mut block = simple_types::Block::default();
         block.number = Some(7);
         block.hash = Some(Default::default());
         block.timestamp = Some(Default::default());
 
         let mut tx = simple_types::Transaction::default();
-        tx.hash = Some(Default::default());
         tx.block_number = Some(7u64.into());
-
-        let mut log = full_log(7);
-        log.transaction_hash = Some(Default::default());
+        tx.transaction_index = Some(0u64.into());
 
         let store = TransactionStore::new();
-        let items = convert_event_items(
+        let (items, blocks) = process_response(
             vec![vec![block]],
             vec![vec![tx]],
-            vec![vec![log]],
+            vec![vec![full_log(7)]],
             &empty_decoder(),
             false,
-            JoinStrategy::FullJoin,
             JoinStrategy::FullJoin,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[TransactionField::BlockNumber],
@@ -823,8 +861,11 @@ mod tests {
         .expect("expected success when block and transaction join");
 
         assert_eq!(
-            items.iter().map(|i| i.block.number).collect::<Vec<_>>(),
-            vec![Some(7)]
+            (
+                items.iter().map(|i| i.block_number).collect::<Vec<_>>(),
+                blocks.iter().map(|b| b.number).collect::<Vec<_>>(),
+            ),
+            (vec![7], vec![Some(7)])
         );
     }
 

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod types;
 
 use config::ClientConfig;
 use decode::DecoderCore;
-use query::{BlockField, FieldSelection, LogField, Query, TransactionField};
+use query::{BlockField, LogField, Query, TransactionField};
 use types::{encode_address, Block, EventParamsInput, ParamValue, RollbackGuard};
 
 static LOGGER_INIT: Once = Once::new();
@@ -117,11 +117,9 @@ impl EvmHypersyncClient {
             .clone()
             .unwrap_or_default();
 
-        // Join logs to their blocks ourselves rather than going through the
-        // client's event API. The block strategy decides whether the join key
-        // can be lifted off the log (block.number) or needs the block fetched.
-        let block_join = JoinStrategy::for_block(&requested_block_fields);
-        apply_block_join(&mut query.field_selection, block_join);
+        // Force-add block.number so the page's blocks can be keyed and the items
+        // can reference them; every EVM event selection includes it already.
+        add_field(&mut query.field_selection.block, BlockField::Number);
         // Transactions are accumulated into the store keyed by
         // (blockNumber, transactionIndex), so those keys must come back on each
         // transaction row whenever any transaction field is requested.
@@ -157,7 +155,6 @@ impl EvmHypersyncClient {
                 response.data.logs,
                 &self.decoder,
                 self.enable_checksum_addresses,
-                block_join,
                 &requested_block_fields,
                 &requested_transaction_fields,
                 &transaction_store,
@@ -270,49 +267,10 @@ fn convert_response(
     })
 }
 
-/// How a log gets joined to its block. Mirrors the client's internal
-/// event-join: when the only requested field is the join key itself
-/// (`block.number`) we lift it off the log instead of fetching the block.
-#[derive(Clone, Copy)]
-enum JoinStrategy {
-    /// No block fields requested — the page carries no blocks.
-    NotSelected,
-    /// Only `block.number` requested; synthesize the block from the log.
-    OnlyLogJoinField,
-    /// Other fields requested; fetch the block and match it to the log by number.
-    FullJoin,
-}
-
-impl JoinStrategy {
-    fn for_block(fields: &[BlockField]) -> Self {
-        match fields {
-            [] => Self::NotSelected,
-            [BlockField::Number] => Self::OnlyLogJoinField,
-            _ => Self::FullJoin,
-        }
-    }
-}
-
 fn add_field<T: PartialEq>(selection: &mut Option<Vec<T>>, field: T) {
     let fields = selection.get_or_insert_with(Vec::new);
     if !fields.contains(&field) {
         fields.push(field);
-    }
-}
-
-fn remove_field<T: PartialEq>(selection: &mut Option<Vec<T>>, field: T) {
-    if let Some(fields) = selection {
-        fields.retain(|f| *f != field);
-    }
-}
-
-// log.blockNumber is already force-selected by `ensure_required_log_fields`, so
-// only the block table itself needs adjusting here.
-fn apply_block_join(selection: &mut FieldSelection, strategy: JoinStrategy) {
-    match strategy {
-        JoinStrategy::NotSelected => {}
-        JoinStrategy::OnlyLogJoinField => remove_field(&mut selection.block, BlockField::Number),
-        JoinStrategy::FullJoin => add_field(&mut selection.block, BlockField::Number),
     }
 }
 
@@ -335,20 +293,13 @@ fn process_response(
     logs: Vec<Vec<simple_types::Log>>,
     decoder: &DecoderCore,
     should_checksum: bool,
-    block_join: JoinStrategy,
     requested_block_fields: &[BlockField],
     requested_transaction_fields: &[TransactionField],
     transaction_store: &TransactionStore,
 ) -> std::result::Result<(Vec<EventItem>, Vec<Block>), ConvertError> {
     // The server returns one block per number; items reference them by number,
-    // so no per-block sharing is needed — keep them owned and track which
-    // numbers are present for the per-log coverage check below.
-    let response_blocks: Vec<simple_types::Block> = if matches!(block_join, JoinStrategy::FullJoin)
-    {
-        blocks.into_iter().flatten().collect()
-    } else {
-        Vec::new()
-    };
+    // so keep them owned and track which numbers are present for coverage.
+    let response_blocks: Vec<simple_types::Block> = blocks.into_iter().flatten().collect();
     let present_block_numbers: HashSet<u64> =
         response_blocks.iter().filter_map(|b| b.number).collect();
 
@@ -388,7 +339,7 @@ fn process_response(
     // Coverage: every log must resolve to its block (when block fields were
     // requested) and its transaction (when transaction fields were requested).
     for log in logs.iter().flatten() {
-        if matches!(block_join, JoinStrategy::FullJoin) {
+        if !requested_block_fields.is_empty() {
             let present = log
                 .block_number
                 .is_some_and(|n| present_block_numbers.contains(&u64::from(n)));
@@ -413,38 +364,12 @@ fn process_response(
         return Err(ConvertError::MissingFields(missing));
     }
 
-    // Deduplicated blocks for the page; items reference them by number.
-    let out_blocks: Vec<Block> = match block_join {
-        JoinStrategy::NotSelected => Vec::new(),
-        JoinStrategy::FullJoin => {
-            let mut blocks = response_blocks
-                .iter()
-                .map(|b| Block::from_simple(b, should_checksum))
-                .collect::<Result<Vec<_>>>()
-                .context("mapping blocks")?;
-            blocks.sort_by_key(|b| b.number);
-            blocks
-        }
-        JoinStrategy::OnlyLogJoinField => {
-            let mut seen: HashSet<u64> = HashSet::new();
-            let mut blocks = Vec::new();
-            for log in logs.iter().flatten() {
-                if let Some(number) = log.block_number {
-                    if seen.insert(u64::from(number)) {
-                        blocks.push(Block::from_simple(
-                            &simple_types::Block {
-                                number: Some(u64::from(number)),
-                                ..Default::default()
-                            },
-                            should_checksum,
-                        )?);
-                    }
-                }
-            }
-            blocks.sort_by_key(|b| b.number);
-            blocks
-        }
-    };
+    // Blocks for the page (one per number); items reference them by number.
+    let out_blocks: Vec<Block> = response_blocks
+        .iter()
+        .map(|b| Block::from_simple(b, should_checksum))
+        .collect::<Result<Vec<_>>>()
+        .context("mapping blocks")?;
 
     let mut items = Vec::with_capacity(logs.iter().map(Vec::len).sum());
     for log in logs.into_iter().flatten() {
@@ -698,7 +623,6 @@ mod tests {
             vec![vec![simple_types::Log::default()]],
             &empty_decoder(),
             false,
-            JoinStrategy::FullJoin,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[],
             &TransactionStore::new(),
@@ -725,7 +649,6 @@ mod tests {
             vec![vec![full_log(1)]],
             &empty_decoder(),
             false,
-            JoinStrategy::FullJoin,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[],
             &TransactionStore::new(),
@@ -756,7 +679,6 @@ mod tests {
             vec![vec![full_log(1)]],
             &empty_decoder(),
             false,
-            JoinStrategy::FullJoin,
             &[
                 BlockField::Number,
                 BlockField::Hash,
@@ -787,7 +709,6 @@ mod tests {
             vec![vec![full_log(1)]],
             &empty_decoder(),
             false,
-            JoinStrategy::FullJoin,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[TransactionField::Hash],
             &TransactionStore::new(),
@@ -817,7 +738,6 @@ mod tests {
             vec![vec![full_log(1)]],
             &empty_decoder(),
             false,
-            JoinStrategy::FullJoin,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[TransactionField::Hash],
             &TransactionStore::new(),
@@ -854,7 +774,6 @@ mod tests {
             vec![vec![full_log(7)]],
             &empty_decoder(),
             false,
-            JoinStrategy::FullJoin,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[TransactionField::BlockNumber],
             &store,

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::{Arc, Once};
 
 use anyhow::{Context, Result};
@@ -340,16 +340,17 @@ fn process_response(
     requested_transaction_fields: &[TransactionField],
     transaction_store: &TransactionStore,
 ) -> std::result::Result<(Vec<EventItem>, Vec<Block>), ConvertError> {
-    let blocks_by_number: HashMap<u64, Arc<simple_types::Block>> =
-        if matches!(block_join, JoinStrategy::FullJoin) {
-            blocks
-                .into_iter()
-                .flatten()
-                .filter_map(|b| b.number.map(|number| (number, Arc::new(b))))
-                .collect()
-        } else {
-            HashMap::new()
-        };
+    // The server returns one block per number; items reference them by number,
+    // so no per-block sharing is needed — keep them owned and track which
+    // numbers are present for the per-log coverage check below.
+    let response_blocks: Vec<simple_types::Block> = if matches!(block_join, JoinStrategy::FullJoin)
+    {
+        blocks.into_iter().flatten().collect()
+    } else {
+        Vec::new()
+    };
+    let present_block_numbers: HashSet<u64> =
+        response_blocks.iter().filter_map(|b| b.number).collect();
 
     let mut missing: Vec<String> = Vec::new();
 
@@ -376,7 +377,7 @@ fn process_response(
     }
 
     // Validate the requested block fields once per distinct block.
-    for block in blocks_by_number.values() {
+    for block in &response_blocks {
         for &field in requested_block_fields {
             if let Some(name) = block_field_missing(block, field) {
                 push_unique(&mut missing, format!("block.{}", name));
@@ -390,7 +391,7 @@ fn process_response(
         if matches!(block_join, JoinStrategy::FullJoin) {
             let present = log
                 .block_number
-                .is_some_and(|n| blocks_by_number.contains_key(&u64::from(n)));
+                .is_some_and(|n| present_block_numbers.contains(&u64::from(n)));
             if !present {
                 push_unique(&mut missing, "block".into());
             }
@@ -416,8 +417,8 @@ fn process_response(
     let out_blocks: Vec<Block> = match block_join {
         JoinStrategy::NotSelected => Vec::new(),
         JoinStrategy::FullJoin => {
-            let mut blocks = blocks_by_number
-                .values()
+            let mut blocks = response_blocks
+                .iter()
                 .map(|b| Block::from_simple(b, should_checksum))
                 .collect::<Result<Vec<_>>>()
                 .context("mapping blocks")?;

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -117,9 +117,13 @@ impl EvmHypersyncClient {
             .clone()
             .unwrap_or_default();
 
-        // Force-add block.number so the page's blocks can be keyed and the items
-        // can reference them; every EVM event selection includes it already.
-        add_field(&mut query.field_selection.block, BlockField::Number);
+        // Force-add the block fields the indexer always needs: number keys the
+        // page's blocks and lets items reference them, while the consumer reads
+        // timestamp and hash off every block unconditionally. Enforcing them here
+        // keeps the guarantee local to the path that relies on it.
+        for field in [BlockField::Number, BlockField::Timestamp, BlockField::Hash] {
+            add_field(&mut query.field_selection.block, field);
+        }
         // Transactions are accumulated into the store keyed by
         // (blockNumber, transactionIndex), so those keys must come back on each
         // transaction row whenever any transaction field is requested.

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -1,7 +1,8 @@
-use std::sync::Once;
+use std::collections::HashMap;
+use std::sync::{Arc, Once};
 
 use anyhow::{Context, Result};
-use hypersync_client::RateLimitResponse;
+use hypersync_client::{simple_types, RateLimitResponse};
 use napi_derive::napi;
 
 use crate::transaction_store::TransactionStore;
@@ -13,7 +14,7 @@ pub(crate) mod types;
 
 use config::ClientConfig;
 use decode::DecoderCore;
-use query::{BlockField, LogField, Query, TransactionField};
+use query::{BlockField, FieldSelection, LogField, Query, TransactionField};
 use types::{encode_address, Block, EventParamsInput, ParamValue, RollbackGuard};
 
 static LOGGER_INIT: Once = Once::new();
@@ -116,10 +117,19 @@ impl EvmHypersyncClient {
             .clone()
             .unwrap_or_default();
 
+        // Join logs to their blocks/transactions ourselves rather than going
+        // through the client's event API. The strategies decide whether the
+        // join key can be lifted off the log (block.number / nothing) or needs
+        // the joined row fetched, and augment the field selection accordingly.
+        let block_join = JoinStrategy::for_block(&requested_block_fields);
+        let transaction_join = JoinStrategy::for_transaction(&requested_transaction_fields);
+        apply_block_join(&mut query.field_selection, block_join);
+        apply_transaction_join(&mut query.field_selection, transaction_join);
+
         let query = query.try_into().context("parse query").map_err(map_err)?;
         let res = self
             .inner
-            .get_events_with_rate_limit(query)
+            .get_with_rate_limit(&query)
             .await
             .context("run inner query")
             .map_err(map_err)?;
@@ -132,9 +142,13 @@ impl EvmHypersyncClient {
         let transaction_store = TransactionStore::with_checksum(self.enable_checksum_addresses);
         let items = tokio::task::block_in_place(|| {
             convert_event_items(
-                response.data,
+                response.data.blocks,
+                response.data.transactions,
+                response.data.logs,
                 &self.decoder,
                 self.enable_checksum_addresses,
+                block_join,
+                transaction_join,
                 &requested_block_fields,
                 &requested_transaction_fields,
                 &transaction_store,
@@ -240,22 +254,143 @@ fn convert_response(
     })
 }
 
-/// Validation + decoding for one page of events. Aborts on the first item that
-/// has a structural defect (server omitted a required field; raw bytes can't
-/// be decoded against the declared ABI).
+/// How a log gets joined to its block (or transaction). Mirrors the client's
+/// internal event-join: when the only requested field is the join key itself
+/// (`block.number`) we lift it off the log instead of fetching the joined row.
+#[derive(Clone, Copy)]
+enum JoinStrategy {
+    /// No fields requested — the joined row is absent from the item.
+    NotSelected,
+    /// Only the join key is requested; synthesize it from the log.
+    OnlyLogJoinField,
+    /// Other fields requested; fetch the joined row and match it to the log.
+    FullJoin,
+}
+
+impl JoinStrategy {
+    fn for_block(fields: &[BlockField]) -> Self {
+        match fields {
+            [] => Self::NotSelected,
+            [BlockField::Number] => Self::OnlyLogJoinField,
+            _ => Self::FullJoin,
+        }
+    }
+
+    fn for_transaction(fields: &[TransactionField]) -> Self {
+        match fields {
+            [] => Self::NotSelected,
+            [TransactionField::Hash] => Self::OnlyLogJoinField,
+            _ => Self::FullJoin,
+        }
+    }
+}
+
+fn add_field<T: PartialEq>(selection: &mut Option<Vec<T>>, field: T) {
+    let fields = selection.get_or_insert_with(Vec::new);
+    if !fields.contains(&field) {
+        fields.push(field);
+    }
+}
+
+fn remove_field<T: PartialEq>(selection: &mut Option<Vec<T>>, field: T) {
+    if let Some(fields) = selection {
+        fields.retain(|f| *f != field);
+    }
+}
+
+// log.blockNumber is already force-selected by `ensure_required_log_fields`, so
+// only the block table itself needs adjusting here.
+fn apply_block_join(selection: &mut FieldSelection, strategy: JoinStrategy) {
+    match strategy {
+        JoinStrategy::NotSelected => {}
+        JoinStrategy::OnlyLogJoinField => remove_field(&mut selection.block, BlockField::Number),
+        JoinStrategy::FullJoin => add_field(&mut selection.block, BlockField::Number),
+    }
+}
+
+fn apply_transaction_join(selection: &mut FieldSelection, strategy: JoinStrategy) {
+    match strategy {
+        JoinStrategy::NotSelected => {}
+        JoinStrategy::OnlyLogJoinField => {
+            add_field(&mut selection.log, LogField::TransactionHash);
+            remove_field(&mut selection.transaction, TransactionField::Hash);
+        }
+        JoinStrategy::FullJoin => {
+            add_field(&mut selection.log, LogField::TransactionHash);
+            add_field(&mut selection.transaction, TransactionField::Hash);
+        }
+    }
+}
+
+/// Joins logs to their blocks/transactions, validates the requested fields and
+/// decodes each log into an `EventItem`. Aborts on the first item that has a
+/// structural defect (server omitted a required field; raw bytes can't be
+/// decoded against the declared ABI).
+#[allow(clippy::too_many_arguments)]
 fn convert_event_items(
-    events: Vec<hypersync_client::simple_types::Event>,
+    blocks: Vec<Vec<simple_types::Block>>,
+    transactions: Vec<Vec<simple_types::Transaction>>,
+    logs: Vec<Vec<simple_types::Log>>,
     decoder: &DecoderCore,
     should_checksum: bool,
+    block_join: JoinStrategy,
+    transaction_join: JoinStrategy,
     requested_block_fields: &[BlockField],
     requested_transaction_fields: &[TransactionField],
     transaction_store: &TransactionStore,
 ) -> std::result::Result<Vec<EventItem>, ConvertError> {
-    let mut items = Vec::with_capacity(events.len());
-    for event in events {
+    use hypersync_client::format::Hash;
+
+    let blocks_by_number: HashMap<u64, Arc<simple_types::Block>> =
+        if matches!(block_join, JoinStrategy::FullJoin) {
+            blocks
+                .into_iter()
+                .flatten()
+                .filter_map(|b| b.number.map(|number| (number, Arc::new(b))))
+                .collect()
+        } else {
+            HashMap::new()
+        };
+
+    let transactions_by_hash: HashMap<Hash, Arc<simple_types::Transaction>> =
+        if matches!(transaction_join, JoinStrategy::FullJoin) {
+            transactions
+                .into_iter()
+                .flatten()
+                .filter_map(|t| t.hash.clone().map(|hash| (hash, Arc::new(t))))
+                .collect()
+        } else {
+            HashMap::new()
+        };
+
+    let mut items = Vec::with_capacity(logs.iter().map(Vec::len).sum());
+    for log in logs.into_iter().flatten() {
+        let block: Option<Arc<simple_types::Block>> = match block_join {
+            JoinStrategy::NotSelected => None,
+            JoinStrategy::OnlyLogJoinField => Some(Arc::new(simple_types::Block {
+                number: log.block_number.map(u64::from),
+                ..Default::default()
+            })),
+            JoinStrategy::FullJoin => log
+                .block_number
+                .and_then(|number| blocks_by_number.get(&u64::from(number)).cloned()),
+        };
+
+        let transaction: Option<Arc<simple_types::Transaction>> = match transaction_join {
+            JoinStrategy::NotSelected => None,
+            JoinStrategy::OnlyLogJoinField => Some(Arc::new(simple_types::Transaction {
+                hash: log.transaction_hash.clone(),
+                ..Default::default()
+            })),
+            JoinStrategy::FullJoin => log
+                .transaction_hash
+                .as_ref()
+                .and_then(|hash| transactions_by_hash.get(hash).cloned()),
+        };
+
         let mut missing: Vec<String> = Vec::new();
 
-        match &event.block {
+        match &block {
             None if !requested_block_fields.is_empty() => missing.push("block".into()),
             Some(block) => {
                 for &field in requested_block_fields {
@@ -267,7 +402,7 @@ fn convert_event_items(
             None => {}
         }
 
-        match &event.transaction {
+        match &transaction {
             None if !requested_transaction_fields.is_empty() => missing.push("transaction".into()),
             Some(transaction) => {
                 for &field in requested_transaction_fields {
@@ -288,12 +423,9 @@ fn convert_event_items(
         // `None` is reserved for "topic0/count doesn't match a registered
         // signature", which is the only outcome the wildcard event path
         // expects to handle.
-        let params = decoder
-            .decode_simple(&event.log)
-            .context("decode event params")?;
+        let params = decoder.decode_simple(&log).context("decode event params")?;
 
-        let block = event
-            .block
+        let item_block = block
             .as_ref()
             .map(|b| Block::from_simple(b, should_checksum))
             .transpose()
@@ -301,11 +433,11 @@ fn convert_event_items(
             .unwrap_or_default();
 
         let (log_index, src_address, topic0, topic_count, block_number, transaction_index) =
-            flatten_log_for_js(&event.log, should_checksum).context("mapping log")?;
+            flatten_log_for_js(&log, should_checksum).context("mapping log")?;
 
         // Move the raw transaction into the store keyed by (block, txIndex). Its
         // fields materialise on demand; logs sharing a tx collapse to one entry.
-        if let Some(tx) = event.transaction {
+        if let Some(tx) = transaction {
             transaction_store.insert_evm_raw(block_number as u64, transaction_index as u32, tx);
         }
 
@@ -314,7 +446,7 @@ fn convert_event_items(
             src_address,
             topic0,
             topic_count,
-            block,
+            block: item_block,
             transaction_index,
             params,
         });
@@ -530,18 +662,30 @@ mod tests {
         DecoderCore::from_params(Vec::new(), false).unwrap()
     }
 
+    fn full_log(block_number: u64) -> simple_types::Log {
+        simple_types::Log {
+            log_index: Some(0.into()),
+            block_number: Some(block_number.into()),
+            transaction_index: Some(0u64.into()),
+            address: Some(Default::default()),
+            data: Some(Default::default()),
+            topics: std::iter::once(Some(Default::default())).collect(),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn missing_block_field_returns_typed_error() {
-        // event.block is None but the user asked for block.number/hash/timestamp.
-        let event = simple_types::Event {
-            transaction: None,
-            block: None,
-            log: simple_types::Log::default(),
-        };
+        // The server returned no block for the log but the user asked for
+        // block.number/hash/timestamp.
         let err = convert_event_items(
-            vec![event],
+            vec![],
+            vec![],
+            vec![vec![simple_types::Log::default()]],
             &empty_decoder(),
             false,
+            JoinStrategy::FullJoin,
+            JoinStrategy::NotSelected,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[],
             &TransactionStore::new(),
@@ -559,18 +703,17 @@ mod tests {
     fn missing_block_field_named_path() {
         // block is present but timestamp is not.
         let mut block = simple_types::Block::default();
-        block.number = Some(1u64.into());
+        block.number = Some(1);
         block.hash = Some(Default::default());
         // timestamp left None
-        let event = simple_types::Event {
-            transaction: None,
-            block: Some(block.into()),
-            log: simple_types::Log::default(),
-        };
         let err = convert_event_items(
-            vec![event],
+            vec![vec![block]],
+            vec![],
+            vec![vec![full_log(1)]],
             &empty_decoder(),
             false,
+            JoinStrategy::FullJoin,
+            JoinStrategy::NotSelected,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[],
             &TransactionStore::new(),
@@ -591,27 +734,18 @@ mod tests {
         // BaseFeePerGas is inherently nullable — server omitting it must not
         // trigger MissingFields, regardless of whether the user requested it.
         let mut block = simple_types::Block::default();
-        block.number = Some(1u64.into());
+        block.number = Some(1);
         block.hash = Some(Default::default());
         block.timestamp = Some(Default::default());
         // base_fee_per_gas left None
-        let event = simple_types::Event {
-            transaction: None,
-            block: Some(block.into()),
-            log: simple_types::Log {
-                log_index: Some(0.into()),
-                block_number: Some(0u64.into()),
-                transaction_index: Some(0u64.into()),
-                address: Some(Default::default()),
-                data: Some(Default::default()),
-                topics: std::iter::once(Some(Default::default())).collect(),
-                ..Default::default()
-            },
-        };
         let res = convert_event_items(
-            vec![event],
+            vec![vec![block]],
+            vec![],
+            vec![vec![full_log(1)]],
             &empty_decoder(),
             false,
+            JoinStrategy::FullJoin,
+            JoinStrategy::NotSelected,
             &[
                 BlockField::Number,
                 BlockField::Hash,
@@ -628,27 +762,19 @@ mod tests {
     #[test]
     fn missing_transaction_field_with_transaction_present() {
         let mut block = simple_types::Block::default();
-        block.number = Some(1u64.into());
+        block.number = Some(1);
         block.hash = Some(Default::default());
         block.timestamp = Some(Default::default());
-        let tx = simple_types::Transaction::default(); // hash absent
-        let event = simple_types::Event {
-            transaction: Some(tx.into()),
-            block: Some(block.into()),
-            log: simple_types::Log {
-                log_index: Some(0.into()),
-                block_number: Some(0u64.into()),
-                transaction_index: Some(0u64.into()),
-                address: Some(Default::default()),
-                data: Some(Default::default()),
-                topics: std::iter::once(Some(Default::default())).collect(),
-                ..Default::default()
-            },
-        };
+        // The log carries no transactionHash, so the synthesized join transaction
+        // has no hash and the requested transaction.hash is reported missing.
         let err = convert_event_items(
-            vec![event],
+            vec![vec![block]],
+            vec![],
+            vec![vec![full_log(1)]],
             &empty_decoder(),
             false,
+            JoinStrategy::FullJoin,
+            JoinStrategy::OnlyLogJoinField,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[TransactionField::Hash],
             &TransactionStore::new(),
@@ -662,6 +788,44 @@ mod tests {
             }
             ConvertError::Other(e) => panic!("unexpected ConvertError::Other: {e:?}"),
         }
+    }
+
+    #[test]
+    fn full_join_matches_block_and_transaction() {
+        // Block and transaction live in separate response arrays; the log is
+        // matched to its block by number and to its transaction by hash, and the
+        // transaction lands in the store keyed by (blockNumber, txIndex).
+        let mut block = simple_types::Block::default();
+        block.number = Some(7);
+        block.hash = Some(Default::default());
+        block.timestamp = Some(Default::default());
+
+        let mut tx = simple_types::Transaction::default();
+        tx.hash = Some(Default::default());
+        tx.block_number = Some(7u64.into());
+
+        let mut log = full_log(7);
+        log.transaction_hash = Some(Default::default());
+
+        let store = TransactionStore::new();
+        let items = convert_event_items(
+            vec![vec![block]],
+            vec![vec![tx]],
+            vec![vec![log]],
+            &empty_decoder(),
+            false,
+            JoinStrategy::FullJoin,
+            JoinStrategy::FullJoin,
+            &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
+            &[TransactionField::BlockNumber],
+            &store,
+        )
+        .expect("expected success when block and transaction join");
+
+        assert_eq!(
+            items.iter().map(|i| i.block.number).collect::<Vec<_>>(),
+            vec![Some(7)]
+        );
     }
 
     #[test]

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -110,20 +110,21 @@ impl EvmHypersyncClient {
         // to the field selection so callers don't have to know the contract.
         ensure_required_log_fields(&mut query.field_selection.log);
 
-        let requested_block_fields = query.field_selection.block.clone().unwrap_or_default();
         let requested_transaction_fields = query
             .field_selection
             .transaction
             .clone()
             .unwrap_or_default();
 
-        // Force-add the block fields the indexer always needs: number keys the
-        // page's blocks and lets items reference them, while the consumer reads
-        // timestamp and hash off every block unconditionally. Enforcing them here
-        // keeps the guarantee local to the path that relies on it.
-        for field in [BlockField::Number, BlockField::Timestamp, BlockField::Hash] {
+        // Force-add the always-required block fields, then snapshot the full
+        // block selection as the set to validate. Validating the forced fields
+        // (not just the user's) is what guarantees the consumer's unconditional
+        // number/timestamp/hash reads — the presence check, not the request, is
+        // the guarantee, so it must cover them here rather than trusting config.
+        for &field in REQUIRED_BLOCK_FIELDS {
             add_field(&mut query.field_selection.block, field);
         }
+        let validated_block_fields = query.field_selection.block.clone().unwrap_or_default();
         // Transactions are accumulated into the store keyed by
         // (blockNumber, transactionIndex), so those keys must come back on each
         // transaction row whenever any transaction field is requested.
@@ -159,7 +160,7 @@ impl EvmHypersyncClient {
                 response.data.logs,
                 &self.decoder,
                 self.enable_checksum_addresses,
-                &requested_block_fields,
+                &validated_block_fields,
                 &requested_transaction_fields,
                 &transaction_store,
             )
@@ -297,7 +298,7 @@ fn process_response(
     logs: Vec<Vec<simple_types::Log>>,
     decoder: &DecoderCore,
     should_checksum: bool,
-    requested_block_fields: &[BlockField],
+    validated_block_fields: &[BlockField],
     requested_transaction_fields: &[TransactionField],
     transaction_store: &TransactionStore,
 ) -> std::result::Result<(Vec<EventItem>, Vec<Block>), ConvertError> {
@@ -331,9 +332,10 @@ fn process_response(
         }
     }
 
-    // Validate the requested block fields once per distinct block.
+    // Validate every block field we requested — the user's selection plus the
+    // always-required number/timestamp/hash — once per distinct block.
     for block in &response_blocks {
-        for &field in requested_block_fields {
+        for &field in validated_block_fields {
             if let Some(name) = block_field_missing(block, field) {
                 push_unique(&mut missing, format!("block.{}", name));
             }
@@ -343,7 +345,7 @@ fn process_response(
     // Coverage: every log must resolve to its block (when block fields were
     // requested) and its transaction (when transaction fields were requested).
     for log in logs.iter().flatten() {
-        if !requested_block_fields.is_empty() {
+        if !validated_block_fields.is_empty() {
             let present = log
                 .block_number
                 .is_some_and(|n| present_block_numbers.contains(&u64::from(n)));
@@ -573,6 +575,13 @@ fn transaction_field_missing(
     }
 }
 
+/// Block fields the indexer always needs: `number` keys the page's blocks and
+/// lets items reference them; the consumer reads `timestamp` and `hash` off
+/// every block unconditionally. Force-added to the query and validated for
+/// presence regardless of the user's selection.
+const REQUIRED_BLOCK_FIELDS: &[BlockField] =
+    &[BlockField::Number, BlockField::Timestamp, BlockField::Hash];
+
 fn ensure_required_log_fields(selection: &mut Option<Vec<LogField>>) {
     use std::collections::BTreeSet;
     const REQUIRED: &[LogField] = &[
@@ -654,6 +663,37 @@ mod tests {
             &empty_decoder(),
             false,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
+            &[],
+            &TransactionStore::new(),
+        )
+        .err()
+        .expect("expected MissingFields error");
+
+        match err {
+            ConvertError::MissingFields(fields) => {
+                assert_eq!(fields, vec!["block.timestamp".to_string()])
+            }
+            ConvertError::Other(e) => panic!("unexpected ConvertError::Other: {e:?}"),
+        }
+    }
+
+    #[test]
+    fn forced_block_fields_validated_even_when_user_requested_none() {
+        // get_event_items force-adds REQUIRED_BLOCK_FIELDS and validates that
+        // forced set, so number/timestamp/hash are guaranteed present even when
+        // the user's config selected no block fields. Here the user requested
+        // nothing yet a missing timestamp is still reported.
+        let mut block = simple_types::Block::default();
+        block.number = Some(1);
+        block.hash = Some(Default::default());
+        // timestamp left None
+        let err = process_response(
+            vec![vec![block]],
+            vec![],
+            vec![vec![full_log(1)]],
+            &empty_decoder(),
+            false,
+            REQUIRED_BLOCK_FIELDS,
             &[],
             &TransactionStore::new(),
         )

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -16,6 +16,8 @@ let reraisIfRateLimited = exn =>
 
 type logsQueryPage = {
   items: array<HyperSyncClient.EventItems.item>,
+  // Blocks referenced by `items`, deduplicated by block number.
+  blocks: array<HyperSyncClient.ResponseTypes.block>,
   nextBlock: int,
   archiveHeight: int,
   rollbackGuard: option<HyperSyncClient.ResponseTypes.rollbackGuard>,
@@ -139,6 +141,7 @@ module GetLogs = {
 
     {
       items: res.items,
+      blocks: res.blocks,
       nextBlock: res.nextBlock,
       archiveHeight: res.archiveHeight->Option.getOr(0), //Archive Height is only None if height is 0
       rollbackGuard: res.rollbackGuard,

--- a/packages/envio/src/sources/HyperSync.resi
+++ b/packages/envio/src/sources/HyperSync.resi
@@ -1,5 +1,6 @@
 type logsQueryPage = {
   items: array<HyperSyncClient.EventItems.item>,
+  blocks: array<HyperSyncClient.ResponseTypes.block>,
   nextBlock: int,
   archiveHeight: int,
   rollbackGuard: option<HyperSyncClient.ResponseTypes.rollbackGuard>,

--- a/packages/envio/src/sources/HyperSyncClient.res
+++ b/packages/envio/src/sources/HyperSyncClient.res
@@ -280,7 +280,9 @@ module EventItems = {
     srcAddress: Address.t,
     topic0: EvmTypes.Hex.t,
     topicCount: int,
-    block: ResponseTypes.block,
+    // Number of the block this log belongs to; the block itself is resolved from
+    // `response.blocks`, deduplicated across items sharing a block.
+    blockNumber: int,
     // Key (with the block number) into the transaction store; the transaction
     // is resolved from the store on demand.
     transactionIndex: int,
@@ -290,6 +292,8 @@ module EventItems = {
   type response = {
     archiveHeight: option<int>,
     nextBlock: int,
+    // One entry per block number referenced by `items`.
+    blocks: array<ResponseTypes.block>,
     items: array<item>,
     rollbackGuard: option<ResponseTypes.rollbackGuard>,
   }

--- a/packages/envio/src/sources/HyperSyncSource.res
+++ b/packages/envio/src/sources/HyperSyncSource.res
@@ -193,17 +193,18 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
 
   let makeEventBatchQueueItem = (
     item: HyperSyncClient.EventItems.item,
+    ~block: HyperSyncClient.ResponseTypes.block,
     ~params: Internal.eventParams,
     ~eventConfig: Internal.evmEventConfig,
   ): Internal.item => {
-    let {block, transactionIndex, logIndex, srcAddress} = item
+    let {transactionIndex, logIndex, srcAddress} = item
     let chainId = chain->ChainMap.Chain.toChainId
 
     Internal.Event({
       eventConfig: (eventConfig :> Internal.eventConfig),
       timestamp: block.timestamp->Option.getUnsafe,
       chain,
-      blockNumber: block.number->Option.getUnsafe,
+      blockNumber: item.blockNumber,
       blockHash: block.hash->Option.getUnsafe,
       logIndex,
       transactionIndex,
@@ -314,6 +315,16 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     //Parse page items into queue items
     let parsedQueueItems = []
 
+    // Blocks are returned once per number; items reference them by blockNumber.
+    let blocksByNumber = Utils.Map.make()
+    pageUnsafe.blocks->Array.forEach(block => {
+      switch block.number {
+      | Some(number) => blocksByNumber->Utils.Map.set(number, block)->ignore
+      | None => ()
+      }
+    })
+    let getBlock = blockNumber => blocksByNumber->Utils.Map.unsafeGet(blockNumber)
+
     let handleDecodeFailure = (
       ~eventConfig: Internal.evmEventConfig,
       ~logIndex,
@@ -349,7 +360,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
           ),
           ~indexingAddresses,
           ~contractAddress=item.srcAddress,
-          ~blockNumber=item.block.number->Option.getUnsafe,
+          ~blockNumber=item.blockNumber,
         )
 
       switch maybeEventConfig {
@@ -359,12 +370,16 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
         ->Nullable.toOption
         ->Option.flatMap(Dict.get(_, eventConfig.contractName)) {
         | Some(params) =>
-          parsedQueueItems->Array.push(makeEventBatchQueueItem(item, ~params, ~eventConfig))->ignore
+          parsedQueueItems
+          ->Array.push(
+            makeEventBatchQueueItem(item, ~block=getBlock(item.blockNumber), ~params, ~eventConfig),
+          )
+          ->ignore
         | None =>
           handleDecodeFailure(
             ~eventConfig,
             ~logIndex=item.logIndex,
-            ~blockNumber=item.block.number->Option.getUnsafe,
+            ~blockNumber=item.blockNumber,
             ~chainId,
             ~exn=UndefinedValue,
           )
@@ -375,11 +390,11 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     let parsingTimeElapsed = parsingTimeRef->Hrtime.timeSince->Hrtime.toSecondsFloat
 
     // Collect (blockNumber, blockHash) pairs we already have from the response —
-    // one per item's block plus, when present, the rollbackGuard's head block
+    // one per returned block plus, when present, the rollbackGuard's head block
     // and the parent of the range's first block. Duplicates are allowed; reorg
     // detection notices same-block-number-different-hash collisions itself.
     let blockHashes = []
-    pageUnsafe.items->Array.forEach(({block}) => {
+    pageUnsafe.blocks->Array.forEach(block => {
       switch (block.number, block.hash) {
       | (Some(blockNumber), Some(blockHash)) =>
         blockHashes->Array.push({ReorgDetection.blockNumber, blockHash})->ignore
@@ -407,8 +422,8 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     | Some({timestamp}) => timestamp
     | None =>
       switch pageUnsafe.items->Array.get(pageUnsafe.items->Array.length - 1) {
-      | Some({block}) if block.number->Option.getUnsafe == heighestBlockQueried =>
-        block.timestamp->Option.getUnsafe
+      | Some(item) if item.blockNumber == heighestBlockQueried =>
+        getBlock(item.blockNumber).timestamp->Option.getUnsafe
       | _ => 0
       }
     }

--- a/scenarios/test_codegen/test/HyperSyncClient_test.res
+++ b/scenarios/test_codegen/test/HyperSyncClient_test.res
@@ -74,7 +74,7 @@ describe("HyperSync client getEventItems (live)", () => {
           usdcAddress->Address.toString->String.toLowerCase
       ),
       "everyBlockInRange": res.items->Array.every(item => {
-        let n = item.block.number->Option.getUnsafe
+        let n = item.blockNumber
         n >= fromBlock && n <= toBlock
       }),
       "everyParamsDecoded": res.items->Array.every(item =>


### PR DESCRIPTION
## Summary

Refactors the HyperSync event response processing to deduplicate blocks across items and enforce validation of required block fields (number, timestamp, hash) regardless of user selection. This reduces data crossing the NAPI boundary and guarantees the indexer can unconditionally read these fields from every block.

## Key Changes

- **Block deduplication**: Blocks are now returned once per block number in `EventItemsResponse.blocks` instead of being embedded in each `EventItem`. Items reference blocks by `block_number` instead of carrying full block objects.

- **Required field validation**: Force-adds `BlockField::Number`, `BlockField::Timestamp`, and `BlockField::Hash` to the query and validates their presence for all returned blocks, ensuring the indexer's unconditional reads are always safe.

- **Transaction field enforcement**: Automatically adds `TransactionField::BlockNumber` and `TransactionField::TransactionIndex` to the query when any transaction field is requested, ensuring transactions can be keyed in the store.

- **Improved coverage checking**: Validates that every log resolves to its block (when block fields requested) and transaction (when transaction fields requested) by checking presence in the response sets, catching missing joined rows upfront.

- **Refactored response processing**: Renamed `convert_event_items` to `process_response` and restructured to:
  - Accumulate transactions into the store once per (blockNumber, txIndex) key
  - Validate all requested fields once per distinct block/transaction
  - Return both items and deduplicated blocks
  - Report all missing fields in a single error

- **ReScript integration**: Updated `HyperSyncSource.res` and `HyperSyncClient.res` to work with the new response shape, building a block lookup map and passing blocks to `makeEventBatchQueueItem`.

## Implementation Details

- Added `add_field` helper to idempotently add fields to selections
- Added `push_unique` helper to avoid duplicate field names in error messages
- Blocks are collected into a `HashSet` by number for O(1) coverage validation
- Transaction keys are tracked separately to validate join coverage without redundant storage
- All validation happens before decoding, so decode errors are propagated cleanly
- Tests updated to reflect new `process_response` signature and validate forced field behavior

https://claude.ai/code/session_01HKTvRRBQUdTR7dYFZEFtGo