### PR TITLE
Refactor buffer prune to hold back ranges and fix partition ID reuse

### DIFF
--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -111,6 +111,8 @@ let rec onQueryResponse = async (
   // Stale epoch (reorg / realtime transition) invalidates every in-flight
   // response; a buffer prune invalidates only the queries it rolled back, whose
   // responses are recognized here by no longer being tracked as pending.
+  // TODO: Move the still-pending gate into ChainState.handleQueryResult so a
+  // future response entry point can't bypass it.
   if (
     state->IndexerState.isStale(~stateId) || !(chainState->ChainState.isQueryStillPending(~query))
   ) {

--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -105,17 +105,17 @@ let rec onQueryResponse = async (
   ~scheduleFetch,
   ~scheduleProcessing,
   ~scheduleRollback,
-) =>
+) => {
+  let chainState = state->IndexerState.getChainState(~chain)
+
   // Stale epoch (reorg / realtime transition) invalidates every in-flight
   // response; a buffer prune invalidates only the queries it rolled back, whose
   // responses are recognized here by no longer being tracked as pending.
   if (
-    state->IndexerState.isStale(~stateId) ||
-      !(state->IndexerState.getChainState(~chain)->ChainState.isQueryStillPending(~query))
+    state->IndexerState.isStale(~stateId) || !(chainState->ChainState.isQueryStillPending(~query))
   ) {
     ()
   } else {
-    let chainState = state->IndexerState.getChainState(~chain)
     let {
       parsedQueueItems,
       transactionStore,
@@ -210,31 +210,24 @@ let rec onQueryResponse = async (
         newItems->Array.push(item)
       }
 
-      // Re-check validity: contract registration is async, so the chain state
-      // may have rolled back or pruned this query by the time we apply the
-      // fetched items.
-      let proceed = (~newItemsWithDcs) =>
-        if (
-          !(state->IndexerState.isStale(~stateId)) &&
-          chainState->ChainState.isQueryStillPending(~query)
-        ) {
-          applyQueryResponse(
-            state,
-            ~chain,
-            ~newItems,
-            ~newItemsWithDcs,
-            ~knownHeight,
-            ~latestFetchedBlock={
-              FetchState.blockNumber: latestFetchedBlockNumber,
-              blockTimestamp: latestFetchedBlockTimestamp,
-            },
-            ~query,
-            ~transactionStore,
-          )
-          ChainMetadata.stage(state)
-          scheduleFetch()
-          scheduleProcessing()
-        }
+      let proceed = (~newItemsWithDcs) => {
+        applyQueryResponse(
+          state,
+          ~chain,
+          ~newItems,
+          ~newItemsWithDcs,
+          ~knownHeight,
+          ~latestFetchedBlock={
+            FetchState.blockNumber: latestFetchedBlockNumber,
+            blockTimestamp: latestFetchedBlockTimestamp,
+          },
+          ~query,
+          ~transactionStore,
+        )
+        ChainMetadata.stage(state)
+        scheduleFetch()
+        scheduleProcessing()
+      }
 
       switch itemsWithContractRegister {
       | [] => proceed(~newItemsWithDcs=[])
@@ -245,11 +238,20 @@ let rec onQueryResponse = async (
           ~page=transactionStore,
         ) {
         | exception exn => IndexerState.errorExit(state, exn->ErrorHandling.make)
-        | newItemsWithDcs => proceed(~newItemsWithDcs)
+        | newItemsWithDcs =>
+          // Re-check validity: contract registration is async, so the chain
+          // state may have rolled back or pruned this query during the await.
+          if (
+            !(state->IndexerState.isStale(~stateId)) &&
+            chainState->ChainState.isQueryStillPending(~query)
+          ) {
+            proceed(~newItemsWithDcs)
+          }
         }
       }
     }
   }
+}
 
 and applyQueryResponse = (
   state: IndexerState.t,

--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -106,7 +106,13 @@ let rec onQueryResponse = async (
   ~scheduleProcessing,
   ~scheduleRollback,
 ) =>
-  if state->IndexerState.isStale(~stateId) {
+  // Stale epoch (reorg / realtime transition) invalidates every in-flight
+  // response; a buffer prune invalidates only the queries it rolled back, whose
+  // responses are recognized here by no longer being tracked as pending.
+  if (
+    state->IndexerState.isStale(~stateId) ||
+      !(state->IndexerState.getChainState(~chain)->ChainState.isQueryStillPending(~query))
+  ) {
     ()
   } else {
     let chainState = state->IndexerState.getChainState(~chain)
@@ -204,10 +210,14 @@ let rec onQueryResponse = async (
         newItems->Array.push(item)
       }
 
-      // Re-check staleness: contract registration is async, so the chain state
-      // may have rolled back by the time we apply the fetched items.
+      // Re-check validity: contract registration is async, so the chain state
+      // may have rolled back or pruned this query by the time we apply the
+      // fetched items.
       let proceed = (~newItemsWithDcs) =>
-        if !(state->IndexerState.isStale(~stateId)) {
+        if (
+          !(state->IndexerState.isStale(~stateId)) &&
+          chainState->ChainState.isQueryStillPending(~query)
+        ) {
           applyQueryResponse(
             state,
             ~chain,

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -457,8 +457,8 @@ let resetPendingQueries = (cs: t) => {
   cs.pendingBudget = 0.
 }
 
-// Propose the chain's candidate queries against the shared buffer budget.
-let getNextQuery = (cs: t, ~budget) => cs.fetchState->FetchState.getNextQuery(~budget)
+// Propose the chain's candidate queries for cross-chain admission.
+let getNextQuery = (cs: t, ~hasBudget) => cs.fetchState->FetchState.getNextQuery(~hasBudget)
 
 // Block to prune above (and how many buffer items that frees) for a given
 // cross-chain progress threshold. See FetchState.getPruneTarget.

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -18,6 +18,11 @@ type t = {
   // scheduler doesn't re-sum pending queries on every tick. Incremented when
   // queries are dispatched, decremented as their responses land.
   mutable pendingBudget: float,
+  // Block the last buffer prune rolled this chain back to. While the indexer-wide
+  // buffer is still above targetBufferSize, cross-chain admission holds back
+  // queries above it so a prune isn't immediately undone by refetching what it
+  // dropped; cleared once the buffer drains back to the target.
+  mutable lastPruneTarget: option<int>,
   mutable reorgDetection: ReorgDetection.t,
   mutable safeCheckpointTracking: option<SafeCheckpointTracking.t>,
   // Holds this chain's transactions (kept in Rust) keyed by (blockNumber,
@@ -82,6 +87,7 @@ let make = (
   committedProgressBlockNumber,
   numEventsProcessed,
   pendingBudget: 0.,
+  lastPruneTarget: None,
   reorgDetection,
   safeCheckpointTracking,
   transactionStore,
@@ -434,6 +440,9 @@ let contractAddresses = (cs: t, ~contractName) =>
   cs.indexingAddresses->IndexingAddresses.getContractAddresses(~contractName)
 let bufferSize = (cs: t) => cs.fetchState->FetchState.bufferSize
 let bufferReadyCount = (cs: t) => cs.fetchState->FetchState.bufferReadyCount
+let lastPruneTarget = (cs: t) => cs.lastPruneTarget
+let clearPruneTarget = (cs: t) => cs.lastPruneTarget = None
+let isQueryStillPending = (cs: t, ~query) => cs.fetchState->FetchState.isQueryStillPending(~query)
 let getProgressPercentage = (cs: t) => cs.fetchState->FetchState.getProgressPercentage
 let getProgressPercentageAt = (cs: t, ~blockNumber) =>
   cs.fetchState->FetchState.getProgressPercentageAt(~blockNumber)
@@ -472,13 +481,17 @@ let getPruneTarget = (cs: t, ~progressThreshold) =>
 // and rolling the partitions that fetched them back to it, so they re-fetch later
 // once processing has caught up. Unlike a reorg rollback this touches only the
 // fetch frontier and transaction store — committed progress, reorg detection and
-// the DB are untouched, since nothing processed is being reverted. Callers must
-// first quiesce in-flight queries (resetPendingQueries + epoch bump); rolled-back
-// partitions collapse to targetBlockNumber and re-merge, de-fragmenting them.
+// the DB are untouched, since nothing processed is being reverted. In-flight
+// queries above the target are dropped by the rollback itself (their late
+// responses fail the still-pending check); queries at/below it keep running.
+// Rolled-back partitions collapse to targetBlockNumber and re-merge,
+// de-fragmenting them.
 let pruneBuffer = (cs: t, ~targetBlockNumber) => {
   cs.fetchState =
     cs.fetchState->FetchState.rollback(~indexingAddresses=cs.indexingAddresses, ~targetBlockNumber)
   cs.transactionStore->TransactionStore.rollback(targetBlockNumber)
+  cs.pendingBudget = cs.fetchState->FetchState.pendingBudgetSize
+  cs.lastPruneTarget = Some(targetBlockNumber)
 }
 
 // Run a fetch tick for this chain against its sources, feeding the owned fetch

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -491,7 +491,16 @@ let pruneBuffer = (cs: t, ~targetBlockNumber) => {
     cs.fetchState->FetchState.rollback(~indexingAddresses=cs.indexingAddresses, ~targetBlockNumber)
   cs.transactionStore->TransactionStore.rollback(targetBlockNumber)
   cs.pendingBudget = cs.fetchState->FetchState.pendingBudgetSize
-  cs.lastPruneTarget = Some(targetBlockNumber)
+
+  // A later prune in the same above-target episode may land on a higher block
+  // while ranges parked at the earlier target are still held back; keep the
+  // lower target, or releasing them would refetch what the first prune dropped.
+  cs.lastPruneTarget = Some(
+    switch cs.lastPruneTarget {
+    | Some(prev) => Pervasives.min(prev, targetBlockNumber)
+    | None => targetBlockNumber
+    },
+  )
 }
 
 // Run a fetch tick for this chain against its sources, feeding the owned fetch

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -56,6 +56,9 @@ let knownHeight: t => int
 let contractAddresses: (t, ~contractName: string) => array<Address.t>
 let bufferSize: t => int
 let bufferReadyCount: t => int
+let lastPruneTarget: t => option<int>
+let clearPruneTarget: t => unit
+let isQueryStillPending: (t, ~query: FetchState.query) => bool
 let getProgressPercentage: t => float
 let getProgressPercentageAt: (t, ~blockNumber: int) => float
 let hasReadyItem: t => bool
@@ -65,7 +68,6 @@ let isReadyToEnterReorgThreshold: t => bool
 let getNextQuery: (t, ~hasBudget: bool) => FetchState.nextQuery
 let getPruneTarget: (t, ~progressThreshold: float) => (int, int)
 let pruneBuffer: (t, ~targetBlockNumber: int) => unit
-let resetPendingQueries: t => unit
 let dispatch: (
   t,
   ~executeQuery: FetchState.query => promise<unit>,

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -62,7 +62,7 @@ let hasReadyItem: t => bool
 let isReadyToEnterReorgThreshold: t => bool
 
 // Fetch control.
-let getNextQuery: (t, ~budget: int) => FetchState.nextQuery
+let getNextQuery: (t, ~hasBudget: bool) => FetchState.nextQuery
 let getPruneTarget: (t, ~progressThreshold: float) => (int, int)
 let pruneBuffer: (t, ~targetBlockNumber: int) => unit
 let resetPendingQueries: t => unit

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -68,6 +68,7 @@ let isReadyToEnterReorgThreshold: t => bool
 let getNextQuery: (t, ~hasBudget: bool) => FetchState.nextQuery
 let getPruneTarget: (t, ~progressThreshold: float) => (int, int)
 let pruneBuffer: (t, ~targetBlockNumber: int) => unit
+let resetPendingQueries: t => unit
 let dispatch: (
   t,
   ~executeQuery: FetchState.query => promise<unit>,

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -214,7 +214,7 @@ let compareByProgress = (a: FetchState.query, b: FetchState.query) =>
 // chains back down to 1.5x and roll back the partitions that fetched them. Prune
 // only during backfill — near the head blockLag keeps the buffer below the reorg
 // window and there is nothing far-ahead to reclaim.
-let maybePrune = (crossChainState: t, ~invalidateInflight) => {
+let maybePrune = (crossChainState: t) => {
   if !crossChainState.isInReorgThreshold {
     let chainIds = crossChainState.chainIds
 
@@ -272,15 +272,14 @@ let maybePrune = (crossChainState: t, ~invalidateInflight) => {
         }
         let (targets, _) = best.contents
 
-        // Quiesce in-flight fetches before rolling partitions back: the epoch bump
-        // makes their responses stale (dropped on arrival) and resetPendingQueries
-        // clears them from every chain, since FetchState.rollback requires no
-        // in-flight queries.
-        invalidateInflight()
+        // Only the chains that actually free something are touched: pruneBuffer's
+        // rollback drops their in-flight queries above the target (late responses
+        // are discarded by the still-pending check), while every other chain's
+        // in-flight work — including the lagging frontier query the prune is
+        // waiting on — keeps running.
         let totalFreed = ref(0)
         for i in 0 to chainIds->Array.length - 1 {
           let cs = crossChainState->getChainState(chainIds->Array.getUnsafe(i))
-          cs->ChainState.resetPendingQueries
           let (target, freed) = targets->Array.getUnsafe(i)
           if freed > 0 {
             cs->ChainState.pruneBuffer(~targetBlockNumber=target)
@@ -309,9 +308,8 @@ let maybePrune = (crossChainState: t, ~invalidateInflight) => {
 let checkAndFetch = async (
   crossChainState: t,
   ~dispatchChain: (~chain: ChainMap.Chain.t, ~action: FetchState.nextQuery) => promise<unit>,
-  ~invalidateInflight: unit => unit,
 ) => {
-  crossChainState->maybePrune(~invalidateInflight)
+  crossChainState->maybePrune
 
   let remaining = Pervasives.max(
     0,
@@ -320,7 +318,19 @@ let checkAndFetch = async (
     crossChainState->totalReservedSize->Float.toInt,
   )
 
+  // A pruned range is not re-admitted while the whole buffer still holds more
+  // than targetBufferSize items — otherwise the tick right after a prune would
+  // refetch exactly what it dropped, since stuck items count toward the prune
+  // trigger but not toward `remaining`. Once the buffer drains back to the
+  // target, processing has caught up and the prune targets are cleared.
+  let bufferAboveTarget = crossChainState->totalBufferSize > crossChainState.targetBufferSize
+
   let chainIds = crossChainState.chainIds
+  if !bufferAboveTarget {
+    for i in 0 to chainIds->Array.length - 1 {
+      crossChainState->getChainState(chainIds->Array.getUnsafe(i))->ChainState.clearPruneTarget
+    }
+  }
   let actionByChain = Dict.make()
   // Candidate queries from every chain. Each query carries its chain id and the
   // chain progress % at its fromBlock (the admission sort key), set here so the
@@ -335,10 +345,17 @@ let checkAndFetch = async (
     | Ready(queries) =>
       // Default to NothingToQuery; replaced below if any candidate is admitted.
       actionByChain->Utils.Dict.setByInt(chainId, FetchState.NothingToQuery)
+      let pruneCeiling = bufferAboveTarget ? cs->ChainState.lastPruneTarget : None
       queries->Array.forEach(query => {
-        query.chainId = chainId
-        query.progress = cs->ChainState.getProgressPercentageAt(~blockNumber=query.fromBlock)
-        candidates->Array.push(query)
+        let isHeldBackPrunedRange = switch pruneCeiling {
+        | Some(ceiling) => query.fromBlock > ceiling
+        | None => false
+        }
+        if !isHeldBackPrunedRange {
+          query.chainId = chainId
+          query.progress = cs->ChainState.getProgressPercentageAt(~blockNumber=query.fromBlock)
+          candidates->Array.push(query)
+        }
       })
     }
   }

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -214,21 +214,20 @@ let compareByProgress = (a: FetchState.query, b: FetchState.query) =>
 // targetBufferSize < low-water < high-water — releasing pruned ranges any
 // earlier would refetch what the prune just dropped.
 let pruneHighWaterMark = (crossChainState: t) => crossChainState.targetBufferSize * 3
-let pruneLowWaterMark = (crossChainState: t) => crossChainState.targetBufferSize * 3 / 2
+let pruneLowWaterMark = (crossChainState: t) => crossChainState.targetBufferSize * 2
 
 // Removing the up-front block cap lets queries run to the head, so fetched-ahead
 // items accumulate as stuck buffer while a lagging partition holds the frontier.
 // This reclaims that memory reactively: once the indexer-wide buffer crosses the
 // high-water mark, drop the highest-progress% (closest-to-head) items across all
 // chains back down to the low-water mark and roll back the partitions that
-// fetched them. Prune only during backfill — near the head blockLag keeps the
-// buffer below the reorg window and there is nothing far-ahead to reclaim.
+// fetched them. Runs in the reorg threshold too: the indexer-wide flag is sticky
+// and set on restart if any single chain resumed near its head, so a chain
+// backfilling from far behind still needs the buffer bound; chains genuinely at
+// their head hold little above the frontier and are naturally rarely pruned.
 // Returns how many items were freed.
 let maybePrune = (crossChainState: t, ~totalBufferSize) =>
-  if (
-    !crossChainState.isInReorgThreshold &&
-    totalBufferSize > crossChainState->pruneHighWaterMark
-  ) {
+  if totalBufferSize > crossChainState->pruneHighWaterMark {
     let chainIds = crossChainState.chainIds
     let need = totalBufferSize - crossChainState->pruneLowWaterMark
 
@@ -255,6 +254,9 @@ let maybePrune = (crossChainState: t, ~totalBufferSize) =>
     // even that is nothing (e.g. the buffer is over the mark but full of ready
     // items), skip: quiescing in-flight fetches here would discard them every
     // tick without making room, stalling progress.
+    // TODO: When 0 < freedAtZero < need (ready items dominate the excess), this
+    // settles at threshold 0 and drops every stuck item even though that frees
+    // far less than `need`; consider pruning proportionally instead.
     let (targetsAtZero, freedAtZero) = pruneTargetsAt(0.)
     if freedAtZero > 0 {
       // Largest progress threshold that still frees `need` items, so we drop

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -62,6 +62,17 @@ let totalReadyCount = (crossChainState: t) => {
   total.contents
 }
 
+// All buffered items across every chain, ready or stuck — the memory footprint
+// the prune high-water mark is checked against.
+let totalBufferSize = (crossChainState: t) => {
+  let total = ref(0)
+  for i in 0 to crossChainState.chainIds->Array.length - 1 {
+    let cs = crossChainState->getChainState(crossChainState.chainIds->Array.getUnsafe(i))
+    total := total.contents + cs->ChainState.bufferSize
+  }
+  total.contents
+}
+
 // --- Derived (pure). ---
 
 let nextItemIsNone = (crossChainState: t): bool =>
@@ -207,67 +218,70 @@ let maybePrune = (crossChainState: t, ~invalidateInflight) => {
   if !crossChainState.isInReorgThreshold {
     let chainIds = crossChainState.chainIds
 
-    let total = ref(0)
-    for i in 0 to chainIds->Array.length - 1 {
-      total :=
-        total.contents +
-        crossChainState->getChainState(chainIds->Array.getUnsafe(i))->ChainState.bufferSize
-    }
-
+    let total = crossChainState->totalBufferSize
     let highWater = crossChainState.targetBufferSize * 3
-    if total.contents > highWater {
+    if total > highWater {
       let lowWater = crossChainState.targetBufferSize * 3 / 2
-      let need = total.contents - lowWater
+      let need = total - lowWater
 
-      // Items freed by pruning everything above the given progress threshold,
-      // summed across chains. Non-increasing in the threshold (higher threshold =
-      // higher per-chain target = fewer items dropped).
-      let freedAt = progressThreshold => {
+      // Per-chain (target, freed) at the given progress threshold, in chainIds
+      // order, plus the summed freed count. The sum is non-increasing in the
+      // threshold (higher threshold = higher per-chain target = fewer items
+      // dropped).
+      let pruneTargetsAt = progressThreshold => {
         let freed = ref(0)
+        let targets = []
         for i in 0 to chainIds->Array.length - 1 {
-          let (_, chainFreed) =
+          let chainTarget =
             crossChainState
             ->getChainState(chainIds->Array.getUnsafe(i))
             ->ChainState.getPruneTarget(~progressThreshold)
+          targets->Array.push(chainTarget)
+          let (_, chainFreed) = chainTarget
           freed := freed.contents + chainFreed
         }
-        freed.contents
+        (targets, freed.contents)
       }
 
-      // Largest progress threshold that still frees `need` items, so we drop only
-      // the closest-to-head items across all chains. If even threshold 0 (drop all
-      // stuck items) can't reach `need`, we settle at 0 and free what we can.
-      let lo = ref(0.)
-      let hi = ref(1.)
-      for _ in 0 to 39 {
-        let mid = (lo.contents +. hi.contents) /. 2.
-        if freedAt(mid) >= need {
-          lo := mid
-        } else {
-          hi := mid
+      // Threshold 0 drops every stuck item — the most any prune can free. When
+      // even that is nothing (e.g. the buffer is over the mark but full of ready
+      // items), skip: quiescing in-flight fetches here would discard them every
+      // tick without making room, stalling progress.
+      let (targetsAtZero, freedAtZero) = pruneTargetsAt(0.)
+      if freedAtZero > 0 {
+        // Largest progress threshold that still frees `need` items, so we drop
+        // only the closest-to-head items across all chains; the per-chain targets
+        // from the winning evaluation are reused for the prune below. If even
+        // threshold 0 can't reach `need`, settle there and free what we can.
+        // 30 bisections resolve the threshold to 2^-30 — below one block even on
+        // a billion-block chain.
+        let best = ref((targetsAtZero, freedAtZero))
+        if freedAtZero >= need {
+          let lo = ref(0.)
+          let hi = ref(1.)
+          for _ in 0 to 29 {
+            let mid = (lo.contents +. hi.contents) /. 2.
+            let (targets, freed) = pruneTargetsAt(mid)
+            if freed >= need {
+              lo := mid
+              best := (targets, freed)
+            } else {
+              hi := mid
+            }
+          }
         }
-      }
-      let progressThreshold = lo.contents
+        let (targets, _) = best.contents
 
-      // Nothing above the frontier is prunable (e.g. the buffer is over the mark
-      // but full of ready items). Skip — quiescing in-flight fetches here would
-      // discard them every tick without making room, stalling progress.
-      if freedAt(progressThreshold) > 0 {
         // Quiesce in-flight fetches before rolling partitions back: the epoch bump
         // makes their responses stale (dropped on arrival) and resetPendingQueries
         // clears them from every chain, since FetchState.rollback requires no
         // in-flight queries.
         invalidateInflight()
-        for i in 0 to chainIds->Array.length - 1 {
-          crossChainState
-          ->getChainState(chainIds->Array.getUnsafe(i))
-          ->ChainState.resetPendingQueries
-        }
-
         let totalFreed = ref(0)
         for i in 0 to chainIds->Array.length - 1 {
           let cs = crossChainState->getChainState(chainIds->Array.getUnsafe(i))
-          let (target, freed) = cs->ChainState.getPruneTarget(~progressThreshold)
+          cs->ChainState.resetPendingQueries
+          let (target, freed) = targets->Array.getUnsafe(i)
           if freed > 0 {
             cs->ChainState.pruneBuffer(~targetBlockNumber=target)
             totalFreed := totalFreed.contents + freed
@@ -276,7 +290,7 @@ let maybePrune = (crossChainState: t, ~invalidateInflight) => {
 
         Logging.trace({
           "msg": "Pruned stale fetch buffer above the processing frontier",
-          "bufferSize": total.contents,
+          "bufferSize": total,
           "freed": totalFreed.contents,
         })
         Prometheus.IndexingBufferPrune.increment(~freed=totalFreed.contents)
@@ -315,7 +329,7 @@ let checkAndFetch = async (
   for i in 0 to chainIds->Array.length - 1 {
     let chainId = chainIds->Array.getUnsafe(i)
     let cs = crossChainState->getChainState(chainId)
-    switch cs->ChainState.getNextQuery(~budget=remaining) {
+    switch cs->ChainState.getNextQuery(~hasBudget=remaining > 0) {
     | (WaitingForNewBlock | NothingToQuery) as action =>
       actionByChain->Utils.Dict.setByInt(chainId, action)
     | Ready(queries) =>

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -207,96 +207,107 @@ let totalReservedSize = (crossChainState: t) => {
 let compareByProgress = (a: FetchState.query, b: FetchState.query) =>
   Float.compare(a.progress, b.progress)
 
+// One hysteresis band governs the prune/hold-back cycle, always measured
+// against the whole buffer (ready and stuck): prune once it exceeds the
+// high-water mark, drop down to the low-water mark, and hold pruned ranges
+// back until it drains to targetBufferSize. The cycle is only correct while
+// targetBufferSize < low-water < high-water — releasing pruned ranges any
+// earlier would refetch what the prune just dropped.
+let pruneHighWaterMark = (crossChainState: t) => crossChainState.targetBufferSize * 3
+let pruneLowWaterMark = (crossChainState: t) => crossChainState.targetBufferSize * 3 / 2
+
 // Removing the up-front block cap lets queries run to the head, so fetched-ahead
 // items accumulate as stuck buffer while a lagging partition holds the frontier.
-// This reclaims that memory reactively: once the indexer-wide buffer crosses 3x
-// targetBufferSize, drop the highest-progress% (closest-to-head) items across all
-// chains back down to 1.5x and roll back the partitions that fetched them. Prune
-// only during backfill — near the head blockLag keeps the buffer below the reorg
-// window and there is nothing far-ahead to reclaim.
-let maybePrune = (crossChainState: t) => {
-  if !crossChainState.isInReorgThreshold {
+// This reclaims that memory reactively: once the indexer-wide buffer crosses the
+// high-water mark, drop the highest-progress% (closest-to-head) items across all
+// chains back down to the low-water mark and roll back the partitions that
+// fetched them. Prune only during backfill — near the head blockLag keeps the
+// buffer below the reorg window and there is nothing far-ahead to reclaim.
+// Returns how many items were freed.
+let maybePrune = (crossChainState: t, ~totalBufferSize) =>
+  if (
+    !crossChainState.isInReorgThreshold &&
+    totalBufferSize > crossChainState->pruneHighWaterMark
+  ) {
     let chainIds = crossChainState.chainIds
+    let need = totalBufferSize - crossChainState->pruneLowWaterMark
 
-    let total = crossChainState->totalBufferSize
-    let highWater = crossChainState.targetBufferSize * 3
-    if total > highWater {
-      let lowWater = crossChainState.targetBufferSize * 3 / 2
-      let need = total - lowWater
-
-      // Per-chain (target, freed) at the given progress threshold, in chainIds
-      // order, plus the summed freed count. The sum is non-increasing in the
-      // threshold (higher threshold = higher per-chain target = fewer items
-      // dropped).
-      let pruneTargetsAt = progressThreshold => {
-        let freed = ref(0)
-        let targets = []
-        for i in 0 to chainIds->Array.length - 1 {
-          let chainTarget =
-            crossChainState
-            ->getChainState(chainIds->Array.getUnsafe(i))
-            ->ChainState.getPruneTarget(~progressThreshold)
-          targets->Array.push(chainTarget)
-          let (_, chainFreed) = chainTarget
-          freed := freed.contents + chainFreed
-        }
-        (targets, freed.contents)
+    // Per-chain (target, freed) at the given progress threshold, in chainIds
+    // order, plus the summed freed count. The sum is non-increasing in the
+    // threshold (higher threshold = higher per-chain target = fewer items
+    // dropped).
+    let pruneTargetsAt = progressThreshold => {
+      let freed = ref(0)
+      let targets = []
+      for i in 0 to chainIds->Array.length - 1 {
+        let chainTarget =
+          crossChainState
+          ->getChainState(chainIds->Array.getUnsafe(i))
+          ->ChainState.getPruneTarget(~progressThreshold)
+        targets->Array.push(chainTarget)
+        let (_, chainFreed) = chainTarget
+        freed := freed.contents + chainFreed
       }
-
-      // Threshold 0 drops every stuck item — the most any prune can free. When
-      // even that is nothing (e.g. the buffer is over the mark but full of ready
-      // items), skip: quiescing in-flight fetches here would discard them every
-      // tick without making room, stalling progress.
-      let (targetsAtZero, freedAtZero) = pruneTargetsAt(0.)
-      if freedAtZero > 0 {
-        // Largest progress threshold that still frees `need` items, so we drop
-        // only the closest-to-head items across all chains; the per-chain targets
-        // from the winning evaluation are reused for the prune below. If even
-        // threshold 0 can't reach `need`, settle there and free what we can.
-        // 30 bisections resolve the threshold to 2^-30 — below one block even on
-        // a billion-block chain.
-        let best = ref((targetsAtZero, freedAtZero))
-        if freedAtZero >= need {
-          let lo = ref(0.)
-          let hi = ref(1.)
-          for _ in 0 to 29 {
-            let mid = (lo.contents +. hi.contents) /. 2.
-            let (targets, freed) = pruneTargetsAt(mid)
-            if freed >= need {
-              lo := mid
-              best := (targets, freed)
-            } else {
-              hi := mid
-            }
-          }
-        }
-        let (targets, _) = best.contents
-
-        // Only the chains that actually free something are touched: pruneBuffer's
-        // rollback drops their in-flight queries above the target (late responses
-        // are discarded by the still-pending check), while every other chain's
-        // in-flight work — including the lagging frontier query the prune is
-        // waiting on — keeps running.
-        let totalFreed = ref(0)
-        for i in 0 to chainIds->Array.length - 1 {
-          let cs = crossChainState->getChainState(chainIds->Array.getUnsafe(i))
-          let (target, freed) = targets->Array.getUnsafe(i)
-          if freed > 0 {
-            cs->ChainState.pruneBuffer(~targetBlockNumber=target)
-            totalFreed := totalFreed.contents + freed
-          }
-        }
-
-        Logging.trace({
-          "msg": "Pruned stale fetch buffer above the processing frontier",
-          "bufferSize": total,
-          "freed": totalFreed.contents,
-        })
-        Prometheus.IndexingBufferPrune.increment(~freed=totalFreed.contents)
-      }
+      (targets, freed.contents)
     }
+
+    // Threshold 0 drops every stuck item — the most any prune can free. When
+    // even that is nothing (e.g. the buffer is over the mark but full of ready
+    // items), skip: quiescing in-flight fetches here would discard them every
+    // tick without making room, stalling progress.
+    let (targetsAtZero, freedAtZero) = pruneTargetsAt(0.)
+    if freedAtZero > 0 {
+      // Largest progress threshold that still frees `need` items, so we drop
+      // only the closest-to-head items across all chains; the per-chain targets
+      // from the winning evaluation are reused for the prune below. If even
+      // threshold 0 can't reach `need`, settle there and free what we can.
+      // 30 bisections resolve the threshold to 2^-30 — below one block even on
+      // a billion-block chain.
+      let best = ref((targetsAtZero, freedAtZero))
+      if freedAtZero >= need {
+        let lo = ref(0.)
+        let hi = ref(1.)
+        for _ in 0 to 29 {
+          let mid = (lo.contents +. hi.contents) /. 2.
+          let (targets, freed) = pruneTargetsAt(mid)
+          if freed >= need {
+            lo := mid
+            best := (targets, freed)
+          } else {
+            hi := mid
+          }
+        }
+      }
+      let (targets, _) = best.contents
+
+      // Only the chains that actually free something are touched: pruneBuffer's
+      // rollback drops their in-flight queries above the target (late responses
+      // are discarded by the still-pending check), while every other chain's
+      // in-flight work — including the lagging frontier query the prune is
+      // waiting on — keeps running.
+      let totalFreed = ref(0)
+      for i in 0 to chainIds->Array.length - 1 {
+        let cs = crossChainState->getChainState(chainIds->Array.getUnsafe(i))
+        let (target, freed) = targets->Array.getUnsafe(i)
+        if freed > 0 {
+          cs->ChainState.pruneBuffer(~targetBlockNumber=target)
+          totalFreed := totalFreed.contents + freed
+        }
+      }
+
+      Logging.trace({
+        "msg": "Pruned stale fetch buffer above the processing frontier",
+        "bufferSize": totalBufferSize,
+        "freed": totalFreed.contents,
+      })
+      Prometheus.IndexingBufferPrune.increment(~freed=totalFreed.contents)
+      totalFreed.contents
+    } else {
+      0
+    }
+  } else {
+    0
   }
-}
 
 // Dispatch a fetch tick across the whole indexer from one shared pool of
 // ~targetBufferSize ready events. Every chain proposes its candidate queries
@@ -309,7 +320,8 @@ let checkAndFetch = async (
   crossChainState: t,
   ~dispatchChain: (~chain: ChainMap.Chain.t, ~action: FetchState.nextQuery) => promise<unit>,
 ) => {
-  crossChainState->maybePrune
+  let totalBufferSize = crossChainState->totalBufferSize
+  let freed = crossChainState->maybePrune(~totalBufferSize)
 
   let remaining = Pervasives.max(
     0,
@@ -323,14 +335,9 @@ let checkAndFetch = async (
   // refetch exactly what it dropped, since stuck items count toward the prune
   // trigger but not toward `remaining`. Once the buffer drains back to the
   // target, processing has caught up and the prune targets are cleared.
-  let bufferAboveTarget = crossChainState->totalBufferSize > crossChainState.targetBufferSize
+  let bufferAboveTarget = totalBufferSize - freed > crossChainState.targetBufferSize
 
   let chainIds = crossChainState.chainIds
-  if !bufferAboveTarget {
-    for i in 0 to chainIds->Array.length - 1 {
-      crossChainState->getChainState(chainIds->Array.getUnsafe(i))->ChainState.clearPruneTarget
-    }
-  }
   let actionByChain = Dict.make()
   // Candidate queries from every chain. Each query carries its chain id and the
   // chain progress % at its fromBlock (the admission sort key), set here so the
@@ -339,13 +346,16 @@ let checkAndFetch = async (
   for i in 0 to chainIds->Array.length - 1 {
     let chainId = chainIds->Array.getUnsafe(i)
     let cs = crossChainState->getChainState(chainId)
+    if !bufferAboveTarget {
+      cs->ChainState.clearPruneTarget
+    }
     switch cs->ChainState.getNextQuery(~hasBudget=remaining > 0) {
     | (WaitingForNewBlock | NothingToQuery) as action =>
       actionByChain->Utils.Dict.setByInt(chainId, action)
     | Ready(queries) =>
       // Default to NothingToQuery; replaced below if any candidate is admitted.
       actionByChain->Utils.Dict.setByInt(chainId, FetchState.NothingToQuery)
-      let pruneCeiling = bufferAboveTarget ? cs->ChainState.lastPruneTarget : None
+      let pruneCeiling = cs->ChainState.lastPruneTarget
       queries->Array.forEach(query => {
         let isHeldBackPrunedRange = switch pruneCeiling {
         | Some(ceiling) => query.fromBlock > ceiling

--- a/packages/envio/src/CrossChainState.resi
+++ b/packages/envio/src/CrossChainState.resi
@@ -36,5 +36,4 @@ let priorityOrder: t => array<ChainState.t>
 let checkAndFetch: (
   t,
   ~dispatchChain: (~chain: ChainMap.Chain.t, ~action: FetchState.nextQuery) => promise<unit>,
-  ~invalidateInflight: unit => unit,
 ) => promise<unit>

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -142,19 +142,17 @@ let getMinHistoryRange = (p: partition) => {
   }
 }
 
+// Seed range for a merged partition, under the same trust policy as chunking
+// itself: each partition contributes its getMinHistoryRange, so a lone small
+// sample stays floored instead of turning into a trusted two-sample history
+// through the merge.
 let getMinQueryRange = (partitions: array<partition>) => {
   let min = ref(0)
   for i in 0 to partitions->Array.length - 1 {
     let p = partitions->Array.getUnsafe(i)
-
-    // Even if it's fetching, set dynamicContract field
-    let a = p.prevQueryRange
-    let b = p.prevPrevQueryRange
-    if a > 0 && (min.contents == 0 || a < min.contents) {
-      min := a
-    }
-    if b > 0 && (min.contents == 0 || b < min.contents) {
-      min := b
+    switch getMinHistoryRange(p) {
+    | Some(range) if min.contents == 0 || range < min.contents => min := range
+    | _ => ()
     }
   }
   min.contents
@@ -439,24 +437,30 @@ module OptimizedPartitions = {
     latestFetchedBlock.contents
   }
 
-  let getPendingQueryOrThrow = (p: partition, ~fromBlock) => {
+  // Matching on both range ends keeps a query's identity exact: a dropped
+  // query's late response must not land on a differently-shaped re-issued
+  // query that happens to start at the same block.
+  let getPendingQuery = (p: partition, ~fromBlock, ~toBlock) => {
     let idxRef = ref(0)
     let pendingQueryRef = ref(None)
     while idxRef.contents < p.mutPendingQueries->Array.length && pendingQueryRef.contents === None {
       let pq = p.mutPendingQueries->Array.getUnsafe(idxRef.contents)
-      if pq.fromBlock === fromBlock {
+      if pq.fromBlock === fromBlock && pq.toBlock == toBlock {
         pendingQueryRef := Some(pq)
       }
       idxRef := idxRef.contents + 1
     }
-    switch pendingQueryRef.contents {
+    pendingQueryRef.contents
+  }
+
+  let getPendingQueryOrThrow = (p: partition, ~fromBlock, ~toBlock) =>
+    switch getPendingQuery(p, ~fromBlock, ~toBlock) {
     | Some(pq) => pq
     | None =>
       JsError.throwWithMessage(
         `Pending query not found for partition ${p.id} fromBlock ${fromBlock->Int.toString}`,
       )
     }
-  }
 
   let handleQueryResponse = (
     optimizedPartitions: t,
@@ -469,7 +473,7 @@ module OptimizedPartitions = {
     let mutEntities = optimizedPartitions.entities->Utils.Dict.shallowCopy
 
     // Mark query as fetched
-    let pendingQuery = getPendingQueryOrThrow(p, ~fromBlock=query.fromBlock)
+    let pendingQuery = getPendingQueryOrThrow(p, ~fromBlock=query.fromBlock, ~toBlock=query.toBlock)
     pendingQuery.fetchedBlock = Some(latestFetchedBlock)
 
     let blockRange = latestFetchedBlock.blockNumber - query.fromBlock + 1
@@ -1466,7 +1470,9 @@ let getNextQuery = (
     WaitingForNewBlock
   } else if !hasBudget {
     // No room left in the shared buffer pool for this chain; wait for processing
-    // to drain before fetching more.
+    // to drain before fetching more. Checked after the head gate on purpose: a
+    // chain that hasn't learned its height must keep returning WaitingForNewBlock
+    // even when the pool is full, so don't hoist this check into the caller.
     NothingToQuery
   } else {
     let isOnBlockBehindTheHead = latestOnBlockBlockNumber < headBlockNumber
@@ -2003,16 +2009,20 @@ let pendingBudgetSize = (fetchState: t) => {
 
 // A response may only be applied while its query is still tracked in flight:
 // the partition exists (deleted partition ids are never reused) and holds an
-// in-flight pending query at the response's fromBlock. A query dropped by a
+// in-flight pending query with the response's exact range. A query dropped by a
 // buffer prune fails the lookup, and a slot already satisfied by an equivalent
 // re-issued query's response has fetchedBlock set — both mean the response must
 // be discarded, which is what keeps a range from being applied twice.
 let isQueryStillPending = (fetchState: t, ~query: query) =>
   switch fetchState.optimizedPartitions.entities->Dict.get(query.partitionId) {
   | Some(p) =>
-    p.mutPendingQueries->Array.some(pq =>
-      pq.fromBlock === query.fromBlock && pq.fetchedBlock === None
-    )
+    switch p->OptimizedPartitions.getPendingQuery(
+      ~fromBlock=query.fromBlock,
+      ~toBlock=query.toBlock,
+    ) {
+    | Some(pq) => pq.fetchedBlock === None
+    | None => false
+    }
   | None => false
   }
 

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -555,8 +555,8 @@ type t = {
   // Buffer of items ordered from earliest to latest
   buffer: array<Internal.item>,
   // Caps how far ahead onBlock items are pre-generated (set to 2x the batch
-  // size). Fetch depth is bounded separately by getNextQuery's itemBudget, the
-  // chain's per-tick slice of the indexer-wide pool.
+  // size). Fetch depth is bounded separately by cross-chain admission against
+  // the shared buffer pool.
   maxOnBlockBufferSize: int,
   onBlockConfigs: array<Internal.onBlockConfig>,
   knownHeight: int,
@@ -1447,14 +1447,16 @@ let pushQueriesForRange = (
   }
 }
 
+// The shared buffer pool is enforced by cross-chain admission, not here — only
+// whether any room is left matters, so the proposal isn't sized to a budget.
 let getNextQuery = (
   {optimizedPartitions, blockLag, latestOnBlockBlockNumber, knownHeight} as fetchState: t,
-  ~budget,
+  ~hasBudget,
 ) => {
   let headBlockNumber = knownHeight - blockLag
   if headBlockNumber <= 0 {
     WaitingForNewBlock
-  } else if budget <= 0 {
+  } else if !hasBudget {
     // No room left in the shared buffer pool for this chain; wait for processing
     // to drain before fetching more.
     NothingToQuery
@@ -1470,9 +1472,9 @@ let getNextQuery = (
 
     // Partitions fetch all the way to the head. Per-query range stays bounded by
     // the per-partition chunk heuristic, and total buffer growth is bounded
-    // reactively by the cross-chain prune (CrossChainState.maybePrune) rather than
-    // an up-front block cap — the cap forced a single block ceiling on every
-    // partition, starving sparse ones into a storm of tiny queries.
+    // reactively by the cross-chain prune (CrossChainState.maybePrune) — a shared
+    // up-front block ceiling would starve sparse partitions into a storm of tiny
+    // queries.
     let maxQueryBlockNumber = knownHeight
 
     let queries = []

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -119,15 +119,25 @@ let calculateEstResponseSize = (p: partition, ~fromBlock, ~toBlock, ~maxQueryBlo
     defaultEstResponseSize
   }
 
+// Random number from my head
+// Not super critical if it's too big or too small
+// We optimize for fastest data which we get in any case.
+// If the value is off, it'll only result in
+// quering the same block range multiple times
+let tooFarBlockRange = 20_000
+
 // Calculate the chunk range from history using min-of-last-3-ranges heuristic.
 // A single observed range is enough to start chunking: it bounds the partition's
 // second query instead of proposing an open-ended tail to the head, whose
 // estimate (density x the whole remaining chain) could reserve the entire shared
-// buffer pool for a full response round-trip.
+// buffer pool for a full response round-trip. One sample isn't trusted to
+// shrink queries though — a small first response (e.g. near the head) must not
+// collapse the follow-up into tiny chunks, so it's floored at tooFarBlockRange
+// and short tails still fall back to a single query.
 let getMinHistoryRange = (p: partition) => {
   switch (p.prevQueryRange, p.prevPrevQueryRange) {
   | (0, _) => None
-  | (a, 0) => Some(a)
+  | (a, 0) => Some(Pervasives.max(a, tooFarBlockRange))
   | (a, b) => Some(a < b ? a : b)
   }
 }
@@ -253,13 +263,6 @@ module OptimizedPartitions = {
       completed
     }
   }
-
-  // Random number from my head
-  // Not super critical if it's too big or too small
-  // We optimize for fastest data which we get in any case.
-  // If the value is off, it'll only result in
-  // quering the same block range multiple times
-  let tooFarBlockRange = 20_000
 
   let ascSortFn = (a, b) =>
     Int.compare(a.latestFetchedBlock.blockNumber, b.latestFetchedBlock.blockNumber)
@@ -873,7 +876,7 @@ OptimizedPartitions.t => {
       | Some(nextStartBlockKey) => {
           let nextStartBlock = nextStartBlockKey->Int.fromString->Option.getUnsafe
           let shouldJoinCurrentStartBlock =
-            nextStartBlock - startBlockRef.contents < OptimizedPartitions.tooFarBlockRange
+            nextStartBlock - startBlockRef.contents < tooFarBlockRange
 
           // Addresses with different start blocks within range share a partition;
           // events before each address's effectiveStartBlock are dropped on the
@@ -967,7 +970,7 @@ OptimizedPartitions.t => {
           }
         }
 
-        let isTooFar = currentPBlock + OptimizedPartitions.tooFarBlockRange < nextPBlock
+        let isTooFar = currentPBlock + tooFarBlockRange < nextPBlock
 
         if isTooFar {
           // Too far: mergeBlock on current, merge addresses into next
@@ -1812,8 +1815,14 @@ let make = (
 let bufferSize = ({buffer}: t) => buffer->Array.length
 
 let rollbackPendingQueries = (mutPendingQueries: array<pendingQuery>, ~targetBlockNumber) => {
-  // - Remove queries where fromBlock > target
-  // - Cap fetchedBlock at target where fetchedBlock > target
+  // - Remove queries where fromBlock > target: an in-flight one would re-add the
+  //   items just discarded (its late response is then dropped by the
+  //   still-pending check), a completed one covered a discarded range.
+  // - Cap fetchedBlock at target where fetchedBlock > target.
+  // - Keep in-flight queries starting at/below the target even when their range
+  //   crosses it: their response data stays valid — on a buffer prune nothing
+  //   above the target is wrong, merely early, and on a reorg rollback
+  //   resetPendingQueries has already removed every in-flight query.
   let adjusted = []
   for qIdx in 0 to mutPendingQueries->Array.length - 1 {
     let pq = mutPendingQueries->Array.getUnsafe(qIdx)
@@ -1826,9 +1835,7 @@ let rollbackPendingQueries = (mutPendingQueries: array<pendingQuery>, ~targetBlo
           fetchedBlock: Some({blockNumber: targetBlockNumber, blockTimestamp: 0}),
         })
         ->ignore
-      | Some(_) => adjusted->Array.push(pq)->ignore
-      | None =>
-        JsError.throwWithMessage("Internal error: Must not have a fetching query during rollback")
+      | Some(_) | None => adjusted->Array.push(pq)->ignore
       }
     }
   }
@@ -1848,9 +1855,11 @@ let rollback = (fetchState: t, ~indexingAddresses: IndexingAddresses.t, ~targetB
   // it's still in the index.
   indexingAddresses->IndexingAddresses.rollbackInPlace(~targetBlockNumber)
 
-  // Step 2: Categorize partitions
+  // Step 2: Categorize partitions. Kept partitions keep their ids and deleted
+  // ids are never reused (recreated partitions take fresh ids from
+  // nextPartitionIndex) — a late response for a deleted partition must fail its
+  // lookup rather than land on a different partition wearing the same id.
   let keptPartitions = []
-  let nextKeptIdRef = ref(0)
   let registeringContractsByContract: dict<dict<indexingAddress>> = Dict.make()
 
   let partitions = fetchState.optimizedPartitions.entities->Dict.valuesToArray
@@ -1859,12 +1868,9 @@ let rollback = (fetchState: t, ~indexingAddresses: IndexingAddresses.t, ~targetB
     switch p {
     // Wildcard: rollback latestFetchedBlock and adjust pending queries
     | {selection: {dependsOnAddresses: false}} =>
-      let id = nextKeptIdRef.contents->Int.toString
-      nextKeptIdRef := nextKeptIdRef.contents + 1
       keptPartitions
       ->Array.push({
         ...p,
-        id,
         latestFetchedBlock: p.latestFetchedBlock.blockNumber > targetBlockNumber
           ? {blockNumber: targetBlockNumber, blockTimestamp: 0}
           : p.latestFetchedBlock,
@@ -1907,12 +1913,9 @@ let rollback = (fetchState: t, ~indexingAddresses: IndexingAddresses.t, ~targetB
         })
 
         if !(rollbackedAddressesByContractName->Utils.Dict.isEmpty) {
-          let id = nextKeptIdRef.contents->Int.toString
-          nextKeptIdRef := nextKeptIdRef.contents + 1
           keptPartitions
           ->Array.push({
             ...p,
-            id,
             addressesByContractName: rollbackedAddressesByContractName,
             mutPendingQueries: rollbackPendingQueries(p.mutPendingQueries, ~targetBlockNumber),
             mergeBlock,
@@ -1929,7 +1932,7 @@ let rollback = (fetchState: t, ~indexingAddresses: IndexingAddresses.t, ~targetB
     ~dynamicContracts=fetchState.optimizedPartitions.dynamicContracts,
     ~normalSelection=fetchState.normalSelection,
     ~maxAddrInPartition=fetchState.optimizedPartitions.maxAddrInPartition,
-    ~nextPartitionIndex=nextKeptIdRef.contents,
+    ~nextPartitionIndex=fetchState.optimizedPartitions.nextPartitionIndex,
     ~existingPartitions=keptPartitions,
     ~progressBlockNumber=targetBlockNumber,
   )
@@ -1979,6 +1982,39 @@ let resetPendingQueries = (fetchState: t) => {
     },
   }
 }
+
+// Sum of in-flight pending-query estimates, for restoring the chain's
+// reservation counter after a rollback dropped some of the queries it covered.
+let pendingBudgetSize = (fetchState: t) => {
+  let total = ref(0.)
+  let partitionIds = fetchState.optimizedPartitions.idsInAscOrder
+  for idx in 0 to partitionIds->Array.length - 1 {
+    let p =
+      fetchState.optimizedPartitions.entities->Dict.getUnsafe(partitionIds->Array.getUnsafe(idx))
+    for qIdx in 0 to p.mutPendingQueries->Array.length - 1 {
+      let pq = p.mutPendingQueries->Array.getUnsafe(qIdx)
+      if pq.fetchedBlock === None {
+        total := total.contents +. pq.estResponseSize
+      }
+    }
+  }
+  total.contents
+}
+
+// A response may only be applied while its query is still tracked in flight:
+// the partition exists (deleted partition ids are never reused) and holds an
+// in-flight pending query at the response's fromBlock. A query dropped by a
+// buffer prune fails the lookup, and a slot already satisfied by an equivalent
+// re-issued query's response has fetchedBlock set — both mean the response must
+// be discarded, which is what keeps a range from being applied twice.
+let isQueryStillPending = (fetchState: t, ~query: query) =>
+  switch fetchState.optimizedPartitions.entities->Dict.get(query.partitionId) {
+  | Some(p) =>
+    p.mutPendingQueries->Array.some(pq =>
+      pq.fromBlock === query.fromBlock && pq.fetchedBlock === None
+    )
+  | None => false
+  }
 
 /**
 * Returns a boolean indicating whether the fetch state is actively indexing

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -119,10 +119,15 @@ let calculateEstResponseSize = (p: partition, ~fromBlock, ~toBlock, ~maxQueryBlo
     defaultEstResponseSize
   }
 
-// Calculate the chunk range from history using min-of-last-3-ranges heuristic
+// Calculate the chunk range from history using min-of-last-3-ranges heuristic.
+// A single observed range is enough to start chunking: it bounds the partition's
+// second query instead of proposing an open-ended tail to the head, whose
+// estimate (density x the whole remaining chain) could reserve the entire shared
+// buffer pool for a full response round-trip.
 let getMinHistoryRange = (p: partition) => {
   switch (p.prevQueryRange, p.prevPrevQueryRange) {
-  | (0, _) | (_, 0) => None
+  | (0, _) => None
+  | (a, 0) => Some(a)
   | (a, b) => Some(a < b ? a : b)
   }
 }

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1629,9 +1629,12 @@ let getReadyItemsCount = (fetchState: t, ~targetSize: int, ~fromItem) => {
 // For a cross-chain progress threshold in [0.,1.], returns the block to prune
 // above (buffer items with a higher block number get dropped and their
 // partitions rolled back) together with how many items that frees. Clamped so we
-// never drop ready items (target >= the ready frontier) nor roll a partition back
-// into the reorg window (target <= knownHeight - maxReorgDepth), keeping restart
-// points on confirmed blocks. Higher progress% = closer to head = pruned first.
+// never drop ready items (target >= the ready frontier) and prefer restart
+// points on confirmed blocks (target <= knownHeight - maxReorgDepth). Inside the
+// reorg threshold the frontier itself may sit past the reorg floor, putting the
+// target on an unconfirmed block — safe, because reorg detection state survives
+// a prune: refetching a reorged range re-reports mismatching hashes and triggers
+// the normal rollback. Higher progress% = closer to head = pruned first.
 let getPruneTarget = (fetchState: t, ~progressThreshold: float, ~maxReorgDepth: int) => {
   let frontier = fetchState->bufferBlockNumber
   let reorgFloor = fetchState.knownHeight - maxReorgDepth

--- a/packages/envio/src/IndexerLoop.res
+++ b/packages/envio/src/IndexerLoop.res
@@ -19,18 +19,16 @@ let start = (state: IndexerState.t) => {
     launch(state, () =>
       state
       ->IndexerState.crossChainState
-      ->CrossChainState.checkAndFetch(
-        ~invalidateInflight=() => state->IndexerState.invalidateInflight,
-        ~dispatchChain=(~chain, ~action) =>
-          ChainFetching.fetchChain(
-            state,
-            chain,
-            ~action,
-            ~stateId=state->IndexerState.epoch,
-            ~scheduleFetch,
-            ~scheduleProcessing,
-            ~scheduleRollback,
-          ),
+      ->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) =>
+        ChainFetching.fetchChain(
+          state,
+          chain,
+          ~action,
+          ~stateId=state->IndexerState.epoch,
+          ~scheduleFetch,
+          ~scheduleProcessing,
+          ~scheduleRollback,
+        )
       )
     )
   and scheduleProcessing = () =>

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -359,7 +359,15 @@ let clearRollback = (state: t) => state.rollbackState = NoRollback
 
 // Invalidate in-flight fetches/waiters without starting a rollback, eg on the
 // realtime transition where the parked waiter is bound to the pre-realtime source.
-let invalidateInflight = (state: t) => state.epoch = state.epoch + 1
+// The epoch bump makes every in-flight response stale, so their pending-query
+// slots and reservations must be dropped with it — otherwise the abandoned
+// ranges are treated as still fetching and never re-proposed.
+let invalidateInflight = (state: t) => {
+  state.epoch = state.epoch + 1
+  state.crossChainState
+  ->CrossChainState.chainStates
+  ->Utils.Dict.forEach(cs => cs->ChainState.resetPendingQueries)
+}
 
 let applyBatchProgress = (state: t, ~batch: Batch.t) =>
   state.crossChainState->CrossChainState.applyBatchProgress(~batch)

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -886,6 +886,8 @@ let make = (
 
   let getSelectionConfig = memoGetSelectionConfig(~chain)
 
+  // TODO: Evict entries for deleted partition ids — ids are never reused, so
+  // the dict grows for the process lifetime (a few bytes per dead partition).
   let mutSuggestedBlockIntervals = Dict.make()
 
   let client = Rpc.makeClient(url, ~headers?)

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -628,6 +628,9 @@ let executeQuery = async (
   let responseRef = ref(None)
   let retryRef = ref(0)
 
+  // TODO: Stop retrying once the query is invalidated (buffer prune / epoch
+  // bump) — the loop keeps burning source capacity on a response that will be
+  // discarded on arrival.
   while responseRef.contents->Option.isNone {
     // Select the best source at the start of every iteration
     let sourceState = switch sourceManager->getNextSource(

--- a/scenarios/test_codegen/test/ClientAddressFilter_test.res
+++ b/scenarios/test_codegen/test/ClientAddressFilter_test.res
@@ -208,7 +208,7 @@ describe("FetchState.handleQueryResult applies clientAddressFilter", () => {
       ~chainId=1,
       ~knownHeight=1000,
     )
-    let query = switch fetchState->FetchState.getNextQuery(~budget=5000) {
+    let query = switch fetchState->FetchState.getNextQuery(~hasBudget=true) {
     | Ready([q]) => q
     | _ => JsError.throwWithMessage("expected a single ready query")
     }
@@ -278,7 +278,7 @@ describe("FetchState.handleQueryResult drops over-fetched non-wildcard srcAddres
       ~chainId=1,
       ~knownHeight=1000,
     )
-    let query = switch fetchState->FetchState.getNextQuery(~budget=5000) {
+    let query = switch fetchState->FetchState.getNextQuery(~hasBudget=true) {
     | Ready([q]) => q
     | _ => JsError.throwWithMessage("expected a single ready query")
     }

--- a/scenarios/test_codegen/test/E2E_test.res
+++ b/scenarios/test_codegen/test/E2E_test.res
@@ -1328,15 +1328,17 @@ describe("E2E tests", () => {
     )
     await Utils.delay(0)
 
-    // Step 1: Resolve height
-    sourceMock.resolveGetHeightOrThrow(100_000)
+    // Step 1: Resolve height. 97k keeps DC2's tail under two floored
+    // single-sample chunks (2 x 36000), so its second query stays a single
+    // bounded range and the merge math below is unaffected.
+    sourceMock.resolveGetHeightOrThrow(97_000)
     await Utils.delay(0)
     await Utils.delay(0)
 
     t.expect(
       sourceMock.getItemsOrThrowCalls->Array.map(c => c.payload),
       ~message="Step 1: initial query for partition 0",
-    ).toEqual([{"fromBlock": 1, "toBlock": Some(99800), "retry": 0, "p": "0"}])
+    ).toEqual([{"fromBlock": 1, "toBlock": Some(96800), "retry": 0, "p": "0"}])
 
     // Step 2: Register DC1 at block 5000, DC2 at block 25100
     // Gap = 25099 - 4999 = 20100 > tooFarBlockRange(20000) → separate partitions
@@ -1408,8 +1410,8 @@ describe("E2E tests", () => {
       ->Array.toSorted(((_, a, _), (_, b, _)) => Int.compare(a, b)),
       ~message="Step 4: DC2 has 10 uniform 540-size chunks",
     ).toEqual([
-      ("2", 5000, Some(99800)),
-      ("0", 25101, Some(99800)),
+      ("2", 5000, Some(96800)),
+      ("0", 25101, Some(96800)),
       ("3", 25901, Some(26440)),
       ("3", 26441, Some(26980)),
       ("3", 26981, Some(27520)),
@@ -1437,7 +1439,7 @@ describe("E2E tests", () => {
     // After merge:
     // DC1("2"): mergeBlock=31300, single query 11401→31300 (no chunk history)
     // DC2("3"): mergeBlock=31300, chunks still pending
-    // P0("0"): still pending 25101→99800
+    // P0("0"): still pending 25101→96800
     // New("4"): lfb=31300, both addresses, inherits minRange=300 from DC2 history.
     //   chunkSize=540, uniform chunks from 31301 up to the per-partition cap of 10.
     t.expect(
@@ -1447,7 +1449,7 @@ describe("E2E tests", () => {
       ~message="After merge: DC1 queries to mergeBlock, DC2 chunks pending, new partition '4'",
     ).toEqual([
       ("2", 11401, Some(31300)),
-      ("0", 25101, Some(99800)),
+      ("0", 25101, Some(96800)),
       ("3", 25901, Some(26440)),
       ("3", 26441, Some(26980)),
       ("3", 26981, Some(27520)),

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -356,7 +356,7 @@ describe("FetchState — where.block._gte drives the first query's fromBlock", (
   let firstQuery = (fetchState: FetchState.t) =>
     switch fetchState
     ->FetchState.updateKnownHeight(~knownHeight=10000)
-    ->FetchState.getNextQuery(~budget=5000) {
+    ->FetchState.getNextQuery(~hasBudget=true) {
     | Ready([q]) => q
     | Ready(qs) =>
       JsError.throwWithMessage(

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -411,6 +411,22 @@ describe("CrossChainState buffer prune", () => {
     })
   })
 
+  it("keeps the lower prune target when pruned again with a higher one", t => {
+    // A second prune in the same above-target episode must not release the
+    // range parked at the first, lower target.
+    let cs = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=10000,
+      ~latestFetchedBlock=100,
+      ~partitionFetchedBlock=8039,
+      ~bufferBlocks=Array.fromInitializer(~length=40, i => 8000 + i),
+    )
+    cs->ChainState.pruneBuffer(~targetBlockNumber=5000)
+    cs->ChainState.pruneBuffer(~targetBlockNumber=8000)
+
+    t.expect(cs->ChainState.lastPruneTarget).toEqual(Some(5000))
+  })
+
   Async.it("clears the prune target and refetches once the buffer drains", async t => {
     // Same shape, but pruned directly and with the buffer already drained below
     // targetBufferSize: the tick clears the target and re-admits the range.

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -80,12 +80,23 @@ let makeChainState = (
 // getNextQuery actually produces a Ready query (unlike the onBlock-only helper
 // above). The partition has no response yet, so each query estimates at the
 // default size.
-let makeFetchingChainState = (~chainId, ~knownHeight, ~latestFetchedBlock, ~bufferBlocks=[]) => {
+let makeFetchingChainState = (
+  ~chainId,
+  ~knownHeight,
+  ~latestFetchedBlock,
+  ~bufferBlocks=[],
+  // The partition's own frontier, when it fetched ahead of the chain frontier
+  // (latestFetchedBlock keeps holding latestOnBlockBlockNumber back).
+  ~partitionFetchedBlock=?,
+) => {
   let normalSelection = {FetchState.dependsOnAddresses: false, eventConfigs: []}
   let address = "0x1234567890123456789012345678901234567890"->Address.unsafeFromString
   let partition: FetchState.partition = {
     id: "0",
-    latestFetchedBlock: {blockNumber: latestFetchedBlock, blockTimestamp: 0},
+    latestFetchedBlock: {
+      blockNumber: partitionFetchedBlock->Option.getOr(latestFetchedBlock),
+      blockTimestamp: 0,
+    },
     selection: normalSelection,
     addressesByContractName: Dict.fromArray([("MockContract", [address])]),
     mergeBlock: None,
@@ -183,7 +194,7 @@ describe("CrossChainState fetch control", () => {
     let cm = makeCrossChainState(~chainStatesList=[a, b], ~isRealtime=true)
 
     let dispatched = []
-    await cm->CrossChainState.checkAndFetch(~invalidateInflight=() => (), ~dispatchChain=(~chain, ~action) => {
+    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
       dispatched->Array.push((chain->ChainMap.Chain.toChainId, action))->ignore
       Promise.resolve()
     })
@@ -213,7 +224,7 @@ describe("CrossChainState fetch control", () => {
     let cm = makeCrossChainState(~chainStatesList=[a, b], ~targetBufferSize=100)
 
     let dispatched = []
-    await cm->CrossChainState.checkAndFetch(~invalidateInflight=() => (), ~dispatchChain=(~chain, ~action as _) => {
+    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action as _) => {
       dispatched->Array.push(chain->ChainMap.Chain.toChainId)->ignore
       Promise.resolve()
     })
@@ -229,7 +240,7 @@ describe("CrossChainState fetch control", () => {
     let cm = makeCrossChainState(~chainStatesList=[cs], ~targetBufferSize=1)
 
     let dispatched = []
-    await cm->CrossChainState.checkAndFetch(~invalidateInflight=() => (), ~dispatchChain=(~chain, ~action) => {
+    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
       dispatched
       ->Array.push((
         chain->ChainMap.Chain.toChainId,
@@ -323,20 +334,23 @@ describe("CrossChainState buffer prune", () => {
     let cs2 = makeStuck(~chainId=2, ~fromBlock=2000)
     let cm = makeCrossChainState(~chainStatesList=[cs1, cs2], ~targetBufferSize=20)
 
-    let invalidateCalled = ref(false)
     await cm->CrossChainState.checkAndFetch(
-      ~invalidateInflight=() => invalidateCalled := true,
       ~dispatchChain=(~chain as _, ~action as _) => Promise.resolve(),
     )
 
     t.expect({
       "chain1Buffer": cs1->ChainState.bufferSize,
       "chain2Buffer": cs2->ChainState.bufferSize,
-      "invalidateCalled": invalidateCalled.contents,
+      // The threshold lands one block below chain 2's 10th-from-last item
+      // (freeing exactly the 10 items needed on top of chain 1's 40), and both
+      // chains record it so admission holds back the pruned ranges.
+      "chain1PruneTarget": cs1->ChainState.lastPruneTarget,
+      "chain2PruneTarget": cs2->ChainState.lastPruneTarget,
     }).toEqual({
       "chain1Buffer": 0,
       "chain2Buffer": 30,
-      "invalidateCalled": true,
+      "chain1PruneTarget": Some(2029),
+      "chain2PruneTarget": Some(2029),
     })
   })
 
@@ -346,20 +360,94 @@ describe("CrossChainState buffer prune", () => {
     let cs2 = makeStuck(~chainId=2, ~fromBlock=2000)
     let cm = makeCrossChainState(~chainStatesList=[cs1, cs2], ~targetBufferSize=100)
 
-    let invalidateCalled = ref(false)
     await cm->CrossChainState.checkAndFetch(
-      ~invalidateInflight=() => invalidateCalled := true,
       ~dispatchChain=(~chain as _, ~action as _) => Promise.resolve(),
     )
 
     t.expect({
       "chain1Buffer": cs1->ChainState.bufferSize,
       "chain2Buffer": cs2->ChainState.bufferSize,
-      "invalidateCalled": invalidateCalled.contents,
+      "chain1PruneTarget": cs1->ChainState.lastPruneTarget,
+      "chain2PruneTarget": cs2->ChainState.lastPruneTarget,
     }).toEqual({
       "chain1Buffer": 40,
       "chain2Buffer": 40,
-      "invalidateCalled": false,
+      "chain1PruneTarget": None,
+      "chain2PruneTarget": None,
+    })
+  })
+
+  Async.it("holds back the pruned range instead of refetching it in the same tick", async t => {
+    // One partition fetched ahead to 8039 while the chain frontier sits at 100,
+    // so all 40 buffered items are stuck. targetBufferSize 10 → prune at 3x (30)
+    // down to 1.5x (15): target lands at 8014. The rolled-back partition
+    // immediately re-proposes 8015+, but the buffer (15) is still above the
+    // target (10), so admission holds the range back and nothing is dispatched.
+    let cs = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=10000,
+      ~latestFetchedBlock=100,
+      ~partitionFetchedBlock=8039,
+      ~bufferBlocks=Array.fromInitializer(~length=40, i => 8000 + i),
+    )
+    let cm = makeCrossChainState(~chainStatesList=[cs], ~targetBufferSize=10)
+
+    let dispatched = []
+    await cm->CrossChainState.checkAndFetch(
+      ~dispatchChain=(~chain, ~action as _) => {
+        dispatched->Array.push(chain->ChainMap.Chain.toChainId)->ignore
+        Promise.resolve()
+      },
+    )
+
+    t.expect({
+      "buffer": cs->ChainState.bufferSize,
+      "pruneTarget": cs->ChainState.lastPruneTarget,
+      "dispatched": dispatched,
+    }).toEqual({
+      "buffer": 15,
+      "pruneTarget": Some(8014),
+      "dispatched": [],
+    })
+  })
+
+  Async.it("clears the prune target and refetches once the buffer drains", async t => {
+    // Same shape, but pruned directly and with the buffer already drained below
+    // targetBufferSize: the tick clears the target and re-admits the range.
+    let cs = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=10000,
+      ~latestFetchedBlock=100,
+      ~partitionFetchedBlock=8039,
+      ~bufferBlocks=Array.fromInitializer(~length=40, i => 8000 + i),
+    )
+    cs->ChainState.pruneBuffer(~targetBlockNumber=8004)
+    let cm = makeCrossChainState(~chainStatesList=[cs], ~targetBufferSize=100)
+
+    let dispatched = []
+    await cm->CrossChainState.checkAndFetch(
+      ~dispatchChain=(~chain, ~action) => {
+        dispatched
+        ->Array.push((
+          chain->ChainMap.Chain.toChainId,
+          switch action {
+          | Ready(queries) => queries->Array.map(q => q.fromBlock)
+          | _ => []
+          },
+        ))
+        ->ignore
+        Promise.resolve()
+      },
+    )
+
+    t.expect({
+      "buffer": cs->ChainState.bufferSize,
+      "pruneTarget": cs->ChainState.lastPruneTarget,
+      "dispatched": dispatched,
+    }).toEqual({
+      "buffer": 5,
+      "pruneTarget": None,
+      "dispatched": [(1, [8005])],
     })
   })
 })

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -162,12 +162,17 @@ let emptyBatch: Batch.t = {
   checkpointEventsProcessed: [],
 }
 
-let makeCrossChainState = (~chainStatesList, ~isRealtime=false, ~targetBufferSize=100) => {
+let makeCrossChainState = (
+  ~chainStatesList,
+  ~isRealtime=false,
+  ~isInReorgThreshold=false,
+  ~targetBufferSize=100,
+) => {
   let chainStates = Dict.make()
   chainStatesList->Array.forEach(cs =>
     chainStates->Utils.Dict.setByInt((cs->ChainState.chainConfig).id, cs)
   )
-  CrossChainState.make(~chainStates, ~isInReorgThreshold=false, ~isRealtime, ~targetBufferSize)
+  CrossChainState.make(~chainStates, ~isInReorgThreshold, ~isRealtime, ~targetBufferSize)
 }
 
 describe("CrossChainState fetch control", () => {
@@ -327,9 +332,10 @@ describe("CrossChainState buffer prune", () => {
     )
 
   Async.it("prunes the closest-to-head items across chains down to the low-water mark", async t => {
-    // targetBufferSize 20 → prune when the buffer exceeds 3x (60), down to 1.5x
-    // (30). Chain 1's items sit at ~0.8 progress, chain 2's at ~0.2, so the
-    // head-closest chain 1 is dropped entirely before chain 2 is touched.
+    // targetBufferSize 20 → prune when the buffer exceeds 3x (60), down to 2x
+    // (40). Chain 1's items sit at ~0.8 progress, chain 2's at ~0.2, so dropping
+    // the head-closest chain 1 entirely frees exactly the 40 items needed and
+    // chain 2 is untouched — only the pruned chain records a hold-back target.
     let cs1 = makeStuck(~chainId=1, ~fromBlock=8000)
     let cs2 = makeStuck(~chainId=2, ~fromBlock=2000)
     let cm = makeCrossChainState(~chainStatesList=[cs1, cs2], ~targetBufferSize=20)
@@ -341,16 +347,13 @@ describe("CrossChainState buffer prune", () => {
     t.expect({
       "chain1Buffer": cs1->ChainState.bufferSize,
       "chain2Buffer": cs2->ChainState.bufferSize,
-      // The threshold lands one block below chain 2's 10th-from-last item
-      // (freeing exactly the 10 items needed on top of chain 1's 40), and both
-      // chains record it so admission holds back the pruned ranges.
       "chain1PruneTarget": cs1->ChainState.lastPruneTarget,
       "chain2PruneTarget": cs2->ChainState.lastPruneTarget,
     }).toEqual({
       "chain1Buffer": 0,
-      "chain2Buffer": 30,
-      "chain1PruneTarget": Some(2029),
-      "chain2PruneTarget": Some(2029),
+      "chain2Buffer": 40,
+      "chain1PruneTarget": Some(7999),
+      "chain2PruneTarget": None,
     })
   })
 
@@ -380,8 +383,8 @@ describe("CrossChainState buffer prune", () => {
   Async.it("holds back the pruned range instead of refetching it in the same tick", async t => {
     // One partition fetched ahead to 8039 while the chain frontier sits at 100,
     // so all 40 buffered items are stuck. targetBufferSize 10 → prune at 3x (30)
-    // down to 1.5x (15): target lands at 8014. The rolled-back partition
-    // immediately re-proposes 8015+, but the buffer (15) is still above the
+    // down to 2x (20): target lands at 8019. The rolled-back partition
+    // immediately re-proposes 8020+, but the buffer (20) is still above the
     // target (10), so admission holds the range back and nothing is dispatched.
     let cs = makeFetchingChainState(
       ~chainId=1,
@@ -405,9 +408,39 @@ describe("CrossChainState buffer prune", () => {
       "pruneTarget": cs->ChainState.lastPruneTarget,
       "dispatched": dispatched,
     }).toEqual({
-      "buffer": 15,
-      "pruneTarget": Some(8014),
+      "buffer": 20,
+      "pruneTarget": Some(8019),
       "dispatched": [],
+    })
+  })
+
+  Async.it("prunes inside the reorg threshold too", async t => {
+    // The indexer-wide threshold flag is sticky and set on restart if any chain
+    // resumed near its head, so a far-behind chain must still get its buffer
+    // bounded while the flag is on.
+    let cs = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=10000,
+      ~latestFetchedBlock=100,
+      ~partitionFetchedBlock=8039,
+      ~bufferBlocks=Array.fromInitializer(~length=40, i => 8000 + i),
+    )
+    let cm = makeCrossChainState(
+      ~chainStatesList=[cs],
+      ~targetBufferSize=10,
+      ~isInReorgThreshold=true,
+    )
+
+    await cm->CrossChainState.checkAndFetch(
+      ~dispatchChain=(~chain as _, ~action as _) => Promise.resolve(),
+    )
+
+    t.expect({
+      "buffer": cs->ChainState.bufferSize,
+      "pruneTarget": cs->ChainState.lastPruneTarget,
+    }).toEqual({
+      "buffer": 20,
+      "pruneTarget": Some(8019),
     })
   })
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -4190,16 +4190,29 @@ describe("FetchState.rollback with in-flight queries", () => {
 
     let result = fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=300)
 
-    let mkQuery = fromBlock => {...defaultQuery, partitionId: "0", fromBlock}
+    let mkQuery = (fromBlock, ~toBlock=None) => {
+      ...defaultQuery,
+      partitionId: "0",
+      fromBlock,
+      toBlock,
+    }
     t.expect({
       "pendingQueries": (result.optimizedPartitions.entities->Dict.getUnsafe("0")).mutPendingQueries,
       "buffer": result.buffer->Array.map(Internal.getItemBlockNumber),
-      // Only the surviving in-flight query still counts as pending: the dropped
-      // one's late response must be discarded and the completed slots must not
-      // accept a second response for the same range.
+      // Only the surviving in-flight query still counts as pending, and only
+      // with its exact range: the dropped one's late response must be discarded,
+      // a differently-shaped query at the same fromBlock must not alias, and the
+      // completed slots must not accept a second response for the same range.
       "crossingStillPending": result->FetchState.isQueryStillPending(~query=mkQuery(280)),
-      "droppedStillPending": result->FetchState.isQueryStillPending(~query=mkQuery(401)),
-      "completedStillPending": result->FetchState.isQueryStillPending(~query=mkQuery(201)),
+      "differentToBlockStillPending": result->FetchState.isQueryStillPending(
+        ~query=mkQuery(280, ~toBlock=Some(999)),
+      ),
+      "droppedStillPending": result->FetchState.isQueryStillPending(
+        ~query=mkQuery(401, ~toBlock=Some(600)),
+      ),
+      "completedStillPending": result->FetchState.isQueryStillPending(
+        ~query=mkQuery(201, ~toBlock=Some(400)),
+      ),
       "pendingBudgetSize": result->FetchState.pendingBudgetSize,
     }).toEqual({
       "pendingQueries": [
@@ -4209,6 +4222,7 @@ describe("FetchState.rollback with in-flight queries", () => {
       ],
       "buffer": [250],
       "crossingStillPending": true,
+      "differentToBlockStillPending": false,
       "droppedStillPending": false,
       "completedStillPending": false,
       "pendingBudgetSize": 30.,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -2468,19 +2468,19 @@ describe("FetchState.getNextQuery & integration", () => {
     let indexingAddresses = makeIntermidiateIndex()
 
     // Rollback to block 2: both DCs survive (regBlock <= 2)
-    // Partition "0" (lfb=10 > 2) -> DELETED, addresses recreated as partition "1"
-    // Partition "2" (lfb=2 <= 2) -> KEPT as partition "0" (IDs reset)
+    // Partition "0" (lfb=10 > 2) -> DELETED, addresses recreated as partition "3"
+    // Partition "2" (lfb=2 <= 2) -> KEPT with its id (deleted ids are never reused)
     let fetchStateAfterRollback1 =
       fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=2)
     t.expect(
       fetchStateAfterRollback1,
-      ~message=`Rollbacks partitions: kept "0", recreated "1" from deleted`,
+      ~message=`Rollbacks partitions: kept "2", recreated "3" from deleted`,
     ).toEqual({
       ...fetchState,
       optimizedPartitions: FetchState.OptimizedPartitions.make(
         ~partitions=[
           {
-            id: "0",
+            id: "2",
             latestFetchedBlock: {
               blockNumber: 2,
               blockTimestamp: 0,
@@ -2496,7 +2496,7 @@ describe("FetchState.getNextQuery & integration", () => {
             mergeBlock: None,
           },
           {
-            id: "1",
+            id: "3",
             latestFetchedBlock: {
               blockNumber: 2,
               blockTimestamp: 0,
@@ -2514,7 +2514,7 @@ describe("FetchState.getNextQuery & integration", () => {
             mergeBlock: None,
           },
         ],
-        ~nextPartitionIndex=2,
+        ~nextPartitionIndex=4,
         ~maxAddrInPartition=fetchState.optimizedPartitions.maxAddrInPartition,
         ~dynamicContracts=fetchState.optimizedPartitions.dynamicContracts,
       ),
@@ -2526,13 +2526,13 @@ describe("FetchState.getNextQuery & integration", () => {
       fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=1)
     t.expect(
       fetchStateAfterRollback2,
-      ~message=`Both partitions deleted, surviving addresses recreated as partition "0"`,
+      ~message=`Both partitions deleted, surviving addresses recreated as partition "3"`,
     ).toEqual({
       ...fetchState,
       optimizedPartitions: FetchState.OptimizedPartitions.make(
         ~partitions=[
           {
-            id: "0",
+            id: "3",
             latestFetchedBlock: {
               blockNumber: 1,
               blockTimestamp: 0,
@@ -2550,7 +2550,7 @@ describe("FetchState.getNextQuery & integration", () => {
           },
           // Removed partition "2"
         ],
-        ~nextPartitionIndex=1,
+        ~nextPartitionIndex=4,
         ~maxAddrInPartition=fetchState.optimizedPartitions.maxAddrInPartition,
         ~dynamicContracts=fetchState.optimizedPartitions.dynamicContracts,
       ),
@@ -2564,13 +2564,13 @@ describe("FetchState.getNextQuery & integration", () => {
       fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=-1)
     t.expect(
       fetchStateAfterRollback3,
-      ~message=`All DCs removed, only static addr0 recreated as partition "0"`,
+      ~message=`All DCs removed, only static addr0 recreated as partition "3"`,
     ).toEqual({
       ...fetchState,
       optimizedPartitions: FetchState.OptimizedPartitions.make(
         ~partitions=[
           {
-            id: "0",
+            id: "3",
             latestFetchedBlock: {
               blockNumber: -1,
               blockTimestamp: 0,
@@ -2586,7 +2586,7 @@ describe("FetchState.getNextQuery & integration", () => {
             mergeBlock: None,
           },
         ],
-        ~nextPartitionIndex=1,
+        ~nextPartitionIndex=4,
         ~maxAddrInPartition=fetchState.optimizedPartitions.maxAddrInPartition,
         ~dynamicContracts=fetchState.optimizedPartitions.dynamicContracts,
       ),
@@ -2678,8 +2678,8 @@ describe("FetchState.getNextQuery & integration", () => {
             mergeBlock: None,
           },
         ],
-        // IDs reset on rollback
-        ~nextPartitionIndex=1,
+        // IDs survive rollback and deleted ids are never reused
+        ~nextPartitionIndex=2,
         ~maxAddrInPartition=fetchState.optimizedPartitions.maxAddrInPartition,
         ~dynamicContracts=fetchState.optimizedPartitions.dynamicContracts,
       ),
@@ -3939,9 +3939,9 @@ describe("Stale query response should not overwrite block range", () => {
       ~message="latestBlockRangeUpdateBlock should be 500 after first query",
     ).toBe(500)
 
-    // -- Query 2: chunking activates after one observed range:
-    // chunkSize = ceil(501 * 1.8) = 902 -> [501..1402], ... Dispatch only the
-    // first chunk. --
+    // -- Query 2: chunking activates after one observed range, floored at
+    // tooFarBlockRange: chunkSize = ceil(20000 * 1.8) = 36000 -> [501..36500],
+    // ... Dispatch only the first chunk. --
     let q2 = switch fs1->getNextQuery {
     | Ready(qs) => qs->Array.getUnsafe(0)
     | _ => JsError.throwWithMessage("Expected chunk queries for second round")
@@ -3949,7 +3949,7 @@ describe("Stale query response should not overwrite block range", () => {
     fs1->FetchState.startFetchingQueries(~queries=[q2])
 
     // Partial response at block 1000 (range = 500)
-    // shouldUpdateBlockRange: 1000 < toBlock 1402 (partial response) = true
+    // shouldUpdateBlockRange: 1000 < toBlock 36500 (partial response) = true
     let fs2 =
       fs1->FetchState.handleQueryResult(
         ~indexingAddresses,
@@ -4119,6 +4119,99 @@ describe("FetchState.rollback consolidation", () => {
       "contract": Some("Gravatar"),
       "mergeBlock": None,
       "addressCount": 2,
+    })
+  })
+})
+
+describe("FetchState.rollback with in-flight queries", () => {
+  // A wildcard partition at block 100 with the full pending-query zoo around a
+  // rollback target of 300: completed below, completed crossing, in-flight
+  // crossing, in-flight above.
+  let completedBelow: FetchState.pendingQuery = {
+    fromBlock: 101,
+    toBlock: Some(200),
+    isChunk: true,
+    estResponseSize: 10.,
+    fetchedBlock: Some({blockNumber: 200, blockTimestamp: 0}),
+  }
+  let completedCrossing: FetchState.pendingQuery = {
+    fromBlock: 201,
+    toBlock: Some(400),
+    isChunk: true,
+    estResponseSize: 20.,
+    fetchedBlock: Some({blockNumber: 400, blockTimestamp: 0}),
+  }
+  let inflightCrossing: FetchState.pendingQuery = {
+    fromBlock: 280,
+    toBlock: None,
+    isChunk: false,
+    estResponseSize: 30.,
+    fetchedBlock: None,
+  }
+  let inflightAbove: FetchState.pendingQuery = {
+    fromBlock: 401,
+    toBlock: Some(600),
+    isChunk: true,
+    estResponseSize: 40.,
+    fetchedBlock: None,
+  }
+
+  let makeWithPending = () => {
+    let (baseFs, indexingAddresses) = makeInitial()
+    let fetchState: FetchState.t = {
+      ...baseFs,
+      buffer: [mockEvent(~blockNumber=250), mockEvent(~blockNumber=350)],
+      optimizedPartitions: FetchState.OptimizedPartitions.make(
+        ~partitions=[
+          {
+            id: "0",
+            latestFetchedBlock: {blockNumber: 100, blockTimestamp: 0},
+            selection: {dependsOnAddresses: false, eventConfigs: []},
+            addressesByContractName: Dict.make(),
+            mergeBlock: None,
+            dynamicContract: None,
+            mutPendingQueries: [completedBelow, completedCrossing, inflightCrossing, inflightAbove],
+            prevQueryRange: 0,
+            prevPrevQueryRange: 0,
+            prevRangeSize: 0,
+            latestBlockRangeUpdateBlock: 0,
+          },
+        ],
+        ~maxAddrInPartition=3,
+        ~nextPartitionIndex=1,
+        ~dynamicContracts=Utils.Set.make(),
+      ),
+    }
+    (fetchState, indexingAddresses)
+  }
+
+  it("drops in-flight queries above the target, keeps crossing and completed ones", t => {
+    let (fetchState, indexingAddresses) = makeWithPending()
+
+    let result = fetchState->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=300)
+
+    let mkQuery = fromBlock => {...defaultQuery, partitionId: "0", fromBlock}
+    t.expect({
+      "pendingQueries": (result.optimizedPartitions.entities->Dict.getUnsafe("0")).mutPendingQueries,
+      "buffer": result.buffer->Array.map(Internal.getItemBlockNumber),
+      // Only the surviving in-flight query still counts as pending: the dropped
+      // one's late response must be discarded and the completed slots must not
+      // accept a second response for the same range.
+      "crossingStillPending": result->FetchState.isQueryStillPending(~query=mkQuery(280)),
+      "droppedStillPending": result->FetchState.isQueryStillPending(~query=mkQuery(401)),
+      "completedStillPending": result->FetchState.isQueryStillPending(~query=mkQuery(201)),
+      "pendingBudgetSize": result->FetchState.pendingBudgetSize,
+    }).toEqual({
+      "pendingQueries": [
+        completedBelow,
+        {...completedCrossing, fetchedBlock: Some({blockNumber: 300, blockTimestamp: 0})},
+        inflightCrossing,
+      ],
+      "buffer": [250],
+      "crossingStillPending": true,
+      "droppedStillPending": false,
+      "completedStillPending": false,
+      "pendingBudgetSize": 30.,
     })
   })
 })

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -3307,12 +3307,14 @@ describe("FetchState unit tests for specific cases", () => {
           {
             // Partition responded with no items, so its density is 0; the
             // estimate is floored at minEstResponseSize (100) so admission still
-            // gates it.
+            // gates it. Chunking is active after the first response, and the
+            // remaining range up to the end block fits in a single chunk query.
             ...queryA,
             partitionId: "1",
             estResponseSize: 100.,
             toBlock: Some(500),
             fromBlock: 401,
+            isChunk: true,
           },
           queries->Array.getUnsafe(1),
         ]),
@@ -3937,15 +3939,17 @@ describe("Stale query response should not overwrite block range", () => {
       ~message="latestBlockRangeUpdateBlock should be 500 after first query",
     ).toBe(500)
 
-    // -- Query 2: uncapped query from block 501 --
+    // -- Query 2: chunking activates after one observed range:
+    // chunkSize = ceil(501 * 1.8) = 902 -> [501..1402], ... Dispatch only the
+    // first chunk. --
     let q2 = switch fs1->getNextQuery {
-    | Ready([q]) => q
-    | _ => JsError.throwWithMessage("Expected a single query for second round")
+    | Ready(qs) => qs->Array.getUnsafe(0)
+    | _ => JsError.throwWithMessage("Expected chunk queries for second round")
     }
     fs1->FetchState.startFetchingQueries(~queries=[q2])
 
-    // Response arrives at block 1000 (range = 500)
-    // shouldUpdateBlockRange: None toBlock => 1000 < 99990 = true
+    // Partial response at block 1000 (range = 500)
+    // shouldUpdateBlockRange: 1000 < toBlock 1402 (partial response) = true
     let fs2 =
       fs1->FetchState.handleQueryResult(
         ~indexingAddresses,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1856,23 +1856,23 @@ describe("FetchState.getNextQuery & integration", () => {
   // The default configuration with ability to overwrite some values.
   // Partitions here have no response yet, so query sizing falls back to
   // FetchState.defaultEstResponseSize (10000).
-  let getNextQuery = (fs, ~endBlock=None, ~knownHeight=10, ~budget=10) =>
+  let getNextQuery = (fs, ~endBlock=None, ~knownHeight=10, ~hasBudget=true) =>
     switch endBlock {
     | Some(_) => {...fs, endBlock}
     | None => fs
     }
     ->FetchState.updateKnownHeight(~knownHeight)
-    ->FetchState.getNextQuery(~budget)
+    ->FetchState.getNextQuery(~hasBudget)
 
   it("Returns NothingToQuery when the buffer budget is exhausted", t => {
-    // Same state queries Ready with a positive budget (see the test below), so a
-    // non-positive budget is the only reason nothing is queried here.
+    // Same state queries Ready when there's budget (see the test below), so the
+    // exhausted budget is the only reason nothing is queried here.
     let (fetchState, _indexingAddresses) = makeInitial()
 
     t.expect(
-      (fetchState->getNextQuery(~budget=0), fetchState->getNextQuery(~budget=-5)),
+      fetchState->getNextQuery(~hasBudget=false),
       ~message="Should skip fetching when there's no room left in the shared buffer pool",
-    ).toEqual((NothingToQuery, NothingToQuery))
+    ).toEqual(NothingToQuery)
   })
 
   it("Emulate first indexer queries with a static event", t => {
@@ -1956,11 +1956,11 @@ describe("FetchState.getNextQuery & integration", () => {
       when block height exceeded the end block`,
     ).toEqual(NothingToQuery)
     t.expect(
-      updatedFetchState->getNextQuery(~budget=2),
+      updatedFetchState->getNextQuery,
       ~message=`Should wait for new block even if partitions have nothing to query`,
     ).toEqual(WaitingForNewBlock)
     t.expect(
-      updatedFetchState->getNextQuery(~budget=2, ~knownHeight=11),
+      updatedFetchState->getNextQuery(~knownHeight=11),
       ~message=`Should fetch the head block once the partition is behind the head,
       with an open-ended range: the query is no longer capped by buffer size`,
     ).toEqual(
@@ -2330,13 +2330,6 @@ describe("FetchState.getNextQuery & integration", () => {
       4,
     ))
 
-    t.expect(
-      fetchStateWithResponse1->getNextQuery(~budget=1),
-      ~message=`Buffer has no items past the ready frontier, so a tight budget no
-      longer caps the proposal here (the shared budget is enforced by cross-chain
-      admission); the merge continuation is proposed the same as with a full budget`,
-    ).toEqual(fetchStateWithResponse1->getNextQuery)
-
     let queries = switch fetchStateWithResponse1->getNextQuery {
     | Ready(queries) => queries
     | _ =>
@@ -2424,7 +2417,7 @@ describe("FetchState.getNextQuery & integration", () => {
     t.expect(fetchState.optimizedPartitions->FetchState.OptimizedPartitions.count).toEqual(3)
 
     let nextQuery =
-      {...fetchState, knownHeight: 10}->FetchState.getNextQuery(~budget=targetBufferSize)
+      {...fetchState, knownHeight: 10}->FetchState.getNextQuery(~hasBudget=true)
 
     t.expect(
       nextQuery,
@@ -2887,7 +2880,7 @@ describe("FetchState unit tests for specific cases", () => {
       )
 
     t.expect(
-      {...fetchState, knownHeight: 2}->FetchState.getNextQuery(~budget=targetBufferSize),
+      {...fetchState, knownHeight: 2}->FetchState.getNextQuery(~hasBudget=true),
       ~message=`Should be possible to query wildcard partition,
       if it didn't reach max queue size limit`,
     ).toEqual(
@@ -2911,10 +2904,10 @@ describe("FetchState unit tests for specific cases", () => {
       {
         ...fetchState,
         knownHeight: 2,
-      }->FetchState.getNextQuery(~budget=1),
-      ~message=`With the buffer-size cap removed, a positive budget proposes the
-      full query range regardless of buffered-ahead items; the shared pool is now
-      enforced by cross-chain admission, not by capping the range here`,
+      }->FetchState.getNextQuery(~hasBudget=true),
+      ~message=`Proposes the full query range regardless of buffered-ahead items;
+      the shared pool is enforced by cross-chain admission, not by capping the
+      range here`,
     ).toEqual(
       Ready([
         {
@@ -3250,7 +3243,7 @@ describe("FetchState unit tests for specific cases", () => {
       let fetchStateWithDcA =
         fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dcA->dcToItem])
 
-      let queries = switch fetchStateWithDcA->FetchState.getNextQuery(~budget=targetBufferSize) {
+      let queries = switch fetchStateWithDcA->FetchState.getNextQuery(~hasBudget=true) {
       | Ready(queries) => queries
       | _ => JsError.throwWithMessage("Expected Ready queries")
       }
@@ -3280,7 +3273,7 @@ describe("FetchState unit tests for specific cases", () => {
       let fetchStateWithDcB =
         fetchStateWithDcA->FetchState.registerDynamicContracts(~indexingAddresses, [dc3->dcToItem])
 
-      let queries = switch fetchStateWithDcB->FetchState.getNextQuery(~budget=targetBufferSize) {
+      let queries = switch fetchStateWithDcB->FetchState.getNextQuery(~hasBudget=true) {
       | Ready(queries) => queries
       | _ => JsError.throwWithMessage("Expected Ready queries")
       }
@@ -3292,7 +3285,7 @@ describe("FetchState unit tests for specific cases", () => {
         fromBlock: 200,
       }
       t.expect(
-        fetchStateWithDcB->FetchState.getNextQuery(~budget=targetBufferSize),
+        fetchStateWithDcB->FetchState.getNextQuery(~hasBudget=true),
         ~message=`Create a new partition for the newly registered contract`,
       ).toEqual(Ready([partition2Query, queries->Array.getUnsafe(1)]))
 
@@ -3306,7 +3299,7 @@ describe("FetchState unit tests for specific cases", () => {
         )
 
       t.expect(
-        fetchStateWithBothDcsAndQueryAResponse->FetchState.getNextQuery(~budget=targetBufferSize),
+        fetchStateWithBothDcsAndQueryAResponse->FetchState.getNextQuery(~hasBudget=true),
         ~message=`We don't merge partition 2 to partition 1, since it already has end block`,
       ).toEqual(
         Ready([
@@ -3725,8 +3718,8 @@ describe("FetchState query range is not capped by buffer size", () => {
       let fetchStateWithTwoPartitions =
         fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dc->dcToItem])
 
-      // Buffer 15 items (blocks 6..20) far past the frontier. Previously a budget
-      // of 10 capped the query at block 15; now the range runs to endBlock/head.
+      // Buffer 15 items (blocks 6..20) far past the frontier; the query range
+      // still runs to endBlock/head.
       let largeQueueEvents = Array.fromInitializer(~length=15, i => mockEvent(~blockNumber=20 - i))
 
       let query0 = {
@@ -3756,7 +3749,7 @@ describe("FetchState query range is not capped by buffer size", () => {
         knownHeight: 30,
       }
 
-      switch fetchStateWithEndBlock->FetchState.getNextQuery(~budget=10) {
+      switch fetchStateWithEndBlock->FetchState.getNextQuery(~hasBudget=true) {
       | Ready([q]) =>
         t.expect(q.toBlock, ~message="Query runs to endBlock (25), not a buffer-size cap").toBe(
           Some(25),
@@ -3766,7 +3759,7 @@ describe("FetchState query range is not capped by buffer size", () => {
 
       // Test case 2: endBlock=None -> open-ended query (no buffer-size cap)
       let fetchStateNoEndBlock = {...fetchStateWithLargeQueue, endBlock: None, knownHeight: 30}
-      switch fetchStateNoEndBlock->FetchState.getNextQuery(~budget=10) {
+      switch fetchStateNoEndBlock->FetchState.getNextQuery(~hasBudget=true) {
       | Ready([q]) =>
         t.expect(
           q.toBlock,
@@ -3797,7 +3790,7 @@ describe("FetchState query range is not capped by buffer size", () => {
         )
         ->FetchState.updateKnownHeight(~knownHeight=30)
 
-      switch fetchStateSmallQueue->FetchState.getNextQuery(~budget=targetBufferSize) {
+      switch fetchStateSmallQueue->FetchState.getNextQuery(~hasBudget=true) {
       | Ready([q]) =>
         t.expect(q.toBlock, ~message="Should use None when buffer is not limited").toBe(None)
       | _ => JsError.throwWithMessage("Expected Ready query")
@@ -3853,7 +3846,7 @@ describe("FetchState with onBlockConfig only (no events)", () => {
       ])
 
       // Test that getNextQuery returns WaitingForNewBlock when knownHeight is 0
-      let nextQuery = fetchState->FetchState.getNextQuery(~budget=targetBufferSize)
+      let nextQuery = fetchState->FetchState.getNextQuery(~hasBudget=true)
       t.expect(
         nextQuery,
         ~message="Should return WaitingForNewBlock when knownHeight is 0",
@@ -3895,7 +3888,7 @@ describe("FetchState with onBlockConfig only (no events)", () => {
       ])
 
       // Test that getNextQuery returns NothingToQuery (no partitions to query)
-      let nextQuery2 = updatedFetchState->FetchState.getNextQuery(~budget=targetBufferSize)
+      let nextQuery2 = updatedFetchState->FetchState.getNextQuery(~hasBudget=true)
       t.expect(
         nextQuery2,
         ~message="Should return NothingToQuery when there are no partitions to query",
@@ -3906,10 +3899,10 @@ describe("FetchState with onBlockConfig only (no events)", () => {
 
 describe("Stale query response should not overwrite block range", () => {
   // The default configuration with ability to overwrite some values
-  let getNextQuery = (fs, ~knownHeight=100000, ~budget=targetBufferSize) =>
+  let getNextQuery = (fs, ~knownHeight=100000) =>
     fs
     ->FetchState.updateKnownHeight(~knownHeight)
-    ->FetchState.getNextQuery(~budget)
+    ->FetchState.getNextQuery(~hasBudget=true)
 
   it("Out-of-order parallel query responses should not degrade chunking heuristic", t => {
     let (fetchState, indexingAddresses) = makeInitial(~knownHeight=100000)

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -372,17 +372,16 @@ describe("SourceManager fetchNext", () => {
 
   // Selection (getNextQuery) now happens in CrossChainState; SourceManager only
   // dispatches the chosen action. This shim keeps the per-chain tests focused on
-  // dispatch by computing the action from the chain's own budget.
+  // dispatch by computing the action from the chain's own state.
   let fetchNext = (
     sourceManager,
     ~fetchState,
     ~executeQuery,
     ~waitForNewBlock,
     ~onNewBlock,
-    ~budget=5000,
     ~stateId,
   ) => {
-    let action = fetchState->FetchState.getNextQuery(~budget)
+    let action = fetchState->FetchState.getNextQuery(~hasBudget=true)
     // CrossChainState marks queries in flight when admitting them; dispatch no
     // longer does, so mirror that here before dispatching.
     switch action {
@@ -509,10 +508,10 @@ describe("SourceManager fetchNext", () => {
 
     t.expect({
       // 10 already pending: the partition is capped, so the scheduler issues nothing.
-      "atCap": withPending(10)->FetchState.getNextQuery(~budget=5000),
+      "atCap": withPending(10)->FetchState.getNextQuery(~hasBudget=true),
       // 9 pending: the two-chunk tail is trimmed down to the one remaining slot.
       "oneSlotLeft": withPending(9)
-      ->FetchState.getNextQuery(~budget=5000)
+      ->FetchState.getNextQuery(~hasBudget=true)
       ->newQueryCount,
     }).toEqual({"atCap": FetchState.NothingToQuery, "oneSlotLeft": 1})
   })
@@ -536,7 +535,6 @@ describe("SourceManager fetchNext", () => {
           ~executeQuery=executeQueryMock.fn,
           ~waitForNewBlock=neverWaitForNewBlock,
           ~onNewBlock=neverOnNewBlock,
-          ~budget=5000,
           ~stateId=0,
         )
 
@@ -605,7 +603,6 @@ describe("SourceManager fetchNext", () => {
           ~executeQuery=executeQueryMock.fn,
           ~waitForNewBlock=neverWaitForNewBlock,
           ~onNewBlock=neverOnNewBlock,
-          ~budget=5000,
           ~stateId=0,
         )
 
@@ -637,7 +634,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=onNewBlockMock.fn,
-        ~budget=5000,
         ~stateId=0,
       )
 
@@ -658,7 +654,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=onNewBlockMock.fn,
-        ~budget=5000,
         ~stateId=0,
       )
 
@@ -686,7 +681,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=onNewBlockMock.fn,
-        ~budget=5000,
         ~stateId=0,
       )
 
@@ -713,7 +707,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=onNewBlockMock.fn,
-        ~budget=5000,
         ~stateId=0,
       )
 
@@ -725,7 +718,6 @@ describe("SourceManager fetchNext", () => {
       ~executeQuery=neverExecutePartitionQuery,
       ~waitForNewBlock=neverWaitForNewBlock,
       ~onNewBlock=neverOnNewBlock,
-      ~budget=5000,
       ~stateId=0,
     )
 
@@ -755,7 +747,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=neverOnNewBlock,
-        ~budget=5000,
         ~stateId=0,
       )
 
@@ -767,7 +758,6 @@ describe("SourceManager fetchNext", () => {
       ~executeQuery=neverExecutePartitionQuery,
       ~waitForNewBlock=neverWaitForNewBlock,
       ~onNewBlock=neverOnNewBlock,
-      ~budget=5000,
       ~stateId=0,
     )
     t.expect(
@@ -781,7 +771,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=onNewBlockMock.fn,
-        ~budget=5000,
         ~stateId=1,
       )
     t.expect(waitForNewBlockMock.calls, ~message=`Should add a new call after a rollback`).toEqual([
@@ -822,7 +811,6 @@ describe("SourceManager fetchNext", () => {
       ~executeQuery=executeQueryMock.fn,
       ~waitForNewBlock=neverWaitForNewBlock,
       ~onNewBlock=neverOnNewBlock,
-      ~budget=5000,
       ~stateId=0,
     )
 

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -230,8 +230,8 @@ describe("E2E rollback tests", () => {
         "fromBlock": 101,
         "toBlock": None,
         "retry": 0,
-        // IDs reset on rollback, recreated partition starts at 0
-        "p": "0",
+        // Deleted partition ids are never reused; the recreated one takes the next id
+        "p": "2",
       }),
     )
     sourceMock.resolveGetItemsOrThrow([
@@ -490,7 +490,7 @@ describe("E2E rollback tests", () => {
     t.expect(
       sourceMock.getItemsOrThrowCalls->Array.map(c => c.payload)->Utils.Array.last,
       ~message="after the parked rollback executes, the indexer re-requests from the valid block",
-    ).toEqual(Some({"fromBlock": 101, "toBlock": None, "retry": 0, "p": "0"}))
+    ).toEqual(Some({"fromBlock": 101, "toBlock": None, "retry": 0, "p": "2"}))
   })
 
   Async.it("Fires onRollbackCommit per affected chain after the rollback write", async t => {
@@ -609,8 +609,8 @@ describe("E2E rollback tests", () => {
         "fromBlock": 101,
         "toBlock": None,
         "retry": 0,
-        // IDs reset on rollback, recreated partition starts at 0
-        "p": "0",
+        // Deleted partition ids are never reused; the recreated one takes the next id
+        "p": "2",
       },
     ])
 
@@ -867,14 +867,14 @@ describe("E2E rollback tests", () => {
         "fromBlock": 103,
         "toBlock": None,
         "retry": 0,
-        "p": "0",
+        "p": "3",
       },
       // DC partition (recreated fresh, no chunking since chunk history lost)
       {
         "fromBlock": 103,
         "toBlock": None,
         "retry": 0,
-        "p": "2",
+        "p": "5",
       },
     ])
 
@@ -922,7 +922,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
     t.expect(
       payloads->Array.map(p => (p["p"], p["fromBlock"], p["toBlock"])),
       ~message="Should correctly continue fetching from block 105 after rolling back the db",
-    ).toEqual([("2", 105, None), ("0", 105, None)])
+    ).toEqual([("5", 105, None), ("3", 105, None)])
   })
 
   Async.it("Rollback of multichain indexer (single entity id change)", async t => {
@@ -1265,7 +1265,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
           "fromBlock": 106,
           "toBlock": None,
           "retry": 0,
-          "p": "0",
+          "p": "2",
         },
       ],
     ))
@@ -1669,7 +1669,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
           "fromBlock": 106,
           "toBlock": None,
           "retry": 0,
-          "p": "0",
+          "p": "2",
         }),
         // Chain 100: partition KEPT, chunk history preserved.
         // chunkRange=3 -> chunkSize=6, first uniform chunk is 106-111.
@@ -2430,7 +2430,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
         "fromBlock": 115,
         "toBlock": None,
         "retry": 0,
-        "p": "0",
+        "p": "2",
       },
     ])
   })
@@ -2556,7 +2556,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
       ).toEqual([
         {
           "fromBlock": 118,
-          "p": "0",
+          "p": "2",
           "retry": 0,
           "toBlock": None,
         },
@@ -2672,7 +2672,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
           "fromBlock": 101,
           "toBlock": None,
           "retry": 0,
-          "p": "0",
+          "p": "2",
         }),
       )
 
@@ -2928,7 +2928,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
           {"fromBlock": 160, "toBlock": Some(165), "retry": 0, "p": "0"},
         ],
         // Chain 1337: partition deleted (lfb > target), recreated fresh
-        [{"fromBlock": 106, "toBlock": None, "retry": 0, "p": "0"}],
+        [{"fromBlock": 106, "toBlock": None, "retry": 0, "p": "2"}],
       ))
 
       sourceMock100.resolveGetItemsOrThrow(
@@ -2999,4 +2999,187 @@ This might be wrong after we start exposing a block hash for progress block.`,
       ))
     },
   )
+  Async.it(
+    "Buffer prune during backfill composes with a pre-threshold reorg rollback",
+    async t => {
+      // End-to-end interplay of the two rollback flavours below the reorg
+      // threshold: fetched-ahead items get pruned while the lagging
+      // dynamic-contract partition's in-flight work keeps running, a reorg is
+      // then detected and resolved, and the indexer still processes every event
+      // exactly once. targetBufferSize 10 -> prune above 30 items, down to 15.
+      let sourceMock = MockIndexer.Source.make(
+        [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+        ~chain=#1337,
+      )
+      let indexerMock = await MockIndexer.Indexer.make(
+        ~chains=[
+          {
+            chain: #1337,
+            sourceConfig: Config.CustomSources([sourceMock.source]),
+          },
+        ],
+        ~targetBufferSize=10,
+      )
+      await Utils.delay(0)
+
+      // Below the reorg threshold the chain lags by maxReorgDepth (200), so with
+      // height 100_000 the first query runs 1..99_800.
+      sourceMock.resolveGetHeightOrThrow(100_000)
+      await Utils.delay(0)
+      await Utils.delay(0)
+      t.expect(
+        sourceMock.getItemsOrThrowCalls->Array.map(c => c.payload),
+        ~message="Backfills up to the reorg threshold",
+      ).toEqual([{"fromBlock": 1, "toBlock": Some(99_800), "retry": 0, "p": "0"}])
+
+      let calls = []
+      let handler = async (
+        {event, context}: Internal.genericHandlerArgs<
+          Internal.genericEvent<unknown, Indexer.Block.t, Indexer.Transaction.t>,
+          Indexer.handlerContext,
+        >,
+      ) => {
+        let call = event.block.number->Int.toString ++ "-" ++ event.logIndex->Int.toString
+        calls->Array.push(call)
+        context.\"SimpleEntity".set({id: "1", value: call})
+      }
+
+      // One ready item (block 500, sets firstEventBlock once processed), a
+      // dynamic contract registered at block 1000 (its partition becomes the
+      // lagging frontier at 999), and 35 fetched-ahead items stuck behind it:
+      // 36 stuck items exceed the 30-item high-water mark.
+      sourceMock.resolveGetItemsOrThrow(
+        Array.concat(
+          [
+            {
+              MockIndexer.Source.blockNumber: 500,
+              logIndex: 0,
+              handler,
+            },
+            {
+              blockNumber: 1000,
+              logIndex: 0,
+              contractRegister: async ({context}) => {
+                context.chain.\"SimpleNft".add(
+                  Envio.TestHelpers.Addresses.mockAddresses->Array.getUnsafe(0),
+                )
+              },
+              handler,
+            },
+          ],
+          Array.fromInitializer(~length=35, i => {
+            MockIndexer.Source.blockNumber: 90_000 + i,
+            logIndex: 0,
+            handler,
+          }),
+        ),
+        ~latestFetchedBlockNumber=99_800,
+      )
+      await indexerMock.getBatchWritePromise()
+
+      t.expect(
+        (
+          calls->Utils.Array.copy,
+          await indexerMock.metric("envio_indexing_buffer_prune_items_total"),
+          sourceMock.getItemsOrThrowCalls->Array.map(c => c.payload),
+        ),
+        ~message=`Only the ready item is processed; no prune yet (nothing was
+        processed when the fetch tick ran) and the dynamic-contract partition
+        starts fetching from its registration block`,
+      ).toEqual((
+        ["500-0"],
+        [{value: "0", labels: Dict.make()}],
+        [{"fromBlock": 1000, "toBlock": Some(99_800), "retry": 0, "p": "2"}],
+      ))
+
+      // The dynamic-contract query returns a partial response: its response tick
+      // is the first one after the batch set firstEventBlock, so the prune fires
+      // now — 36 items minus the one that became ready at block 1000, minus 21
+      // pruned (down to the 15-item low-water mark). The partition's rolled-back
+      // range (90_014+) is held back while the buffer is above targetBufferSize,
+      // so the only new query is the dynamic-contract continuation chunk.
+      sourceMock.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=5000)
+      await indexerMock.getBatchWritePromise()
+
+      t.expect(
+        (
+          calls->Utils.Array.copy,
+          await indexerMock.metric("envio_indexing_buffer_prune_items_total"),
+          sourceMock.getItemsOrThrowCalls->Array.map(c => c.payload),
+        ),
+        ~message=`The prune drops the 21 closest-to-head items and the
+        rolled-back partition is not refetched while the buffer stays above
+        target`,
+      ).toEqual((
+        ["500-0", "1000-0"],
+        [{value: "21", labels: Dict.make()}],
+        [{"fromBlock": 5001, "toBlock": Some(41_000), "retry": 0, "p": "2"}],
+      ))
+
+      // The next response re-reports the recorded block 99_800 with a different
+      // hash: a reorg is detected while still below the reorg threshold. The
+      // detected block is the only recorded one, so depth finding has nothing
+      // to re-verify and the rollback executes right away, quiescing the
+      // response instead of applying it.
+      sourceMock.resolveGetItemsOrThrow(
+        [],
+        ~latestFetchedBlockNumber=41_000,
+        ~prevRangeLastBlock={blockNumber: 99_800, blockHash: "0x99800-reorged"},
+      )
+      await Utils.delay(0)
+      await Utils.delay(0)
+      await indexerMock.getRollbackReadyPromise()
+
+      t.expect(
+        (
+          sourceMock.getItemsOrThrowCalls->Array.map(c => c.payload),
+          await indexerMock.metric("envio_indexing_buffer_size"),
+        ),
+        ~message=`After the rollback only the dynamic-contract partition
+        re-requests its chunk: the buffer is still above targetBufferSize, so
+        the pruned range stays held back`,
+      ).toEqual((
+        [{"fromBlock": 5001, "toBlock": Some(41_000), "retry": 0, "p": "2"}],
+        [{value: "14", labels: Dict.fromArray([("chainId", "1337")])}],
+      ))
+
+      // Drive the dynamic-contract partition forward chunk by chunk with empty
+      // responses. Once its frontier passes the remaining buffered items they
+      // process, and the drained buffer releases the pruned range for
+      // refetching — the loop stops when the pruned partition re-requests.
+      let seenQueries = []
+      let guard = ref(0)
+      while (
+        !(seenQueries->Array.some(payload => payload["fromBlock"] == 90_014)) &&
+        guard.contents < 15
+      ) {
+        guard := guard.contents + 1
+        sourceMock.getItemsOrThrowCalls->Array.forEach(c =>
+          seenQueries->Array.push(c.payload)->ignore
+        )
+        sourceMock.resolveGetItemsOrThrow([])
+        await indexerMock.getBatchWritePromise()
+      }
+
+      t.expect(
+        (
+          calls->Utils.Array.copy,
+          seenQueries->Array.filter(payload => payload["fromBlock"] == 90_014),
+          await indexerMock.query(SimpleEntity),
+        ),
+        ~message=`Every buffered event processes exactly once, and the pruned
+        range is refetched only after the buffer drained below the target`,
+      ).toEqual((
+        Array.concat(
+          ["500-0", "1000-0"],
+          Array.fromInitializer(~length=14, i => (90_000 + i)->Int.toString ++ "-0"),
+        ),
+        // The dynamic-contract partition merged with the pruned one as it
+        // caught up, so the released range is requested by the merged partition.
+        [{"fromBlock": 90_014, "toBlock": Some(99_800), "retry": 0, "p": "3"}],
+        [{Indexer.Entities.SimpleEntity.id: "1", value: "90013-0"}],
+      ))
+    },
+  )
+
 })

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -3006,7 +3006,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
       // threshold: fetched-ahead items get pruned while the lagging
       // dynamic-contract partition's in-flight work keeps running, a reorg is
       // then detected and resolved, and the indexer still processes every event
-      // exactly once. targetBufferSize 10 -> prune above 30 items, down to 15.
+      // exactly once. targetBufferSize 10 -> prune above 30 items, down to 20.
       let sourceMock = MockIndexer.Source.make(
         [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
         ~chain=#1337,
@@ -3094,9 +3094,9 @@ This might be wrong after we start exposing a block hash for progress block.`,
 
       // The dynamic-contract query returns a partial response: its response tick
       // is the first one after the batch set firstEventBlock, so the prune fires
-      // now — 36 items minus the one that became ready at block 1000, minus 21
-      // pruned (down to the 15-item low-water mark). The partition's rolled-back
-      // range (90_014+) is held back while the buffer is above targetBufferSize,
+      // now — 36 items minus the one that became ready at block 1000, minus 16
+      // pruned (down to the 20-item low-water mark). The partition's rolled-back
+      // range (90_019+) is held back while the buffer is above targetBufferSize,
       // so the only new query is the dynamic-contract continuation chunk.
       sourceMock.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=5000)
       await indexerMock.getBatchWritePromise()
@@ -3107,12 +3107,12 @@ This might be wrong after we start exposing a block hash for progress block.`,
           await indexerMock.metric("envio_indexing_buffer_prune_items_total"),
           sourceMock.getItemsOrThrowCalls->Array.map(c => c.payload),
         ),
-        ~message=`The prune drops the 21 closest-to-head items and the
+        ~message=`The prune drops the 16 closest-to-head items and the
         rolled-back partition is not refetched while the buffer stays above
         target`,
       ).toEqual((
         ["500-0", "1000-0"],
-        [{value: "21", labels: Dict.make()}],
+        [{value: "16", labels: Dict.make()}],
         [{"fromBlock": 5001, "toBlock": Some(41_000), "retry": 0, "p": "2"}],
       ))
 
@@ -3140,7 +3140,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
         the pruned range stays held back`,
       ).toEqual((
         [{"fromBlock": 5001, "toBlock": Some(41_000), "retry": 0, "p": "2"}],
-        [{value: "14", labels: Dict.fromArray([("chainId", "1337")])}],
+        [{value: "19", labels: Dict.fromArray([("chainId", "1337")])}],
       ))
 
       // Drive the dynamic-contract partition forward chunk by chunk with empty
@@ -3150,7 +3150,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
       let seenQueries = []
       let guard = ref(0)
       while (
-        !(seenQueries->Array.some(payload => payload["fromBlock"] == 90_014)) &&
+        !(seenQueries->Array.some(payload => payload["fromBlock"] == 90_019)) &&
         guard.contents < 15
       ) {
         guard := guard.contents + 1
@@ -3164,7 +3164,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
       t.expect(
         (
           calls->Utils.Array.copy,
-          seenQueries->Array.filter(payload => payload["fromBlock"] == 90_014),
+          seenQueries->Array.filter(payload => payload["fromBlock"] == 90_019),
           await indexerMock.query(SimpleEntity),
         ),
         ~message=`Every buffered event processes exactly once, and the pruned
@@ -3172,12 +3172,12 @@ This might be wrong after we start exposing a block hash for progress block.`,
       ).toEqual((
         Array.concat(
           ["500-0", "1000-0"],
-          Array.fromInitializer(~length=14, i => (90_000 + i)->Int.toString ++ "-0"),
+          Array.fromInitializer(~length=19, i => (90_000 + i)->Int.toString ++ "-0"),
         ),
         // The dynamic-contract partition merged with the pruned one as it
         // caught up, so the released range is requested by the merged partition.
-        [{"fromBlock": 90_014, "toBlock": Some(99_800), "retry": 0, "p": "3"}],
-        [{Indexer.Entities.SimpleEntity.id: "1", value: "90013-0"}],
+        [{"fromBlock": 90_019, "toBlock": Some(99_800), "retry": 0, "p": "3"}],
+        [{Indexer.Entities.SimpleEntity.id: "1", value: "90018-0"}],
       ))
     },
   )


### PR DESCRIPTION
## Summary

This PR refactors the buffer pruning mechanism to hold back pruned ranges from refetching while the buffer drains, and fixes partition ID allocation to never reuse deleted IDs. It also simplifies the budget API by replacing numeric budgets with a boolean `hasBudget` flag, since the shared buffer pool is now enforced by cross-chain admission rather than per-query sizing.

## Key Changes

**Buffer Prune Refactoring:**
- Changed prune high-water mark from 3x to 3x and low-water mark from 1.5x to 2x `targetBufferSize`
- Prune now records a `lastPruneTarget` per chain and holds back queries above that target until the buffer drains to `targetBufferSize`
- Removed the `invalidateInflight` callback — prune no longer quiesces in-flight fetches; only the queries it rolled back are invalidated by the still-pending check
- Prune now runs inside the reorg threshold too (the sticky flag means chains backfilling from far behind still need the buffer bound)
- Returns the count of freed items for metrics

**Partition ID Allocation:**
- Fixed `nextPartitionIndex` to never reuse deleted partition IDs — deleted IDs are permanently retired
- Updated all test expectations to reflect the new ID sequence (e.g., partition "3" instead of "0" after deletions)

**Budget API Simplification:**
- Replaced `~budget: int` parameter with `~hasBudget: bool` in `FetchState.getNextQuery`
- Removed per-query budget sizing since cross-chain admission now enforces the shared pool
- Updated all call sites and tests

**Query Validation:**
- Enhanced `getPendingQuery` to match on both `fromBlock` and `toBlock` to ensure exact query identity
- Added still-pending check in `onQueryResponse` to drop responses from rolled-back queries

**Test Updates:**
- Removed test asserting tight budget caps query proposals (no longer applicable)
- Updated rollback tests to verify partition IDs survive and aren't reused
- Added comprehensive prune tests covering hold-back behavior, multi-chain scenarios, and reorg threshold interaction
- Added E2E test for buffer prune composing with pre-threshold reorg rollback

## Notable Implementation Details

- The prune uses binary search (30 iterations) to find the largest progress threshold that frees the required items, dropping only the closest-to-head items across all chains
- Hold-back is enforced by cross-chain admission checking `lastPruneTarget` before dispatching queries
- Partition IDs are now allocated sequentially without reuse, simplifying the mental model and preventing subtle bugs from ID collisions

https://claude.ai/code/session_012HPurPU5a9mRc2wzpneezs