### PR TITLE
Move event registration building from ChainState to HandlerRegister

### DIFF
--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -110,7 +110,7 @@ let makeInternal = (
   // the event definitions by `HandlerRegister.finishRegistration`, keyed by
   // chain - this just looks up this chain's slice.
   let onEventRegistrations =
-    registrations.onEventRegistrationsByChainId
+    registrations.registrationsByChainId
     ->Utils.Dict.dangerouslyGetNonOption(chainConfig.id->Int.toString)
     ->Option.getOr([])
 

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -106,133 +106,23 @@ let makeInternal = (
   ~knownHeight=0,
   ~reducedPollingInterval=?,
 ): t => {
-  // We don't need the router itself, but only validation logic,
-  // since now event router is created for selection of events
-  // and validation doesn't work correctly in routers.
-  // Ideally to split it into two different parts.
-  let eventRouter = EventRouter.empty()
-
-  // Build the per-chain registrations (handler binding + `where`-derived fetch
-  // state) by layering the registered handlers onto the event definitions.
-  let onEventRegistrations: array<Internal.onEventRegistration> = []
-
-  let notRegisteredEvents = []
+  // Handler binding + `where`-derived fetch state are already layered onto
+  // the event definitions by `HandlerRegister.finishRegistration`, keyed by
+  // chain - this just looks up this chain's slice.
+  let onEventRegistrations =
+    registrations.onEventRegistrationsByChainId
+    ->Utils.Dict.dangerouslyGetNonOption(chainConfig.id->Int.toString)
+    ->Option.getOr([])
 
   chainConfig.contracts->Array.forEach(contract => {
-    let contractName = contract.name
-
-    contract.events->Array.forEach(eventConfig => {
-      let eventName = eventConfig.name
-      let isWildcard = HandlerRegister.isWildcard(~contractName, ~eventName)
-      let handler = HandlerRegister.getHandler(~contractName, ~eventName)
-      let contractRegister = HandlerRegister.getContractRegister(~contractName, ~eventName)
-
-      let onEventRegistration = switch config.ecosystem.name {
-      | Fuel =>
-        (EventConfigBuilder.buildFuelOnEventRegistration(
-          ~eventConfig=eventConfig->(Utils.magic: Internal.eventConfig => Internal.fuelEventConfig),
-          ~isWildcard,
-          ~handler,
-          ~contractRegister,
-          ~startBlock=?contract.startBlock,
-        ) :> Internal.onEventRegistration)
-      | Svm =>
-        (EventConfigBuilder.buildSvmOnEventRegistration(
-          ~eventConfig=eventConfig->(
-            Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig
-          ),
-          ~isWildcard,
-          ~handler,
-          ~contractRegister,
-          ~startBlock=?contract.startBlock,
-        ) :> Internal.onEventRegistration)
-      | Evm =>
-        (EventConfigBuilder.buildEvmOnEventRegistration(
-          ~eventConfig=eventConfig->(Utils.magic: Internal.eventConfig => Internal.evmEventConfig),
-          ~isWildcard,
-          ~handler,
-          ~contractRegister,
-          ~eventFilters=HandlerRegister.getOnEventWhere(~contractName, ~eventName),
-          ~probeChainId=chainConfig.id,
-          ~onEventBlockFilterSchema=config.ecosystem.onEventBlockFilterSchema,
-          ~startBlock=?contract.startBlock,
-        ) :> Internal.onEventRegistration)
-      }
-
-      // Should validate the events
-      eventRouter->EventRouter.addOrThrow(
-        eventConfig.id,
-        (),
-        ~contractName,
-        ~chain=ChainMap.Chain.makeUnsafe(~chainId=chainConfig.id),
-        ~eventName,
-        ~isWildcard,
-      )
-
-      // Filter out events without a handler/contractRegister so they aren't
-      // fetched or dispatched (unless raw events are enabled).
-      let shouldBeIncluded = if config.enableRawEvents {
-        true
-      } else {
-        let isRegistered = contractRegister->Option.isSome || handler->Option.isSome
-        if !isRegistered {
-          notRegisteredEvents->Array.push(onEventRegistration)
-        }
-        isRegistered
-      }
-
-      // Check if event has Static([]) filters (from a dynamic where
-      // callback returning `false` / SkipAll for this chain).
-      // If so, skip it entirely - it should never be fetched
-      let shouldSkip = try {
-        let getEventFiltersOrThrow = (
-          onEventRegistration->(
-            Utils.magic: Internal.onEventRegistration => Internal.evmOnEventRegistration
-          )
-        ).getEventFiltersOrThrow
-
-        // Check for non-evm chains
-        if (
-          getEventFiltersOrThrow->(Utils.magic: (ChainMap.Chain.t => Internal.eventFilters) => bool)
-        ) {
-          switch getEventFiltersOrThrow(ChainMap.Chain.makeUnsafe(~chainId=chainConfig.id)) {
-          | Static([]) => true
-          | _ => false
-          }
-        } else {
-          false
-        }
-      } catch {
-      // Can throw when filter is invalid
-      // Don't skip an event in this case. Let it throw in a better place - source code
-      | _ => false
-      }
-
-      if shouldBeIncluded && !shouldSkip {
-        onEventRegistrations->Array.push(onEventRegistration)
-      }
-    })
-
     switch contract.startBlock {
     | Some(startBlock) if startBlock < chainConfig.startBlock =>
       JsError.throwWithMessage(
-        `The start block for contract "${contractName}" is less than the chain start block. This is not supported yet.`,
+        `The start block for contract "${contract.name}" is less than the chain start block. This is not supported yet.`,
       )
     | _ => ()
     }
   })
-
-  if notRegisteredEvents->Utils.Array.notEmpty {
-    logger->Logging.childInfo(
-      `The event${if notRegisteredEvents->Array.length > 1 {
-          "s"
-        } else {
-          ""
-        }} ${notRegisteredEvents
-        ->Array.map(reg => `${reg.eventConfig.contractName}.${reg.eventConfig.name}`)
-        ->Array.joinUnsafe(", ")} don't have an event handler and skipped for indexing.`,
-    )
-  }
 
   let onBlockConfigs =
     registrations.onBlockByChainId->Utils.Dict.dangerouslyGetNonOption(chainConfig.id->Int.toString)

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -95,7 +95,7 @@ let makeInternal = (
   ~firstEventBlock=None,
   ~progressBlockNumber,
   ~config: Config.t,
-  ~registrations: HandlerRegister.registrations,
+  ~registrationsByChainId: HandlerRegister.registrationsByChainId,
   ~logger,
   ~timestampCaughtUpToHeadOrEndblock,
   ~numEventsProcessed,
@@ -106,13 +106,13 @@ let makeInternal = (
   ~knownHeight=0,
   ~reducedPollingInterval=?,
 ): t => {
-  // Handler binding + `where`-derived fetch state are already layered onto
-  // the event definitions by `HandlerRegister.finishRegistration`, keyed by
+  // Handler binding + `where`-derived fetch state, and onBlock registrations,
+  // are already collected by `HandlerRegister.finishRegistration`, keyed by
   // chain - this just looks up this chain's slice.
-  let onEventRegistrations =
-    registrations.registrationsByChainId
+  let {onEventRegistrations, onBlockRegistrations} =
+    registrationsByChainId
     ->Utils.Dict.dangerouslyGetNonOption(chainConfig.id->Int.toString)
-    ->Option.getOr([])
+    ->Option.getOr({onEventRegistrations: [], onBlockRegistrations: []})
 
   chainConfig.contracts->Array.forEach(contract => {
     switch contract.startBlock {
@@ -124,30 +124,24 @@ let makeInternal = (
     }
   })
 
-  let onBlockConfigs =
-    registrations.onBlockByChainId->Utils.Dict.dangerouslyGetNonOption(chainConfig.id->Int.toString)
-  switch onBlockConfigs {
-  | Some(onBlockConfigs) =>
-    // TODO: Move it to the HandlerRegister module
-    // so the error is thrown with better stack trace
-    onBlockConfigs->Array.forEach(onBlockConfig => {
-      if onBlockConfig.startBlock->Option.getOr(startBlock) < startBlock {
+  // TODO: Move it to the HandlerRegister module
+  // so the error is thrown with better stack trace
+  onBlockRegistrations->Array.forEach(onBlockRegistration => {
+    if onBlockRegistration.startBlock->Option.getOr(startBlock) < startBlock {
+      JsError.throwWithMessage(
+        `The start block for onBlock handler "${onBlockRegistration.name}" is less than the chain start block (${startBlock->Int.toString}). This is not supported yet.`,
+      )
+    }
+    switch endBlock {
+    | Some(chainEndBlock) =>
+      if onBlockRegistration.endBlock->Option.getOr(chainEndBlock) > chainEndBlock {
         JsError.throwWithMessage(
-          `The start block for onBlock handler "${onBlockConfig.name}" is less than the chain start block (${startBlock->Int.toString}). This is not supported yet.`,
+          `The end block for onBlock handler "${onBlockRegistration.name}" is greater than the chain end block (${chainEndBlock->Int.toString}). This is not supported yet.`,
         )
       }
-      switch endBlock {
-      | Some(chainEndBlock) =>
-        if onBlockConfig.endBlock->Option.getOr(chainEndBlock) > chainEndBlock {
-          JsError.throwWithMessage(
-            `The end block for onBlock handler "${onBlockConfig.name}" is greater than the chain end block (${chainEndBlock->Int.toString}). This is not supported yet.`,
-          )
-        }
-      | None => ()
-      }
-    })
-  | None => ()
-  }
+    | None => ()
+    }
+  })
 
   let contractConfigs = IndexingAddresses.makeContractConfigs(~onEventRegistrations)
   let indexingAddressIndex = IndexingAddresses.make(~contractConfigs, ~addresses=indexingAddresses)
@@ -168,7 +162,7 @@ let makeInternal = (
       !config.shouldRollbackOnReorg || isInReorgThreshold ? 0 : chainConfig.maxReorgDepth,
       chainConfig.blockLag,
     ),
-    ~onBlockConfigs?,
+    ~onBlockRegistrations,
     ~firstEventBlock,
   )
 
@@ -258,13 +252,18 @@ let makeInternal = (
   )
 }
 
-let makeFromConfig = (chainConfig: Config.chain, ~config, ~registrations, ~knownHeight) => {
+let makeFromConfig = (
+  chainConfig: Config.chain,
+  ~config,
+  ~registrationsByChainId,
+  ~knownHeight,
+) => {
   let logger = Logging.createChild(~params={"chainId": chainConfig.id})
 
   makeInternal(
     ~chainConfig,
     ~config,
-    ~registrations,
+    ~registrationsByChainId,
     ~startBlock=chainConfig.startBlock,
     ~endBlock=chainConfig.endBlock,
     ~reorgCheckpoints=[],
@@ -290,7 +289,7 @@ let makeFromDbState = (
   ~isInReorgThreshold,
   ~isRealtime,
   ~config,
-  ~registrations,
+  ~registrationsByChainId,
   ~reducedPollingInterval=?,
 ) => {
   let chainId = chainConfig.id
@@ -310,7 +309,7 @@ let makeFromDbState = (
     ~startBlock=resumedChainState.startBlock,
     ~endBlock=resumedChainState.endBlock,
     ~config,
-    ~registrations,
+    ~registrationsByChainId,
     ~reorgCheckpoints,
     ~maxReorgDepth=resumedChainState.maxReorgDepth,
     ~firstEventBlock=resumedChainState.firstEventBlockNumber,

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -23,7 +23,7 @@ let make: (
 let makeFromConfig: (
   Config.chain,
   ~config: Config.t,
-  ~registrations: HandlerRegister.registrations,
+  ~registrationsByChainId: HandlerRegister.registrationsByChainId,
   ~knownHeight: int,
 ) => t
 
@@ -34,7 +34,7 @@ let makeFromDbState: (
   ~isInReorgThreshold: bool,
   ~isRealtime: bool,
   ~config: Config.t,
-  ~registrations: HandlerRegister.registrations,
+  ~registrationsByChainId: HandlerRegister.registrationsByChainId,
   ~reducedPollingInterval: int=?,
 ) => t
 

--- a/packages/envio/src/Ecosystem.res
+++ b/packages/envio/src/Ecosystem.res
@@ -69,12 +69,12 @@ let getItemLogger = {
     | None =>
       let logger = switch item {
       | Internal.Event(_) => ecosystem.toEventLogger(item->Internal.castUnsafeEventItem)
-      | Block({blockNumber, onBlockConfig}) =>
+      | Block({blockNumber, onBlockRegistration}) =>
         Logging.createChildFrom(
           ~logger=ecosystem.logger,
           ~params={
-            "onBlock": onBlockConfig.name,
-            "chainId": onBlockConfig.chainId,
+            "onBlock": onBlockRegistration.name,
+            "chainId": onBlockRegistration.chainId,
             "block": blockNumber,
           },
         )

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -90,7 +90,7 @@ let runHandlerOrThrow = async (
   ~chains: Internal.chains,
 ) => {
   switch item {
-  | Block({onBlockConfig: {handler}, blockNumber}) =>
+  | Block({onBlockRegistration: {handler}, blockNumber}) =>
     try {
       let contextParams: UserContext.contextParams = {
         item,
@@ -200,7 +200,7 @@ let preloadBatchOrThrow = async (
           | _ => ()
           }
         }
-      | Block({onBlockConfig: {handler}, blockNumber}) =>
+      | Block({onBlockRegistration: {handler}, blockNumber}) =>
         try {
           promises->Array.push(
             handler({

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -551,7 +551,7 @@ type t = {
   // size). Fetch depth is bounded separately by getNextQuery's itemBudget, the
   // chain's per-tick slice of the indexer-wide pool.
   maxOnBlockBufferSize: int,
-  onBlockConfigs: array<Internal.onBlockConfig>,
+  onBlockRegistrations: array<Internal.onBlockRegistration>,
   knownHeight: int,
   firstEventBlock: option<int>,
 }
@@ -608,7 +608,7 @@ let blockItemLogIndex = 16777216
 // are generated at once to prevent OOM.
 let appendOnBlockItems = (
   ~mutItems: array<Internal.item>,
-  ~onBlockConfigs: array<Internal.onBlockConfig>,
+  ~onBlockRegistrations: array<Internal.onBlockRegistration>,
   ~indexerStartBlock,
   ~fromBlock,
   ~maxBlockNumber,
@@ -628,27 +628,27 @@ let appendOnBlockItems = (
     let blockNumber = latestOnBlockBlockNumber.contents + 1
     latestOnBlockBlockNumber := blockNumber
 
-    for configIdx in 0 to onBlockConfigs->Array.length - 1 {
-      let onBlockConfig = onBlockConfigs->Array.getUnsafe(configIdx)
+    for configIdx in 0 to onBlockRegistrations->Array.length - 1 {
+      let onBlockRegistration = onBlockRegistrations->Array.getUnsafe(configIdx)
 
-      let handlerStartBlock = switch onBlockConfig.startBlock {
+      let handlerStartBlock = switch onBlockRegistration.startBlock {
       | Some(startBlock) => startBlock
       | None => indexerStartBlock
       }
 
       if (
         blockNumber >= handlerStartBlock &&
-        switch onBlockConfig.endBlock {
+        switch onBlockRegistration.endBlock {
         | Some(endBlock) => blockNumber <= endBlock
         | None => true
         } &&
-        (blockNumber - handlerStartBlock)->Pervasives.mod(onBlockConfig.interval) === 0
+        (blockNumber - handlerStartBlock)->Pervasives.mod(onBlockRegistration.interval) === 0
       ) {
         mutItems->Array.push(
           Block({
-            onBlockConfig,
+            onBlockRegistration,
             blockNumber,
-            logIndex: blockItemLogIndex + onBlockConfig.index,
+            logIndex: blockItemLogIndex + onBlockRegistration.index,
           }),
         )
         newItemsCounter := newItemsCounter.contents + 1
@@ -672,9 +672,9 @@ let updateInternal = (
 ): t => {
   let mutItemsRef = ref(mutItems)
 
-  let latestOnBlockBlockNumber = switch fetchState.onBlockConfigs {
+  let latestOnBlockBlockNumber = switch fetchState.onBlockRegistrations {
   | [] => knownHeight
-  | onBlockConfigs => {
+  | onBlockRegistrations => {
       // Calculate the max block number we are going to create items for
       // Use maxOnBlockBufferSize to get the last target item in the buffer
       //
@@ -702,7 +702,7 @@ let updateInternal = (
 
       appendOnBlockItems(
         ~mutItems,
-        ~onBlockConfigs,
+        ~onBlockRegistrations,
         ~indexerStartBlock=fetchState.startBlock,
         ~fromBlock=fetchState.latestOnBlockBlockNumber,
         ~maxBlockNumber,
@@ -717,7 +717,7 @@ let updateInternal = (
     contractConfigs: fetchState.contractConfigs,
     normalSelection: fetchState.normalSelection,
     chainId: fetchState.chainId,
-    onBlockConfigs: fetchState.onBlockConfigs,
+    onBlockRegistrations: fetchState.onBlockRegistrations,
     maxOnBlockBufferSize: fetchState.maxOnBlockBufferSize,
     optimizedPartitions,
     latestOnBlockBlockNumber,
@@ -1613,7 +1613,7 @@ let make = (
   ~maxOnBlockBufferSize,
   ~knownHeight,
   ~progressBlockNumber=startBlock - 1,
-  ~onBlockConfigs=[],
+  ~onBlockRegistrations=[],
   ~blockLag=0,
   ~firstEventBlock=None,
 ): t => {
@@ -1694,7 +1694,10 @@ let make = (
     ~progressBlockNumber,
   )
 
-  if optimizedPartitions->OptimizedPartitions.count === 0 && onBlockConfigs->Utils.Array.isEmpty {
+  if (
+    optimizedPartitions->OptimizedPartitions.count === 0 &&
+      onBlockRegistrations->Utils.Array.isEmpty
+  ) {
     JsError.throwWithMessage(
       `Invalid configuration: Nothing to fetch on chain ${chainId->Int.toString}. ` ++
       `addresses=${addresses->Array.length->Int.toString}, ` ++
@@ -1710,14 +1713,14 @@ let make = (
   // fetching, so without seeding the buffer here getNextQuery would return
   // NothingToQuery and the indexer would get stuck.
   let buffer = []
-  let latestOnBlockBlockNumber = if knownHeight > 0 && onBlockConfigs->Utils.Array.notEmpty {
+  let latestOnBlockBlockNumber = if knownHeight > 0 && onBlockRegistrations->Utils.Array.notEmpty {
     let maxBlockNumber = switch optimizedPartitions->OptimizedPartitions.getLatestFullyFetchedBlock {
     | None => knownHeight
     | Some(latestFullyFetchedBlock) => latestFullyFetchedBlock.blockNumber
     }
     appendOnBlockItems(
       ~mutItems=buffer,
-      ~onBlockConfigs,
+      ~onBlockRegistrations,
       ~indexerStartBlock=startBlock,
       ~fromBlock=progressBlockNumber,
       ~maxBlockNumber,
@@ -1736,7 +1739,7 @@ let make = (
     latestOnBlockBlockNumber,
     normalSelection,
     blockLag,
-    onBlockConfigs,
+    onBlockRegistrations,
     maxOnBlockBufferSize,
     knownHeight,
     buffer,

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -89,6 +89,6 @@ let registerAllHandlers = async (~config: Config.t) => {
   })
   ->Promise.all
 
-  let registrations = HandlerRegister.finishRegistration()
+  let registrations = HandlerRegister.finishRegistration(~config)
   (config, registrations)
 }

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -73,9 +73,9 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
 }
 
 // `Config` holds only event definitions; handler + per-chain `where`
-// registration state is layered on as `onEventRegistration`s in
-// `ChainState.makeInternal`. This loads the user handler files and returns the
-// (unchanged) definitions config plus the raw registrations bag.
+// registration state is layered on as `onEventRegistration`s by
+// `HandlerRegister.finishRegistration`. This loads the user handler files and
+// returns the (unchanged) definitions config plus the per-chain registrations.
 let registerAllHandlers = async (~config: Config.t) => {
   HandlerRegister.startRegistration(~ecosystem=config.ecosystem)
 
@@ -89,6 +89,6 @@ let registerAllHandlers = async (~config: Config.t) => {
   })
   ->Promise.all
 
-  let registrations = HandlerRegister.finishRegistration(~config)
-  (config, registrations)
+  let registrationsByChainId = HandlerRegister.finishRegistration(~config)
+  (config, registrationsByChainId)
 }

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -15,7 +15,7 @@ let empty = {
 // whatever handler/contractRegister/eventOptions got registered for them, and
 // the onBlock configs collected during registration.
 type registrations = {
-  onEventRegistrationsByChainId: dict<array<Internal.onEventRegistration>>,
+  registrationsByChainId: dict<array<Internal.onEventRegistration>>,
   onBlockByChainId: dict<array<Internal.onBlockConfig>>,
 }
 
@@ -263,17 +263,17 @@ let finishRegistration = (~config: Config.t) => {
   switch activeRegistration.contents {
   | Some(r) => {
       r.finished = true
-      let onEventRegistrationsByChainId = Dict.make()
+      let registrationsByChainId = Dict.make()
       config.chainMap
       ->ChainMap.values
       ->Array.forEach(chainConfig => {
-        onEventRegistrationsByChainId->Dict.set(
+        registrationsByChainId->Dict.set(
           chainConfig.id->Int.toString,
           buildOnEventRegistrations(~chainConfig, ~config),
         )
       })
       {
-        onEventRegistrationsByChainId,
+        registrationsByChainId,
         onBlockByChainId: r.registrations.onBlockByChainId,
       }
     }

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -10,11 +10,20 @@ let empty = {
   eventOptions: None,
 }
 
-type registrations = {onBlockByChainId: dict<array<Internal.onBlockConfig>>}
+// The finished registration state returned by `finishRegistration`: per-chain
+// onEventRegistrations built from the event definitions in `Config.t` plus
+// whatever handler/contractRegister/eventOptions got registered for them, and
+// the onBlock configs collected during registration.
+type registrations = {
+  onEventRegistrationsByChainId: dict<array<Internal.onEventRegistration>>,
+  onBlockByChainId: dict<array<Internal.onBlockConfig>>,
+}
+
+type pendingRegistrations = {onBlockByChainId: dict<array<Internal.onBlockConfig>>}
 
 type activeRegistration = {
   ecosystem: Ecosystem.t,
-  registrations: registrations,
+  registrations: pendingRegistrations,
   mutable finished: bool,
 }
 
@@ -119,11 +128,154 @@ let startRegistration = (~ecosystem) => {
   }
 }
 
-let finishRegistration = () => {
+// Enrich a chain's static event definitions with the registered
+// handler/contractRegister/where (validating them along the way) to produce
+// the onEventRegistrations ChainState indexes off. Runs once per chain when
+// registration finishes, so a bad `where`/duplicate event throws during
+// startup with a stack trace pointing here instead of surfacing later from
+// inside ChainState's construction.
+let buildOnEventRegistrations = (~chainConfig: Config.chain, ~config: Config.t): array<
+  Internal.onEventRegistration,
+> => {
+  // We don't need the router itself, but only validation logic,
+  // since now event router is created for selection of events
+  // and validation doesn't work correctly in routers.
+  // Ideally to split it into two different parts.
+  let eventRouter = EventRouter.empty()
+
+  let onEventRegistrations: array<Internal.onEventRegistration> = []
+  let notRegisteredEvents = []
+
+  chainConfig.contracts->Array.forEach(contract => {
+    let contractName = contract.name
+
+    contract.events->Array.forEach(eventConfig => {
+      let eventName = eventConfig.name
+      let t = get(~contractName, ~eventName)
+      let isWildcard = t.eventOptions->Option.flatMap(v => v.wildcard)->Option.getOr(false)
+      let handler = t.handler
+      let contractRegister = t.contractRegister
+
+      let onEventRegistration = switch config.ecosystem.name {
+      | Fuel =>
+        (EventConfigBuilder.buildFuelOnEventRegistration(
+          ~eventConfig=eventConfig->(Utils.magic: Internal.eventConfig => Internal.fuelEventConfig),
+          ~isWildcard,
+          ~handler,
+          ~contractRegister,
+          ~startBlock=?contract.startBlock,
+        ) :> Internal.onEventRegistration)
+      | Svm =>
+        (EventConfigBuilder.buildSvmOnEventRegistration(
+          ~eventConfig=eventConfig->(
+            Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig
+          ),
+          ~isWildcard,
+          ~handler,
+          ~contractRegister,
+          ~startBlock=?contract.startBlock,
+        ) :> Internal.onEventRegistration)
+      | Evm =>
+        (EventConfigBuilder.buildEvmOnEventRegistration(
+          ~eventConfig=eventConfig->(Utils.magic: Internal.eventConfig => Internal.evmEventConfig),
+          ~isWildcard,
+          ~handler,
+          ~contractRegister,
+          ~eventFilters=t.eventOptions->Option.flatMap(v => v.where),
+          ~probeChainId=chainConfig.id,
+          ~onEventBlockFilterSchema=config.ecosystem.onEventBlockFilterSchema,
+          ~startBlock=?contract.startBlock,
+        ) :> Internal.onEventRegistration)
+      }
+
+      // Should validate the events
+      eventRouter->EventRouter.addOrThrow(
+        eventConfig.id,
+        (),
+        ~contractName,
+        ~chain=ChainMap.Chain.makeUnsafe(~chainId=chainConfig.id),
+        ~eventName,
+        ~isWildcard,
+      )
+
+      // Filter out events without a handler/contractRegister so they aren't
+      // fetched or dispatched (unless raw events are enabled).
+      let shouldBeIncluded = if config.enableRawEvents {
+        true
+      } else {
+        let isRegistered = contractRegister->Option.isSome || handler->Option.isSome
+        if !isRegistered {
+          notRegisteredEvents->Array.push(onEventRegistration)
+        }
+        isRegistered
+      }
+
+      // Check if event has Static([]) filters (from a dynamic where
+      // callback returning `false` / SkipAll for this chain).
+      // If so, skip it entirely - it should never be fetched
+      let shouldSkip = try {
+        let getEventFiltersOrThrow = (
+          onEventRegistration->(
+            Utils.magic: Internal.onEventRegistration => Internal.evmOnEventRegistration
+          )
+        ).getEventFiltersOrThrow
+
+        // Check for non-evm chains
+        if (
+          getEventFiltersOrThrow->(Utils.magic: (ChainMap.Chain.t => Internal.eventFilters) => bool)
+        ) {
+          switch getEventFiltersOrThrow(ChainMap.Chain.makeUnsafe(~chainId=chainConfig.id)) {
+          | Static([]) => true
+          | _ => false
+          }
+        } else {
+          false
+        }
+      } catch {
+      // Can throw when filter is invalid
+      // Don't skip an event in this case. Let it throw in a better place - source code
+      | _ => false
+      }
+
+      if shouldBeIncluded && !shouldSkip {
+        onEventRegistrations->Array.push(onEventRegistration)
+      }
+    })
+  })
+
+  if notRegisteredEvents->Utils.Array.notEmpty {
+    let logger = Logging.createChild(~params={"chainId": chainConfig.id})
+    logger->Logging.childInfo(
+      `The event${if notRegisteredEvents->Array.length > 1 {
+          "s"
+        } else {
+          ""
+        }} ${notRegisteredEvents
+        ->Array.map(reg => `${reg.eventConfig.contractName}.${reg.eventConfig.name}`)
+        ->Array.joinUnsafe(", ")} don't have an event handler and skipped for indexing.`,
+    )
+  }
+
+  onEventRegistrations
+}
+
+let finishRegistration = (~config: Config.t) => {
   switch activeRegistration.contents {
   | Some(r) => {
       r.finished = true
-      r.registrations
+      let onEventRegistrationsByChainId = Dict.make()
+      config.chainMap
+      ->ChainMap.values
+      ->Array.forEach(chainConfig => {
+        onEventRegistrationsByChainId->Dict.set(
+          chainConfig.id->Int.toString,
+          buildOnEventRegistrations(~chainConfig, ~config),
+        )
+      })
+      {
+        onEventRegistrationsByChainId,
+        onBlockByChainId: r.registrations.onBlockByChainId,
+      }
     }
   | None =>
     JsError.throwWithMessage(

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -137,12 +137,13 @@ let startRegistration = (~ecosystem) => {
 // registration finishes, so a bad `where`/duplicate event throws during
 // startup with a stack trace pointing here instead of surfacing later from
 // inside ChainState's construction. Events without a handler/contractRegister
-// get added to `notRegisteredEvents` (as "ContractName.EventName") so the
-// caller can report them once for the whole indexer instead of per chain.
+// get added to `notRegisteredEventsByContract` (event names grouped by
+// contract name) so the caller can report them once for the whole indexer
+// instead of per chain.
 let buildOnEventRegistrations = (
   ~chainConfig: Config.chain,
   ~config: Config.t,
-  ~notRegisteredEvents: Utils.Set.t<string>,
+  ~notRegisteredEventsByContract: dict<Utils.Set.t<string>>,
 ): array<Internal.onEventRegistration> => {
   // We don't need the router itself, but only validation logic,
   // since now event router is created for selection of events
@@ -211,7 +212,17 @@ let buildOnEventRegistrations = (
       } else {
         let isRegistered = contractRegister->Option.isSome || handler->Option.isSome
         if !isRegistered {
-          notRegisteredEvents->Utils.Set.add(`${contractName}.${eventName}`)->ignore
+          let eventNames = switch notRegisteredEventsByContract->Utils.Dict.dangerouslyGetNonOption(
+            contractName,
+          ) {
+          | Some(set) => set
+          | None => {
+              let set = Utils.Set.make()
+              notRegisteredEventsByContract->Dict.set(contractName, set)
+              set
+            }
+          }
+          eventNames->Utils.Set.add(eventName)->ignore
         }
         isRegistered
       }
@@ -256,7 +267,7 @@ let finishRegistration = (~config: Config.t): registrationsByChainId => {
   switch activeRegistration.contents {
   | Some(r) => {
       r.finished = true
-      let notRegisteredEvents = Utils.Set.make()
+      let notRegisteredEventsByContract: dict<Utils.Set.t<string>> = Dict.make()
       let registrationsByChainId: registrationsByChainId = Dict.make()
       config.chainMap
       ->ChainMap.values
@@ -268,7 +279,7 @@ let finishRegistration = (~config: Config.t): registrationsByChainId => {
             onEventRegistrations: buildOnEventRegistrations(
               ~chainConfig,
               ~config,
-              ~notRegisteredEvents,
+              ~notRegisteredEventsByContract,
             ),
             onBlockRegistrations: r.registrations.onBlockByChainId
             ->Utils.Dict.dangerouslyGetNonOption(key)
@@ -279,16 +290,16 @@ let finishRegistration = (~config: Config.t): registrationsByChainId => {
 
       // Reported once for the whole indexer (a shared contract on multiple
       // chains would otherwise repeat the same message per chain).
-      if notRegisteredEvents->Utils.Set.size > 0 {
-        let names = notRegisteredEvents->Utils.Set.toArray
+      let notRegisteredEntries = notRegisteredEventsByContract->Dict.toArray
+      if notRegisteredEntries->Utils.Array.notEmpty {
+        let groups =
+          notRegisteredEntries
+          ->Array.map(((contractName, eventNames)) =>
+            `${contractName} (${eventNames->Utils.Set.toArray->Array.joinUnsafe(", ")})`
+          )
+          ->Array.joinUnsafe(", ")
         Logging.getLogger()->Logging.childInfo(
-          `The event${if names->Array.length > 1 {
-              "s"
-            } else {
-              ""
-            }} ${names->Array.joinUnsafe(
-              ", ",
-            )} don't have an event handler and skipped for indexing.`,
+          `Events without a handler, skipped for indexing: ${groups}`,
         )
       }
 

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -10,16 +10,19 @@ let empty = {
   eventOptions: None,
 }
 
-// The finished registration state returned by `finishRegistration`: per-chain
-// onEventRegistrations built from the event definitions in `Config.t` plus
-// whatever handler/contractRegister/eventOptions got registered for them, and
-// the onBlock configs collected during registration.
-type registrations = {
-  registrationsByChainId: dict<array<Internal.onEventRegistration>>,
-  onBlockByChainId: dict<array<Internal.onBlockConfig>>,
+// Per-chain onEventRegistrations built from the event definitions in
+// `Config.t` plus whatever handler/contractRegister/eventOptions got
+// registered for them, and the onBlock registrations collected during
+// registration.
+type chainRegistrations = {
+  onEventRegistrations: array<Internal.onEventRegistration>,
+  onBlockRegistrations: array<Internal.onBlockRegistration>,
 }
 
-type pendingRegistrations = {onBlockByChainId: dict<array<Internal.onBlockConfig>>}
+// The finished registration state returned by `finishRegistration`.
+type registrationsByChainId = dict<chainRegistrations>
+
+type pendingRegistrations = {onBlockByChainId: dict<array<Internal.onBlockRegistration>>}
 
 type activeRegistration = {
   ecosystem: Ecosystem.t,
@@ -133,10 +136,14 @@ let startRegistration = (~ecosystem) => {
 // the onEventRegistrations ChainState indexes off. Runs once per chain when
 // registration finishes, so a bad `where`/duplicate event throws during
 // startup with a stack trace pointing here instead of surfacing later from
-// inside ChainState's construction.
-let buildOnEventRegistrations = (~chainConfig: Config.chain, ~config: Config.t): array<
-  Internal.onEventRegistration,
-> => {
+// inside ChainState's construction. Events without a handler/contractRegister
+// get added to `notRegisteredEvents` (as "ContractName.EventName") so the
+// caller can report them once for the whole indexer instead of per chain.
+let buildOnEventRegistrations = (
+  ~chainConfig: Config.chain,
+  ~config: Config.t,
+  ~notRegisteredEvents: Utils.Set.t<string>,
+): array<Internal.onEventRegistration> => {
   // We don't need the router itself, but only validation logic,
   // since now event router is created for selection of events
   // and validation doesn't work correctly in routers.
@@ -144,7 +151,6 @@ let buildOnEventRegistrations = (~chainConfig: Config.chain, ~config: Config.t):
   let eventRouter = EventRouter.empty()
 
   let onEventRegistrations: array<Internal.onEventRegistration> = []
-  let notRegisteredEvents = []
 
   chainConfig.contracts->Array.forEach(contract => {
     let contractName = contract.name
@@ -205,7 +211,7 @@ let buildOnEventRegistrations = (~chainConfig: Config.chain, ~config: Config.t):
       } else {
         let isRegistered = contractRegister->Option.isSome || handler->Option.isSome
         if !isRegistered {
-          notRegisteredEvents->Array.push(onEventRegistration)
+          notRegisteredEvents->Utils.Set.add(`${contractName}.${eventName}`)->ignore
         }
         isRegistered
       }
@@ -243,39 +249,50 @@ let buildOnEventRegistrations = (~chainConfig: Config.chain, ~config: Config.t):
     })
   })
 
-  if notRegisteredEvents->Utils.Array.notEmpty {
-    let logger = Logging.createChild(~params={"chainId": chainConfig.id})
-    logger->Logging.childInfo(
-      `The event${if notRegisteredEvents->Array.length > 1 {
-          "s"
-        } else {
-          ""
-        }} ${notRegisteredEvents
-        ->Array.map(reg => `${reg.eventConfig.contractName}.${reg.eventConfig.name}`)
-        ->Array.joinUnsafe(", ")} don't have an event handler and skipped for indexing.`,
-    )
-  }
-
   onEventRegistrations
 }
 
-let finishRegistration = (~config: Config.t) => {
+let finishRegistration = (~config: Config.t): registrationsByChainId => {
   switch activeRegistration.contents {
   | Some(r) => {
       r.finished = true
-      let registrationsByChainId = Dict.make()
+      let notRegisteredEvents = Utils.Set.make()
+      let registrationsByChainId: registrationsByChainId = Dict.make()
       config.chainMap
       ->ChainMap.values
       ->Array.forEach(chainConfig => {
+        let key = chainConfig.id->Int.toString
         registrationsByChainId->Dict.set(
-          chainConfig.id->Int.toString,
-          buildOnEventRegistrations(~chainConfig, ~config),
+          key,
+          {
+            onEventRegistrations: buildOnEventRegistrations(
+              ~chainConfig,
+              ~config,
+              ~notRegisteredEvents,
+            ),
+            onBlockRegistrations: r.registrations.onBlockByChainId
+            ->Utils.Dict.dangerouslyGetNonOption(key)
+            ->Option.getOr([]),
+          },
         )
       })
-      {
-        registrationsByChainId,
-        onBlockByChainId: r.registrations.onBlockByChainId,
+
+      // Reported once for the whole indexer (a shared contract on multiple
+      // chains would otherwise repeat the same message per chain).
+      if notRegisteredEvents->Utils.Set.size > 0 {
+        let names = notRegisteredEvents->Utils.Set.toArray
+        Logging.getLogger()->Logging.childInfo(
+          `The event${if names->Array.length > 1 {
+              "s"
+            } else {
+              ""
+            }} ${names->Array.joinUnsafe(
+              ", ",
+            )} don't have an event handler and skipped for indexing.`,
+        )
       }
+
+      registrationsByChainId
     }
   | None =>
     JsError.throwWithMessage(
@@ -330,7 +347,7 @@ let registerOnBlock = (
           interval,
           chainId,
           handler,
-        }: Internal.onBlockConfig
+        }: Internal.onBlockRegistration
       ),
     )
   })

--- a/packages/envio/src/HandlerRegister.resi
+++ b/packages/envio/src/HandlerRegister.resi
@@ -1,5 +1,5 @@
 type registrations = {
-  onEventRegistrationsByChainId: dict<array<Internal.onEventRegistration>>,
+  registrationsByChainId: dict<array<Internal.onEventRegistration>>,
   onBlockByChainId: dict<array<Internal.onBlockConfig>>,
 }
 

--- a/packages/envio/src/HandlerRegister.resi
+++ b/packages/envio/src/HandlerRegister.resi
@@ -1,11 +1,12 @@
-type registrations = {
-  registrationsByChainId: dict<array<Internal.onEventRegistration>>,
-  onBlockByChainId: dict<array<Internal.onBlockConfig>>,
+type chainRegistrations = {
+  onEventRegistrations: array<Internal.onEventRegistration>,
+  onBlockRegistrations: array<Internal.onBlockRegistration>,
 }
+type registrationsByChainId = dict<chainRegistrations>
 
 let startRegistration: (~ecosystem: Ecosystem.t) => unit
 let isPendingRegistration: unit => bool
-let finishRegistration: (~config: Config.t) => registrations
+let finishRegistration: (~config: Config.t) => registrationsByChainId
 let throwIfFinishedRegistration: (~methodName: string) => unit
 
 let setHandler: (

--- a/packages/envio/src/HandlerRegister.resi
+++ b/packages/envio/src/HandlerRegister.resi
@@ -1,8 +1,11 @@
-type registrations = {onBlockByChainId: dict<array<Internal.onBlockConfig>>}
+type registrations = {
+  onEventRegistrationsByChainId: dict<array<Internal.onEventRegistration>>,
+  onBlockByChainId: dict<array<Internal.onBlockConfig>>,
+}
 
 let startRegistration: (~ecosystem: Ecosystem.t) => unit
 let isPendingRegistration: unit => bool
-let finishRegistration: unit => registrations
+let finishRegistration: (~config: Config.t) => registrations
 let throwIfFinishedRegistration: (~methodName: string) => unit
 
 let setHandler: (

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -185,7 +185,7 @@ let makeFromDbState = (
   ~config: Config.t,
   ~persistence: Persistence.t,
   ~initialState: Persistence.initialState,
-  ~registrations,
+  ~registrationsByChainId,
   ~isDevelopmentMode=false,
   ~shouldUseTui=false,
   ~exitAfterFirstEventBlock=false,
@@ -231,7 +231,7 @@ let makeFromDbState = (
         ~isInReorgThreshold,
         ~isRealtime,
         ~config,
-        ~registrations,
+        ~registrationsByChainId,
         ~reducedPollingInterval?,
       ),
     )

--- a/packages/envio/src/IndexerState.resi
+++ b/packages/envio/src/IndexerState.resi
@@ -44,7 +44,7 @@ let makeFromDbState: (
   ~config: Config.t,
   ~persistence: Persistence.t,
   ~initialState: Persistence.initialState,
-  ~registrations: HandlerRegister.registrations,
+  ~registrationsByChainId: HandlerRegister.registrationsByChainId,
   ~isDevelopmentMode: bool=?,
   ~shouldUseTui: bool=?,
   ~exitAfterFirstEventBlock: bool=?,

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -597,7 +597,7 @@ type onBlockArgs = {
   context: handlerContext,
 }
 
-type onBlockConfig = {
+type onBlockRegistration = {
   // When there are multiple onBlock handlers per chain,
   // we want to use the order they are defined for sorting
   index: int,
@@ -622,7 +622,7 @@ type item =
       transactionIndex: int,
       payload: eventPayload,
     })
-  | @as(1) Block({onBlockConfig: onBlockConfig, blockNumber: int, logIndex: int})
+  | @as(1) Block({onBlockRegistration: onBlockRegistration, blockNumber: int, logIndex: int})
 
 external castUnsafeEventItem: item => eventItem = "%identity"
 
@@ -634,7 +634,7 @@ external getItemLogIndex: item => int = "logIndex"
 let getItemChainId = item =>
   switch item {
   | Event({chain}) => chain->ChainMap.Chain.toChainId
-  | Block({onBlockConfig: {chainId}}) => chainId
+  | Block({onBlockRegistration: {chainId}}) => chainId
   }
 
 @get

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -685,7 +685,7 @@ let start = async (
   ~reset=false,
   ~isTest=false,
   ~exitAfterFirstEventBlock=false,
-  ~patchConfig: option<(Config.t, HandlerRegister.registrations) => Config.t>=?,
+  ~patchConfig: option<(Config.t, HandlerRegister.registrationsByChainId) => Config.t>=?,
 ) => {
   let mainArgs: mainArgs = process->argv->Yargs.hideBin->Yargs.yargs->Yargs.argv
   let explicitTui = switch mainArgs.tuiOff {
@@ -721,7 +721,7 @@ let start = async (
   // `Config.loadWithoutRegistrations` never sees registration state; handler,
   // contractRegister, and eventFilters are baked into each event config only
   // by the returned value here.
-  let (config, registrations) = await HandlerLoader.registerAllHandlers(
+  let (config, registrationsByChainId) = await HandlerLoader.registerAllHandlers(
     ~config=configWithoutRegistrations,
   )
   let config = if isTest {
@@ -731,7 +731,7 @@ let start = async (
   }
 
   let config = switch patchConfig {
-  | Some(patchConfig) => patchConfig(config, registrations)
+  | Some(patchConfig) => patchConfig(config, registrationsByChainId)
   | None => config
   }
   // The single fatal-error handler, invoked once via IndexerState.errorExit.
@@ -778,7 +778,7 @@ let start = async (
     ~config,
     ~persistence,
     ~initialState=persistence->Persistence.getInitializedState,
-    ~registrations,
+    ~registrationsByChainId,
     ~isDevelopmentMode,
     ~shouldUseTui,
     ~exitAfterFirstEventBlock,

--- a/scenarios/test_codegen/test/IndexerState_test.res
+++ b/scenarios/test_codegen/test/IndexerState_test.res
@@ -165,7 +165,7 @@ let getItemKey = (item: Internal.item) =>
       blockNumber,
       logIndex,
     )
-  | Block({onBlockConfig: {chainId}, blockNumber}) => (chainId, blockNumber, 0)
+  | Block({onBlockRegistration: {chainId}, blockNumber}) => (chainId, blockNumber, 0)
   }
 
 // Advance each chain's fetchState to its post-batch state, simulating the loop

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -284,12 +284,13 @@ module Indexer = {
     | Some(_) => ()
     }
 
-    let (postRegistrationConfig, registrations) = await HandlerLoader.registerAllHandlers(
-      ~config=Config.loadWithoutRegistrations(),
-    )
-
+    // Build the final per-test config (chain overrides, enableRawEvents, ...)
+    // before registering handlers: `HandlerRegister.finishRegistration` now
+    // builds each chain's onEventRegistrations (gated by `enableRawEvents`)
+    // from the config it's given, so registration must see the resolved
+    // config rather than the raw generated one.
     let config = {
-      let config = postRegistrationConfig
+      let config = Config.loadWithoutRegistrations()
 
       let chainMap =
         chains
@@ -317,6 +318,8 @@ module Indexer = {
         batchSize: batchSize->Option.getOr(config.batchSize),
       }
     }
+
+    let (config, registrations) = await HandlerLoader.registerAllHandlers(~config)
 
     let sql = PgStorage.makeClient()
     let pgSchema = Env.Db.publicSchema

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -319,7 +319,7 @@ module Indexer = {
       }
     }
 
-    let (config, registrations) = await HandlerLoader.registerAllHandlers(~config)
+    let (config, registrationsByChainId) = await HandlerLoader.registerAllHandlers(~config)
 
     let sql = PgStorage.makeClient()
     let pgSchema = Env.Db.publicSchema
@@ -353,7 +353,7 @@ module Indexer = {
       ~initialState=persistence->Persistence.getInitializedState,
       ~config,
       ~persistence,
-      ~registrations,
+      ~registrationsByChainId,
       ~reducedPollingInterval?,
       ~targetBufferSize?,
       ~isDevelopmentMode=false,

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -34,7 +34,7 @@ let makeChainState = (
     ~onEventRegistrations,
     ~contractConfigs,
     ~addresses,
-    ~onBlockConfigs=[
+    ~onBlockRegistrations=[
       {
         Internal.index: 0,
         name: "scheduler-test",
@@ -119,7 +119,7 @@ let makeFetchingChainState = (~chainId, ~knownHeight, ~latestFetchedBlock) => {
     chainId,
     contractConfigs: Dict.make(),
     blockLag: 0,
-    onBlockConfigs: [],
+    onBlockRegistrations: [],
     knownHeight,
     firstEventBlock: Some(0),
   }

--- a/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
@@ -31,13 +31,13 @@ let baseEventConfig = (MockIndexer.evmOnEventRegistration(
   ~contractName="Gravatar",
 ) :> Internal.onEventRegistration)
 
-let makeOnBlockConfig = (
+let makeOnBlockRegistration = (
   ~name="testOnBlock",
   ~index=0,
   ~startBlock=None,
   ~endBlock=None,
   ~interval=1,
-): Internal.onBlockConfig => {
+): Internal.onBlockRegistration => {
   index,
   name,
   chainId,
@@ -47,7 +47,7 @@ let makeOnBlockConfig = (
   handler: Utils.magic("mock handler"),
 }
 
-let makeInitialWithOnBlock = (~startBlock=0, ~onBlockConfigs) => {
+let makeInitialWithOnBlock = (~startBlock=0, ~onBlockRegistrations) => {
   let onEventRegistrations = [baseEventConfig]
   let addresses = [
     {
@@ -67,7 +67,7 @@ let makeInitialWithOnBlock = (~startBlock=0, ~onBlockConfigs) => {
     ~maxAddrInPartition=3,
     ~maxOnBlockBufferSize=5000,
     ~chainId,
-    ~onBlockConfigs?,
+    ~onBlockRegistrations?,
     ~knownHeight=0,
   )
   (fetchState, indexingAddresses)
@@ -87,8 +87,8 @@ let mockEvent = (~blockNumber, ~logIndex=0): Internal.item => Internal.Event({
 describe("FetchState onBlock functionality", () => {
   it("should add block items to queue when processing first batch with onBlock config", t => {
     // Create a fetch state with onBlock config
-    let onBlockConfig = makeOnBlockConfig(~interval=2, ~startBlock=Some(0))
-    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockConfigs=Some([onBlockConfig]))
+    let onBlockRegistration = makeOnBlockRegistration(~interval=2, ~startBlock=Some(0))
+    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration]))
 
     // Verify initial state - no items in queue
     t.expect(fetchState->FetchState.bufferSize, ~message="Initial queue should be empty").toBe(0)
@@ -140,8 +140,8 @@ describe("FetchState onBlock functionality", () => {
 
   it("should respect onBlock startBlock configuration", t => {
     // Create onBlock config with startBlock = 5
-    let onBlockConfig = makeOnBlockConfig(~interval=1, ~startBlock=Some(5))
-    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockConfigs=Some([onBlockConfig]))
+    let onBlockRegistration = makeOnBlockRegistration(~interval=1, ~startBlock=Some(5))
+    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration]))
 
     // Process a batch that goes from block 0 to 10
     let query: FetchState.query = {
@@ -190,8 +190,8 @@ describe("FetchState onBlock functionality", () => {
 
   it("should respect onBlock endBlock configuration", t => {
     // Create onBlock config with endBlock = 8
-    let onBlockConfig = makeOnBlockConfig(~interval=1, ~endBlock=Some(8))
-    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockConfigs=Some([onBlockConfig]))
+    let onBlockRegistration = makeOnBlockRegistration(~interval=1, ~endBlock=Some(8))
+    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration]))
 
     // Process a batch that goes from block 0 to 10
     let query: FetchState.query = {
@@ -243,9 +243,9 @@ describe("FetchState onBlock functionality", () => {
 
   it("should handle multiple onBlock configs with different intervals", t => {
     // Create two onBlock configs with different intervals
-    let onBlockConfig1 = makeOnBlockConfig(~name="config1", ~index=0, ~interval=2)
-    let onBlockConfig2 = makeOnBlockConfig(~name="config2", ~index=1, ~interval=3)
-    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockConfigs=Some([onBlockConfig1, onBlockConfig2]))
+    let onBlockRegistration1 = makeOnBlockRegistration(~name="config1", ~index=0, ~interval=2)
+    let onBlockRegistration2 = makeOnBlockRegistration(~name="config2", ~index=1, ~interval=3)
+    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration1, onBlockRegistration2]))
 
     // Process a batch
     let query: FetchState.query = {
@@ -302,7 +302,7 @@ describe("FetchState onBlock functionality", () => {
 
   it("should not add block items when onBlock configs are not provided", t => {
     // Create fetch state without onBlock configs
-    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockConfigs=None)
+    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockRegistrations=None)
 
     // Process a batch
     let query: FetchState.query = {

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -158,7 +158,7 @@ let makeFs = (
   ~maxOnBlockBufferSize,
   ~knownHeight,
   ~progressBlockNumber=?,
-  ~onBlockConfigs=?,
+  ~onBlockRegistrations=?,
   ~blockLag=?,
   ~firstEventBlock=?,
 ) => {
@@ -175,7 +175,7 @@ let makeFs = (
     ~maxOnBlockBufferSize,
     ~knownHeight,
     ~progressBlockNumber=?progressBlockNumber,
-    ~onBlockConfigs=?onBlockConfigs,
+    ~onBlockRegistrations=?onBlockRegistrations,
     ~blockLag=?blockLag,
     ~firstEventBlock=?firstEventBlock,
   )
@@ -255,7 +255,7 @@ describe("FetchState.make", () => {
       chainId: 0,
       contractConfigs: fetchState.contractConfigs,
       blockLag: 0,
-      onBlockConfigs: [],
+      onBlockRegistrations: [],
       knownHeight,
       firstEventBlock: None,
     })
@@ -370,7 +370,7 @@ describe("FetchState.make", () => {
       chainId,
       contractConfigs: fetchState.contractConfigs,
       blockLag: 0,
-      onBlockConfigs: [],
+      onBlockRegistrations: [],
       knownHeight,
       firstEventBlock: None,
     })
@@ -443,7 +443,7 @@ describe("FetchState.make", () => {
         chainId,
         contractConfigs: fetchState.contractConfigs,
         blockLag: 0,
-        onBlockConfigs: [],
+        onBlockRegistrations: [],
         knownHeight,
         firstEventBlock: None,
       })
@@ -561,7 +561,7 @@ describe("FetchState.make", () => {
         chainId,
         contractConfigs: fetchState.contractConfigs,
         blockLag: 0,
-        onBlockConfigs: [],
+        onBlockRegistrations: [],
         knownHeight,
         firstEventBlock: None,
       })
@@ -1716,7 +1716,7 @@ describe("FetchState.registerDynamicContracts", () => {
         chainId,
         contractConfigs: fetchState.contractConfigs,
         blockLag: 0,
-        onBlockConfigs: [],
+        onBlockRegistrations: [],
         knownHeight,
         firstEventBlock: None,
       })
@@ -1777,7 +1777,7 @@ describe("FetchState.getNextQuery & integration", () => {
       normalSelection,
       chainId,
       contractConfigs: makeInitialFs().contractConfigs,
-      onBlockConfigs: [],
+      onBlockRegistrations: [],
       knownHeight,
       firstEventBlock: None,
     }
@@ -1836,7 +1836,7 @@ describe("FetchState.getNextQuery & integration", () => {
       chainId,
       contractConfigs: makeInitialFs().contractConfigs,
       blockLag: 0,
-      onBlockConfigs: [],
+      onBlockRegistrations: [],
       knownHeight,
       firstEventBlock: None,
     }
@@ -3765,14 +3765,14 @@ describe("FetchState buffer overflow prevention", () => {
   )
 })
 
-describe("FetchState with onBlockConfig only (no events)", () => {
-  let makeOnBlockConfig = (
+describe("FetchState with onBlockRegistration only (no events)", () => {
+  let makeOnBlockRegistration = (
     ~name="testOnBlock",
     ~index=0,
     ~startBlock=None,
     ~endBlock=None,
     ~interval=1,
-  ): Internal.onBlockConfig => {
+  ): Internal.onBlockRegistration => {
     index,
     name,
     chainId,
@@ -3785,9 +3785,9 @@ describe("FetchState with onBlockConfig only (no events)", () => {
   it(
     "Creates FetchState with no event configs, triggers WaitingForNewBlock, then fills buffer on updateKnownHeight",
     t => {
-      let onBlockConfig = makeOnBlockConfig(~interval=1, ~startBlock=Some(0))
+      let onBlockRegistration = makeOnBlockRegistration(~interval=1, ~startBlock=Some(0))
 
-      // Create FetchState with no event configs but with onBlockConfig
+      // Create FetchState with no event configs but with onBlockRegistration
       let (fetchState, _indexingAddresses) = makeFs(
         ~onEventRegistrations=[],
         ~addresses=[],
@@ -3797,7 +3797,7 @@ describe("FetchState with onBlockConfig only (no events)", () => {
         ~maxOnBlockBufferSize=10,
         ~chainId,
         ~knownHeight=0,
-        ~onBlockConfigs=[onBlockConfig],
+        ~onBlockRegistrations=[onBlockRegistration],
       )
 
       // Verify initial state
@@ -3807,9 +3807,10 @@ describe("FetchState with onBlockConfig only (no events)", () => {
       ).toEqual([])
       t.expect(fetchState.buffer, ~message="Buffer should be empty initially").toEqual([])
       t.expect(fetchState.knownHeight, ~message="knownHeight should be 0 initially").toBe(0)
-      t.expect(fetchState.onBlockConfigs, ~message="onBlockConfigs should be set").toEqual([
-        onBlockConfig,
-      ])
+      t.expect(
+        fetchState.onBlockRegistrations,
+        ~message="onBlockRegistrations should be set",
+      ).toEqual([onBlockRegistration])
 
       // Test that getNextQuery returns WaitingForNewBlock when knownHeight is 0
       let nextQuery =

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -465,7 +465,7 @@ describe("SourceManager fetchNext", () => {
       chainId: 0,
       contractConfigs: Dict.make(),
       blockLag: 0,
-      onBlockConfigs: [],
+      onBlockRegistrations: [],
       knownHeight,
       firstEventBlock: None,
     }


### PR DESCRIPTION
## Summary

Refactors the registration pipeline to build per-chain event and onBlock registrations during `HandlerRegister.finishRegistration()` instead of deferring this work to `ChainState.makeInternal()`. This centralizes registration logic, enables better error reporting with stack traces pointing to registration time, and simplifies the ChainState constructor.

## Key Changes

- **HandlerRegister**: 
  - Renamed `registrations` type to `pendingRegistrations` (holds only onBlock configs during registration)
  - Added `chainRegistrations` type to hold both `onEventRegistrations` and `onBlockRegistrations` per chain
  - Added `registrationsByChainId` type as the return value of `finishRegistration`
  - Introduced `buildOnEventRegistrations()` function that enriches static event definitions with registered handlers, validates `where` filters, and collects unregistered events for centralized reporting
  - Updated `finishRegistration()` to accept `Config.t`, build all per-chain registrations, and report unregistered events once for the whole indexer instead of per-chain

- **ChainState**:
  - Removed event registration building logic (now done in HandlerRegister)
  - Simplified `makeInternal()` to look up pre-built registrations from `registrationsByChainId` parameter
  - Removed per-chain unregistered event reporting (now centralized in HandlerRegister)
  - Updated function signatures to accept `registrationsByChainId` instead of `registrations`

- **FetchState**:
  - Renamed `onBlockConfigs` to `onBlockRegistrations` throughout for consistency

- **HandlerLoader**:
  - Updated to return `registrationsByChainId` from `registerAllHandlers()`

- **Test files**:
  - Updated MockIndexer, FetchState tests, and other test helpers to use new registration types and naming

## Notable Implementation Details

- Event registration building now happens at startup with proper error context, rather than lazily during ChainState construction
- Unregistered events are collected across all chains and reported once, reducing log noise
- The `where` filter validation that could throw is now caught during registration with a fallback to not skip the event (letting it fail later with better context)
- Raw events mode (`enableRawEvents`) filtering is applied during registration building, not later

https://claude.ai/code/session_01XgMNqjVA7crNJPmbrXwib7