### PR TITLE
Remove budget-based query capping; propose against natural ceiling

### DIFF
--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -457,10 +457,10 @@ let resetPendingQueries = (cs: t) => {
   cs.pendingBudget = 0.
 }
 
-// Propose the chain's candidate queries against the shared buffer budget,
-// accounting for this chain's own in-flight reservations.
-let getNextQuery = (cs: t, ~budget) =>
-  cs.fetchState->FetchState.getNextQuery(~budget, ~chainPendingBudget=cs.pendingBudget)
+// Propose the chain's candidate queries against their natural ceiling
+// (head/endBlock/mergeBlock). CrossChainState admits them against the shared
+// buffer budget afterwards.
+let getNextQuery = (cs: t) => cs.fetchState->FetchState.getNextQuery
 
 // Run a fetch tick for this chain against its sources, feeding the owned fetch
 // frontier to the source manager.

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -62,7 +62,7 @@ let hasReadyItem: t => bool
 let isReadyToEnterReorgThreshold: t => bool
 
 // Fetch control.
-let getNextQuery: (t, ~budget: int) => FetchState.nextQuery
+let getNextQuery: t => FetchState.nextQuery
 let dispatch: (
   t,
   ~executeQuery: FetchState.query => promise<unit>,

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -198,7 +198,8 @@ let compareByProgress = (a: FetchState.query, b: FetchState.query) =>
 
 // Dispatch a fetch tick across the whole indexer from one shared pool of
 // ~targetBufferSize ready events. Every chain proposes its candidate queries
-// (each carrying an estimated response size) against the full free budget; the
+// (each carrying an estimated response size) up to its own natural ceiling
+// (head/endBlock/mergeBlock), unconstrained by the shared budget; the
 // candidates are then pooled, ordered by chain progress (furthest-behind first),
 // and admitted until the budget is consumed. So the budget is split per query
 // across chains rather than per chain — a chain that can only use a little
@@ -223,7 +224,7 @@ let checkAndFetch = async (
   for i in 0 to chainIds->Array.length - 1 {
     let chainId = chainIds->Array.getUnsafe(i)
     let cs = crossChainState->getChainState(chainId)
-    switch cs->ChainState.getNextQuery(~budget=remaining) {
+    switch cs->ChainState.getNextQuery {
     | (WaitingForNewBlock | NothingToQuery) as action =>
       actionByChain->Utils.Dict.setByInt(chainId, action)
     | Ready(queries) =>

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -262,6 +262,7 @@ let checkAndFetch = async (
         {
           "fromBlock": query.fromBlock,
           "targetBlock": query.toBlock,
+          "targetEvents": query.estResponseSize->Math.round->Float.toInt,
         },
       )
     )

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -19,7 +19,7 @@ type t = {
 let calculateTargetBufferSize = () =>
   switch Env.targetBufferSize {
   | Some(size) => size
-  | None => 100_000
+  | None => 50_000
   }
 
 let make = (

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -97,14 +97,14 @@ let defaultEstResponseSize = 10_000.
 
 // Estimated items a query will return, from the partition's event density
 // (items/block derived from its last response) and the query's block range.
-// toBlock None is the open-ended tail, capped at maxQueryBlockNumber. A partition
+// toBlock None is the open-ended tail, capped at knownHeight. A partition
 // that responded with no items has density 0, so its queries cost 0 — correct,
 // they don't fill the buffer. Only a partition that has never responded
 // (prevQueryRange 0) has no signal, so it falls back to defaultEstResponseSize.
-let calculateEstResponseSize = (p: partition, ~fromBlock, ~toBlock, ~maxQueryBlockNumber) =>
+let calculateEstResponseSize = (p: partition, ~fromBlock, ~toBlock, ~knownHeight) =>
   if p.prevQueryRange > 0 {
     let density = p.prevRangeSize->Int.toFloat /. p.prevQueryRange->Int.toFloat
-    (toBlock->Option.getOr(maxQueryBlockNumber) - fromBlock + 1)->Int.toFloat *. density
+    (toBlock->Option.getOr(knownHeight) - fromBlock + 1)->Int.toFloat *. density
   } else {
     defaultEstResponseSize
   }
@@ -545,8 +545,8 @@ type t = {
   // Buffer of items ordered from earliest to latest
   buffer: array<Internal.item>,
   // Caps how far ahead onBlock items are pre-generated (set to 2x the batch
-  // size). Fetch depth is bounded separately by getNextQuery's itemBudget, the
-  // chain's per-tick slice of the indexer-wide pool.
+  // size). Event fetch depth is bounded separately, by CrossChainState's
+  // cross-chain admission against the indexer-wide buffer pool.
   maxOnBlockBufferSize: int,
   onBlockConfigs: array<Internal.onBlockConfig>,
   knownHeight: int,
@@ -1352,14 +1352,14 @@ let pushQueriesForRange = (
   ~partitionId: string,
   ~rangeFromBlock: int,
   ~rangeEndBlock: option<int>,
-  ~maxQueryBlockNumber: int,
+  ~knownHeight: int,
   ~maybeChunkRange: option<int>,
   ~maxChunks: int,
   ~partition: partition,
   ~selection: selection,
   ~addressesByContractName: dict<array<Address.t>>,
 ) => {
-  if rangeFromBlock <= maxQueryBlockNumber && maxChunks > 0 {
+  if rangeFromBlock <= knownHeight && maxChunks > 0 {
     switch rangeEndBlock {
     | Some(endBlock) if rangeFromBlock > endBlock => ()
     | _ =>
@@ -1375,7 +1375,7 @@ let pushQueriesForRange = (
             partition,
             ~fromBlock=rangeFromBlock,
             ~toBlock=rangeEndBlock,
-            ~maxQueryBlockNumber,
+            ~knownHeight,
           ),
           chainId: 0,
           progress: 0.,
@@ -1384,7 +1384,7 @@ let pushQueriesForRange = (
       | Some(chunkRange) =>
         let maxBlock = switch rangeEndBlock {
         | Some(eb) => eb
-        | None => maxQueryBlockNumber
+        | None => knownHeight
         }
         let chunkSize = Js.Math.ceil_int(chunkRange->Int.toFloat *. 1.8)
         if rangeFromBlock + chunkSize * 2 - 1 <= maxBlock {
@@ -1404,7 +1404,7 @@ let pushQueriesForRange = (
                 partition,
                 ~fromBlock=chunkFromBlock.contents,
                 ~toBlock=Some(chunkToBlock),
-                ~maxQueryBlockNumber,
+                ~knownHeight,
               ),
               chainId: 0,
               progress: 0.,
@@ -1425,7 +1425,7 @@ let pushQueriesForRange = (
               partition,
               ~fromBlock=rangeFromBlock,
               ~toBlock=rangeEndBlock,
-              ~maxQueryBlockNumber,
+              ~knownHeight,
             ),
             chainId: 0,
             progress: 0.,
@@ -1437,44 +1437,26 @@ let pushQueriesForRange = (
   }
 }
 
+// Candidate queries are sized against the natural ceiling (head/endBlock/mergeBlock),
+// not a share of the shared buffer — CrossChainState.checkAndFetch's admission loop
+// is what actually bounds how much gets fetched per tick, by estResponseSize (which
+// the HyperSync/SVM sources also enforce server-side via a maxNumLogs-style cap, so
+// a wrong estimate truncates the response instead of overshooting the buffer).
 let getNextQuery = (
-  {buffer, optimizedPartitions, blockLag, latestOnBlockBlockNumber, knownHeight} as fetchState: t,
-  ~budget,
-  ~chainPendingBudget,
+  {optimizedPartitions, blockLag, latestOnBlockBlockNumber, knownHeight, endBlock}: t,
 ) => {
   let headBlockNumber = knownHeight - blockLag
   if headBlockNumber <= 0 {
     WaitingForNewBlock
-  } else if budget <= 0 {
-    // No room left in the shared buffer pool for this chain; wait for processing
-    // to drain before fetching more.
-    NothingToQuery
   } else {
     let isOnBlockBehindTheHead = latestOnBlockBlockNumber < headBlockNumber
     let shouldWaitForNewBlock = ref(
-      switch fetchState.endBlock {
+      switch endBlock {
       | Some(endBlock) => headBlockNumber < endBlock
       | None => true
       } &&
       !isOnBlockBehindTheHead,
     )
-
-    // Fetch at most `budget` items past the ready frontier (plus what's already
-    // in flight) so processing always has buffer without ballooning memory.
-    // budget already excludes items at/below the frontier (they're in the shared
-    // totalReadyCount), so offset the index by bufferReadyCount — otherwise the
-    // ready prefix is subtracted twice and the buffer caps at a fraction of its
-    // target. A partition that fetched further is skipped until the buffer drains.
-    let maxQueryBlockNumber = {
-      switch buffer->Array.get(
-        fetchState->bufferReadyCount + budget + chainPendingBudget->Float.toInt - 1,
-      ) {
-      | Some(item) =>
-        // Just in case check that we don't query beyond the current block
-        Pervasives.min(item->Internal.getItemBlockNumber, knownHeight)
-      | None => knownHeight
-      }
-    }
 
     let queries = []
 
@@ -1501,22 +1483,13 @@ let getNextQuery = (
       let partitionQueriesStart = queries->Array.length
 
       // Compute queryEndBlock for this partition
-      let queryEndBlock = Utils.Math.minOptInt(fetchState.endBlock, p.mergeBlock)
+      let queryEndBlock = Utils.Math.minOptInt(endBlock, p.mergeBlock)
       let queryEndBlock = switch blockLag {
       | 0 => queryEndBlock
       | _ =>
         // Force head block as an endBlock when blockLag is set
         // because otherwise HyperSync might return bigger range
         Utils.Math.minOptInt(Some(headBlockNumber), queryEndBlock)
-      }
-      // Enforce the response range up until target block
-      // Otherwise for indexers with 100+ partitions
-      // we might blow up the buffer size to more than 600k events
-      // simply because of HyperSync returning extra blocks
-      let queryEndBlock = switch (queryEndBlock, maxQueryBlockNumber < knownHeight) {
-      | (Some(endBlock), true) => Some(Pervasives.min(maxQueryBlockNumber, endBlock))
-      | (None, true) => Some(maxQueryBlockNumber)
-      | (_, false) => queryEndBlock
       }
 
       let maybeChunkRange = getMinHistoryRange(p)
@@ -1535,7 +1508,7 @@ let getNextQuery = (
             ~partitionId,
             ~rangeFromBlock=cursor.contents,
             ~rangeEndBlock=Utils.Math.minOptInt(Some(pq.fromBlock - 1), queryEndBlock),
-            ~maxQueryBlockNumber,
+            ~knownHeight,
             ~maybeChunkRange,
             ~maxChunks=maxPendingChunksPerPartition -
             pendingCount -
@@ -1563,7 +1536,7 @@ let getNextQuery = (
           ~partitionId,
           ~rangeFromBlock=cursor.contents,
           ~rangeEndBlock=queryEndBlock,
-          ~maxQueryBlockNumber,
+          ~knownHeight,
           ~maybeChunkRange,
           ~maxChunks=maxPendingChunksPerPartition -
           pendingCount -

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -90,23 +90,41 @@ let deriveContractNameByAddress: dict<array<Address.t>> => dict<
   result
 })
 
+// Bounds for the no-history default estimate below. Also used by SourceManager
+// as the floor for its own maxNumLogs-style safety net.
+let minEstResponseSize = 2_000.
+let maxEstResponseSize = 10_000.
+
 // Default estimate for a query whose partition hasn't responded yet, so the
 // shared budget still accounts for unknown queries instead of treating them as
-// free.
-let defaultEstResponseSize = 5_000.
+// free. Scaled down as partitionsCount grows: assuming every partition's first
+// query is "big" starves the rest of that tick's admission when many
+// partitions share the same buffer, so the per-partition default shrinks
+// accordingly — clamped to [minEstResponseSize, maxEstResponseSize] either way.
+let calculateDefaultEstResponseSize = (~partitionsCount) =>
+  Pervasives.max(
+    minEstResponseSize,
+    Pervasives.min(maxEstResponseSize, 20_000. /. partitionsCount->Int.toFloat),
+  )
 
 // Estimated items a query will return, from the partition's event density
 // (items/block derived from its last response) and the query's block range.
 // toBlock None is the open-ended tail, capped at knownHeight. A partition
 // that responded with no items has density 0, so its queries cost 0 — correct,
 // they don't fill the buffer. Only a partition that has never responded
-// (prevQueryRange 0) has no signal, so it falls back to defaultEstResponseSize.
-let calculateEstResponseSize = (p: partition, ~fromBlock, ~toBlock, ~knownHeight) =>
+// (prevQueryRange 0) has no signal, so it falls back to calculateDefaultEstResponseSize.
+let calculateEstResponseSize = (
+  p: partition,
+  ~fromBlock,
+  ~toBlock,
+  ~knownHeight,
+  ~partitionsCount,
+) =>
   if p.prevQueryRange > 0 {
     let density = p.prevRangeSize->Int.toFloat /. p.prevQueryRange->Int.toFloat
     (toBlock->Option.getOr(knownHeight) - fromBlock + 1)->Int.toFloat *. density
   } else {
-    defaultEstResponseSize
+    calculateDefaultEstResponseSize(~partitionsCount)
   }
 
 // Calculate the chunk range from history using min-of-last-3-ranges heuristic
@@ -1358,6 +1376,7 @@ let pushQueriesForRange = (
   ~partition: partition,
   ~selection: selection,
   ~addressesByContractName: dict<array<Address.t>>,
+  ~partitionsCount: int,
 ) => {
   if rangeFromBlock <= knownHeight && maxChunks > 0 {
     switch rangeEndBlock {
@@ -1376,6 +1395,7 @@ let pushQueriesForRange = (
             ~fromBlock=rangeFromBlock,
             ~toBlock=rangeEndBlock,
             ~knownHeight,
+            ~partitionsCount,
           ),
           chainId: 0,
           progress: 0.,
@@ -1405,6 +1425,7 @@ let pushQueriesForRange = (
                 ~fromBlock=chunkFromBlock.contents,
                 ~toBlock=Some(chunkToBlock),
                 ~knownHeight,
+                ~partitionsCount,
               ),
               chainId: 0,
               progress: 0.,
@@ -1426,6 +1447,7 @@ let pushQueriesForRange = (
               ~fromBlock=rangeFromBlock,
               ~toBlock=rangeEndBlock,
               ~knownHeight,
+              ~partitionsCount,
             ),
             chainId: 0,
             progress: 0.,
@@ -1517,6 +1539,7 @@ let getNextQuery = (
             ~partition=p,
             ~selection=p.selection,
             ~addressesByContractName=p.addressesByContractName,
+            ~partitionsCount,
           )
         }
         switch pq {
@@ -1545,6 +1568,7 @@ let getNextQuery = (
           ~partition=p,
           ~selection=p.selection,
           ~addressesByContractName=p.addressesByContractName,
+          ~partitionsCount,
         )
       }
 

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -93,7 +93,7 @@ let deriveContractNameByAddress: dict<array<Address.t>> => dict<
 // Default estimate for a query whose partition hasn't responded yet, so the
 // shared budget still accounts for unknown queries instead of treating them as
 // free.
-let defaultEstResponseSize = 10_000.
+let defaultEstResponseSize = 5_000.
 
 // Estimated items a query will return, from the partition's event density
 // (items/block derived from its last response) and the query's block range.

--- a/packages/envio/src/sources/HyperFuelSource.res
+++ b/packages/envio/src/sources/HyperFuelSource.res
@@ -239,7 +239,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     ~knownHeight,
     ~partitionId as _,
     ~selection: FetchState.selection,
-    ~maxNumItems as _,
+    ~itemsTarget as _,
     ~retry,
     ~logger,
   ) => {

--- a/packages/envio/src/sources/HyperFuelSource.res
+++ b/packages/envio/src/sources/HyperFuelSource.res
@@ -239,6 +239,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     ~knownHeight,
     ~partitionId as _,
     ~selection: FetchState.selection,
+    ~maxNumItems as _,
     ~retry,
     ~logger,
   ) => {

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -64,6 +64,7 @@ module GetLogs = {
     ~toBlockInclusive,
     ~addressesWithTopics,
     ~fieldSelection,
+    ~maxNumLogs,
   ): HyperSyncClient.QueryTypes.query => {
     fromBlock,
     toBlockExclusive: ?switch toBlockInclusive {
@@ -72,6 +73,7 @@ module GetLogs = {
     },
     logs: addressesWithTopics,
     fieldSelection,
+    maxNumLogs,
   }
 
   // Rust encodes structured failures as a JSON payload in the napi error's
@@ -105,6 +107,7 @@ module GetLogs = {
     ~toBlock,
     ~logSelections: array<LogSelection.t>,
     ~fieldSelection,
+    ~maxNumLogs,
   ): logsQueryPage => {
     let addressesWithTopics = logSelections->Array.flatMap(({addresses, topicSelections}) =>
       topicSelections->Array.map(({topic0, topic1, topic2, topic3}) => {
@@ -123,6 +126,7 @@ module GetLogs = {
       ~toBlockInclusive=toBlock,
       ~addressesWithTopics,
       ~fieldSelection,
+      ~maxNumLogs,
     )
 
     let (res, transactionStore) = switch await client.getEventItems(~query) {

--- a/packages/envio/src/sources/HyperSync.resi
+++ b/packages/envio/src/sources/HyperSync.resi
@@ -33,6 +33,7 @@ module GetLogs: {
     ~toBlock: option<int>,
     ~logSelections: array<LogSelection.t>,
     ~fieldSelection: HyperSyncClient.QueryTypes.fieldSelection,
+    ~maxNumLogs: int,
   ) => promise<logsQueryPage>
 }
 

--- a/packages/envio/src/sources/HyperSyncSource.res
+++ b/packages/envio/src/sources/HyperSyncSource.res
@@ -232,6 +232,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     ~knownHeight,
     ~partitionId as _,
     ~selection,
+    ~maxNumItems,
     ~retry,
     ~logger,
   ) => {
@@ -258,6 +259,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
       ~toBlock,
       ~logSelections,
       ~fieldSelection=selectionConfig.fieldSelection,
+      ~maxNumLogs=maxNumItems,
     ) catch {
     | HyperSync.GetLogs.Error(error) =>
       throw(

--- a/packages/envio/src/sources/HyperSyncSource.res
+++ b/packages/envio/src/sources/HyperSyncSource.res
@@ -232,7 +232,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     ~knownHeight,
     ~partitionId as _,
     ~selection,
-    ~maxNumItems,
+    ~itemsTarget,
     ~retry,
     ~logger,
   ) => {
@@ -259,7 +259,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
       ~toBlock,
       ~logSelections,
       ~fieldSelection=selectionConfig.fieldSelection,
-      ~maxNumLogs=maxNumItems,
+      ~maxNumLogs=itemsTarget,
     ) catch {
     | HyperSync.GetLogs.Error(error) =>
       throw(

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -1162,7 +1162,7 @@ let make = (
     ~knownHeight,
     ~partitionId,
     ~selection: FetchState.selection,
-    ~maxNumItems as _,
+    ~itemsTarget as _,
     ~retry,
     ~logger as _,
   ) => {

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -97,16 +97,24 @@ let getErrorMessage = (exn: exn): option<string> =>
 // never helps — the same range always re-trips the same cap. The reaction is to
 // shrink the range and retry immediately, ratcheting the max range down.
 let isResponseTooLargeError = {
+  // Provider-specific "too many logs" messages, matched loosely since each names
+  // it differently: HyperRPC ("More than 50000 logs returned"), ZkEVM ("query
+  // returned more than N results"), LlamaRPC ("query exceeds max results"),
+  // 1RPC ("response size should not..."), Optimism ("(backend) response too
+  // large"), Arbitrum ("logs matched by query exceeds limit"), Ankr ("block
+  // range is too wide"). Kept as one block rather than per-line comments — the
+  // ReScript formatter doesn't preserve comments attached to regex literals in
+  // an array.
   let patterns = [
-    /more than \d+ logs/i, // HyperRPC: "More than 50000 logs returned"
+    /more than \d+ logs/i,
     /\d+ logs returned/i,
     /too many logs/i,
-    /query returned more than \d+ results/i, // ZkEVM
-    /query exceeds max results/i, // LlamaRPC
-    /response size should not/i, // 1RPC
-    /(backend )?response too large/i, // Optimism
-    /logs matched by query exceeds limit/i, // Arbitrum
-    /block range is too wide/i, // Ankr
+    /query returned more than \d+ results/i,
+    /query exceeds max results/i,
+    /response size should not/i,
+    /(backend )?response too large/i,
+    /logs matched by query exceeds limit/i,
+    /block range is too wide/i,
   ]
   (exn: exn) =>
     switch exn->getErrorMessage {
@@ -353,8 +361,10 @@ let getNextPage = (
   ->Promise.race
   ->Promise.catch(err => {
     let executedBlockInterval = toBlock - fromBlock + 1
-    let shrunkBlockInterval =
-      Pervasives.max(1, (executedBlockInterval->Int.toFloat *. sc.backoffMultiplicative)->Float.toInt)
+    let shrunkBlockInterval = Pervasives.max(
+      1,
+      (executedBlockInterval->Int.toFloat *. sc.backoffMultiplicative)->Float.toInt,
+    )
 
     let throwFailedGettingItems = retry =>
       throw(Source.GetItemsError(FailedGettingItems({exn: err, attemptedToBlock: toBlock, retry})))
@@ -1152,13 +1162,16 @@ let make = (
     ~knownHeight,
     ~partitionId,
     ~selection: FetchState.selection,
+    ~maxNumItems as _,
     ~retry,
     ~logger as _,
   ) => {
     let startFetchingBatchTimeRef = Performance.now()
 
     let sourceMaxBlockInterval =
-      mutSuggestedBlockIntervals->getSourceMaxBlockInterval(~intervalCeiling=syncConfig.intervalCeiling)
+      mutSuggestedBlockIntervals->getSourceMaxBlockInterval(
+        ~intervalCeiling=syncConfig.intervalCeiling,
+      )
     let suggestedBlockInterval = Pervasives.min(
       mutSuggestedBlockIntervals
       ->Utils.Dict.dangerouslyGetNonOption(partitionId)

--- a/packages/envio/src/sources/SimulateSource.res
+++ b/packages/envio/src/sources/SimulateSource.res
@@ -26,7 +26,7 @@ let make = (~items: array<Internal.item>, ~endBlock: int, ~chain: ChainMap.Chain
       ~knownHeight as _,
       ~partitionId as _,
       ~selection as _,
-      ~maxNumItems as _,
+      ~itemsTarget as _,
       ~retry as _,
       ~logger as _,
     ) => {

--- a/packages/envio/src/sources/SimulateSource.res
+++ b/packages/envio/src/sources/SimulateSource.res
@@ -26,6 +26,7 @@ let make = (~items: array<Internal.item>, ~endBlock: int, ~chain: ChainMap.Chain
       ~knownHeight as _,
       ~partitionId as _,
       ~selection as _,
+      ~maxNumItems as _,
       ~retry as _,
       ~logger as _,
     ) => {

--- a/packages/envio/src/sources/Source.res
+++ b/packages/envio/src/sources/Source.res
@@ -64,6 +64,12 @@ type t = {
     ~knownHeight: int,
     ~partitionId: string,
     ~selection: FetchState.selection,
+    // Soft cap on the number of primary items (logs/instructions/receipts) the
+    // source should ask its backend for, from the query's own estResponseSize.
+    // A HyperSync-backed source enforces it server-side, so a wrong estimate
+    // truncates the response instead of overshooting the shared buffer. Sources
+    // without an equivalent lever (RPC, Fuel, Simulate) ignore it.
+    ~maxNumItems: int,
     ~retry: int,
     ~logger: Pino.t,
   ) => promise<blockRangeFetchResponse>,

--- a/packages/envio/src/sources/Source.res
+++ b/packages/envio/src/sources/Source.res
@@ -69,7 +69,7 @@ type t = {
     // A HyperSync-backed source enforces it server-side, so a wrong estimate
     // truncates the response instead of overshooting the shared buffer. Sources
     // without an equivalent lever (RPC, Fuel, Simulate) ignore it.
-    ~maxNumItems: int,
+    ~itemsTarget: int,
     ~retry: int,
     ~logger: Pino.t,
   ) => promise<blockRangeFetchResponse>,

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -680,6 +680,13 @@ let executeQuery = async (
         ~partitionId=query.partitionId,
         ~knownHeight,
         ~selection=query.selection,
+        // Ceil (not truncate) so a sub-1 estimate from a sparse partition over a
+        // small range doesn't round down to 0 and ask the backend to cap the
+        // response at nothing — 0 items is indistinguishable from "no signal".
+        ~maxNumItems={
+          let est = query.estResponseSize->Math.ceil->Float.toInt
+          est > 0 ? est : FetchState.defaultEstResponseSize->Float.toInt
+        },
         ~retry,
         ~logger,
       )

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -685,7 +685,7 @@ let executeQuery = async (
         // response at nothing — 0 items is indistinguishable from "no signal".
         ~itemsTarget={
           let est = query.estResponseSize->Math.ceil->Float.toInt
-          est > 0 ? est : FetchState.defaultEstResponseSize->Float.toInt
+          est > 0 ? est : FetchState.minEstResponseSize->Float.toInt
         },
         ~retry,
         ~logger,

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -683,7 +683,7 @@ let executeQuery = async (
         // Ceil (not truncate) so a sub-1 estimate from a sparse partition over a
         // small range doesn't round down to 0 and ask the backend to cap the
         // response at nothing — 0 items is indistinguishable from "no signal".
-        ~maxNumItems={
+        ~itemsTarget={
           let est = query.estResponseSize->Math.ceil->Float.toInt
           est > 0 ? est : FetchState.defaultEstResponseSize->Float.toInt
         },

--- a/packages/envio/src/sources/Svm.res
+++ b/packages/envio/src/sources/Svm.res
@@ -101,7 +101,7 @@ let makeRPCSource = (~chain, ~rpc: string, ~sourceFor: Source.sourceFor=Sync): S
       ~knownHeight as _,
       ~partitionId as _,
       ~selection as _,
-      ~maxNumItems as _,
+      ~itemsTarget as _,
       ~retry as _,
       ~logger as _,
     ) => JsError.throwWithMessage("Svm does not support getting items"),

--- a/packages/envio/src/sources/Svm.res
+++ b/packages/envio/src/sources/Svm.res
@@ -101,6 +101,7 @@ let makeRPCSource = (~chain, ~rpc: string, ~sourceFor: Source.sourceFor=Sync): S
       ~knownHeight as _,
       ~partitionId as _,
       ~selection as _,
+      ~maxNumItems as _,
       ~retry as _,
       ~logger as _,
     ) => JsError.throwWithMessage("Svm does not support getting items"),

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -340,7 +340,7 @@ let make = ({chain, endpointUrl, apiToken, eventConfigs, clientTimeoutMillis}: o
     ~knownHeight,
     ~partitionId as _,
     ~selection as _,
-    ~maxNumItems,
+    ~itemsTarget,
     ~retry,
     ~logger,
   ) => {
@@ -369,7 +369,7 @@ let make = ({chain, endpointUrl, apiToken, eventConfigs, clientTimeoutMillis}: o
       toSlot: ?(toBlock->Option.map(toBlock => toBlock + 1)),
       instructions: instructionSelections,
       fields,
-      maxNumInstructions: maxNumItems,
+      maxNumInstructions: itemsTarget,
     }
 
     Prometheus.SourceRequestCount.increment(~sourceName=name, ~chainId, ~method="getInstructions")

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -340,6 +340,7 @@ let make = ({chain, endpointUrl, apiToken, eventConfigs, clientTimeoutMillis}: o
     ~knownHeight,
     ~partitionId as _,
     ~selection as _,
+    ~maxNumItems,
     ~retry,
     ~logger,
   ) => {
@@ -368,6 +369,7 @@ let make = ({chain, endpointUrl, apiToken, eventConfigs, clientTimeoutMillis}: o
       toSlot: ?(toBlock->Option.map(toBlock => toBlock + 1)),
       instructions: instructionSelections,
       fields,
+      maxNumInstructions: maxNumItems,
     }
 
     Prometheus.SourceRequestCount.increment(~sourceName=name, ~chainId, ~method="getInstructions")

--- a/scenarios/test_codegen/test/ClientAddressFilter_test.res
+++ b/scenarios/test_codegen/test/ClientAddressFilter_test.res
@@ -208,7 +208,7 @@ describe("FetchState.handleQueryResult applies clientAddressFilter", () => {
       ~chainId=1,
       ~knownHeight=1000,
     )
-    let query = switch fetchState->FetchState.getNextQuery(~budget=5000, ~chainPendingBudget=0.) {
+    let query = switch fetchState->FetchState.getNextQuery {
     | Ready([q]) => q
     | _ => JsError.throwWithMessage("expected a single ready query")
     }
@@ -278,7 +278,7 @@ describe("FetchState.handleQueryResult drops over-fetched non-wildcard srcAddres
       ~chainId=1,
       ~knownHeight=1000,
     )
-    let query = switch fetchState->FetchState.getNextQuery(~budget=5000, ~chainPendingBudget=0.) {
+    let query = switch fetchState->FetchState.getNextQuery {
     | Ready([q]) => q
     | _ => JsError.throwWithMessage("expected a single ready query")
     }

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -354,9 +354,7 @@ describe("FetchState — where.block._gte drives the first query's fromBlock", (
   // Pull the first query the scheduler would dispatch. `updateKnownHeight`
   // is needed so `getNextQuery` sees a non-zero head.
   let firstQuery = (fetchState: FetchState.t) =>
-    switch fetchState
-    ->FetchState.updateKnownHeight(~knownHeight=10000)
-    ->FetchState.getNextQuery(~budget=5000, ~chainPendingBudget=0.) {
+    switch fetchState->FetchState.updateKnownHeight(~knownHeight=10000)->FetchState.getNextQuery {
     | Ready([q]) => q
     | Ready(qs) =>
       JsError.throwWithMessage(

--- a/scenarios/test_codegen/test/HyperSync_test.res
+++ b/scenarios/test_codegen/test/HyperSync_test.res
@@ -35,6 +35,7 @@ describe_skip("Test Hyperliquid broken transaction response", () => {
         log: [Address, Data, LogIndex, Topic0, Topic1, Topic2, Topic3],
         transaction: [Hash],
       },
+      ~maxNumLogs=5000,
     )
 
     Console.log(page)

--- a/scenarios/test_codegen/test/RateLimit_test.res
+++ b/scenarios/test_codegen/test/RateLimit_test.res
@@ -38,6 +38,7 @@ let makeMockSource = (~rateLimitedCalls: int, ~resetMs: int): Source.t => {
       ~knownHeight as _,
       ~partitionId as _,
       ~selection as _,
+      ~maxNumItems as _,
       ~retry as _,
       ~logger as _,
     ) => JsError.throwWithMessage("Not used by rate limit test"),

--- a/scenarios/test_codegen/test/RateLimit_test.res
+++ b/scenarios/test_codegen/test/RateLimit_test.res
@@ -38,7 +38,7 @@ let makeMockSource = (~rateLimitedCalls: int, ~resetMs: int): Source.t => {
       ~knownHeight as _,
       ~partitionId as _,
       ~selection as _,
-      ~maxNumItems as _,
+      ~itemsTarget as _,
       ~retry as _,
       ~logger as _,
     ) => JsError.throwWithMessage("Not used by rate limit test"),

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -1252,6 +1252,7 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
               dependsOnAddresses: true,
               eventConfigs: [(eventConfig :> Internal.eventConfig)],
             },
+            ~maxNumItems=5000,
             ~retry=0,
             ~logger=Logging.createChild(~params={"test": "RpcSource response too large"}),
           )
@@ -1389,6 +1390,7 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
               dependsOnAddresses: true,
               eventConfigs: [(eventConfig :> Internal.eventConfig)],
             },
+            ~maxNumItems=5000,
             ~retry=0,
             ~logger=Logging.createChild(~params={"test": "RpcSource re-grow"}),
           )
@@ -1512,6 +1514,7 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
                 dependsOnAddresses: true,
                 eventConfigs: [(eventConfig :> Internal.eventConfig)],
               },
+              ~maxNumItems=5000,
               ~retry,
               ~logger=Logging.createChild(~params={"test": "RpcSource missing transaction data"}),
             )
@@ -1652,6 +1655,7 @@ describe("RpcSource - getItemsOrThrow fans out multiple selections", () => {
             dependsOnAddresses: true,
             eventConfigs: [(eventConfig :> Internal.eventConfig)],
           },
+          ~maxNumItems=5000,
           ~retry=0,
           ~logger=Logging.createChild(~params={"test": "RpcSource fan-out"}),
         )
@@ -1737,6 +1741,7 @@ describe("RpcSource - getItemsOrThrow with a skip-all event filter", () => {
             dependsOnAddresses: false,
             eventConfigs: [(eventConfig :> Internal.eventConfig)],
           },
+          ~maxNumItems=5000,
           ~retry=0,
           ~logger=Logging.createChild(~params={"test": "RpcSource skip-all"}),
         )
@@ -1897,6 +1902,7 @@ describe("RpcSource - getItemsOrThrow scopes filters to each contract's addresse
             dependsOnAddresses: true,
             eventConfigs: [(eventA :> Internal.eventConfig), (eventB :> Internal.eventConfig)],
           },
+          ~maxNumItems=5000,
           ~retry=0,
           ~logger=Logging.createChild(~params={"test": "RpcSource pooled leak"}),
         )

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -1252,7 +1252,7 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
               dependsOnAddresses: true,
               eventConfigs: [(eventConfig :> Internal.eventConfig)],
             },
-            ~maxNumItems=5000,
+            ~itemsTarget=5000,
             ~retry=0,
             ~logger=Logging.createChild(~params={"test": "RpcSource response too large"}),
           )
@@ -1390,7 +1390,7 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
               dependsOnAddresses: true,
               eventConfigs: [(eventConfig :> Internal.eventConfig)],
             },
-            ~maxNumItems=5000,
+            ~itemsTarget=5000,
             ~retry=0,
             ~logger=Logging.createChild(~params={"test": "RpcSource re-grow"}),
           )
@@ -1514,7 +1514,7 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
                 dependsOnAddresses: true,
                 eventConfigs: [(eventConfig :> Internal.eventConfig)],
               },
-              ~maxNumItems=5000,
+              ~itemsTarget=5000,
               ~retry,
               ~logger=Logging.createChild(~params={"test": "RpcSource missing transaction data"}),
             )
@@ -1655,7 +1655,7 @@ describe("RpcSource - getItemsOrThrow fans out multiple selections", () => {
             dependsOnAddresses: true,
             eventConfigs: [(eventConfig :> Internal.eventConfig)],
           },
-          ~maxNumItems=5000,
+          ~itemsTarget=5000,
           ~retry=0,
           ~logger=Logging.createChild(~params={"test": "RpcSource fan-out"}),
         )
@@ -1741,7 +1741,7 @@ describe("RpcSource - getItemsOrThrow with a skip-all event filter", () => {
             dependsOnAddresses: false,
             eventConfigs: [(eventConfig :> Internal.eventConfig)],
           },
-          ~maxNumItems=5000,
+          ~itemsTarget=5000,
           ~retry=0,
           ~logger=Logging.createChild(~params={"test": "RpcSource skip-all"}),
         )
@@ -1902,7 +1902,7 @@ describe("RpcSource - getItemsOrThrow scopes filters to each contract's addresse
             dependsOnAddresses: true,
             eventConfigs: [(eventA :> Internal.eventConfig), (eventB :> Internal.eventConfig)],
           },
-          ~maxNumItems=5000,
+          ~itemsTarget=5000,
           ~retry=0,
           ~logger=Logging.createChild(~params={"test": "RpcSource pooled leak"}),
         )

--- a/scenarios/test_codegen/test/SourceBlockHashes_test.res
+++ b/scenarios/test_codegen/test/SourceBlockHashes_test.res
@@ -118,7 +118,7 @@ let invoke = async (source: Source.t, ~fromBlock, ~toBlock) => {
     ~knownHeight=toBlock + 1000,
     ~partitionId="0",
     ~selection=makeSelection(),
-    ~maxNumItems=5000,
+    ~itemsTarget=5000,
     ~retry=0,
     ~logger=Logging.createChild(~params={"test": "SourceBlockHashes"}),
   ) catch {

--- a/scenarios/test_codegen/test/SourceBlockHashes_test.res
+++ b/scenarios/test_codegen/test/SourceBlockHashes_test.res
@@ -118,6 +118,7 @@ let invoke = async (source: Source.t, ~fromBlock, ~toBlock) => {
     ~knownHeight=toBlock + 1000,
     ~partitionId="0",
     ~selection=makeSelection(),
+    ~maxNumItems=5000,
     ~retry=0,
     ~logger=Logging.createChild(~params={"test": "SourceBlockHashes"}),
   ) catch {

--- a/scenarios/test_codegen/test/SvmHyperSyncSource_test.res
+++ b/scenarios/test_codegen/test/SvmHyperSyncSource_test.res
@@ -142,7 +142,7 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
       ~contractNameByAddress,
       ~knownHeight=slot + 1000,
       ~partitionId="0",
-      ~maxNumItems=5000,
+      ~itemsTarget=5000,
       ~selection={
         eventConfigs: [(eventConfig :> Internal.eventConfig)],
         dependsOnAddresses: true,
@@ -223,7 +223,7 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
           eventConfigs: [(eventConfig :> Internal.eventConfig)],
           dependsOnAddresses: true,
         },
-        ~maxNumItems=5000,
+        ~itemsTarget=5000,
         ~retry=0,
         ~logger=Logging.createChild(~params={"test": "SvmHyperSyncSource"}),
       )

--- a/scenarios/test_codegen/test/SvmHyperSyncSource_test.res
+++ b/scenarios/test_codegen/test/SvmHyperSyncSource_test.res
@@ -142,6 +142,7 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
       ~contractNameByAddress,
       ~knownHeight=slot + 1000,
       ~partitionId="0",
+      ~maxNumItems=5000,
       ~selection={
         eventConfigs: [(eventConfig :> Internal.eventConfig)],
         dependsOnAddresses: true,
@@ -178,6 +179,7 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
           // Inclusive `toBlock` becomes exclusive `toSlot` on the wire (+1).
           toSlot: slot + 11,
           instructions: [{programId: [metaplexProgramId], d1: ["0x21"]}],
+          maxNumInstructions: 5000,
           fields: {
             block: [Slot, Blockhash, BlockTime],
             transaction: [
@@ -221,6 +223,7 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
           eventConfigs: [(eventConfig :> Internal.eventConfig)],
           dependsOnAddresses: true,
         },
+        ~maxNumItems=5000,
         ~retry=0,
         ~logger=Logging.createChild(~params={"test": "SvmHyperSyncSource"}),
       )

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -735,6 +735,7 @@ module Source = {
             ~knownHeight,
             ~partitionId,
             ~selection as _,
+            ~maxNumItems as _,
             ~retry,
             ~logger as _,
           ) => {

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -735,7 +735,7 @@ module Source = {
             ~knownHeight,
             ~partitionId,
             ~selection as _,
-            ~maxNumItems as _,
+            ~itemsTarget as _,
             ~retry,
             ~logger as _,
           ) => {

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1724,6 +1724,24 @@ describe("FetchState.registerDynamicContracts", () => {
   )
 })
 
+describe("FetchState.calculateDefaultEstResponseSize", () => {
+  it("Scales down as partitionsCount grows, clamped to [2_000, 10_000]", t => {
+    t.expect({
+      "onePartition": FetchState.calculateDefaultEstResponseSize(~partitionsCount=1),
+      "twoPartitions": FetchState.calculateDefaultEstResponseSize(~partitionsCount=2),
+      "threePartitions": FetchState.calculateDefaultEstResponseSize(~partitionsCount=3),
+      "tenPartitions": FetchState.calculateDefaultEstResponseSize(~partitionsCount=10),
+      "hundredPartitions": FetchState.calculateDefaultEstResponseSize(~partitionsCount=100),
+    }).toEqual({
+      "onePartition": 10_000.,
+      "twoPartitions": 10_000.,
+      "threePartitions": 20_000. /. 3.,
+      "tenPartitions": 2_000.,
+      "hundredPartitions": 2_000.,
+    })
+  })
+})
+
 describe("FetchState.getNextQuery & integration", () => {
   let dc1 = makeDynContractRegistration(~blockNumber=1, ~contractAddress=mockAddress1)
   let dc2 = makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress2)
@@ -1844,7 +1862,8 @@ describe("FetchState.getNextQuery & integration", () => {
 
   // The default configuration with ability to overwrite some values.
   // Partitions here have no response yet, so query sizing falls back to
-  // FetchState.defaultEstResponseSize (5000).
+  // FetchState.calculateDefaultEstResponseSize, which scales with partition count
+  // (20_000. /. partitionsCount, clamped to [2_000., 10_000.]).
   let getNextQuery = (fs, ~endBlock=None, ~knownHeight=10) =>
     switch endBlock {
     | Some(_) => {...fs, endBlock}
@@ -1865,7 +1884,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 5000.,
+          estResponseSize: 10000.,
           fromBlock: 0,
           toBlock: None,
           selection: fetchState.normalSelection,
@@ -1890,7 +1909,7 @@ describe("FetchState.getNextQuery & integration", () => {
         fromBlock: 0,
         toBlock: None,
         isChunk: false,
-        estResponseSize: 5000.,
+        estResponseSize: 10000.,
         fetchedBlock: None,
       },
     ])
@@ -1945,7 +1964,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 5000.,
+          estResponseSize: 10000.,
           fromBlock: 11,
           toBlock: None,
           selection: updatedFetchState.normalSelection,
@@ -1980,7 +1999,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 5000.,
+          estResponseSize: 10000.,
           toBlock: Some(8),
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
@@ -1999,7 +2018,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 5000.,
+          estResponseSize: 10000.,
           toBlock: Some(8),
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
@@ -2098,7 +2117,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "1",
-          estResponseSize: 5000.,
+          estResponseSize: 20_000. /. 3.,
           toBlock: Some(10),
           isChunk: false,
           selection: fetchState.normalSelection,
@@ -2108,7 +2127,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          estResponseSize: 5000.,
+          estResponseSize: 20_000. /. 3.,
           fromBlock: 2,
           toBlock: None,
           isChunk: false,
@@ -2159,7 +2178,7 @@ describe("FetchState.getNextQuery & integration", () => {
     let expectedPartition2Query: FetchState.query = {
       ...defaultQuery,
       partitionId: "2",
-      estResponseSize: 5000.,
+      estResponseSize: 10000.,
       fromBlock: 3,
       toBlock: None,
       selection: fetchState.normalSelection,
@@ -2169,7 +2188,7 @@ describe("FetchState.getNextQuery & integration", () => {
     let expectedPartition0Query: FetchState.query = {
       ...defaultQuery,
       partitionId: "0",
-      estResponseSize: 5000.,
+      estResponseSize: 10000.,
       toBlock: None,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.fromArray([
@@ -2215,7 +2234,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          estResponseSize: 5000.,
+          estResponseSize: 10000.,
           toBlock: None,
           selection: originalFetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
@@ -2225,7 +2244,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           FetchState.partitionId: "0",
-          estResponseSize: 5000.,
+          estResponseSize: 10000.,
           toBlock: None,
           selection: originalFetchState.normalSelection,
           addressesByContractName: Dict.fromArray([
@@ -2249,7 +2268,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          estResponseSize: 5000.,
+          estResponseSize: 10000.,
           toBlock: Some(10),
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
@@ -2259,7 +2278,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           FetchState.partitionId: "0",
-          estResponseSize: 5000.,
+          estResponseSize: 10000.,
           toBlock: None,
           selection: originalFetchState.normalSelection,
           addressesByContractName: Dict.fromArray([
@@ -2339,7 +2358,7 @@ describe("FetchState.getNextQuery & integration", () => {
                 fromBlock: 11,
                 toBlock: None,
                 isChunk: false,
-                estResponseSize: 5000.,
+                estResponseSize: 10000.,
                 fetchedBlock: None,
               },
             ],
@@ -2404,7 +2423,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 5000.,
+          estResponseSize: 20_000. /. 3.,
           fromBlock: 0,
           toBlock: None,
           isChunk: false,
@@ -2417,7 +2436,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "1",
-          estResponseSize: 5000.,
+          estResponseSize: 20_000. /. 3.,
           fromBlock: 0,
           toBlock: None,
           isChunk: false,
@@ -2427,7 +2446,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          estResponseSize: 5000.,
+          estResponseSize: 20_000. /. 3.,
           fromBlock: 2,
           toBlock: None,
           isChunk: false,
@@ -2858,7 +2877,7 @@ describe("FetchState unit tests for specific cases", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 5000.,
+          estResponseSize: 10000.,
           fromBlock: 2,
           toBlock: None,
           isChunk: false,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1844,7 +1844,7 @@ describe("FetchState.getNextQuery & integration", () => {
 
   // The default configuration with ability to overwrite some values.
   // Partitions here have no response yet, so query sizing falls back to
-  // FetchState.defaultEstResponseSize (10000).
+  // FetchState.defaultEstResponseSize (5000).
   let getNextQuery = (fs, ~endBlock=None, ~knownHeight=10) =>
     switch endBlock {
     | Some(_) => {...fs, endBlock}
@@ -1865,7 +1865,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           fromBlock: 0,
           toBlock: None,
           selection: fetchState.normalSelection,
@@ -1890,7 +1890,7 @@ describe("FetchState.getNextQuery & integration", () => {
         fromBlock: 0,
         toBlock: None,
         isChunk: false,
-        estResponseSize: 10000.,
+        estResponseSize: 5000.,
         fetchedBlock: None,
       },
     ])
@@ -1945,7 +1945,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           fromBlock: 11,
           toBlock: None,
           selection: updatedFetchState.normalSelection,
@@ -1980,7 +1980,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           toBlock: Some(8),
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
@@ -1999,7 +1999,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           toBlock: Some(8),
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress0])]),
@@ -2098,7 +2098,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "1",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           toBlock: Some(10),
           isChunk: false,
           selection: fetchState.normalSelection,
@@ -2108,7 +2108,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           fromBlock: 2,
           toBlock: None,
           isChunk: false,
@@ -2159,7 +2159,7 @@ describe("FetchState.getNextQuery & integration", () => {
     let expectedPartition2Query: FetchState.query = {
       ...defaultQuery,
       partitionId: "2",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       fromBlock: 3,
       toBlock: None,
       selection: fetchState.normalSelection,
@@ -2169,7 +2169,7 @@ describe("FetchState.getNextQuery & integration", () => {
     let expectedPartition0Query: FetchState.query = {
       ...defaultQuery,
       partitionId: "0",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       toBlock: None,
       selection: fetchState.normalSelection,
       addressesByContractName: Dict.fromArray([
@@ -2215,7 +2215,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           toBlock: None,
           selection: originalFetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
@@ -2225,7 +2225,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           FetchState.partitionId: "0",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           toBlock: None,
           selection: originalFetchState.normalSelection,
           addressesByContractName: Dict.fromArray([
@@ -2249,7 +2249,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           toBlock: Some(10),
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress3])]),
@@ -2259,7 +2259,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           FetchState.partitionId: "0",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           toBlock: None,
           selection: originalFetchState.normalSelection,
           addressesByContractName: Dict.fromArray([
@@ -2339,7 +2339,7 @@ describe("FetchState.getNextQuery & integration", () => {
                 fromBlock: 11,
                 toBlock: None,
                 isChunk: false,
-                estResponseSize: 10000.,
+                estResponseSize: 5000.,
                 fetchedBlock: None,
               },
             ],
@@ -2404,7 +2404,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           fromBlock: 0,
           toBlock: None,
           isChunk: false,
@@ -2417,7 +2417,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "1",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           fromBlock: 0,
           toBlock: None,
           isChunk: false,
@@ -2427,7 +2427,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           fromBlock: 2,
           toBlock: None,
           isChunk: false,
@@ -2599,7 +2599,7 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           toBlock: None,
           selection: {
             dependsOnAddresses: false,
@@ -2714,7 +2714,7 @@ describe("FetchState unit tests for specific cases", () => {
     let query: FetchState.query = {
       ...defaultQuery,
       partitionId: "1",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       fromBlock: 1,
       toBlock: None,
       isChunk: false,
@@ -2758,7 +2758,7 @@ describe("FetchState unit tests for specific cases", () => {
     let query: FetchState.query = {
       ...defaultQuery,
       partitionId: "0",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       fromBlock: 0,
       toBlock: None,
       isChunk: false,
@@ -2812,7 +2812,7 @@ describe("FetchState unit tests for specific cases", () => {
     let query0: FetchState.query = {
       ...defaultQuery,
       partitionId: "0",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       fromBlock: 0,
       toBlock: None,
       isChunk: false,
@@ -2825,7 +2825,7 @@ describe("FetchState unit tests for specific cases", () => {
     let query1: FetchState.query = {
       ...defaultQuery,
       partitionId: "1",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       fromBlock: 0,
       toBlock: None,
       isChunk: false,
@@ -2858,7 +2858,7 @@ describe("FetchState unit tests for specific cases", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           fromBlock: 2,
           toBlock: None,
           isChunk: false,
@@ -2889,7 +2889,7 @@ describe("FetchState unit tests for specific cases", () => {
     let query: FetchState.query = {
       ...defaultQuery,
       partitionId: "0",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       fromBlock: 0,
       toBlock: None,
       isChunk: false,
@@ -2957,7 +2957,7 @@ describe("FetchState unit tests for specific cases", () => {
     let query: FetchState.query = {
       ...defaultQuery,
       partitionId: "0",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       fromBlock: 0,
       toBlock: None,
       isChunk: false,
@@ -3075,7 +3075,7 @@ describe("FetchState unit tests for specific cases", () => {
     let query: FetchState.query = {
       ...defaultQuery,
       partitionId: "0",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       fromBlock: 0,
       toBlock: Some(0),
       isChunk: false,
@@ -3102,7 +3102,7 @@ describe("FetchState unit tests for specific cases", () => {
       let query: FetchState.query = {
         ...defaultQuery,
         partitionId: "0",
-        estResponseSize: 10000.,
+        estResponseSize: 5000.,
         fromBlock: 0,
         toBlock: None,
         isChunk: false,
@@ -3159,7 +3159,7 @@ describe("FetchState unit tests for specific cases", () => {
       let query: FetchState.query = {
         ...defaultQuery,
         partitionId: "0",
-        estResponseSize: 10000.,
+        estResponseSize: 5000.,
         selection: fetchState.normalSelection,
         addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress1])]),
         fromBlock: 0,
@@ -3265,7 +3265,7 @@ describe("FetchState.sortForBatch", () => {
     {
       ...defaultQuery,
       FetchState.partitionId: "0",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       toBlock: None,
       isChunk: false,
       selection: fetchState.normalSelection,
@@ -3580,7 +3580,7 @@ describe("FetchState progress tracking", () => {
     let query = {
       ...defaultQuery,
       FetchState.partitionId: "0",
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       toBlock: None,
       isChunk: false,
       selection: fs0.normalSelection,
@@ -3656,7 +3656,7 @@ describe("FetchState proposes queries against the natural ceiling", () => {
       let query0 = {
         ...defaultQuery,
         FetchState.partitionId: "0",
-        estResponseSize: 10000.,
+        estResponseSize: 5000.,
         toBlock: None,
         isChunk: false,
         selection: fetchStateWithTwoPartitions.normalSelection,
@@ -3704,7 +3704,7 @@ describe("FetchState proposes queries against the natural ceiling", () => {
       let query3 = {
         ...defaultQuery,
         FetchState.partitionId: "0",
-        estResponseSize: 10000.,
+        estResponseSize: 5000.,
         toBlock: None,
         isChunk: false,
         selection: fetchState.normalSelection,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1843,27 +1843,15 @@ describe("FetchState.getNextQuery & integration", () => {
   }
 
   // The default configuration with ability to overwrite some values.
-  // Partitions here have no response yet, so the block window isn't constrained
-  // (the small test heights stay below the buffer-position cap) and query sizing
-  // falls back to FetchState.defaultEstResponseSize (10000).
-  let getNextQuery = (fs, ~endBlock=None, ~knownHeight=10, ~budget=10) =>
+  // Partitions here have no response yet, so query sizing falls back to
+  // FetchState.defaultEstResponseSize (10000).
+  let getNextQuery = (fs, ~endBlock=None, ~knownHeight=10) =>
     switch endBlock {
     | Some(_) => {...fs, endBlock}
     | None => fs
     }
     ->FetchState.updateKnownHeight(~knownHeight)
-    ->FetchState.getNextQuery(~budget, ~chainPendingBudget=0.)
-
-  it("Returns NothingToQuery when the buffer budget is exhausted", t => {
-    // Same state queries Ready with a positive budget (see the test below), so a
-    // non-positive budget is the only reason nothing is queried here.
-    let (fetchState, _indexingAddresses) = makeInitial()
-
-    t.expect(
-      (fetchState->getNextQuery(~budget=0), fetchState->getNextQuery(~budget=-5)),
-      ~message="Should skip fetching when there's no room left in the shared buffer pool",
-    ).toEqual((NothingToQuery, NothingToQuery))
-  })
+    ->FetchState.getNextQuery
 
   it("Emulate first indexer queries with a static event", t => {
     let (fetchState, indexingAddresses) = makeInitial()
@@ -1946,14 +1934,12 @@ describe("FetchState.getNextQuery & integration", () => {
       when block height exceeded the end block`,
     ).toEqual(NothingToQuery)
     t.expect(
-      updatedFetchState->getNextQuery(~budget=2),
+      updatedFetchState->getNextQuery,
       ~message=`Should wait for new block even if partitions have nothing to query`,
     ).toEqual(WaitingForNewBlock)
     t.expect(
-      updatedFetchState->getNextQuery(~budget=2, ~knownHeight=11),
-      ~message=`Should fetch the head block once the partition is behind the head:
-      budget is measured past the ready frontier, so the 2 already-ready items
-      don't eat the budget and pin the target block below the frontier`,
+      updatedFetchState->getNextQuery(~knownHeight=11),
+      ~message=`Should fetch the head block once the partition is behind the head`,
     ).toEqual(
       Ready([
         {
@@ -2321,13 +2307,6 @@ describe("FetchState.getNextQuery & integration", () => {
       4,
     ))
 
-    t.expect(
-      fetchStateWithResponse1->getNextQuery(~budget=1),
-      ~message=`Buffer has no items past the ready frontier, so a tight budget no
-      longer caps the proposal here (the shared budget is enforced by cross-chain
-      admission); the merge continuation is proposed the same as with a full budget`,
-    ).toEqual(fetchStateWithResponse1->getNextQuery)
-
     let queries = switch fetchStateWithResponse1->getNextQuery {
     | Ready(queries) => queries
     | _ =>
@@ -2413,11 +2392,7 @@ describe("FetchState.getNextQuery & integration", () => {
 
     t.expect(fetchState.optimizedPartitions->FetchState.OptimizedPartitions.count).toEqual(3)
 
-    let nextQuery =
-      {...fetchState, knownHeight: 10}->FetchState.getNextQuery(
-        ~budget=targetBufferSize,
-        ~chainPendingBudget=0.,
-      )
+    let nextQuery = {...fetchState, knownHeight: 10}->FetchState.getNextQuery
 
     t.expect(
       nextQuery,
@@ -2875,10 +2850,7 @@ describe("FetchState unit tests for specific cases", () => {
       )
 
     t.expect(
-      {...fetchState, knownHeight: 2}->FetchState.getNextQuery(
-        ~budget=targetBufferSize,
-        ~chainPendingBudget=0.,
-      ),
+      {...fetchState, knownHeight: 2}->FetchState.getNextQuery,
       ~message=`Should be possible to query wildcard partition,
       if it didn't reach max queue size limit`,
     ).toEqual(
@@ -2898,15 +2870,6 @@ describe("FetchState unit tests for specific cases", () => {
         },
       ]),
     )
-    t.expect(
-      {
-        ...fetchState,
-        knownHeight: 2,
-      }->FetchState.getNextQuery(~budget=1, ~chainPendingBudget=0.),
-      ~message=`Budget is measured past the ready frontier; the item already
-      buffered past it consumes the single-item budget, so the behind partition
-      stays capped and nothing new is fetched until the queue drains`,
-    ).toEqual(NothingToQuery)
   })
 
   it("Allows to get event one block earlier than the dc registring event", t => {
@@ -3220,10 +3183,7 @@ describe("FetchState unit tests for specific cases", () => {
       let dcA = makeDynContractRegistration(~contractAddress=mockAddress2, ~blockNumber=100)
       let fetchStateWithDcA = fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dcA->dcToItem])
 
-      let queries = switch fetchStateWithDcA->FetchState.getNextQuery(
-        ~budget=targetBufferSize,
-        ~chainPendingBudget=0.,
-      ) {
+      let queries = switch fetchStateWithDcA->FetchState.getNextQuery {
       | Ready(queries) => queries
       | _ => JsError.throwWithMessage("Expected Ready queries")
       }
@@ -3253,10 +3213,7 @@ describe("FetchState unit tests for specific cases", () => {
       let fetchStateWithDcB =
         fetchStateWithDcA->FetchState.registerDynamicContracts(~indexingAddresses, [dc3->dcToItem])
 
-      let queries = switch fetchStateWithDcB->FetchState.getNextQuery(
-        ~budget=targetBufferSize,
-        ~chainPendingBudget=0.,
-      ) {
+      let queries = switch fetchStateWithDcB->FetchState.getNextQuery {
       | Ready(queries) => queries
       | _ => JsError.throwWithMessage("Expected Ready queries")
       }
@@ -3268,10 +3225,7 @@ describe("FetchState unit tests for specific cases", () => {
         fromBlock: 200,
       }
       t.expect(
-        fetchStateWithDcB->FetchState.getNextQuery(
-          ~budget=targetBufferSize,
-          ~chainPendingBudget=0.,
-        ),
+        fetchStateWithDcB->FetchState.getNextQuery,
         ~message=`Create a new partition for the newly registered contract`,
       ).toEqual(Ready([partition2Query, queries->Array.getUnsafe(1)]))
 
@@ -3285,10 +3239,7 @@ describe("FetchState unit tests for specific cases", () => {
         )
 
       t.expect(
-        fetchStateWithBothDcsAndQueryAResponse->FetchState.getNextQuery(
-          ~budget=targetBufferSize,
-          ~chainPendingBudget=0.,
-        ),
+        fetchStateWithBothDcsAndQueryAResponse->FetchState.getNextQuery,
         ~message=`We don't merge partition 2 to partition 1, since it already has end block`,
       ).toEqual(
         Ready([
@@ -3685,20 +3636,21 @@ describe("FetchState progress tracking", () => {
   })
 })
 
-describe("FetchState buffer overflow prevention", () => {
+describe("FetchState proposes queries against the natural ceiling", () => {
   it(
-    "Should limit endBlock when maxQueryBlockNumber < knownHeight to prevent buffer overflow",
+    "Should not cap a query below endBlock/knownHeight just because the buffer is already large",
     t => {
       let (fetchState, indexingAddresses) = makeInitial(~maxAddrInPartition=1, ~targetBufferSize=10)
 
-      // Create a second partition to ensure buffer limiting logic is exercised across partitions
-      // Register at a later block, so partition "0" remains the earliest and is selected
+      // Create a second partition to make sure a large buffer elsewhere doesn't
+      // affect this partition's own proposal.
       let dc = makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress1)
       let fetchStateWithTwoPartitions =
         fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dc->dcToItem])
 
-      // Buffer 15 items (blocks 6..20). With budget 10 the cap is the block at
-      // buffer index 10-1=9, i.e. block 15 — below both knownHeight and endBlock.
+      // Buffer 15 items (blocks 6..20), far more than targetBufferSize=10. Admission
+      // against the shared budget happens in CrossChainState, not here — getNextQuery
+      // proposes against the natural ceiling regardless of how full the buffer is.
       let largeQueueEvents = Array.fromInitializer(~length=15, i => mockEvent(~blockNumber=20 - i))
 
       let query0 = {
@@ -3721,34 +3673,34 @@ describe("FetchState buffer overflow prevention", () => {
           ~newItems=largeQueueEvents,
         )
 
-      // Test case 1: With endBlock set, should be limited by maxQueryBlockNumber
+      // Test case 1: With endBlock set, should propose all the way to endBlock
       let fetchStateWithEndBlock = {
         ...fetchStateWithLargeQueue,
         endBlock: Some(25),
         knownHeight: 30,
       }
 
-      switch fetchStateWithEndBlock->FetchState.getNextQuery(~budget=10, ~chainPendingBudget=0.) {
+      switch fetchStateWithEndBlock->FetchState.getNextQuery {
       | Ready([q]) =>
         t.expect(
           q.toBlock,
-          ~message="Should limit endBlock to maxQueryBlockNumber (15) when both endBlock and maxQueryBlockNumber are present",
-        ).toBe(Some(15))
-      | _ => JsError.throwWithMessage("Expected Ready query when buffer limiting is active")
+          ~message="Should propose up to endBlock, unconstrained by the buffer's current size",
+        ).toBe(Some(25))
+      | _ => JsError.throwWithMessage("Expected Ready query")
       }
 
-      // Test case 2: endBlock=None, maxQueryBlockNumber=15 -> Should use Some(15)
+      // Test case 2: endBlock=None -> Should use the open-ended head target
       let fetchStateNoEndBlock = {...fetchStateWithLargeQueue, endBlock: None, knownHeight: 30}
-      switch fetchStateNoEndBlock->FetchState.getNextQuery(~budget=10, ~chainPendingBudget=0.) {
+      switch fetchStateNoEndBlock->FetchState.getNextQuery {
       | Ready([q]) =>
         t.expect(
           q.toBlock,
-          ~message="Should set endBlock to maxQueryBlockNumber (15) when no endBlock was specified",
-        ).toBe(Some(15))
-      | _ => JsError.throwWithMessage("Expected Ready query when buffer limiting is active")
+          ~message="Should use None (fetch to head), unconstrained by the buffer's current size",
+        ).toBe(None)
+      | _ => JsError.throwWithMessage("Expected Ready query")
       }
 
-      // Test case 3: Small queue, no buffer limiting -> Should use Head target
+      // Test case 3: Small queue -> Should also use the open-ended head target
       let query3 = {
         ...defaultQuery,
         FetchState.partitionId: "0",
@@ -3770,12 +3722,8 @@ describe("FetchState buffer overflow prevention", () => {
         )
         ->FetchState.updateKnownHeight(~knownHeight=30)
 
-      switch fetchStateSmallQueue->FetchState.getNextQuery(
-        ~budget=targetBufferSize,
-        ~chainPendingBudget=0.,
-      ) {
-      | Ready([q]) =>
-        t.expect(q.toBlock, ~message="Should use None when buffer is not limited").toBe(None)
+      switch fetchStateSmallQueue->FetchState.getNextQuery {
+      | Ready([q]) => t.expect(q.toBlock, ~message="Should use None (fetch to head)").toBe(None)
       | _ => JsError.throwWithMessage("Expected Ready query")
       }
     },
@@ -3829,8 +3777,7 @@ describe("FetchState with onBlockConfig only (no events)", () => {
       ])
 
       // Test that getNextQuery returns WaitingForNewBlock when knownHeight is 0
-      let nextQuery =
-        fetchState->FetchState.getNextQuery(~budget=targetBufferSize, ~chainPendingBudget=0.)
+      let nextQuery = fetchState->FetchState.getNextQuery
       t.expect(
         nextQuery,
         ~message="Should return WaitingForNewBlock when knownHeight is 0",
@@ -3872,8 +3819,7 @@ describe("FetchState with onBlockConfig only (no events)", () => {
       ])
 
       // Test that getNextQuery returns NothingToQuery (no partitions to query)
-      let nextQuery2 =
-        updatedFetchState->FetchState.getNextQuery(~budget=targetBufferSize, ~chainPendingBudget=0.)
+      let nextQuery2 = updatedFetchState->FetchState.getNextQuery
       t.expect(
         nextQuery2,
         ~message="Should return NothingToQuery when there are no partitions to query",
@@ -3884,10 +3830,8 @@ describe("FetchState with onBlockConfig only (no events)", () => {
 
 describe("Stale query response should not overwrite block range", () => {
   // The default configuration with ability to overwrite some values
-  let getNextQuery = (fs, ~knownHeight=100000, ~budget=targetBufferSize) =>
-    fs
-    ->FetchState.updateKnownHeight(~knownHeight)
-    ->FetchState.getNextQuery(~budget, ~chainPendingBudget=0.)
+  let getNextQuery = (fs, ~knownHeight=100000) =>
+    fs->FetchState.updateKnownHeight(~knownHeight)->FetchState.getNextQuery
 
   it("Out-of-order parallel query responses should not degrade chunking heuristic", t => {
     let (fetchState, indexingAddresses) = makeInitial(~knownHeight=100000)

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -372,17 +372,16 @@ describe("SourceManager fetchNext", () => {
 
   // Selection (getNextQuery) now happens in CrossChainState; SourceManager only
   // dispatches the chosen action. This shim keeps the per-chain tests focused on
-  // dispatch by computing the action from the chain's own budget.
+  // dispatch by computing the action from the chain's own fetch state.
   let fetchNext = (
     sourceManager,
     ~fetchState,
     ~executeQuery,
     ~waitForNewBlock,
     ~onNewBlock,
-    ~budget=5000,
     ~stateId,
   ) => {
-    let action = fetchState->FetchState.getNextQuery(~budget, ~chainPendingBudget=0.)
+    let action = fetchState->FetchState.getNextQuery
     // CrossChainState marks queries in flight when admitting them; dispatch no
     // longer does, so mirror that here before dispatching.
     switch action {
@@ -509,11 +508,9 @@ describe("SourceManager fetchNext", () => {
 
     t.expect({
       // 10 already pending: the partition is capped, so the scheduler issues nothing.
-      "atCap": withPending(10)->FetchState.getNextQuery(~budget=5000, ~chainPendingBudget=0.),
+      "atCap": withPending(10)->FetchState.getNextQuery,
       // 9 pending: the two-chunk tail is trimmed down to the one remaining slot.
-      "oneSlotLeft": withPending(9)
-      ->FetchState.getNextQuery(~budget=5000, ~chainPendingBudget=0.)
-      ->newQueryCount,
+      "oneSlotLeft": withPending(9)->FetchState.getNextQuery->newQueryCount,
     }).toEqual({"atCap": FetchState.NothingToQuery, "oneSlotLeft": 1})
   })
 
@@ -536,7 +533,6 @@ describe("SourceManager fetchNext", () => {
           ~executeQuery=executeQueryMock.fn,
           ~waitForNewBlock=neverWaitForNewBlock,
           ~onNewBlock=neverOnNewBlock,
-          ~budget=5000,
           ~stateId=0,
         )
 
@@ -605,7 +601,6 @@ describe("SourceManager fetchNext", () => {
           ~executeQuery=executeQueryMock.fn,
           ~waitForNewBlock=neverWaitForNewBlock,
           ~onNewBlock=neverOnNewBlock,
-          ~budget=5000,
           ~stateId=0,
         )
 
@@ -637,7 +632,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=onNewBlockMock.fn,
-        ~budget=5000,
         ~stateId=0,
       )
 
@@ -658,7 +652,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=onNewBlockMock.fn,
-        ~budget=5000,
         ~stateId=0,
       )
 
@@ -686,7 +679,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=onNewBlockMock.fn,
-        ~budget=5000,
         ~stateId=0,
       )
 
@@ -713,7 +705,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=onNewBlockMock.fn,
-        ~budget=5000,
         ~stateId=0,
       )
 
@@ -725,7 +716,6 @@ describe("SourceManager fetchNext", () => {
       ~executeQuery=neverExecutePartitionQuery,
       ~waitForNewBlock=neverWaitForNewBlock,
       ~onNewBlock=neverOnNewBlock,
-      ~budget=5000,
       ~stateId=0,
     )
 
@@ -755,7 +745,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=neverOnNewBlock,
-        ~budget=5000,
         ~stateId=0,
       )
 
@@ -767,7 +756,6 @@ describe("SourceManager fetchNext", () => {
       ~executeQuery=neverExecutePartitionQuery,
       ~waitForNewBlock=neverWaitForNewBlock,
       ~onNewBlock=neverOnNewBlock,
-      ~budget=5000,
       ~stateId=0,
     )
     t.expect(
@@ -781,7 +769,6 @@ describe("SourceManager fetchNext", () => {
         ~executeQuery=neverExecutePartitionQuery,
         ~waitForNewBlock=waitForNewBlockMock.fn,
         ~onNewBlock=onNewBlockMock.fn,
-        ~budget=5000,
         ~stateId=1,
       )
     t.expect(waitForNewBlockMock.calls, ~message=`Should add a new call after a rollback`).toEqual([
@@ -822,7 +809,6 @@ describe("SourceManager fetchNext", () => {
       ~executeQuery=executeQueryMock.fn,
       ~waitForNewBlock=neverWaitForNewBlock,
       ~onNewBlock=neverOnNewBlock,
-      ~budget=5000,
       ~stateId=0,
     )
 

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -183,7 +183,7 @@ describe("SourceManager source priority with Live sources", () => {
   let mockQuery = (): FetchState.query => {
     ...defaultQuery,
     partitionId: "0",
-    estResponseSize: 10000.,
+    estResponseSize: 5000.,
     fromBlock: 0,
     toBlock: None,
     isChunk: false,
@@ -486,7 +486,7 @@ describe("SourceManager fetchNext", () => {
       fromBlock: idx * 10 + 1,
       toBlock: Some(idx * 10 + 10),
       isChunk: true,
-      estResponseSize: 10000.,
+      estResponseSize: 5000.,
       fetchedBlock: None,
     }
     // Chunking on (prevQueryRange set) so the tail wants two chunks per round.
@@ -543,7 +543,7 @@ describe("SourceManager fetchNext", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           fromBlock: 2,
           toBlock: None,
           isChunk: false,
@@ -553,7 +553,7 @@ describe("SourceManager fetchNext", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           fromBlock: 5,
           toBlock: None,
           isChunk: false,
@@ -563,7 +563,7 @@ describe("SourceManager fetchNext", () => {
         {
           ...defaultQuery,
           partitionId: "1",
-          estResponseSize: 10000.,
+          estResponseSize: 5000.,
           fromBlock: 6,
           toBlock: None,
           isChunk: false,
@@ -1430,7 +1430,7 @@ describe("SourceManager.executeQuery", () => {
   let mockQuery = (): FetchState.query => {
     ...defaultQuery,
     partitionId: "0",
-    estResponseSize: 10000.,
+    estResponseSize: 5000.,
     fromBlock: 0,
     toBlock: None,
     isChunk: false,

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -543,7 +543,7 @@ describe("SourceManager fetchNext", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          estResponseSize: 5000.,
+          estResponseSize: 20_000. /. 3.,
           fromBlock: 2,
           toBlock: None,
           isChunk: false,
@@ -553,7 +553,7 @@ describe("SourceManager fetchNext", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          estResponseSize: 5000.,
+          estResponseSize: 20_000. /. 3.,
           fromBlock: 5,
           toBlock: None,
           isChunk: false,
@@ -563,7 +563,7 @@ describe("SourceManager fetchNext", () => {
         {
           ...defaultQuery,
           partitionId: "1",
-          estResponseSize: 5000.,
+          estResponseSize: 20_000. /. 3.,
           fromBlock: 6,
           toBlock: None,
           isChunk: false,


### PR DESCRIPTION
## Summary

Removes the per-chain budget mechanism from query proposal, simplifying `FetchState.getNextQuery` to propose queries against their natural ceiling (head block, endBlock, or mergeBlock) without buffer-size constraints. Admission against the shared buffer budget now happens exclusively in `CrossChainState`, which pools candidate queries from all chains and admits them in priority order until the budget is consumed.

## Key Changes

- **FetchState.getNextQuery**: Removed `~budget` and `~chainPendingBudget` parameters; no longer caps queries based on buffer fill. Queries are now proposed unconstrained by the shared buffer state.

- **Query sizing**: Reduced `defaultEstResponseSize` from 10,000 to 5,000 items to better reflect typical partition response sizes and improve admission accuracy.

- **Buffer admission**: Moved all budget enforcement to `CrossChainState.checkAndFetch`, which now:
  - Collects candidate queries from all chains via `ChainState.getNextQuery` (simplified signature)
  - Pools them and sorts by chain progress (furthest-behind first)
  - Admits queries in order until the shared budget is exhausted
  - Enforces the soft cap via `itemsTarget` passed to sources (HyperSync enforces server-side; RPC/Fuel/Simulate ignore it)

- **Default buffer target**: Reduced from 100,000 to 50,000 items in `CrossChainState.calculateTargetBufferSize`.

- **Source interface**: Added `~itemsTarget: int` parameter to `Source.t.getItemsOrThrow` to communicate the soft cap from the admission loop to backends that support it (HyperSync via `maxNumLogs`).

- **Test updates**: Removed budget-related test cases and assertions; updated expected `estResponseSize` values throughout to reflect the new default of 5,000.

## Implementation Details

- The `maxQueryBlockNumber` calculation that previously capped queries based on buffer position is removed entirely; `knownHeight` is used directly where needed.
- `SourceManager.executeQuery` now ceils the `estResponseSize` estimate before passing it as `itemsTarget` to avoid rounding sparse partitions down to 0.
- Comments updated to reflect that query proposal is unconstrained by the shared budget; admission happens downstream in `CrossChainState`.

https://claude.ai/code/session_01TPtu2dmeaji6DNdLfUHLuf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fetch requests now better respect estimated response sizes, helping queries target a more appropriate amount of data.
  * Log-based sources can now receive an explicit maximum-log limit, improving control over large log requests.

* **Bug Fixes**
  * Reduced the default buffer fallback size when no custom setting is provided.
  * Prevented very small size estimates from rounding down to zero and causing overly restrictive requests.
  * Query selection now uses natural block ceilings more consistently, improving fetch behavior across chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->