### PR TITLE
Fix buffer budget accounting to measure past ready frontier

### DIFF
--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -592,6 +592,25 @@ let bufferBlock = ({optimizedPartitions, latestOnBlockBlockNumber}: t) => {
   }
 }
 
+// Number of buffered items at or below the ready frontier (processable now,
+// i.e. not stuck behind a gap from a lagging partition or out-of-order chunk).
+// The buffer is kept sorted, so binary-search the frontier in O(log n).
+let bufferReadyCount = (fetchState: t) => {
+  let frontier = fetchState->bufferBlockNumber
+  let buffer = fetchState.buffer
+  let lo = ref(0)
+  let hi = ref(buffer->Array.length)
+  while lo.contents < hi.contents {
+    let mid = (lo.contents + hi.contents) / 2
+    if buffer->Array.getUnsafe(mid)->Internal.getItemBlockNumber <= frontier {
+      lo := mid + 1
+    } else {
+      hi := mid
+    }
+  }
+  lo.contents
+}
+
 /*
 Comparitor for two events from the same chain. No need for chain id or timestamp
 */
@@ -1462,11 +1481,16 @@ let getNextQuery = (
       !isOnBlockBehindTheHead,
     )
 
-    // Limit how far ahead we fetch to budget items (plus what's already in
-    // flight) so processing always has buffer without ballooning memory. A
-    // partition that fetched further is skipped until the buffer drains.
+    // Fetch at most `budget` items past the ready frontier (plus what's already
+    // in flight) so processing always has buffer without ballooning memory.
+    // budget already excludes items at/below the frontier (they're in the shared
+    // totalReadyCount), so offset the index by bufferReadyCount — otherwise the
+    // ready prefix is subtracted twice and the buffer caps at a fraction of its
+    // target. A partition that fetched further is skipped until the buffer drains.
     let maxQueryBlockNumber = {
-      switch buffer->Array.get(budget + chainPendingBudget->Float.toInt - 1) {
+      switch buffer->Array.get(
+        fetchState->bufferReadyCount + budget + chainPendingBudget->Float.toInt - 1,
+      ) {
       | Some(item) =>
         // Just in case check that we don't query beyond the current block
         Pervasives.min(item->Internal.getItemBlockNumber, knownHeight)
@@ -1818,25 +1842,6 @@ let make = (
 }
 
 let bufferSize = ({buffer}: t) => buffer->Array.length
-
-// Number of buffered items at or below the ready frontier (processable now,
-// i.e. not stuck behind a gap from a lagging partition or out-of-order chunk).
-// The buffer is kept sorted, so binary-search the frontier in O(log n).
-let bufferReadyCount = (fetchState: t) => {
-  let frontier = fetchState->bufferBlockNumber
-  let buffer = fetchState.buffer
-  let lo = ref(0)
-  let hi = ref(buffer->Array.length)
-  while lo.contents < hi.contents {
-    let mid = (lo.contents + hi.contents) / 2
-    if buffer->Array.getUnsafe(mid)->Internal.getItemBlockNumber <= frontier {
-      lo := mid + 1
-    } else {
-      hi := mid
-    }
-  }
-  lo.contents
-}
 
 let rollbackPendingQueries = (mutPendingQueries: array<pendingQuery>, ~targetBlockNumber) => {
   // - Remove queries where fromBlock > target

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1889,8 +1889,23 @@ describe("FetchState.getNextQuery & integration", () => {
     ).toEqual(WaitingForNewBlock)
     t.expect(
       updatedFetchState->getNextQuery(~budget=2, ~knownHeight=11),
-      ~message=`Should do nothing if the case above is not waiting for new block`,
-    ).toEqual(NothingToQuery)
+      ~message=`Should fetch the head block once the partition is behind the head:
+      budget is measured past the ready frontier, so the 2 already-ready items
+      don't eat the budget and pin the target block below the frontier`,
+    ).toEqual(
+      Ready([
+        {
+          ...defaultQuery,
+          partitionId: "0",
+          estResponseSize: 10000.,
+          fromBlock: 11,
+          toBlock: None,
+          selection: updatedFetchState.normalSelection,
+          addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
+          isChunk: false,
+        },
+      ]),
+    )
 
     updatedFetchState->FetchState.startFetchingQueries(~queries=[query])
     t.expect(
@@ -2240,9 +2255,10 @@ describe("FetchState.getNextQuery & integration", () => {
 
     t.expect(
       fetchStateWithResponse1->getNextQuery(~budget=1),
-      ~message=`Even if we have a partition with toBlock which wants to merge
-      if it's outside of the budget, we should return NothingToQuery`,
-    ).toEqual(NothingToQuery)
+      ~message=`Buffer has no items past the ready frontier, so a tight budget no
+      longer caps the proposal here (the shared budget is enforced by cross-chain
+      admission); the merge continuation is proposed the same as with a full budget`,
+    ).toEqual(fetchStateWithResponse1->getNextQuery)
 
     let queries = switch fetchStateWithResponse1->getNextQuery {
     | Ready(queries) => queries
@@ -2813,9 +2829,10 @@ describe("FetchState unit tests for specific cases", () => {
       {
         ...fetchState,
         knownHeight: 2,
-      }->FetchState.getNextQuery(~budget=2, ~chainPendingBudget=0.),
-      ~message=`Should wait until queue is processed, to continue fetching.
-      Don't wait for new block, until all partitions reached the head`,
+      }->FetchState.getNextQuery(~budget=1, ~chainPendingBudget=0.),
+      ~message=`Budget is measured past the ready frontier; the item already
+      buffered past it consumes the single-item budget, so the behind partition
+      stays capped and nothing new is fetched until the queue drains`,
     ).toEqual(NothingToQuery)
   })
 


### PR DESCRIPTION
## Summary

Fix a buffer budget accounting bug where the ready prefix was being subtracted twice, causing the buffer to cap at a fraction of its target size. The budget should measure items *past* the ready frontier (processable items), not from the start of the buffer.

## Changes

- **Moved `bufferReadyCount` function earlier** in FetchState.res to make it available before `getNextQuery`, which now uses it to correctly offset the budget calculation
- **Updated budget calculation in `getNextQuery`** to add `bufferReadyCount` when indexing into the buffer, ensuring the budget measures items past the ready frontier rather than from the buffer start
- **Updated test expectations** to reflect the corrected behavior:
  - A partition behind the head can now fetch when budget allows, since ready items no longer consume the budget
  - Tight budgets no longer artificially cap queries when the buffer has no items past the frontier
  - Budget accounting now correctly allows the buffer to reach its target size

## Implementation Details

The buffer is kept sorted by block number. The ready frontier is the highest block number where all partitions have data (no gaps). Items at or below this frontier are processable immediately.

Previously, `maxQueryBlockNumber` was calculated as `buffer[budget + pending - 1]`, which treated the budget as an absolute index. This meant ready items (which should always be processable) were consuming budget slots, leaving less room for buffering ahead.

Now it's calculated as `buffer[bufferReadyCount + budget + pending - 1]`, correctly measuring the budget as "how many items past the ready frontier to fetch" rather than "absolute position in buffer". This ensures:
- Ready items don't consume budget
- The buffer can grow to its intended size
- Partitions aren't artificially starved when they have room to fetch

https://claude.ai/code/session_01N5UqJXYVuTRrYxwGygeW4S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted fetch budgeting so already-ready buffered items are counted correctly when deciding the next query.
  * Tight-budget cases now behave more consistently during partition head and merge continuation flows.
  * Improved handling of “fetch ahead” limits so they no longer undercount available work at the ready frontier.

* **Tests**
  * Updated coverage to reflect the revised budget behavior in several query-planning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->