### PR TITLE
ci: only announce major and minor releases to Discord

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -12,7 +12,30 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.release.draft == false
     steps:
+      # Announce major and minor releases only. A release qualifies when the
+      # tag is an exact "X.Y.0" (strip a leading "v"): patch is 0, and there is
+      # no pre-release suffix. This skips patch releases and release candidates
+      # such as v3.0.0-rc.1, which GitHub does not always flag as prereleases.
+      - name: Check if release is major or minor
+        id: classify
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          version="${TAG#v}"
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            echo "$TAG is a prerelease; skipping"
+            echo "announce=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$version" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+            echo "$TAG is a major/minor release; announcing"
+            echo "announce=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "$TAG is a patch release; skipping"
+            echo "announce=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Post release to Discord
+        if: steps.classify.outputs.announce == 'true'
         uses: SethCohen/github-releases-to-discord@24d166886aee4646d448c8a389ff9e1ebcab3682 # v1.20.0
         with:
           webhook_url: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}


### PR DESCRIPTION
Gates the release announcement workflow so it only posts to Discord for major and minor releases (exact `X.Y.0`).

- Patch releases and prereleases (alpha/rc) are skipped
- Note: some hyperindex RC tags (e.g. `v3.0.0-rc.1`) are not flagged as prereleases on GitHub, so the tag is matched exactly (anchored, no suffix) rather than relying on the prerelease flag
- Discord embed step and its formatting are unchanged

Validated against all 204 historical releases: 38 would post (down from 204), matching the major + minor set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release announcements are now sent to Discord only when the published release tag matches an `X.Y.0` semver pattern (optionally prefixed with `v`), and only when there is no prerelease suffix.
  * Pre-release versions (for example, alpha/rc) are excluded from Discord announcements.
  * The announcement step now runs conditionally based on this tag classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->