### PR TITLE
Replace fetch buffer-size cap with reactive cross-chain prune

### DIFF
--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -457,10 +457,29 @@ let resetPendingQueries = (cs: t) => {
   cs.pendingBudget = 0.
 }
 
-// Propose the chain's candidate queries against the shared buffer budget,
-// accounting for this chain's own in-flight reservations.
-let getNextQuery = (cs: t, ~budget) =>
-  cs.fetchState->FetchState.getNextQuery(~budget, ~chainPendingBudget=cs.pendingBudget)
+// Propose the chain's candidate queries against the shared buffer budget.
+let getNextQuery = (cs: t, ~budget) => cs.fetchState->FetchState.getNextQuery(~budget)
+
+// Block to prune above (and how many buffer items that frees) for a given
+// cross-chain progress threshold. See FetchState.getPruneTarget.
+let getPruneTarget = (cs: t, ~progressThreshold) =>
+  cs.fetchState->FetchState.getPruneTarget(
+    ~progressThreshold,
+    ~maxReorgDepth=cs.chainConfig.maxReorgDepth,
+  )
+
+// Reclaim buffer memory by discarding fetched-ahead items above targetBlockNumber
+// and rolling the partitions that fetched them back to it, so they re-fetch later
+// once processing has caught up. Unlike a reorg rollback this touches only the
+// fetch frontier and transaction store — committed progress, reorg detection and
+// the DB are untouched, since nothing processed is being reverted. Callers must
+// first quiesce in-flight queries (resetPendingQueries + epoch bump); rolled-back
+// partitions collapse to targetBlockNumber and re-merge, de-fragmenting them.
+let pruneBuffer = (cs: t, ~targetBlockNumber) => {
+  cs.fetchState =
+    cs.fetchState->FetchState.rollback(~indexingAddresses=cs.indexingAddresses, ~targetBlockNumber)
+  cs.transactionStore->TransactionStore.rollback(targetBlockNumber)
+}
 
 // Run a fetch tick for this chain against its sources, feeding the owned fetch
 // frontier to the source manager.

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -63,6 +63,9 @@ let isReadyToEnterReorgThreshold: t => bool
 
 // Fetch control.
 let getNextQuery: (t, ~budget: int) => FetchState.nextQuery
+let getPruneTarget: (t, ~progressThreshold: float) => (int, int)
+let pruneBuffer: (t, ~targetBlockNumber: int) => unit
+let resetPendingQueries: t => unit
 let dispatch: (
   t,
   ~executeQuery: FetchState.query => promise<unit>,

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -274,7 +274,7 @@ let maybePrune = (crossChainState: t, ~invalidateInflight) => {
           }
         }
 
-        Logging.info({
+        Logging.trace({
           "msg": "Pruned stale fetch buffer above the processing frontier",
           "bufferSize": total.contents,
           "freed": totalFreed.contents,

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -196,6 +196,95 @@ let totalReservedSize = (crossChainState: t) => {
 let compareByProgress = (a: FetchState.query, b: FetchState.query) =>
   Float.compare(a.progress, b.progress)
 
+// Removing the up-front block cap lets queries run to the head, so fetched-ahead
+// items accumulate as stuck buffer while a lagging partition holds the frontier.
+// This reclaims that memory reactively: once the indexer-wide buffer crosses 3x
+// targetBufferSize, drop the highest-progress% (closest-to-head) items across all
+// chains back down to 1.5x and roll back the partitions that fetched them. Prune
+// only during backfill — near the head blockLag keeps the buffer below the reorg
+// window and there is nothing far-ahead to reclaim.
+let maybePrune = (crossChainState: t, ~invalidateInflight) => {
+  if !crossChainState.isInReorgThreshold {
+    let chainIds = crossChainState.chainIds
+
+    let total = ref(0)
+    for i in 0 to chainIds->Array.length - 1 {
+      total :=
+        total.contents +
+        crossChainState->getChainState(chainIds->Array.getUnsafe(i))->ChainState.bufferSize
+    }
+
+    let highWater = crossChainState.targetBufferSize * 3
+    if total.contents > highWater {
+      let lowWater = crossChainState.targetBufferSize * 3 / 2
+      let need = total.contents - lowWater
+
+      // Items freed by pruning everything above the given progress threshold,
+      // summed across chains. Non-increasing in the threshold (higher threshold =
+      // higher per-chain target = fewer items dropped).
+      let freedAt = progressThreshold => {
+        let freed = ref(0)
+        for i in 0 to chainIds->Array.length - 1 {
+          let (_, chainFreed) =
+            crossChainState
+            ->getChainState(chainIds->Array.getUnsafe(i))
+            ->ChainState.getPruneTarget(~progressThreshold)
+          freed := freed.contents + chainFreed
+        }
+        freed.contents
+      }
+
+      // Largest progress threshold that still frees `need` items, so we drop only
+      // the closest-to-head items across all chains. If even threshold 0 (drop all
+      // stuck items) can't reach `need`, we settle at 0 and free what we can.
+      let lo = ref(0.)
+      let hi = ref(1.)
+      for _ in 0 to 39 {
+        let mid = (lo.contents +. hi.contents) /. 2.
+        if freedAt(mid) >= need {
+          lo := mid
+        } else {
+          hi := mid
+        }
+      }
+      let progressThreshold = lo.contents
+
+      // Nothing above the frontier is prunable (e.g. the buffer is over the mark
+      // but full of ready items). Skip — quiescing in-flight fetches here would
+      // discard them every tick without making room, stalling progress.
+      if freedAt(progressThreshold) > 0 {
+        // Quiesce in-flight fetches before rolling partitions back: the epoch bump
+        // makes their responses stale (dropped on arrival) and resetPendingQueries
+        // clears them from every chain, since FetchState.rollback requires no
+        // in-flight queries.
+        invalidateInflight()
+        for i in 0 to chainIds->Array.length - 1 {
+          crossChainState
+          ->getChainState(chainIds->Array.getUnsafe(i))
+          ->ChainState.resetPendingQueries
+        }
+
+        let totalFreed = ref(0)
+        for i in 0 to chainIds->Array.length - 1 {
+          let cs = crossChainState->getChainState(chainIds->Array.getUnsafe(i))
+          let (target, freed) = cs->ChainState.getPruneTarget(~progressThreshold)
+          if freed > 0 {
+            cs->ChainState.pruneBuffer(~targetBlockNumber=target)
+            totalFreed := totalFreed.contents + freed
+          }
+        }
+
+        Logging.info({
+          "msg": "Pruned stale fetch buffer above the processing frontier",
+          "bufferSize": total.contents,
+          "freed": totalFreed.contents,
+        })
+        Prometheus.IndexingBufferPrune.increment(~freed=totalFreed.contents)
+      }
+    }
+  }
+}
+
 // Dispatch a fetch tick across the whole indexer from one shared pool of
 // ~targetBufferSize ready events. Every chain proposes its candidate queries
 // (each carrying an estimated response size) against the full free budget; the
@@ -206,7 +295,10 @@ let compareByProgress = (a: FetchState.query, b: FetchState.query) =>
 let checkAndFetch = async (
   crossChainState: t,
   ~dispatchChain: (~chain: ChainMap.Chain.t, ~action: FetchState.nextQuery) => promise<unit>,
+  ~invalidateInflight: unit => unit,
 ) => {
+  crossChainState->maybePrune(~invalidateInflight)
+
   let remaining = Pervasives.max(
     0,
     crossChainState.targetBufferSize -

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -200,7 +200,7 @@ let compareByProgress = (a: FetchState.query, b: FetchState.query) =>
 // items accumulate as stuck buffer while a lagging partition holds the frontier.
 // This reclaims that memory reactively: once the indexer-wide buffer crosses 3x
 // targetBufferSize, drop the highest-progress% (closest-to-head) items across all
-// chains back down to 1.5x and roll back the partitions that fetched them. Prune
+// chains back down to 2x and roll back the partitions that fetched them. Prune
 // only during backfill — near the head blockLag keeps the buffer below the reorg
 // window and there is nothing far-ahead to reclaim.
 let maybePrune = (crossChainState: t, ~invalidateInflight) => {
@@ -216,7 +216,7 @@ let maybePrune = (crossChainState: t, ~invalidateInflight) => {
 
     let highWater = crossChainState.targetBufferSize * 3
     if total.contents > highWater {
-      let lowWater = crossChainState.targetBufferSize * 3 / 2
+      let lowWater = crossChainState.targetBufferSize * 2
       let need = total.contents - lowWater
 
       // Items freed by pruning everything above the given progress threshold,

--- a/packages/envio/src/CrossChainState.resi
+++ b/packages/envio/src/CrossChainState.resi
@@ -36,4 +36,5 @@ let priorityOrder: t => array<ChainState.t>
 let checkAndFetch: (
   t,
   ~dispatchChain: (~chain: ChainMap.Chain.t, ~action: FetchState.nextQuery) => promise<unit>,
+  ~invalidateInflight: unit => unit,
 ) => promise<unit>

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1438,9 +1438,8 @@ let pushQueriesForRange = (
 }
 
 let getNextQuery = (
-  {buffer, optimizedPartitions, blockLag, latestOnBlockBlockNumber, knownHeight} as fetchState: t,
+  {optimizedPartitions, blockLag, latestOnBlockBlockNumber, knownHeight} as fetchState: t,
   ~budget,
-  ~chainPendingBudget,
 ) => {
   let headBlockNumber = knownHeight - blockLag
   if headBlockNumber <= 0 {
@@ -1459,22 +1458,12 @@ let getNextQuery = (
       !isOnBlockBehindTheHead,
     )
 
-    // Fetch at most `budget` items past the ready frontier (plus what's already
-    // in flight) so processing always has buffer without ballooning memory.
-    // budget already excludes items at/below the frontier (they're in the shared
-    // totalReadyCount), so offset the index by bufferReadyCount — otherwise the
-    // ready prefix is subtracted twice and the buffer caps at a fraction of its
-    // target. A partition that fetched further is skipped until the buffer drains.
-    let maxQueryBlockNumber = {
-      switch buffer->Array.get(
-        fetchState->bufferReadyCount + budget + chainPendingBudget->Float.toInt - 1,
-      ) {
-      | Some(item) =>
-        // Just in case check that we don't query beyond the current block
-        Pervasives.min(item->Internal.getItemBlockNumber, knownHeight)
-      | None => knownHeight
-      }
-    }
+    // Partitions fetch all the way to the head. Per-query range stays bounded by
+    // the per-partition chunk heuristic, and total buffer growth is bounded
+    // reactively by the cross-chain prune (CrossChainState.maybePrune) rather than
+    // an up-front block cap — the cap forced a single block ceiling on every
+    // partition, starving sparse ones into a storm of tiny queries.
+    let maxQueryBlockNumber = knownHeight
 
     let queries = []
 
@@ -1508,15 +1497,6 @@ let getNextQuery = (
         // Force head block as an endBlock when blockLag is set
         // because otherwise HyperSync might return bigger range
         Utils.Math.minOptInt(Some(headBlockNumber), queryEndBlock)
-      }
-      // Enforce the response range up until target block
-      // Otherwise for indexers with 100+ partitions
-      // we might blow up the buffer size to more than 600k events
-      // simply because of HyperSync returning extra blocks
-      let queryEndBlock = switch (queryEndBlock, maxQueryBlockNumber < knownHeight) {
-      | (Some(endBlock), true) => Some(Pervasives.min(maxQueryBlockNumber, endBlock))
-      | (None, true) => Some(maxQueryBlockNumber)
-      | (_, false) => queryEndBlock
       }
 
       let maybeChunkRange = getMinHistoryRange(p)
@@ -1618,6 +1598,40 @@ let getReadyItemsCount = (fetchState: t, ~targetSize: int, ~fromItem) => {
     }
   }
   acc.contents
+}
+
+// For a cross-chain progress threshold in [0.,1.], returns the block to prune
+// above (buffer items with a higher block number get dropped and their
+// partitions rolled back) together with how many items that frees. Clamped so we
+// never drop ready items (target >= the ready frontier) nor roll a partition back
+// into the reorg window (target <= knownHeight - maxReorgDepth), keeping restart
+// points on confirmed blocks. Higher progress% = closer to head = pruned first.
+let getPruneTarget = (fetchState: t, ~progressThreshold: float, ~maxReorgDepth: int) => {
+  let frontier = fetchState->bufferBlockNumber
+  let reorgFloor = fetchState.knownHeight - maxReorgDepth
+  let progressBlock = switch fetchState.firstEventBlock {
+  | Some(firstEventBlock) =>
+    let totalRange = fetchState.knownHeight - firstEventBlock
+    totalRange <= 0
+      ? fetchState.knownHeight
+      : firstEventBlock + (progressThreshold *. totalRange->Int.toFloat)->Float.toInt
+  | None => fetchState.knownHeight
+  }
+  let target = Pervasives.max(frontier, Pervasives.min(progressBlock, reorgFloor))
+
+  // Buffer is sorted by block asc; count items strictly above target in O(log n).
+  let buffer = fetchState.buffer
+  let lo = ref(0)
+  let hi = ref(buffer->Array.length)
+  while lo.contents < hi.contents {
+    let mid = (lo.contents + hi.contents) / 2
+    if buffer->Array.getUnsafe(mid)->Internal.getItemBlockNumber <= target {
+      lo := mid + 1
+    } else {
+      hi := mid
+    }
+  }
+  (target, buffer->Array.length - lo.contents)
 }
 
 /**

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -555,8 +555,8 @@ type t = {
   // Buffer of items ordered from earliest to latest
   buffer: array<Internal.item>,
   // Caps how far ahead onBlock items are pre-generated (set to 2x the batch
-  // size). Fetch depth is bounded separately by getNextQuery's itemBudget, the
-  // chain's per-tick slice of the indexer-wide pool.
+  // size). Per-partition fetch range is no longer capped here; total buffer
+  // growth is instead bounded reactively by CrossChainState.maybePrune.
   maxOnBlockBufferSize: int,
   onBlockConfigs: array<Internal.onBlockConfig>,
   knownHeight: int,

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -95,16 +95,26 @@ let deriveContractNameByAddress: dict<array<Address.t>> => dict<
 // free.
 let defaultEstResponseSize = 10_000.
 
+// Floor for a query's estimate so cross-chain admission never treats it as free.
+// A density-0 partition (last response had no items) would otherwise estimate 0,
+// letting unlimited such queries be admitted in one tick and overshoot the buffer
+// before the prune can react.
+let minEstResponseSize = 100.
+
 // Estimated items a query will return, from the partition's event density
 // (items/block derived from its last response) and the query's block range.
 // toBlock None is the open-ended tail, capped at maxQueryBlockNumber. A partition
-// that responded with no items has density 0, so its queries cost 0 — correct,
-// they don't fill the buffer. Only a partition that has never responded
-// (prevQueryRange 0) has no signal, so it falls back to defaultEstResponseSize.
+// that responded with no items has density 0; its estimate is floored at
+// minEstResponseSize so admission still gates it. Only a partition that has never
+// responded (prevQueryRange 0) has no signal, so it falls back to
+// defaultEstResponseSize.
 let calculateEstResponseSize = (p: partition, ~fromBlock, ~toBlock, ~maxQueryBlockNumber) =>
   if p.prevQueryRange > 0 {
     let density = p.prevRangeSize->Int.toFloat /. p.prevQueryRange->Int.toFloat
-    (toBlock->Option.getOr(maxQueryBlockNumber) - fromBlock + 1)->Int.toFloat *. density
+    Pervasives.max(
+      minEstResponseSize,
+      (toBlock->Option.getOr(maxQueryBlockNumber) - fromBlock + 1)->Int.toFloat *. density,
+    )
   } else {
     defaultEstResponseSize
   }

--- a/packages/envio/src/IndexerLoop.res
+++ b/packages/envio/src/IndexerLoop.res
@@ -19,16 +19,18 @@ let start = (state: IndexerState.t) => {
     launch(state, () =>
       state
       ->IndexerState.crossChainState
-      ->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) =>
-        ChainFetching.fetchChain(
-          state,
-          chain,
-          ~action,
-          ~stateId=state->IndexerState.epoch,
-          ~scheduleFetch,
-          ~scheduleProcessing,
-          ~scheduleRollback,
-        )
+      ->CrossChainState.checkAndFetch(
+        ~invalidateInflight=() => state->IndexerState.invalidateInflight,
+        ~dispatchChain=(~chain, ~action) =>
+          ChainFetching.fetchChain(
+            state,
+            chain,
+            ~action,
+            ~stateId=state->IndexerState.epoch,
+            ~scheduleFetch,
+            ~scheduleProcessing,
+            ~scheduleRollback,
+          ),
       )
     )
   and scheduleProcessing = () =>

--- a/packages/envio/src/Prometheus.res
+++ b/packages/envio/src/Prometheus.res
@@ -407,6 +407,23 @@ module IndexingTargetBufferSize = {
   }
 }
 
+module IndexingBufferPrune = {
+  let counter = PromClient.Counter.makeCounter({
+    "name": "envio_indexing_buffer_prune_total",
+    "help": "Number of times fetched-ahead buffer items were pruned back to the processing frontier to keep memory bounded.",
+  })
+
+  let itemsCounter = PromClient.Counter.makeCounter({
+    "name": "envio_indexing_buffer_prune_items_total",
+    "help": "Total number of fetched-ahead buffer items dropped by buffer prunes.",
+  })
+
+  let increment = (~freed) => {
+    counter->PromClient.Counter.inc
+    itemsCounter->PromClient.Counter.incMany(freed)
+  }
+}
+
 module IndexingBufferBlockNumber = {
   let gauge = SafeGauge.makeOrThrow(
     ~name="envio_indexing_buffer_block",

--- a/scenarios/test_codegen/test/ClientAddressFilter_test.res
+++ b/scenarios/test_codegen/test/ClientAddressFilter_test.res
@@ -208,7 +208,7 @@ describe("FetchState.handleQueryResult applies clientAddressFilter", () => {
       ~chainId=1,
       ~knownHeight=1000,
     )
-    let query = switch fetchState->FetchState.getNextQuery(~budget=5000, ~chainPendingBudget=0.) {
+    let query = switch fetchState->FetchState.getNextQuery(~budget=5000) {
     | Ready([q]) => q
     | _ => JsError.throwWithMessage("expected a single ready query")
     }
@@ -278,7 +278,7 @@ describe("FetchState.handleQueryResult drops over-fetched non-wildcard srcAddres
       ~chainId=1,
       ~knownHeight=1000,
     )
-    let query = switch fetchState->FetchState.getNextQuery(~budget=5000, ~chainPendingBudget=0.) {
+    let query = switch fetchState->FetchState.getNextQuery(~budget=5000) {
     | Ready([q]) => q
     | _ => JsError.throwWithMessage("expected a single ready query")
     }

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -356,7 +356,7 @@ describe("FetchState — where.block._gte drives the first query's fromBlock", (
   let firstQuery = (fetchState: FetchState.t) =>
     switch fetchState
     ->FetchState.updateKnownHeight(~knownHeight=10000)
-    ->FetchState.getNextQuery(~budget=5000, ~chainPendingBudget=0.) {
+    ->FetchState.getNextQuery(~budget=5000) {
     | Ready([q]) => q
     | Ready(qs) =>
       JsError.throwWithMessage(

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -316,9 +316,10 @@ describe("CrossChainState buffer prune", () => {
     )
 
   Async.it("prunes the closest-to-head items across chains down to the low-water mark", async t => {
-    // targetBufferSize 20 → prune when the buffer exceeds 3x (60), down to 1.5x
-    // (30). Chain 1's items sit at ~0.8 progress, chain 2's at ~0.2, so the
-    // head-closest chain 1 is dropped entirely before chain 2 is touched.
+    // targetBufferSize 20 → prune when the buffer exceeds 3x (60), down to 2x
+    // (40). Chain 1's items sit at ~0.8 progress, chain 2's at ~0.2, so the
+    // head-closest chain 1 is dropped entirely (freeing exactly the needed 40)
+    // before chain 2 is touched.
     let cs1 = makeStuck(~chainId=1, ~fromBlock=8000)
     let cs2 = makeStuck(~chainId=2, ~fromBlock=2000)
     let cm = makeCrossChainState(~chainStatesList=[cs1, cs2], ~targetBufferSize=20)
@@ -335,7 +336,7 @@ describe("CrossChainState buffer prune", () => {
       "invalidateCalled": invalidateCalled.contents,
     }).toEqual({
       "chain1Buffer": 0,
-      "chain2Buffer": 30,
+      "chain2Buffer": 40,
       "invalidateCalled": true,
     })
   })

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -80,7 +80,7 @@ let makeChainState = (
 // getNextQuery actually produces a Ready query (unlike the onBlock-only helper
 // above). The partition has no response yet, so each query estimates at the
 // default size.
-let makeFetchingChainState = (~chainId, ~knownHeight, ~latestFetchedBlock) => {
+let makeFetchingChainState = (~chainId, ~knownHeight, ~latestFetchedBlock, ~bufferBlocks=[]) => {
   let normalSelection = {FetchState.dependsOnAddresses: false, eventConfigs: []}
   let address = "0x1234567890123456789012345678901234567890"->Address.unsafeFromString
   let partition: FetchState.partition = {
@@ -112,7 +112,7 @@ let makeFetchingChainState = (~chainId, ~knownHeight, ~latestFetchedBlock) => {
     ),
     startBlock: 0,
     endBlock: None,
-    buffer: [],
+    buffer: bufferBlocks->Array.map(blockNumber => mockEvent(~blockNumber)),
     normalSelection,
     latestOnBlockBlockNumber: latestFetchedBlock,
     maxOnBlockBufferSize: 10000,
@@ -183,7 +183,7 @@ describe("CrossChainState fetch control", () => {
     let cm = makeCrossChainState(~chainStatesList=[a, b], ~isRealtime=true)
 
     let dispatched = []
-    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
+    await cm->CrossChainState.checkAndFetch(~invalidateInflight=() => (), ~dispatchChain=(~chain, ~action) => {
       dispatched->Array.push((chain->ChainMap.Chain.toChainId, action))->ignore
       Promise.resolve()
     })
@@ -213,7 +213,7 @@ describe("CrossChainState fetch control", () => {
     let cm = makeCrossChainState(~chainStatesList=[a, b], ~targetBufferSize=100)
 
     let dispatched = []
-    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action as _) => {
+    await cm->CrossChainState.checkAndFetch(~invalidateInflight=() => (), ~dispatchChain=(~chain, ~action as _) => {
       dispatched->Array.push(chain->ChainMap.Chain.toChainId)->ignore
       Promise.resolve()
     })
@@ -229,7 +229,7 @@ describe("CrossChainState fetch control", () => {
     let cm = makeCrossChainState(~chainStatesList=[cs], ~targetBufferSize=1)
 
     let dispatched = []
-    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
+    await cm->CrossChainState.checkAndFetch(~invalidateInflight=() => (), ~dispatchChain=(~chain, ~action) => {
       dispatched
       ->Array.push((
         chain->ChainMap.Chain.toChainId,
@@ -299,6 +299,68 @@ describe("CrossChainState readiness", () => {
       "bReady": b->ChainState.isReady,
       "isRealtime": cm->CrossChainState.isRealtime,
     }).toEqual({"aReady": true, "bReady": true, "isRealtime": true})
+  })
+})
+
+describe("CrossChainState buffer prune", () => {
+  // knownHeight 10000, firstEventBlock 0 (from the helper) → progress% == block/10000.
+  // maxReorgDepth defaults to 200, so the reorg floor is 9800 — all the blocks
+  // below stay prunable. Both chains hold the frontier at block 100 with 40
+  // buffered-ahead items each.
+  let makeStuck = (~chainId, ~fromBlock) =>
+    makeFetchingChainState(
+      ~chainId,
+      ~knownHeight=10000,
+      ~latestFetchedBlock=100,
+      ~bufferBlocks=Array.fromInitializer(~length=40, i => fromBlock + i),
+    )
+
+  Async.it("prunes the closest-to-head items across chains down to the low-water mark", async t => {
+    // targetBufferSize 20 → prune when the buffer exceeds 3x (60), down to 1.5x
+    // (30). Chain 1's items sit at ~0.8 progress, chain 2's at ~0.2, so the
+    // head-closest chain 1 is dropped entirely before chain 2 is touched.
+    let cs1 = makeStuck(~chainId=1, ~fromBlock=8000)
+    let cs2 = makeStuck(~chainId=2, ~fromBlock=2000)
+    let cm = makeCrossChainState(~chainStatesList=[cs1, cs2], ~targetBufferSize=20)
+
+    let invalidateCalled = ref(false)
+    await cm->CrossChainState.checkAndFetch(
+      ~invalidateInflight=() => invalidateCalled := true,
+      ~dispatchChain=(~chain as _, ~action as _) => Promise.resolve(),
+    )
+
+    t.expect({
+      "chain1Buffer": cs1->ChainState.bufferSize,
+      "chain2Buffer": cs2->ChainState.bufferSize,
+      "invalidateCalled": invalidateCalled.contents,
+    }).toEqual({
+      "chain1Buffer": 0,
+      "chain2Buffer": 30,
+      "invalidateCalled": true,
+    })
+  })
+
+  Async.it("leaves the buffer untouched below the high-water mark", async t => {
+    // 80 items total but targetBufferSize 100 → high-water 300, so no prune.
+    let cs1 = makeStuck(~chainId=1, ~fromBlock=8000)
+    let cs2 = makeStuck(~chainId=2, ~fromBlock=2000)
+    let cm = makeCrossChainState(~chainStatesList=[cs1, cs2], ~targetBufferSize=100)
+
+    let invalidateCalled = ref(false)
+    await cm->CrossChainState.checkAndFetch(
+      ~invalidateInflight=() => invalidateCalled := true,
+      ~dispatchChain=(~chain as _, ~action as _) => Promise.resolve(),
+    )
+
+    t.expect({
+      "chain1Buffer": cs1->ChainState.bufferSize,
+      "chain2Buffer": cs2->ChainState.bufferSize,
+      "invalidateCalled": invalidateCalled.contents,
+    }).toEqual({
+      "chain1Buffer": 40,
+      "chain2Buffer": 40,
+      "invalidateCalled": false,
+    })
   })
 })
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -174,10 +174,10 @@ let makeFs = (
     ~chainId,
     ~maxOnBlockBufferSize,
     ~knownHeight,
-    ~progressBlockNumber=?progressBlockNumber,
-    ~onBlockConfigs=?onBlockConfigs,
-    ~blockLag=?blockLag,
-    ~firstEventBlock=?firstEventBlock,
+    ~progressBlockNumber?,
+    ~onBlockConfigs?,
+    ~blockLag?,
+    ~firstEventBlock?,
   )
   (fetchState, indexingAddresses)
 }
@@ -305,7 +305,8 @@ describe("FetchState.make", () => {
       t.expect(
         (
           indexingAddresses->IndexingAddresses.size,
-          indexingAddresses->IndexingAddresses.get(mockAddress1->Address.toString)
+          indexingAddresses
+          ->IndexingAddresses.get(mockAddress1->Address.toString)
           ->Option.map(ia => ia.contractName),
           // No partition is created for the contract without events
           fetchState.optimizedPartitions.entities
@@ -865,9 +866,10 @@ describe("FetchState.registerDynamicContracts", () => {
     let (fetchState, indexingAddresses) = makeInitial()
 
     t.expect(
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
-        makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress0)->dcToItem,
-      ]),
+      fetchState->FetchState.registerDynamicContracts(
+        ~indexingAddresses,
+        [makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress0)->dcToItem],
+      ),
       ~message="Should return fetchState without updating it",
     ).toBe(fetchState)
   })
@@ -893,7 +895,8 @@ describe("FetchState.registerDynamicContracts", () => {
           item->Internal.getItemDcs,
           // tracked on indexingAddresses so later conflicting registrations
           // are detected, and so numAddresses reflects it
-          indexingAddresses->IndexingAddresses.get(mockAddress1->Address.toString)
+          indexingAddresses
+          ->IndexingAddresses.get(mockAddress1->Address.toString)
           ->Option.map(ia => ia.contractName),
           // partitions unchanged - no fetching for contracts without events
           updatedFetchState.optimizedPartitions === fetchState.optimizedPartitions,
@@ -955,7 +958,8 @@ describe("FetchState.registerDynamicContracts", () => {
           // Third dc also spliced out - same contract name, already tracked.
           item3->Internal.getItemDcs,
           // First registration is the tracked one (first wins).
-          indexingAddresses->IndexingAddresses.get(mockAddress1->Address.toString)
+          indexingAddresses
+          ->IndexingAddresses.get(mockAddress1->Address.toString)
           ->Option.map(ia => ia.contractName),
           // No new partition created across any of the registrations.
           afterThird.optimizedPartitions.entities === fetchState.optimizedPartitions.entities,
@@ -991,9 +995,11 @@ describe("FetchState.registerDynamicContracts", () => {
 
       t.expect(
         (
-          indexingAddresses->IndexingAddresses.get(mockAddress2->Address.toString)
+          indexingAddresses
+          ->IndexingAddresses.get(mockAddress2->Address.toString)
           ->Option.map(ia => ia.contractName),
-          indexingAddresses->IndexingAddresses.get(mockAddress1->Address.toString)
+          indexingAddresses
+          ->IndexingAddresses.get(mockAddress1->Address.toString)
           ->Option.map(ia => ia.contractName),
           // Only the Gravatar address lands in a partition.
           updatedFetchState.optimizedPartitions.entities
@@ -1045,7 +1051,8 @@ describe("FetchState.registerDynamicContracts", () => {
           // dc spliced out - won't overwrite the existing Gravatar entry in db
           item->Internal.getItemDcs,
           // indexingAddresses still has the original contract name
-          indexingAddresses->IndexingAddresses.get(mockAddress0->Address.toString)
+          indexingAddresses
+          ->IndexingAddresses.get(mockAddress0->Address.toString)
           ->Option.map(ia => ia.contractName),
           // fetchState unchanged - nothing new registered
           updatedFetchState === fetchState,
@@ -1077,7 +1084,8 @@ describe("FetchState.registerDynamicContracts", () => {
 
     t.expect(
       (
-        indexingAddresses->IndexingAddresses.get(mockAddress1->Address.toString)
+        indexingAddresses
+        ->IndexingAddresses.get(mockAddress1->Address.toString)
         ->Option.map(ia => ia.contractName),
         // dc spliced out - won't be persisted to envio_addresses
         item2->Internal.getItemDcs,
@@ -1122,7 +1130,8 @@ describe("FetchState.registerDynamicContracts", () => {
 
       t.expect(
         (
-          indexingAddresses->IndexingAddresses.get(mockAddress1->Address.toString)
+          indexingAddresses
+          ->IndexingAddresses.get(mockAddress1->Address.toString)
           ->Option.map(ia => ia.contractName),
           noEventsItem->Internal.getItemDcs,
         ),
@@ -1157,7 +1166,8 @@ describe("FetchState.registerDynamicContracts", () => {
 
       t.expect(
         (
-          indexingAddresses->IndexingAddresses.get(mockAddress1->Address.toString)
+          indexingAddresses
+          ->IndexingAddresses.get(mockAddress1->Address.toString)
           ->Option.map(ia => ia.contractName),
           eventsItem->Internal.getItemDcs,
           updatedFetchState.optimizedPartitions.entities
@@ -1232,9 +1242,10 @@ describe("FetchState.registerDynamicContracts", () => {
       // This is an edge case we currently don't cover
       // But show a warning in the logs
       t.expect(
-        fetchStateWithDc1->FetchState.registerDynamicContracts(~indexingAddresses, [
-          makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress1)->dcToItem,
-        ]),
+        fetchStateWithDc1->FetchState.registerDynamicContracts(
+          ~indexingAddresses,
+          [makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress1)->dcToItem],
+        ),
         ~message=`BROKEN: Calling it with the same dc
           but earlier block number should create a new short lived partition
           for the specific contract from block 0 to 1. And update the dc in db`,
@@ -1251,12 +1262,10 @@ describe("FetchState.registerDynamicContracts", () => {
     let dc4 = makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress4)
 
     let updatedFetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
-        dc1->dcToItem,
-        dc2->dcToItem,
-        dc3->dcToItem,
-        dc4->dcToItem,
-      ])
+      fetchState->FetchState.registerDynamicContracts(
+        ~indexingAddresses,
+        [dc1->dcToItem, dc2->dcToItem, dc3->dcToItem, dc4->dcToItem],
+      )
 
     t.expect(
       updatedFetchState.optimizedPartitions.entities->Dict.valuesToArray,
@@ -1318,12 +1327,15 @@ describe("FetchState.registerDynamicContracts", () => {
     // the one already populated by the registration above.
     let (fetchState, indexingAddresses) = makeInitial()
     let updatedFetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
-        dc1FromAnotherContract->dcToItem,
-        dc2->dcToItem,
-        dc3->dcToItem,
-        dc4FromAnotherContract->dcToItem,
-      ])
+      fetchState->FetchState.registerDynamicContracts(
+        ~indexingAddresses,
+        [
+          dc1FromAnotherContract->dcToItem,
+          dc2->dcToItem,
+          dc3->dcToItem,
+          dc4FromAnotherContract->dcToItem,
+        ],
+      )
 
     t.expect(
       updatedFetchState.optimizedPartitions.entities->Dict.valuesToArray,
@@ -1438,13 +1450,10 @@ describe("FetchState.registerDynamicContracts", () => {
       )
 
       let updatedFetchState =
-        fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
-          dc1->dcToItem,
-          dc2->dcToItem,
-          dc3->dcToItem,
-          dc4->dcToItem,
-          dc5->dcToItem,
-        ])
+        fetchState->FetchState.registerDynamicContracts(
+          ~indexingAddresses,
+          [dc1->dcToItem, dc2->dcToItem, dc3->dcToItem, dc4->dcToItem, dc5->dcToItem],
+        )
 
       t.expect(
         updatedFetchState.optimizedPartitions.entities
@@ -1488,7 +1497,8 @@ describe("FetchState.registerDynamicContracts", () => {
     let dcItem1 = dc1->dcToItem
     let dcItem2 = dc2->dcToItem
 
-    let updatedFetchState = fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dcItem2, dcItem1])
+    let updatedFetchState =
+      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dcItem2, dcItem1])
 
     t.expect(
       (dcItem1->Internal.getItemDcs, dcItem2->Internal.getItemDcs),
@@ -1554,10 +1564,11 @@ describe("FetchState.registerDynamicContracts", () => {
     // But for too big block difference, we create different partitions just in case
     let dc3 = makeDynContractRegistration(~blockNumber=300_000, ~contractAddress=mockAddress3)
 
-    let updatedFetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, // Order of dcs doesn't matter
+    let updatedFetchState = fetchState->FetchState.registerDynamicContracts(
+      ~indexingAddresses, // Order of dcs doesn't matter
       // but they are not sorted in fetch state
-      [dc1->dcToItem, dc3->dcToItem, dc2->dcToItem])
+      [dc1->dcToItem, dc3->dcToItem, dc2->dcToItem],
+    )
     t.expect(indexingAddresses->IndexingAddresses.size).toBe(4)
     t.expect(updatedFetchState.optimizedPartitions.entities->Dict.valuesToArray).toEqual([
       {
@@ -1843,16 +1854,15 @@ describe("FetchState.getNextQuery & integration", () => {
   }
 
   // The default configuration with ability to overwrite some values.
-  // Partitions here have no response yet, so the block window isn't constrained
-  // (the small test heights stay below the buffer-position cap) and query sizing
-  // falls back to FetchState.defaultEstResponseSize (10000).
+  // Partitions here have no response yet, so query sizing falls back to
+  // FetchState.defaultEstResponseSize (10000).
   let getNextQuery = (fs, ~endBlock=None, ~knownHeight=10, ~budget=10) =>
     switch endBlock {
     | Some(_) => {...fs, endBlock}
     | None => fs
     }
     ->FetchState.updateKnownHeight(~knownHeight)
-    ->FetchState.getNextQuery(~budget, ~chainPendingBudget=0.)
+    ->FetchState.getNextQuery(~budget)
 
   it("Returns NothingToQuery when the buffer budget is exhausted", t => {
     // Same state queries Ready with a positive budget (see the test below), so a
@@ -1951,9 +1961,8 @@ describe("FetchState.getNextQuery & integration", () => {
     ).toEqual(WaitingForNewBlock)
     t.expect(
       updatedFetchState->getNextQuery(~budget=2, ~knownHeight=11),
-      ~message=`Should fetch the head block once the partition is behind the head:
-      budget is measured past the ready frontier, so the 2 already-ready items
-      don't eat the budget and pin the target block below the frontier`,
+      ~message=`Should fetch the head block once the partition is behind the head,
+      with an open-ended range: the query is no longer capped by buffer size`,
     ).toEqual(
       Ready([
         {
@@ -2407,17 +2416,15 @@ describe("FetchState.getNextQuery & integration", () => {
       ~knownHeight,
     )
     let fetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
-        makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress2)->dcToItem,
-      ])
+      fetchState->FetchState.registerDynamicContracts(
+        ~indexingAddresses,
+        [makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress2)->dcToItem],
+      )
 
     t.expect(fetchState.optimizedPartitions->FetchState.OptimizedPartitions.count).toEqual(3)
 
     let nextQuery =
-      {...fetchState, knownHeight: 10}->FetchState.getNextQuery(
-        ~budget=targetBufferSize,
-        ~chainPendingBudget=0.,
-      )
+      {...fetchState, knownHeight: 10}->FetchState.getNextQuery(~budget=targetBufferSize)
 
     t.expect(
       nextQuery,
@@ -2470,7 +2477,8 @@ describe("FetchState.getNextQuery & integration", () => {
     // Rollback to block 2: both DCs survive (regBlock <= 2)
     // Partition "0" (lfb=10 > 2) -> DELETED, addresses recreated as partition "1"
     // Partition "2" (lfb=2 <= 2) -> KEPT as partition "0" (IDs reset)
-    let fetchStateAfterRollback1 = fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=2)
+    let fetchStateAfterRollback1 =
+      fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=2)
     t.expect(
       fetchStateAfterRollback1,
       ~message=`Rollbacks partitions: kept "0", recreated "1" from deleted`,
@@ -2521,7 +2529,8 @@ describe("FetchState.getNextQuery & integration", () => {
 
     // Rollback to block 1: dc2 and dc3 removed (regBlock=2 > 1)
     // Both partitions deleted (lfb > 1), surviving addresses [addr0, addr1] recreated
-    let fetchStateAfterRollback2 = fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=1)
+    let fetchStateAfterRollback2 =
+      fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=1)
     t.expect(
       fetchStateAfterRollback2,
       ~message=`Both partitions deleted, surviving addresses recreated as partition "0"`,
@@ -2558,7 +2567,8 @@ describe("FetchState.getNextQuery & integration", () => {
     })
 
     // Rollback to block -1: all DCs removed, only static addr0 survives
-    let fetchStateAfterRollback3 = fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=-1)
+    let fetchStateAfterRollback3 =
+      fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=-1)
     t.expect(
       fetchStateAfterRollback3,
       ~message=`All DCs removed, only static addr0 recreated as partition "0"`,
@@ -2614,9 +2624,10 @@ describe("FetchState.getNextQuery & integration", () => {
       ~knownHeight,
     )
     let fetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
-        makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress2)->dcToItem,
-      ])
+      fetchState->FetchState.registerDynamicContracts(
+        ~indexingAddresses,
+        [makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress2)->dcToItem],
+      )
 
     // Additionally test that state being reset
     fetchState->FetchState.startFetchingQueries(
@@ -2644,7 +2655,8 @@ describe("FetchState.getNextQuery & integration", () => {
 
     // resetPendingQueries must be called before rollback (removes in-flight queries)
     let fetchStateReset = fetchState->FetchState.resetPendingQueries
-    let fetchStateAfterRollback = fetchStateReset->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=1)
+    let fetchStateAfterRollback =
+      fetchStateReset->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=1)
 
     t.expect(
       fetchStateAfterRollback,
@@ -2875,10 +2887,7 @@ describe("FetchState unit tests for specific cases", () => {
       )
 
     t.expect(
-      {...fetchState, knownHeight: 2}->FetchState.getNextQuery(
-        ~budget=targetBufferSize,
-        ~chainPendingBudget=0.,
-      ),
+      {...fetchState, knownHeight: 2}->FetchState.getNextQuery(~budget=targetBufferSize),
       ~message=`Should be possible to query wildcard partition,
       if it didn't reach max queue size limit`,
     ).toEqual(
@@ -2902,11 +2911,27 @@ describe("FetchState unit tests for specific cases", () => {
       {
         ...fetchState,
         knownHeight: 2,
-      }->FetchState.getNextQuery(~budget=1, ~chainPendingBudget=0.),
-      ~message=`Budget is measured past the ready frontier; the item already
-      buffered past it consumes the single-item budget, so the behind partition
-      stays capped and nothing new is fetched until the queue drains`,
-    ).toEqual(NothingToQuery)
+      }->FetchState.getNextQuery(~budget=1),
+      ~message=`With the buffer-size cap removed, a positive budget proposes the
+      full query range regardless of buffered-ahead items; the shared pool is now
+      enforced by cross-chain admission, not by capping the range here`,
+    ).toEqual(
+      Ready([
+        {
+          ...defaultQuery,
+          partitionId: "0",
+          estResponseSize: 10000.,
+          fromBlock: 2,
+          toBlock: None,
+          isChunk: false,
+          selection: {
+            dependsOnAddresses: false,
+            eventConfigs: [wildcard],
+          },
+          addressesByContractName: Dict.make(),
+        },
+      ]),
+    )
   })
 
   it("Allows to get event one block earlier than the dc registring event", t => {
@@ -2952,12 +2977,15 @@ describe("FetchState unit tests for specific cases", () => {
     )
 
     let fetchStateWithDc =
-      fetchStateWithEvents->FetchState.registerDynamicContracts(~indexingAddresses, [
-        makeDynContractRegistration(
-          ~contractAddress=mockAddress1,
-          ~blockNumber=registeringBlockNumber,
-        )->dcToItem,
-      ])
+      fetchStateWithEvents->FetchState.registerDynamicContracts(
+        ~indexingAddresses,
+        [
+          makeDynContractRegistration(
+            ~contractAddress=mockAddress1,
+            ~blockNumber=registeringBlockNumber,
+          )->dcToItem,
+        ],
+      )
 
     t.expect(
       fetchStateWithDc->getEarliestEvent->getItem,
@@ -3072,9 +3100,10 @@ describe("FetchState unit tests for specific cases", () => {
 
     t.expect(
       fetchState
-      ->FetchState.registerDynamicContracts(~indexingAddresses, [
-        makeDynContractRegistration(~contractAddress=mockAddress1, ~blockNumber=2)->dcToItem,
-      ])
+      ->FetchState.registerDynamicContracts(
+        ~indexingAddresses,
+        [makeDynContractRegistration(~contractAddress=mockAddress1, ~blockNumber=2)->dcToItem],
+      )
       ->getEarliestEvent,
       ~message=`Accounts for registered dynamic contracts`,
     ).toEqual(
@@ -3218,12 +3247,10 @@ describe("FetchState unit tests for specific cases", () => {
 
       //Dynamic contract A registered at block 100
       let dcA = makeDynContractRegistration(~contractAddress=mockAddress2, ~blockNumber=100)
-      let fetchStateWithDcA = fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dcA->dcToItem])
+      let fetchStateWithDcA =
+        fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dcA->dcToItem])
 
-      let queries = switch fetchStateWithDcA->FetchState.getNextQuery(
-        ~budget=targetBufferSize,
-        ~chainPendingBudget=0.,
-      ) {
+      let queries = switch fetchStateWithDcA->FetchState.getNextQuery(~budget=targetBufferSize) {
       | Ready(queries) => queries
       | _ => JsError.throwWithMessage("Expected Ready queries")
       }
@@ -3253,10 +3280,7 @@ describe("FetchState unit tests for specific cases", () => {
       let fetchStateWithDcB =
         fetchStateWithDcA->FetchState.registerDynamicContracts(~indexingAddresses, [dc3->dcToItem])
 
-      let queries = switch fetchStateWithDcB->FetchState.getNextQuery(
-        ~budget=targetBufferSize,
-        ~chainPendingBudget=0.,
-      ) {
+      let queries = switch fetchStateWithDcB->FetchState.getNextQuery(~budget=targetBufferSize) {
       | Ready(queries) => queries
       | _ => JsError.throwWithMessage("Expected Ready queries")
       }
@@ -3268,10 +3292,7 @@ describe("FetchState unit tests for specific cases", () => {
         fromBlock: 200,
       }
       t.expect(
-        fetchStateWithDcB->FetchState.getNextQuery(
-          ~budget=targetBufferSize,
-          ~chainPendingBudget=0.,
-        ),
+        fetchStateWithDcB->FetchState.getNextQuery(~budget=targetBufferSize),
         ~message=`Create a new partition for the newly registered contract`,
       ).toEqual(Ready([partition2Query, queries->Array.getUnsafe(1)]))
 
@@ -3285,10 +3306,7 @@ describe("FetchState unit tests for specific cases", () => {
         )
 
       t.expect(
-        fetchStateWithBothDcsAndQueryAResponse->FetchState.getNextQuery(
-          ~budget=targetBufferSize,
-          ~chainPendingBudget=0.,
-        ),
+        fetchStateWithBothDcsAndQueryAResponse->FetchState.getNextQuery(~budget=targetBufferSize),
         ~message=`We don't merge partition 2 to partition 1, since it already has end block`,
       ).toEqual(
         Ready([
@@ -3563,7 +3581,10 @@ describe("Dynamic contracts with start blocks", () => {
 
     // Register the contract at block 100 (before its startBlock)
     let _ =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dynamicContract->dcToItem])
+      fetchState->FetchState.registerDynamicContracts(
+        ~indexingAddresses,
+        [dynamicContract->dcToItem],
+      )
 
     // The contract should be registered in indexingAddresses
     t.expect(
@@ -3573,7 +3594,8 @@ describe("Dynamic contracts with start blocks", () => {
 
     // Verify the startBlock is set correctly
     let registeredContract =
-      indexingAddresses->IndexingAddresses.get(mockAddress1->Address.toString)
+      indexingAddresses
+      ->IndexingAddresses.get(mockAddress1->Address.toString)
       ->Option.getOrThrow
 
     t.expect(
@@ -3600,15 +3622,20 @@ describe("Dynamic contracts with start blocks", () => {
     )
 
     let _ =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [contract1->dcToItem, contract2->dcToItem])
+      fetchState->FetchState.registerDynamicContracts(
+        ~indexingAddresses,
+        [contract1->dcToItem, contract2->dcToItem],
+      )
 
     // Verify both contracts are registered with correct startBlocks
     let contract1Registered =
-      indexingAddresses->IndexingAddresses.get(mockAddress1->Address.toString)
+      indexingAddresses
+      ->IndexingAddresses.get(mockAddress1->Address.toString)
       ->Option.getOrThrow
 
     let contract2Registered =
-      indexingAddresses->IndexingAddresses.get(mockAddress2->Address.toString)
+      indexingAddresses
+      ->IndexingAddresses.get(mockAddress2->Address.toString)
       ->Option.getOrThrow
 
     t.expect(
@@ -3685,20 +3712,20 @@ describe("FetchState progress tracking", () => {
   })
 })
 
-describe("FetchState buffer overflow prevention", () => {
+describe("FetchState query range is not capped by buffer size", () => {
   it(
-    "Should limit endBlock when maxQueryBlockNumber < knownHeight to prevent buffer overflow",
+    "Fetches to endBlock/head regardless of buffered-ahead items (cross-chain prune bounds memory instead)",
     t => {
       let (fetchState, indexingAddresses) = makeInitial(~maxAddrInPartition=1, ~targetBufferSize=10)
 
-      // Create a second partition to ensure buffer limiting logic is exercised across partitions
-      // Register at a later block, so partition "0" remains the earliest and is selected
+      // Create a second partition. Register at a later block, so partition "0"
+      // remains the earliest and is selected.
       let dc = makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress1)
       let fetchStateWithTwoPartitions =
         fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dc->dcToItem])
 
-      // Buffer 15 items (blocks 6..20). With budget 10 the cap is the block at
-      // buffer index 10-1=9, i.e. block 15 — below both knownHeight and endBlock.
+      // Buffer 15 items (blocks 6..20) far past the frontier. Previously a budget
+      // of 10 capped the query at block 15; now the range runs to endBlock/head.
       let largeQueueEvents = Array.fromInitializer(~length=15, i => mockEvent(~blockNumber=20 - i))
 
       let query0 = {
@@ -3721,31 +3748,30 @@ describe("FetchState buffer overflow prevention", () => {
           ~newItems=largeQueueEvents,
         )
 
-      // Test case 1: With endBlock set, should be limited by maxQueryBlockNumber
+      // Test case 1: With endBlock set, the query runs to endBlock (not a cap)
       let fetchStateWithEndBlock = {
         ...fetchStateWithLargeQueue,
         endBlock: Some(25),
         knownHeight: 30,
       }
 
-      switch fetchStateWithEndBlock->FetchState.getNextQuery(~budget=10, ~chainPendingBudget=0.) {
+      switch fetchStateWithEndBlock->FetchState.getNextQuery(~budget=10) {
       | Ready([q]) =>
-        t.expect(
-          q.toBlock,
-          ~message="Should limit endBlock to maxQueryBlockNumber (15) when both endBlock and maxQueryBlockNumber are present",
-        ).toBe(Some(15))
-      | _ => JsError.throwWithMessage("Expected Ready query when buffer limiting is active")
+        t.expect(q.toBlock, ~message="Query runs to endBlock (25), not a buffer-size cap").toBe(
+          Some(25),
+        )
+      | _ => JsError.throwWithMessage("Expected Ready query")
       }
 
-      // Test case 2: endBlock=None, maxQueryBlockNumber=15 -> Should use Some(15)
+      // Test case 2: endBlock=None -> open-ended query (no buffer-size cap)
       let fetchStateNoEndBlock = {...fetchStateWithLargeQueue, endBlock: None, knownHeight: 30}
-      switch fetchStateNoEndBlock->FetchState.getNextQuery(~budget=10, ~chainPendingBudget=0.) {
+      switch fetchStateNoEndBlock->FetchState.getNextQuery(~budget=10) {
       | Ready([q]) =>
         t.expect(
           q.toBlock,
-          ~message="Should set endBlock to maxQueryBlockNumber (15) when no endBlock was specified",
-        ).toBe(Some(15))
-      | _ => JsError.throwWithMessage("Expected Ready query when buffer limiting is active")
+          ~message="Open-ended query when no endBlock is set, regardless of buffer size",
+        ).toBe(None)
+      | _ => JsError.throwWithMessage("Expected Ready query")
       }
 
       // Test case 3: Small queue, no buffer limiting -> Should use Head target
@@ -3770,10 +3796,7 @@ describe("FetchState buffer overflow prevention", () => {
         )
         ->FetchState.updateKnownHeight(~knownHeight=30)
 
-      switch fetchStateSmallQueue->FetchState.getNextQuery(
-        ~budget=targetBufferSize,
-        ~chainPendingBudget=0.,
-      ) {
+      switch fetchStateSmallQueue->FetchState.getNextQuery(~budget=targetBufferSize) {
       | Ready([q]) =>
         t.expect(q.toBlock, ~message="Should use None when buffer is not limited").toBe(None)
       | _ => JsError.throwWithMessage("Expected Ready query")
@@ -3829,8 +3852,7 @@ describe("FetchState with onBlockConfig only (no events)", () => {
       ])
 
       // Test that getNextQuery returns WaitingForNewBlock when knownHeight is 0
-      let nextQuery =
-        fetchState->FetchState.getNextQuery(~budget=targetBufferSize, ~chainPendingBudget=0.)
+      let nextQuery = fetchState->FetchState.getNextQuery(~budget=targetBufferSize)
       t.expect(
         nextQuery,
         ~message="Should return WaitingForNewBlock when knownHeight is 0",
@@ -3872,8 +3894,7 @@ describe("FetchState with onBlockConfig only (no events)", () => {
       ])
 
       // Test that getNextQuery returns NothingToQuery (no partitions to query)
-      let nextQuery2 =
-        updatedFetchState->FetchState.getNextQuery(~budget=targetBufferSize, ~chainPendingBudget=0.)
+      let nextQuery2 = updatedFetchState->FetchState.getNextQuery(~budget=targetBufferSize)
       t.expect(
         nextQuery2,
         ~message="Should return NothingToQuery when there are no partitions to query",
@@ -3887,7 +3908,7 @@ describe("Stale query response should not overwrite block range", () => {
   let getNextQuery = (fs, ~knownHeight=100000, ~budget=targetBufferSize) =>
     fs
     ->FetchState.updateKnownHeight(~knownHeight)
-    ->FetchState.getNextQuery(~budget, ~chainPendingBudget=0.)
+    ->FetchState.getNextQuery(~budget)
 
   it("Out-of-order parallel query responses should not degrade chunking heuristic", t => {
     let (fetchState, indexingAddresses) = makeInitial(~knownHeight=100000)
@@ -3997,5 +4018,109 @@ describe("Stale query response should not overwrite block range", () => {
       (p4.prevQueryRange, p4.prevPrevQueryRange, p4.latestBlockRangeUpdateBlock),
       ~message="Earlier chunk A stale response should not overwrite range bookkeeping (still 600, 500, 2500)",
     ).toEqual((600, 500, 2500))
+  })
+})
+
+describe("FetchState.getPruneTarget", () => {
+  // No partitions, so the frontier is latestOnBlockBlockNumber. firstEventBlock=0
+  // and knownHeight=1000 make progress% == block/1000.
+  let makeBufferState = (~frontier, ~knownHeight, ~firstEventBlock, ~bufferBlocks): FetchState.t => {
+    ...makeInitialFs(),
+    optimizedPartitions: FetchState.OptimizedPartitions.make(
+      ~partitions=[],
+      ~maxAddrInPartition=3,
+      ~nextPartitionIndex=0,
+      ~dynamicContracts=Utils.Set.make(),
+    ),
+    latestOnBlockBlockNumber: frontier,
+    knownHeight,
+    firstEventBlock: Some(firstEventBlock),
+    buffer: bufferBlocks->Array.map(blockNumber => mockEvent(~blockNumber)),
+  }
+
+  it("maps a progress threshold to a block target and freed count, clamped to frontier and reorg floor", t => {
+    let fs = makeBufferState(
+      ~frontier=100,
+      ~knownHeight=1000,
+      ~firstEventBlock=0,
+      ~bufferBlocks=[100, 200, 300, 400, 500, 600, 700, 800, 900, 1000],
+    )
+    t.expect({
+      // threshold 0.5 → block 500; items > 500 are {600..1000} = 5
+      "mid": fs->FetchState.getPruneTarget(~progressThreshold=0.5, ~maxReorgDepth=0),
+      // threshold 0.0 → clamped up to the frontier (100); items > 100 = 9
+      "all": fs->FetchState.getPruneTarget(~progressThreshold=0.0, ~maxReorgDepth=0),
+      // threshold 1.0 but reorg floor (1000 - 300 = 700) clamps the target down,
+      // so items in the reorg window {800, 900, 1000} = 3 are never the restart point
+      "reorgFloor": fs->FetchState.getPruneTarget(~progressThreshold=1.0, ~maxReorgDepth=300),
+    }).toEqual({
+      "mid": (500, 5),
+      "all": (100, 9),
+      "reorgFloor": (700, 3),
+    })
+  })
+})
+
+describe("FetchState.rollback consolidation", () => {
+  it("rolls far-apart partitions back to the target and re-merges them", t => {
+    // Two Gravatar dynamic-contract partitions that fetched millions of blocks
+    // apart (never merged), whose addresses were both registered below the
+    // rollback target. After rollback they collapse to the target and
+    // consolidate into a single partition — the de-fragmentation a buffer prune
+    // relies on.
+    let dcNear = makeDynContractRegistration(~blockNumber=1, ~contractAddress=mockAddress1)
+    let dcFar = makeDynContractRegistration(~blockNumber=50000, ~contractAddress=mockAddress2)
+    let (baseFs, indexingAddresses) = makeInitial(~maxAddrInPartition=3)
+    let _ =
+      baseFs->FetchState.registerDynamicContracts(
+        ~indexingAddresses,
+        [dcNear->dcToItem, dcFar->dcToItem],
+      )
+
+    let normalSelection = baseFs.normalSelection
+    let makePartition = (~id, ~blockNumber, ~address): FetchState.partition => {
+      id,
+      latestFetchedBlock: {blockNumber, blockTimestamp: 0},
+      dynamicContract: Some("Gravatar"),
+      mutPendingQueries: [],
+      prevQueryRange: 0,
+      prevPrevQueryRange: 0,
+      prevRangeSize: 0,
+      latestBlockRangeUpdateBlock: 0,
+      selection: normalSelection,
+      addressesByContractName: Dict.fromArray([("Gravatar", [address])]),
+      mergeBlock: None,
+    }
+    let fetchState: FetchState.t = {
+      ...baseFs,
+      knownHeight: 6_000_000,
+      buffer: [],
+      optimizedPartitions: FetchState.OptimizedPartitions.make(
+        ~partitions=[
+          makePartition(~id="0", ~blockNumber=1_000_000, ~address=mockAddress1),
+          makePartition(~id="1", ~blockNumber=5_000_000, ~address=mockAddress2),
+        ],
+        ~nextPartitionIndex=2,
+        ~maxAddrInPartition=3,
+        ~dynamicContracts=Utils.Set.fromArray(["Gravatar"]),
+      ),
+    }
+
+    let result = fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=60000)
+    let partitions = result.optimizedPartitions.entities->Dict.valuesToArray
+    let p = partitions->Array.getUnsafe(0)
+    t.expect({
+      "count": partitions->Array.length,
+      "lfb": p.latestFetchedBlock.blockNumber,
+      "contract": p.dynamicContract,
+      "mergeBlock": p.mergeBlock,
+      "addressCount": p.addressesByContractName->Dict.getUnsafe("Gravatar")->Array.length,
+    }).toEqual({
+      "count": 1,
+      "lfb": 60000,
+      "contract": Some("Gravatar"),
+      "mergeBlock": None,
+      "addressCount": 2,
+    })
   })
 })

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -3312,11 +3312,12 @@ describe("FetchState unit tests for specific cases", () => {
         Ready([
           partition2Query,
           {
-            // Partition responded with no items, so its density is 0 and the
-            // estimate is 0 (empty queries don't fill the buffer).
+            // Partition responded with no items, so its density is 0; the
+            // estimate is floored at minEstResponseSize (100) so admission still
+            // gates it.
             ...queryA,
             partitionId: "1",
-            estResponseSize: 0.,
+            estResponseSize: 100.,
             toBlock: Some(500),
             fromBlock: 401,
           },

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -382,7 +382,7 @@ describe("SourceManager fetchNext", () => {
     ~budget=5000,
     ~stateId,
   ) => {
-    let action = fetchState->FetchState.getNextQuery(~budget, ~chainPendingBudget=0.)
+    let action = fetchState->FetchState.getNextQuery(~budget)
     // CrossChainState marks queries in flight when admitting them; dispatch no
     // longer does, so mirror that here before dispatching.
     switch action {
@@ -509,10 +509,10 @@ describe("SourceManager fetchNext", () => {
 
     t.expect({
       // 10 already pending: the partition is capped, so the scheduler issues nothing.
-      "atCap": withPending(10)->FetchState.getNextQuery(~budget=5000, ~chainPendingBudget=0.),
+      "atCap": withPending(10)->FetchState.getNextQuery(~budget=5000),
       // 9 pending: the two-chunk tail is trimmed down to the one remaining slot.
       "oneSlotLeft": withPending(9)
-      ->FetchState.getNextQuery(~budget=5000, ~chainPendingBudget=0.)
+      ->FetchState.getNextQuery(~budget=5000)
       ->newQueryCount,
     }).toEqual({"atCap": FetchState.NothingToQuery, "oneSlotLeft": 1})
   })


### PR DESCRIPTION
## Summary

Big multichain indexers (5M+ addresses, 1000+ partitions) were hitting a query storm: `FetchState.getNextQuery`'s per-tick `maxQueryBlockNumber` cap imposed a single block ceiling on every partition, computed from the densest region of the buffer. Sparse partitions that could leap ahead in one wide query were instead held to that low ceiling, re-querying tiny block ranges every tick and overloading the process with query handling.

- Remove the up-front block cap. Queries now run to `endBlock`/head, sized by the existing per-partition chunk heuristic instead of a global buffer-position ceiling.
- Bound total buffer growth reactively instead: `CrossChainState.maybePrune` runs at the start of every fetch tick (i.e. after every query response, not just periodically); once the indexer-wide buffer exceeds 3x `targetBufferSize`, it drops the closest-to-head (highest progress%) items across all chains back down to 2x and rolls the partitions that fetched them back to the prune point via `FetchState.rollback` (reusing the reorg-rollback cascade — dynamic-contract cleanup, partition re-merge — but touching only the fetch frontier + transaction store, not committed progress/reorg detection/the DB).
- Floor each query's estimated response size at 100 (`FetchState.calculateEstResponseSize`) so a density-0 partition (last response had no items) is never treated as a free query by cross-chain admission — previously such queries estimated 0 and could be admitted unbounded in one tick.
- Clamp the prune target to the ready frontier (never drop processable items) and to the reorg floor (`knownHeight - maxReorgDepth`, never invalidate a confirmed restart point).
- Add `Prometheus.IndexingBufferPrune` counters and a trace log for prune events.

## Test plan

- [x] `pnpm rescript` builds clean in `packages/envio` and `scenarios/test_codegen`
- [x] `pnpm vitest run test/lib_tests/FetchState_test.res.mjs test/lib_tests/CrossChainState_test.res.mjs test/lib_tests/SourceManager_test.res.mjs test/lib_tests/IndexerLoop_test.res.mjs test/IndexerState_test.res.mjs test/ClientAddressFilter_test.res.mjs test/EventBlockFilter_test.res.mjs` — 185 tests pass
- [x] New coverage: `FetchState.getPruneTarget` (block/progress clamping), `FetchState.rollback` partition re-merge after a far-apart rollback, `CrossChainState buffer prune` (hysteresis gating, cross-chain head-closest-first pruning)
- [ ] CI full suite

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_01SxqSFQNKCfA3gBr4Y1QHcV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxqSFQNKCfA3gBr4Y1QHcV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic buffer pruning during cross-chain fetching to keep indexing memory usage under control.
  * Added metrics to track buffer prune events and the number of items removed.

* **Bug Fixes**
  * Improved fetch scheduling so query ranges are no longer limited by buffered-ahead items.
  * Updated query sizing to avoid treating empty or low-density partitions as free, helping maintain more consistent fetch behavior.

* **Tests**
  * Expanded coverage for buffer pruning, query range behavior, and rollback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->