### PR TITLE
Add support for custom HTTP headers in RPC client configuration

### DIFF
--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -675,6 +675,13 @@ pub mod evm {
         )]
         pub ws: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[schemars(
+            description = "Optional HTTP headers sent with every request to this RPC endpoint, \
+                           e.g. an Authorization bearer token for gated endpoints. Values support \
+                           ${ENV_VAR} interpolation."
+        )]
+        pub headers: Option<std::collections::BTreeMap<String, String>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(description = "The starting interval in range of blocks per query")]
         pub initial_block_interval: Option<u32>,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -193,6 +193,8 @@ struct RpcConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     ws: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    headers: Option<std::collections::BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     initial_block_interval: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     backoff_multiplicative: Option<f64>,
@@ -413,6 +415,7 @@ impl SystemConfig {
                                     ),
                                 },
                                 ws: rpc.ws.clone(),
+                                headers: rpc.headers.clone(),
                                 initial_block_interval: rpc.initial_block_interval,
                                 backoff_multiplicative: rpc.backoff_multiplicative,
                                 acceleration_additive: rpc.acceleration_additive,

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -1492,6 +1492,7 @@ impl DataSource {
                 url: url.to_string(),
                 source_for: Some(default_for.clone()),
                 ws: None,
+                headers: None,
                 initial_block_interval: None,
                 backoff_multiplicative: None,
                 acceleration_additive: None,

--- a/packages/cli/src/evm_rpc_source/client.rs
+++ b/packages/cli/src/evm_rpc_source/client.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::json;
@@ -39,7 +40,6 @@ struct JsonRpcResponse {
 pub struct JsonRpcClient {
     http: reqwest::Client,
     url: String,
-    headers: Option<HashMap<String, String>>,
 }
 
 impl JsonRpcClient {
@@ -52,11 +52,21 @@ impl JsonRpcClient {
         http_req_timeout_millis: u64,
         headers: Option<HashMap<String, String>>,
     ) -> Result<Self> {
-        let http = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_millis(http_req_timeout_millis))
-            .build()
-            .context("build http client")?;
-        Ok(Self { http, url, headers })
+        let mut builder = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(http_req_timeout_millis));
+        if let Some(headers) = headers {
+            let mut header_map = HeaderMap::with_capacity(headers.len());
+            for (name, value) in headers {
+                let header_name = HeaderName::try_from(name.as_str())
+                    .with_context(|| format!("invalid RPC header name {name:?}"))?;
+                let header_value = HeaderValue::try_from(value.as_str())
+                    .with_context(|| format!("invalid value for RPC header {name:?}"))?;
+                header_map.insert(header_name, header_value);
+            }
+            builder = builder.default_headers(header_map);
+        }
+        let http = builder.build().context("build http client")?;
+        Ok(Self { http, url })
     }
 
     pub async fn request<T: DeserializeOwned>(
@@ -70,13 +80,10 @@ impl JsonRpcClient {
             "id": 1,
             "jsonrpc": "2.0",
         });
-        let mut request = self.http.post(&self.url).json(&body);
-        if let Some(headers) = &self.headers {
-            for (key, value) in headers {
-                request = request.header(key.as_str(), value.as_str());
-            }
-        }
-        let response = request
+        let response = self
+            .http
+            .post(&self.url)
+            .json(&body)
             .send()
             .await
             .with_context(|| format!("send {method} request"))

--- a/packages/cli/src/evm_rpc_source/client.rs
+++ b/packages/cli/src/evm_rpc_source/client.rs
@@ -3,6 +3,7 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::json;
 use serde_json::value::RawValue;
+use std::collections::HashMap;
 
 /// JSON-RPC level errors are kept separate from transport/parse failures:
 /// provider error messages carry block-range hints the caller inspects.
@@ -38,6 +39,7 @@ struct JsonRpcResponse {
 pub struct JsonRpcClient {
     http: reqwest::Client,
     url: String,
+    headers: Option<HashMap<String, String>>,
 }
 
 impl JsonRpcClient {
@@ -45,12 +47,16 @@ impl JsonRpcClient {
         120_000
     }
 
-    pub fn new(url: String, http_req_timeout_millis: u64) -> Result<Self> {
+    pub fn new(
+        url: String,
+        http_req_timeout_millis: u64,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<Self> {
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_millis(http_req_timeout_millis))
             .build()
             .context("build http client")?;
-        Ok(Self { http, url })
+        Ok(Self { http, url, headers })
     }
 
     pub async fn request<T: DeserializeOwned>(
@@ -64,10 +70,13 @@ impl JsonRpcClient {
             "id": 1,
             "jsonrpc": "2.0",
         });
-        let response = self
-            .http
-            .post(&self.url)
-            .json(&body)
+        let mut request = self.http.post(&self.url).json(&body);
+        if let Some(headers) = &self.headers {
+            for (key, value) in headers {
+                request = request.header(key.as_str(), value.as_str());
+            }
+        }
+        let response = request
             .send()
             .await
             .with_context(|| format!("send {method} request"))

--- a/packages/cli/src/evm_rpc_source/mod.rs
+++ b/packages/cli/src/evm_rpc_source/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use napi_derive::napi;
 use serde::Deserialize;
 use serde_json::json;
+use std::collections::HashMap;
 
 mod client;
 
@@ -13,6 +14,7 @@ use client::{parse_hex_u64, JsonRpcClient, RpcError};
 pub struct EvmRpcClientConfig {
     pub url: String,
     pub http_req_timeout_millis: Option<i64>,
+    pub headers: Option<HashMap<String, String>>,
 }
 
 #[napi(object)]
@@ -113,7 +115,8 @@ impl EvmRpcClient {
             .map_or(JsonRpcClient::default_http_req_timeout_millis(), |v| {
                 v as u64
             });
-        let inner = JsonRpcClient::new(cfg.url, http_req_timeout_millis).map_err(map_err)?;
+        let inner =
+            JsonRpcClient::new(cfg.url, http_req_timeout_millis, cfg.headers).map_err(map_err)?;
         let decoder = DecoderCore::from_params(event_params, checksum_addresses)
             .context("build decoder")
             .map_err(map_err)?;

--- a/packages/envio/evm.schema.json
+++ b/packages/envio/evm.schema.json
@@ -548,6 +548,16 @@
             "null"
           ]
         },
+        "headers": {
+          "description": "Optional HTTP headers sent with every request to this RPC endpoint, e.g. an Authorization bearer token for gated endpoints. Values support ${ENV_VAR} interpolation.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "initial_block_interval": {
           "description": "The starting interval in range of blocks per query",
           "type": [

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -262,11 +262,13 @@ let makeInternal = (
     let evmRpcs: array<EvmChain.rpc> = rpcs->Array.map((rpc): EvmChain.rpc => {
       let syncConfig = rpc.syncConfig
       let ws = rpc.ws
+      let headers = rpc.headers
       {
         url: rpc.url,
         sourceFor: rpc.sourceFor,
         ?syncConfig,
         ?ws,
+        ?headers,
       }
     })
     EvmChain.makeSources(

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -23,6 +23,7 @@ type evmRpcConfig = {
   sourceFor: Source.sourceFor,
   syncConfig: option<sourceSyncOptions>,
   ws: option<string>,
+  headers: option<dict<string>>,
 }
 
 type sourceConfig =
@@ -156,6 +157,7 @@ let rpcConfigSchema = S.schema(s =>
     "url": s.matches(S.string),
     "for": s.matches(rpcSourceForSchema),
     "ws": s.matches(S.option(S.string)),
+    "headers": s.matches(S.option(S.dict(S.string))),
     "initialBlockInterval": s.matches(S.option(S.int)),
     "backoffMultiplicative": s.matches(S.option(S.float)),
     "accelerationAdditive": s.matches(S.option(S.int)),
@@ -907,6 +909,7 @@ let fromPublic = (publicConfigJson: JSON.t) => {
               sourceFor: parseRpcSourceFor(rpcConfig["for"]),
               syncConfig,
               ws: rpcConfig["ws"],
+              headers: rpcConfig["headers"],
             }
           })
         EvmSourceConfig({hypersync: publicChainConfig["hypersync"], rpcs})

--- a/packages/envio/src/sources/EvmChain.res
+++ b/packages/envio/src/sources/EvmChain.res
@@ -3,6 +3,7 @@ type rpc = {
   sourceFor: Source.sourceFor,
   syncConfig?: Config.sourceSyncOptions,
   ws?: string,
+  headers?: dict<string>,
 }
 
 let getSyncConfig = (
@@ -89,7 +90,7 @@ let makeSources = (
     ]
   | _ => []
   }
-  rpcs->Array.forEach(({?syncConfig, url, sourceFor, ?ws}) => {
+  rpcs->Array.forEach(({?syncConfig, url, sourceFor, ?ws, ?headers}) => {
     let source = RpcSource.make({
       chain,
       sourceFor,
@@ -99,6 +100,7 @@ let makeSources = (
       allEventParams,
       lowercaseAddresses,
       ?ws,
+      ?headers,
     })
     let _ = sources->Array.push(source)
   })

--- a/packages/envio/src/sources/EvmRpcClient.res
+++ b/packages/envio/src/sources/EvmRpcClient.res
@@ -1,4 +1,4 @@
-type cfg = {url: string, httpReqTimeoutMillis?: int}
+type cfg = {url: string, httpReqTimeoutMillis?: int, headers?: dict<string>}
 
 // `addresses` omitted matches any address (a wildcard selection). Each `topics`
 // position is `null` (match any) or a list of accepted topic hashes; the
@@ -59,10 +59,10 @@ let coerceErrorOrThrow = exn =>
   | None => exn->throw
   }
 
-let make = (~url, ~checksumAddresses, ~httpReqTimeoutMillis=?, ~allEventParams=[]) => {
+let make = (~url, ~checksumAddresses, ~httpReqTimeoutMillis=?, ~headers=?, ~allEventParams=[]) => {
   let client =
     Core.getAddon().evmRpcClient->classNew(
-      {url, ?httpReqTimeoutMillis},
+      {url, ?httpReqTimeoutMillis, ?headers},
       allEventParams,
       ~checksumAddresses,
     )

--- a/packages/envio/src/sources/Rpc.res
+++ b/packages/envio/src/sources/Rpc.res
@@ -38,7 +38,21 @@ let jsonRpcFetcher: Rest.ApiFetcher.t = async args => {
   }
 }
 
-let makeClient = url => Rest.client(url, ~fetcher=jsonRpcFetcher)
+let makeClient = (url, ~headers=?) => {
+  let fetcher: Rest.ApiFetcher.t = switch headers {
+  | None => jsonRpcFetcher
+  | Some(customHeaders) =>
+    async args => {
+      let headers = switch args.headers {
+      | Some(headers) => headers
+      | None => Dict.make()
+      }
+      customHeaders->Dict.forEachWithKey((value, key) => headers->Dict.set(key, value->Obj.magic))
+      await jsonRpcFetcher({...args, headers: Some(headers)})
+    }
+  }
+  Rest.client(url, ~fetcher)
+}
 
 type hex = string
 let makeHexSchema = fromStr =>

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -858,6 +858,7 @@ type options = {
   allEventParams: array<HyperSyncClient.Decoder.eventParamsInput>,
   lowercaseAddresses: bool,
   ws?: string,
+  headers?: dict<string>,
 }
 
 let make = (
@@ -870,6 +871,7 @@ let make = (
     allEventParams,
     lowercaseAddresses,
     ?ws,
+    ?headers,
   }: options,
 ): t => {
   let chainId = chain->ChainMap.Chain.toChainId
@@ -886,8 +888,13 @@ let make = (
 
   let mutSuggestedBlockIntervals = Dict.make()
 
-  let client = Rpc.makeClient(url)
-  let rpcClient = EvmRpcClient.make(~url, ~allEventParams, ~checksumAddresses=!lowercaseAddresses)
+  let client = Rpc.makeClient(url, ~headers?)
+  let rpcClient = EvmRpcClient.make(
+    ~url,
+    ~allEventParams,
+    ~checksumAddresses=!lowercaseAddresses,
+    ~headers?,
+  )
 
   let makeTransactionLoader = () =>
     LazyLoader.make(

--- a/scenarios/test_codegen/test/helpers/MockRpcServer.res
+++ b/scenarios/test_codegen/test/helpers/MockRpcServer.res
@@ -17,7 +17,10 @@ type address = {port: int}
 @send external setEncoding: (req, string) => unit = "setEncoding"
 @send external onData: (req, @as("data") _, string => unit) => unit = "on"
 @send external onEnd: (req, @as("end") _, unit => unit) => unit = "on"
-@get external reqHeaders: req => dict<string> = "headers"
+// Node's IncomingHttpHeaders values are `string | string[]` (duplicated headers
+// arrive as arrays); model both and expose a single-value accessor below.
+@unboxed type headerValue = Single(string) | Multiple(array<string>)
+@get external reqHeaders: req => dict<headerValue> = "headers"
 
 @send external writeHead: (res, int, dict<string>) => unit = "writeHead"
 @send external end_: (res, string) => unit = "end"
@@ -25,9 +28,17 @@ type address = {port: int}
 type t = {
   url: string,
   requests: array<string>,
-  requestHeaders: array<dict<string>>,
+  requestHeaders: array<dict<headerValue>>,
   close: unit => unit,
 }
+
+// Read a single-valued request header (first value if it was repeated).
+let getHeader = (headers: dict<headerValue>, name: string): option<string> =>
+  switch headers->Dict.get(name) {
+  | Some(Single(value)) => Some(value)
+  | Some(Multiple(values)) => values->Array.get(0)
+  | None => None
+  }
 
 let start = (~handler: string => (int, string)) =>
   Promise.make((resolve, _reject) => {

--- a/scenarios/test_codegen/test/helpers/MockRpcServer.res
+++ b/scenarios/test_codegen/test/helpers/MockRpcServer.res
@@ -17,21 +17,29 @@ type address = {port: int}
 @send external setEncoding: (req, string) => unit = "setEncoding"
 @send external onData: (req, @as("data") _, string => unit) => unit = "on"
 @send external onEnd: (req, @as("end") _, unit => unit) => unit = "on"
+@get external reqHeaders: req => dict<string> = "headers"
 
 @send external writeHead: (res, int, dict<string>) => unit = "writeHead"
 @send external end_: (res, string) => unit = "end"
 
-type t = {url: string, requests: array<string>, close: unit => unit}
+type t = {
+  url: string,
+  requests: array<string>,
+  requestHeaders: array<dict<string>>,
+  close: unit => unit,
+}
 
 let start = (~handler: string => (int, string)) =>
   Promise.make((resolve, _reject) => {
     let requests = []
+    let requestHeaders = []
     let server = createServer((req, res) => {
       req->setEncoding("utf8")
       let data = ref("")
       req->onData(chunk => data := data.contents ++ chunk)
       req->onEnd(() => {
         requests->Array.push(data.contents)->ignore
+        requestHeaders->Array.push(req->reqHeaders)->ignore
         let (status, body) = handler(data.contents)
         res->writeHead(status, Dict.fromArray([("Content-Type", "application/json")]))
         res->end_(body)
@@ -41,6 +49,7 @@ let start = (~handler: string => (int, string)) =>
       resolve({
         url: `http://127.0.0.1:${(server->address).port->Int.toString}`,
         requests,
+        requestHeaders,
         close: () => {
           server->closeAllConnections
           server->close(() => ())

--- a/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
@@ -111,9 +111,23 @@ describe("EvmRpcClient - getHeight via napi", () => {
     mock.close()
 
     // Node lowercases header names on the way in.
-    t.expect(mock.requestHeaders->Array.getUnsafe(0)->Dict.get("authorization")).toEqual(
-      Some("Bearer test-token"),
-    )
+    t.expect(
+      MockRpcServer.getHeader(mock.requestHeaders->Array.getUnsafe(0), "authorization"),
+    ).toEqual(Some("Bearer test-token"))
+  })
+
+  it("Rejects an invalid header value at construction with a clear error", t => {
+    let message = try {
+      let _ = EvmRpcClient.make(
+        ~url="http://127.0.0.1:1",
+        ~checksumAddresses=false,
+        ~headers=Dict.fromArray([("Authorization", "Bearer bad\nvalue")]),
+      )
+      None
+    } catch {
+    | JsExn(e) => e->JsExn.message
+    }
+    t.expect(message->Option.getOr("no error")).toMatch(/invalid value for RPC header/)
   })
 })
 

--- a/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
@@ -95,6 +95,26 @@ describe("EvmRpcClient - getHeight via napi", () => {
 
     t.expect(message->Option.getOr("no error")).toMatch(/parse eth_blockNumber result/)
   })
+
+  Async.it("Sends configured custom headers with the request", async t => {
+    let mock = await MockRpcServer.makeRaw(
+      ~status=200,
+      ~body=`{"jsonrpc":"2.0","id":1,"result":"0x1b4"}`,
+    )
+    let client = EvmRpcClient.make(
+      ~url=mock.url,
+      ~checksumAddresses=false,
+      ~headers=Dict.fromArray([("Authorization", "Bearer test-token")]),
+    )
+
+    let _ = await client.getHeight()
+    mock.close()
+
+    // Node lowercases header names on the way in.
+    t.expect(mock.requestHeaders->Array.getUnsafe(0)->Dict.get("authorization")).toEqual(
+      Some("Bearer test-token"),
+    )
+  })
 })
 
 describe("EvmRpcClient - getLogs via napi", () => {

--- a/scenarios/test_codegen/test/lib_tests/RpcRestClient_test.res
+++ b/scenarios/test_codegen/test/lib_tests/RpcRestClient_test.res
@@ -1,0 +1,27 @@
+open Vitest
+
+describe("Rpc.makeClient - headers", () => {
+  Async.it("Sends configured custom headers with the request", async t => {
+    let mock = await MockRpcServer.makeRaw(
+      ~status=200,
+      ~body=`{"jsonrpc":"2.0","id":1,"result":null}`,
+    )
+    let client = Rpc.makeClient(
+      mock.url,
+      ~headers=Dict.fromArray([("Authorization", "Bearer rest-token")]),
+    )
+
+    let _ = try await Rpc.GetBlockByNumber.route->Rest.fetch(
+      {"blockNumber": 1, "includeTransactions": false},
+      ~client,
+    ) catch {
+    | _ => None
+    }
+    mock.close()
+
+    // Node lowercases header names on the way in.
+    t.expect(mock.requestHeaders->Array.getUnsafe(0)->Dict.get("authorization")).toEqual(
+      Some("Bearer rest-token"),
+    )
+  })
+})

--- a/scenarios/test_codegen/test/lib_tests/RpcRestClient_test.res
+++ b/scenarios/test_codegen/test/lib_tests/RpcRestClient_test.res
@@ -20,8 +20,8 @@ describe("Rpc.makeClient - headers", () => {
     mock.close()
 
     // Node lowercases header names on the way in.
-    t.expect(mock.requestHeaders->Array.getUnsafe(0)->Dict.get("authorization")).toEqual(
-      Some("Bearer rest-token"),
-    )
+    t.expect(
+      MockRpcServer.getHeader(mock.requestHeaders->Array.getUnsafe(0), "authorization"),
+    ).toEqual(Some("Bearer rest-token"))
   })
 })


### PR DESCRIPTION
## Summary
Adds support for configuring custom HTTP headers (e.g., Authorization tokens) that are sent with every request to RPC endpoints. This enables integration with gated or authenticated RPC services.

## Key Changes
- **Config schema updates**: Added optional `headers` field to RPC configuration in `evm.schema.json`, `human_config.rs`, and `public_config.rs` with support for `${ENV_VAR}` interpolation
- **Rust RPC client**: Modified `JsonRpcClient` to accept and apply custom headers to all outgoing requests
- **ReScript runtime**: Updated `Rpc.makeClient` and `EvmRpcClient.make` to accept optional headers parameter and propagate through the request pipeline
- **Config parsing**: Extended `Config.res`, `ChainState.res`, and `EvmChain.res` to thread headers through the configuration system
- **Tests**: Added test cases verifying custom headers are correctly sent with requests in both `EvmRpcClient_test.res` and new `RpcRestClient_test.res`
- **Test infrastructure**: Enhanced `MockRpcServer` to capture and expose request headers for assertion

## Implementation Details
- Headers are passed as `Option<HashMap<String, String>>` in Rust and `dict<string>` in ReScript
- In the ReScript REST client, custom headers are merged with any existing headers from the request arguments
- The implementation maintains backward compatibility—headers are optional throughout the stack

https://claude.ai/code/session_01F1aBD3VP4BKukt2hedVRQU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional custom HTTP headers on RPC connections.
  * Headers can now be configured per RPC endpoint and included in generated config.
  * Request headers are passed through to both REST and JSON-RPC clients.

* **Tests**
  * Added coverage to verify custom headers are sent and received correctly in RPC requests.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->