### PR TITLE
Remove RPC source configuration from indexer skills

### DIFF
--- a/packages/cli/templates/static/shared/.claude/skills/indexer-configuration/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-configuration/SKILL.md
@@ -148,8 +148,4 @@ Add at top of file for IDE schema validation:
 - `rpc_config` — replaced by `rpc:` under chains
 - `unordered_multichain_mode` — removed
 
-## RPC Configuration
-
-RPC tuning parameters are documented in the `indexer-performance` skill.
-
 > If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/packages/cli/templates/static/shared/.claude/skills/indexer-performance/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-performance/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: indexer-performance
 description: >-
-  Use when optimizing indexer speed or tuning sync performance. HyperSync vs
-  RPC, batch size, RPC tuning parameters, WebSocket config, and preload
-  optimization.
+  Use when optimizing indexer speed or tuning sync performance. HyperSync,
+  batch size, WebSocket realtime config, and preload optimization.
 metadata:
   managed-by: envio
 ---
@@ -22,36 +21,7 @@ full_batch_size: 5000  # Target events per batch (default: 5000)
 
 Reduce if handlers make many slow Effect API calls that can't be batched.
 
-## RPC Tuning
-
-When using RPC as a data source, tune these parameters per chain:
-
-```yaml
-chains:
-  - id: 1
-    rpc:
-      - url: ${ENVIO_RPC_URL}
-        for: sync                    # sync | realtime | fallback
-        ws: ${ENVIO_WS_URL}               # WebSocket for lower-latency realtime block detection
-        initial_block_interval: 5000 # Starting blocks per query
-        backoff_multiplicative: 0.8  # Scale factor after RPC error (0.5-0.9)
-        acceleration_additive: 1000  # Blocks added per successful query
-        interval_ceiling: 10000      # Max blocks per query
-        backoff_millis: 5000         # Wait after error before retry (ms)
-        query_timeout_millis: 20000  # Cancel RPC request after this (ms)
-        fallback_stall_timeout: 5000 # Switch to next RPC after stall (ms)
-        polling_interval: 1000       # Check for new blocks every N ms (default: 1000)
-```
-
-### RPC `for` Options
-
-| Value | Description |
-|-------|-------------|
-| `sync` | RPC as main data source for both historical and realtime |
-| `realtime` | HyperSync for historical, switch to RPC for realtime (lower latency) |
-| `fallback` | Backup when primary stalls (default when HyperSync available) |
-
-### WebSocket for Realtime Indexing
+## WebSocket for Realtime Indexing
 
 Add `ws:` for lower-latency new block detection via `eth_subscribe("newHeads")`:
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexer-troubleshooting/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-troubleshooting/SKILL.md
@@ -2,7 +2,7 @@
 name: indexer-troubleshooting
 description: >-
   Use when the indexer fails to start, codegen errors, types are stale,
-  Docker or database issues, RPC errors, or something is not working.
+  Docker or database issues, or something is not working.
   Common error messages and fixes.
 metadata:
   managed-by: envio
@@ -44,9 +44,7 @@ rpc:
   - url: ${ENVIO_RPC_URL}
 ```
 
-## RPC / HyperSync Errors
-
-**"rate limited" or timeout errors:** See `indexer-performance` skill for RPC tuning parameters.
+## HyperSync Errors
 
 **Missing `ENVIO_API_TOKEN`:** Required for HyperSync. Get an Envio API token at https://envio.dev/app/api-tokens, then set it in `.env` or shell environment.
 


### PR DESCRIPTION
Removes the dedicated **RPC-as-a-data-source** documentation from the managed indexer skill set (`packages/cli/templates/static/shared/.claude/skills/`). RPC source configuration is no longer surfaced as guidance in the skills — except the WebSocket realtime section, kept by request.

## Removed
- **indexer-performance** — the `## RPC Tuning` section (tuning params, `for` options table); RPC-tuning wording dropped from the frontmatter description. The `WebSocket for Realtime Indexing` section is **kept** (promoted from `###` to `##` now that its parent section is gone).
- **indexer-configuration** — the `## RPC Configuration` pointer section.
- **indexer-troubleshooting** — the "rate limited / RPC tuning" error bullet; renamed `RPC / HyperSync Errors` → `HyperSync Errors`; dropped RPC from the frontmatter description.

## Intentionally left in place
These reference RPC but aren't RPC source-configuration docs:
- **indexer-external-calls** / **indexer-traces** — handler-level RPC calls via the Effect API / viem (a different feature).
- The `## Environment Variables` sections in **indexer-configuration** and **indexer-troubleshooting** — they teach the required `ENVIO_` prefix and only use an `rpc:` URL as the example.
- The `rpc_config` deprecation note in **indexer-configuration** — a "do not use" warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for indexer-related skills to better reflect current optimization and troubleshooting topics.
  * Simplified one skill by removing an outdated configuration section.
  * Refined performance guidance to emphasize WebSocket-based realtime indexing and related optimization tips.
  * Streamlined troubleshooting content by focusing on HyperSync errors and removing RPC-specific references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->