### PR TITLE
Fix RPC cross-contract event-filter leak

### DIFF
--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -367,16 +367,12 @@ type selectionConfig = {
 }
 
 let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
-  let entries =
-    selection.eventConfigs
-    ->(Utils.magic: array<Internal.eventConfig> => array<Internal.evmEventConfig>)
-    ->Array.map(({isWildcard, dependsOnAddresses, getEventFiltersOrThrow}) => (
-      isWildcard,
-      dependsOnAddresses,
-      getEventFiltersOrThrow(chain),
-    ))
+  let evmEventConfigs =
+    selection.eventConfigs->(
+      Utils.magic: array<Internal.eventConfig> => array<Internal.evmEventConfig>
+    )
 
-  if entries->Utils.Array.isEmpty {
+  if evmEventConfigs->Utils.Array.isEmpty {
     throw(
       Source.GetItemsError(
         UnsupportedSelection({
@@ -386,12 +382,51 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
     )
   }
 
-  // eth_getLogs expresses one topic selection per request, so fan out to one
-  // request per selection. Wildcard events match any address (their address
-  // constraint, if any, lives in the topics); address-bound events are scoped
-  // to the partition's addresses. `compressTopicSelections` folds the
-  // filter-less events into a single topic0 OR-set, keeping the common case at
-  // one request.
+  // eth_getLogs takes one address list and one topic selection per request, so
+  // fan out to one request per selection. Each address-bound event is grouped by
+  // its contract and later scoped to that contract's own addresses — pooling all
+  // contracts' addresses would let one contract's query fetch a sibling's logs,
+  // which route back by address and bypass the sibling's filter (routing never
+  // re-applies it). Pure-wildcard events carry no address constraint, so they're
+  // pooled and resolved once.
+  let noAddressTopicSelections = []
+  let staticByContract = Dict.make()
+  let dynamicByContract = Dict.make()
+  let dynamicWildcardByContract = Dict.make()
+  let contractNames = Utils.Set.make()
+
+  evmEventConfigs->Array.forEach(({
+    contractName,
+    isWildcard,
+    dependsOnAddresses,
+    getEventFiltersOrThrow,
+  }) => {
+    let eventFilters = getEventFiltersOrThrow(chain)
+    if dependsOnAddresses {
+      contractNames->Utils.Set.add(contractName)->ignore
+      switch eventFilters {
+      | Internal.Static(topicSelections) =>
+        staticByContract->Utils.Dict.pushMany(contractName, topicSelections)
+      | Dynamic(fn) =>
+        (isWildcard ? dynamicWildcardByContract : dynamicByContract)->Utils.Dict.push(
+          contractName,
+          fn,
+        )
+      }
+    } else {
+      noAddressTopicSelections
+      ->Array.pushMany(
+        switch eventFilters {
+        | Static(s) => s
+        | Dynamic(fn) => fn([])
+        },
+      )
+      ->ignore
+    }
+  })
+
+  // `compressTopicSelections` folds the filter-less events into a single topic0
+  // OR-set, keeping the common case at one request.
   let toLogSelections = (~addresses, topicSelections): array<logSelection> =>
     topicSelections
     ->LogSelection.compressTopicSelections
@@ -400,43 +435,51 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
       topicQuery: topicSelection->Rpc.GetLogs.mapTopicQuery,
     })
 
-  let buildLogSelections = (~addresses) => {
-    let wildcardTopicSelections = []
-    let addressedTopicSelections = []
-    entries->Array.forEach(((isWildcard, _, eventFilters)) => {
-      let topicSelections = switch eventFilters {
-      | Internal.Static(s) => s
-      | Dynamic(fn) => fn(addresses)
-      }
-      (isWildcard ? wildcardTopicSelections : addressedTopicSelections)
-      ->Array.pushMany(topicSelections)
-      ->ignore
-    })
+  // Address-independent, so resolve once (the wildcard partition reuses this).
+  let noAddressLogSelections = toLogSelections(~addresses=None, noAddressTopicSelections)
 
-    let logSelections = toLogSelections(~addresses=None, wildcardTopicSelections)
-    // Address-bound events have nothing to match without a concrete address set.
-    switch addresses {
-    | [] => ()
-    | _ =>
-      logSelections
-      ->Array.pushMany(toLogSelections(~addresses=Some(addresses), addressedTopicSelections))
-      ->ignore
-    }
-    logSelections
-  }
-
-  // When no event depends on addresses (the wildcard partition), the fanned
-  // selections are identical every batch, so build them once.
-  let getLogSelectionsOrThrow = if (
-    entries->Array.every(((_, dependsOnAddresses, _)) => !dependsOnAddresses)
-  ) {
-    let logSelections = buildLogSelections(~addresses=[])
-    (~addressesByContractName as _) => logSelections
+  let getLogSelectionsOrThrow = if contractNames->Utils.Set.size === 0 {
+    (~addressesByContractName as _) => noAddressLogSelections
   } else {
-    (~addressesByContractName) =>
-      buildLogSelections(
-        ~addresses=addressesByContractName->FetchState.addressesByContractNameGetAll,
-      )
+    (~addressesByContractName): array<logSelection> => {
+      let logSelections = noAddressLogSelections->Array.copy
+      contractNames->Utils.Set.forEach(contractName => {
+        switch addressesByContractName->Utils.Dict.dangerouslyGetNonOption(contractName) {
+        | None
+        | Some([]) => ()
+        | Some(addresses) =>
+          // Static + dynamic non-wildcard filters, scoped to this contract's addresses.
+          let addressedTopicSelections = []
+          switch staticByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
+          | Some(s) => addressedTopicSelections->Array.pushMany(s)->ignore
+          | None => ()
+          }
+          switch dynamicByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
+          | Some(fns) =>
+            fns->Array.forEach(fn =>
+              addressedTopicSelections->Array.pushMany(fn(addresses))->ignore
+            )
+          | None => ()
+          }
+          logSelections
+          ->Array.pushMany(toLogSelections(~addresses=Some(addresses), addressedTopicSelections))
+          ->ignore
+
+          // Dynamic wildcard-by-address filters fold the address into the topics,
+          // so they still match any address.
+          switch dynamicWildcardByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
+          | Some(fns) =>
+            logSelections
+            ->Array.pushMany(
+              toLogSelections(~addresses=None, fns->Array.flatMap(fn => fn(addresses))),
+            )
+            ->ignore
+          | None => ()
+          }
+        }
+      })
+      logSelections
+    }
   }
 
   {

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -1465,24 +1465,20 @@ describe("RpcSource - getItemsOrThrow with a skip-all event filter", () => {
   )
 })
 
-describe("RpcSource - getItemsOrThrow pooled selections leak across contracts", () => {
+describe("RpcSource - getItemsOrThrow scopes filters to each contract's addresses", () => {
   let sighash = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
   let filterTopic1 = "0x0000000000000000000000000000000000000000000000000000000000000001"
   let addrA = Envio.TestHelpers.Addresses.mockAddresses[0]->Option.getOrThrow
   let addrB = Envio.TestHelpers.Addresses.mockAddresses[1]->Option.getOrThrow
 
-  // Reproduction of a filter-bypass bug: non-wildcard selections are pooled and
-  // queried against `addressesByContractNameGetAll` (every contract's addresses).
-  // ContractA filters on topic1; ContractB is unfiltered. Both share topic0, so
-  // ContractB's `[sig]` query is scoped to ContractA's address too and fetches a
-  // ContractA log — which routes back to ContractA (by address) and bypasses its
-  // filter, since routing never re-applies the topic filter.
-  //
-  // Uses `it_fails`: the assertion states the CORRECT behavior (no leak), which
-  // currently fails, so the test passes today and flips red once the selection
-  // logic scopes each contract's query to its own addresses.
-  Async.it_fails(
-    "a filtered contract must not receive a log fetched by another contract's pooled query",
+  // Regression guard against a cross-contract filter leak: ContractA filters on
+  // topic1, ContractB is unfiltered, and both share topic0. Each contract's query
+  // must be scoped to its own addresses — otherwise ContractB's `[sig]` query
+  // would also cover ContractA's address, fetch a ContractA log, and route it back
+  // to ContractA (by address), bypassing its filter since routing never re-applies
+  // the topic filter.
+  Async.it(
+    "a filtered contract must not receive a log fetched by another contract's query",
     async t => {
       let eventA = MockIndexer.evmEventConfig(
         ~contractName="ContractA",
@@ -1617,8 +1613,9 @@ describe("RpcSource - getItemsOrThrow pooled selections leak across contracts", 
         throw(exn)
       }
 
-      // Correct behavior: the addrA log matches neither contract's own scoped
-      // query, so nothing is emitted. Today the pooled query leaks it to ContractA.
+      // The addrA log matches neither contract's own scoped query (ContractA's
+      // filters it out on topic1; ContractB's query never covers addrA), so
+      // nothing is emitted.
       t.expect(result.parsedQueueItems->Array.length).toEqual(0)
     },
   )

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -1464,3 +1464,162 @@ describe("RpcSource - getItemsOrThrow with a skip-all event filter", () => {
     },
   )
 })
+
+describe("RpcSource - getItemsOrThrow pooled selections leak across contracts", () => {
+  let sighash = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+  let filterTopic1 = "0x0000000000000000000000000000000000000000000000000000000000000001"
+  let addrA = Envio.TestHelpers.Addresses.mockAddresses[0]->Option.getOrThrow
+  let addrB = Envio.TestHelpers.Addresses.mockAddresses[1]->Option.getOrThrow
+
+  // Reproduction of a filter-bypass bug: non-wildcard selections are pooled and
+  // queried against `addressesByContractNameGetAll` (every contract's addresses).
+  // ContractA filters on topic1; ContractB is unfiltered. Both share topic0, so
+  // ContractB's `[sig]` query is scoped to ContractA's address too and fetches a
+  // ContractA log — which routes back to ContractA (by address) and bypasses its
+  // filter, since routing never re-applies the topic filter.
+  //
+  // Uses `it_fails`: the assertion states the CORRECT behavior (no leak), which
+  // currently fails, so the test passes today and flips red once the selection
+  // logic scopes each contract's query to its own addresses.
+  Async.it_fails(
+    "a filtered contract must not receive a log fetched by another contract's pooled query",
+    async t => {
+      let eventA = MockIndexer.evmEventConfig(
+        ~contractName="ContractA",
+        ~id=`${sighash}_1`,
+        ~eventFilters=Static([
+          {
+            topic0: [sighash->EvmTypes.Hex.fromStringUnsafe],
+            topic1: [filterTopic1->EvmTypes.Hex.fromStringUnsafe],
+            topic2: [],
+            topic3: [],
+          },
+        ]),
+      )
+      // Unfiltered, but pin topic0 to the bare sighash (MockIndexer otherwise
+      // derives it from `id`, which we set to the router key `sighash_1`).
+      let eventB = MockIndexer.evmEventConfig(
+        ~contractName="ContractB",
+        ~id=`${sighash}_1`,
+        ~eventFilters=Static([
+          {
+            topic0: [sighash->EvmTypes.Hex.fromStringUnsafe],
+            topic1: [],
+            topic2: [],
+            topic3: [],
+          },
+        ]),
+      )
+
+      // A log emitted by ContractA's address, carrying only topic0 (so it does
+      // NOT match ContractA's topic1 filter). ContractA's own query would never
+      // return it; only ContractB's unfiltered query can.
+      let leakedLog = JSON.Object(
+        Dict.fromArray([
+          ("address", JSON.String(addrA->Address.toString)),
+          ("topics", JSON.Array([JSON.String(sighash)])),
+          ("data", JSON.String("0x")),
+          ("blockNumber", JSON.String("0x64")),
+          (
+            "transactionHash",
+            JSON.String("0x27e26f21f744064a4af53810d8002bbd7208a2ca4865503a99b9c529e5cff5ea"),
+          ),
+          ("transactionIndex", JSON.String("0x1")),
+          ("blockHash", JSON.String("0xb64")),
+          ("logIndex", JSON.String("0x2")),
+          ("removed", JSON.Boolean(false)),
+        ]),
+      )
+      let blockJson = JSON.Object(
+        Dict.fromArray([
+          ("number", JSON.String("0x64")),
+          ("timestamp", JSON.String("0x64")),
+          ("hash", JSON.String("0xb64")),
+          ("parentHash", JSON.String("0xb63")),
+        ]),
+      )
+
+      // Honor the query's `address` and `topics` like a real eth_getLogs, so a
+      // per-contract-scoped query (the fix) would exclude addrA and return nothing.
+      let queryReturnsLeakedLog = (params: JSON.t) =>
+        switch params {
+        | JSON.Array([JSON.Object(filter)]) =>
+          let addressOk = switch filter->Dict.get("address") {
+          | Some(JSON.Array(addrs)) =>
+            addrs->Array.some(a =>
+              switch a {
+              | JSON.String(s) =>
+                s->String.toLowerCase == addrA->Address.toString->String.toLowerCase
+              | _ => false
+              }
+            )
+          | _ => true
+          }
+          let topics = switch filter->Dict.get("topics") {
+          | Some(JSON.Array(t)) => t
+          | _ => []
+          }
+          let topic0Ok = switch topics->Array.get(0) {
+          | Some(JSON.Array(hs)) => hs->Array.some(h => h == JSON.String(sighash))
+          | _ => true
+          }
+          // The leaked log has no topic1, so any topic1 constraint excludes it.
+          let topic1Ok = switch topics->Array.get(1) {
+          | Some(JSON.Array(_)) => false
+          | _ => true
+          }
+          addressOk && topic0Ok && topic1Ok
+        | _ => false
+        }
+
+      let mock = await MockRpcServer.makeWithParams(~getResult=(~method, ~params) =>
+        switch method {
+        | "eth_getLogs" => queryReturnsLeakedLog(params) ? JSON.Array([leakedLog]) : JSON.Array([])
+        | "eth_getBlockByNumber" => blockJson
+        | _ => JSON.Null
+        }
+      )
+
+      let addressesByContractName = Dict.fromArray([("ContractA", [addrA]), ("ContractB", [addrB])])
+      let source = RpcSource.make({
+        url: mock.url,
+        chain,
+        eventRouter: [eventA, eventB]->EventRouter.fromEvmEventModsOrThrow(~chain),
+        sourceFor: Sync,
+        syncConfig: EvmChain.getSyncConfig({}),
+        allEventParams: [
+          {sighash, topicCount: 1, eventName: eventA.name, contractName: "ContractA", params: []},
+          {sighash, topicCount: 1, eventName: eventB.name, contractName: "ContractB", params: []},
+        ],
+        lowercaseAddresses: false,
+      })
+
+      let result = try {
+        let page = await source.getItemsOrThrow(
+          ~fromBlock=0,
+          ~toBlock=Some(100),
+          ~addressesByContractName,
+          ~contractNameByAddress=FetchState.deriveContractNameByAddress(addressesByContractName),
+          ~knownHeight=100,
+          ~partitionId="0",
+          ~selection={
+            dependsOnAddresses: true,
+            eventConfigs: [(eventA :> Internal.eventConfig), (eventB :> Internal.eventConfig)],
+          },
+          ~retry=0,
+          ~logger=Logging.createChild(~params={"test": "RpcSource pooled leak"}),
+        )
+        mock.close()
+        page
+      } catch {
+      | exn =>
+        mock.close()
+        throw(exn)
+      }
+
+      // Correct behavior: the addrA log matches neither contract's own scoped
+      // query, so nothing is emitted. Today the pooled query leaks it to ContractA.
+      t.expect(result.parsedQueueItems->Array.length).toEqual(0)
+    },
+  )
+})


### PR DESCRIPTION
## Summary

Fixes a filter-bypass bug in the RPC data source (surfaced by CodeRabbit on #1368), with a regression test.

## The bug

`RpcSource.getSelectionConfig` pooled **all** non-wildcard events' topic selections and queried each against `addressesByContractNameGetAll` — the union of *every* contract's addresses. When two non-wildcard contracts share a `topic0` (same event signature) but have different `where` filters, one contract's query fetches the other's logs:

- `ContractA` — `Transfer` with `where: { to: … }` → selection `[transferSig, [to]]`
- `ContractB` — `Transfer` unfiltered → selection `[transferSig]`

`ContractB`'s unfiltered query ran against `{ContractA, ContractB}` addresses, so it fetched `ContractA`'s transfers. Those routed back to `ContractA` by address (`getItemsOrThrow` routes on `topic0` + `topicCount` + address and **never re-applies the topic filter**), so `ContractA`'s handler received logs its `where` filter should have excluded. It only affected literal-value filters — address-param filters bound to `chain.Contract.addresses` are re-checked by `clientAddressFilter`.

## The fix

Group address-bound events **by contract** and scope each contract's selections to its **own** addresses (`addressesByContractName->Dict.get(contractName)`), mirroring how `HyperSyncSource` already groups per contract. Now `ContractB`'s query only covers `ContractB`'s addresses and can't reach `ContractA`'s logs.

Pure-wildcard events (`dependsOnAddresses == false`) carry no address constraint, so they stay pooled and are resolved once — the wildcard partition still fans out to a single request.

Trade-off: distinct contracts sharing an event signature now issue one `eth_getLogs` each instead of a single pooled request. That's inherent to `eth_getLogs` taking one address list per call; a single contract (even a factory with many addresses) is still one request, and per-contract `compressTopicSelections` still folds its filter-less events into one topic0 OR-set.

## Test

`scenarios/test_codegen/test/RpcSource_test.res` — an e2e regression test through `getItemsOrThrow` with a `MockRpcServer` that honors the query's `address` filter. `ContractA` filters on `topic1`, `ContractB` is unfiltered and shares `topic0`; the test asserts `ContractB`'s query no longer leaks a `ContractA` log past `ContractA`'s filter. It started as a `it_fails` reproduction and is now a plain passing assertion. All existing `getSelectionConfig` cases are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHkGCPKogsoJjSGo4oKbpF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how log filters are scoped when multiple contracts are selected, reducing the risk of events being matched or routed to the wrong contract.
  * Ensured event queries correctly respect each contract’s addresses and topic filters, including cases with shared event signatures.
  * Added coverage for a scenario where unrelated logs could previously slip through across contract-specific queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->