### PR TITLE
Fix water-fill budget redistribution to account for partition footprint

### DIFF
--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1539,11 +1539,11 @@ let getNextQuery = (
       }
     }
 
-    // Each partition's existing pending itemsTarget sum, computed once and
-    // reused both for chainReserved (the call-wide fresh-budget ceiling below)
-    // and for seeding reservedByPartition (the per-partition running total the
-    // water-fill rounds check against) — walking mutPendingQueries twice for
-    // the same sum was pure waste.
+    // Each partition's existing in-flight itemsTarget, summed once and reused
+    // both for chainReserved (the call-wide fresh-budget ceiling below) and to
+    // seed each partition's water-fill footprint — so a partition already
+    // holding in-flight queries is counted toward its even share and doesn't
+    // get topped up past the others.
     let existingReservedByPartition = Dict.make()
     let chainReserved = ref(0.)
     for idx in 0 to partitionsCount - 1 {
@@ -1623,13 +1623,19 @@ let getNextQuery = (
       }
     }
 
-    let rangeBudget = ref(
-      Pervasives.max(0., chainTargetItems -. chainReserved.contents -. gapFillCost.contents),
+    // Fresh budget for this call — what's left of chainTargetItems after
+    // existing in-flight queries and this tick's gap-fill. The water-fill
+    // rounds below hand it out; a partition already holding a large share
+    // (seeded below) gets proportionally less so totals stay even.
+    let rangeItemsTarget = Pervasives.max(
+      0.,
+      chainTargetItems -. chainReserved.contents -. gapFillCost.contents,
     )
 
-    // Seed each in-range partition's running reservation with its existing
-    // pending itemsTarget (already summed above) plus any gap-fill just
-    // created for it (already in fs.bucket at this point).
+    // Each in-range partition's running footprint: existing in-flight plus any
+    // gap-fill just pushed into its bucket. The water-fill levels every
+    // partition up toward a shared line, so this seed is what a partition
+    // starts the fill already holding.
     let reservedByPartition = Dict.make()
     fillStates->Array.forEach(fs => {
       let cost = ref(existingReservedByPartition->Dict.getUnsafe(fs.partitionId))
@@ -1721,45 +1727,50 @@ let getNextQuery = (
       } &&
       fs.pendingCount + fs.chunksUsedThisCall < maxPendingChunksPerPartition
 
-    let rangePartitions = ref(fillStates->Array.filter(isInRange))
-    // Every partition active in a round either finishes (single-shot, or hits
-    // its ceiling/chainTargetBlock) or advances chunksUsedThisCall, which caps
-    // at maxPendingChunksPerPartition — and all active partitions progress in
-    // the same round together, not one-at-a-time — so no partition survives
-    // past maxPendingChunksPerPartition rounds regardless of how many there
-    // are. +1 for the round that observes the last one finish.
-    let roundsRef = ref(0)
+    // Water-fill. Range membership is fixed by chainTargetBlock/queryEndBlock,
+    // so the in-range partitions are filtered once up front; each round levels
+    // every still-not-filled partition up toward a shared line and keeps only
+    // those still in range for the next round.
+    //
+    // The line is (remaining fresh budget + those partitions' current
+    // footprint) / count: a partition already holding more than the line gets
+    // nothing and drops out (its head start is its whole share), while the
+    // rest are topped up to the line — so leftover from an under-using or
+    // filled partition redistributes to whoever can still use it, and totals
+    // stay even regardless of processing order (the line is fixed before the
+    // round's emits).
+    //
+    // No explicit round cap: a partition survives a round only by advancing
+    // chunksUsedThisCall (capped at maxPendingChunksPerPartition) or by
+    // consuming fresh budget, so the not-filled set drains on its own and the
+    // loop also stops once the whole budget is reserved.
+    let notFilledPartitions = ref(fillStates->Array.filter(isInRange))
+    let reservedFromRange = ref(0.)
     while (
-      rangePartitions.contents->Array.length > 0 &&
-      rangeBudget.contents > 0. &&
-      roundsRef.contents < maxPendingChunksPerPartition + 1
+      notFilledPartitions.contents->Array.length > 0 &&
+        reservedFromRange.contents < rangeItemsTarget
     ) {
-      let n = rangePartitions.contents->Array.length
-      // Fixed for the whole round, from what's left after previous rounds —
-      // every partition's share this round is ipb - reserved, independent of
-      // what any other partition in the SAME round consumes. A partition can
-      // still overshoot its share (a chunked partition forced to take at
-      // least one full chunk), but that no longer steals from whoever's
-      // processed after it: rangeBudget is only re-derived once, from this
-      // round's actual total, after everyone's had their fixed shot.
-      let ipb = rangeBudget.contents /. n->Int.toFloat
+      let n = notFilledPartitions.contents->Array.length
+      let footprintSum = ref(0.)
+      notFilledPartitions.contents->Array.forEach(fs =>
+        footprintSum := footprintSum.contents +. reservedByPartition->Dict.getUnsafe(fs.partitionId)
+      )
+      let line =
+        (rangeItemsTarget -. reservedFromRange.contents +. footprintSum.contents) /. n->Int.toFloat
       let next = []
-      let roundConsumed = ref(0.)
-      rangePartitions.contents->Array.forEach(fs => {
+      notFilledPartitions.contents->Array.forEach(fs => {
         let reserved = reservedByPartition->Dict.getUnsafe(fs.partitionId)
-        let budget = ipb -. reserved
+        let budget = line -. reserved
         if budget > 0. {
           let consumed = emitQueries(fs, ~budget)
           reservedByPartition->Dict.set(fs.partitionId, reserved +. consumed)
-          roundConsumed := roundConsumed.contents +. consumed
+          reservedFromRange := reservedFromRange.contents +. consumed
           if fs->isInRange {
             next->Array.push(fs)->ignore
           }
         }
       })
-      rangeBudget := Pervasives.max(0., rangeBudget.contents -. roundConsumed.contents)
-      rangePartitions := next
-      roundsRef := roundsRef.contents + 1
+      notFilledPartitions := next
     }
 
     // Each partition pushed only into its own bucket (indexed by its

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -4099,3 +4099,77 @@ describe("FetchState.getNextQuery water-fill round is order-independent", () => 
     ))
   })
 })
+
+describe("FetchState.getNextQuery water-fill redistributes a filled partition's leftover", () => {
+  // Two equal-density partitions, chunk cost 180 (density 10 × chunkSize 18).
+  // "capped" can only fetch one chunk (mergeBlock caps its range), so it fills
+  // after a single 180-item chunk and leaves the rest of its share behind;
+  // "deep" has unbounded range. The freed budget must flow to "deep" across
+  // rounds. Before the water-fill line accounted for each partition's own
+  // already-emitted footprint, "deep" was dropped the moment its running
+  // reservation passed a round's fresh share — so it stopped at 2 chunks and
+  // a third of the 900-item budget went unused.
+  let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
+
+  let makeChunkPartition = (~id, ~address, ~mergeBlock): FetchState.partition => {
+    id,
+    latestFetchedBlock: {blockNumber: 0, blockTimestamp: 0},
+    selection: normalSelection,
+    addressesByContractName: Dict.fromArray([("MockContract", [address])]),
+    mergeBlock,
+    dynamicContract: None,
+    mutPendingQueries: [],
+    prevQueryRange: 10,
+    prevPrevQueryRange: 10,
+    prevRangeSize: 100, // density = 100 / 10 = 10 items/block
+    latestBlockRangeUpdateBlock: 0,
+  }
+
+  let fetchState: FetchState.t = {
+    optimizedPartitions: FetchState.OptimizedPartitions.make(
+      ~partitions=[
+        makeChunkPartition(~id="deep", ~address=mockAddress0, ~mergeBlock=None),
+        makeChunkPartition(~id="capped", ~address=mockAddress1, ~mergeBlock=Some(18)),
+      ],
+      ~maxAddrInPartition=2,
+      ~nextPartitionIndex=2,
+      ~dynamicContracts=Utils.Set.make(),
+    ),
+    startBlock: 0,
+    endBlock: None,
+    buffer: [],
+    normalSelection,
+    latestOnBlockBlockNumber: 0,
+    maxOnBlockBufferSize: 10000,
+    chainId,
+    contractConfigs: Dict.make(),
+    blockLag: 0,
+    onBlockRegistrations: [],
+    knownHeight: 100000,
+    firstEventBlock: Some(0),
+  }
+
+  it("keeps topping up the partition with range left until the whole budget is spent", t => {
+    let byPartition = Dict.make()
+    switch fetchState->FetchState.getNextQuery(~chainTargetBlock=100000, ~chainTargetItems=900.) {
+    | Ready(queries) =>
+      queries->Array.forEach((q: FetchState.query) =>
+        switch byPartition->Dict.get(q.partitionId) {
+        | Some(arr) => arr->Array.push((q.fromBlock, q.itemsTarget))->ignore
+        | None => byPartition->Dict.set(q.partitionId, [(q.fromBlock, q.itemsTarget)])
+        }
+      )
+    | _ => ()
+    }
+
+    t.expect(
+      byPartition,
+      ~message="deep absorbs capped's freed budget: 4 chunks (720 items) vs capped's single 180-item chunk",
+    ).toEqual(
+      Dict.fromArray([
+        ("deep", [(1, 180.), (19, 180.), (37, 180.), (55, 180.)]),
+        ("capped", [(1, 180.)]),
+      ]),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

The water-fill algorithm that distributes query budget across partitions was not properly accounting for each partition's existing in-flight queries when computing the fair-share line. This caused partitions that filled early to not properly redistribute their leftover budget to partitions with remaining range.

## Changes

- **Rewrote water-fill loop logic**: Changed from a per-round fresh-budget share (`ipb`) to a per-round fair-share line that accounts for each partition's current footprint (existing in-flight + gap-fill). The line is computed as `(remaining fresh budget + all partitions' current footprint) / partition count`, ensuring that a partition already holding queries gets proportionally less fresh budget so totals stay even.

- **Renamed variables for clarity**:
  - `rangeBudget` → `rangeItemsTarget` (the total fresh budget available for this call)
  - `rangePartitions` → `notFilledPartitions` (partitions still eligible for more queries)
  - `roundConsumed` → `reservedFromRange` (cumulative budget consumed across all rounds)
  - `ipb` (items per bucket) removed in favor of `line` (the fair-share ceiling)

- **Simplified loop termination**: Removed the explicit round counter (`roundsRef`) and round limit check. The loop now terminates naturally when either all partitions are filled or the entire fresh budget is consumed, which is guaranteed by the algorithm's structure (partitions only survive rounds by advancing `chunksUsedThisCall` or consuming budget).

- **Updated comments**: Clarified the water-fill semantics to explain that the algorithm levels partitions toward a shared line, redistributes leftover budget from filled partitions, and maintains even totals regardless of processing order.

- **Added regression test**: New test case verifies that when one partition fills early (due to `mergeBlock` cap), its leftover budget flows to the other partition across multiple rounds, rather than being wasted.

## Implementation Details

The key insight is that the fair-share line must be recomputed each round based on the current footprint of all still-not-filled partitions. This ensures that:
- A partition already holding a large share (seeded with existing in-flight queries) gets proportionally less fresh budget
- Leftover budget from a partition that fills or hits its ceiling redistributes to partitions with remaining range
- Total reserved budget stays even across partitions, independent of processing order

https://claude.ai/code/session_0134TTgxQ3ci5mWUnt928yr9