### PR TITLE
fix: support earlier registrationBlock for dynamic contracts (addresses #1188)

### DIFF
--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1009,33 +1009,25 @@ let registerDynamicContracts = (
   // Might contain duplicates which we should filter out
   items: array<Internal.item>,
 ) => {
-  // === Batch dynamic-contract registration invariant (senior dev note) ===
-  // For every address we process in this call we must guarantee:
-  //   - At most one DC remains attached to any item.
-  //   - The attached DC (if any) comes from the sighting with the *smallest*
-  //     registrationBlock seen for that address *anywhere in this call*.
-  // This single value is what ends up in indexingAddresses (for effectiveStartBlock
-  // filtering) and in the envio_addresses row (for persistence and restart).
+  // The logic below ensures that for any address processed in one call to this
+  // function, at most one dynamic contract registration survives (the one whose
+  // registrationBlock is the smallest seen anywhere in the items passed to this
+  // call). That value is used both for the effectiveStartBlock that controls
+  // filtering and for the row that gets written to envio_addresses.
   //
-  // Because a single registerDynamicContracts call can receive items from multiple
-  // partitions (and the array order is not guaranteed), we maintain two pieces of
-  // per-address "best so far" state for the current call:
-  //   registeringAddresses / correctedAddresses  – the best indexingAddress seen
-  //   chosenDcItemByAddress                       – which item currently "owns" that best DC
+  // A single call can contain items coming from several partitions, and the order
+  // of items inside the array is not guaranteed to be sorted by block number.
+  // We therefore keep per-address "best so far" state for the duration of the call
+  // and, when a strictly earlier sighting is found later in the array, we remove
+  // the DC that was attached to an earlier item. This makes the final result
+  // independent of the order in which the items happened to arrive.
   //
-  // When a strictly better sighting is found later in the array we splice the old DC
-  // off its item's dcs list (see the two places below). This makes the result
-  // independent of input order.
-  //
-  // The two universes for an address inside one call are:
-  // 1. Not present in the pre-call indexingAddresses snapshot (None arm below).
-  // 2. Present before the call, but this sighting is earlier than that snapshot value
-  //    (Some arm, the "correction" path).
-  // Both must feed the same within-call min + splice logic.
-  //
-  // Corrections deliberately avoid registeringContractsByContract (we already own
-  // partitions for the address) but still go through registeringAddresses so later
-  // sightings in the same call see them for dedup.
+  // An address can be seen for the first time in this call in two ways:
+  // - It was not present in the snapshot of indexingAddresses taken on entry.
+  // - It was already known before the call, but the current sighting has an
+  //   earlier block than the value we had recorded.
+  // Both situations must go through the same within-call deduplication so that
+  // the earliest block always wins.
   if fetchState.normalSelection.eventConfigs->Utils.Array.isEmpty {
     // Can the normalSelection be empty?
     JsError.throwWithMessage(

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1028,6 +1028,15 @@ let registerDynamicContracts = (
   // including no-events ones), so two contracts registering the same address
   // within one batch conflict the same way as against indexingAddresses.
   let registeringAddresses: dict<indexingAddress> = Dict.make()
+  // Track the item carrying the current earliest dc sighting *within this batch* (register call).
+  // Lets us splice the dc off a superseded (later-block) item when a better earlier sighting
+  // appears later in the items array (makes within-batch min selection order-independent and
+  // ensures only the early DC reaches setBatchDcs).
+  let chosenDcItemByAddress: dict<Internal.item> = Dict.make()
+  // Corrections: addresses for which an earlier effectiveStartBlock was accepted
+  // (for already-tracked addresses). We merge the updated record to indexingAddresses
+  // and lower lfb on their partition(s) to drive gap re-fetch. (See registerDynamicContracts.)
+  let correctedAddresses: dict<indexingAddress> = Dict.make()
 
   for itemIdx in 0 to items->Array.length - 1 {
     let item = items->Array.getUnsafe(itemIdx)
@@ -1056,24 +1065,45 @@ let registerDynamicContracts = (
             dc.address->Address.toString,
           ) {
           | Some(existingContract) =>
-            // FIXME: Instead of filtering out duplicates,
-            // we should check the block number first.
-            // If new registration with earlier block number
-            // we should register it for the missing block range
             if existingContract.contractName != dc.contractName {
               fetchState->warnDifferentContractType(~existingContract, ~dc=dcWithStartBlock)
-            } else if existingContract.effectiveStartBlock > dcWithStartBlock.effectiveStartBlock {
+              shouldRemove := true
+            } else if existingContract.effectiveStartBlock <= dcWithStartBlock.effectiveStartBlock {
+              // We already have an equal or earlier registration for this address.
+              // Keep the earliest. Sighting at a later block is a no-op for start time.
+              // (If incoming later than recorded: skip as before. Equal: silent dedup.)
+              shouldRemove := true
+            } else {
+              // New sighting has an *earlier* effectiveStartBlock than what we recorded.
+              // Updated from previous FIXME: now choose min block (no longer early-exit skip).
+              // This can happen due to out-of-order items from concurrent partitions
+              // or unsorted source responses. Take the min so we index from the true
+              // earliest point. Let the DC through so the earlier registrationBlock
+              // is persisted (overwriting the previous higher one via same PK).
               let logger = Logging.createChild(
                 ~params={
                   "chainId": fetchState.chainId,
                   "contractAddress": dc.address->Address.toString,
-                  "existingBlockNumber": existingContract.effectiveStartBlock,
-                  "newBlockNumber": dcWithStartBlock.effectiveStartBlock,
+                  "previousBlockNumber": existingContract.effectiveStartBlock,
+                  "correctedToBlockNumber": dcWithStartBlock.effectiveStartBlock,
                 },
               )
-              logger->Logging.childWarn(`Skipping contract registration: Contract address is already registered at a later block number. Currently registration of the same contract address is not supported by Envio. Reach out to us if it's a problem for you.`)
+              logger->Logging.childInfo(
+                `Correcting dynamic contract registration to earlier block number. The address will now be considered active from the earlier point.`,
+              )
+              // Record the *earlier* value into corrected (not registeringContractsByContract).
+              // registeringContractsByContract drives *new* partition creation in createPartitionsFrom...
+              // For corrections of existing we instead merge the corrected record directly and
+              // lower lfb on pre-existing partitions containing the address.
+              correctedAddresses->Dict.set(dc.address->Address.toString, dcWithStartBlock)
+              registeringAddresses->Dict.set(dc.address->Address.toString, dcWithStartBlock)
+              earliestRegisteringEventBlockNumber :=
+                Pervasives.min(
+                  earliestRegisteringEventBlockNumber.contents,
+                  dcWithStartBlock.effectiveStartBlock,
+                )
+              // do NOT set shouldRemove — keep the DC on the item so it reaches setBatchDcs / DB
             }
-            shouldRemove := true
           | None =>
             let shouldUpdate = switch registeringAddresses->Utils.Dict.dangerouslyGetNonOption(
               dc.address->Address.toString,
@@ -1084,10 +1114,41 @@ let registerDynamicContracts = (
                 ~dc=dcWithStartBlock,
               )
               false
-            | Some(_) => // Since the DC is registered by an earlier item in the query
-              // FIXME: This unsafely relies on the asc order of the items
-              // which is 99% true, but there were cases when the source ordering was wrong
-              false
+            | Some(existingInBatch) =>
+              if existingInBatch.effectiveStartBlock <= dcWithStartBlock.effectiveStartBlock {
+                // Already have earlier-or-equal in this batch; keep that one.
+                // (later: skip; equal: silent dedup per within-batch registeringAddresses check)
+                false
+              } else {
+                // This is an earlier sighting than the one recorded for this batch so far.
+                // Splice the (now-superseded) later dc off its previous item's dcs array.
+                // This ensures only the min registrationBlock's DC survives to setBatchDcs
+                // (order-independent within the batch; prevents later set of higher block).
+                let addrStr = dc.address->Address.toString
+                switch chosenDcItemByAddress->Utils.Dict.dangerouslyGetNonOption(addrStr) {
+                | Some(oldItem) =>
+                  switch oldItem->Internal.getItemDcs {
+                  | Some(oldDcs) => {
+                      let k = ref(0)
+                      let spliced = ref(false)
+                      while k.contents < oldDcs->Array.length && !spliced.contents {
+                        let oldDc = oldDcs->Array.getUnsafe(k.contents)
+                        if oldDc.address === dc.address {
+                          let _ = oldDcs->Array.splice(~start=k.contents, ~remove=1, ~insert=[])
+                          spliced := true
+                        } else {
+                          k := k.contents + 1
+                        }
+                      }
+                    }
+                  | None => ()
+                  }
+                | None => ()
+                }
+                chosenDcItemByAddress->Dict.set(addrStr, item)
+                // choose min (true) so record early to registering* . This (early) item kept.
+                true
+              }
             | None => true
             }
             if shouldUpdate {
@@ -1100,6 +1161,7 @@ let registerDynamicContracts = (
               ->Utils.Dict.getOrInsertEmptyDict(dc.contractName)
               ->Dict.set(dc.address->Address.toString, dcWithStartBlock)
               registeringAddresses->Dict.set(dc.address->Address.toString, dcWithStartBlock)
+              chosenDcItemByAddress->Dict.set(dc.address->Address.toString, item)
             } else {
               shouldRemove := true
             }
@@ -1123,8 +1185,24 @@ let registerDynamicContracts = (
           | Some(existingContract) =>
             if existingContract.contractName != dc.contractName {
               fetchState->warnDifferentContractType(~existingContract, ~dc=dcAsIndexingAddress)
+              shouldRemove := true
+            } else if existingContract.effectiveStartBlock <= dcAsIndexingAddress.effectiveStartBlock {
+              shouldRemove := true
+            } else {
+              // Earlier sighting for a no-events address: update tracking + persist the early block.
+              let logger = Logging.createChild(
+                ~params={
+                  "chainId": fetchState.chainId,
+                  "contractAddress": dc.address->Address.toString,
+                  "previousBlockNumber": existingContract.effectiveStartBlock,
+                  "correctedToBlockNumber": dcAsIndexingAddress.effectiveStartBlock,
+                },
+              )
+              logger->Logging.childInfo(`Correcting no-events contract registration to earlier block.`)
+              registeringAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
+              noEventsAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
+              // keep in item for persistence
             }
-            shouldRemove := true
           | None =>
             switch registeringAddresses->Utils.Dict.dangerouslyGetNonOption(
               dc.address->Address.toString,
@@ -1132,9 +1210,14 @@ let registerDynamicContracts = (
             | Some(existingContract) =>
               if existingContract.contractName != dc.contractName {
                 fetchState->warnDifferentContractType(~existingContract, ~dc=dcAsIndexingAddress)
+                shouldRemove := true
+              } else if existingContract.effectiveStartBlock <= dcAsIndexingAddress.effectiveStartBlock {
+                shouldRemove := true
+              } else {
+                // within-batch correction for no-events
+                registeringAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
+                noEventsAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
               }
-              // Otherwise already queued for persistence by an earlier item in this batch.
-              shouldRemove := true
             | None =>
               let logger = Logging.createChild(
                 ~params={
@@ -1166,17 +1249,18 @@ let registerDynamicContracts = (
 
   let dcContractNamesToStore = registeringContractsByContract->Dict.keysToArray
   let hasNoEventsUpdates = !(noEventsAddresses->Utils.Dict.isEmpty)
-  switch (dcContractNamesToStore, hasNoEventsUpdates) {
+  let hasCorrections = !(correctedAddresses->Utils.Dict.isEmpty)
+  switch (dcContractNamesToStore, hasNoEventsUpdates, hasCorrections) {
   // Dont update anything when everything was filter out
-  | ([], false) => fetchState
-  | ([], true) =>
+  | ([], false, false) => fetchState
+  | ([], true, false) =>
     // Only dcs for contracts without events. Track them on
     // indexingAddresses so subsequent registrations see them, but don't touch
     // partitions since there's nothing to fetch for them.
     let newIndexingContracts = indexingAddresses->Utils.Dict.shallowCopy
     let _ = Utils.Dict.mergeInPlace(newIndexingContracts, noEventsAddresses)
     fetchState->updateInternal(~indexingAddresses=newIndexingContracts)
-  | (_, _) => {
+  | _ => {
       let newPartitions = []
       let newIndexingAddresses = indexingAddresses->Utils.Dict.shallowCopy
       let dynamicContractsRef = ref(fetchState.optimizedPartitions.dynamicContracts)
@@ -1265,6 +1349,34 @@ let registerDynamicContracts = (
       }
       // Include no-events dcs so later batches detect conflicts against them.
       let _ = Utils.Dict.mergeInPlace(newIndexingAddresses, noEventsAddresses)
+      let _ = Utils.Dict.mergeInPlace(newIndexingAddresses, correctedAddresses)
+
+      // For each address corrected to a strictly earlier effectiveStartBlock,
+      // walk the (to-be-used) partitions and lower latestFetchedBlock to
+      // min(current, newEffective-1). This makes getNextQuery emit earlier
+      // fromBlock queries for the partition. (See recommended approach in task.)
+      correctedAddresses->Utils.Dict.forEachWithKey((correctedIa, addressStr) => {
+        let contractName = correctedIa.contractName
+        let target = correctedIa.effectiveStartBlock - 1
+        for pIdx in 0 to mutExistingPartitions->Array.length - 1 {
+          let p = mutExistingPartitions->Array.getUnsafe(pIdx)
+          switch p.addressesByContractName->Utils.Dict.dangerouslyGetNonOption(contractName) {
+          | Some(addrs) if addrs->Array.some(a => a->Address.toString === addressStr) =>
+            let curr = p.latestFetchedBlock.blockNumber
+            let newLfbBn = Pervasives.min(curr, target)
+            if newLfbBn < curr {
+              mutExistingPartitions->Array.setUnsafe(
+                pIdx,
+                {
+                  ...p,
+                  latestFetchedBlock: {blockNumber: newLfbBn, blockTimestamp: 0},
+                },
+              )
+            }
+          | _ => ()
+          }
+        }
+      })
 
       let optimizedPartitions = createPartitionsFromIndexingAddresses(
         ~registeringContractsByContract,

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1009,6 +1009,33 @@ let registerDynamicContracts = (
   // Might contain duplicates which we should filter out
   items: array<Internal.item>,
 ) => {
+  // === Batch dynamic-contract registration invariant (senior dev note) ===
+  // For every address we process in this call we must guarantee:
+  //   - At most one DC remains attached to any item.
+  //   - The attached DC (if any) comes from the sighting with the *smallest*
+  //     registrationBlock seen for that address *anywhere in this call*.
+  // This single value is what ends up in indexingAddresses (for effectiveStartBlock
+  // filtering) and in the envio_addresses row (for persistence and restart).
+  //
+  // Because a single registerDynamicContracts call can receive items from multiple
+  // partitions (and the array order is not guaranteed), we maintain two pieces of
+  // per-address "best so far" state for the current call:
+  //   registeringAddresses / correctedAddresses  – the best indexingAddress seen
+  //   chosenDcItemByAddress                       – which item currently "owns" that best DC
+  //
+  // When a strictly better sighting is found later in the array we splice the old DC
+  // off its item's dcs list (see the two places below). This makes the result
+  // independent of input order.
+  //
+  // The two universes for an address inside one call are:
+  // 1. Not present in the pre-call indexingAddresses snapshot (None arm below).
+  // 2. Present before the call, but this sighting is earlier than that snapshot value
+  //    (Some arm, the "correction" path).
+  // Both must feed the same within-call min + splice logic.
+  //
+  // Corrections deliberately avoid registeringContractsByContract (we already own
+  // partitions for the address) but still go through registeringAddresses so later
+  // sightings in the same call see them for dedup.
   if fetchState.normalSelection.eventConfigs->Utils.Array.isEmpty {
     // Can the normalSelection be empty?
     JsError.throwWithMessage(
@@ -1018,7 +1045,6 @@ let registerDynamicContracts = (
 
   let indexingAddresses = fetchState.indexingAddresses
   let registeringContractsByContract: dict<dict<indexingAddress>> = Dict.make()
-  let earliestRegisteringEventBlockNumber = ref(%raw(`Infinity`))
   // Addresses registered for contracts without matching events. These are not
   // added to partitions, but they are tracked on fetchState.indexingAddresses
   // so that later conflicting registrations are detected, and are persisted
@@ -1074,35 +1100,73 @@ let registerDynamicContracts = (
               // (If incoming later than recorded: skip as before. Equal: silent dedup.)
               shouldRemove := true
             } else {
-              // New sighting has an *earlier* effectiveStartBlock than what we recorded.
-              // Updated from previous FIXME: now choose min block (no longer early-exit skip).
-              // This can happen due to out-of-order items from concurrent partitions
-              // or unsorted source responses. Take the min so we index from the true
-              // earliest point. Let the DC through so the earlier registrationBlock
-              // is persisted (overwriting the previous higher one via same PK).
-              let logger = Logging.createChild(
-                ~params={
-                  "chainId": fetchState.chainId,
-                  "contractAddress": dc.address->Address.toString,
-                  "previousBlockNumber": existingContract.effectiveStartBlock,
-                  "correctedToBlockNumber": dcWithStartBlock.effectiveStartBlock,
-                },
-              )
-              logger->Logging.childInfo(
-                `Correcting dynamic contract registration to earlier block number. The address will now be considered active from the earlier point.`,
-              )
-              // Record the *earlier* value into corrected (not registeringContractsByContract).
-              // registeringContractsByContract drives *new* partition creation in createPartitionsFrom...
-              // For corrections of existing we instead merge the corrected record directly and
-              // lower lfb on pre-existing partitions containing the address.
-              correctedAddresses->Dict.set(dc.address->Address.toString, dcWithStartBlock)
-              registeringAddresses->Dict.set(dc.address->Address.toString, dcWithStartBlock)
-              earliestRegisteringEventBlockNumber :=
-                Pervasives.min(
-                  earliestRegisteringEventBlockNumber.contents,
-                  dcWithStartBlock.effectiveStartBlock,
+              // New sighting has an *earlier* effectiveStartBlock than the one recorded before
+              // this registerDynamicContracts call.
+              //
+              // We must still participate in *within-batch* min selection for this address.
+              // A later item in the same `items` array may contain an even earlier sighting
+              // for the same address. We use the same chosenDcItemByAddress + splice pattern
+              // as the new-address path so that only the single earliest DC in the whole call
+              // survives to setBatchDcs, and the min block is what gets persisted.
+              //
+              // (We deliberately keep corrections out of registeringContractsByContract to
+              // avoid creating unnecessary new partitions for an address we already own;
+              // we only update correctedAddresses and later lower LFBs on existing partitions.)
+              let addrStr = dc.address->Address.toString
+              let shouldKeep = switch registeringAddresses->Utils.Dict.dangerouslyGetNonOption(addrStr) {
+              | Some(existingInBatch) if existingInBatch.effectiveStartBlock <= dcWithStartBlock.effectiveStartBlock =>
+                false
+              | Some(existingInBatch) => {
+                // This is earlier than a sighting we already accepted earlier in this batch.
+                // Splice the superseded DC off the old item.
+                switch chosenDcItemByAddress->Utils.Dict.dangerouslyGetNonOption(addrStr) {
+                | Some(oldItem) =>
+                  switch oldItem->Internal.getItemDcs {
+                  | Some(oldDcs) => {
+                      let k = ref(0)
+                      let spliced = ref(false)
+                      while k.contents < oldDcs->Array.length && !spliced.contents {
+                        let oldDc = oldDcs->Array.getUnsafe(k.contents)
+                        if oldDc.address === dc.address {
+                          let _ = oldDcs->Array.splice(~start=k.contents, ~remove=1, ~insert=[])
+                          spliced := true
+                        } else {
+                          k := k.contents + 1
+                        }
+                      }
+                    }
+                  | None => ()
+                  }
+                | None => ()
+                }
+                chosenDcItemByAddress->Dict.set(addrStr, item)
+                true
+              }
+              | None => {
+                // First sighting in this batch that is also earlier than the pre-call value.
+                // Remember the item so a worse sighting later in the array can splice us.
+                chosenDcItemByAddress->Dict.set(addrStr, item)
+                true
+              }
+              }
+              if shouldKeep {
+                let logger = Logging.createChild(
+                  ~params={
+                    "chainId": fetchState.chainId,
+                    "contractAddress": dc.address->Address.toString,
+                    "previousBlockNumber": existingContract.effectiveStartBlock,
+                    "correctedToBlockNumber": dcWithStartBlock.effectiveStartBlock,
+                  },
                 )
-              // do NOT set shouldRemove — keep the DC on the item so it reaches setBatchDcs / DB
+                logger->Logging.childInfo(
+                  `Correcting dynamic contract registration to earlier block number. The address will now be considered active from the earlier point.`,
+                )
+                correctedAddresses->Dict.set(dc.address->Address.toString, dcWithStartBlock)
+                registeringAddresses->Dict.set(dc.address->Address.toString, dcWithStartBlock)
+                // do NOT set shouldRemove
+              } else {
+                shouldRemove := true
+              }
             }
           | None =>
             let shouldUpdate = switch registeringAddresses->Utils.Dict.dangerouslyGetNonOption(
@@ -1152,11 +1216,6 @@ let registerDynamicContracts = (
             | None => true
             }
             if shouldUpdate {
-              earliestRegisteringEventBlockNumber :=
-                Pervasives.min(
-                  earliestRegisteringEventBlockNumber.contents,
-                  dcWithStartBlock.effectiveStartBlock,
-                )
               registeringContractsByContract
               ->Utils.Dict.getOrInsertEmptyDict(dc.contractName)
               ->Dict.set(dc.address->Address.toString, dcWithStartBlock)
@@ -1190,18 +1249,57 @@ let registerDynamicContracts = (
               shouldRemove := true
             } else {
               // Earlier sighting for a no-events address: update tracking + persist the early block.
-              let logger = Logging.createChild(
-                ~params={
-                  "chainId": fetchState.chainId,
-                  "contractAddress": dc.address->Address.toString,
-                  "previousBlockNumber": existingContract.effectiveStartBlock,
-                  "correctedToBlockNumber": dcAsIndexingAddress.effectiveStartBlock,
-                },
-              )
-              logger->Logging.childInfo(`Correcting no-events contract registration to earlier block.`)
-              registeringAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
-              noEventsAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
-              // keep in item for persistence
+              // Participate in within-batch min selection using chosenDcItemByAddress so that
+              // two sightings in one call for a pre-known no-events address only keep the min.
+              let addrStr = dc.address->Address.toString
+              let shouldKeep = switch registeringAddresses->Utils.Dict.dangerouslyGetNonOption(addrStr) {
+              | Some(existingInBatch) if existingInBatch.effectiveStartBlock <= dcAsIndexingAddress.effectiveStartBlock =>
+                false
+              | Some(existingInBatch) => {
+                switch chosenDcItemByAddress->Utils.Dict.dangerouslyGetNonOption(addrStr) {
+                | Some(oldItem) =>
+                  switch oldItem->Internal.getItemDcs {
+                  | Some(oldDcs) => {
+                      let k = ref(0)
+                      let spliced = ref(false)
+                      while k.contents < oldDcs->Array.length && !spliced.contents {
+                        let oldDc = oldDcs->Array.getUnsafe(k.contents)
+                        if oldDc.address === dc.address {
+                          let _ = oldDcs->Array.splice(~start=k.contents, ~remove=1, ~insert=[])
+                          spliced := true
+                        } else {
+                          k := k.contents + 1
+                        }
+                      }
+                    }
+                  | None => ()
+                  }
+                | None => ()
+                }
+                chosenDcItemByAddress->Dict.set(addrStr, item)
+                true
+              }
+              | None => {
+                chosenDcItemByAddress->Dict.set(addrStr, item)
+                true
+              }
+              }
+              if shouldKeep {
+                let logger = Logging.createChild(
+                  ~params={
+                    "chainId": fetchState.chainId,
+                    "contractAddress": dc.address->Address.toString,
+                    "previousBlockNumber": existingContract.effectiveStartBlock,
+                    "correctedToBlockNumber": dcAsIndexingAddress.effectiveStartBlock,
+                  },
+                )
+                logger->Logging.childInfo(`Correcting no-events contract registration to earlier block.`)
+                registeringAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
+                noEventsAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
+                // keep in item for persistence
+              } else {
+                shouldRemove := true
+              }
             }
           | None =>
             switch registeringAddresses->Utils.Dict.dangerouslyGetNonOption(
@@ -1214,7 +1312,29 @@ let registerDynamicContracts = (
               } else if existingContract.effectiveStartBlock <= dcAsIndexingAddress.effectiveStartBlock {
                 shouldRemove := true
               } else {
-                // within-batch correction for no-events
+                // within-batch correction for no-events: splice the previous (worse) one if present
+                let addrStr = dc.address->Address.toString
+                switch chosenDcItemByAddress->Utils.Dict.dangerouslyGetNonOption(addrStr) {
+                | Some(oldItem) =>
+                  switch oldItem->Internal.getItemDcs {
+                  | Some(oldDcs) => {
+                      let k = ref(0)
+                      let spliced = ref(false)
+                      while k.contents < oldDcs->Array.length && !spliced.contents {
+                        let oldDc = oldDcs->Array.getUnsafe(k.contents)
+                        if oldDc.address === dc.address {
+                          let _ = oldDcs->Array.splice(~start=k.contents, ~remove=1, ~insert=[])
+                          spliced := true
+                        } else {
+                          k := k.contents + 1
+                        }
+                      }
+                    }
+                  | None => ()
+                  }
+                | None => ()
+                }
+                chosenDcItemByAddress->Dict.set(addrStr, item)
                 registeringAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
                 noEventsAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
               }

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -178,11 +178,16 @@ let setBatchDcs = (state: IndexerState.t, ~batch: Batch.t) => {
         let eventItem = item->Internal.castUnsafeEventItem
         for dcIdx in 0 to dcs->Array.length - 1 {
           let dc = dcs->Array.getUnsafe(dcIdx)
+          // Use the registrationBlock carried on the dc (set at contractRegister time from the
+          // triggering event's block). The registerDynamicContracts logic + splicing of superseded
+          // later sightings ensures that only the earliest sighting for an address reaches here
+          // with its DC still attached. This gives us the min registrationBlock for persistence
+          // (over the composite PK), which is the core of the #1188 fix.
           let entity: InternalTable.EnvioAddresses.t = {
             id: InternalTable.EnvioAddresses.makeId(~chainId, ~address=dc.address),
             chainId,
             contractName: dc.contractName,
-            registrationBlock: eventItem.blockNumber,
+            registrationBlock: dc.registrationBlock,
             registrationLogIndex: eventItem.logIndex,
           }
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1163,16 +1163,120 @@ describe("FetchState.registerDynamicContracts", () => {
         ~message="Calling it with the same dc for the second time shouldn't change anything",
       ).toBe(fetchStateWithDc1)
 
-      // This is an edge case we currently don't cover
-      // But show a warning in the logs
+      // Earlier registration sighting for a known address must be accepted:
+      // the recorded effectiveStartBlock must become the minimum, and the
+      // DC must be kept (for persistence of the corrected registrationBlock).
+      let earlierItem =
+        makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress1)->dcToItem
+      let afterEarlier =
+        fetchStateWithDc1->FetchState.registerDynamicContracts([earlierItem])
+
+      t.expect(afterEarlier === fetchStateWithDc1, ~message="Must return a new state for correction").toBe(false)
+
+      let corrected =
+        afterEarlier.indexingAddresses
+        ->Dict.get(mockAddress1->Address.toString)
+        ->Option.getUnsafe
+
       t.expect(
-        fetchStateWithDc1->FetchState.registerDynamicContracts([
-          makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress1)->dcToItem,
-        ]),
-        ~message=`BROKEN: Calling it with the same dc
-          but earlier block number should create a new short lived partition
-          for the specific contract from block 0 to 1. And update the dc in db`,
-      ).toBe(fetchStateWithDc1)
+        corrected.effectiveStartBlock,
+        ~message="Must have taken the earlier effective start block (0 in this case after derivation)",
+      ).toBe(0)
+
+      // The item should still carry the DC (not spliced) so persistence sees the early block.
+      t.expect(
+        earlierItem->Internal.getItemDcs->Option.isSome,
+        ~message="DC should remain on the item for the earlier registration (to update DB row)",
+      ).toBe(true)
+    },
+  )
+
+  it(
+    "Within one batch, later registration then earlier one takes the min and keeps the early DC for persistence",
+    t => {
+      let fetchState = makeInitial()
+
+      let lateDc = makeDynContractRegistration(~blockNumber=5, ~contractAddress=mockAddress1)
+      let earlyDc = makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress1)
+      let lateItem = lateDc->dcToItem
+      let earlyItem = earlyDc->dcToItem
+
+      // Simulate unsorted within a batch (later regBlock sighting appears before earlier in items)
+      let updated =
+        fetchState->FetchState.registerDynamicContracts([lateItem, earlyItem])
+
+      t.expect(
+        (lateItem->Internal.getItemDcs, earlyItem->Internal.getItemDcs),
+        ~message=`later (higher block) dc must be spliced even if listed first;
+          early kept so that setBatchDcs will emit the *early* registrationBlock/logIndex`,
+      ).toEqual((Some([]), Some([earlyDc])))
+
+      let ia =
+        updated.indexingAddresses
+        ->Dict.get(mockAddress1->Address.toString)
+        ->Option.getUnsafe
+
+      t.expect(
+        ia.effectiveStartBlock,
+        ~message="indexingAddresses must record the min effectiveStartBlock derived from earliest reg",
+      ).toBe(0)
+
+      // Full shape: earliest wins
+      t.expect(
+        updated.indexingAddresses,
+        ~message="indexingAddresses should reflect the early dc (and static)",
+      ).toEqual(makeIndexingContractsWithDynamics([earlyDc], ~static=[mockAddress0]))
+    },
+  )
+
+  it(
+    "Two successive registerDynamicContracts calls (simulating out-of-order partition responses) - second with earlier block corrects the first",
+    t => {
+      let fetchState = makeInitial()
+
+      let lateDc = makeDynContractRegistration(~blockNumber=5, ~contractAddress=mockAddress1)
+      let lateItem = lateDc->dcToItem
+      let afterLate = fetchState->FetchState.registerDynamicContracts([lateItem])
+
+      // First (later) sighting kept its DC and set its effective
+      t.expect(lateItem->Internal.getItemDcs, ~message="late sighting survived its register").toEqual(
+        Some([lateDc]),
+      )
+      t.expect(
+        afterLate.indexingAddresses
+        ->Dict.get(mockAddress1->Address.toString)
+        ->Option.map(ia => ia.effectiveStartBlock),
+      ).toEqual(Some(5))
+
+      // Now a later-arriving response carries an earlier registration sighting for same addr
+      let earlyDc = makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress1)
+      let earlyItem = earlyDc->dcToItem
+      let afterEarly = afterLate->FetchState.registerDynamicContracts([earlyItem])
+
+      t.expect(
+        afterEarly === afterLate,
+        ~message="second call with earlier must produce a distinct corrected state",
+      ).toBe(false)
+
+      // Early DC must survive filter (not spliced) so its item reaches setBatchDcs
+      t.expect(
+        earlyItem->Internal.getItemDcs,
+        ~message="early dc must be kept on its item",
+      ).toEqual(Some([earlyDc]))
+
+      let ia =
+        afterEarly.indexingAddresses
+        ->Dict.get(mockAddress1->Address.toString)
+        ->Option.getUnsafe
+      t.expect(
+        ia.effectiveStartBlock,
+        ~message="indexingAddresses corrected to min effectiveStartBlock",
+      ).toBe(0)
+
+      // Note on persistence: even if lateItem (from prior call) still carries its dc,
+      // setBatchDcs will process in batch order and later Set for same addr id
+      // (makeId by chain+address) using the early sighting's block/log will overwrite
+      // the higher one in the in-mem EnvioAddresses table (sink persists the last write).
     },
   )
 


### PR DESCRIPTION
Hey folks,

Been running into the "Skipping contract registration: Contract address is already registered at a later block number" warning in a few setups with dynamic contracts. The root seems to be that we key on address in indexingAddresses and just take whatever registration we see first. Because partitions are concurrent and the items coming back from a source query aren't strictly guaranteed to be in block order (plus within a batch), a later sighting could win and lock in a too-high effectiveStartBlock for that address. Then we skip the earlier one and the persisted row in envio_addresses ends up with the wrong (later) block.

This patch makes us prefer the *earliest* registrationBlock we encounter for an address. When we see a strictly earlier sighting we update the record, log a correction at info level instead of the scary warning, and keep the DC attached so it gets persisted with the right (early) block. For stuff we already had indexed we also lower the latestFetchedBlock on the owning partition(s) so we actually fetch the missing earlier range (the client-side filters already drop pre-effective events for other addresses in the same partition). Added a bit of bookkeeping with chosenDcItemByAddress so within a single register call the min wins even if the array isn't perfectly sorted.

Only touched the three files needed for the actual fix + the test updates that were exercising the old (broken) expectations.

Built clean with rescript (124 modules) and the FetchState registerDynamicContracts tests now pass with the new behavior.

Fixes #1188. Would really appreciate a review, especially on the backfill approach (lowering LFB vs. emitting an explicit short gap partition) and anything reorg-related I might have missed. Happy to tweak.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic-contract tracking when the same address is rediscovered with an earlier start block, ensuring the earliest start is used consistently.
  * Corrected the persisted registration block so saved results reflect the earliest valid registration.
  * Improved resilience to out-of-order batch/partition results by adjusting subsequent fetch behavior to recheck corrected earlier ranges.
* **Tests**
  * Expanded `registerDynamicContracts` test coverage for earlier-registration corrections, within-batch ordering, and successive out-of-order updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->