### PR TITLE
Move query completion logging into onQueryResponse

### DIFF
--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -334,15 +334,6 @@ let fetchChain = async (
     // there's nothing to fetch. During backfill any such chain is idle.
     let reducedPolling = !isRealtime
 
-    // Accumulated across all queries dispatched in this tick so their per-query
-    // results collapse into a single completion log instead of one per query.
-    let dispatchedCount = switch action {
-    | FetchState.Ready(queries) => queries->Array.length
-    | WaitingForNewBlock | NothingToQuery => 0
-    }
-    let fetchedByPartition = Dict.make()
-    let fetchedCount = ref(0)
-
     // Owns its error boundary: launch doesn't catch, so any failure here (the
     // query, response handling, or dispatch itself) must stop the indexer.
     try {
@@ -368,22 +359,22 @@ let fetchChain = async (
               ~knownHeight=chainState->ChainState.knownHeight,
               ~isRealtime,
             )
-            fetchedCount := fetchedCount.contents + 1
-            fetchedByPartition->Dict.set(
-              query.partitionId,
-              {
-                "fromBlock": response.fromBlockQueried,
-                "toBlock": response.latestFetchedBlockNumber,
-                "numEvents": response.parsedQueueItems->Array.length,
-              },
-            )
-            if dispatchedCount > 0 && fetchedCount.contents === dispatchedCount {
-              Logging.trace({
-                "msg": "Finished querying",
-                "chainId": chain->ChainMap.Chain.toChainId,
-                "partitions": fetchedByPartition,
-              })
-            }
+            let numContractRegisterEvents = response.parsedQueueItems->Array.reduce(0, (
+              count,
+              item,
+            ) => {
+              let eventItem = item->Internal.castUnsafeEventItem
+              eventItem.eventConfig.contractRegister !== None ? count + 1 : count
+            })
+            Logging.trace({
+              "msg": "Finished querying",
+              "chainId": chain->ChainMap.Chain.toChainId,
+              "partitionId": query.partitionId,
+              "fromBlock": response.fromBlockQueried,
+              "toBlock": response.latestFetchedBlockNumber,
+              "numEvents": response.parsedQueueItems->Array.length,
+              "numContractRegisterEvents": numContractRegisterEvents,
+            })
             await onQueryResponse(
               state,
               {chain, response, query},

--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -204,6 +204,16 @@ let rec onQueryResponse = async (
         newItems->Array.push(item)
       }
 
+      Logging.trace({
+        "msg": "Finished querying",
+        "chainId": chain->ChainMap.Chain.toChainId,
+        "partitionId": query.partitionId,
+        "fromBlock": fromBlockQueried,
+        "toBlock": latestFetchedBlockNumber,
+        "numEvents": parsedQueueItems->Array.length,
+        "numContractRegisterEvents": itemsWithContractRegister->Array.length,
+      })
+
       // Re-check staleness: contract registration is async, so the chain state
       // may have rolled back by the time we apply the fetched items.
       let proceed = (~newItemsWithDcs) =>
@@ -359,22 +369,6 @@ let fetchChain = async (
               ~knownHeight=chainState->ChainState.knownHeight,
               ~isRealtime,
             )
-            let numContractRegisterEvents = response.parsedQueueItems->Array.reduce(0, (
-              count,
-              item,
-            ) => {
-              let eventItem = item->Internal.castUnsafeEventItem
-              eventItem.eventConfig.contractRegister !== None ? count + 1 : count
-            })
-            Logging.trace({
-              "msg": "Finished querying",
-              "chainId": chain->ChainMap.Chain.toChainId,
-              "partitionId": query.partitionId,
-              "fromBlock": response.fromBlockQueried,
-              "toBlock": response.latestFetchedBlockNumber,
-              "numEvents": response.parsedQueueItems->Array.length,
-              "numContractRegisterEvents": numContractRegisterEvents,
-            })
             await onQueryResponse(
               state,
               {chain, response, query},

--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -140,6 +140,20 @@ let rec onQueryResponse = async (
       ~blockRangeSize=latestFetchedBlockNumber - fromBlockQueried + 1,
     )
 
+    let numContractRegisterEvents = parsedQueueItems->Array.reduce(0, (count, item) => {
+      let eventItem = item->Internal.castUnsafeEventItem
+      eventItem.eventConfig.contractRegister !== None ? count + 1 : count
+    })
+    Logging.trace({
+      "msg": "Finished querying",
+      "chainId": chain->ChainMap.Chain.toChainId,
+      "partitionId": query.partitionId,
+      "fromBlock": fromBlockQueried,
+      "toBlock": latestFetchedBlockNumber,
+      "numEvents": parsedQueueItems->Array.length,
+      "numContractRegisterEvents": numContractRegisterEvents,
+    })
+
     let reorgResult = chainState->ChainState.registerReorgGuard(~blockHashes, ~knownHeight)
 
     let rollbackWithReorgDetectedBlockNumber = switch reorgResult {
@@ -203,16 +217,6 @@ let rec onQueryResponse = async (
         // when there's no handler (besides raw_events, processed counter, and dcsToStore consuming)
         newItems->Array.push(item)
       }
-
-      Logging.trace({
-        "msg": "Finished querying",
-        "chainId": chain->ChainMap.Chain.toChainId,
-        "partitionId": query.partitionId,
-        "fromBlock": fromBlockQueried,
-        "toBlock": latestFetchedBlockNumber,
-        "numEvents": parsedQueueItems->Array.length,
-        "numContractRegisterEvents": itemsWithContractRegister->Array.length,
-      })
 
       // Re-check staleness: contract registration is async, so the chain state
       // may have rolled back by the time we apply the fetched items.


### PR DESCRIPTION
## Summary
Refactored query completion logging to be emitted per-query within `onQueryResponse` instead of being accumulated and emitted once per tick in `fetchChain`. This provides more granular visibility into individual query completions and simplifies the control flow.

## Key Changes
- Moved the "Finished querying" trace log from `fetchChain` into `onQueryResponse`, now logged immediately after each query completes with its specific results
- Removed the per-tick accumulation logic in `fetchChain` that tracked `dispatchedCount`, `fetchedByPartition`, and `fetchedCount`
- Each query now logs its own completion details: `chainId`, `partitionId`, `fromBlock`, `toBlock`, `numEvents`, and `numContractRegisterEvents`

## Implementation Details
The logging now captures partition-specific metrics directly from the query response, eliminating the need to aggregate results across multiple queries dispatched in a single tick. This makes the log output more immediate and easier to correlate with specific query executions.

https://claude.ai/code/session_01HLzAxQms9kMmEhSaJ2YJ5d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query completion logging to emit a per-query, per-partition trace that includes chain/partition identifiers, block range, and both total and contract register event counts.
  * Removed the prior aggregated “tick-level” completion log, so progress and completion details are more granular and clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->