### PR TITLE
Normalize address casing in simulate and contractRegister

### DIFF
--- a/packages/envio/src/Address.res
+++ b/packages/envio/src/Address.res
@@ -14,6 +14,9 @@ module Evm = {
   @module("viem")
   external fromStringLowercaseOrThrow: string => bool = "isAddress"
 
+  @module("viem")
+  external isValid: string => bool = "isAddress"
+
   // Reassign since the function might be used in the handler code
   // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
   // of generated code instead of adding it to the indexer project dependencies.

--- a/packages/envio/src/Address.res
+++ b/packages/envio/src/Address.res
@@ -11,8 +11,11 @@ module Evm = {
   external fromStringOrThrow: string => t = "getAddress"
 
   // NOTE: the function is named to be overshadowed by the one below, so that we don't have to import viem in the handler code
+  // strict:false checks only the 20-byte hex shape, not EIP-55 checksum casing —
+  // since we're about to lowercase it anyway, an all-uppercase or wrongly-cased
+  // input address is just as valid as one that's already lowercase.
   @module("viem")
-  external fromStringLowercaseOrThrow: string => bool = "isAddress"
+  external fromStringLowercaseOrThrow: (string, {"strict": bool}) => bool = "isAddress"
 
   // Reassign since the function might be used in the handler code
   // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
@@ -20,7 +23,7 @@ module Evm = {
   // Also, we want a custom error message, which is searchable in our codebase.
   // Validate that the string is a proper address but return a lowercased value
   let fromStringLowercaseOrThrow = string => {
-    if fromStringLowercaseOrThrow(string) {
+    if fromStringLowercaseOrThrow(string, {"strict": false}) {
       unsafeFromString(string->String.toLowerCase)
     } else {
       JsError.throwWithMessage(

--- a/packages/envio/src/Address.res
+++ b/packages/envio/src/Address.res
@@ -14,9 +14,6 @@ module Evm = {
   @module("viem")
   external fromStringLowercaseOrThrow: string => bool = "isAddress"
 
-  @module("viem")
-  external isValid: string => bool = "isAddress"
-
   // Reassign since the function might be used in the handler code
   // and we don't want to have a "viem" import there. It's needed to keep "viem" a dependency
   // of generated code instead of adding it to the indexer project dependencies.

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -1034,6 +1034,31 @@ let normalizeUserAddress = (config: t, address: Address.t): Address.t =>
   | Ecosystem.Fuel | Ecosystem.Svm => address
   }
 
+// Relaxed counterpart to normalizeUserAddress, used only for simulate srcAddress.
+// Tests commonly use short placeholder strings like "0xfoo" as a stand-in
+// identity (e.g. for a wildcard event whose srcAddress doesn't need to resolve
+// to any real contract), so only the "0x" prefix is enforced here. A properly
+// formatted 20-byte address is still canonicalized to the configured casing so
+// it can match a real config address during routing.
+let normalizeSimulateAddress = (config: t, address: Address.t): Address.t =>
+  switch config.ecosystem.name {
+  | Ecosystem.Evm =>
+    let str = address->Address.toString
+    if !(str->String.startsWith("0x")) {
+      JsError.throwWithMessage(
+        `simulate: srcAddress "${str}" is invalid. Expected a string starting with "0x".`,
+      )
+    }
+    if Address.Evm.isValid(str) {
+      config->normalizeUserAddress(address)
+    } else if config.lowercaseAddresses {
+      address->Address.Evm.fromAddressLowercaseOrThrow
+    } else {
+      address
+    }
+  | Ecosystem.Fuel | Ecosystem.Svm => address
+  }
+
 // Look up an event config by (contract, event) name. When `chainId` is given,
 // returns that chain's per-chain event config (matters for where-callback
 // probe detection, which runs with the chain's real id). Without `chainId`,

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -1037,9 +1037,10 @@ let normalizeUserAddress = (config: t, address: Address.t): Address.t =>
 // Relaxed counterpart to normalizeUserAddress, used only for simulate srcAddress.
 // Tests commonly use short placeholder strings like "0xfoo" as a stand-in
 // identity (e.g. for a wildcard event whose srcAddress doesn't need to resolve
-// to any real contract), so only the "0x" prefix is enforced here. A properly
-// formatted 20-byte address is still canonicalized to the configured casing so
-// it can match a real config address during routing.
+// to any real contract), so only the "0x" prefix is enforced here. Under
+// address_format: checksum, a real address is checksummed even if the input
+// casing doesn't match (getAddress doesn't require the input to already be
+// checksummed) — a placeholder that isn't valid hex falls back unchanged.
 let normalizeSimulateAddress = (config: t, address: Address.t): Address.t =>
   switch config.ecosystem.name {
   | Ecosystem.Evm =>
@@ -1049,12 +1050,14 @@ let normalizeSimulateAddress = (config: t, address: Address.t): Address.t =>
         `simulate: srcAddress "${str}" is invalid. Expected a string starting with "0x".`,
       )
     }
-    if Address.Evm.isValid(str) {
-      config->normalizeUserAddress(address)
-    } else if config.lowercaseAddresses {
+    if config.lowercaseAddresses {
       address->Address.Evm.fromAddressLowercaseOrThrow
     } else {
-      address
+      try {
+        address->Address.Evm.fromAddressOrThrow
+      } catch {
+      | _ => address
+      }
     }
   | Ecosystem.Fuel | Ecosystem.Svm => address
   }

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -1018,6 +1018,22 @@ let fromPublic = (publicConfigJson: JSON.t) => {
   }
 }
 
+// Canonicalize a user-provided address to the configured casing so it matches
+// addresses parsed from config.yaml during routing. HyperSync/RPC data arrives
+// already canonical; only user-land input (simulate srcAddress, contractRegister
+// add) can carry arbitrary casing and needs this before comparison.
+let normalizeUserAddress = (config: t, address: Address.t): Address.t =>
+  switch config.ecosystem.name {
+  | Ecosystem.Evm =>
+    if config.lowercaseAddresses {
+      address->Address.Evm.fromAddressLowercaseOrThrow
+    } else {
+      address->Address.Evm.fromAddressOrThrow
+    }
+  // TODO: Ideally we should do the same for other ecosystems
+  | Ecosystem.Fuel | Ecosystem.Svm => address
+  }
+
 // Look up an event config by (contract, event) name. When `chainId` is given,
 // returns that chain's per-chain event config (matters for where-callback
 // probe detection, which runs with the chain's real id). Without `chainId`,

--- a/packages/envio/src/ContractRegisterContext.res
+++ b/packages/envio/src/ContractRegisterContext.res
@@ -22,18 +22,8 @@ let makeAddFunction = (~params: contractRegisterParams, ~contractName: string): 
         ~logger=Ecosystem.getItemLogger(params.item, ~ecosystem=params.config.ecosystem),
       )
     }
-    let validatedAddress = if params.config.ecosystem.name === Evm {
-      // The value is passed from the user-land,
-      // so we need to validate and checksum/lowercase the address.
-      if params.config.lowercaseAddresses {
-        contractAddress->Address.Evm.fromAddressLowercaseOrThrow
-      } else {
-        contractAddress->Address.Evm.fromAddressOrThrow
-      }
-    } else {
-      // TODO: Ideally we should do the same for other ecosystems
-      contractAddress
-    }
+    // The value is passed from user-land, so validate and checksum/lowercase it.
+    let validatedAddress = params.config->Config.normalizeUserAddress(contractAddress)
 
     params.onRegister(~item=params.item, ~contractAddress=validatedAddress, ~contractName)
   }

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -216,9 +216,12 @@ let deriveSrcAddress = (
   ~providedSrcAddress: option<Address.t>,
   ~eventConfig: Internal.eventConfig,
   ~chainConfig: Config.chain,
+  ~config: Config.t,
 ): Address.t => {
   switch providedSrcAddress {
-  | Some(addr) => addr
+  // Canonicalize to the configured casing; the fallback addresses below already
+  // come from the parsed config and need no normalization.
+  | Some(addr) => config->Config.normalizeUserAddress(addr)
   | None =>
     if eventConfig.isWildcard {
       dummySrcAddress
@@ -287,6 +290,7 @@ let parse = (~simulateItems: array<JSON.t>, ~config: Config.t, ~chainConfig: Con
         ~providedSrcAddress=item.srcAddress,
         ~eventConfig,
         ~chainConfig,
+        ~config,
       )
 
       let rawItem = rawJson->(Utils.magic: JSON.t => {..})

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -220,8 +220,9 @@ let deriveSrcAddress = (
 ): Address.t => {
   switch providedSrcAddress {
   // Canonicalize to the configured casing; the fallback addresses below already
-  // come from the parsed config and need no normalization.
-  | Some(addr) => config->Config.normalizeUserAddress(addr)
+  // come from the parsed config and need no normalization. Relaxed (not
+  // Config.normalizeUserAddress) so test placeholders like "0xfoo" are allowed.
+  | Some(addr) => config->Config.normalizeSimulateAddress(addr)
   | None =>
     if eventConfig.isWildcard {
       dummySrcAddress

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -319,11 +319,10 @@ describe("Config.fromPublic", () => {
     t.expect(address->Address.toString, ~message="Address must be preserved verbatim").toBe(uni)
   })
 
-  // config.yaml addresses go through the strict parser (Address.Evm.fromStringOrThrow /
-  // fromStringLowercaseOrThrow), unlike simulate's srcAddress which only requires a
-  // "0x" prefix. A malformed address here must still fail config load.
-  it("throws when a contract address in config is not a valid 20-byte hex address", t => {
-    let publicConfigJson: JSON.t = %raw(`{
+  // Builds a minimal single-chain, single-contract public config with one
+  // configurable contract address, for exercising address_format handling.
+  let makeAddressFormatConfigJson = (~addressFormat: string, ~address: string): JSON.t =>
+    JSON.parseOrThrow(`{
       "version": "0.0.1-dev",
       "name": "test",
       "storage": { "postgres": true },
@@ -335,7 +334,7 @@ describe("Config.fromPublic", () => {
             "rpcs": [{ "url": "https://eth.com", "for": "sync" }],
             "contracts": {
               "ERC20": {
-                "addresses": ["0xfoo"]
+                "addresses": ["${address}"]
               }
             }
           }
@@ -346,13 +345,55 @@ describe("Config.fromPublic", () => {
             "events": [{ "event": "Transfer()", "name": "Transfer", "sighash": "0x00000000" }]
           }
         },
-        "addressFormat": "checksum"
+        "addressFormat": "${addressFormat}"
       }
     }`)
 
-    t.expect(() => Config.fromPublic(publicConfigJson)->ignore).toThrowError(
-      `Address "0xfoo" is invalid. Expected a 20-byte hex string starting with 0x.`,
-    )
+  let getFirstContractAddress = (config: Config.t): string => {
+    let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
+    let contract = chain.contracts->Array.getUnsafe(0)
+    contract.addresses->Array.getUnsafe(0)->Address.toString
+  }
+
+  // config.yaml addresses go through the strict parser (Address.Evm.fromStringOrThrow /
+  // fromStringLowercaseOrThrow), unlike simulate's srcAddress which only requires a
+  // "0x" prefix. A malformed address here must still fail config load.
+  it("throws when a contract address in config is not a valid 20-byte hex address (checksum format)", t => {
+    t.expect(
+      () =>
+        Config.fromPublic(
+          makeAddressFormatConfigJson(~addressFormat="checksum", ~address="0xfoo"),
+        )->ignore,
+    ).toThrowError(`Address "0xfoo" is invalid. Expected a 20-byte hex string starting with 0x.`)
+  })
+
+  it("throws when a contract address in config is not a valid 20-byte hex address (lowercase format)", t => {
+    t.expect(
+      () =>
+        Config.fromPublic(
+          makeAddressFormatConfigJson(~addressFormat="lowercase", ~address="0xfoo"),
+        )->ignore,
+    ).toThrowError(`Address "0xfoo" is invalid. Expected a 20-byte hex string starting with 0x.`)
+  })
+
+  // Whatever casing a valid 20-byte address is written in, address_format
+  // adjusts it internally instead of rejecting it — that's the whole point of
+  // the setting: don't make the user care about case.
+  [
+    ("checksum", "0xa2f6e6029638ccb484a2ccb6414499ad3e825cac", "all-lowercase"),
+    ("checksum", "0xA2F6E6029638CCB484A2CCB6414499AD3E825CAC", "all-uppercase"),
+    ("lowercase", "0xa2f6e6029638ccb484a2ccb6414499ad3e825cac", "all-lowercase"),
+    ("lowercase", "0xA2F6E6029638CCB484A2CCB6414499AD3E825CAC", "all-uppercase"),
+  ]->Array.forEach(((addressFormat, address, caseDescription)) => {
+    it(`normalizes a ${caseDescription} address under address_format: ${addressFormat}`, t => {
+      let config = Config.fromPublic(makeAddressFormatConfigJson(~addressFormat, ~address))
+      t.expect(config->getFirstContractAddress).toBe(
+        switch addressFormat {
+        | "lowercase" => "0xa2f6e6029638ccb484a2ccb6414499ad3e825cac"
+        | _ => "0xa2F6E6029638cCb484A2ccb6414499aD3e825CaC"
+        },
+      )
+    })
   })
 
   it("parses entity and field descriptions from public config", t => {

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -319,6 +319,42 @@ describe("Config.fromPublic", () => {
     t.expect(address->Address.toString, ~message="Address must be preserved verbatim").toBe(uni)
   })
 
+  // config.yaml addresses go through the strict parser (Address.Evm.fromStringOrThrow /
+  // fromStringLowercaseOrThrow), unlike simulate's srcAddress which only requires a
+  // "0x" prefix. A malformed address here must still fail config load.
+  it("throws when a contract address in config is not a valid 20-byte hex address", t => {
+    let publicConfigJson: JSON.t = %raw(`{
+      "version": "0.0.1-dev",
+      "name": "test",
+      "storage": { "postgres": true },
+      "evm": {
+        "chains": {
+          "ethereumMainnet": {
+            "id": 1,
+            "startBlock": 0,
+            "rpcs": [{ "url": "https://eth.com", "for": "sync" }],
+            "contracts": {
+              "ERC20": {
+                "addresses": ["0xfoo"]
+              }
+            }
+          }
+        },
+        "contracts": {
+          "ERC20": {
+            "abi": [{"type":"event","name":"Transfer","inputs":[],"anonymous":false}],
+            "events": [{ "event": "Transfer()", "name": "Transfer", "sighash": "0x00000000" }]
+          }
+        },
+        "addressFormat": "checksum"
+      }
+    }`)
+
+    t.expect(() => Config.fromPublic(publicConfigJson)->ignore).toThrowError(
+      `Address "0xfoo" is invalid. Expected a 20-byte hex string starting with 0x.`,
+    )
+  })
+
   it("parses entity and field descriptions from public config", t => {
     let publicConfigJson: JSON.t = %raw(`{
       "version": "0.0.1-dev",

--- a/scenarios/test_codegen/test/SimulateDynamicAddress_test.res
+++ b/scenarios/test_codegen/test/SimulateDynamicAddress_test.res
@@ -35,6 +35,15 @@ let expectedToken: Indexer.Entities.Token.t = {
   owner_id: owner->Address.toString,
 }
 
+let expectedCollection: Indexer.Entities.NftCollection.t = {
+  id: newNft->Address.toString,
+  contractAddress: newNft->Address.toString,
+  name: "n",
+  symbol: "s",
+  maxSupply: 0n,
+  currentSupply: 0,
+}
+
 // SimpleNft has no configured address; it's registered dynamically by
 // NftFactory.SimpleNftCreated. A non-wildcard SimpleNft.Transfer for an address
 // registered in an earlier process() call routes to the handler unchanged.
@@ -104,6 +113,31 @@ Async.it("reports a non-wildcard simulate item whose srcAddress is never indexed
       `simulate: 1 item you passed to simulate never reached a handler, so nothing ran for them. Each was filtered out before the handler — usually a non-wildcard srcAddress that isn't indexed for the contract, or a where/block filter that excluded the event. Unrouted items, by index in each chain's simulate array:` ++ "\n  - chain 1337: 0",
     ),
   )
+})
+
+// config.yaml stores NftFactory's address checksummed; a simulate srcAddress in a
+// different casing (here lowercase) must still route the non-wildcard
+// SimpleNftCreated event. Before normalization the raw string compare dropped it,
+// leaving no way to construct a mixed-case routable address for simulate.
+Async.it("routes a simulate event whose srcAddress casing differs from the configured address", async t => {
+  let indexer = Indexer.createTestIndexer()
+  let _ = await indexer.process({
+    chains: {
+      \"1337": {
+        startBlock: 1,
+        endBlock: 100,
+        simulate: [
+          {
+            ...createNft,
+            srcAddress: Address.unsafeFromString("0xa2f6e6029638ccb484a2ccb6414499ad3e825cac"),
+          },
+        ],
+      },
+    },
+  })
+
+  let collections = await indexer.\"NftCollection".getAll()
+  t.expect(collections).toEqual([expectedCollection])
 })
 
 // Two items resolving to the same (block, logIndex) is an ambiguous input that

--- a/scenarios/test_codegen/test/SimulateDynamicAddress_test.res
+++ b/scenarios/test_codegen/test/SimulateDynamicAddress_test.res
@@ -140,6 +140,30 @@ Async.it("routes a simulate event whose srcAddress casing differs from the confi
   t.expect(collections).toEqual([expectedCollection])
 })
 
+// An address with an invalid EIP-55 checksum (here all-uppercase hex) is still
+// a valid 20-byte address — normalization recomputes its checksum rather than
+// requiring the input to already carry the correct one, so it still routes.
+Async.it("routes a simulate event whose srcAddress has an invalid checksum casing", async t => {
+  let indexer = Indexer.createTestIndexer()
+  let _ = await indexer.process({
+    chains: {
+      \"1337": {
+        startBlock: 1,
+        endBlock: 100,
+        simulate: [
+          {
+            ...createNft,
+            srcAddress: Address.unsafeFromString("0xA2F6E6029638CCB484A2CCB6414499AD3E825CAC"),
+          },
+        ],
+      },
+    },
+  })
+
+  let collections = await indexer.\"NftCollection".getAll()
+  t.expect(collections).toEqual([expectedCollection])
+})
+
 // Two items resolving to the same (block, logIndex) is an ambiguous input that
 // the dead-input tracker and event ordering both key on — rejected at parse.
 Async.it("rejects simulate items that resolve to the same block and logIndex", async t => {

--- a/scenarios/test_codegen/test/WildcardSimulate_test.res
+++ b/scenarios/test_codegen/test/WildcardSimulate_test.res
@@ -32,3 +32,29 @@ Async.it("routes a handler-registered wildcard event to its handler regardless o
     ),
   ).toEqual([{"block": 1, "chainId": 100, "eventsProcessed": 1}])
 })
+
+// simulate only requires srcAddress to start with "0x" — a placeholder like
+// "0xfoo" is accepted, unlike a real address which must be valid 20-byte hex.
+Async.it("accepts a non-address placeholder srcAddress starting with 0x", async t => {
+  let indexer = Indexer.createTestIndexer()
+
+  let wildcardTransfer: Envio.evmSimulateItem = {
+    ...Indexer.makeSimulateItem(
+      OnEvent({
+        event: EventFiltersTest(Transfer),
+        params: {from: zero, to: whitelisted100, amount: 0n},
+      }),
+    ),
+    srcAddress: Address.unsafeFromString("0xfoo"),
+  }
+
+  let result = await indexer.process({
+    chains: {\"100": {startBlock: 1, endBlock: 100, simulate: [wildcardTransfer]}},
+  })
+
+  t.expect(
+    result.changes->(
+      Utils.magic: array<unknown> => array<{"block": int, "chainId": int, "eventsProcessed": int}>
+    ),
+  ).toEqual([{"block": 1, "chainId": 100, "eventsProcessed": 1}])
+})


### PR DESCRIPTION
## Summary

Adds address normalization for user-provided addresses in simulate events and contractRegister calls, ensuring they match the configured address format (checksum or lowercase) before routing and comparison. This allows simulate srcAddress and contractRegister add to work correctly regardless of input casing.

## Key Changes

- **Config.res**: Added two new address normalization functions:
  - `normalizeUserAddress`: Strict validation for contractRegister, requires valid 20-byte hex and applies configured casing
  - `normalizeSimulateAddress`: Relaxed validation for simulate srcAddress, only requires "0x" prefix to support test placeholders like "0xfoo", applies configured casing to valid addresses

- **Address.res**: Updated `fromStringLowercaseOrThrow` to use `strict: false` when calling viem's `isAddress`, allowing valid 20-byte hex addresses regardless of casing (since they're about to be lowercased anyway)

- **SimulateItems.res**: Modified `deriveSrcAddress` to normalize provided srcAddress through `normalizeSimulateAddress` before returning, ensuring it matches the configured address format

- **ContractRegisterContext.res**: Refactored address validation to use `Config.normalizeUserAddress` instead of inline logic, centralizing the normalization behavior

- **Tests**: Added comprehensive test coverage:
  - Config parsing tests for address format handling with various casings
  - Simulate routing tests for mixed-case and invalid-checksum addresses
  - Wildcard simulate test for non-address placeholders

## Implementation Details

The normalization approach differs between the two use cases:
- `normalizeUserAddress` is strict: rejects invalid addresses since they come from config.yaml or contractRegister which should be validated
- `normalizeSimulateAddress` is relaxed: accepts any "0x"-prefixed string to support test placeholders, but still applies checksum/lowercase normalization to valid addresses

This allows simulate to be flexible for testing while maintaining strict validation where it matters.

https://claude.ai/code/session_01U3UcHPYjx9eE145k9voQYh