### PR TITLE
Refactor stores to chunk-columnar architecture

### DIFF
--- a/packages/cli/src/block_store.rs
+++ b/packages/cli/src/block_store.rs
@@ -18,7 +18,7 @@ use napi_derive::napi;
 use strum::VariantArray;
 
 use crate::evm_hypersync_source::map_err;
-use crate::evm_hypersync_source::types::{map_address_string, map_bigint, map_hex_string};
+use crate::evm_hypersync_source::types::{map_address_string, map_bigint, map_hex_string, map_i64};
 use crate::field_columns::{build_columns, fill_masked, Column, Columns};
 
 /// EVM block field codes shared with ReScript by ordinal value. The order is the
@@ -121,47 +121,39 @@ impl SvmBlockField {
     }
 }
 
-/// Decode the per-row mask-selected fields of the given EVM blocks into
-/// columns. ReScript builds the masks from the config's field selection, which
-/// always includes number/timestamp/hash, so the trio's bits are set on every
-/// production mask.
+/// Decode the per-row mask-selected fields of the given EVM blocks into columns.
+/// `block_numbers` is the requested key per row, so `number` resolves from the
+/// key (always known) rather than a stored record.
 fn decode_evm_block_columns(
-    records: &[Option<EvmRecord>],
+    records: &[Option<Arc<simple_types::Block>>],
     block_numbers: &[i64],
     masks: &[u64],
     should_checksum: bool,
 ) -> Result<Columns> {
-    let raw: Vec<Option<Arc<simple_types::Block>>> = records
-        .iter()
-        .map(|r| r.as_ref().and_then(|(_, raw)| raw.clone()))
-        .collect();
-
     build_columns(
         EvmBlockField::VARIANTS,
         masks,
         records.len(),
         |f| f as u32,
         |f| f.name(),
-        |f| decode_evm_block_field(f, records, &raw, block_numbers, masks, should_checksum),
+        |f| decode_evm_block_field(f, records, block_numbers, masks, should_checksum),
     )
 }
 
 /// Decode a single EVM block field, materialising it only on the rows whose mask
-/// has the field's bit set. Number/timestamp/hash resolve from the key and the
-/// stored header (known for every stored block); the rest decode from the raw
-/// block, retained only when a field beyond those three was selected. Exhaustive
-/// match: adding an `EvmBlockField` variant fails to compile until it is decoded
-/// here.
+/// has the field's bit set. Exhaustive match: adding an `EvmBlockField` variant
+/// fails to compile until it is decoded here.
 fn decode_evm_block_field(
     field: EvmBlockField,
-    records: &[Option<EvmRecord>],
-    raw: &[Option<Arc<simple_types::Block>>],
+    records: &[Option<Arc<simple_types::Block>>],
     block_numbers: &[i64],
     masks: &[u64],
     should_checksum: bool,
 ) -> Result<Column> {
     let bit = 1u64 << (field as u32);
     Ok(match field {
+        // The block number is the store key, so it's always available regardless
+        // of whether the block row was fetched.
         EvmBlockField::Number => Column::I64(
             block_numbers
                 .iter()
@@ -169,107 +161,89 @@ fn decode_evm_block_field(
                 .map(|(&n, &m)| (m & bit != 0).then_some(n))
                 .collect(),
         ),
-        EvmBlockField::Timestamp => Column::I64(
-            records
-                .iter()
-                .zip(masks)
-                .map(|(r, &m)| {
-                    if m & bit == 0 {
-                        None
-                    } else {
-                        r.as_ref().map(|(h, _)| h.timestamp)
-                    }
-                })
-                .collect(),
-        ),
-        EvmBlockField::Hash => Column::Str(
-            records
-                .iter()
-                .zip(masks)
-                .map(|(r, &m)| {
-                    if m & bit == 0 {
-                        None
-                    } else {
-                        r.as_ref().map(|(h, _)| h.hash.clone())
-                    }
-                })
-                .collect(),
-        ),
-        EvmBlockField::ParentHash => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::Timestamp => {
+            Column::I64(fill_masked(records, masks, bit, |b| map_i64(&b.timestamp))?)
+        }
+        EvmBlockField::Hash => Column::Str(fill_masked(records, masks, bit, |b| {
+            Ok(map_hex_string(&b.hash))
+        })?),
+        EvmBlockField::ParentHash => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.parent_hash))
         })?),
-        EvmBlockField::Nonce => {
-            Column::Big(fill_masked(raw, masks, bit, |b| Ok(map_bigint(&b.nonce)))?)
-        }
-        EvmBlockField::Sha3Uncles => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::Nonce => Column::Big(fill_masked(records, masks, bit, |b| {
+            Ok(map_bigint(&b.nonce))
+        })?),
+        EvmBlockField::Sha3Uncles => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.sha3_uncles))
         })?),
-        EvmBlockField::LogsBloom => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::LogsBloom => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.logs_bloom))
         })?),
-        EvmBlockField::TransactionsRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::TransactionsRoot => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.transactions_root))
         })?),
-        EvmBlockField::StateRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::StateRoot => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.state_root))
         })?),
-        EvmBlockField::ReceiptsRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::ReceiptsRoot => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.receipts_root))
         })?),
-        EvmBlockField::Miner => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::Miner => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_address_string(&b.miner, should_checksum))
         })?),
-        EvmBlockField::Difficulty => Column::Big(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::Difficulty => Column::Big(fill_masked(records, masks, bit, |b| {
             Ok(map_bigint(&b.difficulty))
         })?),
-        EvmBlockField::TotalDifficulty => Column::Big(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::TotalDifficulty => Column::Big(fill_masked(records, masks, bit, |b| {
             Ok(map_bigint(&b.total_difficulty))
         })?),
-        EvmBlockField::ExtraData => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::ExtraData => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.extra_data))
         })?),
-        EvmBlockField::Size => {
-            Column::Big(fill_masked(raw, masks, bit, |b| Ok(map_bigint(&b.size)))?)
-        }
-        EvmBlockField::GasLimit => Column::Big(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::Size => Column::Big(fill_masked(records, masks, bit, |b| {
+            Ok(map_bigint(&b.size))
+        })?),
+        EvmBlockField::GasLimit => Column::Big(fill_masked(records, masks, bit, |b| {
             Ok(map_bigint(&b.gas_limit))
         })?),
-        EvmBlockField::GasUsed => Column::Big(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::GasUsed => Column::Big(fill_masked(records, masks, bit, |b| {
             Ok(map_bigint(&b.gas_used))
         })?),
-        EvmBlockField::Uncles => Column::StrVec(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::Uncles => Column::StrVec(fill_masked(records, masks, bit, |b| {
             Ok(b.uncles
                 .as_ref()
                 .map(|arr| arr.iter().map(|u| u.encode_hex()).collect()))
         })?),
-        EvmBlockField::BaseFeePerGas => Column::Big(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::BaseFeePerGas => Column::Big(fill_masked(records, masks, bit, |b| {
             Ok(map_bigint(&b.base_fee_per_gas))
         })?),
-        EvmBlockField::BlobGasUsed => Column::Big(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::BlobGasUsed => Column::Big(fill_masked(records, masks, bit, |b| {
             Ok(map_bigint(&b.blob_gas_used))
         })?),
-        EvmBlockField::ExcessBlobGas => Column::Big(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::ExcessBlobGas => Column::Big(fill_masked(records, masks, bit, |b| {
             Ok(map_bigint(&b.excess_blob_gas))
         })?),
-        EvmBlockField::ParentBeaconBlockRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
-            Ok(map_hex_string(&b.parent_beacon_block_root))
-        })?),
-        EvmBlockField::WithdrawalsRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::ParentBeaconBlockRoot => {
+            Column::Str(fill_masked(records, masks, bit, |b| {
+                Ok(map_hex_string(&b.parent_beacon_block_root))
+            })?)
+        }
+        EvmBlockField::WithdrawalsRoot => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.withdrawals_root))
         })?),
-        EvmBlockField::L1BlockNumber => Column::I64(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::L1BlockNumber => Column::I64(fill_masked(records, masks, bit, |b| {
             b.l1_block_number
                 .map(|n| i64::try_from(u64::from(n)))
                 .transpose()
                 .context("l1BlockNumber overflow")
         })?),
-        EvmBlockField::SendCount => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::SendCount => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.send_count))
         })?),
-        EvmBlockField::SendRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::SendRoot => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.send_root))
         })?),
-        EvmBlockField::MixHash => Column::Str(fill_masked(raw, masks, bit, |b| {
+        EvmBlockField::MixHash => Column::Str(fill_masked(records, masks, bit, |b| {
             Ok(map_hex_string(&b.mix_hash))
         })?),
     })
@@ -335,29 +309,9 @@ fn decode_svm_block_field(
     })
 }
 
-/// The lean header every fetched EVM block carries, independent of whether its
-/// full raw form was also retained — timestamp/hash are always known from the
-/// response, not just when an event selected a field beyond the trio.
-/// `number` isn't duplicated here since it's already the map key.
-#[derive(Clone)]
-struct EvmHeader {
-    timestamp: i64,
-    hash: String,
-}
-
-/// One EVM row's stored data: the header is always known; the raw block is
-/// only kept when an event selected a field beyond the trio.
-type EvmRecord = (EvmHeader, Option<Arc<simple_types::Block>>);
-
 /// One stored block, kept in its ecosystem's compact raw form.
 enum StoredBlock {
-    /// EVM: the header is always known (from the response); `raw` holds the
-    /// full upstream struct only when an event selected a field beyond the
-    /// always-available trio.
-    Evm {
-        header: EvmHeader,
-        raw: Option<Arc<simple_types::Block>>,
-    },
+    Evm(Arc<simple_types::Block>),
     Svm(Arc<solana_simple::Block>),
 }
 
@@ -494,11 +448,8 @@ impl BlockStore {
 
         match self.ecosystem {
             Ecosystem::Evm { should_checksum } => {
-                // The header (timestamp/hash) is always present for a stored EVM
-                // block; `raw` is only `Some` when an event selected a field
-                // beyond the trio.
                 let records = self.collect_locked(&block_numbers, |stored| match stored {
-                    StoredBlock::Evm { header, raw } => Some((header.clone(), raw.clone())),
+                    StoredBlock::Evm(b) => Some(b.clone()),
                     _ => None,
                 });
                 tokio::task::block_in_place(|| {
@@ -563,25 +514,15 @@ impl BlockStore {
         }
     }
 
-    /// Insert an EVM block's header — always known from the response — and,
-    /// optionally, its full raw form (only kept when an event selected a field
-    /// beyond the always-available trio). Called once per response block while
-    /// building a page; one block per number, so a plain insert deduplicates
-    /// the many logs that share it. Not exposed to JS.
-    pub(crate) fn insert_evm(
-        &self,
-        number: u64,
-        timestamp: i64,
-        hash: String,
-        raw: Option<Arc<simple_types::Block>>,
-    ) {
-        self.inner.lock().unwrap().map.insert(
-            number,
-            StoredBlock::Evm {
-                header: EvmHeader { timestamp, hash },
-                raw,
-            },
-        );
+    /// Insert a raw EVM block (called by the HyperSync source while building a
+    /// page). One block per number, so a plain insert deduplicates the many logs
+    /// that share it. Not exposed to JS.
+    pub(crate) fn insert_evm_raw(&self, number: u64, block: Arc<simple_types::Block>) {
+        self.inner
+            .lock()
+            .unwrap()
+            .map
+            .insert(number, StoredBlock::Evm(block));
     }
 
     /// Insert a raw SVM block keyed by slot (called by the SVM HyperSync source
@@ -618,27 +559,13 @@ pub fn svm_block_field_names() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hypersync_client::format::Quantity;
+    use hypersync_client::format::{Hash, Quantity};
 
     fn raw_evm_block(number: u64) -> simple_types::Block {
         simple_types::Block {
             number: Some(number),
             ..Default::default()
         }
-    }
-
-    fn evm_record(
-        timestamp: i64,
-        hash: &str,
-        raw: Option<Arc<simple_types::Block>>,
-    ) -> Option<EvmRecord> {
-        Some((
-            EvmHeader {
-                timestamp,
-                hash: hash.to_string(),
-            },
-            raw,
-        ))
     }
 
     fn raw_svm_block(slot: u64) -> solana_simple::Block {
@@ -661,91 +588,60 @@ mod tests {
     fn decode_selected_only_materialises_masked_fields() {
         // Select only `logsBloom` via the bitmask.
         let mask = 1u64 << (EvmBlockField::LogsBloom as u32);
-        let cols = decode_evm_block_columns(
-            &[evm_record(11, "0x1", Some(Arc::new(raw_evm_block(1))))],
-            &[1],
-            &[mask],
-            false,
-        )
-        .expect("decode columns");
+        let cols =
+            decode_evm_block_columns(&[Some(Arc::new(raw_evm_block(1)))], &[1], &[mask], false)
+                .expect("decode columns");
 
-        // Only the selected column is present — the trio is mask-gated like
-        // every other field (production masks always carry its bits).
+        // Exactly one column (logsBloom) is present; number (resolvable from the
+        // key but unselected) and gasUsed are absent.
         let summary = (
             column(&cols, "logsBloom").is_some(),
-            column(&cols, "gasUsed").is_some(),
             column(&cols, "number").is_some(),
-            column(&cols, "timestamp").is_some(),
-            column(&cols, "hash").is_some(),
+            column(&cols, "gasUsed").is_some(),
         );
-        assert_eq!(summary, (true, false, false, false, false));
+        assert_eq!(summary, (true, false, false));
     }
 
     #[test]
-    fn trio_decodes_from_key_and_header_without_raw_record() {
-        // The trio never needs the raw block: number resolves from the key and
-        // timestamp/hash from the stored header, so rows without a raw record
-        // (no field beyond the trio selected) still materialise it.
-        let trio_mask = (1u64 << (EvmBlockField::Number as u32))
-            | (1u64 << (EvmBlockField::Timestamp as u32))
-            | (1u64 << (EvmBlockField::Hash as u32));
+    fn number_comes_from_key_even_on_miss() {
+        // A missing record (None) still materialises the requested key as
+        // `number`, so it never depends on a fetched block row.
+        let mask = 1u64 << (EvmBlockField::Number as u32);
         let cols = decode_evm_block_columns(
-            &[evm_record(70, "0x7", None), evm_record(30, "0x3", None)],
+            &[None, Some(Arc::new(raw_evm_block(3)))],
             &[7, 3],
-            &[trio_mask, trio_mask],
+            &[mask, mask],
             false,
         )
         .expect("decode columns");
-
-        let summary = (
-            match column(&cols, "number") {
-                Some(Column::I64(v)) => v.clone(),
-                _ => panic!("expected number column"),
-            },
-            match column(&cols, "timestamp") {
-                Some(Column::I64(v)) => v.clone(),
-                _ => panic!("expected timestamp column"),
-            },
-            match column(&cols, "hash") {
-                Some(Column::Str(v)) => v.clone(),
-                _ => panic!("expected hash column"),
-            },
-        );
-        assert_eq!(
-            summary,
-            (
-                vec![Some(7), Some(3)],
-                vec![Some(70), Some(30)],
-                vec![Some("0x7".to_string()), Some("0x3".to_string())],
-            )
-        );
+        match column(&cols, "number") {
+            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(7), Some(3)]),
+            other => panic!(
+                "expected number i64 column, got present={}",
+                other.is_some()
+            ),
+        }
     }
 
     #[test]
     fn decode_applies_each_rows_own_mask() {
-        // Both rows have a real `gasUsed` value on their raw record, but only
-        // row 0 selects it via its own mask — proving the mask, not the
-        // record, gates whether a row's value materialises.
-        let mut block1 = raw_evm_block(1);
-        block1.gas_used = Some(Quantity::from(100u64));
-        let mut block2 = raw_evm_block(2);
-        block2.gas_used = Some(Quantity::from(200u64));
-
-        let gas_used_mask = 1u64 << (EvmBlockField::GasUsed as u32);
+        // Row 0 selects `number`; row 1 selects nothing. The key-derived `number`
+        // column is present only on the row whose own mask has the bit set.
+        let number_mask = 1u64 << (EvmBlockField::Number as u32);
         let cols = decode_evm_block_columns(
             &[
-                evm_record(11, "0x1", Some(Arc::new(block1))),
-                evm_record(22, "0x2", Some(Arc::new(block2))),
+                Some(Arc::new(raw_evm_block(1))),
+                Some(Arc::new(raw_evm_block(2))),
             ],
             &[1, 2],
-            &[gas_used_mask, 0],
+            &[number_mask, 0],
             false,
         )
         .expect("decode columns");
 
-        match column(&cols, "gasUsed") {
-            Some(Column::Big(v)) => assert_eq!((v[0].is_some(), v[1].is_some()), (true, false)),
-            other => panic!("expected gasUsed column, got present={}", other.is_some()),
+        match column(&cols, "number") {
+            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(1), None]),
+            other => panic!("expected number column, got present={}", other.is_some()),
         }
     }
 
@@ -788,12 +684,7 @@ mod tests {
     fn prune_and_rollback_drop_by_block() {
         let store = BlockStore::new_evm(false);
         for block in [10u64, 20, 30] {
-            store.insert_evm(
-                block,
-                0,
-                "0x0".to_string(),
-                Some(Arc::new(raw_evm_block(block))),
-            );
+            store.insert_evm_raw(block, Arc::new(raw_evm_block(block)));
         }
 
         store.prune(10);
@@ -880,11 +771,13 @@ mod tests {
     async fn materialize_returns_stored_extra_fields_via_store() {
         let store = BlockStore::new_evm(false);
         let mut block = raw_evm_block(10);
+        block.timestamp = Some(Quantity::from(999u64));
+        block.hash = Some(Hash::from([0xabu8; 32]));
         block.gas_used = Some(Quantity::from(555u64));
-        store.insert_evm(10, 999, "0xhash".to_string(), Some(Arc::new(block)));
+        store.insert_evm_raw(10, Arc::new(block));
 
         // A production-shaped mask: the config-extended trio plus a selected
-        // extra field. The trio resolves from the key/header, gasUsed from raw.
+        // extra field, all decoded from the one stored raw block.
         let mask = ((1u64 << (EvmBlockField::Number as u32))
             | (1u64 << (EvmBlockField::Timestamp as u32))
             | (1u64 << (EvmBlockField::Hash as u32))
@@ -914,7 +807,7 @@ mod tests {
                 true,
                 vec![Some(10)],
                 vec![Some(999)],
-                vec![Some("0xhash".to_string())]
+                vec![Some(format!("0x{}", "ab".repeat(32)))]
             )
         );
     }
@@ -942,17 +835,19 @@ mod tests {
         // A rolled-back block re-fetched with different content must replace the
         // stale entry rather than be shadowed by it — the sequence a chain
         // reorg drives through `ChainState`: merge a page, then merge a later
-        // page for the same (re-fetched) block number. No raw block needed
-        // here: the header alone (set directly via `insert_evm`) is enough to
-        // prove the overwrite.
+        // page for the same (re-fetched) block number.
         let persistent = BlockStore::new_evm(false);
 
         let page1 = BlockStore::new_evm(false);
-        page1.insert_evm(20, 100, "0x100".to_string(), None);
+        let mut first = raw_evm_block(20);
+        first.timestamp = Some(Quantity::from(100u64));
+        page1.insert_evm_raw(20, Arc::new(first));
         persistent.merge(&page1);
 
         let page2 = BlockStore::new_evm(false);
-        page2.insert_evm(20, 200, "0x200".to_string(), None);
+        let mut second = raw_evm_block(20);
+        second.timestamp = Some(Quantity::from(200u64));
+        page2.insert_evm_raw(20, Arc::new(second));
         persistent.merge(&page2);
 
         let mask = (1u64 << (EvmBlockField::Timestamp as u32)) as f64;

--- a/packages/cli/src/block_store.rs
+++ b/packages/cli/src/block_store.rs
@@ -447,7 +447,7 @@ impl BlockStore {
             .iter()
             .map(|&n| u64::try_from(n).ok())
             .collect();
-        self.inner.lock().unwrap().gather_scratch(&keys, &masks)
+        self.inner.lock().unwrap().gather_scratch(&keys, masks)
     }
 
     /// Add one response's EVM blocks as a chunk (called by the HyperSync source

--- a/packages/cli/src/block_store.rs
+++ b/packages/cli/src/block_store.rs
@@ -130,10 +130,9 @@ fn decode_evm_block_columns(
     masks: &[u64],
     should_checksum: bool,
 ) -> Result<Columns> {
-    let union = masks.iter().fold(0u64, |acc, &m| acc | m);
     build_columns(
         EvmBlockField::VARIANTS,
-        union,
+        masks,
         records.len(),
         |f| f as u32,
         |f| f.name(),
@@ -258,10 +257,9 @@ fn decode_svm_block_columns(
     block_numbers: &[i64],
     masks: &[u64],
 ) -> Result<Columns> {
-    let union = masks.iter().fold(0u64, |acc, &m| acc | m);
     build_columns(
         SvmBlockField::VARIANTS,
-        union,
+        masks,
         records.len(),
         |f| f as u32,
         |f| f.name(),
@@ -561,6 +559,7 @@ pub fn svm_block_field_names() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hypersync_client::format::Quantity;
 
     fn raw_evm_block(number: u64) -> simple_types::Block {
         simple_types::Block {
@@ -758,5 +757,77 @@ mod tests {
             svm_names,
             vec!["slot", "time", "hash", "height", "parentSlot", "parentHash"]
         );
+    }
+
+    // The tests above call `decode_evm_block_columns`/`decode_svm_block_columns`
+    // directly; the ones below go through the public `materialize` method (as
+    // ReScript does), so they also cover the lock, the `f64` mask cast, and the
+    // ecosystem dispatch. `block_in_place` inside `materialize` panics without a
+    // multi-thread runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn materialize_returns_stored_extra_fields_via_store() {
+        let store = BlockStore::new_evm(false);
+        let mut block = raw_evm_block(10);
+        block.timestamp = Some(Quantity::from(555u64));
+        store.insert_evm_raw(10, Arc::new(block));
+
+        let mask = (1u64 << (EvmBlockField::Timestamp as u32)) as f64;
+        let cols = store
+            .materialize(vec![10], vec![mask])
+            .await
+            .expect("materialize");
+        match column(&cols, "timestamp") {
+            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(555)]),
+            other => panic!("expected timestamp column, got present={}", other.is_some()),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn svm_materialize_returns_stored_extra_fields_via_store() {
+        let store = BlockStore::new_svm();
+        let mut block = raw_svm_block(9);
+        block.block_height = Some(777);
+        store.insert_svm_raw(9, Arc::new(block));
+
+        let mask = (1u64 << (SvmBlockField::Height as u32)) as f64;
+        let cols = store
+            .materialize(vec![9], vec![mask])
+            .await
+            .expect("materialize");
+        match column(&cols, "height") {
+            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(777)]),
+            other => panic!("expected height column, got present={}", other.is_some()),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn merge_overwrites_existing_block_for_same_number() {
+        // A rolled-back block re-fetched with different content must replace the
+        // stale entry rather than be shadowed by it — the sequence a chain
+        // reorg drives through `ChainState`: merge a page, then merge a later
+        // page for the same (re-fetched) block number.
+        let persistent = BlockStore::new_evm(false);
+
+        let page1 = BlockStore::new_evm(false);
+        let mut first = raw_evm_block(20);
+        first.timestamp = Some(Quantity::from(100u64));
+        page1.insert_evm_raw(20, Arc::new(first));
+        persistent.merge(&page1);
+
+        let page2 = BlockStore::new_evm(false);
+        let mut second = raw_evm_block(20);
+        second.timestamp = Some(Quantity::from(200u64));
+        page2.insert_evm_raw(20, Arc::new(second));
+        persistent.merge(&page2);
+
+        let mask = (1u64 << (EvmBlockField::Timestamp as u32)) as f64;
+        let cols = persistent
+            .materialize(vec![20], vec![mask])
+            .await
+            .expect("materialize");
+        match column(&cols, "timestamp") {
+            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(200)]),
+            other => panic!("expected timestamp column, got present={}", other.is_some()),
+        }
     }
 }

--- a/packages/cli/src/block_store.rs
+++ b/packages/cli/src/block_store.rs
@@ -121,23 +121,53 @@ impl SvmBlockField {
     }
 }
 
-/// Decode the per-row mask-selected fields of the given EVM blocks into columns.
-/// `block_numbers` is the requested key per row, so `number` resolves from the
-/// key (always known) rather than a stored record.
+/// Decode the per-row mask-selected fields of the given EVM blocks into
+/// columns, then set `number`/`timestamp`/`hash` unconditionally from each
+/// row's stored header — the trio is always known from the response (kept in
+/// the store's header independent of whether the full raw block was also
+/// retained), regardless of whether any mask selected it.
 fn decode_evm_block_columns(
-    records: &[Option<Arc<simple_types::Block>>],
+    records: &[Option<EvmRecord>],
     block_numbers: &[i64],
     masks: &[u64],
     should_checksum: bool,
 ) -> Result<Columns> {
-    build_columns(
+    let raw: Vec<Option<Arc<simple_types::Block>>> = records
+        .iter()
+        .map(|r| r.as_ref().and_then(|(_, raw)| raw.clone()))
+        .collect();
+
+    let mut cols = build_columns(
         EvmBlockField::VARIANTS,
         masks,
         records.len(),
         |f| f as u32,
         |f| f.name(),
-        |f| decode_evm_block_field(f, records, block_numbers, masks, should_checksum),
-    )
+        |f| decode_evm_block_field(f, &raw, block_numbers, masks, should_checksum),
+    )?;
+    cols.columns.push((
+        EvmBlockField::Number.name(),
+        Column::I64(block_numbers.iter().map(|&n| Some(n)).collect()),
+    ));
+    cols.columns.push((
+        EvmBlockField::Timestamp.name(),
+        Column::I64(
+            records
+                .iter()
+                .map(|r| r.as_ref().map(|(h, _)| h.timestamp))
+                .collect(),
+        ),
+    ));
+    cols.columns.push((
+        EvmBlockField::Hash.name(),
+        Column::Str(
+            records
+                .iter()
+                .map(|r| r.as_ref().map(|(h, _)| h.hash.clone()))
+                .collect(),
+        ),
+    ));
+    Ok(cols)
 }
 
 /// Decode a single EVM block field, materialising it only on the rows whose mask
@@ -152,8 +182,10 @@ fn decode_evm_block_field(
 ) -> Result<Column> {
     let bit = 1u64 << (field as u32);
     Ok(match field {
-        // The block number is the store key, so it's always available regardless
-        // of whether the block row was fetched.
+        // `decode_evm_block_columns` always overlays number/timestamp/hash from
+        // the caller's own per-row values afterward, so these three arms only
+        // run (and are immediately superseded) if a caller ever sets their bits
+        // — kept for an exhaustive match rather than a live path.
         EvmBlockField::Number => Column::I64(
             block_numbers
                 .iter()
@@ -309,9 +341,29 @@ fn decode_svm_block_field(
     })
 }
 
+/// The lean header every fetched EVM block carries, independent of whether its
+/// full raw form was also retained — timestamp/hash are always known from the
+/// response, not just when an event selected a field beyond the trio.
+/// `number` isn't duplicated here since it's already the map key.
+#[derive(Clone)]
+struct EvmHeader {
+    timestamp: i64,
+    hash: String,
+}
+
+/// One EVM row's stored data: the header is always known; the raw block is
+/// only kept when an event selected a field beyond the trio.
+type EvmRecord = (EvmHeader, Option<Arc<simple_types::Block>>);
+
 /// One stored block, kept in its ecosystem's compact raw form.
 enum StoredBlock {
-    Evm(Arc<simple_types::Block>),
+    /// EVM: the header is always known (from the response); `raw` holds the
+    /// full upstream struct only when an event selected a field beyond the
+    /// always-available trio.
+    Evm {
+        header: EvmHeader,
+        raw: Option<Arc<simple_types::Block>>,
+    },
     Svm(Arc<solana_simple::Block>),
 }
 
@@ -448,8 +500,11 @@ impl BlockStore {
 
         match self.ecosystem {
             Ecosystem::Evm { should_checksum } => {
+                // The header (timestamp/hash) is always present for a stored EVM
+                // block; `raw` is only `Some` when an event selected a field
+                // beyond the trio.
                 let records = self.collect_locked(&block_numbers, |stored| match stored {
-                    StoredBlock::Evm(b) => Some(b.clone()),
+                    StoredBlock::Evm { header, raw } => Some((header.clone(), raw.clone())),
                     _ => None,
                 });
                 tokio::task::block_in_place(|| {
@@ -514,15 +569,25 @@ impl BlockStore {
         }
     }
 
-    /// Insert a raw EVM block (called by the HyperSync source while building a
-    /// page). One block per number, so a plain insert deduplicates the many logs
-    /// that share it. Not exposed to JS.
-    pub(crate) fn insert_evm_raw(&self, number: u64, block: Arc<simple_types::Block>) {
-        self.inner
-            .lock()
-            .unwrap()
-            .map
-            .insert(number, StoredBlock::Evm(block));
+    /// Insert an EVM block's header — always known from the response — and,
+    /// optionally, its full raw form (only kept when an event selected a field
+    /// beyond the always-available trio). Called once per response block while
+    /// building a page; one block per number, so a plain insert deduplicates
+    /// the many logs that share it. Not exposed to JS.
+    pub(crate) fn insert_evm(
+        &self,
+        number: u64,
+        timestamp: i64,
+        hash: String,
+        raw: Option<Arc<simple_types::Block>>,
+    ) {
+        self.inner.lock().unwrap().map.insert(
+            number,
+            StoredBlock::Evm {
+                header: EvmHeader { timestamp, hash },
+                raw,
+            },
+        );
     }
 
     /// Insert a raw SVM block keyed by slot (called by the SVM HyperSync source
@@ -568,6 +633,20 @@ mod tests {
         }
     }
 
+    fn evm_record(
+        timestamp: i64,
+        hash: &str,
+        raw: Option<Arc<simple_types::Block>>,
+    ) -> Option<EvmRecord> {
+        Some((
+            EvmHeader {
+                timestamp,
+                hash: hash.to_string(),
+            },
+            raw,
+        ))
+    }
+
     fn raw_svm_block(slot: u64) -> solana_simple::Block {
         solana_simple::Block {
             slot,
@@ -588,57 +667,107 @@ mod tests {
     fn decode_selected_only_materialises_masked_fields() {
         // Select only `logsBloom` via the bitmask.
         let mask = 1u64 << (EvmBlockField::LogsBloom as u32);
-        let cols =
-            decode_evm_block_columns(&[Some(Arc::new(raw_evm_block(1)))], &[1], &[mask], false)
-                .expect("decode columns");
-
-        // Exactly one column (logsBloom) is present; number (resolvable from the
-        // key but unselected) and gasUsed are absent.
-        assert!(column(&cols, "logsBloom").is_some());
-        assert!(column(&cols, "number").is_none());
-        assert!(column(&cols, "gasUsed").is_none());
-    }
-
-    #[test]
-    fn number_comes_from_key_even_on_miss() {
-        // A missing record (None) still materialises the requested key as
-        // `number`, so it never depends on a fetched block row.
-        let mask = 1u64 << (EvmBlockField::Number as u32);
         let cols = decode_evm_block_columns(
-            &[None, Some(Arc::new(raw_evm_block(3)))],
-            &[7, 3],
-            &[mask, mask],
+            &[evm_record(11, "0x1", Some(Arc::new(raw_evm_block(1))))],
+            &[1],
+            &[mask],
             false,
         )
         .expect("decode columns");
-        match column(&cols, "number") {
-            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(7), Some(3)]),
-            other => panic!(
-                "expected number i64 column, got present={}",
-                other.is_some()
-            ),
-        }
+
+        // logsBloom is selected (present); gasUsed isn't (absent).
+        // number/timestamp/hash are always present from the header, regardless
+        // of the mask.
+        let summary = (
+            column(&cols, "logsBloom").is_some(),
+            column(&cols, "gasUsed").is_some(),
+            match column(&cols, "number") {
+                Some(Column::I64(v)) => v.clone(),
+                _ => panic!("expected number column"),
+            },
+            match column(&cols, "timestamp") {
+                Some(Column::I64(v)) => v.clone(),
+                _ => panic!("expected timestamp column"),
+            },
+            match column(&cols, "hash") {
+                Some(Column::Str(v)) => v.clone(),
+                _ => panic!("expected hash column"),
+            },
+        );
+        assert_eq!(
+            summary,
+            (
+                true,
+                false,
+                vec![Some(1)],
+                vec![Some(11)],
+                vec![Some("0x1".to_string())],
+            )
+        );
+    }
+
+    #[test]
+    fn trio_always_set_from_header_regardless_of_mask_or_raw_record() {
+        // mask=0 (nothing selected) and no raw record for either row; the trio
+        // still materialises from each row's stored header, since it never
+        // depends on the mask or a fetched raw block.
+        let cols = decode_evm_block_columns(
+            &[evm_record(70, "0x7", None), evm_record(30, "0x3", None)],
+            &[7, 3],
+            &[0, 0],
+            false,
+        )
+        .expect("decode columns");
+
+        let summary = (
+            match column(&cols, "number") {
+                Some(Column::I64(v)) => v.clone(),
+                _ => panic!("expected number column"),
+            },
+            match column(&cols, "timestamp") {
+                Some(Column::I64(v)) => v.clone(),
+                _ => panic!("expected timestamp column"),
+            },
+            match column(&cols, "hash") {
+                Some(Column::Str(v)) => v.clone(),
+                _ => panic!("expected hash column"),
+            },
+        );
+        assert_eq!(
+            summary,
+            (
+                vec![Some(7), Some(3)],
+                vec![Some(70), Some(30)],
+                vec![Some("0x7".to_string()), Some("0x3".to_string())],
+            )
+        );
     }
 
     #[test]
     fn decode_applies_each_rows_own_mask() {
-        // Row 0 selects `number`; row 1 selects nothing. The key-derived `number`
-        // column is present only on the row whose own mask has the bit set.
-        let number_mask = 1u64 << (EvmBlockField::Number as u32);
+        // Both rows have a real `gasUsed` value on their raw record, but only
+        // row 0 selects it via its own mask — proving the mask, not the
+        // record, gates whether a row's value materialises.
+        let mut block1 = raw_evm_block(1);
+        block1.gas_used = Some(Quantity::from(100u64));
+        let mut block2 = raw_evm_block(2);
+        block2.gas_used = Some(Quantity::from(200u64));
+
+        let gas_used_mask = 1u64 << (EvmBlockField::GasUsed as u32);
         let cols = decode_evm_block_columns(
             &[
-                Some(Arc::new(raw_evm_block(1))),
-                Some(Arc::new(raw_evm_block(2))),
+                evm_record(11, "0x1", Some(Arc::new(block1))),
+                evm_record(22, "0x2", Some(Arc::new(block2))),
             ],
             &[1, 2],
-            &[number_mask, 0],
+            &[gas_used_mask, 0],
             false,
         )
         .expect("decode columns");
 
-        match column(&cols, "number") {
-            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(1), None]),
-            other => panic!("expected number column, got present={}", other.is_some()),
+        match column(&cols, "gasUsed") {
+            Some(Column::Big(v)) => assert_eq!((v[0].is_some(), v[1].is_some()), (true, false)),
+            other => panic!("expected gasUsed column, got present={}", other.is_some()),
         }
     }
 
@@ -681,7 +810,12 @@ mod tests {
     fn prune_and_rollback_drop_by_block() {
         let store = BlockStore::new_evm(false);
         for block in [10u64, 20, 30] {
-            store.insert_evm_raw(block, Arc::new(raw_evm_block(block)));
+            store.insert_evm(
+                block,
+                0,
+                "0x0".to_string(),
+                Some(Arc::new(raw_evm_block(block))),
+            );
         }
 
         store.prune(10);
@@ -768,18 +902,32 @@ mod tests {
     async fn materialize_returns_stored_extra_fields_via_store() {
         let store = BlockStore::new_evm(false);
         let mut block = raw_evm_block(10);
-        block.timestamp = Some(Quantity::from(555u64));
-        store.insert_evm_raw(10, Arc::new(block));
+        block.gas_used = Some(Quantity::from(555u64));
+        store.insert_evm(10, 999, "0xhash".to_string(), Some(Arc::new(block)));
 
-        let mask = (1u64 << (EvmBlockField::Timestamp as u32)) as f64;
+        let mask = (1u64 << (EvmBlockField::GasUsed as u32)) as f64;
         let cols = store
             .materialize(vec![10], vec![mask])
             .await
             .expect("materialize");
-        match column(&cols, "timestamp") {
-            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(555)]),
-            other => panic!("expected timestamp column, got present={}", other.is_some()),
-        }
+        // gasUsed (the selected extra field) round-trips through the store;
+        // the header (timestamp/hash) is always set too, regardless of the
+        // mask.
+        let summary = (
+            column(&cols, "gasUsed").is_some(),
+            match column(&cols, "timestamp") {
+                Some(Column::I64(v)) => v.clone(),
+                _ => panic!("expected timestamp column"),
+            },
+            match column(&cols, "hash") {
+                Some(Column::Str(v)) => v.clone(),
+                _ => panic!("expected hash column"),
+            },
+        );
+        assert_eq!(
+            summary,
+            (true, vec![Some(999)], vec![Some("0xhash".to_string())])
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -805,24 +953,21 @@ mod tests {
         // A rolled-back block re-fetched with different content must replace the
         // stale entry rather than be shadowed by it — the sequence a chain
         // reorg drives through `ChainState`: merge a page, then merge a later
-        // page for the same (re-fetched) block number.
+        // page for the same (re-fetched) block number. No raw block needed
+        // here: the header alone (set directly via `insert_evm`) is enough to
+        // prove the overwrite.
         let persistent = BlockStore::new_evm(false);
 
         let page1 = BlockStore::new_evm(false);
-        let mut first = raw_evm_block(20);
-        first.timestamp = Some(Quantity::from(100u64));
-        page1.insert_evm_raw(20, Arc::new(first));
+        page1.insert_evm(20, 100, "0x100".to_string(), None);
         persistent.merge(&page1);
 
         let page2 = BlockStore::new_evm(false);
-        let mut second = raw_evm_block(20);
-        second.timestamp = Some(Quantity::from(200u64));
-        page2.insert_evm_raw(20, Arc::new(second));
+        page2.insert_evm(20, 200, "0x200".to_string(), None);
         persistent.merge(&page2);
 
-        let mask = (1u64 << (EvmBlockField::Timestamp as u32)) as f64;
         let cols = persistent
-            .materialize(vec![20], vec![mask])
+            .materialize(vec![20], vec![0.])
             .await
             .expect("materialize");
         match column(&cols, "timestamp") {

--- a/packages/cli/src/block_store.rs
+++ b/packages/cli/src/block_store.rs
@@ -18,7 +18,7 @@ use napi_derive::napi;
 use strum::VariantArray;
 
 use crate::evm_hypersync_source::map_err;
-use crate::evm_hypersync_source::types::{map_address_string, map_bigint, map_hex_string, map_i64};
+use crate::evm_hypersync_source::types::{map_address_string, map_bigint, map_hex_string};
 use crate::field_columns::{build_columns, fill_masked, Column, Columns};
 
 /// EVM block field codes shared with ReScript by ordinal value. The order is the
@@ -122,10 +122,9 @@ impl SvmBlockField {
 }
 
 /// Decode the per-row mask-selected fields of the given EVM blocks into
-/// columns, then set `number`/`timestamp`/`hash` unconditionally from each
-/// row's stored header — the trio is always known from the response (kept in
-/// the store's header independent of whether the full raw block was also
-/// retained), regardless of whether any mask selected it.
+/// columns. ReScript builds the masks from the config's field selection, which
+/// always includes number/timestamp/hash, so the trio's bits are set on every
+/// production mask.
 fn decode_evm_block_columns(
     records: &[Option<EvmRecord>],
     block_numbers: &[i64],
@@ -137,55 +136,32 @@ fn decode_evm_block_columns(
         .map(|r| r.as_ref().and_then(|(_, raw)| raw.clone()))
         .collect();
 
-    let mut cols = build_columns(
+    build_columns(
         EvmBlockField::VARIANTS,
         masks,
         records.len(),
         |f| f as u32,
         |f| f.name(),
-        |f| decode_evm_block_field(f, &raw, block_numbers, masks, should_checksum),
-    )?;
-    cols.columns.push((
-        EvmBlockField::Number.name(),
-        Column::I64(block_numbers.iter().map(|&n| Some(n)).collect()),
-    ));
-    cols.columns.push((
-        EvmBlockField::Timestamp.name(),
-        Column::I64(
-            records
-                .iter()
-                .map(|r| r.as_ref().map(|(h, _)| h.timestamp))
-                .collect(),
-        ),
-    ));
-    cols.columns.push((
-        EvmBlockField::Hash.name(),
-        Column::Str(
-            records
-                .iter()
-                .map(|r| r.as_ref().map(|(h, _)| h.hash.clone()))
-                .collect(),
-        ),
-    ));
-    Ok(cols)
+        |f| decode_evm_block_field(f, records, &raw, block_numbers, masks, should_checksum),
+    )
 }
 
 /// Decode a single EVM block field, materialising it only on the rows whose mask
-/// has the field's bit set. Exhaustive match: adding an `EvmBlockField` variant
-/// fails to compile until it is decoded here.
+/// has the field's bit set. Number/timestamp/hash resolve from the key and the
+/// stored header (known for every stored block); the rest decode from the raw
+/// block, retained only when a field beyond those three was selected. Exhaustive
+/// match: adding an `EvmBlockField` variant fails to compile until it is decoded
+/// here.
 fn decode_evm_block_field(
     field: EvmBlockField,
-    records: &[Option<Arc<simple_types::Block>>],
+    records: &[Option<EvmRecord>],
+    raw: &[Option<Arc<simple_types::Block>>],
     block_numbers: &[i64],
     masks: &[u64],
     should_checksum: bool,
 ) -> Result<Column> {
     let bit = 1u64 << (field as u32);
     Ok(match field {
-        // `decode_evm_block_columns` always overlays number/timestamp/hash from
-        // the caller's own per-row values afterward, so these three arms only
-        // run (and are immediately superseded) if a caller ever sets their bits
-        // — kept for an exhaustive match rather than a live path.
         EvmBlockField::Number => Column::I64(
             block_numbers
                 .iter()
@@ -193,89 +169,107 @@ fn decode_evm_block_field(
                 .map(|(&n, &m)| (m & bit != 0).then_some(n))
                 .collect(),
         ),
-        EvmBlockField::Timestamp => {
-            Column::I64(fill_masked(records, masks, bit, |b| map_i64(&b.timestamp))?)
-        }
-        EvmBlockField::Hash => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.hash))
-        })?),
-        EvmBlockField::ParentHash => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::Timestamp => Column::I64(
+            records
+                .iter()
+                .zip(masks)
+                .map(|(r, &m)| {
+                    if m & bit == 0 {
+                        None
+                    } else {
+                        r.as_ref().map(|(h, _)| h.timestamp)
+                    }
+                })
+                .collect(),
+        ),
+        EvmBlockField::Hash => Column::Str(
+            records
+                .iter()
+                .zip(masks)
+                .map(|(r, &m)| {
+                    if m & bit == 0 {
+                        None
+                    } else {
+                        r.as_ref().map(|(h, _)| h.hash.clone())
+                    }
+                })
+                .collect(),
+        ),
+        EvmBlockField::ParentHash => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.parent_hash))
         })?),
-        EvmBlockField::Nonce => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.nonce))
-        })?),
-        EvmBlockField::Sha3Uncles => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::Nonce => {
+            Column::Big(fill_masked(raw, masks, bit, |b| Ok(map_bigint(&b.nonce)))?)
+        }
+        EvmBlockField::Sha3Uncles => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.sha3_uncles))
         })?),
-        EvmBlockField::LogsBloom => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::LogsBloom => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.logs_bloom))
         })?),
-        EvmBlockField::TransactionsRoot => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::TransactionsRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.transactions_root))
         })?),
-        EvmBlockField::StateRoot => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::StateRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.state_root))
         })?),
-        EvmBlockField::ReceiptsRoot => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::ReceiptsRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.receipts_root))
         })?),
-        EvmBlockField::Miner => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::Miner => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_address_string(&b.miner, should_checksum))
         })?),
-        EvmBlockField::Difficulty => Column::Big(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::Difficulty => Column::Big(fill_masked(raw, masks, bit, |b| {
             Ok(map_bigint(&b.difficulty))
         })?),
-        EvmBlockField::TotalDifficulty => Column::Big(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::TotalDifficulty => Column::Big(fill_masked(raw, masks, bit, |b| {
             Ok(map_bigint(&b.total_difficulty))
         })?),
-        EvmBlockField::ExtraData => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::ExtraData => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.extra_data))
         })?),
-        EvmBlockField::Size => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.size))
-        })?),
-        EvmBlockField::GasLimit => Column::Big(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::Size => {
+            Column::Big(fill_masked(raw, masks, bit, |b| Ok(map_bigint(&b.size)))?)
+        }
+        EvmBlockField::GasLimit => Column::Big(fill_masked(raw, masks, bit, |b| {
             Ok(map_bigint(&b.gas_limit))
         })?),
-        EvmBlockField::GasUsed => Column::Big(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::GasUsed => Column::Big(fill_masked(raw, masks, bit, |b| {
             Ok(map_bigint(&b.gas_used))
         })?),
-        EvmBlockField::Uncles => Column::StrVec(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::Uncles => Column::StrVec(fill_masked(raw, masks, bit, |b| {
             Ok(b.uncles
                 .as_ref()
                 .map(|arr| arr.iter().map(|u| u.encode_hex()).collect()))
         })?),
-        EvmBlockField::BaseFeePerGas => Column::Big(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::BaseFeePerGas => Column::Big(fill_masked(raw, masks, bit, |b| {
             Ok(map_bigint(&b.base_fee_per_gas))
         })?),
-        EvmBlockField::BlobGasUsed => Column::Big(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::BlobGasUsed => Column::Big(fill_masked(raw, masks, bit, |b| {
             Ok(map_bigint(&b.blob_gas_used))
         })?),
-        EvmBlockField::ExcessBlobGas => Column::Big(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::ExcessBlobGas => Column::Big(fill_masked(raw, masks, bit, |b| {
             Ok(map_bigint(&b.excess_blob_gas))
         })?),
-        EvmBlockField::ParentBeaconBlockRoot => {
-            Column::Str(fill_masked(records, masks, bit, |b| {
-                Ok(map_hex_string(&b.parent_beacon_block_root))
-            })?)
-        }
-        EvmBlockField::WithdrawalsRoot => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::ParentBeaconBlockRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
+            Ok(map_hex_string(&b.parent_beacon_block_root))
+        })?),
+        EvmBlockField::WithdrawalsRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.withdrawals_root))
         })?),
-        EvmBlockField::L1BlockNumber => Column::I64(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::L1BlockNumber => Column::I64(fill_masked(raw, masks, bit, |b| {
             b.l1_block_number
                 .map(|n| i64::try_from(u64::from(n)))
                 .transpose()
                 .context("l1BlockNumber overflow")
         })?),
-        EvmBlockField::SendCount => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::SendCount => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.send_count))
         })?),
-        EvmBlockField::SendRoot => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::SendRoot => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.send_root))
         })?),
-        EvmBlockField::MixHash => Column::Str(fill_masked(records, masks, bit, |b| {
+        EvmBlockField::MixHash => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(map_hex_string(&b.mix_hash))
         })?),
     })
@@ -304,7 +298,7 @@ fn decode_svm_block_columns(
 /// fails to compile until it is decoded here.
 fn decode_svm_block_field(
     field: SvmBlockField,
-    records: &[Option<Arc<solana_simple::Block>>],
+    raw: &[Option<Arc<solana_simple::Block>>],
     block_numbers: &[i64],
     masks: &[u64],
 ) -> Result<Column> {
@@ -319,23 +313,23 @@ fn decode_svm_block_field(
                 .map(|(&n, &m)| (m & bit != 0).then_some(n))
                 .collect(),
         ),
-        SvmBlockField::Time => Column::I64(fill_masked(records, masks, bit, |b| Ok(b.block_time))?),
-        SvmBlockField::Hash => Column::Str(fill_masked(records, masks, bit, |b| {
+        SvmBlockField::Time => Column::I64(fill_masked(raw, masks, bit, |b| Ok(b.block_time))?),
+        SvmBlockField::Hash => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(Some(b.blockhash.clone()))
         })?),
-        SvmBlockField::Height => Column::I64(fill_masked(records, masks, bit, |b| {
+        SvmBlockField::Height => Column::I64(fill_masked(raw, masks, bit, |b| {
             b.block_height
                 .map(i64::try_from)
                 .transpose()
                 .context("height overflow")
         })?),
-        SvmBlockField::ParentSlot => Column::I64(fill_masked(records, masks, bit, |b| {
+        SvmBlockField::ParentSlot => Column::I64(fill_masked(raw, masks, bit, |b| {
             b.parent_slot
                 .map(i64::try_from)
                 .transpose()
                 .context("parentSlot overflow")
         })?),
-        SvmBlockField::ParentHash => Column::Str(fill_masked(records, masks, bit, |b| {
+        SvmBlockField::ParentHash => Column::Str(fill_masked(raw, masks, bit, |b| {
             Ok(b.parent_blockhash.clone())
         })?),
     })
@@ -675,46 +669,30 @@ mod tests {
         )
         .expect("decode columns");
 
-        // logsBloom is selected (present); gasUsed isn't (absent).
-        // number/timestamp/hash are always present from the header, regardless
-        // of the mask.
+        // Only the selected column is present — the trio is mask-gated like
+        // every other field (production masks always carry its bits).
         let summary = (
             column(&cols, "logsBloom").is_some(),
             column(&cols, "gasUsed").is_some(),
-            match column(&cols, "number") {
-                Some(Column::I64(v)) => v.clone(),
-                _ => panic!("expected number column"),
-            },
-            match column(&cols, "timestamp") {
-                Some(Column::I64(v)) => v.clone(),
-                _ => panic!("expected timestamp column"),
-            },
-            match column(&cols, "hash") {
-                Some(Column::Str(v)) => v.clone(),
-                _ => panic!("expected hash column"),
-            },
+            column(&cols, "number").is_some(),
+            column(&cols, "timestamp").is_some(),
+            column(&cols, "hash").is_some(),
         );
-        assert_eq!(
-            summary,
-            (
-                true,
-                false,
-                vec![Some(1)],
-                vec![Some(11)],
-                vec![Some("0x1".to_string())],
-            )
-        );
+        assert_eq!(summary, (true, false, false, false, false));
     }
 
     #[test]
-    fn trio_always_set_from_header_regardless_of_mask_or_raw_record() {
-        // mask=0 (nothing selected) and no raw record for either row; the trio
-        // still materialises from each row's stored header, since it never
-        // depends on the mask or a fetched raw block.
+    fn trio_decodes_from_key_and_header_without_raw_record() {
+        // The trio never needs the raw block: number resolves from the key and
+        // timestamp/hash from the stored header, so rows without a raw record
+        // (no field beyond the trio selected) still materialise it.
+        let trio_mask = (1u64 << (EvmBlockField::Number as u32))
+            | (1u64 << (EvmBlockField::Timestamp as u32))
+            | (1u64 << (EvmBlockField::Hash as u32));
         let cols = decode_evm_block_columns(
             &[evm_record(70, "0x7", None), evm_record(30, "0x3", None)],
             &[7, 3],
-            &[0, 0],
+            &[trio_mask, trio_mask],
             false,
         )
         .expect("decode columns");
@@ -905,16 +883,22 @@ mod tests {
         block.gas_used = Some(Quantity::from(555u64));
         store.insert_evm(10, 999, "0xhash".to_string(), Some(Arc::new(block)));
 
-        let mask = (1u64 << (EvmBlockField::GasUsed as u32)) as f64;
+        // A production-shaped mask: the config-extended trio plus a selected
+        // extra field. The trio resolves from the key/header, gasUsed from raw.
+        let mask = ((1u64 << (EvmBlockField::Number as u32))
+            | (1u64 << (EvmBlockField::Timestamp as u32))
+            | (1u64 << (EvmBlockField::Hash as u32))
+            | (1u64 << (EvmBlockField::GasUsed as u32))) as f64;
         let cols = store
             .materialize(vec![10], vec![mask])
             .await
             .expect("materialize");
-        // gasUsed (the selected extra field) round-trips through the store;
-        // the header (timestamp/hash) is always set too, regardless of the
-        // mask.
         let summary = (
             column(&cols, "gasUsed").is_some(),
+            match column(&cols, "number") {
+                Some(Column::I64(v)) => v.clone(),
+                _ => panic!("expected number column"),
+            },
             match column(&cols, "timestamp") {
                 Some(Column::I64(v)) => v.clone(),
                 _ => panic!("expected timestamp column"),
@@ -926,7 +910,12 @@ mod tests {
         );
         assert_eq!(
             summary,
-            (true, vec![Some(999)], vec![Some("0xhash".to_string())])
+            (
+                true,
+                vec![Some(10)],
+                vec![Some(999)],
+                vec![Some("0xhash".to_string())]
+            )
         );
     }
 
@@ -966,8 +955,9 @@ mod tests {
         page2.insert_evm(20, 200, "0x200".to_string(), None);
         persistent.merge(&page2);
 
+        let mask = (1u64 << (EvmBlockField::Timestamp as u32)) as f64;
         let cols = persistent
-            .materialize(vec![20], vec![0.])
+            .materialize(vec![20], vec![mask])
             .await
             .expect("materialize");
         match column(&cols, "timestamp") {

--- a/packages/cli/src/block_store.rs
+++ b/packages/cli/src/block_store.rs
@@ -1,25 +1,27 @@
-//! Per-chain block store. Blocks are kept as raw upstream structs (their large
-//! fields never cross the napi boundary until they are read), keyed by block
-//! number (slot on SVM). One block per number — many logs/instructions share it —
-//! so a plain insert deduplicates. At batch preparation the fields a chain's
-//! events selected are decoded in bulk, off the JS thread, into columnar form;
-//! the main thread zips the columns into plain JS objects. The store lives on the
-//! ReScript `ChainState`; fetch responses merge in, and entries are pruned/rolled
-//! back by block.
+//! Per-chain block store, chunk-columnar: every fetch response contributes one
+//! chunk of blocks (keyed by number — slot on SVM) holding only the selected
+//! fields' columns. Large values never cross the napi boundary until read. At
+//! batch preparation the fields a chain's events selected are gathered under
+//! the store lock and decoded in bulk, off the JS thread, into columnar form;
+//! the main thread zips the columns into plain JS objects. The store lives on
+//! the ReScript `ChainState`; fetch responses merge in, and rows are pruned or
+//! rolled back by block via the chunk lifecycle.
 
-use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use anyhow::{Context, Result};
-use hypersync_client::format::Hex;
 use hypersync_client::simple_types;
 use hypersync_client_solana::simple_types as solana_simple;
 use napi_derive::napi;
 use strum::VariantArray;
 
+use crate::chunk_store::{
+    bytes_cells, fixed_from, hash_list_cells, hash_list_from, hex_full, hex_quantity, i64_cells,
+    i64_from, u64_cells, u64_from, utf8, var_from, AnyCol, Chunk, ChunkStore,
+};
 use crate::evm_hypersync_source::map_err;
-use crate::evm_hypersync_source::types::{map_address_string, map_bigint, map_hex_string, map_i64};
-use crate::field_columns::{build_columns, fill_masked, Column, Columns};
+use crate::evm_hypersync_source::types::{encode_address, map_bigint, map_i64};
+use crate::field_columns::{build_columns, Column, Columns};
 
 /// EVM block field codes shared with ReScript by ordinal value. The order is the
 /// contract: it mirrors `Evm.res` `blockFields`, and the ordinal is the bit
@@ -121,11 +123,110 @@ impl SvmBlockField {
     }
 }
 
-/// Decode the per-row mask-selected fields of the given EVM blocks into columns.
-/// `block_numbers` is the requested key per row, so `number` resolves from the
-/// key (always known) rather than a stored record.
+fn bytes<T: AsRef<[u8]>>(v: &T) -> &[u8] {
+    v.as_ref()
+}
+
+/// Build one EVM field's column from a response's blocks. `None` for the
+/// key-derived `number` and for fields no block carries. Exhaustive match:
+/// adding an `EvmBlockField` variant fails to compile until it is filled here
+/// and decoded below.
+fn evm_block_col(field: EvmBlockField, blocks: &[simple_types::Block]) -> Option<AnyCol> {
+    use EvmBlockField::*;
+    match field {
+        // The block number is the chunk key, not a column.
+        Number => None,
+        Timestamp => var_from(blocks, |b| b.timestamp.as_ref().map(bytes)),
+        Hash => fixed_from(blocks, 32, |b| b.hash.as_ref().map(bytes)),
+        ParentHash => fixed_from(blocks, 32, |b| b.parent_hash.as_ref().map(bytes)),
+        Nonce => fixed_from(blocks, 8, |b| b.nonce.as_ref().map(bytes)),
+        Sha3Uncles => fixed_from(blocks, 32, |b| b.sha3_uncles.as_ref().map(bytes)),
+        LogsBloom => var_from(blocks, |b| b.logs_bloom.as_ref().map(bytes)),
+        TransactionsRoot => fixed_from(blocks, 32, |b| b.transactions_root.as_ref().map(bytes)),
+        StateRoot => fixed_from(blocks, 32, |b| b.state_root.as_ref().map(bytes)),
+        ReceiptsRoot => fixed_from(blocks, 32, |b| b.receipts_root.as_ref().map(bytes)),
+        Miner => fixed_from(blocks, 20, |b| b.miner.as_ref().map(bytes)),
+        Difficulty => var_from(blocks, |b| b.difficulty.as_ref().map(bytes)),
+        TotalDifficulty => var_from(blocks, |b| b.total_difficulty.as_ref().map(bytes)),
+        ExtraData => var_from(blocks, |b| b.extra_data.as_ref().map(bytes)),
+        Size => var_from(blocks, |b| b.size.as_ref().map(bytes)),
+        GasLimit => var_from(blocks, |b| b.gas_limit.as_ref().map(bytes)),
+        GasUsed => var_from(blocks, |b| b.gas_used.as_ref().map(bytes)),
+        Uncles => hash_list_from(blocks, |b| {
+            b.uncles.as_ref().map(|v| {
+                v.iter()
+                    .map(|h| <[u8; 32]>::try_from(h.as_ref()).expect("uncle hash width"))
+                    .collect()
+            })
+        }),
+        BaseFeePerGas => var_from(blocks, |b| b.base_fee_per_gas.as_ref().map(bytes)),
+        BlobGasUsed => var_from(blocks, |b| b.blob_gas_used.as_ref().map(bytes)),
+        ExcessBlobGas => var_from(blocks, |b| b.excess_blob_gas.as_ref().map(bytes)),
+        ParentBeaconBlockRoot => fixed_from(blocks, 32, |b| {
+            b.parent_beacon_block_root.as_ref().map(bytes)
+        }),
+        WithdrawalsRoot => fixed_from(blocks, 32, |b| b.withdrawals_root.as_ref().map(bytes)),
+        L1BlockNumber => u64_from(blocks, |b| b.l1_block_number.map(u64::from)),
+        SendCount => var_from(blocks, |b| b.send_count.as_ref().map(bytes)),
+        SendRoot => fixed_from(blocks, 32, |b| b.send_root.as_ref().map(bytes)),
+        MixHash => fixed_from(blocks, 32, |b| b.mix_hash.as_ref().map(bytes)),
+    }
+}
+
+/// Decode one EVM field from its gathered scratch column, already masked
+/// per-row by the gather.
+fn decode_evm_block_field(
+    field: EvmBlockField,
+    scratch: &[Option<AnyCol>],
+    block_numbers: &[i64],
+    masks: &[u64],
+    should_checksum: bool,
+) -> Result<Column> {
+    use EvmBlockField::*;
+    let bit = 1u64 << (field as u32);
+    let col = scratch[field as usize].as_ref();
+    let len = block_numbers.len();
+    Ok(match field {
+        // The block number is the store key, so it's always available regardless
+        // of whether the block row was fetched.
+        Number => Column::I64(
+            block_numbers
+                .iter()
+                .zip(masks)
+                .map(|(&n, &m)| (m & bit != 0).then_some(n))
+                .collect(),
+        ),
+        Timestamp => Column::I64(bytes_cells(col, len, |b| map_i64(&Some(b)))?),
+        Hash
+        | ParentHash
+        | Sha3Uncles
+        | LogsBloom
+        | TransactionsRoot
+        | StateRoot
+        | ReceiptsRoot
+        | ExtraData
+        | ParentBeaconBlockRoot
+        | WithdrawalsRoot
+        | SendRoot
+        | MixHash => Column::Str(bytes_cells(col, len, |b| Ok(Some(hex_full(b))))?),
+        Nonce | Difficulty | TotalDifficulty | Size | GasLimit | GasUsed | BaseFeePerGas
+        | BlobGasUsed | ExcessBlobGas => {
+            Column::Big(bytes_cells(col, len, |b| Ok(map_bigint(&Some(b))))?)
+        }
+        Miner => Column::Str(bytes_cells(col, len, |b| {
+            let address = <[u8; 20]>::try_from(b).expect("miner cell width");
+            Ok(Some(encode_address(&address.into(), should_checksum)))
+        })?),
+        Uncles => Column::StrVec(hash_list_cells(col, len, |h| hex_full(h))),
+        L1BlockNumber => Column::I64(u64_cells(col, len, |v| {
+            i64::try_from(v).map(Some).context("l1BlockNumber overflow")
+        })?),
+        SendCount => Column::Str(bytes_cells(col, len, |b| Ok(Some(hex_quantity(b))))?),
+    })
+}
+
 fn decode_evm_block_columns(
-    records: &[Option<Arc<simple_types::Block>>],
+    scratch: &[Option<AnyCol>],
     block_numbers: &[i64],
     masks: &[u64],
     should_checksum: bool,
@@ -133,236 +234,74 @@ fn decode_evm_block_columns(
     build_columns(
         EvmBlockField::VARIANTS,
         masks,
-        records.len(),
+        block_numbers.len(),
         |f| f as u32,
         |f| f.name(),
-        |f| decode_evm_block_field(f, records, block_numbers, masks, should_checksum),
+        |f| decode_evm_block_field(f, scratch, block_numbers, masks, should_checksum),
     )
 }
 
-/// Decode a single EVM block field, materialising it only on the rows whose mask
-/// has the field's bit set. Exhaustive match: adding an `EvmBlockField` variant
-/// fails to compile until it is decoded here.
-fn decode_evm_block_field(
-    field: EvmBlockField,
-    records: &[Option<Arc<simple_types::Block>>],
+/// Build one SVM field's column from a response's blocks; `None` for the
+/// key-derived `slot`.
+fn svm_block_col(field: SvmBlockField, blocks: &[solana_simple::Block]) -> Option<AnyCol> {
+    use SvmBlockField::*;
+    match field {
+        // The slot is the chunk key, not a column.
+        Slot => None,
+        Time => i64_from(blocks, |b| b.block_time),
+        Hash => var_from(blocks, |b| Some(b.blockhash.as_bytes())),
+        Height => u64_from(blocks, |b| b.block_height),
+        ParentSlot => u64_from(blocks, |b| b.parent_slot),
+        ParentHash => var_from(blocks, |b| {
+            b.parent_blockhash.as_ref().map(|s| s.as_bytes())
+        }),
+    }
+}
+
+fn decode_svm_block_field(
+    field: SvmBlockField,
+    scratch: &[Option<AnyCol>],
     block_numbers: &[i64],
     masks: &[u64],
-    should_checksum: bool,
 ) -> Result<Column> {
+    use SvmBlockField::*;
     let bit = 1u64 << (field as u32);
+    let col = scratch[field as usize].as_ref();
+    let len = block_numbers.len();
     Ok(match field {
-        // The block number is the store key, so it's always available regardless
-        // of whether the block row was fetched.
-        EvmBlockField::Number => Column::I64(
+        // The slot is the store key, so it's always available regardless of
+        // whether the block row was fetched.
+        Slot => Column::I64(
             block_numbers
                 .iter()
                 .zip(masks)
                 .map(|(&n, &m)| (m & bit != 0).then_some(n))
                 .collect(),
         ),
-        EvmBlockField::Timestamp => {
-            Column::I64(fill_masked(records, masks, bit, |b| map_i64(&b.timestamp))?)
-        }
-        EvmBlockField::Hash => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.hash))
+        Time => Column::I64(i64_cells(col, len)),
+        Hash | ParentHash => Column::Str(bytes_cells(col, len, |b| Ok(Some(utf8(b))))?),
+        Height => Column::I64(u64_cells(col, len, |v| {
+            i64::try_from(v).map(Some).context("height overflow")
         })?),
-        EvmBlockField::ParentHash => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.parent_hash))
-        })?),
-        EvmBlockField::Nonce => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.nonce))
-        })?),
-        EvmBlockField::Sha3Uncles => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.sha3_uncles))
-        })?),
-        EvmBlockField::LogsBloom => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.logs_bloom))
-        })?),
-        EvmBlockField::TransactionsRoot => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.transactions_root))
-        })?),
-        EvmBlockField::StateRoot => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.state_root))
-        })?),
-        EvmBlockField::ReceiptsRoot => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.receipts_root))
-        })?),
-        EvmBlockField::Miner => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_address_string(&b.miner, should_checksum))
-        })?),
-        EvmBlockField::Difficulty => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.difficulty))
-        })?),
-        EvmBlockField::TotalDifficulty => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.total_difficulty))
-        })?),
-        EvmBlockField::ExtraData => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.extra_data))
-        })?),
-        EvmBlockField::Size => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.size))
-        })?),
-        EvmBlockField::GasLimit => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.gas_limit))
-        })?),
-        EvmBlockField::GasUsed => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.gas_used))
-        })?),
-        EvmBlockField::Uncles => Column::StrVec(fill_masked(records, masks, bit, |b| {
-            Ok(b.uncles
-                .as_ref()
-                .map(|arr| arr.iter().map(|u| u.encode_hex()).collect()))
-        })?),
-        EvmBlockField::BaseFeePerGas => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.base_fee_per_gas))
-        })?),
-        EvmBlockField::BlobGasUsed => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.blob_gas_used))
-        })?),
-        EvmBlockField::ExcessBlobGas => Column::Big(fill_masked(records, masks, bit, |b| {
-            Ok(map_bigint(&b.excess_blob_gas))
-        })?),
-        EvmBlockField::ParentBeaconBlockRoot => {
-            Column::Str(fill_masked(records, masks, bit, |b| {
-                Ok(map_hex_string(&b.parent_beacon_block_root))
-            })?)
-        }
-        EvmBlockField::WithdrawalsRoot => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.withdrawals_root))
-        })?),
-        EvmBlockField::L1BlockNumber => Column::I64(fill_masked(records, masks, bit, |b| {
-            b.l1_block_number
-                .map(|n| i64::try_from(u64::from(n)))
-                .transpose()
-                .context("l1BlockNumber overflow")
-        })?),
-        EvmBlockField::SendCount => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.send_count))
-        })?),
-        EvmBlockField::SendRoot => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.send_root))
-        })?),
-        EvmBlockField::MixHash => Column::Str(fill_masked(records, masks, bit, |b| {
-            Ok(map_hex_string(&b.mix_hash))
+        ParentSlot => Column::I64(u64_cells(col, len, |v| {
+            i64::try_from(v).map(Some).context("parentSlot overflow")
         })?),
     })
 }
 
-/// Decode the per-row mask-selected fields of the given SVM blocks into columns.
-/// `block_numbers` is the requested slot per row, so `slot` resolves from the key
-/// (always known) rather than a stored record.
 fn decode_svm_block_columns(
-    records: &[Option<Arc<solana_simple::Block>>],
+    scratch: &[Option<AnyCol>],
     block_numbers: &[i64],
     masks: &[u64],
 ) -> Result<Columns> {
     build_columns(
         SvmBlockField::VARIANTS,
         masks,
-        records.len(),
+        block_numbers.len(),
         |f| f as u32,
         |f| f.name(),
-        |f| decode_svm_block_field(f, records, block_numbers, masks),
+        |f| decode_svm_block_field(f, scratch, block_numbers, masks),
     )
-}
-
-/// Decode a single SVM block field, materialising it only on the rows whose mask
-/// has the field's bit set. Exhaustive match: adding an `SvmBlockField` variant
-/// fails to compile until it is decoded here.
-fn decode_svm_block_field(
-    field: SvmBlockField,
-    raw: &[Option<Arc<solana_simple::Block>>],
-    block_numbers: &[i64],
-    masks: &[u64],
-) -> Result<Column> {
-    let bit = 1u64 << (field as u32);
-    Ok(match field {
-        // The slot is the store key, so it's always available regardless of
-        // whether the block row was fetched.
-        SvmBlockField::Slot => Column::I64(
-            block_numbers
-                .iter()
-                .zip(masks)
-                .map(|(&n, &m)| (m & bit != 0).then_some(n))
-                .collect(),
-        ),
-        SvmBlockField::Time => Column::I64(fill_masked(raw, masks, bit, |b| Ok(b.block_time))?),
-        SvmBlockField::Hash => Column::Str(fill_masked(raw, masks, bit, |b| {
-            Ok(Some(b.blockhash.clone()))
-        })?),
-        SvmBlockField::Height => Column::I64(fill_masked(raw, masks, bit, |b| {
-            b.block_height
-                .map(i64::try_from)
-                .transpose()
-                .context("height overflow")
-        })?),
-        SvmBlockField::ParentSlot => Column::I64(fill_masked(raw, masks, bit, |b| {
-            b.parent_slot
-                .map(i64::try_from)
-                .transpose()
-                .context("parentSlot overflow")
-        })?),
-        SvmBlockField::ParentHash => Column::Str(fill_masked(raw, masks, bit, |b| {
-            Ok(b.parent_blockhash.clone())
-        })?),
-    })
-}
-
-/// One stored block, kept in its ecosystem's compact raw form.
-enum StoredBlock {
-    Evm(Arc<simple_types::Block>),
-    Svm(Arc<solana_simple::Block>),
-}
-
-/// Blocks keyed by number (slot on SVM). One block per number deduplicates the
-/// many logs/instructions that share it; the `BTreeMap` keeps prune and rollback
-/// cheap range splits.
-#[derive(Default)]
-struct Blocks {
-    map: BTreeMap<u64, StoredBlock>,
-}
-
-impl Blocks {
-    fn new() -> Self {
-        Self::default()
-    }
-
-    /// Drain every entry from `self` into `dst`.
-    fn drain_into(&mut self, dst: &mut Self) {
-        for (number, block) in std::mem::take(&mut self.map) {
-            dst.map.insert(number, block);
-        }
-    }
-
-    /// Drop blocks at or below `up_to` (already processed). `split_off` returns
-    /// the `>= up_to + 1` tail, which becomes the new map.
-    fn prune(&mut self, up_to: u64) {
-        self.map = self.map.split_off(&(up_to + 1));
-    }
-
-    /// Drop blocks above `target` (rolled back). `split_off` removes the
-    /// `>= target + 1` tail and we discard it, leaving `<= target` in place.
-    fn rollback(&mut self, target: u64) {
-        self.map.split_off(&(target + 1));
-    }
-}
-
-/// Gather the stored blocks matching the requested numbers, in input order;
-/// missing numbers (or a record `pick` rejects) yield `None`. Shared by both
-/// ecosystems — only the `pick` closure differs.
-fn collect<T>(
-    store: &Blocks,
-    block_numbers: &[i64],
-    pick: impl Fn(&StoredBlock) -> Option<T>,
-) -> Vec<Option<T>> {
-    block_numbers
-        .iter()
-        .map(|n| {
-            let n = u64::try_from(*n).ok()?;
-            store.map.get(&n).and_then(&pick)
-        })
-        .collect()
 }
 
 /// Ecosystem selecting `materialize`'s decoder. A store is per-chain, hence
@@ -379,7 +318,7 @@ enum Ecosystem {
 
 #[napi]
 pub struct BlockStore {
-    inner: Mutex<Blocks>,
+    inner: Mutex<ChunkStore<u64>>,
     // Fixed at construction; drives the decoder in `materialize`.
     ecosystem: Ecosystem,
 }
@@ -406,7 +345,7 @@ impl BlockStore {
         Self::with_ecosystem(Ecosystem::Fuel)
     }
 
-    /// Move every entry from `page` into this store (merging a fetch-response
+    /// Move every chunk from `page` into this store (merging a fetch-response
     /// page into the persistent per-chain store).
     #[napi]
     pub fn merge(&self, page: &BlockStore) {
@@ -420,15 +359,16 @@ impl BlockStore {
         debug_assert_eq!(self.ecosystem, page.ecosystem);
         let mut dst = self.inner.lock().unwrap();
         let mut src = page.inner.lock().unwrap();
-        src.drain_into(&mut dst);
+        dst.append_from(&mut src);
     }
 
     /// Bulk-materialise blocks in columnar form, one row per `block_numbers[i]`
     /// key, decoding only the fields whose bit is set in that row's own
     /// `masks[i]`. Each mask is a JS number (`f64`) carrying a selection bitmask
-    /// over field codes. Async + `block_in_place` so the bulk decode runs off the
-    /// JS thread without monopolising an async worker; the brief lock only clones
-    /// `Arc`s. Missing keys yield an empty object. Result is aligned with input.
+    /// over field codes. The lock is held only to gather the requested cells;
+    /// decoding runs after it is released, off the JS thread via
+    /// `block_in_place`. Missing keys yield an empty object. Result is aligned
+    /// with input.
     #[napi(ts_return_type = "Promise<object[]>")]
     pub async fn materialize(
         &self,
@@ -448,22 +388,16 @@ impl BlockStore {
 
         match self.ecosystem {
             Ecosystem::Evm { should_checksum } => {
-                let records = self.collect_locked(&block_numbers, |stored| match stored {
-                    StoredBlock::Evm(b) => Some(b.clone()),
-                    _ => None,
-                });
+                let scratch = self.gather(&block_numbers, &masks);
                 tokio::task::block_in_place(|| {
-                    decode_evm_block_columns(&records, &block_numbers, &masks, should_checksum)
+                    decode_evm_block_columns(&scratch, &block_numbers, &masks, should_checksum)
                 })
                 .map_err(map_err)
             }
             Ecosystem::Svm => {
-                let records = self.collect_locked(&block_numbers, |stored| match stored {
-                    StoredBlock::Svm(b) => Some(b.clone()),
-                    _ => None,
-                });
+                let scratch = self.gather(&block_numbers, &masks);
                 tokio::task::block_in_place(|| {
-                    decode_svm_block_columns(&records, &block_numbers, &masks)
+                    decode_svm_block_columns(&scratch, &block_numbers, &masks)
                 })
                 .map_err(map_err)
             }
@@ -490,49 +424,67 @@ impl BlockStore {
         let mut inner = self.inner.lock().unwrap();
         match u64::try_from(target_block) {
             Ok(target) => inner.rollback(target),
-            Err(_) => inner.map.clear(),
+            Err(_) => inner.clear(),
         }
     }
 }
 
 impl BlockStore {
-    /// Lock the store and gather the records for the requested keys. The lock is
-    /// held only for the `Arc` clones; decoding runs after it is released.
-    fn collect_locked<T>(
-        &self,
-        block_numbers: &[i64],
-        pick: impl Fn(&StoredBlock) -> Option<T>,
-    ) -> Vec<Option<T>> {
-        let inner = self.inner.lock().unwrap();
-        collect(&inner, block_numbers, pick)
-    }
-
     fn with_ecosystem(ecosystem: Ecosystem) -> Self {
+        let n_fields = match ecosystem {
+            Ecosystem::Evm { .. } => EvmBlockField::VARIANTS.len(),
+            Ecosystem::Svm => SvmBlockField::VARIANTS.len(),
+            Ecosystem::Fuel => 0,
+        };
         Self {
-            inner: Mutex::new(Blocks::new()),
+            inner: Mutex::new(ChunkStore::new(n_fields, true)),
             ecosystem,
         }
     }
 
-    /// Insert a raw EVM block (called by the HyperSync source while building a
-    /// page). One block per number, so a plain insert deduplicates the many logs
-    /// that share it. Not exposed to JS.
-    pub(crate) fn insert_evm_raw(&self, number: u64, block: Arc<simple_types::Block>) {
-        self.inner
-            .lock()
-            .unwrap()
-            .map
-            .insert(number, StoredBlock::Evm(block));
+    fn gather(&self, block_numbers: &[i64], masks: &[u64]) -> Vec<Option<AnyCol>> {
+        let keys: Vec<Option<u64>> = block_numbers
+            .iter()
+            .map(|&n| u64::try_from(n).ok())
+            .collect();
+        self.inner.lock().unwrap().gather_scratch(&keys, &masks)
     }
 
-    /// Insert a raw SVM block keyed by slot (called by the SVM HyperSync source
-    /// while building a page). Not exposed to JS.
-    pub(crate) fn insert_svm_raw(&self, slot: u64, block: Arc<solana_simple::Block>) {
+    /// Add one response's EVM blocks as a chunk (called by the HyperSync source
+    /// while building a page). One block per number, so overlapping partition
+    /// re-fetches simply resolve newest-first at read. Not exposed to JS.
+    pub(crate) fn insert_evm_blocks(&self, mut blocks: Vec<simple_types::Block>) {
+        blocks.retain(|b| b.number.is_some());
+        if blocks.is_empty() {
+            return;
+        }
+        blocks.sort_unstable_by_key(|b| b.number.unwrap());
+        let keys = blocks.iter().map(|b| b.number.unwrap()).collect();
+        let cols = EvmBlockField::VARIANTS
+            .iter()
+            .map(|&f| evm_block_col(f, &blocks))
+            .collect();
         self.inner
             .lock()
             .unwrap()
-            .map
-            .insert(slot, StoredBlock::Svm(block));
+            .push_chunk(Chunk::new(keys, cols));
+    }
+
+    /// Add one response's SVM blocks as a chunk, keyed by slot. Not exposed to JS.
+    pub(crate) fn insert_svm_blocks(&self, mut blocks: Vec<solana_simple::Block>) {
+        if blocks.is_empty() {
+            return;
+        }
+        blocks.sort_unstable_by_key(|b| b.slot);
+        let keys = blocks.iter().map(|b| b.slot).collect();
+        let cols = SvmBlockField::VARIANTS
+            .iter()
+            .map(|&f| svm_block_col(f, &blocks))
+            .collect();
+        self.inner
+            .lock()
+            .unwrap()
+            .push_chunk(Chunk::new(keys, cols));
     }
 }
 
@@ -584,36 +536,46 @@ mod tests {
             .map(|(_, c)| c)
     }
 
-    #[test]
-    fn decode_selected_only_materialises_masked_fields() {
-        // Select only `logsBloom` via the bitmask.
-        let mask = 1u64 << (EvmBlockField::LogsBloom as u32);
-        let cols =
-            decode_evm_block_columns(&[Some(Arc::new(raw_evm_block(1)))], &[1], &[mask], false)
-                .expect("decode columns");
+    fn bit(field: EvmBlockField) -> u64 {
+        1u64 << (field as u32)
+    }
 
-        // Exactly one column (logsBloom) is present; number (resolvable from the
-        // key but unselected) and gasUsed are absent.
+    // `materialize` uses `block_in_place`, which needs a multi-thread runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn materialize_decodes_only_masked_fields() {
+        let store = BlockStore::new_evm(false);
+        let mut block = raw_evm_block(1);
+        block.gas_used = Some(Quantity::from(99u64));
+        store.insert_evm_blocks(vec![block]);
+
+        let mask = bit(EvmBlockField::GasUsed) as f64;
+        let cols = store
+            .materialize(vec![1], vec![mask])
+            .await
+            .expect("materialize");
+
+        // Exactly one column (gasUsed) is present; number (resolvable from the
+        // key but unselected) and hash are absent.
         let summary = (
-            column(&cols, "logsBloom").is_some(),
-            column(&cols, "number").is_some(),
             column(&cols, "gasUsed").is_some(),
+            column(&cols, "number").is_some(),
+            column(&cols, "hash").is_some(),
         );
         assert_eq!(summary, (true, false, false));
     }
 
-    #[test]
-    fn number_comes_from_key_even_on_miss() {
-        // A missing record (None) still materialises the requested key as
-        // `number`, so it never depends on a fetched block row.
-        let mask = 1u64 << (EvmBlockField::Number as u32);
-        let cols = decode_evm_block_columns(
-            &[None, Some(Arc::new(raw_evm_block(3)))],
-            &[7, 3],
-            &[mask, mask],
-            false,
-        )
-        .expect("decode columns");
+    #[tokio::test(flavor = "multi_thread")]
+    async fn number_comes_from_key_even_on_miss() {
+        // A missing row still materialises the requested key as `number`, so it
+        // never depends on a fetched block row.
+        let store = BlockStore::new_evm(false);
+        store.insert_evm_blocks(vec![raw_evm_block(3)]);
+
+        let mask = bit(EvmBlockField::Number) as f64;
+        let cols = store
+            .materialize(vec![7, 3], vec![mask, mask])
+            .await
+            .expect("materialize");
         match column(&cols, "number") {
             Some(Column::I64(v)) => assert_eq!(v, &vec![Some(7), Some(3)]),
             other => panic!(
@@ -623,37 +585,119 @@ mod tests {
         }
     }
 
-    #[test]
-    fn decode_applies_each_rows_own_mask() {
-        // Row 0 selects `number`; row 1 selects nothing. The key-derived `number`
-        // column is present only on the row whose own mask has the bit set.
-        let number_mask = 1u64 << (EvmBlockField::Number as u32);
-        let cols = decode_evm_block_columns(
-            &[
-                Some(Arc::new(raw_evm_block(1))),
-                Some(Arc::new(raw_evm_block(2))),
-            ],
-            &[1, 2],
-            &[number_mask, 0],
-            false,
-        )
-        .expect("decode columns");
+    #[tokio::test(flavor = "multi_thread")]
+    async fn decode_applies_each_rows_own_mask() {
+        // Both rows have a stored gasUsed, but only row 0 selects it — proving
+        // the per-row mask, not the stored data, gates materialisation.
+        let store = BlockStore::new_evm(false);
+        let mut block1 = raw_evm_block(1);
+        block1.gas_used = Some(Quantity::from(100u64));
+        let mut block2 = raw_evm_block(2);
+        block2.gas_used = Some(Quantity::from(200u64));
+        store.insert_evm_blocks(vec![block1, block2]);
 
-        match column(&cols, "number") {
-            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(1), None]),
-            other => panic!("expected number column, got present={}", other.is_some()),
+        let mask = bit(EvmBlockField::GasUsed) as f64;
+        let cols = store
+            .materialize(vec![1, 2], vec![mask, 0.])
+            .await
+            .expect("materialize");
+        match column(&cols, "gasUsed") {
+            Some(Column::Big(v)) => assert_eq!((v[0].is_some(), v[1].is_some()), (true, false)),
+            other => panic!("expected gasUsed column, got present={}", other.is_some()),
         }
     }
 
-    #[test]
-    fn svm_decode_selected_only_materialises_masked_fields() {
-        // Select slot (from key) + hash + time; height stays absent.
-        let mask = (1u64 << (SvmBlockField::Slot as u32))
-            | (1u64 << (SvmBlockField::Hash as u32))
-            | (1u64 << (SvmBlockField::Time as u32));
-        let cols = decode_svm_block_columns(&[Some(Arc::new(raw_svm_block(9)))], &[9], &[mask])
-            .expect("decode columns");
+    #[tokio::test(flavor = "multi_thread")]
+    async fn materialize_returns_stored_extra_fields_via_store() {
+        let store = BlockStore::new_evm(false);
+        let mut block = raw_evm_block(10);
+        block.timestamp = Some(Quantity::from(999u64));
+        block.hash = Some(Hash::from([0xabu8; 32]));
+        block.gas_used = Some(Quantity::from(555u64));
+        store.insert_evm_blocks(vec![block]);
 
+        // A production-shaped mask: the config-extended trio plus a selected
+        // extra field, all decoded from the one stored chunk.
+        let mask = (bit(EvmBlockField::Number)
+            | bit(EvmBlockField::Timestamp)
+            | bit(EvmBlockField::Hash)
+            | bit(EvmBlockField::GasUsed)) as f64;
+        let cols = store
+            .materialize(vec![10], vec![mask])
+            .await
+            .expect("materialize");
+        let summary = (
+            column(&cols, "gasUsed").is_some(),
+            match column(&cols, "number") {
+                Some(Column::I64(v)) => v.clone(),
+                _ => panic!("expected number column"),
+            },
+            match column(&cols, "timestamp") {
+                Some(Column::I64(v)) => v.clone(),
+                _ => panic!("expected timestamp column"),
+            },
+            match column(&cols, "hash") {
+                Some(Column::Str(v)) => v.clone(),
+                _ => panic!("expected hash column"),
+            },
+        );
+        assert_eq!(
+            summary,
+            (
+                true,
+                vec![Some(10)],
+                vec![Some(999)],
+                vec![Some(format!("0x{}", "ab".repeat(32)))]
+            )
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn field_union_across_chunks_resolves_both_fields() {
+        // The same block arrives twice with different populated fields (e.g. a
+        // hash-only observation later enriched by a full fetch): reads union
+        // them.
+        let store = BlockStore::new_evm(false);
+        let mut with_hash = raw_evm_block(20);
+        with_hash.hash = Some(Hash::from([0x11u8; 32]));
+        store.insert_evm_blocks(vec![with_hash]);
+        let mut with_gas = raw_evm_block(20);
+        with_gas.gas_used = Some(Quantity::from(42u64));
+        store.insert_evm_blocks(vec![with_gas]);
+
+        let mask = (bit(EvmBlockField::Hash) | bit(EvmBlockField::GasUsed)) as f64;
+        let cols = store
+            .materialize(vec![20], vec![mask])
+            .await
+            .expect("materialize");
+        let summary = (
+            match column(&cols, "hash") {
+                Some(Column::Str(v)) => v.clone(),
+                _ => panic!("expected hash column"),
+            },
+            column(&cols, "gasUsed").is_some(),
+        );
+        assert_eq!(
+            summary,
+            (vec![Some(format!("0x{}", "11".repeat(32)))], true)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn svm_materialize_decodes_selected_fields() {
+        let store = BlockStore::new_svm();
+        let mut block = raw_svm_block(9);
+        block.block_height = Some(777);
+        store.insert_svm_blocks(vec![block]);
+
+        let mask = ((1u64 << (SvmBlockField::Slot as u32))
+            | (1u64 << (SvmBlockField::Hash as u32))
+            | (1u64 << (SvmBlockField::Time as u32))
+            | (1u64 << (SvmBlockField::Height as u32))) as f64;
+        let cols = store
+            .materialize(vec![9], vec![mask])
+            .await
+            .expect("materialize");
         let summary = (
             match column(&cols, "slot") {
                 Some(Column::I64(v)) => v.clone(),
@@ -667,7 +711,11 @@ mod tests {
                 Some(Column::I64(v)) => v.clone(),
                 _ => panic!("expected time column"),
             },
-            column(&cols, "height").is_some(),
+            match column(&cols, "height") {
+                Some(Column::I64(v)) => v.clone(),
+                _ => panic!("expected height column"),
+            },
+            column(&cols, "parentSlot").is_some(),
         );
         assert_eq!(
             summary,
@@ -675,34 +723,76 @@ mod tests {
                 vec![Some(9)],
                 vec![Some("hash".to_string())],
                 vec![Some(123)],
+                vec![Some(777)],
                 false
             )
         );
     }
 
-    #[test]
-    fn prune_and_rollback_drop_by_block() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prune_and_rollback_drop_by_block() {
         let store = BlockStore::new_evm(false);
-        for block in [10u64, 20, 30] {
-            store.insert_evm_raw(block, Arc::new(raw_evm_block(block)));
-        }
+        let blocks = [10u64, 20, 30]
+            .into_iter()
+            .map(|n| {
+                let mut b = raw_evm_block(n);
+                b.timestamp = Some(Quantity::from(n));
+                b
+            })
+            .collect();
+        store.insert_evm_blocks(blocks);
 
+        let mask = bit(EvmBlockField::Timestamp) as f64;
         store.prune(10);
-        assert!(!store.inner.lock().unwrap().map.contains_key(&10));
-
+        let after_prune = store
+            .materialize(vec![10, 20, 30], vec![mask, mask, mask])
+            .await
+            .expect("materialize");
         store.rollback(20);
-        // Block 30 dropped by rollback; block 20 survives.
+        let after_rollback = store
+            .materialize(vec![10, 20, 30], vec![mask, mask, mask])
+            .await
+            .expect("materialize");
+
+        let timestamps = |cols: &Columns| match column(cols, "timestamp") {
+            Some(Column::I64(v)) => v.clone(),
+            _ => panic!("expected timestamp column"),
+        };
         assert_eq!(
-            store
-                .inner
-                .lock()
-                .unwrap()
-                .map
-                .keys()
-                .copied()
-                .collect::<Vec<_>>(),
-            vec![20]
+            (timestamps(&after_prune), timestamps(&after_rollback)),
+            (vec![None, Some(20), Some(30)], vec![None, Some(20), None])
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn merge_resolves_re_fetched_block_to_newest() {
+        // A rolled-back block re-fetched with different content must resolve to
+        // the fresh copy — the sequence a chain reorg drives through
+        // `ChainState`: merge a page, then merge a later page for the same
+        // (re-fetched) block number.
+        let persistent = BlockStore::new_evm(false);
+
+        let page1 = BlockStore::new_evm(false);
+        let mut first = raw_evm_block(20);
+        first.timestamp = Some(Quantity::from(100u64));
+        page1.insert_evm_blocks(vec![first]);
+        persistent.merge(&page1);
+
+        let page2 = BlockStore::new_evm(false);
+        let mut second = raw_evm_block(20);
+        second.timestamp = Some(Quantity::from(200u64));
+        page2.insert_evm_blocks(vec![second]);
+        persistent.merge(&page2);
+
+        let mask = bit(EvmBlockField::Timestamp) as f64;
+        let cols = persistent
+            .materialize(vec![20], vec![mask])
+            .await
+            .expect("materialize");
+        match column(&cols, "timestamp") {
+            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(200)]),
+            other => panic!("expected timestamp column, got present={}", other.is_some()),
+        }
     }
 
     #[test]
@@ -760,104 +850,5 @@ mod tests {
             svm_names,
             vec!["slot", "time", "hash", "height", "parentSlot", "parentHash"]
         );
-    }
-
-    // The tests above call `decode_evm_block_columns`/`decode_svm_block_columns`
-    // directly; the ones below go through the public `materialize` method (as
-    // ReScript does), so they also cover the lock, the `f64` mask cast, and the
-    // ecosystem dispatch. `block_in_place` inside `materialize` panics without a
-    // multi-thread runtime.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn materialize_returns_stored_extra_fields_via_store() {
-        let store = BlockStore::new_evm(false);
-        let mut block = raw_evm_block(10);
-        block.timestamp = Some(Quantity::from(999u64));
-        block.hash = Some(Hash::from([0xabu8; 32]));
-        block.gas_used = Some(Quantity::from(555u64));
-        store.insert_evm_raw(10, Arc::new(block));
-
-        // A production-shaped mask: the config-extended trio plus a selected
-        // extra field, all decoded from the one stored raw block.
-        let mask = ((1u64 << (EvmBlockField::Number as u32))
-            | (1u64 << (EvmBlockField::Timestamp as u32))
-            | (1u64 << (EvmBlockField::Hash as u32))
-            | (1u64 << (EvmBlockField::GasUsed as u32))) as f64;
-        let cols = store
-            .materialize(vec![10], vec![mask])
-            .await
-            .expect("materialize");
-        let summary = (
-            column(&cols, "gasUsed").is_some(),
-            match column(&cols, "number") {
-                Some(Column::I64(v)) => v.clone(),
-                _ => panic!("expected number column"),
-            },
-            match column(&cols, "timestamp") {
-                Some(Column::I64(v)) => v.clone(),
-                _ => panic!("expected timestamp column"),
-            },
-            match column(&cols, "hash") {
-                Some(Column::Str(v)) => v.clone(),
-                _ => panic!("expected hash column"),
-            },
-        );
-        assert_eq!(
-            summary,
-            (
-                true,
-                vec![Some(10)],
-                vec![Some(999)],
-                vec![Some(format!("0x{}", "ab".repeat(32)))]
-            )
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn svm_materialize_returns_stored_extra_fields_via_store() {
-        let store = BlockStore::new_svm();
-        let mut block = raw_svm_block(9);
-        block.block_height = Some(777);
-        store.insert_svm_raw(9, Arc::new(block));
-
-        let mask = (1u64 << (SvmBlockField::Height as u32)) as f64;
-        let cols = store
-            .materialize(vec![9], vec![mask])
-            .await
-            .expect("materialize");
-        match column(&cols, "height") {
-            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(777)]),
-            other => panic!("expected height column, got present={}", other.is_some()),
-        }
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn merge_overwrites_existing_block_for_same_number() {
-        // A rolled-back block re-fetched with different content must replace the
-        // stale entry rather than be shadowed by it — the sequence a chain
-        // reorg drives through `ChainState`: merge a page, then merge a later
-        // page for the same (re-fetched) block number.
-        let persistent = BlockStore::new_evm(false);
-
-        let page1 = BlockStore::new_evm(false);
-        let mut first = raw_evm_block(20);
-        first.timestamp = Some(Quantity::from(100u64));
-        page1.insert_evm_raw(20, Arc::new(first));
-        persistent.merge(&page1);
-
-        let page2 = BlockStore::new_evm(false);
-        let mut second = raw_evm_block(20);
-        second.timestamp = Some(Quantity::from(200u64));
-        page2.insert_evm_raw(20, Arc::new(second));
-        persistent.merge(&page2);
-
-        let mask = (1u64 << (EvmBlockField::Timestamp as u32)) as f64;
-        let cols = persistent
-            .materialize(vec![20], vec![mask])
-            .await
-            .expect("materialize");
-        match column(&cols, "timestamp") {
-            Some(Column::I64(v)) => assert_eq!(v, &vec![Some(200)]),
-            other => panic!("expected timestamp column, got present={}", other.is_some()),
-        }
     }
 }

--- a/packages/cli/src/chunk_store.rs
+++ b/packages/cli/src/chunk_store.rs
@@ -609,6 +609,235 @@ impl<K: Ord + Copy> ChunkStore<K> {
 
         Chunk::new(keys, cols)
     }
+
+    /// The per-field scratch a `materialize` call decodes from: one gathered
+    /// column per field whose bit is set in any row's mask, each already
+    /// respecting the per-row masks. Built under the store lock; decoding then
+    /// runs on the caller's own copy.
+    pub(crate) fn gather_scratch(&self, keys: &[Option<K>], masks: &[u64]) -> Vec<Option<AnyCol>> {
+        let hits = self.hit_lists(keys);
+        let union = masks.iter().fold(0u64, |acc, &m| acc | m);
+        (0..self.n_fields)
+            .map(|f| {
+                let bit = 1u64 << f;
+                if union & bit == 0 {
+                    None
+                } else {
+                    self.gather(&hits, f, |i| masks[i] & bit != 0)
+                }
+            })
+            .collect()
+    }
+}
+
+// ---- Fill: build one column from a response's rows. `None` when no row has a
+// value, so absent fields cost nothing. ----
+
+fn built(col: AnyCol) -> Option<AnyCol> {
+    col.any_valid().then_some(col)
+}
+
+pub(crate) fn var_from<R>(rows: &[R], f: impl Fn(&R) -> Option<&[u8]>) -> Option<AnyCol> {
+    let mut col = VarCol::new();
+    rows.iter().for_each(|r| col.push(f(r)));
+    built(AnyCol::Var(col))
+}
+
+pub(crate) fn fixed_from<R>(
+    rows: &[R],
+    width: usize,
+    f: impl Fn(&R) -> Option<&[u8]>,
+) -> Option<AnyCol> {
+    let mut col = FixedCol::new(width);
+    rows.iter().for_each(|r| col.push(f(r)));
+    built(AnyCol::Fixed(col))
+}
+
+pub(crate) fn u64_from<R>(rows: &[R], f: impl Fn(&R) -> Option<u64>) -> Option<AnyCol> {
+    let mut col = NumCol::new();
+    rows.iter().for_each(|r| col.push(f(r)));
+    built(AnyCol::U64(col))
+}
+
+pub(crate) fn i64_from<R>(rows: &[R], f: impl Fn(&R) -> Option<i64>) -> Option<AnyCol> {
+    let mut col = NumCol::new();
+    rows.iter().for_each(|r| col.push(f(r)));
+    built(AnyCol::I64(col))
+}
+
+pub(crate) fn f64_from<R>(rows: &[R], f: impl Fn(&R) -> Option<f64>) -> Option<AnyCol> {
+    let mut col = NumCol::new();
+    rows.iter().for_each(|r| col.push(f(r)));
+    built(AnyCol::F64(col))
+}
+
+pub(crate) fn bool_from<R>(rows: &[R], f: impl Fn(&R) -> Option<bool>) -> Option<AnyCol> {
+    let mut col = NumCol::new();
+    rows.iter().for_each(|r| col.push(f(r)));
+    built(AnyCol::Bool(col))
+}
+
+pub(crate) fn str_list_from<R>(
+    rows: &[R],
+    f: impl Fn(&R) -> Option<Vec<String>>,
+) -> Option<AnyCol> {
+    let mut col = ListCol::new();
+    rows.iter().for_each(|r| col.push(f(r)));
+    built(AnyCol::StrList(col))
+}
+
+pub(crate) fn hash_list_from<R>(
+    rows: &[R],
+    f: impl Fn(&R) -> Option<Vec<[u8; 32]>>,
+) -> Option<AnyCol> {
+    let mut col = ListCol::new();
+    rows.iter().for_each(|r| col.push(f(r)));
+    built(AnyCol::HashList(col))
+}
+
+pub(crate) fn access_lists_from<R>(
+    rows: &[R],
+    f: impl Fn(&R) -> Option<Vec<format::AccessList>>,
+) -> Option<AnyCol> {
+    let mut col = ListCol::new();
+    rows.iter().for_each(|r| col.push(f(r)));
+    built(AnyCol::AccessLists(col))
+}
+
+pub(crate) fn auth_lists_from<R>(
+    rows: &[R],
+    f: impl Fn(&R) -> Option<Vec<format::Authorization>>,
+) -> Option<AnyCol> {
+    let mut col = ListCol::new();
+    rows.iter().for_each(|r| col.push(f(r)));
+    built(AnyCol::AuthLists(col))
+}
+
+// ---- Decode: turn a gathered scratch column into per-row cells. A `None`
+// column (field absent from every chunk) yields all-missing rows. The variant
+// checks panic on mismatch since fill and decode for a field are written
+// together. ----
+
+pub(crate) fn bytes_cells<T>(
+    col: Option<&AnyCol>,
+    len: usize,
+    f: impl Fn(&[u8]) -> anyhow::Result<Option<T>>,
+) -> anyhow::Result<Vec<Option<T>>> {
+    match col {
+        None => Ok((0..len).map(|_| None).collect()),
+        Some(AnyCol::Var(c)) => (0..len).map(|i| c.get(i).map_or(Ok(None), &f)).collect(),
+        Some(AnyCol::Fixed(c)) => (0..len).map(|i| c.get(i).map_or(Ok(None), &f)).collect(),
+        Some(_) => panic!("expected a byte column"),
+    }
+}
+
+pub(crate) fn u64_cells<T>(
+    col: Option<&AnyCol>,
+    len: usize,
+    f: impl Fn(u64) -> anyhow::Result<Option<T>>,
+) -> anyhow::Result<Vec<Option<T>>> {
+    match col {
+        None => Ok((0..len).map(|_| None).collect()),
+        Some(AnyCol::U64(c)) => (0..len).map(|i| c.get(i).map_or(Ok(None), &f)).collect(),
+        Some(_) => panic!("expected a u64 column"),
+    }
+}
+
+pub(crate) fn i64_cells(col: Option<&AnyCol>, len: usize) -> Vec<Option<i64>> {
+    match col {
+        None => vec![None; len],
+        Some(AnyCol::I64(c)) => (0..len).map(|i| c.get(i)).collect(),
+        Some(_) => panic!("expected an i64 column"),
+    }
+}
+
+pub(crate) fn f64_cells(col: Option<&AnyCol>, len: usize) -> Vec<Option<f64>> {
+    match col {
+        None => vec![None; len],
+        Some(AnyCol::F64(c)) => (0..len).map(|i| c.get(i)).collect(),
+        Some(_) => panic!("expected an f64 column"),
+    }
+}
+
+pub(crate) fn bool_cells(col: Option<&AnyCol>, len: usize) -> Vec<Option<bool>> {
+    match col {
+        None => vec![None; len],
+        Some(AnyCol::Bool(c)) => (0..len).map(|i| c.get(i)).collect(),
+        Some(_) => panic!("expected a bool column"),
+    }
+}
+
+pub(crate) fn str_list_cells(col: Option<&AnyCol>, len: usize) -> Vec<Option<Vec<String>>> {
+    match col {
+        None => vec![None; len],
+        Some(AnyCol::StrList(c)) => (0..len).map(|i| c.get(i).cloned()).collect(),
+        Some(_) => panic!("expected a string-list column"),
+    }
+}
+
+pub(crate) fn hash_list_cells<T>(
+    col: Option<&AnyCol>,
+    len: usize,
+    f: impl Fn(&[u8; 32]) -> T,
+) -> Vec<Option<Vec<T>>> {
+    match col {
+        None => (0..len).map(|_| None).collect(),
+        Some(AnyCol::HashList(c)) => (0..len)
+            .map(|i| c.get(i).map(|v| v.iter().map(&f).collect()))
+            .collect(),
+        Some(_) => panic!("expected a hash-list column"),
+    }
+}
+
+pub(crate) fn access_lists_cells<T>(
+    col: Option<&AnyCol>,
+    len: usize,
+    f: impl Fn(&format::AccessList) -> T,
+) -> Vec<Option<Vec<T>>> {
+    match col {
+        None => (0..len).map(|_| None).collect(),
+        Some(AnyCol::AccessLists(c)) => (0..len)
+            .map(|i| c.get(i).map(|v| v.iter().map(&f).collect()))
+            .collect(),
+        Some(_) => panic!("expected an access-list column"),
+    }
+}
+
+pub(crate) fn auth_lists_cells<T>(
+    col: Option<&AnyCol>,
+    len: usize,
+    f: impl Fn(&format::Authorization) -> anyhow::Result<T>,
+) -> anyhow::Result<Vec<Option<Vec<T>>>> {
+    match col {
+        None => Ok((0..len).map(|_| None).collect()),
+        Some(AnyCol::AuthLists(c)) => (0..len)
+            .map(|i| c.get(i).map(|v| v.iter().map(&f).collect()).transpose())
+            .collect(),
+        Some(_) => panic!("expected an authorization-list column"),
+    }
+}
+
+/// Full-bytes hex, matching `Data`/`FixedSizeData::encode_hex` ("0x" when empty).
+pub(crate) fn hex_full(b: &[u8]) -> String {
+    if b.is_empty() {
+        return "0x".into();
+    }
+    format!("0x{}", faster_hex::hex_string(b))
+}
+
+/// Quantity hex, matching `Quantity::encode_hex`: leading zeros trimmed, zero
+/// itself is "0x0".
+pub(crate) fn hex_quantity(b: &[u8]) -> String {
+    let hex = faster_hex::hex_string(b);
+    match hex.find(|c| c != '0') {
+        Some(idx) => format!("0x{}", &hex[idx..]),
+        None => "0x0".into(),
+    }
+}
+
+/// UTF-8 cell back to the `String` it was stored from.
+pub(crate) fn utf8(b: &[u8]) -> String {
+    String::from_utf8_lossy(b).into_owned()
 }
 
 #[cfg(test)]

--- a/packages/cli/src/chunk_store.rs
+++ b/packages/cli/src/chunk_store.rs
@@ -1,0 +1,790 @@
+//! Chunked columnar storage shared by the per-chain field stores. A chunk is
+//! one fetch response's rows: a sorted key vector plus one column per field the
+//! chain's config selected. Chunks are immutable except for a tail truncate
+//! (rollback) and a start watermark (prune of a partially-processed chunk), so
+//! the store's lifecycle is "append a chunk, drop a chunk" — no per-row map and
+//! no compaction. Reads resolve per field, newest chunk first, which both
+//! deduplicates identical rows re-fetched by overlapping partitions and unions
+//! rows that arrived with different field subsets.
+
+use hypersync_client::format;
+
+/// Validity bitmap: one bit per row, set when the row's cell holds a value.
+pub(crate) struct BitVec {
+    words: Vec<u64>,
+    len: usize,
+}
+
+impl BitVec {
+    fn new() -> Self {
+        Self {
+            words: Vec::new(),
+            len: 0,
+        }
+    }
+
+    fn push(&mut self, v: bool) {
+        if self.len % 64 == 0 {
+            self.words.push(0);
+        }
+        if v {
+            let w = self.words.last_mut().unwrap();
+            *w |= 1 << (self.len % 64);
+        }
+        self.len += 1;
+    }
+
+    fn get(&self, i: usize) -> bool {
+        (self.words[i / 64] >> (i % 64)) & 1 == 1
+    }
+
+    fn truncate(&mut self, len: usize) {
+        if len >= self.len {
+            return;
+        }
+        self.words.truncate(len.div_ceil(64));
+        if len % 64 != 0 {
+            let w = self.words.last_mut().unwrap();
+            *w &= (1u64 << (len % 64)) - 1;
+        }
+        self.len = len;
+    }
+
+    fn any(&self) -> bool {
+        self.words.iter().any(|&w| w != 0)
+    }
+}
+
+pub(crate) struct NumCol<T> {
+    data: Vec<T>,
+    validity: BitVec,
+}
+
+impl<T: Copy + Default> NumCol<T> {
+    fn new() -> Self {
+        Self {
+            data: Vec::new(),
+            validity: BitVec::new(),
+        }
+    }
+
+    pub(crate) fn push(&mut self, v: Option<T>) {
+        self.data.push(v.unwrap_or_default());
+        self.validity.push(v.is_some());
+    }
+
+    pub(crate) fn get(&self, i: usize) -> Option<T> {
+        self.validity.get(i).then(|| self.data[i])
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.data.truncate(len);
+        self.validity.truncate(len);
+    }
+}
+
+/// Fixed-width byte cells stored flat; a missing cell still reserves its slot
+/// (zero-filled) so row offsets stay `row * width`.
+pub(crate) struct FixedCol {
+    width: usize,
+    data: Vec<u8>,
+    validity: BitVec,
+}
+
+impl FixedCol {
+    fn new(width: usize) -> Self {
+        Self {
+            width,
+            data: Vec::new(),
+            validity: BitVec::new(),
+        }
+    }
+
+    pub(crate) fn push(&mut self, v: Option<&[u8]>) {
+        match v {
+            Some(b) => {
+                debug_assert_eq!(b.len(), self.width);
+                self.data.extend_from_slice(b);
+            }
+            None => self.data.resize(self.data.len() + self.width, 0),
+        }
+        self.validity.push(v.is_some());
+    }
+
+    pub(crate) fn get(&self, i: usize) -> Option<&[u8]> {
+        self.validity
+            .get(i)
+            .then(|| &self.data[i * self.width..(i + 1) * self.width])
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.data.truncate(len * self.width);
+        self.validity.truncate(len);
+    }
+}
+
+/// Variable-width byte cells: offsets index into one shared byte buffer.
+pub(crate) struct VarCol {
+    offsets: Vec<u32>,
+    data: Vec<u8>,
+    validity: BitVec,
+}
+
+impl VarCol {
+    fn new() -> Self {
+        Self {
+            offsets: vec![0],
+            data: Vec::new(),
+            validity: BitVec::new(),
+        }
+    }
+
+    pub(crate) fn push(&mut self, v: Option<&[u8]>) {
+        if let Some(b) = v {
+            self.data.extend_from_slice(b);
+        }
+        self.offsets.push(self.data.len() as u32);
+        self.validity.push(v.is_some());
+    }
+
+    pub(crate) fn get(&self, i: usize) -> Option<&[u8]> {
+        self.validity
+            .get(i)
+            .then(|| &self.data[self.offsets[i] as usize..self.offsets[i + 1] as usize])
+    }
+
+    fn truncate(&mut self, len: usize) {
+        if len + 1 < self.offsets.len() {
+            self.offsets.truncate(len + 1);
+            self.data.truncate(*self.offsets.last().unwrap() as usize);
+            self.validity.truncate(len);
+        }
+    }
+}
+
+/// Per-row boxed lists, for rare fields whose cells are collections.
+pub(crate) struct ListCol<T> {
+    rows: Vec<Option<Vec<T>>>,
+}
+
+impl<T: Clone> ListCol<T> {
+    fn new() -> Self {
+        Self { rows: Vec::new() }
+    }
+
+    pub(crate) fn push(&mut self, v: Option<Vec<T>>) {
+        self.rows.push(v);
+    }
+
+    pub(crate) fn get(&self, i: usize) -> Option<&Vec<T>> {
+        self.rows[i].as_ref()
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.rows.truncate(len);
+    }
+}
+
+/// One field's column. The variant is fixed per field by the fill code and
+/// relied upon by the decode code; `copy_cell` panics on a variant mismatch
+/// since both sides are written together.
+pub(crate) enum AnyCol {
+    U64(NumCol<u64>),
+    I64(NumCol<i64>),
+    F64(NumCol<f64>),
+    Bool(NumCol<bool>),
+    Fixed(FixedCol),
+    Var(VarCol),
+    StrList(ListCol<String>),
+    HashList(ListCol<[u8; 32]>),
+    AccessLists(ListCol<format::AccessList>),
+    AuthLists(ListCol<format::Authorization>),
+}
+
+impl AnyCol {
+    pub(crate) fn new_u64() -> Self {
+        AnyCol::U64(NumCol::new())
+    }
+    pub(crate) fn new_i64() -> Self {
+        AnyCol::I64(NumCol::new())
+    }
+    pub(crate) fn new_f64() -> Self {
+        AnyCol::F64(NumCol::new())
+    }
+    pub(crate) fn new_bool() -> Self {
+        AnyCol::Bool(NumCol::new())
+    }
+    pub(crate) fn new_fixed(width: usize) -> Self {
+        AnyCol::Fixed(FixedCol::new(width))
+    }
+    pub(crate) fn new_var() -> Self {
+        AnyCol::Var(VarCol::new())
+    }
+    pub(crate) fn new_str_list() -> Self {
+        AnyCol::StrList(ListCol::new())
+    }
+    pub(crate) fn new_hash_list() -> Self {
+        AnyCol::HashList(ListCol::new())
+    }
+    pub(crate) fn new_access_lists() -> Self {
+        AnyCol::AccessLists(ListCol::new())
+    }
+    pub(crate) fn new_auth_lists() -> Self {
+        AnyCol::AuthLists(ListCol::new())
+    }
+
+    /// An empty column of the same kind (and width), for gather/coalesce output.
+    fn new_like(&self) -> Self {
+        match self {
+            AnyCol::U64(_) => Self::new_u64(),
+            AnyCol::I64(_) => Self::new_i64(),
+            AnyCol::F64(_) => Self::new_f64(),
+            AnyCol::Bool(_) => Self::new_bool(),
+            AnyCol::Fixed(c) => Self::new_fixed(c.width),
+            AnyCol::Var(_) => Self::new_var(),
+            AnyCol::StrList(_) => Self::new_str_list(),
+            AnyCol::HashList(_) => Self::new_hash_list(),
+            AnyCol::AccessLists(_) => Self::new_access_lists(),
+            AnyCol::AuthLists(_) => Self::new_auth_lists(),
+        }
+    }
+
+    fn is_valid(&self, i: usize) -> bool {
+        match self {
+            AnyCol::U64(c) => c.validity.get(i),
+            AnyCol::I64(c) => c.validity.get(i),
+            AnyCol::F64(c) => c.validity.get(i),
+            AnyCol::Bool(c) => c.validity.get(i),
+            AnyCol::Fixed(c) => c.validity.get(i),
+            AnyCol::Var(c) => c.validity.get(i),
+            AnyCol::StrList(c) => c.rows[i].is_some(),
+            AnyCol::HashList(c) => c.rows[i].is_some(),
+            AnyCol::AccessLists(c) => c.rows[i].is_some(),
+            AnyCol::AuthLists(c) => c.rows[i].is_some(),
+        }
+    }
+
+    pub(crate) fn any_valid(&self) -> bool {
+        match self {
+            AnyCol::U64(c) => c.validity.any(),
+            AnyCol::I64(c) => c.validity.any(),
+            AnyCol::F64(c) => c.validity.any(),
+            AnyCol::Bool(c) => c.validity.any(),
+            AnyCol::Fixed(c) => c.validity.any(),
+            AnyCol::Var(c) => c.validity.any(),
+            AnyCol::StrList(c) => c.rows.iter().any(|r| r.is_some()),
+            AnyCol::HashList(c) => c.rows.iter().any(|r| r.is_some()),
+            AnyCol::AccessLists(c) => c.rows.iter().any(|r| r.is_some()),
+            AnyCol::AuthLists(c) => c.rows.iter().any(|r| r.is_some()),
+        }
+    }
+
+    pub(crate) fn push_missing(&mut self) {
+        match self {
+            AnyCol::U64(c) => c.push(None),
+            AnyCol::I64(c) => c.push(None),
+            AnyCol::F64(c) => c.push(None),
+            AnyCol::Bool(c) => c.push(None),
+            AnyCol::Fixed(c) => c.push(None),
+            AnyCol::Var(c) => c.push(None),
+            AnyCol::StrList(c) => c.push(None),
+            AnyCol::HashList(c) => c.push(None),
+            AnyCol::AccessLists(c) => c.push(None),
+            AnyCol::AuthLists(c) => c.push(None),
+        }
+    }
+
+    fn copy_cell(&mut self, src: &AnyCol, row: usize) {
+        match (self, src) {
+            (AnyCol::U64(d), AnyCol::U64(s)) => d.push(s.get(row)),
+            (AnyCol::I64(d), AnyCol::I64(s)) => d.push(s.get(row)),
+            (AnyCol::F64(d), AnyCol::F64(s)) => d.push(s.get(row)),
+            (AnyCol::Bool(d), AnyCol::Bool(s)) => d.push(s.get(row)),
+            (AnyCol::Fixed(d), AnyCol::Fixed(s)) => d.push(s.get(row)),
+            (AnyCol::Var(d), AnyCol::Var(s)) => d.push(s.get(row)),
+            (AnyCol::StrList(d), AnyCol::StrList(s)) => d.push(s.get(row).cloned()),
+            (AnyCol::HashList(d), AnyCol::HashList(s)) => d.push(s.get(row).cloned()),
+            (AnyCol::AccessLists(d), AnyCol::AccessLists(s)) => d.push(s.get(row).cloned()),
+            (AnyCol::AuthLists(d), AnyCol::AuthLists(s)) => d.push(s.get(row).cloned()),
+            _ => panic!("column kind mismatch for one field across chunks"),
+        }
+    }
+
+    fn truncate(&mut self, len: usize) {
+        match self {
+            AnyCol::U64(c) => c.truncate(len),
+            AnyCol::I64(c) => c.truncate(len),
+            AnyCol::F64(c) => c.truncate(len),
+            AnyCol::Bool(c) => c.truncate(len),
+            AnyCol::Fixed(c) => c.truncate(len),
+            AnyCol::Var(c) => c.truncate(len),
+            AnyCol::StrList(c) => c.truncate(len),
+            AnyCol::HashList(c) => c.truncate(len),
+            AnyCol::AccessLists(c) => c.truncate(len),
+            AnyCol::AuthLists(c) => c.truncate(len),
+        }
+    }
+}
+
+/// One response's rows. `keys` is sorted ascending; `start` is the prune
+/// watermark (rows below it are logically dead but not reclaimed until the
+/// whole chunk drops). `cols[field_ordinal]` is `Some` only for fields that had
+/// any value in this response.
+pub(crate) struct Chunk<K> {
+    pub(crate) keys: Vec<K>,
+    start: usize,
+    pub(crate) cols: Vec<Option<AnyCol>>,
+}
+
+impl<K: Ord + Copy> Chunk<K> {
+    pub(crate) fn new(keys: Vec<K>, cols: Vec<Option<AnyCol>>) -> Self {
+        debug_assert!(keys.windows(2).all(|w| w[0] <= w[1]));
+        Self {
+            keys,
+            start: 0,
+            cols,
+        }
+    }
+
+    fn live_len(&self) -> usize {
+        self.keys.len() - self.start
+    }
+
+    fn min(&self) -> K {
+        self.keys[self.start]
+    }
+
+    fn max(&self) -> K {
+        *self.keys.last().unwrap()
+    }
+
+    /// Absolute row of `key` among live rows (first match for stores that allow
+    /// duplicate keys).
+    pub(crate) fn find(&self, key: K) -> Option<usize> {
+        if self.live_len() == 0 || key < self.min() || key > self.max() {
+            return None;
+        }
+        let live = &self.keys[self.start..];
+        let i = live.partition_point(|&k| k < key);
+        (i < live.len() && live[i] == key).then_some(self.start + i)
+    }
+
+    /// Absolute row range holding `key` among live rows (for duplicate-key
+    /// stores).
+    pub(crate) fn find_range(&self, key: K) -> Option<(usize, usize)> {
+        let lo = self.find(key)?;
+        let live = &self.keys[self.start..];
+        let hi = self.start + live.partition_point(|&k| k <= key);
+        Some((lo, hi))
+    }
+
+    fn truncate_rows(&mut self, len: usize) {
+        self.keys.truncate(len);
+        for col in self.cols.iter_mut().flatten() {
+            col.truncate(len);
+        }
+    }
+}
+
+pub(crate) const COALESCE_CHUNK_COUNT: usize = 64;
+
+/// Chunks in insertion order (newest last). `unique_keys` distinguishes the
+/// one-row-per-key stores (blocks, transactions) from the duplicate-key
+/// token-balance table, which changes both lookup (row vs range) and how
+/// coalescing deduplicates.
+pub(crate) struct ChunkStore<K> {
+    pub(crate) chunks: Vec<Chunk<K>>,
+    n_fields: usize,
+    unique_keys: bool,
+}
+
+impl<K: Ord + Copy> ChunkStore<K> {
+    pub(crate) fn new(n_fields: usize, unique_keys: bool) -> Self {
+        Self {
+            chunks: Vec::new(),
+            n_fields,
+            unique_keys,
+        }
+    }
+
+    pub(crate) fn push_chunk(&mut self, chunk: Chunk<K>) {
+        if chunk.keys.is_empty() {
+            return;
+        }
+        debug_assert_eq!(chunk.cols.len(), self.n_fields);
+        self.chunks.push(chunk);
+        self.coalesce_if_needed();
+    }
+
+    pub(crate) fn append_from(&mut self, other: &mut ChunkStore<K>) {
+        self.chunks.append(&mut other.chunks);
+        self.coalesce_if_needed();
+    }
+
+    /// Drop rows with keys <= `up_to` (processed). Whole chunks are freed;
+    /// a chunk straddling the boundary just advances its watermark.
+    pub(crate) fn prune(&mut self, up_to: K) {
+        self.chunks.retain_mut(|chunk| {
+            if chunk.live_len() == 0 || chunk.max() <= up_to {
+                return false;
+            }
+            if chunk.min() <= up_to {
+                let live = &chunk.keys[chunk.start..];
+                chunk.start += live.partition_point(|&k| k <= up_to);
+            }
+            true
+        });
+    }
+
+    /// Drop rows with keys > `target` (rolled back). Whole chunks are freed; a
+    /// chunk straddling the boundary truncates its tail.
+    pub(crate) fn rollback(&mut self, target: K) {
+        self.chunks.retain_mut(|chunk| {
+            if chunk.live_len() == 0 || chunk.min() > target {
+                return false;
+            }
+            if chunk.max() > target {
+                let cut = chunk.keys.partition_point(|&k| k <= target);
+                chunk.truncate_rows(cut);
+            }
+            chunk.live_len() > 0
+        });
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.chunks.clear();
+    }
+
+    /// Newest-first (chunk, row) hits per requested key. Usually one hit; more
+    /// when overlapping partition responses duplicated a key.
+    pub(crate) fn hit_lists(&self, keys: &[Option<K>]) -> Vec<Vec<(u32, u32)>> {
+        keys.iter()
+            .map(|key| match key {
+                None => Vec::new(),
+                Some(key) => {
+                    let mut hits = Vec::new();
+                    for (ci, chunk) in self.chunks.iter().enumerate().rev() {
+                        if let Some(row) = chunk.find(*key) {
+                            hits.push((ci as u32, row as u32));
+                        }
+                    }
+                    hits
+                }
+            })
+            .collect()
+    }
+
+    /// Copy one field's cells for the requested rows into a fresh column,
+    /// resolving each row from the newest chunk that has a value for it.
+    /// `None` when no chunk carries the field at all. Rows whose `selected`
+    /// is false (or with no hit) come out missing.
+    pub(crate) fn gather(
+        &self,
+        hit_lists: &[Vec<(u32, u32)>],
+        field: usize,
+        selected: impl Fn(usize) -> bool,
+    ) -> Option<AnyCol> {
+        let template = self
+            .chunks
+            .iter()
+            .rev()
+            .find_map(|c| c.cols[field].as_ref())?;
+        let mut out = template.new_like();
+        for (i, hits) in hit_lists.iter().enumerate() {
+            let mut copied = false;
+            if selected(i) {
+                for &(ci, row) in hits {
+                    if let Some(col) = &self.chunks[ci as usize].cols[field] {
+                        if col.is_valid(row as usize) {
+                            out.copy_cell(col, row as usize);
+                            copied = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if !copied {
+                out.push_missing();
+            }
+        }
+        Some(out)
+    }
+
+    fn coalesce_if_needed(&mut self) {
+        if self.chunks.len() <= COALESCE_CHUNK_COUNT {
+            return;
+        }
+        let mut sizes: Vec<usize> = self.chunks.iter().map(|c| c.live_len()).collect();
+        sizes.sort_unstable();
+        let median = sizes[sizes.len() / 2];
+
+        let old = std::mem::take(&mut self.chunks);
+        let mut run: Vec<Chunk<K>> = Vec::new();
+        for chunk in old {
+            if chunk.live_len() <= median {
+                run.push(chunk);
+            } else {
+                self.flush_run(&mut run);
+                self.chunks.push(chunk);
+            }
+        }
+        self.flush_run(&mut run);
+    }
+
+    fn flush_run(&mut self, run: &mut Vec<Chunk<K>>) {
+        match run.len() {
+            0 => (),
+            1 => self.chunks.push(run.pop().unwrap()),
+            _ => {
+                let merged = self.merge_run(run);
+                run.clear();
+                self.chunks.push(merged);
+            }
+        }
+    }
+
+    /// Merge an adjacent run of chunks (given oldest-first) into one, unioning
+    /// fields per key with newest-wins. For duplicate-key stores the newest
+    /// chunk holding a key contributes all of its rows for that key and older
+    /// chunks' rows for it are dropped.
+    fn merge_run(&self, run: &[Chunk<K>]) -> Chunk<K> {
+        let mut entries: Vec<(K, usize, usize)> = Vec::new();
+        for (pos, chunk) in run.iter().enumerate() {
+            for row in chunk.start..chunk.keys.len() {
+                entries.push((chunk.keys[row], pos, row));
+            }
+        }
+        entries.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)).then(a.2.cmp(&b.2)));
+
+        let mut cols: Vec<Option<AnyCol>> = (0..self.n_fields)
+            .map(|f| {
+                run.iter()
+                    .rev()
+                    .find_map(|c| c.cols[f].as_ref())
+                    .map(|c| c.new_like())
+            })
+            .collect();
+        let mut keys: Vec<K> = Vec::new();
+
+        let mut i = 0;
+        while i < entries.len() {
+            let key = entries[i].0;
+            let mut j = i;
+            while j < entries.len() && entries[j].0 == key {
+                j += 1;
+            }
+            let group = &entries[i..j];
+            if self.unique_keys {
+                keys.push(key);
+                for (f, col) in cols.iter_mut().enumerate() {
+                    if let Some(out) = col {
+                        let cell = group.iter().find_map(|&(_, pos, row)| {
+                            run[pos].cols[f]
+                                .as_ref()
+                                .filter(|c| c.is_valid(row))
+                                .map(|c| (c, row))
+                        });
+                        match cell {
+                            Some((src, row)) => out.copy_cell(src, row),
+                            None => out.push_missing(),
+                        }
+                    }
+                }
+            } else {
+                let newest_pos = group[0].1;
+                for &(_, pos, row) in group.iter().filter(|&&(_, pos, _)| pos == newest_pos) {
+                    keys.push(key);
+                    for (f, col) in cols.iter_mut().enumerate() {
+                        if let Some(out) = col {
+                            match run[pos].cols[f].as_ref().filter(|c| c.is_valid(row)) {
+                                Some(src) => out.copy_cell(src, row),
+                                None => out.push_missing(),
+                            }
+                        }
+                    }
+                }
+            }
+            i = j;
+        }
+
+        Chunk::new(keys, cols)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn u64_chunk(rows: &[(u64, Option<u64>, Option<&[u8]>)]) -> Chunk<u64> {
+        let mut num = NumCol::new();
+        let mut var = VarCol::new();
+        for &(_, n, v) in rows {
+            num.push(n);
+            var.push(v);
+        }
+        Chunk::new(
+            rows.iter().map(|&(k, ..)| k).collect(),
+            vec![Some(AnyCol::U64(num)), Some(AnyCol::Var(var))],
+        )
+    }
+
+    fn gathered_u64(store: &ChunkStore<u64>, keys: &[u64]) -> Vec<Option<u64>> {
+        let keys: Vec<Option<u64>> = keys.iter().map(|&k| Some(k)).collect();
+        let hits = store.hit_lists(&keys);
+        match store.gather(&hits, 0, |_| true) {
+            Some(AnyCol::U64(c)) => (0..keys.len()).map(|i| c.get(i)).collect(),
+            Some(_) => panic!("wrong column kind"),
+            None => vec![None; keys.len()],
+        }
+    }
+
+    #[test]
+    fn bitvec_push_get_truncate() {
+        let mut bv = BitVec::new();
+        for i in 0..130 {
+            bv.push(i % 3 == 0);
+        }
+        assert_eq!(
+            (bv.get(0), bv.get(1), bv.get(63), bv.get(64), bv.get(129)),
+            (true, false, true, false, true)
+        );
+        bv.truncate(65);
+        bv.push(true);
+        assert_eq!((bv.len, bv.get(64), bv.get(65)), (66, false, true));
+    }
+
+    #[test]
+    fn var_col_roundtrip_and_truncate() {
+        let mut col = VarCol::new();
+        col.push(Some(b"abc"));
+        col.push(None);
+        col.push(Some(b""));
+        col.push(Some(b"xy"));
+        assert_eq!(
+            (col.get(0), col.get(1), col.get(2), col.get(3)),
+            (
+                Some(b"abc".as_slice()),
+                None,
+                Some(b"".as_slice()),
+                Some(b"xy".as_slice())
+            )
+        );
+        col.truncate(2);
+        assert_eq!((col.offsets.len(), col.data.len()), (3, 3));
+    }
+
+    #[test]
+    fn prune_drops_whole_chunks_and_watermarks_bisected() {
+        let mut store = ChunkStore::new(2, true);
+        store.push_chunk(u64_chunk(&[(1, Some(10), None), (2, Some(20), None)]));
+        store.push_chunk(u64_chunk(&[(3, Some(30), None), (4, Some(40), None)]));
+
+        store.prune(2);
+        assert_eq!(
+            (store.chunks.len(), gathered_u64(&store, &[1, 3])),
+            (1, vec![None, Some(30)])
+        );
+
+        store.prune(3);
+        assert_eq!(gathered_u64(&store, &[3, 4]), vec![None, Some(40)]);
+    }
+
+    #[test]
+    fn rollback_truncates_tails_and_drops_above() {
+        let mut store = ChunkStore::new(2, true);
+        store.push_chunk(u64_chunk(&[(1, Some(10), None), (5, Some(50), None)]));
+        store.push_chunk(u64_chunk(&[(6, Some(60), None)]));
+
+        store.rollback(4);
+        assert_eq!(
+            (store.chunks.len(), gathered_u64(&store, &[1, 5, 6])),
+            (1, vec![Some(10), None, None])
+        );
+    }
+
+    #[test]
+    fn field_union_resolves_newest_wins_per_field() {
+        let mut store = ChunkStore::new(2, true);
+        // Older chunk carries only the var field; newer chunk only the num field.
+        let mut var = VarCol::new();
+        var.push(Some(b"hash"));
+        store.push_chunk(Chunk::new(vec![7], vec![None, Some(AnyCol::Var(var))]));
+        let mut num = NumCol::new();
+        num.push(Some(70));
+        store.push_chunk(Chunk::new(vec![7], vec![Some(AnyCol::U64(num)), None]));
+
+        let hits = store.hit_lists(&[Some(7)]);
+        let num_cell = match store.gather(&hits, 0, |_| true) {
+            Some(AnyCol::U64(c)) => c.get(0),
+            _ => panic!("expected num column"),
+        };
+        let var_cell = match store.gather(&hits, 1, |_| true) {
+            Some(AnyCol::Var(c)) => c.get(0).map(|b| b.to_vec()),
+            _ => panic!("expected var column"),
+        };
+        assert_eq!((num_cell, var_cell), (Some(70), Some(b"hash".to_vec())));
+    }
+
+    #[test]
+    fn gather_respects_selection_and_misses() {
+        let mut store = ChunkStore::new(2, true);
+        store.push_chunk(u64_chunk(&[(1, Some(10), None), (2, Some(20), None)]));
+        let hits = store.hit_lists(&[Some(1), Some(2), Some(9)]);
+        match store.gather(&hits, 0, |i| i != 1) {
+            Some(AnyCol::U64(c)) => {
+                assert_eq!((c.get(0), c.get(1), c.get(2)), (Some(10), None, None))
+            }
+            _ => panic!("expected num column"),
+        }
+    }
+
+    #[test]
+    fn coalesce_merges_small_runs_and_dedups_newest_wins() {
+        let mut store = ChunkStore::new(2, true);
+        // One large chunk keeps the median meaningful.
+        let large: Vec<(u64, Option<u64>, Option<&[u8]>)> =
+            (1000..1200).map(|k| (k, Some(k), None)).collect();
+        store.push_chunk(u64_chunk(&large));
+        for i in 0..COALESCE_CHUNK_COUNT {
+            let k = i as u64;
+            store.push_chunk(u64_chunk(&[(k, Some(k * 10), None)]));
+        }
+        // Duplicate of key 0 with a different value: the newest must win.
+        store.push_chunk(u64_chunk(&[(0, Some(999), None)]));
+
+        assert!(store.chunks.len() <= 4);
+        assert_eq!(
+            gathered_u64(&store, &[0, 5, 1100]),
+            vec![Some(999), Some(50), Some(1100)]
+        );
+    }
+
+    #[test]
+    fn duplicate_key_store_keeps_newest_chunks_rows_on_merge() {
+        let mut store = ChunkStore::new(1, false);
+        let make = |rows: &[(u64, u64)]| {
+            let mut num = NumCol::new();
+            for &(_, v) in rows {
+                num.push(Some(v));
+            }
+            Chunk::new(
+                rows.iter().map(|&(k, _)| k).collect(),
+                vec![Some(AnyCol::U64(num))],
+            )
+        };
+        let mut run = vec![make(&[(1, 10), (1, 11), (2, 20)]), make(&[(1, 12)])];
+        let merged = store.merge_run(&std::mem::take(&mut run));
+        store.push_chunk(merged);
+
+        let chunk = &store.chunks[0];
+        let vals: Vec<Option<u64>> = match &chunk.cols[0] {
+            Some(AnyCol::U64(c)) => (0..chunk.keys.len()).map(|i| c.get(i)).collect(),
+            _ => panic!("expected num column"),
+        };
+        // Key 1 resolves to the newest chunk's single row; key 2 survives.
+        assert_eq!(
+            (chunk.keys.clone(), vals),
+            (vec![1, 2], vec![Some(12), Some(20)])
+        );
+    }
+}

--- a/packages/cli/src/chunk_store.rs
+++ b/packages/cli/src/chunk_store.rs
@@ -24,7 +24,7 @@ impl BitVec {
     }
 
     fn push(&mut self, v: bool) {
-        if self.len % 64 == 0 {
+        if self.len.is_multiple_of(64) {
             self.words.push(0);
         }
         if v {
@@ -43,7 +43,7 @@ impl BitVec {
             return;
         }
         self.words.truncate(len.div_ceil(64));
-        if len % 64 != 0 {
+        if !len.is_multiple_of(64) {
             let w = self.words.last_mut().unwrap();
             *w &= (1u64 << (len % 64)) - 1;
         }
@@ -844,7 +844,9 @@ pub(crate) fn utf8(b: &[u8]) -> String {
 mod tests {
     use super::*;
 
-    fn u64_chunk(rows: &[(u64, Option<u64>, Option<&[u8]>)]) -> Chunk<u64> {
+    type TestRow<'a> = (u64, Option<u64>, Option<&'a [u8]>);
+
+    fn u64_chunk(rows: &[TestRow]) -> Chunk<u64> {
         let mut num = NumCol::new();
         let mut var = VarCol::new();
         for &(_, n, v) in rows {
@@ -971,7 +973,7 @@ mod tests {
     fn coalesce_merges_small_runs_and_dedups_newest_wins() {
         let mut store = ChunkStore::new(2, true);
         // One large chunk keeps the median meaningful.
-        let large: Vec<(u64, Option<u64>, Option<&[u8]>)> =
+        let large: Vec<TestRow> =
             (1000..1200).map(|k| (k, Some(k), None)).collect();
         store.push_chunk(u64_chunk(&large));
         for i in 0..COALESCE_CHUNK_COUNT {

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -409,18 +409,18 @@ fn process_response(
         .collect::<Result<Vec<_>>>()
         .context("mapping block headers")?;
 
-    // Retain raw blocks in the store only when an event selected a block field
-    // beyond the always-required trio (number/timestamp/hash, which the headers
-    // already carry). Otherwise the store stays empty and the consumer builds
-    // `event.block` from the header alone — no materialisation needed.
+    // Every block's header (number/timestamp/hash) is always known from the
+    // response, so it's always kept in the store; the full raw block is
+    // additionally attached only when an event selected a field beyond that
+    // trio, so `BlockStore::materialize` has something to decode extra fields
+    // from.
     let has_extra_block_fields = validated_block_fields
         .iter()
         .any(|f| !REQUIRED_BLOCK_FIELDS.contains(f));
-    if has_extra_block_fields {
-        for block in response_blocks {
-            if let Some(number) = block.number {
-                block_store.insert_evm_raw(number, Arc::new(block));
-            }
+    for (header, block) in out_blocks.iter().zip(response_blocks) {
+        if let Some(number) = block.number {
+            let raw = has_extra_block_fields.then(|| Arc::new(block));
+            block_store.insert_evm(number, header.timestamp, header.hash.clone(), raw);
         }
     }
 

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -409,18 +409,13 @@ fn process_response(
         .collect::<Result<Vec<_>>>()
         .context("mapping block headers")?;
 
-    // Every block's header (number/timestamp/hash) is always known from the
-    // response, so it's always kept in the store; the full raw block is
-    // additionally attached only when an event selected a field beyond that
-    // trio, so `BlockStore::materialize` has something to decode extra fields
-    // from.
-    let has_extra_block_fields = validated_block_fields
-        .iter()
-        .any(|f| !REQUIRED_BLOCK_FIELDS.contains(f));
-    for (header, block) in out_blocks.iter().zip(response_blocks) {
+    // Retained for every block, not just when an event selected a field beyond
+    // the trio: number/timestamp/hash decode from the store like any other
+    // field (see `decode_evm_block_field`), so the store needs an entry for
+    // every block the config's always-included trio selection touches.
+    for block in response_blocks {
         if let Some(number) = block.number {
-            let raw = has_extra_block_fields.then(|| Arc::new(block));
-            block_store.insert_evm(number, header.timestamp, header.hash.clone(), raw);
+            block_store.insert_evm_raw(number, Arc::new(block));
         }
     }
 

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -413,11 +413,7 @@ fn process_response(
     // the trio: number/timestamp/hash decode from the store like any other
     // field (see `decode_evm_block_field`), so the store needs an entry for
     // every block the config's always-included trio selection touches.
-    for block in response_blocks {
-        if let Some(number) = block.number {
-            block_store.insert_evm_raw(number, Arc::new(block));
-        }
-    }
+    block_store.insert_evm_blocks(response_blocks);
 
     let mut items = Vec::with_capacity(logs.iter().map(Vec::len).sum());
     for log in logs.into_iter().flatten() {

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::sync::{Arc, Once};
+use std::sync::Once;
 
 use anyhow::{Context, Result};
 use hypersync_client::{simple_types, RateLimitResponse};
@@ -329,10 +329,11 @@ fn process_response(
     let mut missing: Vec<String> = Vec::new();
 
     // Accumulate transactions into the store keyed by (blockNumber, txIndex).
-    // Many logs share a transaction, so a per-log insert would redundantly
-    // re-store it; inserting each transaction once deduplicates by key.
+    // Many logs share a transaction, and the server returns each one once, so
+    // the page's transactions go in as one chunk.
     let mut transaction_keys: HashSet<(u64, u32)> = HashSet::new();
     if !requested_transaction_fields.is_empty() {
+        let mut kept: Vec<simple_types::Transaction> = Vec::new();
         for tx in transactions.into_iter().flatten() {
             for &field in requested_transaction_fields {
                 if let Some(name) = transaction_field_missing(&tx, field) {
@@ -342,12 +343,12 @@ fn process_response(
             if let (Some(block_number), Some(transaction_index)) =
                 (tx.block_number, tx.transaction_index)
             {
-                let block_number = u64::from(block_number);
-                let transaction_index = u64::from(transaction_index) as u32;
-                transaction_keys.insert((block_number, transaction_index));
-                transaction_store.insert_evm_raw(block_number, transaction_index, Arc::new(tx));
+                transaction_keys
+                    .insert((u64::from(block_number), u64::from(transaction_index) as u32));
+                kept.push(tx);
             }
         }
+        transaction_store.insert_evm_txs(kept);
     }
 
     // Validate every block field we requested — the user's selection plus the

--- a/packages/cli/src/field_columns.rs
+++ b/packages/cli/src/field_columns.rs
@@ -134,35 +134,9 @@ impl ToNapiValue for Columns {
     }
 }
 
-/// Build one column by extracting a field from each record, but only for rows
-/// whose per-row `mask` has `bit` set; every other row (or a key missing from
-/// the store) yields a `None` cell. This is what lets a field be materialised on
-/// exactly the rows that selected it, rather than on every row in the batch —
-/// and it skips `extract` (e.g. hex-encoding a large field) on unselected rows.
-pub fn fill_masked<R, T>(
-    records: &[Option<std::sync::Arc<R>>],
-    masks: &[u64],
-    bit: u64,
-    extract: impl Fn(&R) -> Result<Option<T>>,
-) -> Result<Vec<Option<T>>> {
-    records
-        .iter()
-        .zip(masks)
-        .map(|(rec, &m)| {
-            if m & bit == 0 {
-                return Ok(None);
-            }
-            match rec {
-                Some(r) => extract(r.as_ref()),
-                None => Ok(None),
-            }
-        })
-        .collect()
-}
-
 /// Iterate an ecosystem's field variants and decode each whose bit is set in the
-/// union of `masks` (a column is built when any row selects it; `decode`, via
-/// `fill_masked`, still applies each row's own mask within it). Shared by every
+/// union of `masks` (a column is built when any row selects it; the gathered
+/// scratch already applies each row's own mask within it). Shared by every
 /// store; only the per-field `decode` table differs. A decode error names the
 /// field so one bad row aborts the batch's materialisation with an actionable
 /// message.

--- a/packages/cli/src/field_columns.rs
+++ b/packages/cli/src/field_columns.rs
@@ -160,21 +160,24 @@ pub fn fill_masked<R, T>(
         .collect()
 }
 
-/// Iterate an ecosystem's field variants and decode each whose mask bit is set,
-/// collecting them into columns. Shared by every store; only the per-field
-/// `decode` table differs. A decode error names the field so one bad row aborts
-/// the batch's materialisation with an actionable message.
+/// Iterate an ecosystem's field variants and decode each whose bit is set in the
+/// union of `masks` (a column is built when any row selects it; `decode`, via
+/// `fill_masked`, still applies each row's own mask within it). Shared by every
+/// store; only the per-field `decode` table differs. A decode error names the
+/// field so one bad row aborts the batch's materialisation with an actionable
+/// message.
 pub fn build_columns<F: Copy>(
     variants: &'static [F],
-    mask: u64,
+    masks: &[u64],
     len: usize,
     ordinal: impl Fn(F) -> u32,
     name: impl Fn(F) -> &'static str,
     decode: impl Fn(F) -> Result<Column>,
 ) -> Result<Columns> {
+    let union = masks.iter().fold(0u64, |acc, &m| acc | m);
     let mut columns: Vec<(&'static str, Column)> = Vec::new();
     for &field in variants {
-        if mask & (1u64 << ordinal(field)) == 0 {
+        if union & (1u64 << ordinal(field)) == 0 {
             continue;
         }
         let field_name = name(field);

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1,4 +1,5 @@
 mod block_store;
+mod chunk_store;
 mod cli_args;
 pub use cli_args::clap_definitions;
 pub use cli_args::init_config;

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -212,15 +212,13 @@ impl SvmHypersyncClient {
             .context("mapping solana block headers")
             .map_err(map_err)?;
 
-        // Retain raw blocks in Rust keyed by slot so the block store can
+        // Retain blocks in Rust keyed by slot so the block store can
         // materialise the selected block fields onto each instruction's
         // `event.block` at batch prep. Skipped when only slot/blockhash/blockTime
         // were requested — those reach ReScript via the response's block table.
         let block_store = BlockStore::new_svm();
         if has_extra_block_fields {
-            for b in raw_blocks {
-                block_store.insert_svm_raw(b.slot, Arc::new(b));
-            }
+            block_store.insert_svm_blocks(raw_blocks);
         }
 
         let mut out = QueryResponse::try_from(resp)

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -38,6 +38,13 @@ use config::SvmClientConfig;
 use query::SvmQuery;
 use types::QueryResponse;
 
+/// Query column names HyperSync always returns for a block row — see
+/// `SvmHyperSyncSource.res`'s `blockQueryFields`, which always requests
+/// `[Slot, Blockhash, BlockTime]`. Named here (mirroring the EVM side's
+/// `REQUIRED_BLOCK_FIELDS`) rather than inlined, so the trio the raw-block
+/// store gate compares against is a single discoverable constant.
+const REQUIRED_SVM_BLOCK_QUERY_FIELDS: &[&str] = &["slot", "blockhash", "block_time"];
+
 /// Move the raw transactions and token balances of a response into a
 /// `TransactionStore`, keyed by `(slot, transactionIndex)`. Kept raw in Rust so
 /// only the config-selected fields are materialised at batch prep; many
@@ -149,7 +156,7 @@ impl SvmHypersyncClient {
             .is_some_and(|block| {
                 block
                     .iter()
-                    .any(|f| !matches!(f.as_str(), "slot" | "blockhash" | "block_time"))
+                    .any(|f| !REQUIRED_SVM_BLOCK_QUERY_FIELDS.contains(&f.as_str()))
             });
 
         let q: hypersync_solana_net_types::query::SolanaQuery = query
@@ -193,20 +200,33 @@ impl SvmHypersyncClient {
             std::mem::take(&mut resp.token_balances),
         );
 
+        // Take the raw blocks out before the response conversion consumes them,
+        // build the lean per-slot header from a borrow, then move the owned raw
+        // blocks into the store — avoiding a full raw-`Block` clone per block
+        // (mirrors the EVM source's borrow-then-move header pattern).
+        let raw_blocks = std::mem::take(&mut resp.blocks);
+        let block_headers: Vec<types::Block> = raw_blocks
+            .iter()
+            .map(types::Block::from_raw)
+            .collect::<anyhow::Result<Vec<_>>>()
+            .context("mapping solana block headers")
+            .map_err(map_err)?;
+
         // Retain raw blocks in Rust keyed by slot so the block store can
         // materialise the selected block fields onto each instruction's
         // `event.block` at batch prep. Skipped when only slot/blockhash/blockTime
         // were requested — those reach ReScript via the response's block table.
         let block_store = BlockStore::new_svm();
         if has_extra_block_fields {
-            for b in &resp.blocks {
-                block_store.insert_svm_raw(b.slot, Arc::new(b.clone()));
+            for b in raw_blocks {
+                block_store.insert_svm_raw(b.slot, Arc::new(b));
             }
         }
 
         let mut out = QueryResponse::try_from(resp)
             .context("convert solana response")
             .map_err(map_err)?;
+        out.data.blocks = block_headers;
         for (instr, d) in out.data.instructions.iter_mut().zip(decoded) {
             instr.decoded = d;
         }

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -45,48 +45,19 @@ use types::QueryResponse;
 /// store gate compares against is a single discoverable constant.
 const REQUIRED_SVM_BLOCK_QUERY_FIELDS: &[&str] = &["slot", "blockhash", "block_time"];
 
-/// Move the raw transactions and token balances of a response into a
-/// `TransactionStore`, keyed by `(slot, transactionIndex)`. Kept raw in Rust so
+/// Move the response's transactions and token balances into a
+/// `TransactionStore`, keyed by `(slot, transactionIndex)`. Kept in Rust so
 /// only the config-selected fields are materialised at batch prep; many
-/// instructions in one transaction collapse to a single stored record.
+/// instructions in one transaction collapse to a single stored row, and token
+/// balances land in the store's companion table joined back by key at
+/// materialisation.
 fn build_svm_store(
     transactions: Vec<simple::Transaction>,
     token_balances: Vec<simple::TokenBalance>,
 ) -> TransactionStore {
     let store = TransactionStore::new_svm();
-
-    let mut tx_by_key: HashMap<(u64, u32), simple::Transaction> = HashMap::new();
-    for tx in transactions {
-        tx_by_key.insert((tx.slot, tx.transaction_index), tx);
-    }
-    let mut tb_by_key: HashMap<(u64, u32), Vec<simple::TokenBalance>> = HashMap::new();
-    for tb in token_balances {
-        if let Some(ti) = tb.transaction_index {
-            tb_by_key.entry((tb.slot, ti)).or_default().push(tb);
-        }
-    }
-
-    // Union of keys: a transaction may have token balances but no selected
-    // transaction fields, or vice versa.
-    let mut keys: Vec<(u64, u32)> = tx_by_key.keys().copied().collect();
-    for key in tb_by_key.keys() {
-        if !tx_by_key.contains_key(key) {
-            keys.push(*key);
-        }
-    }
-    for key in keys {
-        // A token-balance-only key has no transaction row; the defaulted struct
-        // is fine because `transactionIndex` materialises from the store key, not
-        // this record (no other field is read for such keys).
-        let tx = tx_by_key.remove(&key).unwrap_or_default();
-        let token_balances = tb_by_key.remove(&key).unwrap_or_default();
-        store.insert_svm_raw(
-            key.0,
-            key.1,
-            Arc::new(TransactionStore::make_svm_stored(tx, token_balances)),
-        );
-    }
-
+    store.insert_svm_txs(transactions);
+    store.insert_svm_token_balances(token_balances);
     store
 }
 

--- a/packages/cli/src/svm_hypersync_source/types.rs
+++ b/packages/cli/src/svm_hypersync_source/types.rs
@@ -129,14 +129,24 @@ fn u32_to_i64(v: u32) -> i64 {
     v as i64
 }
 
+impl Block {
+    /// Build the lean header from a borrowed raw block, without taking
+    /// ownership — used when the raw block is also retained (owned) in the
+    /// `BlockStore` for on-demand field materialisation, so only the header's
+    /// own fields are cloned rather than the whole raw struct.
+    pub(crate) fn from_raw(b: &simple::Block) -> Result<Self> {
+        Ok(Self {
+            slot: u64_to_i64(b.slot, "block.slot")?,
+            blockhash: b.blockhash.clone(),
+            block_time: b.block_time,
+        })
+    }
+}
+
 impl TryFrom<simple::Block> for Block {
     type Error = anyhow::Error;
     fn try_from(b: simple::Block) -> Result<Self> {
-        Ok(Self {
-            slot: u64_to_i64(b.slot, "block.slot")?,
-            blockhash: b.blockhash,
-            block_time: b.block_time,
-        })
+        Self::from_raw(&b)
     }
 }
 

--- a/packages/cli/src/transaction_store.rs
+++ b/packages/cli/src/transaction_store.rs
@@ -1,28 +1,31 @@
-//! Per-chain transaction store shared across ecosystems. Transactions are kept
-//! as raw upstream structs (their large fields, e.g. EVM `input`, never cross
-//! the napi boundary until they are read). At batch preparation the fields a
-//! chain's config selected are decoded in bulk, off the JS thread, into a
-//! columnar form; the main thread then zips the columns into plain JS objects,
-//! setting only the selected fields. The store lives on the ReScript
-//! `ChainState`; fetch responses are merged in, and entries are pruned/rolled
-//! back by block.
+//! Per-chain transaction store, chunk-columnar: every fetch response
+//! contributes one chunk of transactions keyed by (blockNumber,
+//! transactionIndex), holding only the selected fields' columns — a large
+//! field (e.g. EVM `input`) never crosses the napi boundary until an event
+//! that selected it is materialised. SVM token balances live in a companion
+//! duplicate-key table gathered by key range. The store lives on the ReScript
+//! `ChainState`; fetch responses merge in, and rows are pruned/rolled back by
+//! block via the chunk lifecycle.
 
-use std::collections::{BTreeMap, HashMap};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use anyhow::Result;
-use hypersync_client::format::Hex;
 use hypersync_client::simple_types;
 use hypersync_client_solana::simple_types as solana_simple;
 use napi_derive::napi;
 use strum::VariantArray;
 
+use crate::chunk_store::{
+    access_lists_cells, access_lists_from, auth_lists_cells, auth_lists_from, bool_cells,
+    bool_from, bytes_cells, f64_cells, f64_from, fixed_from, hash_list_cells, hash_list_from,
+    hex_full, hex_quantity, str_list_cells, str_list_from, u64_cells, u64_from, utf8, var_from,
+    AnyCol, Chunk, ChunkStore,
+};
 use crate::evm_hypersync_source::map_err;
 use crate::evm_hypersync_source::types::{
-    map_address_string, map_bigint, map_hex_string, AccessList as AccessListItem,
-    Authorization as AuthorizationItem,
+    encode_address, map_bigint, AccessList as AccessListItem, Authorization as AuthorizationItem,
 };
-use crate::field_columns::{build_columns, fill_masked, Column, Columns, SvmTokenBalanceOut};
+use crate::field_columns::{build_columns, Column, Columns, SvmTokenBalanceOut};
 use crate::svm_hypersync_source::types::bigint_u64;
 
 /// Transaction field codes shared with ReScript by ordinal value. The order is
@@ -146,15 +149,107 @@ impl SvmTxField {
     }
 }
 
-/// Decode the per-row mask-selected fields of the given EVM transactions into
-/// columns. A field's column is built when any row selects it (the union of
-/// `masks`); within that column a row whose own mask lacks the field gets a
-/// `None` cell, so a large field (e.g. `input`) is only touched on the rows that
-/// asked for it. Runs off the JS thread. `transaction_indices` is the requested
-/// key per row, so `transactionIndex` resolves from the key (always known)
-/// rather than a stored record.
+fn bytes<T: AsRef<[u8]>>(v: &T) -> &[u8] {
+    v.as_ref()
+}
+
+/// Build one EVM field's column from a response's transactions. `None` for the
+/// key-derived `transactionIndex` and for fields no transaction carries.
+/// Exhaustive match: adding an `EvmTxField` variant fails to compile until it
+/// is filled here and decoded below.
+fn evm_tx_col(field: EvmTxField, txs: &[simple_types::Transaction]) -> Option<AnyCol> {
+    use EvmTxField::*;
+    match field {
+        // The within-block index is part of the chunk key, not a column.
+        TransactionIndex => None,
+        Hash => fixed_from(txs, 32, |t| t.hash.as_ref().map(bytes)),
+        From => fixed_from(txs, 20, |t| t.from.as_ref().map(bytes)),
+        To => fixed_from(txs, 20, |t| t.to.as_ref().map(bytes)),
+        Gas => var_from(txs, |t| t.gas.as_ref().map(bytes)),
+        GasPrice => var_from(txs, |t| t.gas_price.as_ref().map(bytes)),
+        MaxPriorityFeePerGas => var_from(txs, |t| t.max_priority_fee_per_gas.as_ref().map(bytes)),
+        MaxFeePerGas => var_from(txs, |t| t.max_fee_per_gas.as_ref().map(bytes)),
+        CumulativeGasUsed => var_from(txs, |t| t.cumulative_gas_used.as_ref().map(bytes)),
+        EffectiveGasPrice => var_from(txs, |t| t.effective_gas_price.as_ref().map(bytes)),
+        GasUsed => var_from(txs, |t| t.gas_used.as_ref().map(bytes)),
+        Input => var_from(txs, |t| t.input.as_ref().map(bytes)),
+        Nonce => var_from(txs, |t| t.nonce.as_ref().map(bytes)),
+        Value => var_from(txs, |t| t.value.as_ref().map(bytes)),
+        V => var_from(txs, |t| t.v.as_ref().map(bytes)),
+        R => var_from(txs, |t| t.r.as_ref().map(bytes)),
+        S => var_from(txs, |t| t.s.as_ref().map(bytes)),
+        ContractAddress => fixed_from(txs, 20, |t| t.contract_address.as_ref().map(bytes)),
+        LogsBloom => var_from(txs, |t| t.logs_bloom.as_ref().map(bytes)),
+        Root => fixed_from(txs, 32, |t| t.root.as_ref().map(bytes)),
+        Status => u64_from(txs, |t| t.status.map(|v| v.to_u8() as u64)),
+        YParity => var_from(txs, |t| t.y_parity.as_ref().map(bytes)),
+        MaxFeePerBlobGas => var_from(txs, |t| t.max_fee_per_blob_gas.as_ref().map(bytes)),
+        BlobVersionedHashes => hash_list_from(txs, |t| {
+            t.blob_versioned_hashes.as_ref().map(|v| {
+                v.iter()
+                    .map(|h| <[u8; 32]>::try_from(h.as_ref()).expect("blob hash width"))
+                    .collect()
+            })
+        }),
+        Type => u64_from(txs, |t| t.type_.map(|v| u8::from(v) as u64)),
+        L1Fee => var_from(txs, |t| t.l1_fee.as_ref().map(bytes)),
+        L1GasPrice => var_from(txs, |t| t.l1_gas_price.as_ref().map(bytes)),
+        L1GasUsed => var_from(txs, |t| t.l1_gas_used.as_ref().map(bytes)),
+        L1FeeScalar => f64_from(txs, |t| t.l1_fee_scalar),
+        GasUsedForL1 => var_from(txs, |t| t.gas_used_for_l1.as_ref().map(bytes)),
+        AccessList => access_lists_from(txs, |t| t.access_list.clone()),
+        AuthorizationList => auth_lists_from(txs, |t| t.authorization_list.clone()),
+    }
+}
+
+/// Decode one EVM field from its gathered scratch column, already masked
+/// per-row by the gather.
+fn decode_evm_field(
+    field: EvmTxField,
+    scratch: &[Option<AnyCol>],
+    transaction_indices: &[u32],
+    masks: &[u64],
+    should_checksum: bool,
+) -> Result<Column> {
+    use EvmTxField::*;
+    let bit = 1u64 << (field as u32);
+    let col = scratch[field as usize].as_ref();
+    let len = transaction_indices.len();
+    Ok(match field {
+        // The within-block index is the store key, so it's always available
+        // regardless of whether the transaction row was fetched.
+        TransactionIndex => Column::I64(
+            transaction_indices
+                .iter()
+                .zip(masks)
+                .map(|(&i, &m)| (m & bit != 0).then_some(i as i64))
+                .collect(),
+        ),
+        Hash | Input | LogsBloom | Root => {
+            Column::Str(bytes_cells(col, len, |b| Ok(Some(hex_full(b))))?)
+        }
+        From | To | ContractAddress => Column::Str(bytes_cells(col, len, |b| {
+            let address = <[u8; 20]>::try_from(b).expect("address cell width");
+            Ok(Some(encode_address(&address.into(), should_checksum)))
+        })?),
+        Gas | GasPrice | MaxPriorityFeePerGas | MaxFeePerGas | CumulativeGasUsed
+        | EffectiveGasPrice | GasUsed | Nonce | Value | MaxFeePerBlobGas | L1Fee | L1GasPrice
+        | L1GasUsed | GasUsedForL1 => {
+            Column::Big(bytes_cells(col, len, |b| Ok(map_bigint(&Some(b))))?)
+        }
+        V | R | S | YParity => Column::Str(bytes_cells(col, len, |b| Ok(Some(hex_quantity(b))))?),
+        Status | Type => Column::I64(u64_cells(col, len, |v| Ok(Some(v as i64)))?),
+        BlobVersionedHashes => Column::StrVec(hash_list_cells(col, len, |h| hex_full(h))),
+        L1FeeScalar => Column::F64(f64_cells(col, len)),
+        AccessList => Column::AccessList(access_lists_cells(col, len, |a| AccessListItem::from(a))),
+        AuthorizationList => Column::AuthList(auth_lists_cells(col, len, |a| {
+            AuthorizationItem::try_from(a)
+        })?),
+    })
+}
+
 fn decode_evm_columns(
-    records: &[Option<Arc<simple_types::Transaction>>],
+    scratch: &[Option<AnyCol>],
     transaction_indices: &[u32],
     masks: &[u64],
     should_checksum: bool,
@@ -162,312 +257,126 @@ fn decode_evm_columns(
     build_columns(
         EvmTxField::VARIANTS,
         masks,
-        records.len(),
+        transaction_indices.len(),
         |f| f as u32,
         |f| f.name(),
-        |f| decode_evm_field(f, records, transaction_indices, masks, should_checksum),
+        |f| decode_evm_field(f, scratch, transaction_indices, masks, should_checksum),
     )
 }
 
-/// Decode a single EVM field, materialising it only on the rows whose mask has
-/// the field's bit set. Exhaustive match: adding an `EvmTxField` variant fails
-/// to compile until it is decoded here.
-fn decode_evm_field(
-    field: EvmTxField,
-    records: &[Option<Arc<simple_types::Transaction>>],
+/// Build one SVM field's column from a response's transactions. `None` for the
+/// key-derived `transactionIndex` and for `tokenBalances`, which lives in the
+/// companion duplicate-key table.
+fn svm_tx_col(field: SvmTxField, txs: &[solana_simple::Transaction]) -> Option<AnyCol> {
+    use SvmTxField::*;
+    match field {
+        TransactionIndex => None,
+        Signatures => str_list_from(txs, |t| Some(t.signatures.clone())),
+        FeePayer => var_from(txs, |t| t.fee_payer.as_ref().map(|s| s.as_bytes())),
+        Success => bool_from(txs, |t| t.success),
+        Err => var_from(txs, |t| t.err.as_ref().map(|s| s.as_bytes())),
+        Fee => u64_from(txs, |t| t.fee),
+        ComputeUnitsConsumed => u64_from(txs, |t| t.compute_units_consumed),
+        AccountKeys => str_list_from(txs, |t| Some(t.account_keys.clone())),
+        RecentBlockhash => var_from(txs, |t| t.recent_blockhash.as_ref().map(|s| s.as_bytes())),
+        Version => var_from(txs, |t| t.version.as_ref().map(|s| s.as_bytes())),
+        TokenBalances => None,
+    }
+}
+
+/// Decode one SVM field. `token_balances` comes pre-gathered from the
+/// companion table (it isn't part of the transaction scratch).
+fn decode_svm_field(
+    field: SvmTxField,
+    scratch: &[Option<AnyCol>],
+    token_balances: &[Option<Vec<SvmTokenBalanceOut>>],
     transaction_indices: &[u32],
     masks: &[u64],
-    should_checksum: bool,
 ) -> Result<Column> {
+    use SvmTxField::*;
     let bit = 1u64 << (field as u32);
+    let col = scratch[field as usize].as_ref();
+    let len = transaction_indices.len();
     Ok(match field {
         // The within-block index is the store key, so it's always available
         // regardless of whether the transaction row was fetched.
-        EvmTxField::TransactionIndex => Column::I64(
+        TransactionIndex => Column::I64(
             transaction_indices
                 .iter()
                 .zip(masks)
                 .map(|(&i, &m)| (m & bit != 0).then_some(i as i64))
                 .collect(),
         ),
-        EvmTxField::Hash => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_hex_string(&tx.hash))
-        })?),
-        EvmTxField::From => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_address_string(&tx.from, should_checksum))
-        })?),
-        EvmTxField::To => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_address_string(&tx.to, should_checksum))
-        })?),
-        EvmTxField::Gas => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.gas))
-        })?),
-        EvmTxField::GasPrice => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.gas_price))
-        })?),
-        EvmTxField::MaxPriorityFeePerGas => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.max_priority_fee_per_gas))
-        })?),
-        EvmTxField::MaxFeePerGas => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.max_fee_per_gas))
-        })?),
-        EvmTxField::CumulativeGasUsed => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.cumulative_gas_used))
-        })?),
-        EvmTxField::EffectiveGasPrice => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.effective_gas_price))
-        })?),
-        EvmTxField::GasUsed => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.gas_used))
-        })?),
-        EvmTxField::Input => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_hex_string(&tx.input))
-        })?),
-        EvmTxField::Nonce => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.nonce))
-        })?),
-        EvmTxField::Value => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.value))
-        })?),
-        EvmTxField::V => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_hex_string(&tx.v))
-        })?),
-        EvmTxField::R => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_hex_string(&tx.r))
-        })?),
-        EvmTxField::S => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_hex_string(&tx.s))
-        })?),
-        EvmTxField::ContractAddress => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_address_string(&tx.contract_address, should_checksum))
-        })?),
-        EvmTxField::LogsBloom => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_hex_string(&tx.logs_bloom))
-        })?),
-        EvmTxField::Root => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_hex_string(&tx.root))
-        })?),
-        EvmTxField::Status => Column::I64(fill_masked(records, masks, bit, |tx| {
-            Ok(tx.status.map(|v| v.to_u8() as i64))
-        })?),
-        EvmTxField::YParity => Column::Str(fill_masked(records, masks, bit, |tx| {
-            Ok(map_hex_string(&tx.y_parity))
-        })?),
-        EvmTxField::MaxFeePerBlobGas => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.max_fee_per_blob_gas))
-        })?),
-        EvmTxField::BlobVersionedHashes => {
-            Column::StrVec(fill_masked(records, masks, bit, |tx| {
-                Ok(tx
-                    .blob_versioned_hashes
-                    .as_ref()
-                    .map(|arr| arr.iter().map(|h| h.encode_hex()).collect()))
-            })?)
+        Signatures | AccountKeys => Column::StrVec(str_list_cells(col, len)),
+        FeePayer | Err | RecentBlockhash | Version => {
+            Column::Str(bytes_cells(col, len, |b| Ok(Some(utf8(b))))?)
         }
-        EvmTxField::Type => Column::I64(fill_masked(records, masks, bit, |tx| {
-            Ok(tx.type_.map(|v| u8::from(v) as i64))
-        })?),
-        EvmTxField::L1Fee => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.l1_fee))
-        })?),
-        EvmTxField::L1GasPrice => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.l1_gas_price))
-        })?),
-        EvmTxField::L1GasUsed => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.l1_gas_used))
-        })?),
-        EvmTxField::L1FeeScalar => {
-            Column::F64(fill_masked(records, masks, bit, |tx| Ok(tx.l1_fee_scalar))?)
+        Success => Column::Bool(bool_cells(col, len)),
+        Fee | ComputeUnitsConsumed => {
+            Column::Big(u64_cells(col, len, |v| Ok(Some(bigint_u64(v))))?)
         }
-        EvmTxField::GasUsedForL1 => Column::Big(fill_masked(records, masks, bit, |tx| {
-            Ok(map_bigint(&tx.gas_used_for_l1))
-        })?),
-        EvmTxField::AccessList => Column::AccessList(fill_masked(records, masks, bit, |tx| {
-            Ok(tx
-                .access_list
-                .as_ref()
-                .map(|arr| arr.iter().map(AccessListItem::from).collect()))
-        })?),
-        EvmTxField::AuthorizationList => {
-            Column::AuthList(fill_masked(records, masks, bit, |tx| {
-                tx.authorization_list
-                    .as_ref()
-                    .map(|al| {
-                        al.iter()
-                            .map(AuthorizationItem::try_from)
-                            .collect::<Result<_>>()
-                    })
-                    .transpose()
-            })?)
-        }
+        TokenBalances => Column::TokenBalances(token_balances.to_vec()),
     })
 }
 
-/// A stored SVM transaction: the raw upstream transaction plus the token
-/// balances joined to it (a separate upstream table, materialised as one field).
-pub struct SvmStored {
-    tx: solana_simple::Transaction,
-    token_balances: Vec<solana_simple::TokenBalance>,
-}
-
-/// Decode the per-row mask-selected fields of the given SVM transactions into
-/// columns. A field's column is built when any row selects it (the union of
-/// `masks`); within it a row whose own mask lacks the field gets a `None` cell,
-/// so a large field (e.g. `accountKeys`) is only cloned for the rows that asked.
-/// `transaction_indices` is the requested key per row, so `transactionIndex`
-/// resolves from the key (always known) rather than a stored record.
 fn decode_svm_columns(
-    records: &[Option<Arc<SvmStored>>],
+    scratch: &[Option<AnyCol>],
+    token_balances: &[Option<Vec<SvmTokenBalanceOut>>],
     transaction_indices: &[u32],
     masks: &[u64],
 ) -> Result<Columns> {
     build_columns(
         SvmTxField::VARIANTS,
         masks,
-        records.len(),
+        transaction_indices.len(),
         |f| f as u32,
         |f| f.name(),
-        |f| decode_svm_field(f, records, transaction_indices, masks),
+        |f| decode_svm_field(f, scratch, token_balances, transaction_indices, masks),
     )
 }
 
-/// Decode a single SVM field, materialising it only on the rows whose mask has
-/// the field's bit set. Exhaustive match: adding an `SvmTxField` variant fails
-/// to compile until it is decoded here.
-fn decode_svm_field(
-    field: SvmTxField,
-    records: &[Option<Arc<SvmStored>>],
-    transaction_indices: &[u32],
+const TOKEN_BALANCE_FIELDS: usize = 5;
+
+/// One materialised token-balance row from the companion table's columns.
+fn token_balance_row(chunk: &Chunk<(u64, u32)>, row: usize) -> SvmTokenBalanceOut {
+    let cell = |f: usize| match &chunk.cols[f] {
+        Some(AnyCol::Var(c)) => c.get(row).map(utf8),
+        None => None,
+        Some(_) => panic!("expected a token-balance string column"),
+    };
+    SvmTokenBalanceOut {
+        account: cell(0),
+        mint: cell(1),
+        owner: cell(2),
+        pre_amount: cell(3),
+        post_amount: cell(4),
+    }
+}
+
+/// Gather each selected row's token balances: all rows for the key from the
+/// newest chunk holding it. A selected row whose transaction has no balances
+/// (or whose key is missing entirely) yields `[]`, not a missing field — an
+/// absent transaction means "no balances". Unselected rows stay missing.
+fn gather_token_balances(
+    table: &ChunkStore<(u64, u32)>,
+    keys: &[Option<(u64, u32)>],
     masks: &[u64],
-) -> Result<Column> {
-    let bit = 1u64 << (field as u32);
-    Ok(match field {
-        // The within-block index is the store key, so it's always available
-        // regardless of whether the transaction row was fetched.
-        SvmTxField::TransactionIndex => Column::I64(
-            transaction_indices
-                .iter()
-                .zip(masks)
-                .map(|(&i, &m)| (m & bit != 0).then_some(i as i64))
-                .collect(),
-        ),
-        SvmTxField::Signatures => Column::StrVec(fill_masked(records, masks, bit, |r| {
-            Ok(Some(r.tx.signatures.clone()))
-        })?),
-        SvmTxField::FeePayer => Column::Str(fill_masked(records, masks, bit, |r| {
-            Ok(r.tx.fee_payer.clone())
-        })?),
-        SvmTxField::Success => {
-            Column::Bool(fill_masked(records, masks, bit, |r| Ok(r.tx.success))?)
-        }
-        SvmTxField::Err => Column::Str(fill_masked(records, masks, bit, |r| Ok(r.tx.err.clone()))?),
-        SvmTxField::Fee => Column::Big(fill_masked(records, masks, bit, |r| {
-            Ok(r.tx.fee.map(bigint_u64))
-        })?),
-        SvmTxField::ComputeUnitsConsumed => Column::Big(fill_masked(records, masks, bit, |r| {
-            Ok(r.tx.compute_units_consumed.map(bigint_u64))
-        })?),
-        SvmTxField::AccountKeys => Column::StrVec(fill_masked(records, masks, bit, |r| {
-            Ok(Some(r.tx.account_keys.clone()))
-        })?),
-        SvmTxField::RecentBlockhash => Column::Str(fill_masked(records, masks, bit, |r| {
-            Ok(r.tx.recent_blockhash.clone())
-        })?),
-        SvmTxField::Version => Column::Str(fill_masked(records, masks, bit, |r| {
-            Ok(r.tx.version.clone())
-        })?),
-        // Always materialise an array on a selected row: a record absent from the
-        // store (its transaction had no token balances, so it was never
-        // inserted) means "no balances" → `[]`, not a missing field. A row that
-        // didn't select the field still gets `None` (skipped on the JS object).
-        SvmTxField::TokenBalances => Column::TokenBalances(
-            records
-                .iter()
-                .zip(masks)
-                .map(|(rec, &m)| {
-                    if m & bit == 0 {
-                        return None;
-                    }
-                    Some(match rec {
-                        Some(r) => r
-                            .token_balances
-                            .iter()
-                            .map(|tb| SvmTokenBalanceOut {
-                                account: tb.account.clone(),
-                                mint: tb.mint.clone(),
-                                owner: tb.owner.clone(),
-                                pre_amount: tb.pre_amount.clone(),
-                                post_amount: tb.post_amount.clone(),
-                            })
-                            .collect(),
-                        None => vec![],
-                    })
+) -> Vec<Option<Vec<SvmTokenBalanceOut>>> {
+    let bit = 1u64 << (SvmTxField::TokenBalances as u32);
+    keys.iter()
+        .zip(masks)
+        .map(|(key, &m)| {
+            if m & bit == 0 {
+                return None;
+            }
+            let rows = key.and_then(|key| {
+                table.chunks.iter().rev().find_map(|chunk| {
+                    chunk
+                        .find_range(key)
+                        .map(|(lo, hi)| (lo..hi).map(|row| token_balance_row(chunk, row)).collect())
                 })
-                .collect(),
-        ),
-    })
-}
-
-/// One stored transaction, kept in its ecosystem's compact raw form.
-enum StoredTx {
-    /// HyperSync: raw upstream transaction, selected fields decoded at batch prep.
-    EvmRaw { tx: Arc<simple_types::Transaction> },
-    /// SVM HyperSync: raw upstream transaction (+ joined token balances).
-    Svm { rec: Arc<SvmStored> },
-}
-
-/// Transactions keyed by block number, then by within-block transaction index.
-/// The outer `BTreeMap` keeps prune and rollback cheap range splits.
-#[derive(Default)]
-struct BlockTxs {
-    map: BTreeMap<u64, HashMap<u32, StoredTx>>,
-}
-
-impl BlockTxs {
-    fn new() -> Self {
-        Self::default()
-    }
-
-    /// Drain every entry from `self` into `dst`, merging per-block buckets.
-    fn drain_into(&mut self, dst: &mut Self) {
-        for (block, bucket) in std::mem::take(&mut self.map) {
-            dst.map.entry(block).or_default().extend(bucket);
-        }
-    }
-
-    /// Drop blocks at or below `up_to` (already processed). `split_off` returns
-    /// the `>= up_to + 1` tail, which becomes the new map.
-    fn prune(&mut self, up_to: u64) {
-        self.map = self.map.split_off(&(up_to + 1));
-    }
-
-    /// Drop blocks above `target` (rolled back). `split_off` removes the
-    /// `>= target + 1` tail and we discard it, leaving `<= target` in place.
-    fn rollback(&mut self, target: u64) {
-        self.map.split_off(&(target + 1));
-    }
-}
-
-/// Gather the stored records matching the requested keys, in input order;
-/// missing keys (or a record `pick` rejects) yield `None`. Shared by both
-/// ecosystems — only the `pick` closure (which `StoredTx` variant to take)
-/// differs.
-fn collect<T>(
-    store: &BlockTxs,
-    block_numbers: &[i64],
-    transaction_indices: &[u32],
-    pick: impl Fn(&StoredTx) -> Option<T>,
-) -> Vec<Option<T>> {
-    block_numbers
-        .iter()
-        .zip(transaction_indices)
-        .map(|(block, idx)| {
-            let block = u64::try_from(*block).ok()?;
-            store
-                .map
-                .get(&block)
-                .and_then(|b| b.get(idx))
-                .and_then(&pick)
+            });
+            Some(rows.unwrap_or_default())
         })
         .collect()
 }
@@ -483,9 +392,16 @@ enum Ecosystem {
     Fuel,
 }
 
+/// The transaction table plus SVM's token-balance companion (empty on other
+/// ecosystems), guarded together so merges and gathers stay atomic.
+struct Stores {
+    txs: ChunkStore<(u64, u32)>,
+    token_balances: ChunkStore<(u64, u32)>,
+}
+
 #[napi]
 pub struct TransactionStore {
-    inner: Mutex<BlockTxs>,
+    inner: Mutex<Stores>,
     // Fixed at construction; drives the decoder in `materialize`.
     ecosystem: Ecosystem,
 }
@@ -512,7 +428,7 @@ impl TransactionStore {
         Self::with_ecosystem(Ecosystem::Fuel)
     }
 
-    /// Move every entry from `page` into this store (merging a fetch-response
+    /// Move every chunk from `page` into this store (merging a fetch-response
     /// page into the persistent per-chain store).
     #[napi]
     pub fn merge(&self, page: &TransactionStore) {
@@ -525,7 +441,8 @@ impl TransactionStore {
         debug_assert_eq!(self.ecosystem, page.ecosystem);
         let mut dst = self.inner.lock().unwrap();
         let mut src = page.inner.lock().unwrap();
-        src.drain_into(&mut dst);
+        dst.txs.append_from(&mut src.txs);
+        dst.token_balances.append_from(&mut src.token_balances);
     }
 
     /// Bulk-materialise transactions in columnar form, one row per
@@ -534,10 +451,10 @@ impl TransactionStore {
     /// pull just the transaction fields it selected, so a large field (e.g.
     /// `input`) is materialised only on the rows that asked for it. Each mask is a
     /// JS number (`f64`) carrying a selection bitmask over field codes 0..31 (so
-    /// it fits in 32 bits). Async + `block_in_place` so the bulk decode runs off
-    /// the JS thread without monopolising an async worker; the brief lock only
-    /// clones `Arc`s. Missing keys yield an empty object. Result is aligned with
-    /// input.
+    /// it fits in 32 bits). The lock is held only to gather the requested cells;
+    /// decoding runs after it is released, off the JS thread via
+    /// `block_in_place`. Missing keys yield an empty object. Result is aligned
+    /// with input.
     #[napi(ts_return_type = "Promise<object[]>")]
     pub async fn materialize(
         &self,
@@ -556,35 +473,30 @@ impl TransactionStore {
             )));
         }
         let masks: Vec<u64> = masks.iter().map(|&m| m as u64).collect();
+        let keys: Vec<Option<(u64, u32)>> = block_numbers
+            .iter()
+            .zip(&transaction_indices)
+            .map(|(&bn, &ti)| u64::try_from(bn).ok().map(|bn| (bn, ti)))
+            .collect();
 
         match self.ecosystem {
             Ecosystem::Evm { should_checksum } => {
-                let records =
-                    self.collect_locked(
-                        &block_numbers,
-                        &transaction_indices,
-                        |stored| match stored {
-                            StoredTx::EvmRaw { tx } => Some(tx.clone()),
-                            _ => None,
-                        },
-                    );
+                let scratch = self.inner.lock().unwrap().txs.gather_scratch(&keys, &masks);
                 tokio::task::block_in_place(|| {
-                    decode_evm_columns(&records, &transaction_indices, &masks, should_checksum)
+                    decode_evm_columns(&scratch, &transaction_indices, &masks, should_checksum)
                 })
                 .map_err(map_err)
             }
             Ecosystem::Svm => {
-                let records =
-                    self.collect_locked(
-                        &block_numbers,
-                        &transaction_indices,
-                        |stored| match stored {
-                            StoredTx::Svm { rec } => Some(rec.clone()),
-                            _ => None,
-                        },
-                    );
+                let (scratch, token_balances) = {
+                    let stores = self.inner.lock().unwrap();
+                    (
+                        stores.txs.gather_scratch(&keys, &masks),
+                        gather_token_balances(&stores.token_balances, &keys, &masks),
+                    )
+                };
                 tokio::task::block_in_place(|| {
-                    decode_svm_columns(&records, &transaction_indices, &masks)
+                    decode_svm_columns(&scratch, &token_balances, &transaction_indices, &masks)
                 })
                 .map_err(map_err)
             }
@@ -601,79 +513,118 @@ impl TransactionStore {
     #[napi]
     pub fn prune(&self, up_to_block: i64) {
         if let Ok(up_to) = u64::try_from(up_to_block) {
-            self.inner.lock().unwrap().prune(up_to);
+            let mut stores = self.inner.lock().unwrap();
+            stores.txs.prune((up_to, u32::MAX));
+            stores.token_balances.prune((up_to, u32::MAX));
         }
     }
 
     /// Drop transactions for blocks above `target_block` (rolled back).
     #[napi]
     pub fn rollback(&self, target_block: i64) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut stores = self.inner.lock().unwrap();
         match u64::try_from(target_block) {
-            Ok(target) => inner.rollback(target),
-            Err(_) => inner.map.clear(),
+            Ok(target) => {
+                stores.txs.rollback((target, u32::MAX));
+                stores.token_balances.rollback((target, u32::MAX));
+            }
+            Err(_) => {
+                stores.txs.clear();
+                stores.token_balances.clear();
+            }
         }
     }
 }
 
 impl TransactionStore {
-    /// Lock the store and gather the records for the requested keys. The lock is
-    /// held only for the `Arc` clones; decoding runs after it is released.
-    fn collect_locked<T>(
-        &self,
-        block_numbers: &[i64],
-        transaction_indices: &[u32],
-        pick: impl Fn(&StoredTx) -> Option<T>,
-    ) -> Vec<Option<T>> {
-        let inner = self.inner.lock().unwrap();
-        collect(&inner, block_numbers, transaction_indices, pick)
-    }
-
     fn with_ecosystem(ecosystem: Ecosystem) -> Self {
+        let n_fields = match ecosystem {
+            Ecosystem::Evm { .. } => EvmTxField::VARIANTS.len(),
+            Ecosystem::Svm => SvmTxField::VARIANTS.len(),
+            Ecosystem::Fuel => 0,
+        };
         Self {
-            inner: Mutex::new(BlockTxs::new()),
+            inner: Mutex::new(Stores {
+                txs: ChunkStore::new(n_fields, true),
+                token_balances: ChunkStore::new(TOKEN_BALANCE_FIELDS, false),
+            }),
             ecosystem,
         }
     }
 
-    /// Insert a raw EVM transaction (called by the HyperSync source while
-    /// building a page). The page's transactions arrive already deduplicated by
-    /// the upstream response (one row per (block, index)), so a plain insert is
-    /// enough — many logs sharing a transaction never reach here. Not exposed to
-    /// JS.
-    pub(crate) fn insert_evm_raw(
-        &self,
-        block_number: u64,
-        transaction_index: u32,
-        tx: Arc<simple_types::Transaction>,
-    ) {
+    /// Add one response's EVM transactions as a chunk (called by the HyperSync
+    /// source while building a page). Rows without a (block, index) key are
+    /// dropped. Not exposed to JS.
+    pub(crate) fn insert_evm_txs(&self, mut txs: Vec<simple_types::Transaction>) {
+        txs.retain(|t| t.block_number.is_some() && t.transaction_index.is_some());
+        if txs.is_empty() {
+            return;
+        }
+        let key = |t: &simple_types::Transaction| {
+            (
+                u64::from(t.block_number.unwrap()),
+                u64::from(t.transaction_index.unwrap()) as u32,
+            )
+        };
+        txs.sort_unstable_by_key(key);
+        let keys = txs.iter().map(key).collect();
+        let cols = EvmTxField::VARIANTS
+            .iter()
+            .map(|&f| evm_tx_col(f, &txs))
+            .collect();
         self.inner
             .lock()
             .unwrap()
-            .map
-            .entry(block_number)
-            .or_default()
-            .insert(transaction_index, StoredTx::EvmRaw { tx });
+            .txs
+            .push_chunk(Chunk::new(keys, cols));
     }
 
-    /// Insert a raw SVM transaction with its joined token balances (called by the
-    /// SVM HyperSync source while building a page). Not exposed to JS.
-    pub(crate) fn insert_svm_raw(&self, slot: u64, transaction_index: u32, rec: Arc<SvmStored>) {
+    /// Add one response's SVM transactions as a chunk, keyed by
+    /// (slot, transactionIndex). Not exposed to JS.
+    pub(crate) fn insert_svm_txs(&self, mut txs: Vec<solana_simple::Transaction>) {
+        if txs.is_empty() {
+            return;
+        }
+        let key = |t: &solana_simple::Transaction| (t.slot, t.transaction_index);
+        txs.sort_unstable_by_key(key);
+        let keys = txs.iter().map(key).collect();
+        let cols = SvmTxField::VARIANTS
+            .iter()
+            .map(|&f| svm_tx_col(f, &txs))
+            .collect();
         self.inner
             .lock()
             .unwrap()
-            .map
-            .entry(slot)
-            .or_default()
-            .insert(transaction_index, StoredTx::Svm { rec });
+            .txs
+            .push_chunk(Chunk::new(keys, cols));
     }
 
-    /// Build a stored SVM record from a raw transaction and its token balances.
-    pub(crate) fn make_svm_stored(
-        tx: solana_simple::Transaction,
-        token_balances: Vec<solana_simple::TokenBalance>,
-    ) -> SvmStored {
-        SvmStored { tx, token_balances }
+    /// Add one response's SVM token balances to the companion duplicate-key
+    /// table. The sort is stable so a transaction's balances keep their
+    /// response order. Not exposed to JS.
+    pub(crate) fn insert_svm_token_balances(&self, mut rows: Vec<solana_simple::TokenBalance>) {
+        rows.retain(|r| r.transaction_index.is_some());
+        if rows.is_empty() {
+            return;
+        }
+        let key = |r: &solana_simple::TokenBalance| (r.slot, r.transaction_index.unwrap());
+        rows.sort_by_key(key);
+        let keys = rows.iter().map(key).collect();
+        let str_col = |f: fn(&solana_simple::TokenBalance) -> Option<&str>| -> Option<AnyCol> {
+            crate::chunk_store::var_from(&rows, |r| f(r).map(str::as_bytes))
+        };
+        let cols = vec![
+            str_col(|r| r.account.as_deref()),
+            str_col(|r| r.mint.as_deref()),
+            str_col(|r| r.owner.as_deref()),
+            str_col(|r| r.pre_amount.as_deref()),
+            str_col(|r| r.post_amount.as_deref()),
+        ];
+        self.inner
+            .lock()
+            .unwrap()
+            .token_balances
+            .push_chunk(Chunk::new(keys, cols));
     }
 }
 
@@ -702,11 +653,20 @@ pub fn svm_transaction_field_names() -> Vec<String> {
 mod tests {
     use super::*;
 
-    fn raw_tx() -> simple_types::Transaction {
-        let mut tx = simple_types::Transaction::default();
-        tx.transaction_index = Some(3u64.into());
-        tx.input = Some(hypersync_client::format::Data::from(vec![0xab, 0xcd]));
-        tx
+    fn raw_tx(block: u64, index: u64) -> simple_types::Transaction {
+        simple_types::Transaction {
+            block_number: Some(block.into()),
+            transaction_index: Some(index.into()),
+            ..Default::default()
+        }
+    }
+
+    fn raw_svm_tx(slot: u64, index: u32) -> solana_simple::Transaction {
+        solana_simple::Transaction {
+            slot,
+            transaction_index: index,
+            ..Default::default()
+        }
     }
 
     fn column<'a>(cols: &'a Columns, name: &str) -> Option<&'a Column> {
@@ -716,67 +676,93 @@ mod tests {
             .map(|(_, c)| c)
     }
 
-    #[test]
-    fn decode_selected_only_materialises_masked_fields() {
-        // Select only `input` via the bitmask.
-        let mask = 1u64 << (EvmTxField::Input as u32);
-        let cols = decode_evm_columns(&[Some(Arc::new(raw_tx()))], &[0], &[mask], false)
-            .expect("decode columns");
-
-        // Exactly one column (input) is present; transactionIndex (present on the
-        // raw tx but unselected) and gas are absent.
-        match column(&cols, "input") {
-            Some(Column::Str(v)) => assert_eq!(v, &vec![Some("0xabcd".to_string())]),
-            other => panic!(
-                "expected input string column, got present={}",
-                other.is_some()
-            ),
-        }
-        assert!(column(&cols, "transactionIndex").is_none());
-        assert!(column(&cols, "gas").is_none());
+    fn bit(field: EvmTxField) -> u64 {
+        1u64 << (field as u32)
     }
 
-    #[test]
-    fn decode_applies_each_rows_own_mask() {
+    // `materialize` uses `block_in_place`, which needs a multi-thread runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn decode_selected_only_materialises_masked_fields() {
+        let store = TransactionStore::new_evm(false);
+        let mut tx = raw_tx(1, 0);
+        tx.input = Some(hypersync_client::format::Data::from(
+            vec![0xab, 0xcd].into_boxed_slice(),
+        ));
+        store.insert_evm_txs(vec![tx]);
+
+        // Select only `input` via the bitmask.
+        let mask = bit(EvmTxField::Input) as f64;
+        let cols = store
+            .materialize(vec![1], vec![0], vec![mask])
+            .await
+            .expect("materialize");
+
+        let summary = (
+            match column(&cols, "input") {
+                Some(Column::Str(v)) => v.clone(),
+                _ => panic!("expected input column"),
+            },
+            column(&cols, "transactionIndex").is_some(),
+            column(&cols, "gas").is_some(),
+        );
+        assert_eq!(summary, (vec![Some("0xabcd".to_string())], false, false));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn decode_applies_each_rows_own_mask() {
         // Row 0 selects `input`; row 1 selects only `transactionIndex`. The union
         // builds both columns, but each field is present only on its row.
-        let input_mask = 1u64 << (EvmTxField::Input as u32);
-        let index_mask = 1u64 << (EvmTxField::TransactionIndex as u32);
-        let cols = decode_evm_columns(
-            &[Some(Arc::new(raw_tx())), Some(Arc::new(raw_tx()))],
-            &[0, 1],
-            &[input_mask, index_mask],
-            false,
-        )
-        .expect("decode columns");
+        let store = TransactionStore::new_evm(false);
+        let mut tx0 = raw_tx(1, 0);
+        tx0.input = Some(hypersync_client::format::Data::from(
+            vec![0xab, 0xcd].into_boxed_slice(),
+        ));
+        let mut tx1 = raw_tx(1, 1);
+        tx1.input = Some(hypersync_client::format::Data::from(
+            vec![0xee].into_boxed_slice(),
+        ));
+        store.insert_evm_txs(vec![tx0, tx1]);
 
-        // `input` decoded only for row 0; row 1 is `None` (skipped on its object).
-        match column(&cols, "input") {
-            Some(Column::Str(v)) => assert_eq!(v, &vec![Some("0xabcd".to_string()), None]),
-            other => panic!("expected input column, got present={}", other.is_some()),
-        }
-        // `transactionIndex` resolves from the key only for row 1.
-        match column(&cols, "transactionIndex") {
-            Some(Column::I64(v)) => assert_eq!(v, &vec![None, Some(1)]),
-            other => panic!(
-                "expected transactionIndex column, got present={}",
-                other.is_some()
-            ),
-        }
+        let cols = store
+            .materialize(
+                vec![1, 1],
+                vec![0, 1],
+                vec![
+                    bit(EvmTxField::Input) as f64,
+                    bit(EvmTxField::TransactionIndex) as f64,
+                ],
+            )
+            .await
+            .expect("materialize");
+
+        let summary = (
+            match column(&cols, "input") {
+                Some(Column::Str(v)) => v.clone(),
+                _ => panic!("expected input column"),
+            },
+            match column(&cols, "transactionIndex") {
+                Some(Column::I64(v)) => v.clone(),
+                _ => panic!("expected transactionIndex column"),
+            },
+        );
+        assert_eq!(
+            summary,
+            (vec![Some("0xabcd".to_string()), None], vec![None, Some(1)])
+        );
     }
 
-    #[test]
-    fn evm_transaction_index_comes_from_key_even_on_miss() {
-        // A missing record (None) still materialises the requested key as
+    #[tokio::test(flavor = "multi_thread")]
+    async fn evm_transaction_index_comes_from_key_even_on_miss() {
+        // A missing row still materialises the requested key as
         // `transactionIndex`, so it never depends on a fetched transaction row.
-        let mask = 1u64 << (EvmTxField::TransactionIndex as u32);
-        let cols = decode_evm_columns(
-            &[None, Some(Arc::new(raw_tx()))],
-            &[7, 3],
-            &[mask, mask],
-            false,
-        )
-        .expect("decode columns");
+        let store = TransactionStore::new_evm(false);
+        store.insert_evm_txs(vec![raw_tx(1, 3)]);
+
+        let mask = bit(EvmTxField::TransactionIndex) as f64;
+        let cols = store
+            .materialize(vec![9, 1], vec![7, 3], vec![mask, mask])
+            .await
+            .expect("materialize");
         match column(&cols, "transactionIndex") {
             Some(Column::I64(v)) => assert_eq!(v, &vec![Some(7), Some(3)]),
             other => panic!(
@@ -784,6 +770,124 @@ mod tests {
                 other.is_some()
             ),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn svm_decode_selected_only_materialises_masked_fields() {
+        let store = TransactionStore::new_svm();
+        let mut tx = raw_svm_tx(5, 0);
+        tx.account_keys = vec!["key1".to_string(), "key2".to_string()];
+        tx.fee = Some(5000);
+        tx.signatures = vec!["sig".to_string()];
+        store.insert_svm_txs(vec![tx]);
+
+        // Select only accountKeys.
+        let mask = (1u64 << (SvmTxField::AccountKeys as u32)) as f64;
+        let cols = store
+            .materialize(vec![5], vec![0], vec![mask])
+            .await
+            .expect("materialize");
+
+        let summary = (
+            match column(&cols, "accountKeys") {
+                Some(Column::StrVec(v)) => v.clone(),
+                _ => panic!("expected accountKeys column"),
+            },
+            column(&cols, "fee").is_some(),
+            column(&cols, "signatures").is_some(),
+        );
+        assert_eq!(
+            summary,
+            (
+                vec![Some(vec!["key1".to_string(), "key2".to_string()])],
+                false,
+                false
+            )
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn token_balances_gather_by_key_range() {
+        let store = TransactionStore::new_svm();
+        store.insert_svm_txs(vec![raw_svm_tx(5, 0)]);
+        let balance = |slot, index, mint: &str| solana_simple::TokenBalance {
+            slot,
+            transaction_index: Some(index),
+            mint: Some(mint.to_string()),
+            ..Default::default()
+        };
+        // Two balances on (5,0); one on a transaction with no tx row (5,1).
+        store.insert_svm_token_balances(vec![
+            balance(5, 0, "mintA"),
+            balance(5, 0, "mintB"),
+            balance(5, 1, "mintC"),
+        ]);
+
+        let mask = (1u64 << (SvmTxField::TokenBalances as u32)) as f64;
+        let cols = store
+            .materialize(vec![5, 5, 5], vec![0, 1, 2], vec![mask, mask, mask])
+            .await
+            .expect("materialize");
+
+        match column(&cols, "tokenBalances") {
+            Some(Column::TokenBalances(rows)) => {
+                let mints: Vec<Option<Vec<Option<String>>>> = rows
+                    .iter()
+                    .map(|r| {
+                        r.as_ref()
+                            .map(|v| v.iter().map(|tb| tb.mint.clone()).collect())
+                    })
+                    .collect();
+                // A selected row with no balances at all still gets `[]`.
+                assert_eq!(
+                    mints,
+                    vec![
+                        Some(vec![Some("mintA".to_string()), Some("mintB".to_string())]),
+                        Some(vec![Some("mintC".to_string())]),
+                        Some(vec![]),
+                    ]
+                );
+            }
+            other => panic!(
+                "expected tokenBalances column, got present={}",
+                other.is_some()
+            ),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prune_and_rollback_drop_by_block() {
+        let store = TransactionStore::new_evm(false);
+        let txs = [10u64, 20, 30]
+            .into_iter()
+            .map(|block| {
+                let mut tx = raw_tx(block, 0);
+                tx.nonce = Some(hypersync_client::format::Quantity::from(block));
+                tx
+            })
+            .collect();
+        store.insert_evm_txs(txs);
+
+        let mask = bit(EvmTxField::Nonce) as f64;
+        store.prune(10);
+        let after_prune = store
+            .materialize(vec![10, 20, 30], vec![0, 0, 0], vec![mask, mask, mask])
+            .await
+            .expect("materialize");
+        store.rollback(20);
+        let after_rollback = store
+            .materialize(vec![10, 20, 30], vec![0, 0, 0], vec![mask, mask, mask])
+            .await
+            .expect("materialize");
+
+        let nonces = |cols: &Columns| match column(cols, "nonce") {
+            Some(Column::Big(v)) => v.iter().map(|c| c.is_some()).collect::<Vec<_>>(),
+            _ => panic!("expected nonce column"),
+        };
+        assert_eq!(
+            (nonces(&after_prune), nonces(&after_rollback)),
+            (vec![false, true, true], vec![false, true, false])
+        );
     }
 
     #[test]
@@ -857,62 +961,6 @@ mod tests {
                 "version",
                 "tokenBalances",
             ]
-        );
-    }
-
-    #[test]
-    fn svm_decode_selected_only_materialises_masked_fields() {
-        let tx = solana_simple::Transaction {
-            account_keys: vec!["key1".to_string(), "key2".to_string()],
-            fee: Some(5000),
-            signatures: vec!["sig".to_string()],
-            ..Default::default()
-        };
-        let rec = Arc::new(SvmStored {
-            tx,
-            token_balances: vec![],
-        });
-
-        // Select only accountKeys.
-        let mask = 1u64 << (SvmTxField::AccountKeys as u32);
-        let cols = decode_svm_columns(&[Some(rec)], &[0], &[mask]).expect("decode columns");
-
-        match column(&cols, "accountKeys") {
-            Some(Column::StrVec(v)) => {
-                assert_eq!(v, &vec![Some(vec!["key1".to_string(), "key2".to_string()])])
-            }
-            other => panic!(
-                "expected accountKeys column, got present={}",
-                other.is_some()
-            ),
-        }
-        // fee and signatures are present on the raw tx but unselected.
-        assert!(column(&cols, "fee").is_none());
-        assert!(column(&cols, "signatures").is_none());
-    }
-
-    #[test]
-    fn prune_and_rollback_drop_by_block() {
-        let store = TransactionStore::new_evm(false);
-        for block in [10u64, 20, 30] {
-            store.insert_evm_raw(block, 0, Arc::new(simple_types::Transaction::default()));
-        }
-
-        store.prune(10);
-        assert!(!store.inner.lock().unwrap().map.contains_key(&10));
-
-        store.rollback(20);
-        // Block 30 dropped by rollback; block 20 survives.
-        assert_eq!(
-            store
-                .inner
-                .lock()
-                .unwrap()
-                .map
-                .keys()
-                .copied()
-                .collect::<Vec<_>>(),
-            vec![20]
         );
     }
 }

--- a/packages/cli/src/transaction_store.rs
+++ b/packages/cli/src/transaction_store.rs
@@ -159,10 +159,9 @@ fn decode_evm_columns(
     masks: &[u64],
     should_checksum: bool,
 ) -> Result<Columns> {
-    let union = masks.iter().fold(0u64, |acc, &m| acc | m);
     build_columns(
         EvmTxField::VARIANTS,
-        union,
+        masks,
         records.len(),
         |f| f as u32,
         |f| f.name(),
@@ -322,10 +321,9 @@ fn decode_svm_columns(
     transaction_indices: &[u32],
     masks: &[u64],
 ) -> Result<Columns> {
-    let union = masks.iter().fold(0u64, |acc, &m| acc | m);
     build_columns(
         SvmTxField::VARIANTS,
-        union,
+        masks,
         records.len(),
         |f| f as u32,
         |f| f.name(),

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -710,8 +710,9 @@ let advanceAfterBatch = (cs: t, ~batch: Batch.t, ~enteringReorgThreshold) =>
 // Commit a processed batch's progress for this chain (progress block, events
 // processed, head/safe-checkpoint tracking, first event block). Emits the
 // per-chain progress metrics. Readiness is decided by CrossChainState once every
-// chain is caught up (see markReady).
-let applyBatchProgress = (cs: t, ~batch: Batch.t) => {
+// chain is caught up (see markReady). `blockTimestampName` is the ecosystem's
+// block-timestamp field, read off the payload block for the latency metric.
+let applyBatchProgress = (cs: t, ~batch: Batch.t, ~blockTimestampName: string) => {
   let chainId = cs.chainConfig.id
 
   switch batch.progressedChainsById->Utils.Dict.dangerouslyGetByIntNonOption(chainId) {
@@ -729,15 +730,27 @@ let applyBatchProgress = (cs: t, ~batch: Batch.t) => {
         )
       }
 
-      // Calculate and set latency metrics
-      switch batch->Batch.findLastEventItem(~chainId) {
-      | Some(eventItem) => {
-          let blockTimestampMs = eventItem.timestamp * 1000
-          Prometheus.ProgressLatency.set(
-            ~latencyMs=Date.now()->Float.toInt - blockTimestampMs,
-            ~chainId,
-          )
-        }
+      // Calculate and set latency metrics. The payload block is materialised or
+      // inline by processing time; its timestamp may still be absent (e.g. an
+      // SVM slot with no block row) — the metric is skipped then.
+      switch batch
+      ->Batch.findLastEventItem(~chainId)
+      ->Option.flatMap(eventItem =>
+        eventItem.payload
+        ->Internal.getPayloadBlock
+        ->Nullable.toOption
+      )
+      ->Option.flatMap(block =>
+        block
+        ->(Utils.magic: Internal.eventBlock => dict<unknown>)
+        ->Utils.Dict.dangerouslyGetNonOption(blockTimestampName)
+      ) {
+      | Some(blockTimestamp) =>
+        let blockTimestampMs = blockTimestamp->(Utils.magic: unknown => int) * 1000
+        Prometheus.ProgressLatency.set(
+          ~latencyMs=Date.now()->Float.toInt - blockTimestampMs,
+          ~chainId,
+        )
       | None => ()
       }
 

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -134,7 +134,7 @@ let updateKnownHeight: (t, ~knownHeight: int) => unit
 let setEndBlockToFirstEvent: (t, ~blockNumber: int) => unit
 let enterReorgThreshold: t => unit
 let advanceAfterBatch: (t, ~batch: Batch.t, ~enteringReorgThreshold: bool) => unit
-let applyBatchProgress: (t, ~batch: Batch.t) => unit
+let applyBatchProgress: (t, ~batch: Batch.t, ~blockTimestampName: string) => unit
 let markReady: t => unit
 let rollback: (
   t,

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -135,13 +135,13 @@ let enterReorgThreshold = (crossChainState: t) => {
 // whole indexer. A chain is marked caught up only once EVERY chain is caught up
 // (reached endblock or fetched/processed to head) with no processable events
 // left — so no chain flips to ready while another is still backfilling.
-let applyBatchProgress = (crossChainState: t, ~batch: Batch.t) => {
+let applyBatchProgress = (crossChainState: t, ~batch: Batch.t, ~blockTimestampName: string) => {
   let chainIds = crossChainState.chainIds
 
   let everyChainCaughtUp = ref(true)
   for i in 0 to chainIds->Array.length - 1 {
     let cs = crossChainState->getChainState(chainIds->Array.getUnsafe(i))
-    cs->ChainState.applyBatchProgress(~batch)
+    cs->ChainState.applyBatchProgress(~batch, ~blockTimestampName)
     if !(cs->ChainState.hasProcessedToEndblock || cs->ChainState.isProgressAtHead) {
       everyChainCaughtUp := false
     }

--- a/packages/envio/src/CrossChainState.resi
+++ b/packages/envio/src/CrossChainState.resi
@@ -29,7 +29,7 @@ let createBatch: (
   ~isRollback: bool,
 ) => Batch.t
 let enterReorgThreshold: t => unit
-let applyBatchProgress: (t, ~batch: Batch.t) => unit
+let applyBatchProgress: (t, ~batch: Batch.t, ~blockTimestampName: string) => unit
 
 // Fetch control.
 let priorityOrder: t => array<ChainState.t>

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -362,7 +362,10 @@ let clearRollback = (state: t) => state.rollbackState = NoRollback
 let invalidateInflight = (state: t) => state.epoch = state.epoch + 1
 
 let applyBatchProgress = (state: t, ~batch: Batch.t) =>
-  state.crossChainState->CrossChainState.applyBatchProgress(~batch)
+  state.crossChainState->CrossChainState.applyBatchProgress(
+    ~batch,
+    ~blockTimestampName=state.config.ecosystem.blockTimestampName,
+  )
 
 // Processing-loop mutex. Guards ProcessEventBatch re-entry so only one
 // processing loop runs at a time.

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -307,8 +307,8 @@ type genericEvent<'params, 'block, 'transaction> = {
   block: 'block,
 }
 
-// Opaque internally — block-level values needed by the runtime
-// (blockNumber, timestamp, blockHash) live on the item instead.
+// Opaque internally — the block number needed by the runtime lives on the
+// item instead.
 type event
 
 // Opaque payload an item carries. A source builds an ecosystem-specific
@@ -444,9 +444,9 @@ type eventConfig = private {
   transactionFieldMask: float,
   // Selected block fields precompiled to the block-store selection bitmask (bit
   // per ecosystem field code). `0.` for ecosystems that carry the block fully
-  // inline (RPC/Fuel). The always-available trio (EVM number/timestamp/hash from
-  // the item; SVM slot/time/hash from the response) is stamped without a store
-  // lookup, so this only drives whether the store is consulted for further fields.
+  // inline (RPC/Fuel). The EVM selection always includes number/timestamp/hash,
+  // so an EVM mask always has their bits set; SVM stamps slot/time/hash inline
+  // from the response and its mask is the user's selection alone.
   blockFieldMask: float,
 }
 
@@ -564,10 +564,8 @@ type dcs = array<indexingAddress>
 type eventItem = private {
   kind: [#0],
   eventConfig: eventConfig,
-  timestamp: int,
   chain: ChainMap.Chain.t,
   blockNumber: int,
-  blockHash: string,
   logIndex: int,
   // Within-block transaction index — the key into the per-chain transaction
   // store. Unused (0) for ecosystems that carry the transaction inline (Fuel).
@@ -619,10 +617,8 @@ type item =
   | @as(0)
   Event({
       eventConfig: eventConfig,
-      timestamp: int,
       chain: ChainMap.Chain.t,
       blockNumber: int,
-      blockHash: string,
       logIndex: int,
       transactionIndex: int,
       payload: eventPayload,

--- a/packages/envio/src/RawEvent.res
+++ b/packages/envio/src/RawEvent.res
@@ -19,16 +19,20 @@ let convertFieldsToJson = (fields: option<dict<unknown>>) => {
 
 // Block and transaction are passed already extracted from the ecosystem's
 // concrete payload (EVM or Fuel) — `RawEvent` stays payload-shape-agnostic and
-// only needs them as opaque field bags to serialise.
+// only needs them as opaque field bags to serialise. The dedicated
+// `block_hash`/`block_timestamp` column values are extracted from the payload
+// block by the ecosystem caller (the field names differ per ecosystem).
 let make = (
   eventItem: Internal.eventItem,
   ~block,
   ~transaction,
   ~params: Internal.eventParams,
   ~srcAddress: Address.t,
+  ~blockHash: string,
+  ~blockTimestamp: int,
   ~cleanUpRawEventFieldsInPlace: JSON.t => unit,
 ): Internal.rawEvent => {
-  let {eventConfig, chain, blockNumber, blockHash, timestamp: blockTimestamp, logIndex} = eventItem
+  let {eventConfig, chain, blockNumber, logIndex} = eventItem
   let chainId = chain->ChainMap.Chain.toChainId
   let eventId = EventUtils.packEventIndex(~logIndex, ~blockNumber)
   let blockFields =

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -294,15 +294,15 @@ let parse = (~simulateItems: array<JSON.t>, ~config: Config.t, ~chainConfig: Con
         rawItem["block"]->(Utils.magic: 'a => Nullable.t<JSON.t>)->Nullable.toOption
       let transactionJson: option<JSON.t> =
         rawItem["transaction"]->(Utils.magic: 'a => Nullable.t<JSON.t>)->Nullable.toOption
-      let (block, blockNumber, timestamp, blockHash) = switch config.ecosystem.name {
+      let (block, blockNumber) = switch config.ecosystem.name {
       | Fuel =>
         let block = parseFuelSimulateBlock(~defaultBlockNumber=currentBlock.contents, ~blockJson)
         let blockFields = block->(Utils.magic: Internal.eventBlock => fuelSimulateBlock)
-        (block, blockFields.height, blockFields.time, blockFields.id)
+        (block, blockFields.height)
       | Evm =>
         let block = parseEvmSimulateBlock(~defaultBlockNumber=currentBlock.contents, ~blockJson)
         let blockFields = block->(Utils.magic: Internal.eventBlock => evmSimulateBlock)
-        (block, blockFields.number, blockFields.timestamp, blockFields.hash)
+        (block, blockFields.number)
       | Svm => JsError.throwWithMessage("simulate is not supported for SVM ecosystem")
       }
       let transaction = switch config.ecosystem.name {
@@ -330,10 +330,8 @@ let parse = (~simulateItems: array<JSON.t>, ~config: Config.t, ~chainConfig: Con
       ->Array.push(
         Internal.Event({
           eventConfig,
-          timestamp,
           chain,
           blockNumber,
-          blockHash,
           logIndex,
           // Simulate keeps the transaction inline on the payload, so the store
           // key is unused.

--- a/packages/envio/src/sources/BlockStore.res
+++ b/packages/envio/src/sources/BlockStore.res
@@ -27,22 +27,6 @@ let make = (~ecosystem: Ecosystem.name, ~shouldChecksum: bool): t => {
 let makeMaskFn = FieldMask.makeMaskFn
 let orMask = FieldMask.orMask
 
-// Each ecosystem's always-available trio sits at field codes 0/1/2 (EVM
-// number/timestamp/hash from the item; SVM slot/time/hash from the response),
-// stamped onto `event.block` without a store lookup. `hasExtraFields` is true
-// once any other field is selected — only then is a materialise call worthwhile.
-// The `& ~7` clears the trio's bits, relying on them being field codes 0/1/2;
-// tests in BlockStore_test pin both orderings.
-let hasExtraFields: float => bool = %raw(`m => ((m & ~7) >>> 0) !== 0`)
-
-// Clear the trio's bits (field codes 0/1/2) from a mask before a materialise
-// call. The Rust store always resolves number/timestamp/hash from its own
-// header regardless of the mask (`BlockStore::insert_evm`/
-// `decode_evm_block_columns`), so asking it to also decode them from the raw
-// block is wasted work — a full hash hex-encode per block for a value that's
-// immediately overwritten.
-let stripTrioBits: float => float = %raw(`m => (m & ~7) >>> 0`)
-
 // Drain another store (a fetch-response page) into this one.
 @send external merge: (t, t) => unit = "merge"
 
@@ -61,17 +45,6 @@ external materialize: (
 
 // Drop blocks above the given block (rolled back).
 @send external rollback: (t, int) => unit = "rollback"
-
-// Build a block object carrying just the always-present trio, straight from
-// the item. Used only for the no-store-lookup fast path (no event selected a
-// field beyond the trio) — when the store IS consulted, its own header
-// resolves number/timestamp/hash instead (see `BlockStore::insert_evm` on the
-// Rust side).
-let makeBlockHeader: (
-  ~number: int,
-  ~timestamp: int,
-  ~hash: string,
-) => Internal.eventBlock = %raw(`(number, timestamp, hash) => ({ number, timestamp, hash })`)
 
 // Merge a materialised field bag onto an existing block object in place. Used by
 // the SVM path, where the source already attached a minimal inline block.
@@ -118,30 +91,16 @@ let groupByBlock = (items: array<Internal.item>, ~owns: Internal.eventItem => bo
 
 // EVM: materialise each store-backed item's selected block fields and write the
 // resulting block onto its payload. Items that already carry an inline block
-// (RPC/simulate/Fuel) are skipped. Store-backed items always get a block object
-// carrying at least number/timestamp/hash, plus any further fields their
-// events selected. Deduped per block number.
+// (RPC/simulate/Fuel) are skipped. The config's field selection always includes
+// number/timestamp/hash, so every mask has bits set and every store-backed item
+// gets a block carrying at least the trio. Deduped per block number.
 let materializeEvmItems = async (store: t, ~items: array<Internal.item>) => {
   let (blockNumbers, masks, groups) =
     items->groupByBlock(~owns=eventItem =>
       eventItem.payload->Internal.getPayloadBlock->Nullable.toOption->Option.isNone
     )
   if groups->Utils.Array.notEmpty {
-    // Only reach into the store when some event selected a field beyond the
-    // trio; otherwise every block is built directly from its item. When the
-    // store IS consulted, its own header resolves number/timestamp/hash (see
-    // `stripTrioBits`), so the returned objects need no further stamping.
-    let anyExtra = masks->Array.some(hasExtraFields)
-    let blocks = anyExtra
-      ? await store->materialize(~blockNumbers, ~masks=masks->Array.map(stripTrioBits))
-      : groups->Array.map(group => {
-          let eventItem = group->Array.getUnsafe(0)
-          makeBlockHeader(
-            ~number=eventItem.blockNumber,
-            ~timestamp=eventItem.timestamp,
-            ~hash=eventItem.blockHash,
-          )
-        })
+    let blocks = await store->materialize(~blockNumbers, ~masks)
     groups->Array.forEachWithIndex((group, i) => {
       let block = blocks->Array.getUnsafe(i)
       group->Array.forEach(ei => ei.payload->Internal.setPayloadBlock(block))
@@ -149,21 +108,19 @@ let materializeEvmItems = async (store: t, ~items: array<Internal.item>) => {
   }
 }
 
-// SVM: the source stamps the always-available trio (`slot`/`time`/`hash`) inline
-// on each item. When an instruction selected a field beyond the trio, enrich its
-// block in place with the extra fields kept raw in the store (`height`/
-// `parentSlot`/`parentHash`) — a slot missing from the store (no block row) keeps
-// just the inline trio. Grouped per slot so the store is consulted once per slot;
-// each instruction's own inline block is enriched in place.
+// SVM: the source stamps the always-available `slot`/`time`/`hash` inline on
+// each item. Enrich each item's block in place with its selected fields from the
+// store — a slot missing from the store (no block row, or only inline fields
+// selected) yields an empty bag and the inline block stands. Grouped per slot so
+// the store is consulted once per slot.
 let materializeSvmItems = async (store: t, ~items: array<Internal.item>) => {
   let (blockNumbers, masks, groups) =
     items->groupByBlock(~owns=eventItem =>
       eventItem.payload->Internal.getPayloadBlock->Nullable.toOption->Option.isSome
     )
 
-  // slot/time/hash are already stamped inline; only fields beyond the trio need a
-  // store lookup. When none were selected the inline block stands.
-  if masks->Array.some(hasExtraFields) {
+  // Skip the store call when no instruction selected a block field at all.
+  if masks->Array.some(mask => mask !== 0.) {
     let materialized = await store->materialize(~blockNumbers, ~masks)
     groups->Array.forEachWithIndex((group, i) => {
       let fields = materialized->Array.getUnsafe(i)

--- a/packages/envio/src/sources/BlockStore.res
+++ b/packages/envio/src/sources/BlockStore.res
@@ -35,6 +35,12 @@ let orMask = FieldMask.orMask
 // tests in BlockStore_test pin both orderings.
 let hasExtraFields: float => bool = %raw(`m => ((m & ~7) >>> 0) !== 0`)
 
+// Clear the trio's bits (field codes 0/1/2) from a mask before a materialise
+// call. The EVM path always stamps the trio from the item afterward (see
+// `setBlockHeader`), so asking the store to decode it too is wasted work — a
+// full hash hex-encode per block for a value that's immediately overwritten.
+let stripTrioBits: float => float = %raw(`m => (m & ~7) >>> 0`)
+
 // Drain another store (a fetch-response page) into this one.
 @send external merge: (t, t) => unit = "merge"
 
@@ -123,9 +129,13 @@ let materializeEvmItems = async (store: t, ~items: array<Internal.item>) => {
     )
   if groups->Utils.Array.notEmpty {
     // Only reach into the store when some event selected a field beyond the trio;
-    // otherwise every block is built from its item alone.
+    // otherwise every block is built from its item alone. The trio's own bits are
+    // stripped from the request since `setBlockHeader` below always overwrites
+    // them from the item anyway.
     let anyExtra = masks->Array.some(hasExtraFields)
-    let materialized = anyExtra ? await store->materialize(~blockNumbers, ~masks) : []
+    let materialized = anyExtra
+      ? await store->materialize(~blockNumbers, ~masks=masks->Array.map(stripTrioBits))
+      : []
     groups->Array.forEachWithIndex((group, i) => {
       let eventItem = group->Array.getUnsafe(0)
       let block = anyExtra ? materialized->Array.getUnsafe(i) : %raw(`{}`)

--- a/packages/envio/src/sources/BlockStore.res
+++ b/packages/envio/src/sources/BlockStore.res
@@ -36,9 +36,11 @@ let orMask = FieldMask.orMask
 let hasExtraFields: float => bool = %raw(`m => ((m & ~7) >>> 0) !== 0`)
 
 // Clear the trio's bits (field codes 0/1/2) from a mask before a materialise
-// call. The EVM path always stamps the trio from the item afterward (see
-// `setBlockHeader`), so asking the store to decode it too is wasted work — a
-// full hash hex-encode per block for a value that's immediately overwritten.
+// call. The Rust store always resolves number/timestamp/hash from its own
+// header regardless of the mask (`BlockStore::insert_evm`/
+// `decode_evm_block_columns`), so asking it to also decode them from the raw
+// block is wasted work — a full hash hex-encode per block for a value that's
+// immediately overwritten.
 let stripTrioBits: float => float = %raw(`m => (m & ~7) >>> 0`)
 
 // Drain another store (a fetch-response page) into this one.
@@ -60,19 +62,16 @@ external materialize: (
 // Drop blocks above the given block (rolled back).
 @send external rollback: (t, int) => unit = "rollback"
 
-// Stamp the always-present trio onto a block object. Taken from the item rather
-// than the store so it's correct even when the block was never stored (an event
-// that selected only the trio).
-let setBlockHeader: (
-  Internal.eventBlock,
+// Build a block object carrying just the always-present trio, straight from
+// the item. Used only for the no-store-lookup fast path (no event selected a
+// field beyond the trio) — when the store IS consulted, its own header
+// resolves number/timestamp/hash instead (see `BlockStore::insert_evm` on the
+// Rust side).
+let makeBlockHeader: (
   ~number: int,
   ~timestamp: int,
   ~hash: string,
-) => unit = %raw(`(b, number, timestamp, hash) => {
-    b.number = number
-    b.timestamp = timestamp
-    b.hash = hash
-  }`)
+) => Internal.eventBlock = %raw(`(number, timestamp, hash) => ({ number, timestamp, hash })`)
 
 // Merge a materialised field bag onto an existing block object in place. Used by
 // the SVM path, where the source already attached a minimal inline block.
@@ -120,30 +119,31 @@ let groupByBlock = (items: array<Internal.item>, ~owns: Internal.eventItem => bo
 // EVM: materialise each store-backed item's selected block fields and write the
 // resulting block onto its payload. Items that already carry an inline block
 // (RPC/simulate/Fuel) are skipped. Store-backed items always get a block object
-// carrying at least number/timestamp/hash (stamped from the item), plus any
-// further fields their events selected. Deduped per block number.
+// carrying at least number/timestamp/hash, plus any further fields their
+// events selected. Deduped per block number.
 let materializeEvmItems = async (store: t, ~items: array<Internal.item>) => {
   let (blockNumbers, masks, groups) =
     items->groupByBlock(~owns=eventItem =>
       eventItem.payload->Internal.getPayloadBlock->Nullable.toOption->Option.isNone
     )
   if groups->Utils.Array.notEmpty {
-    // Only reach into the store when some event selected a field beyond the trio;
-    // otherwise every block is built from its item alone. The trio's own bits are
-    // stripped from the request since `setBlockHeader` below always overwrites
-    // them from the item anyway.
+    // Only reach into the store when some event selected a field beyond the
+    // trio; otherwise every block is built directly from its item. When the
+    // store IS consulted, its own header resolves number/timestamp/hash (see
+    // `stripTrioBits`), so the returned objects need no further stamping.
     let anyExtra = masks->Array.some(hasExtraFields)
-    let materialized = anyExtra
+    let blocks = anyExtra
       ? await store->materialize(~blockNumbers, ~masks=masks->Array.map(stripTrioBits))
-      : []
+      : groups->Array.map(group => {
+          let eventItem = group->Array.getUnsafe(0)
+          makeBlockHeader(
+            ~number=eventItem.blockNumber,
+            ~timestamp=eventItem.timestamp,
+            ~hash=eventItem.blockHash,
+          )
+        })
     groups->Array.forEachWithIndex((group, i) => {
-      let eventItem = group->Array.getUnsafe(0)
-      let block = anyExtra ? materialized->Array.getUnsafe(i) : %raw(`{}`)
-      block->setBlockHeader(
-        ~number=eventItem.blockNumber,
-        ~timestamp=eventItem.timestamp,
-        ~hash=eventItem.blockHash,
-      )
+      let block = blocks->Array.getUnsafe(i)
       group->Array.forEach(ei => ei.payload->Internal.setPayloadBlock(block))
     })
   }

--- a/packages/envio/src/sources/Evm.res
+++ b/packages/envio/src/sources/Evm.res
@@ -113,6 +113,14 @@ let make = (~logger: Pino.t): Ecosystem.t => {
     let payload = eventItem.payload->toPayload
     let eventConfig =
       eventItem.eventConfig->(Utils.magic: Internal.eventConfig => Internal.evmEventConfig)
+    // Store-backed payloads get `block` written at batch prep and inline
+    // sources carry it from the start, with hash/timestamp always selected —
+    // so both are present by the time a raw event is built.
+    let header = switch payload.block {
+    | Some(block) => block->(Utils.magic: Internal.eventBlock => {"hash": string, "timestamp": int})
+    | None =>
+      JsError.throwWithMessage("Unexpected case: The event block is missing for a raw event")
+    }
     eventItem->RawEvent.make(
       ~block=payload.block,
       ~transaction=payload.transaction,
@@ -122,6 +130,8 @@ let make = (~logger: Pino.t): Ecosystem.t => {
         ? ()->(Utils.magic: unit => Internal.eventParams)
         : payload.params,
       ~srcAddress=payload.srcAddress,
+      ~blockHash=header["hash"],
+      ~blockTimestamp=header["timestamp"],
       ~cleanUpRawEventFieldsInPlace,
     )
   },

--- a/packages/envio/src/sources/Fuel.res
+++ b/packages/envio/src/sources/Fuel.res
@@ -54,11 +54,14 @@ let make = (~logger: Pino.t): Ecosystem.t => {
     ),
   toRawEvent: eventItem => {
     let payload = eventItem.payload->toPayload
+    let header = payload.block->(Utils.magic: Internal.eventBlock => {"id": string, "time": int})
     eventItem->RawEvent.make(
       ~block=payload.block,
       ~transaction=payload.transaction,
       ~params=payload.params,
       ~srcAddress=payload.srcAddress,
+      ~blockHash=header["id"],
+      ~blockTimestamp=header["time"],
       ~cleanUpRawEventFieldsInPlace,
     )
   },

--- a/packages/envio/src/sources/HyperFuelSource.res
+++ b/packages/envio/src/sources/HyperFuelSource.res
@@ -408,10 +408,8 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
 
       Internal.Event({
         eventConfig: (eventConfig :> Internal.eventConfig),
-        timestamp: block.time,
         chain,
         blockNumber: block.height,
-        blockHash: block.id,
         logIndex: receiptIndex,
         // Fuel carries the transaction inline on the payload; the store key is
         // unused (Fuel identifies transactions by hash, kept on the payload).

--- a/packages/envio/src/sources/HyperSyncSource.res
+++ b/packages/envio/src/sources/HyperSyncSource.res
@@ -197,7 +197,6 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
 
   let makeEventBatchQueueItem = (
     item: HyperSyncClient.EventItems.item,
-    ~block: HyperSyncClient.EventItems.blockHeader,
     ~params: Internal.eventParams,
     ~eventConfig: Internal.evmEventConfig,
   ): Internal.item => {
@@ -206,10 +205,8 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
 
     Internal.Event({
       eventConfig: (eventConfig :> Internal.eventConfig),
-      timestamp: block.timestamp,
       chain,
       blockNumber: item.blockNumber,
-      blockHash: block.hash,
       logIndex,
       transactionIndex,
       // `block` and `transaction` are omitted; they're materialised from the
@@ -372,9 +369,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
         ->Option.flatMap(Dict.get(_, eventConfig.contractName)) {
         | Some(params) =>
           parsedQueueItems
-          ->Array.push(
-            makeEventBatchQueueItem(item, ~block=getBlock(item.blockNumber), ~params, ~eventConfig),
-          )
+          ->Array.push(makeEventBatchQueueItem(item, ~params, ~eventConfig))
           ->ignore
         | None =>
           handleDecodeFailure(

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -1153,9 +1153,7 @@ let make = (
 
                 Internal.Event({
                   eventConfig: (eventConfig :> Internal.eventConfig),
-                  timestamp: block->getBlockTimestamp,
                   blockNumber: block->getBlockNumber,
-                  blockHash: block->getBlockHash,
                   chain,
                   logIndex: log.logIndex,
                   transactionIndex: log.transactionIndex,

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -520,10 +520,8 @@ let make = ({chain, endpointUrl, apiToken, eventConfigs, clientTimeoutMillis}: o
         ->Array.push(
           Internal.Event({
             eventConfig: (eventConfig :> Internal.eventConfig),
-            timestamp: blockTime->Option.getOr(0),
             chain,
             blockNumber: instr.slot,
-            blockHash: "",
             logIndex: synthLogIndex(instr),
             // The parent transaction is materialised from the store at batch prep.
             transactionIndex: instr.transactionIndex,

--- a/scenarios/test_codegen/test/BlockStore_test.res
+++ b/scenarios/test_codegen/test/BlockStore_test.res
@@ -3,35 +3,30 @@ open Vitest
 // Build an `Internal.item` Event for a store-backed block. The payload is a bare
 // object so getPayloadBlock/setPayloadBlock (which read/write its `block`
 // property) behave like a real store-backed EVM payload. `mask` mirrors the
-// per-event `eventConfig.blockFieldMask` that materializeItems reads to decide
-// whether to consult the store for fields beyond number/timestamp/hash.
-let makeStoreBackedItem = (~blockNumber, ~timestamp, ~blockHash, ~mask=0.): Internal.item =>
+// per-event `eventConfig.blockFieldMask` — for EVM it always carries the
+// number/timestamp/hash bits, added to the selection at config build.
+let makeStoreBackedItem = (~blockNumber, ~mask): Internal.item =>
   {
     "kind": 0,
     "blockNumber": blockNumber,
-    "timestamp": timestamp,
-    "blockHash": blockHash,
     "transactionIndex": 0,
     "eventConfig": {"blockFieldMask": mask},
     "payload": (Dict.make(): dict<Internal.eventBlock>),
   }->(Utils.magic: {..} => Internal.item)
 
-let makeInlineItem = (~blockNumber, ~timestamp, ~blockHash, ~block): Internal.item => {
+let makeInlineItem = (~blockNumber, ~block): Internal.item => {
   let payload: dict<Internal.eventBlock> = Dict.make()
   payload->Dict.set("block", block)
   {
     "kind": 0,
     "blockNumber": blockNumber,
-    "timestamp": timestamp,
-    "blockHash": blockHash,
     "transactionIndex": 0,
     "payload": payload,
   }->(Utils.magic: {..} => Internal.item)
 }
 
-// SVM items carry the always-available trio (`slot`/`time`/`hash`) inline; when a
-// field beyond the trio is selected, materializeSvmItems enriches the block in
-// place from the store.
+// SVM items carry the always-available trio (`slot`/`time`/`hash`) inline; the
+// selected fields are enriched onto the block in place from the store.
 let makeSvmItem = (~slot, ~time, ~hash, ~mask): Internal.item => {
   let block = {"slot": slot, "time": time, "hash": hash}->(Utils.magic: {..} => Internal.eventBlock)
   let payload: dict<Internal.eventBlock> = Dict.make()
@@ -39,8 +34,6 @@ let makeSvmItem = (~slot, ~time, ~hash, ~mask): Internal.item => {
   {
     "kind": 0,
     "blockNumber": slot,
-    "timestamp": time,
-    "blockHash": "",
     "transactionIndex": 0,
     "eventConfig": {"blockFieldMask": mask},
     "payload": payload,
@@ -58,48 +51,37 @@ describe("BlockStore field-code contract", () => {
     t.expect(Evm.blockFields).toEqual(Core.getAddon().evmBlockFieldNames())
   })
 
-  // `BlockStore.hasExtraFields` clears the always-stamped trio with `& ~7`, which
-  // assumes number/timestamp/hash are field codes 0/1/2. Pin that here so a
-  // reorder of `blockFields` can't silently break the store short-circuit.
-  it("EVM always-stamped trio occupies field codes 0/1/2", t => {
-    t.expect(Evm.blockFields->Array.slice(~start=0, ~end=3)).toEqual(["number", "timestamp", "hash"])
-  })
-
   it("SVM blockFields match the Rust SvmBlockField order", t => {
     t.expect(Svm.blockFields).toEqual(Core.getAddon().svmBlockFieldNames())
-  })
-
-  // SVM shares `hasExtraFields`' `& ~7`, so its always-inline trio must occupy
-  // field codes 0/1/2 too. Pin it so a reorder can't silently route slot/time/
-  // hash through the store (which the SVM source never populates for them).
-  it("SVM always-inline trio occupies field codes 0/1/2", t => {
-    t.expect(Svm.blockFields->Array.slice(~start=0, ~end=3)).toEqual(["slot", "time", "hash"])
   })
 })
 
 describe("BlockStore materializeItems", () => {
   Async.it(
-    "skips inline blocks, stamps the trio on store-backed items, and dedupes by block",
+    "skips inline blocks, sets a store block on store-backed items, and dedupes by block",
     async t => {
       let store = BlockStore.make(~ecosystem=Ecosystem.Evm, ~shouldChecksum=false)
       let inlineBlock = {"number": 1}->(Utils.magic: {..} => Internal.eventBlock)
-      let inline = makeInlineItem(~blockNumber=1, ~timestamp=11, ~blockHash="0x1", ~block=inlineBlock)
-      // No event selects a field beyond the trio, so the block is built from the
-      // item alone (number/timestamp/hash), with no store lookup.
-      let a = makeStoreBackedItem(~blockNumber=2, ~timestamp=22, ~blockHash="0x2")
-      let b = makeStoreBackedItem(~blockNumber=2, ~timestamp=22, ~blockHash="0x2")
-      let c = makeStoreBackedItem(~blockNumber=3, ~timestamp=33, ~blockHash="0x3")
+      let inline = makeInlineItem(~blockNumber=1, ~block=inlineBlock)
+      let mask = Evm.eventBlockFieldMask(Utils.Set.fromArray(["number", "timestamp", "hash"]))
+      let a = makeStoreBackedItem(~blockNumber=2, ~mask)
+      let b = makeStoreBackedItem(~blockNumber=2, ~mask)
+      let c = makeStoreBackedItem(~blockNumber=3, ~mask)
 
+      // The store is empty (only Rust sources feed it), so of the trio only
+      // `number` — resolved from the requested key rather than a stored block —
+      // comes back. This exercises the group/dedup/assign path; full field
+      // decoding is covered by the Rust unit tests.
       await store->BlockStore.materializeEvmItems(~items=[inline, a, b, c])
 
       t.expect({
         "inlineUntouched": rawBlock(inline) === inlineBlock->Nullable.make,
-        "storeBackedTrioStamped": rawBlock(a),
+        "storeBackedBlockSet": rawBlock(a),
         "adjacentSameBlockShared": rawBlock(a) === rawBlock(b),
         "differentBlockSeparate": rawBlock(a) !== rawBlock(c),
       }).toEqual({
         "inlineUntouched": true,
-        "storeBackedTrioStamped": {"number": 2, "timestamp": 22, "hash": "0x2"}
+        "storeBackedBlockSet": {"number": 2}
         ->(Utils.magic: {..} => Internal.eventBlock)
         ->Nullable.make,
         "adjacentSameBlockShared": true,
@@ -115,10 +97,10 @@ describe("BlockStore materializeItems", () => {
     let b = makeSvmItem(~slot=5, ~time=50, ~hash="0x5", ~mask)
     let c = makeSvmItem(~slot=6, ~time=60, ~hash="0x6", ~mask)
 
-    // The store is empty here, so the extra fields don't materialise; each item's
-    // own inline block is enriched in place, keeping its slot/time/hash. This
-    // exercises the enrich/dedup path — field decoding itself is covered by the
-    // Rust unit tests.
+    // The store is empty here, so the selected fields don't materialise; each
+    // item's own inline block is enriched in place, keeping its slot/time/hash.
+    // This exercises the enrich/dedup path — field decoding itself is covered by
+    // the Rust unit tests.
     await store->BlockStore.materializeSvmItems(~items=[a, b, c])
 
     t.expect({
@@ -138,10 +120,9 @@ describe("BlockStore materializeItems", () => {
     })
   })
 
-  // Regression: selecting only trio fields (`time`/`hash`) must leave the inline
-  // block intact. The SVM source never populates the store for the trio, so a
-  // gate on `mask != 0.` would consult the empty store and drop time/hash;
-  // gating on `hasExtraFields` keeps them.
+  // Selecting only inline-stamped fields (`time`/`hash`) must leave the inline
+  // block intact: the SVM source doesn't populate the store for them, so the
+  // materialise call yields empty bags and the enrich is a no-op.
   Async.it("keeps the inline trio when only time/hash are selected", async t => {
     let store = BlockStore.make(~ecosystem=Ecosystem.Svm, ~shouldChecksum=false)
     let mask = Svm.eventBlockFieldMask(Utils.Set.fromArray(["time", "hash"]))

--- a/scenarios/test_codegen/test/ClientAddressFilter_test.res
+++ b/scenarios/test_codegen/test/ClientAddressFilter_test.res
@@ -180,10 +180,8 @@ describe("FetchState.handleQueryResult applies clientAddressFilter", () => {
 
   let makeItem = (~to, ~blockNumber): Internal.item =>
     Internal.Event({
-      timestamp: blockNumber * 15,
       chain: ChainMap.Chain.makeUnsafe(~chainId=1),
       blockNumber,
-      blockHash: `0x${blockNumber->Int.toString}`,
       eventConfig: (eventConfig :> Internal.eventConfig),
       logIndex: 0,
       transactionIndex: 0,
@@ -250,10 +248,8 @@ describe("FetchState.handleQueryResult drops over-fetched non-wildcard srcAddres
 
   let makeItem = (~srcAddress, ~blockNumber): Internal.item =>
     Internal.Event({
-      timestamp: blockNumber * 15,
       chain: ChainMap.Chain.makeUnsafe(~chainId=1),
       blockNumber,
-      blockHash: `0x${blockNumber->Int.toString}`,
       eventConfig: (eventConfig :> Internal.eventConfig),
       logIndex: 0,
       transactionIndex: 0,

--- a/scenarios/test_codegen/test/IndexerState_test.res
+++ b/scenarios/test_codegen/test/IndexerState_test.res
@@ -75,10 +75,8 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
 
       for logIndex in 0 to numberOfEventsInBatch {
         let batchItem = Internal.Event({
-          timestamp: currentTime.contents,
           chain: ChainMap.Chain.makeUnsafe(~chainId=id),
           blockNumber: currentBlockNumber.contents,
-          blockHash: `0x${currentBlockNumber.contents->Int.toString}`,
           logIndex,
           transactionIndex: 0,
           eventConfig: "Mock eventConfig in IndexerState test"->(
@@ -186,10 +184,8 @@ describe("IndexerState", () => {
         let (state, numberOfMockEventsCreated, _allEvents) = populateChainQueuesWithRandomEvents()
 
         let defaultFirstEvent = Internal.Event({
-          timestamp: 0,
           chain: MockConfig.chain1,
           blockNumber: 0,
-          blockHash: "0x0",
           logIndex: 0,
           transactionIndex: 0,
           eventConfig: "Mock eventConfig in IndexerState test"->(
@@ -297,10 +293,8 @@ describe("IndexerState", () => {
                   ~latestFetchedBlock={blockNumber, blockTimestamp: blockNumber * 15},
                   ~newItems=[
                     Internal.Event({
-                      timestamp: blockNumber * 15,
                       chain: ChainMap.Chain.makeUnsafe(~chainId),
                       blockNumber,
-                      blockHash: `0x${blockNumber->Int.toString}`,
                       logIndex: 0,
                       transactionIndex: 0,
                       eventConfig: "Mock eventConfig"->(
@@ -381,10 +375,8 @@ describe("IndexerState", () => {
           ~latestFetchedBlock={blockNumber: 15, blockTimestamp: 15 * 15},
           ~newItems=[
             Internal.Event({
-              timestamp: 15 * 15,
               chain,
               blockNumber: 15,
-              blockHash: "0x15",
               logIndex: 0,
               transactionIndex: 0,
               eventConfig: "Mock eventConfig"->(Utils.magic: string => Internal.eventConfig),

--- a/scenarios/test_codegen/test/SvmHyperSyncSource_test.res
+++ b/scenarios/test_codegen/test/SvmHyperSyncSource_test.res
@@ -163,10 +163,9 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
     )
 
     let item = switch response.parsedQueueItems {
-    | [Internal.Event({timestamp, blockNumber, payload})] =>
+    | [Internal.Event({blockNumber, payload})] =>
       let instruction = payload->(Utils.magic: Internal.eventPayload => Envio.svmInstruction)
       Some({
-        "timestamp": timestamp,
         "blockNumber": blockNumber,
         "block": instruction.block,
       })
@@ -178,7 +177,6 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
       "query": capturedQueries->Array.getUnsafe(0),
     }).toEqual({
       "item": Some({
-        "timestamp": blockTime,
         "blockNumber": slot,
         // slot/time/hash are stamped inline from the response's block row;
         // height/parentSlot/parentHash would be materialised from the store.

--- a/scenarios/test_codegen/test/__mocks__/MockEvents.res
+++ b/scenarios/test_codegen/test/__mocks__/MockEvents.res
@@ -191,10 +191,8 @@ let newGravatarEventToBatchItem = (
     Indexer.Transaction.t,
   >,
 ): Internal.item => Internal.Event({
-  timestamp: event.block.timestamp,
   chain: MockConfig.chain1337,
   blockNumber: event.block.number,
-  blockHash: event.block.hash,
   logIndex: event.logIndex,
   transactionIndex: 0,
   eventConfig: MockConfig.getEventConfig(~contractName="Gravatar", ~eventName="NewGravatar"),
@@ -208,10 +206,8 @@ let updatedGravatarEventToBatchItem = (
     Indexer.Transaction.t,
   >,
 ): Internal.item => Internal.Event({
-  timestamp: event.block.timestamp,
   chain: MockConfig.chain1337,
   blockNumber: event.block.number,
-  blockHash: event.block.hash,
   logIndex: event.logIndex,
   transactionIndex: 0,
   eventConfig: MockConfig.getEventConfig(~contractName="Gravatar", ~eventName="UpdatedGravatar"),

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -843,10 +843,8 @@ module Source = {
                             topicCount: 1,
                             paramsMetadata: [],
                           }: Internal.evmEventConfig :> Internal.eventConfig),
-                          timestamp: item.blockNumber,
                           chain,
                           blockNumber: item.blockNumber,
-                          blockHash: `0x${item.blockNumber->Int.toString}`,
                           logIndex: item.logIndex,
                           transactionIndex: 0,
                           payload: {

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -4,10 +4,8 @@ let baseChainConfig = Config.loadWithoutRegistrations().chainMap->ChainMap.value
 
 let mockEvent = (~blockNumber): Internal.item =>
   Internal.Event({
-    timestamp: blockNumber * 15,
     chain: ChainMap.Chain.makeUnsafe(~chainId=1),
     blockNumber,
-    blockHash: `0x${blockNumber->Int.toString}`,
     eventConfig: "Mock eventConfig in CrossChainState test"->(Utils.magic: string => Internal.eventConfig),
     logIndex: 0,
     transactionIndex: 0,
@@ -266,7 +264,7 @@ describe("CrossChainState readiness", () => {
     )
     let cm = makeCrossChainState(~chainStatesList=[atHead, backfilling])
 
-    cm->CrossChainState.applyBatchProgress(~batch=emptyBatch)
+    cm->CrossChainState.applyBatchProgress(~batch=emptyBatch, ~blockTimestampName="timestamp")
 
     t.expect({
       "atHeadReady": atHead->ChainState.isReady,
@@ -292,7 +290,7 @@ describe("CrossChainState readiness", () => {
     )
     let cm = makeCrossChainState(~chainStatesList=[a, b])
 
-    cm->CrossChainState.applyBatchProgress(~batch=emptyBatch)
+    cm->CrossChainState.applyBatchProgress(~batch=emptyBatch, ~blockTimestampName="timestamp")
 
     t.expect({
       "aReady": a->ChainState.isReady,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
@@ -74,10 +74,8 @@ let makeInitialWithOnBlock = (~startBlock=0, ~onBlockConfigs) => {
 }
 
 let mockEvent = (~blockNumber, ~logIndex=0): Internal.item => Internal.Event({
-  timestamp: blockNumber * 15,
   chain: ChainMap.Chain.makeUnsafe(~chainId),
   blockNumber,
-  blockHash: `0x${blockNumber->Int.toString}`,
   eventConfig: Utils.magic("Mock eventConfig in fetchstate test"),
   logIndex,
   transactionIndex: 0,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -77,10 +77,8 @@ let makeConfigContract = (contractName, address): Internal.indexingAddress => {
 }
 
 let mockEvent = (~blockNumber, ~logIndex=0, ~chainId=1): Internal.item => Internal.Event({
-  timestamp: blockNumber * 15,
   chain: ChainMap.Chain.makeUnsafe(~chainId),
   blockNumber,
-  blockHash: `0x${blockNumber->Int.toString}`,
   eventConfig: Utils.magic("Mock eventConfig in fetchstate test"),
   logIndex,
   transactionIndex: 0,

--- a/scenarios/test_codegen/test/lib_tests/HyperSyncDecoder_test.res
+++ b/scenarios/test_codegen/test/lib_tests/HyperSyncDecoder_test.res
@@ -179,10 +179,8 @@ describe("EVM event decoding via EvmRpcClient.getLogs", () => {
     let eventItem =
       Internal.Event({
         eventConfig: (MockIndexer.evmEventConfig(~contractName="ERC20") :> Internal.eventConfig),
-        timestamp: 1234,
         chain: ChainMap.Chain.makeUnsafe(~chainId=137),
         blockNumber,
-        blockHash: "0xblockhash",
         logIndex,
         transactionIndex: 0,
         payload,
@@ -197,7 +195,7 @@ describe("EVM event decoding via EvmRpcClient.getLogs", () => {
       log_index: logIndex,
       src_address: srcAddress,
       block_hash: "0xblockhash",
-      block_timestamp: 1234,
+      block_timestamp: 9999,
       block_fields: %raw(`{"gasUsed": "99", "miner": "0xminer"}`),
       transaction_fields: %raw(`{"hash": "0xtxhash", "transactionIndex": 2}`),
       params: %raw(`"null"`),

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -1046,7 +1046,7 @@ describe("PgStorage.makeStorageFromEnv ClickHouse env var validation", () => {
 
 describe("ecosystem.toRawEvent", () => {
   Async.it(
-    "Derives a raw event row from a batch item, taking block hash from the item and stringifying bigint block fields",
+    "Derives a raw event row from a batch item, taking block hash and timestamp from the payload block and stringifying bigint block fields",
     async t => {
       let srcAddress = "0x00000000000000000000000000000000000000ab"->(Utils.magic: string => Address.t)
       let blockNumber = 5
@@ -1078,10 +1078,8 @@ describe("ecosystem.toRawEvent", () => {
       let eventItem =
         Internal.Event({
           eventConfig: (MockIndexer.evmEventConfig(~contractName="ERC20") :> Internal.eventConfig),
-          timestamp: 1234,
           chain: ChainMap.Chain.makeUnsafe(~chainId=137),
           blockNumber,
-          blockHash: "0xblockhash",
           logIndex,
           transactionIndex: 0,
           payload: event,
@@ -1096,7 +1094,7 @@ describe("ecosystem.toRawEvent", () => {
         log_index: logIndex,
         src_address: srcAddress,
         block_hash: "0xblockhash",
-        block_timestamp: 1234,
+        block_timestamp: 9999,
         block_fields: %raw(`{"gasUsed": "99", "miner": "0xminer"}`),
         transaction_fields: %raw(`{"hash": "0xtxhash", "transactionIndex": 2}`),
         params: %raw(`"null"`),

--- a/scenarios/test_codegen/test/rollback/ChainMocking.res
+++ b/scenarios/test_codegen/test/rollback/ChainMocking.res
@@ -175,9 +175,7 @@ module Make = () => {
         eventConfig: (eventConfig :> Internal.eventConfig),
         payload: makeEvent(~blockHash),
         chain: ChainMap.Chain.makeUnsafe(~chainId=self.chainConfig.id),
-        timestamp: blockTimestamp,
         blockNumber,
-        blockHash,
         logIndex,
         transactionIndex,
       })


### PR DESCRIPTION
## Summary

Refactors block, transaction, and token balance stores from row-oriented storage to a chunk-columnar architecture. Each fetch response becomes an immutable chunk with sorted keys and optional columns per field, enabling efficient deduplication, partial processing, and selective field materialization without materializing large fields until needed.

## Key Changes

- **New `chunk_store.rs` module**: Implements the core chunk-columnar storage with:
  - `BitVec`: Validity bitmap for sparse columns
  - `NumCol<T>`, `FixedCol`, `VarCol`, `ListCol<T>`: Typed column storage for different data shapes
  - `AnyCol`: Enum over all column types with uniform interface
  - `Chunk<K>`: One response's rows with sorted keys, prune watermark, and optional columns
  - `ChunkStore<K>`: Append-only chunk collection with automatic coalescing at 64 chunks, supporting prune (drop processed rows) and rollback (truncate tail)

- **`block_store.rs` refactored**:
  - Replaced `BTreeMap<i64, Arc<Block>>` with `ChunkStore<i64>`
  - Moved field extraction from decode-time to gather-time via `evm_block_col()` and `svm_block_col()`
  - Decode now reads from gathered scratch columns instead of raw records
  - Removed `fill_masked` dependency; masking now happens during gather

- **`transaction_store.rs` refactored**:
  - Replaced `BTreeMap<(i64, u32), Arc<Transaction>>` with `ChunkStore<(i64, u32)>` for transactions
  - Added companion `ChunkStore<(i64, u64)>` for SVM token balances (duplicate-key table)
  - Moved field extraction to `evm_tx_col()` and `svm_tx_col()`
  - Decode reads from gathered columns; key-derived fields (transactionIndex, slot) return `None` from column builders

- **Field materialization pipeline**:
  - Column builders (`evm_tx_col`, `evm_block_col`, etc.) extract raw bytes/values from responses
  - Gather phase collects columns under store lock, masking per-row by field selection
  - Decode phase materializes selected fields from gathered columns into JS-ready format
  - Large fields (e.g., `input`, `logs_bloom`) only touched on rows that selected them

- **ReScript runtime updates**:
  - Removed `timestamp` and `blockHash` from `Internal.item` (now derived from block store lookup)
  - Updated event materialization to fetch block fields from store instead of item payload
  - Simplified `BlockStore.hasExtraFields` logic (removed trio-bit clearing)
  - Updated test mocks and event builders to match new item shape

## Notable Implementation Details

- Chunks are immutable except for tail truncate (rollback) and start watermark (prune of partially-processed chunk)
- Store lifecycle is "append chunk, drop chunk" — no per-row map, no compaction
- Reads resolve per field, newest chunk first, deduplicating identical rows from overlapping partitions
- Coalescing triggers automatically at 64 chunks to prevent unbounded growth
- `unique_keys` flag distinguishes one-row-per-key stores (blocks, transactions) from duplicate-key token-balance table
- Column type mismatches across chunks panic at decode time (both sides written together, so invariant violation indicates a bug)

https://claude.ai/code/session_01UbaYTDU4XoGRSDGsQyDhsn