### PR TITLE
Add eth_getLogs support to EvmRpcClient with event decoding

### DIFF
--- a/packages/cli/src/evm_hypersync_source/decode.rs
+++ b/packages/cli/src/evm_hypersync_source/decode.rs
@@ -7,11 +7,9 @@ use alloy_primitives::B256;
 use anyhow::{Context, Result};
 use hypersync_client::format::{Data, Hex, LogArgument};
 use hypersync_client::simple_types;
-use napi_derive::napi;
 
-use crate::evm_hypersync_source::{
-    map_err,
-    types::{sol_value_to_param, Event, EventParamsInput, Log, ParamMeta, ParamValue},
+use crate::evm_hypersync_source::types::{
+    sol_value_to_param, EventParamsInput, Log, ParamMeta, ParamValue,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -260,38 +258,6 @@ fn same_decode_layout(a: &[ParamMeta], b: &[ParamMeta]) -> bool {
                     _ => false,
                 }
         })
-}
-
-#[napi]
-#[derive(Clone)]
-pub struct EvmDecoder {
-    core: DecoderCore,
-}
-
-#[napi]
-impl EvmDecoder {
-    #[napi(factory)]
-    pub fn from_params(
-        event_params: Vec<EventParamsInput>,
-        checksum_addresses: Option<bool>,
-    ) -> napi::Result<EvmDecoder> {
-        let core = DecoderCore::from_params(event_params, checksum_addresses.unwrap_or(false))
-            .map_err(map_err)?;
-        Ok(Self { core })
-    }
-
-    #[napi]
-    pub async fn decode_logs(&self, events: Vec<Event>) -> napi::Result<Vec<Option<ParamValue>>> {
-        let core = self.core.clone();
-        tokio::task::spawn_blocking(move || {
-            events
-                .iter()
-                .map(|event| core.decode_napi(&event.log).ok().flatten())
-                .collect::<Vec<_>>()
-        })
-        .await
-        .map_err(|e| map_err(anyhow::anyhow!("decode_logs worker join failure: {e}")))
-    }
 }
 
 #[cfg(test)]

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -8,7 +8,7 @@ use napi_derive::napi;
 use crate::transaction_store::TransactionStore;
 
 mod config;
-mod decode;
+pub(crate) mod decode;
 mod query;
 pub(crate) mod types;
 

--- a/packages/cli/src/evm_hypersync_source/types.rs
+++ b/packages/cli/src/evm_hypersync_source/types.rs
@@ -10,15 +10,6 @@ use hypersync_client::{
 use napi::bindgen_prelude::{BigInt, FromNapiValue, ToNapiValue};
 use napi_derive::napi;
 
-/// Data relating to a single event (log). Only the log is needed: params are
-/// decoded from it, and the transaction/block are served from the store.
-#[napi(object)]
-#[derive(Default, Clone)]
-pub struct Event {
-    /// Evm log data
-    pub log: Log,
-}
-
 /// Evm log object
 ///
 /// See ethereum rpc spec for the meaning of fields
@@ -245,38 +236,6 @@ impl Block {
             send_count: map_hex_string(&b.send_count),
             send_root: map_hex_string(&b.send_root),
             mix_hash: map_hex_string(&b.mix_hash),
-        })
-    }
-}
-
-impl Log {
-    pub fn from_simple(l: &simple_types::Log, should_checksum: bool) -> Result<Self> {
-        Ok(Self {
-            removed: l.removed,
-            log_index: l
-                .log_index
-                .map(|n| u64::from(n).try_into())
-                .transpose()
-                .context("mapping log.log_index")?,
-            transaction_index: l
-                .transaction_index
-                .map(|n| u64::from(n).try_into())
-                .transpose()
-                .context("mapping log.transaction_index")?,
-            transaction_hash: map_hex_string(&l.transaction_hash),
-            block_hash: map_hex_string(&l.block_hash),
-            block_number: l
-                .block_number
-                .map(|n| u64::from(n).try_into())
-                .transpose()
-                .context("mapping log.block_number")?,
-            address: map_address_string(&l.address, should_checksum),
-            data: map_hex_string(&l.data),
-            topics: l
-                .topics
-                .iter()
-                .map(|t| t.as_ref().map(|v| v.encode_hex()))
-                .collect(),
         })
     }
 }

--- a/packages/cli/src/evm_rpc_source/mod.rs
+++ b/packages/cli/src/evm_rpc_source/mod.rs
@@ -133,6 +133,15 @@ impl EvmRpcClient {
 
     #[napi]
     pub async fn get_logs(&self, params: GetLogsParams) -> napi::Result<Vec<RpcEventItem>> {
+        // Hex-formatting a negative i64 yields a two's-complement quantity, which
+        // would silently widen the queried range; reject it at the boundary.
+        if params.from_block < 0 || params.to_block < 0 {
+            return Err(map_err(anyhow::anyhow!(
+                "block bounds must be non-negative, got from_block={}, to_block={}",
+                params.from_block,
+                params.to_block,
+            )));
+        }
         let mut filter = json!({
             "fromBlock": format!("0x{:x}", params.from_block),
             "toBlock": format!("0x{:x}", params.to_block),

--- a/packages/cli/src/evm_rpc_source/mod.rs
+++ b/packages/cli/src/evm_rpc_source/mod.rs
@@ -29,17 +29,18 @@ pub struct GetLogsParams {
 /// A log returned from `eth_getLogs`, with hex quantities decoded to integers.
 /// Field names cross the napi boundary as camelCase, matching the ReScript
 /// `Rpc.GetLogs.log` record.
+// Only the fields the ReScript side reads cross the boundary. `data` is consumed
+// by the decoder on the Rust side (see `to_decoder_log`) and `removed` is unused,
+// so neither is carried here.
 #[napi(object)]
 pub struct RpcLog {
     pub address: String,
     pub topics: Vec<String>,
-    pub data: String,
     pub block_number: i64,
     pub transaction_hash: String,
     pub transaction_index: i64,
     pub block_hash: String,
     pub log_index: i64,
-    pub removed: bool,
 }
 
 #[napi(object)]
@@ -63,7 +64,6 @@ struct RawLog {
     transaction_index: String,
     block_hash: String,
     log_index: String,
-    removed: bool,
 }
 
 impl RawLog {
@@ -79,10 +79,8 @@ impl RawLog {
             log_index: to_i64(&self.log_index).context("log.logIndex")?,
             address: self.address,
             topics: self.topics,
-            data: self.data,
             transaction_hash: self.transaction_hash,
             block_hash: self.block_hash,
-            removed: self.removed,
         })
     }
 
@@ -107,7 +105,7 @@ impl EvmRpcClient {
     pub fn new(
         cfg: EvmRpcClientConfig,
         event_params: Vec<EventParamsInput>,
-        checksum_addresses: Option<bool>,
+        checksum_addresses: bool,
     ) -> napi::Result<EvmRpcClient> {
         let http_req_timeout_millis = cfg
             .http_req_timeout_millis
@@ -116,7 +114,7 @@ impl EvmRpcClient {
                 v as u64
             });
         let inner = JsonRpcClient::new(cfg.url, http_req_timeout_millis).map_err(map_err)?;
-        let decoder = DecoderCore::from_params(event_params, checksum_addresses.unwrap_or(false))
+        let decoder = DecoderCore::from_params(event_params, checksum_addresses)
             .context("build decoder")
             .map_err(map_err)?;
         Ok(EvmRpcClient { inner, decoder })

--- a/packages/cli/src/evm_rpc_source/mod.rs
+++ b/packages/cli/src/evm_rpc_source/mod.rs
@@ -1,9 +1,13 @@
 use anyhow::Context;
 use napi_derive::napi;
+use serde::Deserialize;
+use serde_json::json;
 
 mod client;
 
-use client::{JsonRpcClient, RpcError};
+use crate::evm_hypersync_source::decode::DecoderCore;
+use crate::evm_hypersync_source::types::{EventParamsInput, Log as DecoderLog, ParamValue};
+use client::{parse_hex_u64, JsonRpcClient, RpcError};
 
 #[napi(object)]
 pub struct EvmRpcClientConfig {
@@ -11,15 +15,100 @@ pub struct EvmRpcClientConfig {
     pub http_req_timeout_millis: Option<i64>,
 }
 
+#[napi(object)]
+pub struct GetLogsParams {
+    pub from_block: i64,
+    pub to_block: i64,
+    pub addresses: Option<Vec<String>>,
+    /// One entry per topic position. `None` matches any value; `Some(values)`
+    /// matches any of the listed topic hashes (a one-element list is an exact
+    /// match). The JS side flattens its `Single | Multiple | Null` filter here.
+    pub topics: Vec<Option<Vec<String>>>,
+}
+
+/// A log returned from `eth_getLogs`, with hex quantities decoded to integers.
+/// Field names cross the napi boundary as camelCase, matching the ReScript
+/// `Rpc.GetLogs.log` record.
+#[napi(object)]
+pub struct RpcLog {
+    pub address: String,
+    pub topics: Vec<String>,
+    pub data: String,
+    pub block_number: i64,
+    pub transaction_hash: String,
+    pub transaction_index: i64,
+    pub block_hash: String,
+    pub log_index: i64,
+    pub removed: bool,
+}
+
+#[napi(object)]
+pub struct RpcEventItem {
+    pub log: RpcLog,
+    /// Decoded params keyed by contract name, or `None` when no registered event
+    /// signature matches the log's topic0/topic-count (or decoding failed).
+    pub params: Option<ParamValue>,
+}
+
+/// Raw `eth_getLogs` entry as the provider serialises it: integer fields are
+/// 0x-prefixed hex quantities that `RpcLog` later decodes.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawLog {
+    address: String,
+    topics: Vec<String>,
+    data: String,
+    block_number: String,
+    transaction_hash: String,
+    transaction_index: String,
+    block_hash: String,
+    log_index: String,
+    removed: bool,
+}
+
+impl RawLog {
+    fn into_rpc_log(self) -> anyhow::Result<RpcLog> {
+        let to_i64 = |hex: &str| -> anyhow::Result<i64> {
+            parse_hex_u64(hex)?
+                .try_into()
+                .context("hex quantity exceeds i64::MAX")
+        };
+        Ok(RpcLog {
+            block_number: to_i64(&self.block_number).context("log.blockNumber")?,
+            transaction_index: to_i64(&self.transaction_index).context("log.transactionIndex")?,
+            log_index: to_i64(&self.log_index).context("log.logIndex")?,
+            address: self.address,
+            topics: self.topics,
+            data: self.data,
+            transaction_hash: self.transaction_hash,
+            block_hash: self.block_hash,
+            removed: self.removed,
+        })
+    }
+
+    fn to_decoder_log(&self) -> DecoderLog {
+        DecoderLog {
+            data: Some(self.data.clone()),
+            topics: self.topics.iter().map(|t| Some(t.clone())).collect(),
+            ..Default::default()
+        }
+    }
+}
+
 #[napi]
 pub struct EvmRpcClient {
     inner: JsonRpcClient,
+    decoder: DecoderCore,
 }
 
 #[napi]
 impl EvmRpcClient {
     #[napi(factory)]
-    pub fn new(cfg: EvmRpcClientConfig) -> napi::Result<EvmRpcClient> {
+    pub fn new(
+        cfg: EvmRpcClientConfig,
+        event_params: Vec<EventParamsInput>,
+        checksum_addresses: Option<bool>,
+    ) -> napi::Result<EvmRpcClient> {
         let http_req_timeout_millis = cfg
             .http_req_timeout_millis
             .filter(|v| *v > 0)
@@ -27,7 +116,10 @@ impl EvmRpcClient {
                 v as u64
             });
         let inner = JsonRpcClient::new(cfg.url, http_req_timeout_millis).map_err(map_err)?;
-        Ok(EvmRpcClient { inner })
+        let decoder = DecoderCore::from_params(event_params, checksum_addresses.unwrap_or(false))
+            .context("build decoder")
+            .map_err(map_err)?;
+        Ok(EvmRpcClient { inner, decoder })
     }
 
     #[napi]
@@ -37,6 +129,42 @@ impl EvmRpcClient {
             .try_into()
             .context("block height exceeds i64::MAX")
             .map_err(map_err)
+    }
+
+    #[napi]
+    pub async fn get_logs(&self, params: GetLogsParams) -> napi::Result<Vec<RpcEventItem>> {
+        let mut filter = json!({
+            "fromBlock": format!("0x{:x}", params.from_block),
+            "toBlock": format!("0x{:x}", params.to_block),
+            "topics": params.topics,
+        });
+        if let Some(addresses) = params.addresses {
+            filter["address"] = json!(addresses);
+        }
+
+        let raw_logs: Vec<RawLog> = self
+            .inner
+            .request("eth_getLogs", json!([filter]))
+            .await
+            .map_err(rpc_error_to_napi)?;
+
+        let decoder = self.decoder.clone();
+        // Decoding is CPU-bound ABI work; keep it off the libuv async thread.
+        tokio::task::spawn_blocking(move || {
+            raw_logs
+                .into_iter()
+                .map(|raw| {
+                    let params = decoder.decode_napi(&raw.to_decoder_log()).ok().flatten();
+                    Ok(RpcEventItem {
+                        log: raw.into_rpc_log()?,
+                        params,
+                    })
+                })
+                .collect::<anyhow::Result<Vec<_>>>()
+        })
+        .await
+        .map_err(|e| map_err(anyhow::anyhow!("get_logs worker join failure: {e}")))?
+        .map_err(map_err)
     }
 }
 

--- a/packages/envio/src/Core.res
+++ b/packages/envio/src/Core.res
@@ -6,7 +6,6 @@
 // tighter `Null.t` captures the exact boundary shape.
 type evmHypersyncClientCtor
 type evmRpcClientCtor
-type evmDecoderCtor
 type svmHypersyncClientCtor
 type hyperfuelClientCtor
 type transactionStoreCtor
@@ -18,8 +17,6 @@ type addon = {
   evmHypersyncClient: evmHypersyncClientCtor,
   @as("EvmRpcClient")
   evmRpcClient: evmRpcClientCtor,
-  @as("EvmDecoder")
-  evmDecoder: evmDecoderCtor,
   @as("SvmHypersyncClient")
   svmHypersyncClient: svmHypersyncClientCtor,
   @as("HyperfuelClient")

--- a/packages/envio/src/sources/EvmRpcClient.res
+++ b/packages/envio/src/sources/EvmRpcClient.res
@@ -1,9 +1,34 @@
 type cfg = {url: string, httpReqTimeoutMillis?: int}
 
-type t = {getHeight: unit => promise<int>}
+// `addresses` omitted matches any address (a wildcard selection). Each `topics`
+// position is `null` (match any) or a list of accepted topic hashes; the
+// single-match case is a one-element list.
+type getLogsParams = {
+  fromBlock: int,
+  toBlock: int,
+  addresses?: array<Address.t>,
+  topics: array<Nullable.t<array<string>>>,
+}
+
+// Decoded `params` keyed by contract name, matching the HyperSync decoder's
+// shape so the caller routes by address then picks its contract's params.
+type rpcEventItem = {
+  log: Rpc.GetLogs.log,
+  params: Nullable.t<dict<Internal.eventParams>>,
+}
+
+type t = {
+  getHeight: unit => promise<int>,
+  getLogs: getLogsParams => promise<array<rpcEventItem>>,
+}
 
 @send
-external classNew: (Core.evmRpcClientCtor, cfg) => t = "new"
+external classNew: (
+  Core.evmRpcClientCtor,
+  cfg,
+  array<HyperSyncClient.Decoder.eventParamsInput>,
+  ~checksumAddresses: bool=?,
+) => t = "new"
 
 // Rust encodes JSON-RPC errors as a JSON payload in the napi error's
 // message: `{"kind":"JsonRpcError","code":-32005,"message":"..."}`.
@@ -34,9 +59,15 @@ let coerceErrorOrThrow = exn =>
   | None => exn->throw
   }
 
-let make = (~url, ~httpReqTimeoutMillis=?) => {
-  let client = Core.getAddon().evmRpcClient->classNew({url, ?httpReqTimeoutMillis})
+let make = (~url, ~httpReqTimeoutMillis=?, ~allEventParams=[], ~checksumAddresses=false) => {
+  let client =
+    Core.getAddon().evmRpcClient->classNew(
+      {url, ?httpReqTimeoutMillis},
+      allEventParams,
+      ~checksumAddresses,
+    )
   {
     getHeight: () => client.getHeight()->Promise.catch(coerceErrorOrThrow),
+    getLogs: params => client.getLogs(params)->Promise.catch(coerceErrorOrThrow),
   }
 }

--- a/packages/envio/src/sources/EvmRpcClient.res
+++ b/packages/envio/src/sources/EvmRpcClient.res
@@ -27,7 +27,7 @@ external classNew: (
   Core.evmRpcClientCtor,
   cfg,
   array<HyperSyncClient.Decoder.eventParamsInput>,
-  ~checksumAddresses: bool=?,
+  ~checksumAddresses: bool,
 ) => t = "new"
 
 // Rust encodes JSON-RPC errors as a JSON payload in the napi error's
@@ -59,7 +59,7 @@ let coerceErrorOrThrow = exn =>
   | None => exn->throw
   }
 
-let make = (~url, ~httpReqTimeoutMillis=?, ~allEventParams=[], ~checksumAddresses=false) => {
+let make = (~url, ~checksumAddresses, ~httpReqTimeoutMillis=?, ~allEventParams=[]) => {
   let client =
     Core.getAddon().evmRpcClient->classNew(
       {url, ?httpReqTimeoutMillis},

--- a/packages/envio/src/sources/HyperSyncClient.res
+++ b/packages/envio/src/sources/HyperSyncClient.res
@@ -208,22 +208,6 @@ module ResponseTypes = {
     mixHash?: string,
   }
 
-  type log = {
-    removed?: bool,
-    @as("logIndex") index?: int,
-    transactionIndex?: int,
-    transactionHash?: string,
-    blockHash?: string,
-    blockNumber?: int,
-    address?: Address.t,
-    data?: string,
-    topics?: array<Nullable.t<EvmTypes.Hex.t>>,
-  }
-
-  // Only the log is needed for decoding; the transaction/block are served from
-  // the store (event items) or unused (block-hash query).
-  type event = {log: log}
-
   type rollbackGuard = {
     blockNumber: int,
     timestamp: int,
@@ -253,25 +237,6 @@ module Decoder = {
     contractName: string,
     params: array<Internal.paramMeta>,
   }
-
-  // Decoded params keyed by contract name. Contracts that emit the same-signature
-  // event share one decode but get their own param names, so the caller picks the
-  // entry for the contract its router resolved the log to.
-  type tWithParams = {
-    decodeLogs: array<ResponseTypes.event> => promise<
-      array<Nullable.t<dict<Internal.eventParams>>>,
-    >,
-  }
-
-  @send
-  external classFromParams: (
-    Core.evmDecoderCtor,
-    array<eventParamsInput>,
-    ~checksumAddresses: bool=?,
-  ) => tWithParams = "fromParams"
-
-  let fromParams = (eventParams, ~checksumAddresses=?) =>
-    Core.getAddon().evmDecoder->classFromParams(eventParams, ~checksumAddresses?)
 }
 
 module EventItems = {

--- a/packages/envio/src/sources/Rpc.res
+++ b/packages/envio/src/sources/Rpc.res
@@ -103,13 +103,11 @@ module GetLogs = {
   type log = {
     address: Address.t,
     topics: array<hex>,
-    data: hex,
     blockNumber: int,
     transactionHash: hex,
     transactionIndex: int,
     blockHash: hex,
     logIndex: int,
-    removed: bool,
   }
 }
 

--- a/packages/envio/src/sources/Rpc.res
+++ b/packages/envio/src/sources/Rpc.res
@@ -70,13 +70,7 @@ let decimalFloatSchema: S.schema<float> = S.string->S.transform(s => {
 module GetLogs = {
   @unboxed
   type topicFilter = Single(hex) | Multiple(array<hex>) | @as(null) Null
-  let topicFilterSchema = S.union([
-    S.literal(Null),
-    S.schema(s => Multiple(s.matches(S.array(S.string)))),
-    S.schema(s => Single(s.matches(S.string))),
-  ])
   type topicQuery = array<topicFilter>
-  let topicQuerySchema = S.array(topicFilterSchema)
 
   let makeTopicQuery = (~topic0=[], ~topic1=[], ~topic2=[], ~topic3=[]) => {
     let topics = [topic0, topic1, topic2, topic3]
@@ -106,24 +100,6 @@ module GetLogs = {
   let mapTopicQuery = ({topic0, topic1, topic2, topic3}: Internal.topicSelection): topicQuery =>
     makeTopicQuery(~topic0, ~topic1, ~topic2, ~topic3)
 
-  type param = {
-    fromBlock: int,
-    toBlock: int,
-    address?: array<Address.t>,
-    topics: topicQuery,
-    // blockHash?: string,
-  }
-
-  let paramsSchema = S.object((s): param => {
-    fromBlock: s.field("fromBlock", hexIntSchema),
-    toBlock: s.field("toBlock", hexIntSchema),
-    address: ?s.field("address", S.option(S.array(Address.schema))),
-    topics: s.field("topics", topicQuerySchema),
-    // blockHash: ?s.field("blockHash", S.option(S.string)),
-  })
-
-  let fullParamsSchema = S.tuple1(paramsSchema)
-
   type log = {
     address: Address.t,
     topics: array<hex>,
@@ -135,22 +111,6 @@ module GetLogs = {
     logIndex: int,
     removed: bool,
   }
-
-  let logSchema = S.object((s): log => {
-    address: s.field("address", Address.schema),
-    topics: s.field("topics", S.array(S.string)),
-    data: s.field("data", S.string),
-    blockNumber: s.field("blockNumber", hexIntSchema),
-    transactionHash: s.field("transactionHash", S.string),
-    transactionIndex: s.field("transactionIndex", hexIntSchema),
-    blockHash: s.field("blockHash", S.string),
-    logIndex: s.field("logIndex", hexIntSchema),
-    removed: s.field("removed", S.bool),
-  })
-
-  let resultSchema = S.array(logSchema)
-
-  let route = makeRpcRoute("eth_getLogs", fullParamsSchema, resultSchema)
 }
 
 module GetBlockByNumber = {
@@ -228,10 +188,6 @@ module GetTransactionReceipt = {
     S.tuple1(S.string),
     S.null(S.json(~validate=false)),
   )
-}
-
-let getLogs = async (~client: Rest.client, ~param: GetLogs.param) => {
-  await GetLogs.route->Rest.fetch(param, ~client)
 }
 
 let getBlock = async (~client: Rest.client, ~blockNumber: int) => {

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -224,7 +224,7 @@ let getSuggestedBlockIntervalFromExn = {
 }
 
 type eventBatchQuery = {
-  logs: array<Rpc.GetLogs.log>,
+  items: array<EvmRpcClient.rpcEventItem>,
   latestFetchedBlockInfo: blockInfo,
 }
 
@@ -234,10 +234,10 @@ let getNextPage = (
   ~fromBlock,
   ~toBlock,
   ~addresses,
-  ~topicQuery,
+  ~topicQuery: Rpc.GetLogs.topicQuery,
   ~loadBlock,
   ~syncConfig as sc: Config.sourceSync,
-  ~client,
+  ~rpcClient: EvmRpcClient.t,
   ~mutSuggestedBlockIntervals,
   ~partitionId,
   ~sourceName,
@@ -253,17 +253,20 @@ let getNextPage = (
 
   let latestFetchedBlockPromise = loadBlock(toBlock)
   Prometheus.SourceRequestCount.increment(~sourceName, ~chainId, ~method="eth_getLogs")
-  let logsPromise = Rpc.getLogs(
-    ~client,
-    ~param={
-      address: ?addresses,
-      topics: topicQuery,
-      fromBlock,
-      toBlock,
-    },
-  )->Promise.then(async logs => {
+  let logsPromise = rpcClient.getLogs({
+    fromBlock,
+    toBlock,
+    ?addresses,
+    topics: topicQuery->Array.map(filter =>
+      switch filter {
+      | Rpc.GetLogs.Null => Nullable.null
+      | Single(topic) => Nullable.make([topic])
+      | Multiple(topics) => Nullable.make(topics)
+      }
+    ),
+  })->Promise.then(async items => {
     {
-      logs,
+      items,
       latestFetchedBlockInfo: await latestFetchedBlockPromise,
     }
   })
@@ -884,7 +887,7 @@ let make = (
   let mutSuggestedBlockIntervals = Dict.make()
 
   let client = Rpc.makeClient(url)
-  let rpcClient = EvmRpcClient.make(~url)
+  let rpcClient = EvmRpcClient.make(~url, ~allEventParams, ~checksumAddresses=!lowercaseAddresses)
 
   let makeTransactionLoader = () =>
     LazyLoader.make(
@@ -1000,36 +1003,6 @@ let make = (
     ~lowercaseAddresses,
   )
 
-  let convertLogToHyperSyncEvent = (log: Rpc.GetLogs.log): HyperSyncClient.ResponseTypes.event => {
-    let hyperSyncLog: HyperSyncClient.ResponseTypes.log = {
-      removed: log.removed,
-      index: log.logIndex,
-      transactionIndex: log.transactionIndex,
-      transactionHash: log.transactionHash,
-      blockHash: log.blockHash,
-      blockNumber: log.blockNumber,
-      address: log.address,
-      data: log.data,
-      topics: log.topics->(Utils.magic: array<string> => array<Nullable.t<EvmTypes.Hex.t>>),
-    }
-    {log: hyperSyncLog}
-  }
-
-  let hscDecoder: ref<option<HyperSyncClient.Decoder.tWithParams>> = ref(None)
-  let getHscDecoder = () => {
-    switch hscDecoder.contents {
-    | Some(decoder) => decoder
-    | None => {
-        let decoder = HyperSyncClient.Decoder.fromParams(
-          allEventParams,
-          ~checksumAddresses=!lowercaseAddresses,
-        )
-        hscDecoder := Some(decoder)
-        decoder
-      }
-    }
-  }
-
   let getItemsOrThrow = async (
     ~fromBlock,
     ~toBlock,
@@ -1073,7 +1046,7 @@ let make = (
     let {getLogSelectionOrThrow} = getSelectionConfig(selection)
     let {addresses, topicQuery} = getLogSelectionOrThrow(~addressesByContractName)
 
-    let {logs, latestFetchedBlockInfo} = await getNextPage(
+    let {items, latestFetchedBlockInfo} = await getNextPage(
       ~fromBlock,
       ~toBlock=suggestedToBlock,
       ~addresses,
@@ -1083,7 +1056,7 @@ let make = (
         ->LazyLoader.get(blockNumber)
         ->Promise.thenResolve(parseBlockInfo),
       ~syncConfig,
-      ~client,
+      ~rpcClient,
       ~mutSuggestedBlockIntervals,
       ~partitionId,
       ~sourceName=name,
@@ -1110,31 +1083,8 @@ let make = (
       )
     }
 
-    // Convert RPC logs to HyperSync events
-    let hyperSyncEvents = logs->Array.map(convertLogToHyperSyncEvent)
-
-    // Decode using HyperSyncClient decoder
-    let parsedEvents = try await getHscDecoder().decodeLogs(hyperSyncEvents) catch {
-    | exn =>
-      throw(
-        Source.GetItemsError(
-          FailedGettingItems({
-            exn,
-            attemptedToBlock: toBlock,
-            retry: ImpossibleForTheQuery({
-              message: "Failed to parse events using hypersync client decoder. Please double-check your ABI.",
-            }),
-          }),
-        ),
-      )
-    }
-
-    let parsedQueueItems = await logs
-    ->Array.zip(parsedEvents)
-    ->Array.filterMap(((
-      log: Rpc.GetLogs.log,
-      maybeDecodedEvent: Nullable.t<dict<Internal.eventParams>>,
-    )) => {
+    let parsedQueueItems = await items
+    ->Array.filterMap(({log, params: maybeDecodedEvent}: EvmRpcClient.rpcEventItem) => {
       let topic0 = log.topics[0]->Option.getOr("0x0")
       let routedAddress = if lowercaseAddresses {
         log.address->Address.Evm.fromAddressLowercaseOrThrow
@@ -1242,7 +1192,7 @@ let make = (
     | Some(b) => pushBlockInfo(b)
     | None => ()
     }
-    logs->Array.forEach(log =>
+    items->Array.forEach(({log}) =>
       blockHashes
       ->Array.push({ReorgDetection.blockNumber: log.blockNumber, blockHash: log.blockHash})
       ->ignore

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -11,9 +11,7 @@ let mockLog = (
 ): Rpc.GetLogs.log => {
   blockNumber: 123456,
   blockHash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-  removed: false,
   address: Address.Evm.fromStringOrThrow("0x1234567890abcdef1234567890abcdef12345678"),
-  data: "0xdeadbeefdeadbeefdeadbeefdeadbeef",
   topics: [
     "0xd78ad95fa46c994b6551d0da85fc275fe613dbe680204dd5837f03aa2f863b9b",
     "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -1046,70 +1046,7 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
 
   // eth_getLogs runs through the Rust client's own HTTP stack, so a
   // globalThis.fetch stub can't intercept it; route every method through a
-  // real local JSON-RPC server instead.
-  module MockRpcServer = {
-    type server
-    type req
-    type res
-
-    @module("node:http")
-    external createServer: ((req, res) => unit) => server = "createServer"
-    @send external listen: (server, int, unit => unit) => unit = "listen"
-    @send external closeAllConnections: server => unit = "closeAllConnections"
-    @send external close: (server, unit => unit) => unit = "close"
-
-    type address = {port: int}
-    @send external address: server => address = "address"
-
-    @send external setEncoding: (req, string) => unit = "setEncoding"
-    @send external onData: (req, @as("data") _, string => unit) => unit = "on"
-    @send external onEnd: (req, @as("end") _, unit => unit) => unit = "on"
-
-    @send external writeHead: (res, int, dict<string>) => unit = "writeHead"
-    @send external end_: (res, string) => unit = "end"
-
-    type t = {url: string, close: unit => unit}
-
-    let make = (~getResult: string => JSON.t) =>
-      Promise.make((resolve, _reject) => {
-        let server = createServer((req, res) => {
-          req->setEncoding("utf8")
-          let data = ref("")
-          req->onData(chunk => data := data.contents ++ chunk)
-          req->onEnd(() => {
-            let method =
-              data.contents
-              ->JSON.parseOrThrow
-              ->JSON.Decode.object
-              ->Option.flatMap(Dict.get(_, "method"))
-              ->Option.flatMap(JSON.Decode.string)
-              ->Option.getOr("")
-            res->writeHead(200, Dict.fromArray([("Content-Type", "application/json")]))
-            res->end_(
-              JSON.stringify(
-                JSON.Object(
-                  Dict.fromArray([
-                    ("jsonrpc", JSON.String("2.0")),
-                    ("id", JSON.Number(1.)),
-                    ("result", getResult(method)),
-                  ]),
-                ),
-              ),
-            )
-          })
-        })
-        server->listen(0, () => {
-          resolve({
-            url: `http://127.0.0.1:${(server->address).port->Int.toString}`,
-            close: () => {
-              server->closeAllConnections
-              server->close(() => ())
-            },
-          })
-        })
-      })
-  }
-
+  // real local JSON-RPC server (MockRpcServer helper) instead.
   Async.it(
     "Throws a retryable error instead of a source-disabling one when the receipt is null",
     async t => {

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -1044,21 +1044,71 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
   let transactionHash = "0x27e26f21f744064a4af53810d8002bbd7208a2ca4865503a99b9c529e5cff5ea"
   let mockAddress = Envio.TestHelpers.Addresses.mockAddresses[0]->Option.getOrThrow
 
-  // Replaces globalThis.fetch with a JSON-RPC stub routed by request method.
-  // Returns a restore function.
-  let stubJsonRpcFetch: (string => JSON.t) => unit => unit = %raw(`(getResult) => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (_url, args) => {
-      const method = JSON.parse(args.body).method;
-      return new Response(
-        JSON.stringify({ jsonrpc: "2.0", id: 1, result: getResult(method) }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    };
-    return () => {
-      globalThis.fetch = originalFetch;
-    };
-  }`)
+  // eth_getLogs runs through the Rust client's own HTTP stack, so a
+  // globalThis.fetch stub can't intercept it; route every method through a
+  // real local JSON-RPC server instead.
+  module MockRpcServer = {
+    type server
+    type req
+    type res
+
+    @module("node:http")
+    external createServer: ((req, res) => unit) => server = "createServer"
+    @send external listen: (server, int, unit => unit) => unit = "listen"
+    @send external closeAllConnections: server => unit = "closeAllConnections"
+    @send external close: (server, unit => unit) => unit = "close"
+
+    type address = {port: int}
+    @send external address: server => address = "address"
+
+    @send external setEncoding: (req, string) => unit = "setEncoding"
+    @send external onData: (req, @as("data") _, string => unit) => unit = "on"
+    @send external onEnd: (req, @as("end") _, unit => unit) => unit = "on"
+
+    @send external writeHead: (res, int, dict<string>) => unit = "writeHead"
+    @send external end_: (res, string) => unit = "end"
+
+    type t = {url: string, close: unit => unit}
+
+    let make = (~getResult: string => JSON.t) =>
+      Promise.make((resolve, _reject) => {
+        let server = createServer((req, res) => {
+          req->setEncoding("utf8")
+          let data = ref("")
+          req->onData(chunk => data := data.contents ++ chunk)
+          req->onEnd(() => {
+            let method =
+              data.contents
+              ->JSON.parseOrThrow
+              ->JSON.Decode.object
+              ->Option.flatMap(Dict.get(_, "method"))
+              ->Option.flatMap(JSON.Decode.string)
+              ->Option.getOr("")
+            res->writeHead(200, Dict.fromArray([("Content-Type", "application/json")]))
+            res->end_(
+              JSON.stringify(
+                JSON.Object(
+                  Dict.fromArray([
+                    ("jsonrpc", JSON.String("2.0")),
+                    ("id", JSON.Number(1.)),
+                    ("result", getResult(method)),
+                  ]),
+                ),
+              ),
+            )
+          })
+        })
+        server->listen(0, () => {
+          resolve({
+            url: `http://127.0.0.1:${(server->address).port->Int.toString}`,
+            close: () => {
+              server->closeAllConnections
+              server->close(() => ())
+            },
+          })
+        })
+      })
+  }
 
   Async.it(
     "Throws a retryable error instead of a source-disabling one when the receipt is null",
@@ -1067,23 +1117,6 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
         ~id=`${sighash}_1`,
         ~transactionFieldNames=[GasUsed],
       )
-      let source = RpcSource.make({
-        url: "http://localhost:8545",
-        chain,
-        eventRouter: [eventConfig]->EventRouter.fromEvmEventModsOrThrow(~chain),
-        sourceFor: Sync,
-        syncConfig: EvmChain.getSyncConfig({}),
-        allEventParams: [
-          {
-            sighash,
-            topicCount: 1,
-            eventName: eventConfig.name,
-            contractName: eventConfig.contractName,
-            params: [],
-          },
-        ],
-        lowercaseAddresses: false,
-      })
 
       let logJson = JSON.Object(
         Dict.fromArray([
@@ -1107,7 +1140,7 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
         ]),
       )
 
-      let restoreFetch = stubJsonRpcFetch(method =>
+      let mock = await MockRpcServer.make(~getResult=method =>
         switch method {
         | "eth_getLogs" => JSON.Array([logJson])
         | "eth_getBlockByNumber" => blockJson
@@ -1116,6 +1149,24 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
         | _ => JSON.Null
         }
       )
+
+      let source = RpcSource.make({
+        url: mock.url,
+        chain,
+        eventRouter: [eventConfig]->EventRouter.fromEvmEventModsOrThrow(~chain),
+        sourceFor: Sync,
+        syncConfig: EvmChain.getSyncConfig({}),
+        allEventParams: [
+          {
+            sighash,
+            topicCount: 1,
+            eventName: eventConfig.name,
+            contractName: eventConfig.contractName,
+            params: [],
+          },
+        ],
+        lowercaseAddresses: false,
+      })
 
       let caught = try {
         let callGetItemsOrThrow = async (~retry) =>
@@ -1141,11 +1192,11 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
           | Source.GetItemsError(error) => Some(error)
           }
         let result = (await callGetItemsOrThrow(~retry=0), await callGetItemsOrThrow(~retry=2))
-        restoreFetch()
+        mock.close()
         result
       } catch {
       | exn =>
-        restoreFetch()
+        mock.close()
         throw(exn)
       }
 

--- a/scenarios/test_codegen/test/helpers/MockRpcServer.res
+++ b/scenarios/test_codegen/test/helpers/MockRpcServer.res
@@ -53,23 +53,23 @@ let start = (~handler: string => (int, string)) =>
 let makeRaw = (~status, ~body) => start(~handler=_ => (status, body))
 
 // Reply 200 with a JSON-RPC envelope whose `result` is routed by the request's
-// `method`.
+// `method`, echoing the request's `id` back.
 let make = (~getResult: string => JSON.t) =>
   start(~handler=requestBody => {
+    let parsed = requestBody->JSON.parseOrThrow->JSON.Decode.object
     let method =
-      requestBody
-      ->JSON.parseOrThrow
-      ->JSON.Decode.object
+      parsed
       ->Option.flatMap(Dict.get(_, "method"))
       ->Option.flatMap(JSON.Decode.string)
       ->Option.getOr("")
+    let id = parsed->Option.flatMap(Dict.get(_, "id"))->Option.getOr(JSON.Number(1.))
     (
       200,
       JSON.stringify(
         JSON.Object(
           Dict.fromArray([
             ("jsonrpc", JSON.String("2.0")),
-            ("id", JSON.Number(1.)),
+            ("id", id),
             ("result", getResult(method)),
           ]),
         ),

--- a/scenarios/test_codegen/test/helpers/MockRpcServer.res
+++ b/scenarios/test_codegen/test/helpers/MockRpcServer.res
@@ -1,0 +1,78 @@
+// A real local JSON-RPC server. eth_getLogs runs through the Rust client's own
+// HTTP stack, which a globalThis.fetch stub can't intercept — tests point the
+// source/client at one of these instead.
+type server
+type req
+type res
+
+@module("node:http")
+external createServer: ((req, res) => unit) => server = "createServer"
+@send external listen: (server, int, unit => unit) => unit = "listen"
+@send external closeAllConnections: server => unit = "closeAllConnections"
+@send external close: (server, unit => unit) => unit = "close"
+
+type address = {port: int}
+@send external address: server => address = "address"
+
+@send external setEncoding: (req, string) => unit = "setEncoding"
+@send external onData: (req, @as("data") _, string => unit) => unit = "on"
+@send external onEnd: (req, @as("end") _, unit => unit) => unit = "on"
+
+@send external writeHead: (res, int, dict<string>) => unit = "writeHead"
+@send external end_: (res, string) => unit = "end"
+
+type t = {url: string, requests: array<string>, close: unit => unit}
+
+let start = (~handler: string => (int, string)) =>
+  Promise.make((resolve, _reject) => {
+    let requests = []
+    let server = createServer((req, res) => {
+      req->setEncoding("utf8")
+      let data = ref("")
+      req->onData(chunk => data := data.contents ++ chunk)
+      req->onEnd(() => {
+        requests->Array.push(data.contents)->ignore
+        let (status, body) = handler(data.contents)
+        res->writeHead(status, Dict.fromArray([("Content-Type", "application/json")]))
+        res->end_(body)
+      })
+    })
+    server->listen(0, () => {
+      resolve({
+        url: `http://127.0.0.1:${(server->address).port->Int.toString}`,
+        requests,
+        close: () => {
+          server->closeAllConnections
+          server->close(() => ())
+        },
+      })
+    })
+  })
+
+// Reply with a fixed status and body to every request.
+let makeRaw = (~status, ~body) => start(~handler=_ => (status, body))
+
+// Reply 200 with a JSON-RPC envelope whose `result` is routed by the request's
+// `method`.
+let make = (~getResult: string => JSON.t) =>
+  start(~handler=requestBody => {
+    let method =
+      requestBody
+      ->JSON.parseOrThrow
+      ->JSON.Decode.object
+      ->Option.flatMap(Dict.get(_, "method"))
+      ->Option.flatMap(JSON.Decode.string)
+      ->Option.getOr("")
+    (
+      200,
+      JSON.stringify(
+        JSON.Object(
+          Dict.fromArray([
+            ("jsonrpc", JSON.String("2.0")),
+            ("id", JSON.Number(1.)),
+            ("result", getResult(method)),
+          ]),
+        ),
+      ),
+    )
+  })

--- a/scenarios/test_codegen/test/helpers/NativeDecoder.res
+++ b/scenarios/test_codegen/test/helpers/NativeDecoder.res
@@ -27,7 +27,7 @@ let decodeLogs = async (
     | _ => JSON.Null
     }
   )
-  let client = EvmRpcClient.make(~url=mock.url, ~allEventParams=eventParams)
+  let client = EvmRpcClient.make(~url=mock.url, ~checksumAddresses=false, ~allEventParams=eventParams)
   let items = try await client.getLogs({fromBlock: 0, toBlock: 0, topics: []}) catch {
   | exn =>
     mock.close()

--- a/scenarios/test_codegen/test/helpers/NativeDecoder.res
+++ b/scenarios/test_codegen/test/helpers/NativeDecoder.res
@@ -1,0 +1,38 @@
+// Decodes logs through the production path: feed crafted logs to a mock
+// eth_getLogs endpoint and let EvmRpcClient decode them with the shared
+// DecoderCore. Returns params per log (keyed by contract name), mirroring the
+// shape the old standalone decoder's decodeLogs returned.
+let decodeLogs = async (
+  ~eventParams: array<HyperSyncClient.Decoder.eventParamsInput>,
+  ~logs: array<(array<string>, string)>,
+): array<Nullable.t<dict<Internal.eventParams>>> => {
+  let logJsons = logs->Array.map(((topics, data)) =>
+    JSON.Object(
+      Dict.fromArray([
+        ("address", JSON.String("0x000000000000000000000000000000000000abcd")),
+        ("topics", JSON.Array(topics->Array.map(t => JSON.String(t)))),
+        ("data", JSON.String(data)),
+        ("blockNumber", JSON.String("0x1")),
+        ("transactionHash", JSON.String("0xabc")),
+        ("transactionIndex", JSON.String("0x0")),
+        ("blockHash", JSON.String("0xb01")),
+        ("logIndex", JSON.String("0x0")),
+        ("removed", JSON.Boolean(false)),
+      ]),
+    )
+  )
+  let mock = await MockRpcServer.make(~getResult=method =>
+    switch method {
+    | "eth_getLogs" => JSON.Array(logJsons)
+    | _ => JSON.Null
+    }
+  )
+  let client = EvmRpcClient.make(~url=mock.url, ~allEventParams=eventParams)
+  let items = try await client.getLogs({fromBlock: 0, toBlock: 0, topics: []}) catch {
+  | exn =>
+    mock.close()
+    throw(exn)
+  }
+  mock.close()
+  items->Array.map(item => item.params)
+}

--- a/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
@@ -22,7 +22,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
       ~status=200,
       ~body=`{"jsonrpc":"2.0","id":1,"result":"0x1b4"}`,
     )
-    let client = EvmRpcClient.make(~url=mock.url)
+    let client = EvmRpcClient.make(~url=mock.url, ~checksumAddresses=false)
 
     let height = await client.getHeight()
     mock.close()
@@ -38,7 +38,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
       ~status=200,
       ~body=`{"jsonrpc":"2.0","id":1,"error":{"code":-32005,"message":"limited to a 1000 blocks range"}}`,
     )
-    let client = EvmRpcClient.make(~url=mock.url)
+    let client = EvmRpcClient.make(~url=mock.url, ~checksumAddresses=false)
 
     let error = await getHeightJsonRpcError(client)
     mock.close()
@@ -51,7 +51,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
       ~status=429,
       ~body=`{"jsonrpc":"2.0","id":1,"error":{"code":-32029,"message":"rate limited"}}`,
     )
-    let client = EvmRpcClient.make(~url=mock.url)
+    let client = EvmRpcClient.make(~url=mock.url, ~checksumAddresses=false)
 
     let error = await getHeightJsonRpcError(client)
     mock.close()
@@ -61,7 +61,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
 
   Async.it("Reports HTTP status and body snippet for a non-JSON response", async t => {
     let mock = await MockRpcServer.makeRaw(~status=502, ~body="upstream exploded")
-    let client = EvmRpcClient.make(~url=mock.url)
+    let client = EvmRpcClient.make(~url=mock.url, ~checksumAddresses=false)
 
     let message = await getHeightErrorMessage(client)
     mock.close()
@@ -73,7 +73,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
 
   Async.it("Fails when the response has neither result nor error", async t => {
     let mock = await MockRpcServer.makeRaw(~status=200, ~body=`{"jsonrpc":"2.0","id":1}`)
-    let client = EvmRpcClient.make(~url=mock.url)
+    let client = EvmRpcClient.make(~url=mock.url, ~checksumAddresses=false)
 
     let message = await getHeightErrorMessage(client)
     mock.close()
@@ -88,7 +88,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
       ~status=200,
       ~body=`{"jsonrpc":"2.0","id":1,"result":null}`,
     )
-    let client = EvmRpcClient.make(~url=mock.url)
+    let client = EvmRpcClient.make(~url=mock.url, ~checksumAddresses=false)
 
     let message = await getHeightErrorMessage(client)
     mock.close()
@@ -112,6 +112,7 @@ describe("EvmRpcClient - getLogs via napi", () => {
     )
     let client = EvmRpcClient.make(
       ~url=mock.url,
+      ~checksumAddresses=false,
       ~allEventParams=[
         {
           sighash: transferSighash,
@@ -175,6 +176,7 @@ describe("EvmRpcClient - getLogs via napi", () => {
     )
     let client = EvmRpcClient.make(
       ~url=mock.url,
+      ~checksumAddresses=false,
       ~allEventParams=[
         {
           sighash: transferSighash,
@@ -199,7 +201,7 @@ describe("EvmRpcClient - getLogs via napi", () => {
       ~status=200,
       ~body=`{"jsonrpc":"2.0","id":1,"error":{"code":-32005,"message":"eth_getLogs is limited to a 1000 blocks range"}}`,
     )
-    let client = EvmRpcClient.make(~url=mock.url)
+    let client = EvmRpcClient.make(~url=mock.url, ~checksumAddresses=false)
 
     let error = try {
       let _ = await client.getLogs({fromBlock: 0, toBlock: 5000, topics: []})

--- a/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
@@ -1,58 +1,5 @@
 open Vitest
 
-module MockJsonRpcServer = {
-  type server
-  type req
-  type res
-
-  @module("node:http")
-  external createServer: ((req, res) => unit) => server = "createServer"
-  @send external listen: (server, int, unit => unit) => unit = "listen"
-  @send external closeAllConnections: server => unit = "closeAllConnections"
-  @send external close: (server, unit => unit) => unit = "close"
-
-  type address = {port: int}
-  @send external address: server => address = "address"
-
-  @send external setEncoding: (req, string) => unit = "setEncoding"
-  @send external onData: (req, @as("data") _, string => unit) => unit = "on"
-  @send external onEnd: (req, @as("end") _, unit => unit) => unit = "on"
-
-  @send external writeHead: (res, int, dict<string>) => unit = "writeHead"
-  @send external end_: (res, string) => unit = "end"
-
-  type t = {
-    url: string,
-    requests: array<string>,
-    close: unit => unit,
-  }
-
-  let make = (~status, ~body) =>
-    Promise.make((resolve, _reject) => {
-      let requests = []
-      let server = createServer((req, res) => {
-        req->setEncoding("utf8")
-        let data = ref("")
-        req->onData(chunk => data := data.contents ++ chunk)
-        req->onEnd(() => {
-          requests->Array.push(data.contents)
-          res->writeHead(status, Dict.fromArray([("Content-Type", "application/json")]))
-          res->end_(body)
-        })
-      })
-      server->listen(0, () => {
-        resolve({
-          url: `http://127.0.0.1:${(server->address).port->Int.toString}`,
-          requests,
-          close: () => {
-            server->closeAllConnections
-            server->close(() => ())
-          },
-        })
-      })
-    })
-}
-
 let getHeightJsonRpcError = async (client: EvmRpcClient.t): option<Rpc.rpcError> =>
   try {
     let _ = await client.getHeight()
@@ -71,7 +18,7 @@ let getHeightErrorMessage = async (client: EvmRpcClient.t) =>
 
 describe("EvmRpcClient - getHeight via napi", () => {
   Async.it("Parses hex result and sends a JSON-RPC request", async t => {
-    let mock = await MockJsonRpcServer.make(
+    let mock = await MockRpcServer.makeRaw(
       ~status=200,
       ~body=`{"jsonrpc":"2.0","id":1,"result":"0x1b4"}`,
     )
@@ -87,7 +34,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
   })
 
   Async.it("Transfers JSON-RPC error as structured Rpc.JsonRpcError", async t => {
-    let mock = await MockJsonRpcServer.make(
+    let mock = await MockRpcServer.makeRaw(
       ~status=200,
       ~body=`{"jsonrpc":"2.0","id":1,"error":{"code":-32005,"message":"limited to a 1000 blocks range"}}`,
     )
@@ -100,7 +47,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
   })
 
   Async.it("Parses JSON-RPC error body even with a non-200 status", async t => {
-    let mock = await MockJsonRpcServer.make(
+    let mock = await MockRpcServer.makeRaw(
       ~status=429,
       ~body=`{"jsonrpc":"2.0","id":1,"error":{"code":-32029,"message":"rate limited"}}`,
     )
@@ -113,7 +60,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
   })
 
   Async.it("Reports HTTP status and body snippet for a non-JSON response", async t => {
-    let mock = await MockJsonRpcServer.make(~status=502, ~body="upstream exploded")
+    let mock = await MockRpcServer.makeRaw(~status=502, ~body="upstream exploded")
     let client = EvmRpcClient.make(~url=mock.url)
 
     let message = await getHeightErrorMessage(client)
@@ -125,7 +72,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
   })
 
   Async.it("Fails when the response has neither result nor error", async t => {
-    let mock = await MockJsonRpcServer.make(~status=200, ~body=`{"jsonrpc":"2.0","id":1}`)
+    let mock = await MockRpcServer.makeRaw(~status=200, ~body=`{"jsonrpc":"2.0","id":1}`)
     let client = EvmRpcClient.make(~url=mock.url)
 
     let message = await getHeightErrorMessage(client)
@@ -137,7 +84,7 @@ describe("EvmRpcClient - getHeight via napi", () => {
   })
 
   Async.it("Fails when getHeight result is null", async t => {
-    let mock = await MockJsonRpcServer.make(
+    let mock = await MockRpcServer.makeRaw(
       ~status=200,
       ~body=`{"jsonrpc":"2.0","id":1,"result":null}`,
     )
@@ -159,7 +106,7 @@ describe("EvmRpcClient - getLogs via napi", () => {
   ]
 
   Async.it("Decodes event params and parses hex log fields", async t => {
-    let mock = await MockJsonRpcServer.make(
+    let mock = await MockRpcServer.makeRaw(
       ~status=200,
       ~body=`{"jsonrpc":"2.0","id":1,"result":[{"address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","topics":["${transferSighash}","0x0000000000000000000000000000000000000000000000000000000000000001","0x0000000000000000000000000000000000000000000000000000000000000002"],"data":"0x00000000000000000000000000000000000000000000000000000000000003e8","blockNumber":"0x64","transactionHash":"0xabc","transactionIndex":"0x1","blockHash":"0xb64","logIndex":"0x2","removed":false}]}`,
     )
@@ -215,7 +162,7 @@ describe("EvmRpcClient - getLogs via napi", () => {
   })
 
   Async.it("Leaves params null when no registered signature matches", async t => {
-    let mock = await MockJsonRpcServer.make(
+    let mock = await MockRpcServer.makeRaw(
       ~status=200,
       ~body=`{"jsonrpc":"2.0","id":1,"result":[{"address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","topics":["0x0000000000000000000000000000000000000000000000000000000000000009"],"data":"0x","blockNumber":"0x1","transactionHash":"0xabc","transactionIndex":"0x0","blockHash":"0xb01","logIndex":"0x0","removed":false}]}`,
     )
@@ -241,7 +188,7 @@ describe("EvmRpcClient - getLogs via napi", () => {
   })
 
   Async.it("Transfers a JSON-RPC error as structured Rpc.JsonRpcError", async t => {
-    let mock = await MockJsonRpcServer.make(
+    let mock = await MockRpcServer.makeRaw(
       ~status=200,
       ~body=`{"jsonrpc":"2.0","id":1,"error":{"code":-32005,"message":"eth_getLogs is limited to a 1000 blocks range"}}`,
     )

--- a/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
@@ -149,3 +149,112 @@ describe("EvmRpcClient - getHeight via napi", () => {
     t.expect(message->Option.getOr("no error")).toMatch(/parse eth_blockNumber result/)
   })
 })
+
+describe("EvmRpcClient - getLogs via napi", () => {
+  let transferSighash = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+  let transferParams: array<Internal.paramMeta> = [
+    {name: "from", abiType: "address", indexed: true},
+    {name: "to", abiType: "address", indexed: true},
+    {name: "value", abiType: "uint256", indexed: false},
+  ]
+
+  Async.it("Decodes event params and parses hex log fields", async t => {
+    let mock = await MockJsonRpcServer.make(
+      ~status=200,
+      ~body=`{"jsonrpc":"2.0","id":1,"result":[{"address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","topics":["${transferSighash}","0x0000000000000000000000000000000000000000000000000000000000000001","0x0000000000000000000000000000000000000000000000000000000000000002"],"data":"0x00000000000000000000000000000000000000000000000000000000000003e8","blockNumber":"0x64","transactionHash":"0xabc","transactionIndex":"0x1","blockHash":"0xb64","logIndex":"0x2","removed":false}]}`,
+    )
+    let client = EvmRpcClient.make(
+      ~url=mock.url,
+      ~allEventParams=[
+        {
+          sighash: transferSighash,
+          topicCount: 3,
+          eventName: "Transfer",
+          contractName: "ERC20",
+          params: transferParams,
+        },
+      ],
+    )
+
+    let items = await client.getLogs({
+      fromBlock: 100,
+      toBlock: 100,
+      topics: [Nullable.make([transferSighash])],
+    })
+    mock.close()
+
+    t.expect(
+      items->Array.map(({log, params}) => {
+        let decoded =
+          params
+          ->Nullable.toOption
+          ->Option.getUnsafe
+          ->Dict.getUnsafe("ERC20")
+          ->(Utils.magic: Internal.eventParams => {..})
+        {
+          "blockNumber": log.blockNumber,
+          "transactionIndex": log.transactionIndex,
+          "logIndex": log.logIndex,
+          "topicCount": log.topics->Array.length,
+          "from": decoded["from"],
+          "to": decoded["to"],
+          "value": decoded["value"]->BigInt.toString,
+        }
+      }),
+    ).toEqual([
+      {
+        "blockNumber": 100,
+        "transactionIndex": 1,
+        "logIndex": 2,
+        "topicCount": 3,
+        "from": "0x0000000000000000000000000000000000000001",
+        "to": "0x0000000000000000000000000000000000000002",
+        "value": "1000",
+      },
+    ])
+  })
+
+  Async.it("Leaves params null when no registered signature matches", async t => {
+    let mock = await MockJsonRpcServer.make(
+      ~status=200,
+      ~body=`{"jsonrpc":"2.0","id":1,"result":[{"address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","topics":["0x0000000000000000000000000000000000000000000000000000000000000009"],"data":"0x","blockNumber":"0x1","transactionHash":"0xabc","transactionIndex":"0x0","blockHash":"0xb01","logIndex":"0x0","removed":false}]}`,
+    )
+    let client = EvmRpcClient.make(
+      ~url=mock.url,
+      ~allEventParams=[
+        {
+          sighash: transferSighash,
+          topicCount: 3,
+          eventName: "Transfer",
+          contractName: "ERC20",
+          params: transferParams,
+        },
+      ],
+    )
+
+    let items = await client.getLogs({fromBlock: 1, toBlock: 1, topics: []})
+    mock.close()
+
+    t.expect(items->Array.map(({params}) => params->Nullable.toOption->Option.isNone)).toEqual([
+      true,
+    ])
+  })
+
+  Async.it("Transfers a JSON-RPC error as structured Rpc.JsonRpcError", async t => {
+    let mock = await MockJsonRpcServer.make(
+      ~status=200,
+      ~body=`{"jsonrpc":"2.0","id":1,"error":{"code":-32005,"message":"eth_getLogs is limited to a 1000 blocks range"}}`,
+    )
+    let client = EvmRpcClient.make(~url=mock.url)
+
+    let error = try {
+      let _ = await client.getLogs({fromBlock: 0, toBlock: 5000, topics: []})
+      None
+    } catch {
+    | Rpc.JsonRpcError(e) => Some(e)
+    }
+    mock.close()
+
+    t.expect(error).toEqual(Some({code: -32005, message: "eth_getLogs is limited to a 1000 blocks range"}))
+  })
+})

--- a/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
@@ -128,9 +128,12 @@ describe("EvmRpcClient - getLogs via napi", () => {
       toBlock: 100,
       topics: [Nullable.make([transferSighash])],
     })
+    // Lock down the outgoing request contract (hex block bounds + topic nesting)
+    // alongside the decoded response.
+    let sentRequest = mock.requests->Array.getUnsafe(0)->JSON.parseOrThrow
     mock.close()
 
-    t.expect(
+    t.expect((
       items->Array.map(({log, params}) => {
         let decoded =
           params
@@ -148,17 +151,21 @@ describe("EvmRpcClient - getLogs via napi", () => {
           "value": decoded["value"]->BigInt.toString,
         }
       }),
-    ).toEqual([
-      {
-        "blockNumber": 100,
-        "transactionIndex": 1,
-        "logIndex": 2,
-        "topicCount": 3,
-        "from": "0x0000000000000000000000000000000000000001",
-        "to": "0x0000000000000000000000000000000000000002",
-        "value": "1000",
-      },
-    ])
+      sentRequest,
+    )).toEqual((
+      [
+        {
+          "blockNumber": 100,
+          "transactionIndex": 1,
+          "logIndex": 2,
+          "topicCount": 3,
+          "from": "0x0000000000000000000000000000000000000001",
+          "to": "0x0000000000000000000000000000000000000002",
+          "value": "1000",
+        },
+      ],
+      `{"method":"eth_getLogs","params":[{"fromBlock":"0x64","toBlock":"0x64","topics":[["${transferSighash}"]]}],"id":1,"jsonrpc":"2.0"}`->JSON.parseOrThrow,
+    ))
   })
 
   Async.it("Leaves params null when no registered signature matches", async t => {

--- a/scenarios/test_codegen/test/lib_tests/HyperSyncDecoder_test.res
+++ b/scenarios/test_codegen/test/lib_tests/HyperSyncDecoder_test.res
@@ -14,24 +14,23 @@ let fromAddr = "0x000000000000000000000000000000000000aaaa"
 let toAddr = "0x000000000000000000000000000000000000bbbb"
 let value = 42n
 
-let makeEvent = (~topics: array<string>, ~data: string): HyperSyncClient.ResponseTypes.event =>
-  {"log": {"topics": topics, "data": data}}->(
-    Utils.magic: {..} => HyperSyncClient.ResponseTypes.event
-  )
-
+// A crafted log as (topics, data); fed to a mock eth_getLogs endpoint and
+// decoded through EvmRpcClient.
 let decodeSingle = async (
   ~eventName: string,
   ~params: array<Internal.paramMeta>,
-  ~event: HyperSyncClient.ResponseTypes.event,
+  ~log: (array<string>, string),
 ) => {
   let sighash = toEventSelector(
-    `event ${eventName}(${params->Array.map(p => p.indexed ? `${p.abiType} indexed` : p.abiType)->Array.joinUnsafe(", ")})`,
+    `event ${eventName}(${params
+      ->Array.map(p => p.indexed ? `${p.abiType} indexed` : p.abiType)
+      ->Array.joinUnsafe(", ")})`,
   )
   let topicCount = params->Array.reduce(1, (acc, p) => p.indexed ? acc + 1 : acc)
-  let decoder = HyperSyncClient.Decoder.fromParams([
-    {sighash, topicCount, eventName, contractName: "TestContract", params},
-  ])
-  let decoded = await decoder.decodeLogs([event])
+  let decoded = await NativeDecoder.decodeLogs(
+    ~eventParams=[{sighash, topicCount, eventName, contractName: "TestContract", params}],
+    ~logs=[log],
+  )
   decoded[0]
   ->Option.getUnsafe
   ->Nullable.toOption
@@ -39,55 +38,60 @@ let decodeSingle = async (
   ->Dict.getUnsafe("TestContract")
 }
 
-let allIndexedLog = makeEvent(
-  ~topics=[
+let allIndexedLog = (
+  [
     sighash,
     fromAddr->pad,
     toAddr->pad,
     Viem.bigintToHex(value, ~options={size: 32})->(Utils.magic: Viem.hex => string),
   ],
-  ~data="0x",
+  "0x",
 )
 
-let noneIndexedLog = makeEvent(
-  ~topics=[sighash],
-  ~data=encodeAbiParameters(
+let noneIndexedLog = (
+  [sighash],
+  encodeAbiParameters(
     %raw(`[{"type":"address"},{"type":"address"},{"type":"uint256"}]`),
     %raw(`["0x000000000000000000000000000000000000aaaa","0x000000000000000000000000000000000000bbbb",42n]`),
   ),
 )
 
-describe("HyperSync decoder – fromParams + decodeLogs", () => {
+describe("EVM event decoding via EvmRpcClient.getLogs", () => {
   Async.it("produces named params directly for different indexed layouts", async t => {
-    let decoder = HyperSyncClient.Decoder.fromParams([
-      {
-        sighash,
-        topicCount: 4,
-        eventName: "Transfer",
-        contractName: "TestContract",
-        params: [
-          {name: "from", abiType: "address", indexed: true},
-          {name: "to", abiType: "address", indexed: true},
-          {name: "value", abiType: "uint256", indexed: true},
-        ],
-      },
-      {
-        sighash,
-        topicCount: 1,
-        eventName: "Transfer",
-        contractName: "TestContract",
-        params: [
-          {name: "from", abiType: "address", indexed: false},
-          {name: "to", abiType: "address", indexed: false},
-          {name: "value", abiType: "uint256", indexed: false},
-        ],
-      },
-    ])
-
-    let decoded = await decoder.decodeLogs([allIndexedLog, noneIndexedLog])
+    let decoded = await NativeDecoder.decodeLogs(
+      ~eventParams=[
+        {
+          sighash,
+          topicCount: 4,
+          eventName: "Transfer",
+          contractName: "TestContract",
+          params: [
+            {name: "from", abiType: "address", indexed: true},
+            {name: "to", abiType: "address", indexed: true},
+            {name: "value", abiType: "uint256", indexed: true},
+          ],
+        },
+        {
+          sighash,
+          topicCount: 1,
+          eventName: "Transfer",
+          contractName: "TestContract",
+          params: [
+            {name: "from", abiType: "address", indexed: false},
+            {name: "to", abiType: "address", indexed: false},
+            {name: "value", abiType: "uint256", indexed: false},
+          ],
+        },
+      ],
+      ~logs=[allIndexedLog, noneIndexedLog],
+    )
 
     let pick = i =>
-      decoded[i]->Option.getUnsafe->Nullable.toOption->Option.getUnsafe->Dict.getUnsafe("TestContract")
+      decoded[i]
+      ->Option.getUnsafe
+      ->Nullable.toOption
+      ->Option.getUnsafe
+      ->Dict.getUnsafe("TestContract")
     let paramsAll = pick(0)
     let paramsNone = pick(1)
 
@@ -105,34 +109,35 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
     let result = await decodeSingle(
       ~eventName="Transfer",
       ~params,
-      ~event=makeEvent(
-        ~topics=[
-          sighash,
-          "0xabc"->pad,
-          "0xdef"->pad,
-        ],
-        ~data=encodeAbiParameters(
-          %raw(`[{"type":"uint256"}]`),
-          %raw(`[100n]`),
-        ),
+      ~log=(
+        [sighash, "0xabc"->pad, "0xdef"->pad],
+        encodeAbiParameters(%raw(`[{"type":"uint256"}]`), %raw(`[100n]`)),
       ),
     )
-    t.expect(result).toEqual({"from": "0x0000000000000000000000000000000000000abc", "to": "0x0000000000000000000000000000000000000def", "value": 100n}->Utils.magic)
+    t
+    .expect(result)
+    .toEqual(
+      {
+        "from": "0x0000000000000000000000000000000000000abc",
+        "to": "0x0000000000000000000000000000000000000def",
+        "value": 100n,
+      }->Utils.magic,
+    )
   })
 
   Async.it("handles empty params", async t => {
-    let decoder = HyperSyncClient.Decoder.fromParams([
-      {
-        sighash: toEventSelector("event Empty()"),
-        topicCount: 1,
-        eventName: "Empty",
-        contractName: "TestContract",
-        params: [],
-      },
-    ])
-    let decoded = await decoder.decodeLogs([
-      makeEvent(~topics=[toEventSelector("event Empty()")], ~data="0x"),
-    ])
+    let decoded = await NativeDecoder.decodeLogs(
+      ~eventParams=[
+        {
+          sighash: toEventSelector("event Empty()"),
+          topicCount: 1,
+          eventName: "Empty",
+          contractName: "TestContract",
+          params: [],
+        },
+      ],
+      ~logs=[([toEventSelector("event Empty()")], "0x")],
+    )
     let result =
       decoded[0]
       ->Option.getUnsafe
@@ -150,7 +155,7 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
     let params = await decodeSingle(
       ~eventName="Empty",
       ~params=[],
-      ~event=makeEvent(~topics=[toEventSelector("event Empty()")], ~data="0x"),
+      ~log=([toEventSelector("event Empty()")], "0x"),
     )
     t.expect(params).toEqual(%raw(`{}`))
 
@@ -224,14 +229,14 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
       let result = await decodeSingle(
         ~eventName="VehicleCreated",
         ~params,
-        ~event=makeEvent(
-          ~topics=[
+        ~log=(
+          [
             toEventSelector(
               "event VehicleCreated(address indexed, address, (address,address,address[],uint256,address))",
             ),
             "0x00000000000000000000000000000000000000aa"->pad,
           ],
-          ~data=encodeAbiParameters(
+          encodeAbiParameters(
             %raw(`[{"type":"address"},{"type":"tuple","components":[{"type":"address"},{"type":"address"},{"type":"address[]"},{"type":"uint256"},{"type":"address"}]}]`),
             %raw(`["0x0000000000000000000000000000000000000001",["0x0000000000000000000000000000000000000002","0x0000000000000000000000000000000000000003",["0x0000000000000000000000000000000000000004","0x0000000000000000000000000000000000000005"],1000n,"0x0000000000000000000000000000000000000006"]]`),
           ),
@@ -239,29 +244,29 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
       )
 
       t
-        .expect(result)
-        .toEqual(
-          {
-            "deployer": "0x00000000000000000000000000000000000000aa",
-            "vehicle": "0x0000000000000000000000000000000000000001",
-            "params": {
-              "asset": "0x0000000000000000000000000000000000000002",
-              "poolAddressesProvider": "0x0000000000000000000000000000000000000003",
-              "forbiddenAddresses": [
-                "0x0000000000000000000000000000000000000004",
-                "0x0000000000000000000000000000000000000005",
-              ],
-              "initialExpectedSupply": 1000n,
-              "registry": "0x0000000000000000000000000000000000000006",
-            },
-          }->Utils.magic,
-        )
+      .expect(result)
+      .toEqual(
+        {
+          "deployer": "0x00000000000000000000000000000000000000aa",
+          "vehicle": "0x0000000000000000000000000000000000000001",
+          "params": {
+            "asset": "0x0000000000000000000000000000000000000002",
+            "poolAddressesProvider": "0x0000000000000000000000000000000000000003",
+            "forbiddenAddresses": [
+              "0x0000000000000000000000000000000000000004",
+              "0x0000000000000000000000000000000000000005",
+            ],
+            "initialExpectedSupply": 1000n,
+            "registry": "0x0000000000000000000000000000000000000006",
+          },
+        }->Utils.magic,
+      )
 
       let json = result->S.reverseConvertToJsonOrThrow(schema)
       t
-        .expect(json)
-        .toEqual(
-          %raw(`{
+      .expect(json)
+      .toEqual(
+        %raw(`{
         "deployer": "0x00000000000000000000000000000000000000aa",
         "vehicle": "0x0000000000000000000000000000000000000001",
         "params": {
@@ -272,7 +277,7 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
           "registry": "0x0000000000000000000000000000000000000006"
         }
       }`),
-        )
+      )
     },
   )
 
@@ -294,9 +299,9 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
     let result = await decodeSingle(
       ~eventName="MixedEvent",
       ~params,
-      ~event=makeEvent(
-        ~topics=[toEventSelector("event MixedEvent((string,uint256,address,bool))")],
-        ~data=encodeAbiParameters(
+      ~log=(
+        [toEventSelector("event MixedEvent((string,uint256,address,bool))")],
+        encodeAbiParameters(
           %raw(`[{"type":"tuple","components":[{"type":"string"},{"type":"uint256"},{"type":"address"},{"type":"bool"}]}]`),
           %raw(`[["hi", 42n, "0x0000000000000000000000000000000000000abc", true]]`),
         ),
@@ -304,17 +309,17 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
     )
 
     t
-      .expect(result)
-      .toEqual(
-        {
-          "mixed": {
-            "label": "hi",
-            "1": 42n,
-            "recipient": "0x0000000000000000000000000000000000000abc",
-            "3": true,
-          },
-        }->Utils.magic,
-      )
+    .expect(result)
+    .toEqual(
+      {
+        "mixed": {
+          "label": "hi",
+          "1": 42n,
+          "recipient": "0x0000000000000000000000000000000000000abc",
+          "3": true,
+        },
+      }->Utils.magic,
+    )
   })
 
   Async.it("leaves indexed struct params as topic hashes", async t => {
@@ -334,17 +339,11 @@ describe("HyperSync decoder – fromParams + decodeLogs", () => {
     let result = await decodeSingle(
       ~eventName="StructEvent",
       ~params,
-      ~event=makeEvent(
-        ~topics=[
-          toEventSelector("event StructEvent((address,uint256) indexed)"),
-          topicHash,
-        ],
-        ~data="0x",
-      ),
+      ~log=([toEventSelector("event StructEvent((address,uint256) indexed)"), topicHash], "0x"),
     )
 
     t
-      .expect(result)
-      .toEqual({"indexedStruct": topicHash}->Utils.magic)
+    .expect(result)
+    .toEqual({"indexedStruct": topicHash}->Utils.magic)
   })
 })

--- a/scenarios/test_codegen/test/lib_tests/RenamedEventDecode_test.res
+++ b/scenarios/test_codegen/test/lib_tests/RenamedEventDecode_test.res
@@ -8,44 +8,38 @@ external toEventSelector: string => string = "toEventSelector"
 
 // Reproduces https://github.com/enviodev/hyperindex/issues/1285
 // An event given a `name:` that differs from its on-chain name must still
-// decode over HyperSync. The native decoder rebuilds the inner signature from
-// the display `name:` (`reconstruct_signature` in decode.rs), so its topic0
-// becomes keccak256("ApprovalRenamed(address,uint256)") and never matches the
-// real log's keccak256("Approval(address,uint256)"); the log decodes as null.
+// decode. The decoder keys on the on-chain sighash, not the keccak of the
+// display `name:`, so the real log still matches.
 let onChainSighash = toEventSelector("event Approval(address owner, uint256 value)")
 
 let owner = "0x000000000000000000000000000000000000aaaa"
 let value = 42n
 
-let makeEvent = (~topics: array<string>, ~data: string): HyperSyncClient.ResponseTypes.event =>
-  {"log": {"topics": topics, "data": data}}->(
-    Utils.magic: {..} => HyperSyncClient.ResponseTypes.event
-  )
-
-let approvalLog = makeEvent(
-  ~topics=[onChainSighash],
-  ~data=encodeAbiParameters(
+let approvalLog = (
+  [onChainSighash],
+  encodeAbiParameters(
     %raw(`[{"type":"address"},{"type":"uint256"}]`),
     %raw(`["0x000000000000000000000000000000000000aaaa",42n]`),
   ),
 )
 
-describe("Renamed event decoding over HyperSync (issue #1285)", () => {
+describe("Renamed event decoding (issue #1285)", () => {
   Async.it("decodes a renamed event under its real on-chain signature", async t => {
-    let decoder = HyperSyncClient.Decoder.fromParams([
-      {
-        sighash: onChainSighash,
-        topicCount: 1,
-        eventName: "ApprovalRenamed",
-        contractName: "TestContract",
-        params: [
-          {name: "owner", abiType: "address", indexed: false},
-          {name: "value", abiType: "uint256", indexed: false},
-        ],
-      },
-    ])
-
-    let decoded = await decoder.decodeLogs([approvalLog])
+    let decoded = await NativeDecoder.decodeLogs(
+      ~eventParams=[
+        {
+          sighash: onChainSighash,
+          topicCount: 1,
+          eventName: "ApprovalRenamed",
+          contractName: "TestContract",
+          params: [
+            {name: "owner", abiType: "address", indexed: false},
+            {name: "value", abiType: "uint256", indexed: false},
+          ],
+        },
+      ],
+      ~logs=[approvalLog],
+    )
     let paramsByContractName = decoded[0]->Option.getUnsafe->Nullable.toOption
 
     t

--- a/scenarios/test_codegen/test/lib_tests/Rpc_Test.res
+++ b/scenarios/test_codegen/test/lib_tests/Rpc_Test.res
@@ -40,48 +40,4 @@ describe_skip("Rpc Test", () => {
       }),
     )
   })
-
-  Async.it("GetLogs rpc call wildcard call", async t => {
-    let logs = await Rpc.GetLogs.route->Rest.fetch(
-      {
-        fromBlock: 20742567,
-        toBlock: 20742567,
-        address: [],
-        topics: [Single("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")],
-      },
-      ~client,
-    )
-
-    t.expect(logs->Array.length, ~message="Should have 88 transfer logs").toEqual(88)
-  })
-
-  Async.it("GetLogs rpc call with address", async t => {
-    let logs = await Rpc.GetLogs.route->Rest.fetch(
-      {
-        fromBlock: 20742567,
-        toBlock: 20742567,
-        address: ["0xF57e7e7C23978C3cAEC3C3548E3D615c346e79fF"->Address.Evm.fromStringOrThrow],
-        topics: [Single("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")],
-      },
-      ~client,
-    )
-
-    t.expect(logs, ~message="Should have 1 transfer logs").toEqual([
-      {
-        address: "0xf57e7e7c23978c3caec3c3548e3d615c346e79ff"->Address.unsafeFromString,
-        blockHash: "0xd6b9a4d49a8ae1af5a13d2de596d0c045ec80b2cc41754ff09547521eca7bf66",
-        blockNumber: 20742567,
-        data: "0x000000000000000000000000000000000000000000000009c2007651b2500000",
-        logIndex: 125,
-        removed: false,
-        topics: [
-          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          "0x00000000000000000000000074dec05e5b894b0efec69cdf6316971802a2f9a1",
-          "0x0000000000000000000000008eadea389180f8d21393d6c7e9a914b4bb23cbca",
-        ],
-        transactionHash: "0x32461781e65b36f321fb8c9532a2729d6e16026a8f5b242401ff9993ddc0bf27",
-        transactionIndex: 101,
-      },
-    ])
-  })
 })

--- a/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
@@ -50,30 +50,24 @@ let tokenB = makeContract(
   ]: array<Internal.paramMeta>),
 )
 
-let makeEvent = (~topics: array<string>, ~data: string): HyperSyncClient.ResponseTypes.event =>
-  {"log": {"topics": topics, "data": data}}->(
-    Utils.magic: {..} => HyperSyncClient.ResponseTypes.event
-  )
-
 let fromAddr = "0x000000000000000000000000000000000000aaaa"
 let toAddr = "0x000000000000000000000000000000000000bbbb"
 let value = 42n
 
-let transferLog = makeEvent(
-  ~topics=[transferSighash, fromAddr->pad, toAddr->pad],
-  ~data=encodeAbiParameters(%raw(`[{"type":"uint256"}]`), %raw(`[42n]`)),
+let transferLog = (
+  [transferSighash, fromAddr->pad, toAddr->pad],
+  encodeAbiParameters(%raw(`[{"type":"uint256"}]`), %raw(`[42n]`)),
 )
 
 describe("Same-signature event across contracts with different param names", () => {
   Async.it("decodes the shared Transfer under each contract's own param names", async t => {
-    // Full production path: collect the decoder inputs for both contracts,
-    // build the native decoder, decode the shared Transfer log. The decoder
-    // returns params keyed by contract name so each contract's router can pick
-    // its own names instead of the first-registered contract's.
+    // Full production path: collect the decoder inputs for both contracts and
+    // decode the shared Transfer log through EvmRpcClient. The decoder returns
+    // params keyed by contract name so each contract's router can pick its own
+    // names instead of the first-registered contract's.
     let allEventParams = EvmChain.collectEventParams([tokenA, tokenB])
-    let decoder = HyperSyncClient.Decoder.fromParams(allEventParams)
 
-    let decoded = await decoder.decodeLogs([transferLog])
+    let decoded = await NativeDecoder.decodeLogs(~eventParams=allEventParams, ~logs=[transferLog])
     let paramsByContractName = decoded[0]->Option.getUnsafe->Nullable.toOption->Option.getUnsafe
 
     t


### PR DESCRIPTION
## Summary

Adds `eth_getLogs` RPC method support to the Rust-based `EvmRpcClient`, with integrated event parameter decoding. This replaces the previous JavaScript-based `Rpc.getLogs` approach with a native implementation that decodes event logs using the same `DecoderCore` infrastructure as HyperSync.

## Key Changes

- **Rust EvmRpcClient (`packages/cli/src/evm_rpc_source/mod.rs`)**:
  - Added `GetLogsParams` struct to define filter parameters (block range, addresses, topics)
  - Added `RpcLog` struct to represent decoded log fields (hex quantities converted to i64)
  - Added `RpcEventItem` struct pairing logs with their decoded params
  - Implemented `get_logs()` async method that:
    - Calls `eth_getLogs` via JSON-RPC
    - Decodes hex quantities (blockNumber, transactionIndex, logIndex) to integers
    - Spawns blocking task to decode event parameters using `DecoderCore`
    - Returns logs with optional decoded params keyed by contract name
  - Updated `EvmRpcClient::new()` to accept `event_params` and `checksum_addresses` for decoder initialization

- **ReScript bindings (`packages/envio/src/sources/EvmRpcClient.res`)**:
  - Added `getLogsParams` type matching the Rust struct
  - Added `rpcEventItem` type with log and decoded params
  - Updated `t` type to include `getLogs` method
  - Updated `classNew` binding to pass event params and checksum flag to Rust constructor
  - Added error coercion for JSON-RPC errors in `getLogs` calls

- **RpcSource integration (`packages/envio/src/sources/RpcSource.res`)**:
  - Replaced `Rpc.getLogs` call with `rpcClient.getLogs()`
  - Removed separate HyperSync decoder initialization and log-to-event conversion
  - Simplified event processing by using pre-decoded params from `RpcEventItem`
  - Updated `getNextPage` to use `EvmRpcClient.t` instead of generic `Rpc.client`

- **Test infrastructure**:
  - Replaced JavaScript `fetch` stub with `MockJsonRpcServer` module that runs a real local HTTP server (required because Rust client uses its own HTTP stack)
  - Added comprehensive tests for `EvmRpcClient.getLogs()` covering:
    - Event parameter decoding with indexed/non-indexed fields
    - Hex field parsing (blockNumber, transactionIndex, logIndex)
    - Null params when no registered signature matches
    - JSON-RPC error propagation

## Implementation Details

- Hex quantity parsing uses existing `parse_hex_u64` utility and validates against i64::MAX
- Event decoding runs on a tokio blocking task to avoid blocking the async runtime
- Topic filter format matches the flattened structure from JavaScript (null for any, Some(vec) for specific values)
- Decoded params are keyed by contract name, allowing callers to route by address then select the appropriate contract's params

https://claude.ai/code/session_014HcYHxx8g1htYJS1G8Wq4g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EVM log retrieval via the RPC client, with block range plus topic/address filtering and ABI-decoded event parameters returned per log.
  * Updated client initialization to accept event parameter definitions and optional checksum-address behavior.

* **Bug Fixes**
  * Improved decoding flow and surfaced JSON-RPC errors and decoding failures more consistently during log fetching.

* **Refactor**
  * Reworked the public decoder/addon bindings to use separate hypersync vs RPC client interfaces.

* **Tests**
  * Expanded scenario coverage for `getLogs`, decoding correctness, and retry/error behavior using a dedicated mock RPC server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->