### PR TITLE
Lazily derive contractNameByAddress with memoization

### DIFF
--- a/packages/cli/src/config_parsing/chain_helpers.rs
+++ b/packages/cli/src/config_parsing/chain_helpers.rs
@@ -385,7 +385,6 @@ pub enum Network {
     #[subenum(HypersyncChain, NetworkWithExplorer)]
     SophonTestnet = 531050104,
 
-    #[subenum(HypersyncChain)]
     StatusSepolia = 1660990954,
 
     #[subenum(HypersyncChain)]

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -78,15 +78,12 @@ type query = {
   addressesByContractName: dict<array<Address.t>>,
 }
 
-// Invert addressesByContractName into address→contractName. 1:1 today (each
-// address belongs to one contract), so no key collisions.
-//
-// Resolved lazily when a response needs routing (SourceManager hands it to the
-// source's EventRouter), not stored on the partition. Memoized on the
-// addressesByContractName object so a partition's many responses share one
-// derivation, and a factory with millions of addresses never rebuilds the whole
-// index. The dict is immutable after construction (every mutation produces a new
-// dict), so identity is sound.
+// Invert addressesByContractName into address→contractName for log-ownership
+// routing. 1:1 today (each address belongs to one contract), so no key
+// collisions. Memoized on the addressesByContractName object so a partition's
+// many responses share one derivation and a large factory never rebuilds the
+// whole index; sound because the dict is immutable after construction (every
+// mutation produces a new dict).
 let deriveContractNameByAddress: dict<array<Address.t>> => dict<
   string,
 > = Utils.WeakMap.memoize(addressesByContractName => {

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -41,12 +41,6 @@ type partition = {
   latestFetchedBlock: blockNumberAndTimestamp,
   selection: selection,
   addressesByContractName: dict<array<Address.t>>,
-  // Reverse index address→contractName, derived from addressesByContractName.
-  // Used by EventRouter to resolve a log's owning contract from the partition
-  // that fetched it (instead of a chain-wide snapshot). Always recomputed in
-  // OptimizedPartitions.make, so partition literals can seed it with an empty
-  // dict.
-  contractNameByAddress: dict<string>,
   mergeBlock: option<int>,
   // When set, partition indexes a single dynamic contract type.
   // The addressesByContractName must contain only addresses for this contract.
@@ -82,16 +76,20 @@ type query = {
   mutable progress: float,
   selection: selection,
   addressesByContractName: dict<array<Address.t>>,
-  // The owning partition's reverse index, referenced (not copied) so routing
-  // resolves ownership without a chain-wide snapshot.
-  contractNameByAddress: dict<string>,
 }
 
 // Invert addressesByContractName into address→contractName. 1:1 today (each
 // address belongs to one contract), so no key collisions.
-let deriveContractNameByAddress = (addressesByContractName: dict<array<Address.t>>): dict<
+//
+// Resolved lazily when a response needs routing (SourceManager hands it to the
+// source's EventRouter), not stored on the partition. Memoized on the
+// addressesByContractName object so a partition's many responses share one
+// derivation, and a factory with millions of addresses never rebuilds the whole
+// index. The dict is immutable after construction (every mutation produces a new
+// dict), so identity is sound.
+let deriveContractNameByAddress: dict<array<Address.t>> => dict<
   string,
-> => {
+> = Utils.WeakMap.memoize(addressesByContractName => {
   let result = Dict.make()
   addressesByContractName->Utils.Dict.forEachWithKey((addresses, contractName) => {
     for i in 0 to addresses->Array.length - 1 {
@@ -99,7 +97,7 @@ let deriveContractNameByAddress = (addressesByContractName: dict<array<Address.t
     }
   })
   result
-}
+})
 
 // Default estimate for a query whose partition hasn't responded yet, so the
 // shared budget still accounts for unknown queries instead of treating them as
@@ -214,7 +212,6 @@ module OptimizedPartitions = {
         latestFetchedBlock: {blockNumber: potentialMergeBlock, blockTimestamp: 0},
         mergeBlock: None,
         addressesByContractName: Dict.make(), // set below
-        contractNameByAddress: Dict.make(), // derived in make
         mutPendingQueries: [],
         prevQueryRange: minRange,
         prevPrevQueryRange: minRange,
@@ -397,12 +394,7 @@ module OptimizedPartitions = {
     for idx in 0 to partitionsCount - 1 {
       let p = newPartitions->Array.getUnsafe(idx)
       idsInAscOrder->Array.setUnsafe(idx, p.id)
-      // Single point where every partition's reverse index is (re)derived, so all
-      // construction paths (literals, spreads, merges, splits) stay consistent.
-      entities->Dict.set(
-        p.id,
-        {...p, contractNameByAddress: deriveContractNameByAddress(p.addressesByContractName)},
-      )
+      entities->Dict.set(p.id, p)
     }
 
     {
@@ -901,7 +893,6 @@ OptimizedPartitions.t => {
             selection: normalSelection,
             dynamicContract: isDynamic ? Some(contractName) : None,
             addressesByContractName,
-            contractNameByAddress: Dict.make(), // derived in make
             mergeBlock: None,
             mutPendingQueries: [],
             prevQueryRange: 0,
@@ -1244,7 +1235,6 @@ let registerDynamicContracts = (
                         selection: fetchState.normalSelection,
                         dynamicContract: Some(contractName),
                         addressesByContractName,
-                        contractNameByAddress: Dict.make(), // derived in make
                         mergeBlock: None,
                         mutPendingQueries: p.mutPendingQueries,
                         prevQueryRange: p.prevQueryRange,
@@ -1396,7 +1386,6 @@ let pushQueriesForRange = (
           chainId: 0,
           progress: 0.,
           addressesByContractName,
-          contractNameByAddress: partition.contractNameByAddress,
         })
       | Some(chunkRange) =>
         let maxBlock = switch rangeEndBlock {
@@ -1426,7 +1415,6 @@ let pushQueriesForRange = (
               chainId: 0,
               progress: 0.,
               addressesByContractName,
-              contractNameByAddress: partition.contractNameByAddress,
             })
             chunkFromBlock := chunkToBlock + 1
             chunkIdx := chunkIdx.contents + 1
@@ -1448,7 +1436,6 @@ let pushQueriesForRange = (
             chainId: 0,
             progress: 0.,
             addressesByContractName,
-            contractNameByAddress: partition.contractNameByAddress,
           })
         }
       }
@@ -1703,7 +1690,6 @@ let make = (
         eventConfigs: notDependingOnAddresses,
       },
       addressesByContractName: Dict.make(),
-      contractNameByAddress: Dict.make(), // derived in make
       mergeBlock: None,
       dynamicContract: None,
       mutPendingQueries: [],

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -676,7 +676,7 @@ let executeQuery = async (
         ~fromBlock=query.fromBlock,
         ~toBlock,
         ~addressesByContractName=query.addressesByContractName,
-        ~contractNameByAddress=query.contractNameByAddress,
+        ~contractNameByAddress=query.addressesByContractName->FetchState.deriveContractNameByAddress,
         ~partitionId=query.partitionId,
         ~knownHeight,
         ~selection=query.selection,

--- a/scenarios/test_codegen/test/IndexerState_test.res
+++ b/scenarios/test_codegen/test/IndexerState_test.res
@@ -13,7 +13,6 @@ let defaultQuery: FetchState.query = {
   progress: 0.,
   selection: {FetchState.dependsOnAddresses: false, eventConfigs: []},
   addressesByContractName: Dict.make(),
-  contractNameByAddress: Dict.make(),
 }
 
 let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) => {
@@ -99,7 +98,6 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
             eventConfigs,
           },
           addressesByContractName: Dict.make(),
-          contractNameByAddress: Dict.make(),
         }
 
         fetchState.contents->FetchState.startFetchingQueries(~queries=[query])
@@ -280,7 +278,6 @@ describe("IndexerState", () => {
                 isChunk: false,
                 selection: {dependsOnAddresses: false, eventConfigs},
                 addressesByContractName: Dict.make(),
-                contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
               }
               fetchState.contents->FetchState.startFetchingQueries(~queries=[query])
               fetchState :=
@@ -363,7 +360,6 @@ describe("IndexerState", () => {
           isChunk: false,
           selection: {dependsOnAddresses: false, eventConfigs},
           addressesByContractName: Dict.make(),
-          contractNameByAddress: Dict.make(),
         }
         cs->ChainState.startFetchingQueries(~queries=[concurrentQuery])
         cs->ChainState.handleQueryResult(

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -82,7 +82,6 @@ let makeFetchingChainState = (~chainId, ~knownHeight, ~latestFetchedBlock) => {
     latestFetchedBlock: {blockNumber: latestFetchedBlock, blockTimestamp: 0},
     selection: normalSelection,
     addressesByContractName: Dict.fromArray([("MockContract", [address])]),
-    contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("MockContract", [address])])),
     mergeBlock: None,
     dynamicContract: None,
     mutPendingQueries: [],

--- a/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
@@ -15,7 +15,6 @@ let defaultQuery: FetchState.query = {
   progress: 0.,
   selection: {FetchState.dependsOnAddresses: false, eventConfigs: []},
   addressesByContractName: Dict.make(),
-  contractNameByAddress: Dict.make(),
 }
 
 let mockAddress0 = Envio.TestHelpers.Addresses.mockAddresses[0]->Option.getOrThrow
@@ -98,7 +97,6 @@ describe("FetchState onBlock functionality", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
       fromBlock: 0,
     }
     fetchState->FetchState.startFetchingQueries(~queries=[query])
@@ -147,7 +145,6 @@ describe("FetchState onBlock functionality", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
       fromBlock: 0,
     }
     fetchState->FetchState.startFetchingQueries(~queries=[query])
@@ -197,7 +194,6 @@ describe("FetchState onBlock functionality", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
       fromBlock: 0,
     }
     fetchState->FetchState.startFetchingQueries(~queries=[query])
@@ -251,7 +247,6 @@ describe("FetchState onBlock functionality", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
       fromBlock: 0,
     }
     fetchState->FetchState.startFetchingQueries(~queries=[query])
@@ -308,7 +303,6 @@ describe("FetchState onBlock functionality", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
       fromBlock: 0,
     }
     fetchState->FetchState.startFetchingQueries(~queries=[query])

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -17,7 +17,6 @@ let defaultQuery: FetchState.query = {
   progress: 0.,
   selection: {FetchState.dependsOnAddresses: false, eventConfigs: []},
   addressesByContractName: Dict.make(),
-  contractNameByAddress: Dict.make(),
 }
 
 // Keep for backward compatibility of tests
@@ -181,7 +180,6 @@ describe("FetchState.make", () => {
             },
             selection: fetchState.normalSelection,
             addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
             mergeBlock: None,
             dynamicContract: None,
             mutPendingQueries: [],
@@ -301,7 +299,6 @@ describe("FetchState.make", () => {
             addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress1, mockAddress2])]),
             mergeBlock: None,
             dynamicContract: Some("Gravatar"),
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress1, mockAddress2])])),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -360,7 +357,6 @@ describe("FetchState.make", () => {
               addressesByContractName: Dict.fromArray([("ContractA", [mockAddress1])]),
               mergeBlock: None,
               dynamicContract: None,
-              contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("ContractA", [mockAddress1])])),
               mutPendingQueries: [],
               prevQueryRange: 0,
               prevRangeSize: 0,
@@ -377,7 +373,6 @@ describe("FetchState.make", () => {
               addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress2])]),
               mergeBlock: None,
               dynamicContract: Some("Gravatar"),
-              contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress2])])),
               mutPendingQueries: [],
               prevQueryRange: 0,
               prevRangeSize: 0,
@@ -449,7 +444,6 @@ describe("FetchState.make", () => {
               addressesByContractName: Dict.fromArray([("ContractA", [mockAddress1])]),
               mergeBlock: None,
               dynamicContract: None,
-              contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("ContractA", [mockAddress1])])),
               mutPendingQueries: [],
               prevQueryRange: 0,
               prevRangeSize: 0,
@@ -466,7 +460,6 @@ describe("FetchState.make", () => {
               addressesByContractName: Dict.fromArray([("ContractA", [mockAddress2])]),
               mergeBlock: None,
               dynamicContract: None,
-              contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("ContractA", [mockAddress2])])),
               mutPendingQueries: [],
               prevQueryRange: 0,
               prevRangeSize: 0,
@@ -483,7 +476,6 @@ describe("FetchState.make", () => {
               addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
               mergeBlock: None,
               dynamicContract: Some("Gravatar"),
-              contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress3])])),
               mutPendingQueries: [],
               prevQueryRange: 0,
               prevRangeSize: 0,
@@ -500,7 +492,6 @@ describe("FetchState.make", () => {
               addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress4])]),
               mergeBlock: None,
               dynamicContract: Some("Gravatar"),
-              contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress4])])),
               mutPendingQueries: [],
               prevQueryRange: 0,
               prevRangeSize: 0,
@@ -783,6 +774,31 @@ describe("FetchState.make", () => {
       (partitions.entities->Dict.getUnsafe("0")).mergeBlock,
       ~message="filterByAddresses: merged partition has no mergeBlock",
     ).toEqual(None)
+  })
+})
+
+describe("FetchState.deriveContractNameByAddress", () => {
+  // The reverse index is derived lazily at routing time, not stored on the
+  // partition. Memoization on the addressesByContractName object is what keeps a
+  // factory with millions of addresses from rebuilding it on every one of a
+  // partition's responses, so guard the cache: the same addresses object reuses
+  // the same index, a different object derives its own, and both are correct.
+  it("Memoizes the reverse index by addressesByContractName identity", t => {
+    let addressesByContractName = Dict.fromArray([("Gravatar", [mockAddress0, mockAddress1])])
+    let first = addressesByContractName->FetchState.deriveContractNameByAddress
+    let again = addressesByContractName->FetchState.deriveContractNameByAddress
+    let other =
+      Dict.fromArray([("Gravatar", [mockAddress2])])->FetchState.deriveContractNameByAddress
+
+    t.expect(
+      (
+        first === again,
+        first === other,
+        first->Dict.get(mockAddress0->Address.toString),
+        other->Dict.get(mockAddress2->Address.toString),
+      ),
+      ~message="same addresses object reuses the cached index; a new object derives its own",
+    ).toEqual((true, false, Some("Gravatar"), Some("Gravatar")))
   })
 })
 
@@ -1213,9 +1229,6 @@ describe("FetchState.registerDynamicContracts", () => {
         ]),
         mergeBlock: None,
         dynamicContract: Some("Gravatar"),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([
-          ("Gravatar", [mockAddress1, mockAddress2, mockAddress3]),
-        ])),
         mutPendingQueries: [],
         prevQueryRange: 0,
         prevRangeSize: 0,
@@ -1232,7 +1245,6 @@ describe("FetchState.registerDynamicContracts", () => {
         addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress4, mockAddress0])]),
         mergeBlock: None,
         dynamicContract: Some("Gravatar"),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress4, mockAddress0])])),
         mutPendingQueries: [],
         prevQueryRange: 0,
         prevRangeSize: 0,
@@ -1280,7 +1292,6 @@ describe("FetchState.registerDynamicContracts", () => {
         addressesByContractName: Dict.fromArray([("NftFactory", [mockAddress1, mockAddress4])]),
         mergeBlock: None,
         dynamicContract: Some("NftFactory"),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("NftFactory", [mockAddress1, mockAddress4])])),
         mutPendingQueries: [],
         prevQueryRange: 0,
         prevRangeSize: 0,
@@ -1299,9 +1310,6 @@ describe("FetchState.registerDynamicContracts", () => {
         ]),
         mergeBlock: None,
         dynamicContract: Some("Gravatar"),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([
-          ("Gravatar", [mockAddress2, mockAddress3, mockAddress0]),
-        ])),
         mutPendingQueries: [],
         prevQueryRange: 0,
         prevRangeSize: 0,
@@ -1457,7 +1465,6 @@ describe("FetchState.registerDynamicContracts", () => {
         addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress1, mockAddress0])]),
         mergeBlock: None,
         dynamicContract: Some("Gravatar"),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress1, mockAddress0])])),
         mutPendingQueries: [],
         prevQueryRange: 0,
         prevRangeSize: 0,
@@ -1508,9 +1515,6 @@ describe("FetchState.registerDynamicContracts", () => {
           ("Gravatar", [mockAddress1, mockAddress2, mockAddress0]),
         ]),
         dynamicContract: Some("Gravatar"),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([
-          ("Gravatar", [mockAddress1, mockAddress2, mockAddress0]),
-        ])),
         mutPendingQueries: [],
         prevQueryRange: 0,
         prevRangeSize: 0,
@@ -1528,7 +1532,6 @@ describe("FetchState.registerDynamicContracts", () => {
         // The partition is too far, so we don't merge addresses from the prev partition too early
         addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
         dynamicContract: Some("Gravatar"),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress3])])),
         mutPendingQueries: [],
         prevQueryRange: 0,
         prevRangeSize: 0,
@@ -1609,7 +1612,6 @@ describe("FetchState.registerDynamicContracts", () => {
               addressesByContractName: Dict.make(),
               mergeBlock: None,
               dynamicContract: None,
-              contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
               mutPendingQueries: [],
               prevQueryRange: 0,
               prevRangeSize: 0,
@@ -1631,9 +1633,6 @@ describe("FetchState.registerDynamicContracts", () => {
               ]),
               mergeBlock: None,
               dynamicContract: Some("NftFactory"),
-              contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([
-                ("NftFactory", [mockAddress0, mockAddress1, mockAddress5]),
-              ])),
               mutPendingQueries: [],
               prevQueryRange: 0,
               prevRangeSize: 0,
@@ -1680,7 +1679,6 @@ describe("FetchState.getNextQuery & integration", () => {
               blockTimestamp: 10,
             },
             dynamicContract: None,
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -1735,9 +1733,6 @@ describe("FetchState.getNextQuery & integration", () => {
               blockTimestamp: 10,
             },
             dynamicContract: Some("Gravatar"),
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([
-              ("Gravatar", [mockAddress0, mockAddress1, mockAddress2]),
-            ])),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -1756,9 +1751,6 @@ describe("FetchState.getNextQuery & integration", () => {
               blockTimestamp: 0,
             },
             dynamicContract: Some("Gravatar"),
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([
-              ("Gravatar", [mockAddress0, mockAddress1, mockAddress2]),
-            ])),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -1829,7 +1821,6 @@ describe("FetchState.getNextQuery & integration", () => {
           toBlock: None,
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
           isChunk: false,
         },
       ]),
@@ -1930,7 +1921,6 @@ describe("FetchState.getNextQuery & integration", () => {
           toBlock: Some(8),
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
           fromBlock: 0,
           isChunk: false,
         },
@@ -1950,7 +1940,6 @@ describe("FetchState.getNextQuery & integration", () => {
           toBlock: Some(8),
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
           fromBlock: 0,
           isChunk: false,
         },
@@ -2000,9 +1989,6 @@ describe("FetchState.getNextQuery & integration", () => {
         addressesByContractName: Dict.fromArray([
           ("Gravatar", [mockAddress0, mockAddress1, mockAddress2]),
         ]),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(
-          Dict.fromArray([("Gravatar", [mockAddress0, mockAddress1, mockAddress2])]),
-        ),
       },
       {
         id: "1",
@@ -2014,7 +2000,6 @@ describe("FetchState.getNextQuery & integration", () => {
         addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress1, mockAddress2])]),
         mergeBlock: Some(10),
         dynamicContract: Some("Gravatar"),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress1, mockAddress2])])),
         mutPendingQueries: [],
         prevQueryRange: 0,
         prevRangeSize: 0,
@@ -2032,7 +2017,6 @@ describe("FetchState.getNextQuery & integration", () => {
         addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
         mergeBlock: None,
         dynamicContract: Some("Gravatar"),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress3])])),
         mutPendingQueries: [],
         prevQueryRange: 0,
         prevRangeSize: 0,
@@ -2054,7 +2038,6 @@ describe("FetchState.getNextQuery & integration", () => {
           isChunk: false,
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress1, mockAddress2])]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress1, mockAddress2])])),
           fromBlock: 1,
         },
         {
@@ -2066,7 +2049,6 @@ describe("FetchState.getNextQuery & integration", () => {
           isChunk: false,
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress3])])),
         },
         // Partition 0 is not included since it's below knownHeight
       ]),
@@ -2115,7 +2097,6 @@ describe("FetchState.getNextQuery & integration", () => {
       toBlock: None,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress3])])),
       isChunk: false,
     }
     let expectedPartition0Query: FetchState.query = {
@@ -2127,9 +2108,6 @@ describe("FetchState.getNextQuery & integration", () => {
       addressesByContractName: Dict.fromArray([
         ("Gravatar", [mockAddress0, mockAddress1, mockAddress2]),
       ]),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([
-        ("Gravatar", [mockAddress0, mockAddress1, mockAddress2]),
-      ])),
       fromBlock: 11,
       isChunk: false,
     }
@@ -2174,7 +2152,6 @@ describe("FetchState.getNextQuery & integration", () => {
           toBlock: None,
           selection: originalFetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress3])])),
           fromBlock: 3,
           isChunk: false,
         },
@@ -2187,9 +2164,6 @@ describe("FetchState.getNextQuery & integration", () => {
           addressesByContractName: Dict.fromArray([
             ("Gravatar", [mockAddress0, mockAddress1, mockAddress2]),
           ]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([
-            ("Gravatar", [mockAddress0, mockAddress1, mockAddress2]),
-          ])),
           fromBlock: 11,
           isChunk: false,
         },
@@ -2211,7 +2185,6 @@ describe("FetchState.getNextQuery & integration", () => {
           toBlock: Some(10),
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress3])])),
           fromBlock: 3,
           isChunk: false,
         },
@@ -2224,9 +2197,6 @@ describe("FetchState.getNextQuery & integration", () => {
           addressesByContractName: Dict.fromArray([
             ("Gravatar", [mockAddress0, mockAddress1, mockAddress2, mockAddress3]),
           ]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([
-            ("Gravatar", [mockAddress0, mockAddress1, mockAddress2, mockAddress3]),
-          ])),
           fromBlock: 11,
           isChunk: false,
         },
@@ -2300,9 +2270,6 @@ describe("FetchState.getNextQuery & integration", () => {
           {
             id: "0",
             dynamicContract: Some("Gravatar"),
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([
-              ("Gravatar", [mockAddress0, mockAddress1, mockAddress2, mockAddress3]),
-            ])),
             mutPendingQueries: [
               {
                 fromBlock: 11,
@@ -2385,7 +2352,6 @@ describe("FetchState.getNextQuery & integration", () => {
             eventConfigs: [wildcard],
           },
           addressesByContractName: Dict.make(),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
         },
         {
           ...defaultQuery,
@@ -2396,7 +2362,6 @@ describe("FetchState.getNextQuery & integration", () => {
           isChunk: false,
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("ContractA", [mockAddress1])]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("ContractA", [mockAddress1])])),
         },
         {
           ...defaultQuery,
@@ -2407,7 +2372,6 @@ describe("FetchState.getNextQuery & integration", () => {
           isChunk: false,
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress2])]),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress2])])),
         },
       ]),
     )
@@ -2434,7 +2398,6 @@ describe("FetchState.getNextQuery & integration", () => {
               blockTimestamp: 0,
             },
             dynamicContract: Some("Gravatar"),
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress3])])),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -2451,7 +2414,6 @@ describe("FetchState.getNextQuery & integration", () => {
               blockTimestamp: 0,
             },
             dynamicContract: Some("Gravatar"),
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress3])])),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -2488,7 +2450,6 @@ describe("FetchState.getNextQuery & integration", () => {
               blockTimestamp: 0,
             },
             dynamicContract: Some("Gravatar"),
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0, mockAddress1])])),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -2527,7 +2488,6 @@ describe("FetchState.getNextQuery & integration", () => {
               blockTimestamp: 0,
             },
             dynamicContract: Some("Gravatar"),
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -2585,7 +2545,6 @@ describe("FetchState.getNextQuery & integration", () => {
             eventConfigs: wildcardEventConfigs,
           },
           addressesByContractName: Dict.make(),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
           fromBlock: 0,
           isChunk: false,
         },
@@ -2616,7 +2575,6 @@ describe("FetchState.getNextQuery & integration", () => {
               blockTimestamp: 0,
             },
             dynamicContract: None,
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -2654,7 +2612,6 @@ describe("FetchState unit tests for specific cases", () => {
               blockTimestamp: 10,
             },
             dynamicContract: None,
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -2671,7 +2628,6 @@ describe("FetchState unit tests for specific cases", () => {
               blockTimestamp: 0,
             },
             dynamicContract: None,
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -2704,7 +2660,6 @@ describe("FetchState unit tests for specific cases", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.make(),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
     }
 
     fetchState->FetchState.startFetchingQueries(~queries=[query])
@@ -2748,7 +2703,6 @@ describe("FetchState unit tests for specific cases", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.make(),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
     }
 
     fetchState->FetchState.startFetchingQueries(~queries=[query])
@@ -2805,7 +2759,6 @@ describe("FetchState unit tests for specific cases", () => {
         eventConfigs: [wildcard],
       },
       addressesByContractName: Dict.make(),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
     }
     let query1: FetchState.query = {
       ...defaultQuery,
@@ -2816,7 +2769,6 @@ describe("FetchState unit tests for specific cases", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.make(),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
     }
 
     fetchState->FetchState.startFetchingQueries(~queries=[query0, query1])
@@ -2854,7 +2806,6 @@ describe("FetchState unit tests for specific cases", () => {
             eventConfigs: [wildcard],
           },
           addressesByContractName: Dict.make(),
-          contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
         },
       ]),
     )
@@ -2891,7 +2842,6 @@ describe("FetchState unit tests for specific cases", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.make(),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
     }
 
     fetchState->FetchState.startFetchingQueries(~queries=[query])
@@ -2959,7 +2909,6 @@ describe("FetchState unit tests for specific cases", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.make(),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
     }
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     let updatedFetchState =
@@ -2990,7 +2939,6 @@ describe("FetchState unit tests for specific cases", () => {
             id: "0",
             latestFetchedBlock,
             dynamicContract: None,
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -3004,7 +2952,6 @@ describe("FetchState unit tests for specific cases", () => {
             id: "1",
             latestFetchedBlock,
             dynamicContract: None,
-            contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
             mutPendingQueries: [],
             prevQueryRange: 0,
             prevRangeSize: 0,
@@ -3078,7 +3025,6 @@ describe("FetchState unit tests for specific cases", () => {
       isChunk: false,
       selection: makeInitial().normalSelection,
       addressesByContractName: Dict.make(),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
     }
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     t.expect(
@@ -3104,7 +3050,6 @@ describe("FetchState unit tests for specific cases", () => {
         isChunk: false,
         selection: fetchState.normalSelection,
         addressesByContractName: Dict.make(),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
       }
       fetchState->FetchState.startFetchingQueries(~queries=[query])
       fetchState->FetchState.handleQueryResult(
@@ -3158,7 +3103,6 @@ describe("FetchState unit tests for specific cases", () => {
         estResponseSize: 10000.,
         selection: fetchState.normalSelection,
         addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress1])]),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress1])])),
         fromBlock: 0,
         toBlock: None,
         isChunk: false,
@@ -3222,7 +3166,6 @@ describe("FetchState unit tests for specific cases", () => {
       let partition2Query = {
         ...queries->Array.getUnsafe(0),
         addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress3])])),
         partitionId: "2",
         toBlock: None, // Didn't merge because reached max addresses in partition
         fromBlock: 200,
@@ -3278,7 +3221,6 @@ describe("FetchState.sortForBatch", () => {
       isChunk: false,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.make(),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
       fromBlock: 0,
     }
   }
@@ -3598,7 +3540,6 @@ describe("FetchState progress tracking", () => {
       isChunk: false,
       selection: fs0.normalSelection,
       addressesByContractName: Dict.make(),
-      contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.make()),
       fromBlock: 0,
     }
     fs0->FetchState.startFetchingQueries(~queries=[query])
@@ -3673,7 +3614,6 @@ describe("FetchState buffer overflow prevention", () => {
         isChunk: false,
         selection: fetchStateWithTwoPartitions.normalSelection,
         addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
         fromBlock: 0,
       }
 
@@ -3721,7 +3661,6 @@ describe("FetchState buffer overflow prevention", () => {
         isChunk: false,
         selection: fetchState.normalSelection,
         addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
-        contractNameByAddress: FetchState.deriveContractNameByAddress(Dict.fromArray([("Gravatar", [mockAddress0])])),
         fromBlock: 0,
       }
       fetchState->FetchState.startFetchingQueries(~queries=[query3])

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -13,7 +13,6 @@ let defaultQuery: FetchState.query = {
   progress: 0.,
   selection: {FetchState.dependsOnAddresses: false, eventConfigs: []},
   addressesByContractName: Dict.make(),
-  contractNameByAddress: Dict.make(),
 }
 
 type executeQueryMock = {
@@ -190,7 +189,6 @@ describe("SourceManager source priority with Live sources", () => {
     isChunk: false,
     selection,
     addressesByContractName,
-    contractNameByAddress: Dict.make(),
   }
 
   Async.it(
@@ -424,7 +422,6 @@ describe("SourceManager fetchNext", () => {
       },
       selection: normalSelection,
       addressesByContractName,
-      contractNameByAddress: FetchState.deriveContractNameByAddress(addressesByContractName),
       mergeBlock: None,
       dynamicContract: None,
       mutPendingQueries: [],
@@ -579,7 +576,6 @@ describe("SourceManager fetchNext", () => {
           isChunk: false,
           selection: normalSelection,
           addressesByContractName: partition2.addressesByContractName,
-          contractNameByAddress: partition2.contractNameByAddress,
         },
         {
           ...defaultQuery,
@@ -590,7 +586,6 @@ describe("SourceManager fetchNext", () => {
           isChunk: false,
           selection: normalSelection,
           addressesByContractName: partition0.addressesByContractName,
-          contractNameByAddress: partition0.contractNameByAddress,
         },
         {
           ...defaultQuery,
@@ -601,7 +596,6 @@ describe("SourceManager fetchNext", () => {
           isChunk: false,
           selection: normalSelection,
           addressesByContractName: partition1.addressesByContractName,
-          contractNameByAddress: partition1.contractNameByAddress,
         },
       ])
 
@@ -1479,7 +1473,6 @@ describe("SourceManager.executeQuery", () => {
     isChunk: false,
     selection,
     addressesByContractName,
-    contractNameByAddress: Dict.make(),
   }
 
   Async.it("Successfully executes the query", async t => {


### PR DESCRIPTION
## Summary

Move `contractNameByAddress` derivation from partition construction time to lazy evaluation at routing time, with memoization on the `addressesByContractName` object identity to avoid redundant recomputation.

## Changes

- **Remove stored field**: Delete `contractNameByAddress` from both `partition` and `query` types in `FetchState.res`
- **Implement memoization**: Wrap `deriveContractNameByAddress` with `Utils.WeakMap.memoize` so the same `addressesByContractName` object always returns the cached index
- **Lazy derivation**: Compute the reverse index on-demand in `SourceManager.executeQuery` when passing it to `EventRouter`, rather than storing it on every partition
- **Update tests**: Remove all `contractNameByAddress` field assignments from test fixtures and add a new test verifying memoization behavior by object identity

## Implementation Details

The `deriveContractNameByAddress` function now uses weak-map memoization keyed by the `addressesByContractName` dict object. This ensures:
- A partition's many responses share a single derived index (no redundant work)
- A factory with millions of addresses never rebuilds the whole index per response
- Identity-based caching is sound because dicts are immutable after construction

The reverse index is resolved only when a response needs routing, eliminating the need to store it on every partition and query object, reducing memory overhead and simplifying the data model.

https://claude.ai/code/session_01UmHVvaGi25B8eyzLxNrnyN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contract routing during query execution by deriving the address-to-contract mapping on demand for more consistent results.
  * Updated partition and query handling so reverse mapping is derived from existing inputs rather than stored redundantly.
  * Corrected how `StatusSepolia` is classified in CLI network parsing.
* **Tests**
  * Added coverage to confirm derived mapping reuse when inputs match.
  * Updated expected query/partition shapes to reflect the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->