### PR TITLE
Resolve event filters per-chain at registration time

### DIFF
--- a/packages/cli/src/config_parsing/entity_parsing.rs
+++ b/packages/cli/src/config_parsing/entity_parsing.rs
@@ -110,7 +110,7 @@ impl Schema {
         let schema_string = std::fs::read_to_string(&schema_path).context(format!(
             "Failed to read schema file at {}. Please ensure that the schema file is \
              placed correctly in the directory.",
-            &schema_path.to_str().unwrap_or("bad file path"),
+            schema_path.to_str().unwrap_or("bad file path"),
         ))?;
 
         Self::from_string(&schema_string)
@@ -811,7 +811,7 @@ impl Field {
                     }
                     let precision = get_positive_integer(arg_value).context(format!(
                         "Parsing precision.digits directive on BigInt field with field name {}",
-                        &field.name
+                        field.name
                     ))?;
                     pg_type_modifications.big_int_precision = Some(precision);
                 }
@@ -828,14 +828,14 @@ impl Field {
                                     Some(get_positive_integer(arg_value).context(format!(
                                         "Parsing numeric.precision directive on BigDecimal with \
                                          field name {}",
-                                        &field.name
+                                        field.name
                                     ))?);
                             }
                             "scale" => {
                                 scale = Some(get_positive_integer(arg_value).context(format!(
                                     "Parsing numeric.scale directive on BigDecimal with field \
                                      name {}",
-                                    &field.name
+                                    field.name
                                 ))?);
                             }
                             unknown_param => {

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -1094,7 +1094,7 @@ impl SystemConfig {
                 "Failed to resolve config path {0} (--config {1} resolved relative to \
                  --directory {2}). Make sure the file exists. Note that --config and \
                  ENVIO_CONFIG are interpreted relative to --directory.",
-                &project_paths.config.to_str().unwrap_or("{unknown}"),
+                project_paths.config.to_str().unwrap_or("{unknown}"),
                 project_paths.config_relative_to_root().display(),
                 project_paths.project_root.display(),
             ))?;

--- a/packages/cli/src/config_parsing/validation.rs
+++ b/packages/cli/src/config_parsing/validation.rs
@@ -136,7 +136,7 @@ impl human_config::evm::Chain {
                 return Err(anyhow!(
                     "The config file has an endBlock that is less than the startBlock for \
                      network id: {}. The endBlock must be greater than the startBlock.",
-                    &self.id.to_string()
+                    self.id
                 ));
             }
         }

--- a/packages/cli/src/executor/init.rs
+++ b/packages/cli/src/executor/init.rs
@@ -76,7 +76,7 @@ pub async fn run_init_args(
                 )
                 .context(format!(
                     "Failed initializing Fuel template {} at path {:?}",
-                    &template, &parsed_project_paths.project_root,
+                    template, parsed_project_paths.project_root,
                 ))?;
         }
         Ecosystem::Svm {
@@ -90,7 +90,7 @@ pub async fn run_init_args(
                 )
                 .context(format!(
                     "Failed initializing Svm template {} at path {:?}",
-                    &template, &parsed_project_paths.project_root,
+                    template, parsed_project_paths.project_root,
                 ))?;
         }
         Ecosystem::Evm {
@@ -104,7 +104,7 @@ pub async fn run_init_args(
                 )
                 .context(format!(
                     "Failed initializing Evm template {} at path {:?}",
-                    &template, &parsed_project_paths.project_root,
+                    template, parsed_project_paths.project_root,
                 ))?;
         }
         Ecosystem::Fuel {
@@ -169,7 +169,7 @@ pub async fn run_init_args(
                 .context(format!(
                     "Failed initializing blank template for Contract Import with language {} at \
                      path {:?}",
-                    &init_config.language, &parsed_project_paths.project_root,
+                    init_config.language, parsed_project_paths.project_root,
                 ))?;
 
             auto_schema_handler_template
@@ -233,7 +233,7 @@ pub async fn run_init_args(
                 .context(format!(
                     "Failed initializing blank template for Contract Import with language {} at \
                      path {:?}",
-                    &init_config.language, &parsed_project_paths.project_root,
+                    init_config.language, parsed_project_paths.project_root,
                 ))?;
 
             auto_schema_handler_template

--- a/packages/cli/src/hbs_templating/hbs_dir_generator.rs
+++ b/packages/cli/src/hbs_templating/hbs_dir_generator.rs
@@ -88,17 +88,17 @@ impl<'a, T: Serialize> HandleBarsDirGenerator<'a, T> {
                         })?;
 
                         //ensure the dir exists or is created
-                        fs::create_dir_all(&output_dir_path).context(format!(
-                            "create_dir_all failed at {}",
-                            &output_dir_path_str,
-                        ))?;
+                        fs::create_dir_all(&output_dir_path)
+                            .context(
+                                format!("create_dir_all failed at {}", output_dir_path_str,),
+                            )?;
 
                         //append the filename
                         let output_file_path = output_dir_path.join(file_stem);
 
                         //Write the file
                         fs::write(&output_file_path, rendered_file)
-                            .context(format!("file write failed at {}", &output_dir_path_str))?;
+                            .context(format!("file write failed at {}", output_dir_path_str))?;
                     }
                 }
                 DirEntry::Dir(dir) => Self::generate_hbs_templates_internal_recursive(

--- a/packages/cli/src/type_schema.rs
+++ b/packages/cli/src/type_schema.rs
@@ -100,7 +100,7 @@ impl TypeDecl {
         };
         format!(
             "{type_name}{parameters} = {type_expr}",
-            type_name = &self.name,
+            type_name = self.name,
             type_expr = self.type_expr
         )
     }
@@ -124,7 +124,7 @@ impl TypeDecl {
         };
         format!(
             "type {name}{parameters} = {type_expr};",
-            name = &self.name,
+            name = self.name,
             type_expr = self.type_expr.to_ts_type_string_with_namespace(ns)
         )
     }
@@ -144,7 +144,7 @@ impl TypeDecl {
             let args_joined = arguments.join(", ");
             format!("<{args_joined}>")
         };
-        Ok(format!("{}{arguments_code}", &self.name))
+        Ok(format!("{}{arguments_code}", self.name))
     }
 }
 
@@ -420,7 +420,7 @@ impl TypeIdent {
                 format!("{{{inner}}}")
             }
             Self::SchemaEnum(enum_name) => {
-                format!("Enums.{}.t", &enum_name.capitalized)
+                format!("Enums.{}.t", enum_name.capitalized)
             }
             // Lowercase generic params because of the issue https://github.com/rescript-lang/rescript-compiler/issues/6759
             Self::GenericParam(name) => format!("'{}", name.to_lowercase()),
@@ -563,7 +563,7 @@ impl TypeIdent {
             Self::SchemaEnum(enum_name) => {
                 // References the file-level `Enums` lookup table emitted by
                 // codegen_templates.rs::wrap_envio_module_augmentation.
-                format!("Enums[\"{}\"]", &enum_name.original)
+                format!("Enums[\"{}\"]", enum_name.original)
             }
             Self::GenericParam(name) => name.clone(),
             Self::TypeApplication {
@@ -597,7 +597,7 @@ impl TypeIdent {
             Self::Array(_) => "[]".to_string(),
             Self::Option(_) => "None".to_string(),
             Self::SchemaEnum(enum_name) => {
-                format!("Enums.{}.default", &enum_name.capitalized)
+                format!("Enums.{}.default", enum_name.capitalized)
             }
             Self::Tuple(inner_types) => {
                 let inner_types_str = inner_types
@@ -681,7 +681,7 @@ impl TypeIdent {
             Self::Array(_) => "[]".to_string(),
             Self::Option(_) => "null".to_string(),
             Self::SchemaEnum(enum_name) => {
-                format!("{}Default", &enum_name.uncapitalized)
+                format!("{}Default", enum_name.uncapitalized)
             }
             Self::Tuple(inner_types) => {
                 let inner_types_str = inner_types

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -129,25 +129,6 @@ let makeInternal = (
     }
   })
 
-  // TODO: Move it to the HandlerRegister module
-  // so the error is thrown with better stack trace
-  onBlockRegistrations->Array.forEach(onBlockRegistration => {
-    if onBlockRegistration.startBlock->Option.getOr(startBlock) < startBlock {
-      JsError.throwWithMessage(
-        `The start block for onBlock handler "${onBlockRegistration.name}" is less than the chain start block (${startBlock->Int.toString}). This is not supported yet.`,
-      )
-    }
-    switch endBlock {
-    | Some(chainEndBlock) =>
-      if onBlockRegistration.endBlock->Option.getOr(chainEndBlock) > chainEndBlock {
-        JsError.throwWithMessage(
-          `The end block for onBlock handler "${onBlockRegistration.name}" is greater than the chain end block (${chainEndBlock->Int.toString}). This is not supported yet.`,
-        )
-      }
-    | None => ()
-    }
-  })
-
   let contractConfigs = IndexingAddresses.makeContractConfigs(~onEventRegistrations)
   let indexingAddressIndex = IndexingAddresses.make(~contractConfigs, ~addresses=indexingAddresses)
 

--- a/packages/envio/src/EnvioGlobal.res
+++ b/packages/envio/src/EnvioGlobal.res
@@ -1,0 +1,53 @@
+// The single process-wide mutable state record, stashed on `globalThis` so a
+// duplicate envio module instance — e.g. when the CLI's `bin.mjs` resolves
+// envio from one path but the user's handlers resolve it from
+// `node_modules/envio` — shares one state. Without this, each copy keeps its
+// own module-level state: registration would read an empty registry and the
+// `indexer.chains` getters would silently fall back to static config values.
+//
+// Slots are opaque (`unknown`) so this module stays at the bottom of the
+// dependency graph; each owning module casts its slot to the real type once
+// (`HandlerRegister` for the registration slots, `Main` for the runtime
+// slots, `RollbackCommit` for its callbacks).
+//
+// Version-gated: the slot shapes can evolve between envio versions, so the
+// guard uses strict full-version equality. On mismatch we throw with a
+// deduplication hint instead of silently mixing shapes across builds.
+type t = {
+  version: string,
+  eventRegistrations: dict<unknown>,
+  mutable activeRegistration: option<unknown>,
+  preRegistered: array<unknown>,
+  rollbackCommitCallbacks: array<unknown>,
+  mutable indexerState: option<unknown>,
+  mutable persistence: option<unknown>,
+}
+
+// Record type with `mutable` so assignment typechecks; ReScript keeps the
+// field name verbatim in the generated JS so the globalThis slot is
+// `__envioGlobal`.
+type globalThis = {mutable __envioGlobal: Nullable.t<t>}
+@val external globalThis: globalThis = "globalThis"
+
+let value: t = {
+  let version = Utils.EnvioPackage.value.version
+  switch globalThis.__envioGlobal->Nullable.toOption {
+  | Some(existing) if existing.version === version => existing
+  | Some(existing) =>
+    JsError.throwWithMessage(
+      `Multiple incompatible envio versions loaded in the same process: ${existing.version} and ${version}. Deduplicate the 'envio' dependency in your project.`,
+    )
+  | None =>
+    let fresh = {
+      version,
+      eventRegistrations: Dict.make(),
+      activeRegistration: None,
+      preRegistered: [],
+      rollbackCommitCallbacks: [],
+      indexerState: None,
+      persistence: None,
+    }
+    globalThis.__envioGlobal = Nullable.make(fresh)
+    fresh
+  }
+}

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -243,9 +243,13 @@ let getTopicEncoder = (abiType: string): (unknown => EvmTypes.Hex.t) => {
   } else {
     switch abiType {
     | "address" =>
-      TopicFilter.fromAddress->(
-        Utils.magic: (Address.t => EvmTypes.Hex.t) => unknown => EvmTypes.Hex.t
-      )
+      // Lowercase before encoding so mixed-case (checksummed) user input
+      // still matches the lowercase hex topics returned by sources.
+
+      (
+        (value: string) =>
+          value->String.toLowerCase->Address.unsafeFromString->TopicFilter.fromAddress
+      )->(Utils.magic: (string => EvmTypes.Hex.t) => unknown => EvmTypes.Hex.t)
 
     | "bool" =>
       TopicFilter.fromBool->(Utils.magic: (bool => EvmTypes.Hex.t) => unknown => EvmTypes.Hex.t)
@@ -413,31 +417,26 @@ let buildEvmEventConfig = (
 }
 
 // Enrich an EVM definition into a per-(event,chain) registration: resolve the
-// registered `where` (with `probeChainId`) into the lazy `getEventFiltersOrThrow`
-// closure + address filters, and override `startBlock` with `where.block._gte`.
+// registered `where` for this chain into `resolvedWhere` + address filters,
+// and override `startBlock` with `where.block._gte`.
 let buildEvmOnEventRegistration = (
   ~eventConfig: Internal.evmEventConfig,
   ~isWildcard: bool,
   ~handler: option<Internal.handler>,
   ~contractRegister: option<Internal.contractRegister>,
-  ~eventFilters: option<JSON.t>,
-  ~probeChainId: int,
+  ~where: option<JSON.t>,
+  ~chainId: int,
   ~onEventBlockFilterSchema: S.t<option<unknown>>,
   ~startBlock: option<int>=?,
 ): Internal.evmOnEventRegistration => {
   let indexedParams = eventConfig.paramsMetadata->Array.filter(p => p.indexed)
 
-  let {
-    getEventFiltersOrThrow,
-    filterByAddresses,
-    addressFilterParamGroups,
-    startBlock: whereStartBlock,
-  } = LogSelection.parseEventFiltersOrThrow(
-    ~eventFilters,
+  let {resolvedWhere, filterByAddresses, addressFilterParamGroups} = LogSelection.parseWhereOrThrow(
+    ~where,
     ~sighash=eventConfig.sighash,
     ~params=indexedParams->Array.map(p => p.name),
     ~contractName=eventConfig.contractName,
-    ~probeChainId,
+    ~chainId,
     ~onEventBlockFilterSchema,
     ~topic1=?indexedParams->Array.get(0)->Option.map(buildTopicGetter),
     ~topic2=?indexedParams->Array.get(1)->Option.map(buildTopicGetter),
@@ -447,7 +446,7 @@ let buildEvmOnEventRegistration = (
   // `where.block.number._gte` overrides the contract-level startBlock when
   // present (an explicit per-event opt-in that wins over `config.yaml`);
   // otherwise the contract/chain value passes through.
-  let resolvedStartBlock = switch whereStartBlock {
+  let resolvedStartBlock = switch resolvedWhere.startBlock {
   | Some(_) as sb => sb
   | None => startBlock
   }
@@ -457,7 +456,7 @@ let buildEvmOnEventRegistration = (
     isWildcard,
     handler,
     contractRegister,
-    getEventFiltersOrThrow,
+    resolvedWhere,
     filterByAddresses,
     clientAddressFilter: ?buildAddressFilter(addressFilterParamGroups, ~isWildcard),
     dependsOnAddresses: Internal.dependsOnAddresses(~isWildcard, ~filterByAddresses),

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -78,7 +78,7 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
 // (populating the global `HandlerRegister` registry as a side effect) and
 // returns the resulting per-chain registrations.
 let registerAllHandlers = async (~config: Config.t): HandlerRegister.registrationsByChainId => {
-  HandlerRegister.startRegistration(~ecosystem=config.ecosystem)
+  HandlerRegister.startRegistration(~config)
 
   // Auto-load all .js files from src/handlers directory
   await autoLoadFromSrcHandlers(~handlers=config.handlers)

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -22,18 +22,25 @@ type chainRegistrations = {
 // The finished registration state returned by `finishRegistration`.
 type registrationsByChainId = dict<chainRegistrations>
 
-type pendingRegistrations = {onBlockByChainId: dict<array<Internal.onBlockRegistration>>}
+// Incrementally built during registration: every `indexer.onEvent` /
+// `.contractRegister` call resolves its `where` per chain right away and
+// stores the resulting registration here, keyed by "Contract.Event", so
+// invalid configuration throws at the user's registration call site.
+type pendingChainRegistrations = {
+  onEventRegistrations: dict<Internal.onEventRegistration>,
+  onBlockRegistrations: array<Internal.onBlockRegistration>,
+}
 
 type activeRegistration = {
-  ecosystem: Ecosystem.t,
-  registrations: pendingRegistrations,
+  config: Config.t,
+  registrationsByChainId: dict<pendingChainRegistrations>,
   mutable finished: bool,
 }
 
 // Stashed on `globalThis` so a duplicate envio module instance — e.g. when the
 // CLI's `bin.mjs` resolves envio from one path but the user's handlers resolve
 // it from `node_modules/envio` — shares one registry. Without this, each copy
-// keeps its own dict and `buildOnEventRegistrations` reads empty state.
+// keeps its own dict and `finishRegistration` reads empty state.
 //
 // Version-gated: the record shapes below can evolve between envio versions,
 // so the guard uses strict full-version equality. On mismatch we throw with
@@ -113,12 +120,15 @@ let withRegistration = (fn: activeRegistration => unit) => {
   }
 }
 
-let startRegistration = (~ecosystem) => {
+// Defer a callback until registration is active so it sees the registration's
+// config, which may be a narrowed version of the generated one (TestIndexer
+// runs with a per-test chain subset).
+let withConfig = (fn: Config.t => unit) => withRegistration(r => fn(r.config))
+
+let startRegistration = (~config: Config.t) => {
   let r = {
-    ecosystem,
-    registrations: {
-      onBlockByChainId: Dict.make(),
-    },
+    config,
+    registrationsByChainId: Dict.make(),
     finished: false,
   }
   activeRegistration.contents = Some(r)
@@ -131,24 +141,30 @@ let startRegistration = (~ecosystem) => {
   }
 }
 
-// Enrich one event definition into its (event, chain) registration using
-// whatever handler/contractRegister/where the user registered for it. Shared
-// by chain startup (`buildOnEventRegistrations`), `simulate`, and test
-// helpers so the three stay in sync instead of re-deriving the per-ecosystem
-// dispatch each place.
-let buildOnEventRegistration = (
+let getPendingChainRegistrations = (r: activeRegistration, ~chainId: int) => {
+  let key = chainId->Int.toString
+  switch r.registrationsByChainId->Utils.Dict.dangerouslyGetNonOption(key) {
+  | Some(pending) => pending
+  | None =>
+    let fresh = {
+      onEventRegistrations: Dict.make(),
+      onBlockRegistrations: [],
+    }
+    r.registrationsByChainId->Dict.set(key, fresh)
+    fresh
+  }
+}
+
+let buildOnEventRegistrationWith = (
   ~config: Config.t,
   ~chainId: int,
   ~eventConfig: Internal.eventConfig,
+  ~isWildcard: bool,
+  ~handler: option<Internal.handler>,
+  ~contractRegister: option<Internal.contractRegister>,
+  ~where: option<JSON.t>,
   ~startBlock=?,
 ): Internal.onEventRegistration => {
-  let contractName = eventConfig.contractName
-  let eventName = eventConfig.name
-  let t = get(~contractName, ~eventName)
-  let isWildcard = t.eventOptions->Option.flatMap(v => v.wildcard)->Option.getOr(false)
-  let handler = t.handler
-  let contractRegister = t.contractRegister
-
   switch config.ecosystem.name {
   | Fuel =>
     (EventConfigBuilder.buildFuelOnEventRegistration(
@@ -174,116 +190,329 @@ let buildOnEventRegistration = (
       ~isWildcard,
       ~handler,
       ~contractRegister,
-      ~eventFilters=t.eventOptions->Option.flatMap(v => v.where),
-      ~probeChainId=chainId,
+      ~where,
+      ~chainId,
       ~onEventBlockFilterSchema=config.ecosystem.onEventBlockFilterSchema,
       ~startBlock?,
     ) :> Internal.onEventRegistration)
   }
 }
 
-// Enrich a chain's static event definitions with the registered
-// handler/contractRegister/where (validating them along the way) to produce
-// the onEventRegistrations ChainState indexes off. Runs once per chain when
-// registration finishes, so a bad `where`/duplicate event throws during
-// startup with a stack trace pointing here instead of surfacing later from
-// inside ChainState's construction. Events without a handler/contractRegister
-// get added to `notRegisteredEventsByContract` (event names grouped by
-// contract name) so the caller can report them once for the whole indexer
-// instead of per chain.
-let buildOnEventRegistrations = (
-  ~chainConfig: Config.chain,
+// Enrich one event definition into its (event, chain) registration using
+// whatever handler/contractRegister/where the user registered for it. Shared
+// by the incremental per-chain sync below, `simulate`, and test helpers so
+// they stay in sync instead of re-deriving the per-ecosystem dispatch each
+// place.
+let buildOnEventRegistration = (
   ~config: Config.t,
-  ~notRegisteredEventsByContract: dict<Utils.Set.t<string>>,
-): array<Internal.onEventRegistration> => {
-  // We don't need the router itself, but only validation logic,
-  // since now event router is created for selection of events
-  // and validation doesn't work correctly in routers.
-  // Ideally to split it into two different parts.
-  let eventRouter = EventRouter.empty()
+  ~chainId: int,
+  ~eventConfig: Internal.eventConfig,
+  ~startBlock=?,
+): Internal.onEventRegistration => {
+  let t = get(~contractName=eventConfig.contractName, ~eventName=eventConfig.name)
+  buildOnEventRegistrationWith(
+    ~config,
+    ~chainId,
+    ~eventConfig,
+    ~isWildcard=t.eventOptions->Option.flatMap(v => v.wildcard)->Option.getOr(false),
+    ~handler=t.handler,
+    ~contractRegister=t.contractRegister,
+    ~where=t.eventOptions->Option.flatMap(v => v.where),
+    ~startBlock?,
+  )
+}
 
-  let onEventRegistrations: array<Internal.onEventRegistration> = []
+let getHandler = (~contractName, ~eventName) => get(~contractName, ~eventName).handler
 
-  chainConfig.contracts->Array.forEach(contract => {
-    let contractName = contract.name
+let getContractRegister = (~contractName, ~eventName) =>
+  get(~contractName, ~eventName).contractRegister
 
-    contract.events->Array.forEach(eventConfig => {
-      let eventName = eventConfig.name
+let isWildcard = (~contractName, ~eventName) =>
+  get(~contractName, ~eventName).eventOptions
+  ->Option.flatMap(value => value.wildcard)
+  ->Option.getOr(false)
 
-      let onEventRegistration = buildOnEventRegistration(
-        ~config,
-        ~chainId=chainConfig.id,
-        ~eventConfig,
-        ~startBlock=?contract.startBlock,
-      )
-      let {isWildcard, handler, contractRegister} = onEventRegistration
+let hasRegistration = (~contractName, ~eventName) => {
+  let r = get(~contractName, ~eventName)
+  r.handler->Option.isSome || r.contractRegister->Option.isSome
+}
 
-      // Should validate the events
-      eventRouter->EventRouter.addOrThrow(
-        eventConfig.id,
-        (),
-        ~contractName,
-        ~chain=ChainMap.Chain.makeUnsafe(~chainId=chainConfig.id),
-        ~eventName,
-        ~isWildcard,
-      )
+type eventNamespace = {contractName: string, eventName: string}
 
-      // Filter out events without a handler/contractRegister so they aren't
-      // fetched or dispatched (unless raw events are enabled).
-      let shouldBeIncluded = if config.enableRawEvents {
-        true
-      } else {
-        let isRegistered = contractRegister->Option.isSome || handler->Option.isSome
-        if !isRegistered {
-          let eventNames = switch notRegisteredEventsByContract->Utils.Dict.dangerouslyGetNonOption(
-            contractName,
-          ) {
-          | Some(set) => set
-          | None => {
-              let set = Utils.Set.make()
-              notRegisteredEventsByContract->Dict.set(contractName, set)
-              set
-            }
-          }
-          eventNames->Utils.Set.add(eventName)->ignore
-        }
-        isRegistered
-      }
+let raiseDuplicateRegistration = (~contractName, ~eventName, ~msg, ~logger) => {
+  let fullMsg = msg ++ " for " ++ contractName ++ "." ++ eventName
+  Logging.createChildFrom(~logger, ~params={contractName, eventName})->Logging.childError(fullMsg)
+  JsError.throwWithMessage(fullMsg)
+}
 
-      // Check if event has Static([]) filters (from a dynamic where
-      // callback returning `false` / SkipAll for this chain).
-      // If so, skip it entirely - it should never be fetched
-      let shouldSkip = try {
-        let getEventFiltersOrThrow = (
-          onEventRegistration->(
-            Utils.magic: Internal.onEventRegistration => Internal.evmOnEventRegistration
+// `where` equality is checked per chain on the resolved structure (see
+// `syncOnEventRegistrations`), so registration options only need to agree on
+// `wildcard` here — two callbacks that resolve to identical filters count as
+// identical options even when the function references differ.
+let eventOptionsMatch = (
+  existing: option<Internal.eventOptions<JSON.t>>,
+  incoming: option<Internal.eventOptions<JSON.t>>,
+) => {
+  switch (existing, incoming) {
+  | (None, None) => true
+  | (Some(a), Some(b)) => a.wildcard === b.wildcard
+  | _ => false
+  }
+}
+
+let getResolvedWhere = (reg: Internal.onEventRegistration) =>
+  (
+    reg->(Utils.magic: Internal.onEventRegistration => Internal.evmOnEventRegistration)
+  ).resolvedWhere
+
+// Resolve the registration for every configured chain that defines the event
+// and store it in the pending per-chain registry. When the chain already
+// holds a registration for this event, the resolved `where` structures must
+// deep-compare equal (`Values` by hex arrays, `ContractAddresses` by contract
+// name, plus `startBlock`) — otherwise it's a conflicting duplicate
+// registration. Both live registrations and `preRegistered` callbacks
+// replayed by `startRegistration` run through this single code path.
+let syncOnEventRegistrations = (
+  r: activeRegistration,
+  ~contractName,
+  ~eventName,
+  ~where: option<JSON.t>,
+  ~duplicateMsg,
+  ~logger,
+) => {
+  let config = r.config
+  let t = get(~contractName, ~eventName)
+  let isWildcard = t.eventOptions->Option.flatMap(v => v.wildcard)->Option.getOr(false)
+  let key = getKey(~contractName, ~eventName)
+
+  config.chainMap
+  ->ChainMap.values
+  ->Array.forEach(chainConfig => {
+    chainConfig.contracts->Array.forEach(contract => {
+      if contract.name === contractName {
+        switch contract.events->Array.find(e => e.name === eventName) {
+        | None => ()
+        | Some(eventConfig) =>
+          let newRegistration = buildOnEventRegistrationWith(
+            ~config,
+            ~chainId=chainConfig.id,
+            ~eventConfig,
+            ~isWildcard,
+            ~handler=t.handler,
+            ~contractRegister=t.contractRegister,
+            ~where,
+            ~startBlock=?contract.startBlock,
           )
-        ).getEventFiltersOrThrow
-
-        // Check for non-evm chains
-        if (
-          getEventFiltersOrThrow->(Utils.magic: (ChainMap.Chain.t => Internal.eventFilters) => bool)
-        ) {
-          switch getEventFiltersOrThrow(ChainMap.Chain.makeUnsafe(~chainId=chainConfig.id)) {
-          | Static([]) => true
-          | _ => false
+          let pending = r->getPendingChainRegistrations(~chainId=chainConfig.id)
+          switch pending.onEventRegistrations->Utils.Dict.dangerouslyGetNonOption(key) {
+          | Some(existing) if config.ecosystem.name === Evm =>
+            if !(existing->getResolvedWhere == newRegistration->getResolvedWhere) {
+              raiseDuplicateRegistration(~contractName, ~eventName, ~msg=duplicateMsg, ~logger)
+            }
+          | _ => ()
           }
-        } else {
-          false
+          pending.onEventRegistrations->Dict.set(key, newRegistration)
         }
-      } catch {
-      // Can throw when filter is invalid
-      // Don't skip an event in this case. Let it throw in a better place - source code
-      | _ => false
-      }
-
-      if shouldBeIncluded && !shouldSkip {
-        onEventRegistrations->Array.push(onEventRegistration)
       }
     })
   })
+}
 
-  onEventRegistrations
+let setEventOptions = (~contractName, ~eventName, ~eventOptions, ~logger=Logging.getLogger()) => {
+  switch eventOptions {
+  | Some(value) =>
+    let value = value->(Utils.magic: Internal.eventOptions<'where> => Internal.eventOptions<JSON.t>)
+    let t = get(~contractName, ~eventName)
+    switch t.eventOptions {
+    | None => set(~contractName, ~eventName, {...t, eventOptions: Some(value)})
+    | Some(existingValue) =>
+      if !eventOptionsMatch(Some(existingValue), Some(value)) {
+        raiseDuplicateRegistration(
+          ~contractName,
+          ~eventName,
+          ~msg="Cannot register handler with different options. Make sure all handlers for the same event use identical options (wildcard, where)",
+          ~logger,
+        )
+      }
+    }
+  | None => ()
+  }
+}
+
+let setHandler = (
+  ~contractName,
+  ~eventName,
+  handler,
+  ~eventOptions,
+  ~logger=Logging.getLogger(),
+) => {
+  withRegistration(registration => {
+    let t = get(~contractName, ~eventName)
+    let newHandler = handler->(Utils.magic: Internal.genericHandler<'args> => Internal.handler)
+    let incomingEventOptions =
+      eventOptions->Option.map(v =>
+        v->(Utils.magic: Internal.eventOptions<'where> => Internal.eventOptions<JSON.t>)
+      )
+    switch t.handler {
+    | None =>
+      setEventOptions(~contractName, ~eventName, ~eventOptions, ~logger)
+      let t = get(~contractName, ~eventName)
+      set(
+        ~contractName,
+        ~eventName,
+        {
+          ...t,
+          handler: Some(newHandler),
+        },
+      )
+    | Some(prevHandler) =>
+      if eventOptionsMatch(t.eventOptions, incomingEventOptions) {
+        let composedHandler: Internal.handler = async args => {
+          await prevHandler(args)
+          await newHandler(args)
+        }
+        set(
+          ~contractName,
+          ~eventName,
+          {
+            ...t,
+            handler: Some(composedHandler),
+          },
+        )
+      } else {
+        raiseDuplicateRegistration(
+          ~contractName,
+          ~eventName,
+          ~msg="Cannot register a second handler with different options. Make sure all handlers for the same event use identical options (wildcard, where)",
+          ~logger,
+        )
+      }
+    }
+    registration->syncOnEventRegistrations(
+      ~contractName,
+      ~eventName,
+      ~where=incomingEventOptions->Option.flatMap(v => v.where),
+      ~duplicateMsg="Cannot register a second handler with different options. Make sure all handlers for the same event use identical options (wildcard, where)",
+      ~logger,
+    )
+  })
+}
+
+let setContractRegister = (
+  ~contractName,
+  ~eventName,
+  contractRegister,
+  ~eventOptions,
+  ~logger=Logging.getLogger(),
+) => {
+  withRegistration(registration => {
+    let t = get(~contractName, ~eventName)
+    let newContractRegister =
+      contractRegister->(
+        Utils.magic: Internal.genericContractRegister<
+          Internal.genericContractRegisterArgs<'event, 'context>,
+        > => Internal.contractRegister
+      )
+    let incomingEventOptions =
+      eventOptions->Option.map(v =>
+        v->(Utils.magic: Internal.eventOptions<'where> => Internal.eventOptions<JSON.t>)
+      )
+    switch t.contractRegister {
+    | None =>
+      setEventOptions(~contractName, ~eventName, ~eventOptions, ~logger)
+      let t = get(~contractName, ~eventName)
+      set(
+        ~contractName,
+        ~eventName,
+        {
+          ...t,
+          contractRegister: Some(newContractRegister),
+        },
+      )
+    | Some(prevContractRegister) =>
+      if eventOptionsMatch(t.eventOptions, incomingEventOptions) {
+        let composedContractRegister: Internal.contractRegister = async args => {
+          await prevContractRegister(args)
+          await newContractRegister(args)
+        }
+        set(
+          ~contractName,
+          ~eventName,
+          {
+            ...t,
+            contractRegister: Some(composedContractRegister),
+          },
+        )
+      } else {
+        raiseDuplicateRegistration(
+          ~contractName,
+          ~eventName,
+          ~msg="Cannot register a second contractRegister with different options. Make sure all handlers for the same event use identical options (wildcard, where)",
+          ~logger,
+        )
+      }
+    }
+    registration->syncOnEventRegistrations(
+      ~contractName,
+      ~eventName,
+      ~where=incomingEventOptions->Option.flatMap(v => v.where),
+      ~duplicateMsg="Cannot register a second contractRegister with different options. Make sure all handlers for the same event use identical options (wildcard, where)",
+      ~logger,
+    )
+  })
+}
+
+let registerOnBlock = (
+  ~name,
+  ~chainId,
+  ~interval,
+  ~startBlock,
+  ~endBlock,
+  ~handler: Internal.onBlockArgs => promise<unit>,
+) => {
+  withRegistration(registration => {
+    let chainConfig =
+      registration.config.chainMap
+      ->ChainMap.values
+      ->Array.find(chainConfig => chainConfig.id === chainId)
+    switch chainConfig {
+    | None =>
+      JsError.throwWithMessage(
+        `The onBlock handler "${name}" is registered for chain ${chainId->Int.toString} which is not in the config.`,
+      )
+    | Some(chainConfig) =>
+      if startBlock->Option.getOr(chainConfig.startBlock) < chainConfig.startBlock {
+        JsError.throwWithMessage(
+          `The start block for onBlock handler "${name}" is less than the chain start block (${chainConfig.startBlock->Int.toString}). This is not supported yet.`,
+        )
+      }
+      switch chainConfig.endBlock {
+      | Some(chainEndBlock) =>
+        if endBlock->Option.getOr(chainEndBlock) > chainEndBlock {
+          JsError.throwWithMessage(
+            `The end block for onBlock handler "${name}" is greater than the chain end block (${chainEndBlock->Int.toString}). This is not supported yet.`,
+          )
+        }
+      | None => ()
+      }
+      let pending = registration->getPendingChainRegistrations(~chainId)
+      pending.onBlockRegistrations
+      ->Array.push(
+        (
+          {
+            index: pending.onBlockRegistrations->Array.length,
+            name,
+            startBlock,
+            endBlock,
+            interval,
+            chainId,
+            handler,
+          }: Internal.onBlockRegistration
+        ),
+      )
+      ->ignore
+    }
+  })
 }
 
 let finishRegistration = (~config: Config.t): registrationsByChainId => {
@@ -296,17 +525,103 @@ let finishRegistration = (~config: Config.t): registrationsByChainId => {
       ->ChainMap.values
       ->Array.forEach(chainConfig => {
         let key = chainConfig.id->Int.toString
+        let pending = r.registrationsByChainId->Utils.Dict.dangerouslyGetNonOption(key)
+
+        // We don't need the router itself, but only validation logic,
+        // since now event router is created for selection of events
+        // and validation doesn't work correctly in routers.
+        // Ideally to split it into two different parts.
+        let eventRouter = EventRouter.empty()
+
+        let onEventRegistrations: array<Internal.onEventRegistration> = []
+
+        chainConfig.contracts->Array.forEach(contract => {
+          let contractName = contract.name
+
+          contract.events->Array.forEach(
+            eventConfig => {
+              let eventName = eventConfig.name
+              let registration =
+                pending->Option.flatMap(
+                  pending =>
+                    pending.onEventRegistrations->Utils.Dict.dangerouslyGetNonOption(
+                      getKey(~contractName, ~eventName),
+                    ),
+                )
+
+              // Should validate the events
+              eventRouter->EventRouter.addOrThrow(
+                eventConfig.id,
+                (),
+                ~contractName,
+                ~chain=ChainMap.Chain.makeUnsafe(~chainId=chainConfig.id),
+                ~eventName,
+                ~isWildcard=switch registration {
+                | Some(registration) => registration.isWildcard
+                | None => isWildcard(~contractName, ~eventName)
+                },
+              )
+
+              let registration = switch registration {
+              | Some(_) as registration => registration
+              | None =>
+                // No entry in the incremental store, but the persistent dict
+                // may still hold a handler: handler modules are import-cached,
+                // so a repeated registration cycle in the same process (tests
+                // restarting the indexer) never re-runs the `indexer.onEvent`
+                // calls. Rebuild from the dict in that case. Events without a
+                // handler/contractRegister aren't fetched or dispatched
+                // (unless raw events are enabled).
+                if hasRegistration(~contractName, ~eventName) || config.enableRawEvents {
+                  Some(
+                    buildOnEventRegistration(
+                      ~config,
+                      ~chainId=chainConfig.id,
+                      ~eventConfig,
+                      ~startBlock=?contract.startBlock,
+                    ),
+                  )
+                } else {
+                  let eventNames = switch notRegisteredEventsByContract->Utils.Dict.dangerouslyGetNonOption(
+                    contractName,
+                  ) {
+                  | Some(set) => set
+                  | None => {
+                      let set = Utils.Set.make()
+                      notRegisteredEventsByContract->Dict.set(contractName, set)
+                      set
+                    }
+                  }
+                  eventNames->Utils.Set.add(eventName)->ignore
+                  None
+                }
+              }
+
+              switch registration {
+              | Some(registration) =>
+                // A `where` that resolved to no topic selections (`false` for
+                // this chain) drops the chain's registration entirely — the
+                // event should never be fetched here.
+                let isDroppedByWhere =
+                  config.ecosystem.name === Evm &&
+                    (registration->getResolvedWhere).topicSelections->Utils.Array.isEmpty
+                if !isDroppedByWhere {
+                  onEventRegistrations->Array.push(registration)
+                }
+              | None => ()
+              }
+            },
+          )
+        })
+
         registrationsByChainId->Dict.set(
           key,
           {
-            onEventRegistrations: buildOnEventRegistrations(
-              ~chainConfig,
-              ~config,
-              ~notRegisteredEventsByContract,
-            ),
-            onBlockRegistrations: r.registrations.onBlockByChainId
-            ->Utils.Dict.dangerouslyGetNonOption(key)
-            ->Option.getOr([]),
+            onEventRegistrations,
+            onBlockRegistrations: switch pending {
+            | Some(pending) => pending.onBlockRegistrations
+            | None => []
+            },
           },
         )
       })
@@ -353,221 +668,4 @@ let throwIfFinishedRegistration = (~methodName) => {
     )
   | _ => ()
   }
-}
-
-let registerOnBlock = (
-  ~name,
-  ~chainId,
-  ~interval,
-  ~startBlock,
-  ~endBlock,
-  ~handler: Internal.onBlockArgs => promise<unit>,
-) => {
-  withRegistration(registration => {
-    let onBlockByChainId = registration.registrations.onBlockByChainId
-    let key = chainId->Int.toString
-    let index =
-      onBlockByChainId
-      ->Utils.Dict.dangerouslyGetNonOption(key)
-      ->Option.mapOr(0, configs => configs->Array.length)
-    onBlockByChainId->Utils.Dict.push(
-      key,
-      (
-        {
-          index,
-          name,
-          startBlock,
-          endBlock,
-          interval,
-          chainId,
-          handler,
-        }: Internal.onBlockRegistration
-      ),
-    )
-  })
-}
-
-let getHandler = (~contractName, ~eventName) => get(~contractName, ~eventName).handler
-
-let getContractRegister = (~contractName, ~eventName) =>
-  get(~contractName, ~eventName).contractRegister
-
-let getOnEventWhere = (~contractName, ~eventName) =>
-  get(~contractName, ~eventName).eventOptions->Option.flatMap(value => value.where)
-
-let isWildcard = (~contractName, ~eventName) =>
-  get(~contractName, ~eventName).eventOptions
-  ->Option.flatMap(value => value.wildcard)
-  ->Option.getOr(false)
-
-let hasRegistration = (~contractName, ~eventName) => {
-  let r = get(~contractName, ~eventName)
-  r.handler->Option.isSome || r.contractRegister->Option.isSome
-}
-
-type eventNamespace = {contractName: string, eventName: string}
-
-let raiseDuplicateRegistration = (~contractName, ~eventName, ~msg, ~logger) => {
-  let fullMsg = msg ++ " for " ++ contractName ++ "." ++ eventName
-  Logging.createChildFrom(~logger, ~params={contractName, eventName})->Logging.childError(fullMsg)
-  JsError.throwWithMessage(fullMsg)
-}
-
-// Compare two raw `where` configs as the user passed them (object/array/bool/function).
-// At registration time we haven't parsed the config into `Internal.eventFilters` yet,
-// so structural equality on the raw JSON shape is what users actually wrote. For a
-// dynamic callback (a function value) structural equality is meaningless, so fall
-// back to referential equality on the function reference.
-let whereMatch = (a: option<JSON.t>, b: option<JSON.t>) => {
-  switch (a, b) {
-  | (None, None) => true
-  | (Some(a), Some(b)) =>
-    if typeof(a) === #function || typeof(b) === #function {
-      a === b
-    } else {
-      a == b
-    }
-  | _ => false
-  }
-}
-
-let eventOptionsMatch = (
-  existing: option<Internal.eventOptions<JSON.t>>,
-  incoming: option<Internal.eventOptions<JSON.t>>,
-) => {
-  switch (existing, incoming) {
-  | (None, None) => true
-  | (Some(a), Some(b)) => a.wildcard === b.wildcard && whereMatch(a.where, b.where)
-  | _ => false
-  }
-}
-
-let setEventOptions = (~contractName, ~eventName, ~eventOptions, ~logger=Logging.getLogger()) => {
-  switch eventOptions {
-  | Some(value) =>
-    let value = value->(Utils.magic: Internal.eventOptions<'where> => Internal.eventOptions<JSON.t>)
-    let t = get(~contractName, ~eventName)
-    switch t.eventOptions {
-    | None => set(~contractName, ~eventName, {...t, eventOptions: Some(value)})
-    | Some(existingValue) =>
-      if !eventOptionsMatch(Some(existingValue), Some(value)) {
-        raiseDuplicateRegistration(
-          ~contractName,
-          ~eventName,
-          ~msg="Cannot register handler with different options. Make sure all handlers for the same event use identical options (wildcard, where)",
-          ~logger,
-        )
-      }
-    }
-  | None => ()
-  }
-}
-
-let setHandler = (
-  ~contractName,
-  ~eventName,
-  handler,
-  ~eventOptions,
-  ~logger=Logging.getLogger(),
-) => {
-  withRegistration(_registration => {
-    let t = get(~contractName, ~eventName)
-    let newHandler = handler->(Utils.magic: Internal.genericHandler<'args> => Internal.handler)
-    switch t.handler {
-    | None =>
-      setEventOptions(~contractName, ~eventName, ~eventOptions, ~logger)
-      let t = get(~contractName, ~eventName)
-      set(
-        ~contractName,
-        ~eventName,
-        {
-          ...t,
-          handler: Some(newHandler),
-        },
-      )
-    | Some(prevHandler) =>
-      let incomingEventOptions =
-        eventOptions->Option.map(v =>
-          v->(Utils.magic: Internal.eventOptions<'where> => Internal.eventOptions<JSON.t>)
-        )
-      if eventOptionsMatch(t.eventOptions, incomingEventOptions) {
-        let composedHandler: Internal.handler = async args => {
-          await prevHandler(args)
-          await newHandler(args)
-        }
-        set(
-          ~contractName,
-          ~eventName,
-          {
-            ...t,
-            handler: Some(composedHandler),
-          },
-        )
-      } else {
-        raiseDuplicateRegistration(
-          ~contractName,
-          ~eventName,
-          ~msg="Cannot register a second handler with different options. Make sure all handlers for the same event use identical options (wildcard, where)",
-          ~logger,
-        )
-      }
-    }
-  })
-}
-
-let setContractRegister = (
-  ~contractName,
-  ~eventName,
-  contractRegister,
-  ~eventOptions,
-  ~logger=Logging.getLogger(),
-) => {
-  withRegistration(_registration => {
-    let t = get(~contractName, ~eventName)
-    let newContractRegister =
-      contractRegister->(
-        Utils.magic: Internal.genericContractRegister<
-          Internal.genericContractRegisterArgs<'event, 'context>,
-        > => Internal.contractRegister
-      )
-    switch t.contractRegister {
-    | None =>
-      setEventOptions(~contractName, ~eventName, ~eventOptions, ~logger)
-      let t = get(~contractName, ~eventName)
-      set(
-        ~contractName,
-        ~eventName,
-        {
-          ...t,
-          contractRegister: Some(newContractRegister),
-        },
-      )
-    | Some(prevContractRegister) =>
-      let incomingEventOptions =
-        eventOptions->Option.map(v =>
-          v->(Utils.magic: Internal.eventOptions<'where> => Internal.eventOptions<JSON.t>)
-        )
-      if eventOptionsMatch(t.eventOptions, incomingEventOptions) {
-        let composedContractRegister: Internal.contractRegister = async args => {
-          await prevContractRegister(args)
-          await newContractRegister(args)
-        }
-        set(
-          ~contractName,
-          ~eventName,
-          {
-            ...t,
-            contractRegister: Some(composedContractRegister),
-          },
-        )
-      } else {
-        raiseDuplicateRegistration(
-          ~contractName,
-          ~eventName,
-          ~msg="Cannot register a second contractRegister with different options. Make sure all handlers for the same event use identical options (wildcard, where)",
-          ~logger,
-        )
-      }
-    }
-  })
 }

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -120,11 +120,6 @@ let withRegistration = (fn: activeRegistration => unit) => {
   }
 }
 
-// Defer a callback until registration is active so it sees the registration's
-// config, which may be a narrowed version of the generated one (TestIndexer
-// runs with a per-test chain subset).
-let withConfig = (fn: Config.t => unit) => withRegistration(r => fn(r.config))
-
 let startRegistration = (~config: Config.t) => {
   let r = {
     config,
@@ -462,55 +457,168 @@ let setContractRegister = (
   })
 }
 
+// Shape of the user-returned `{_gte?, _lte?, _every?}` filter chunk after
+// the ecosystem-specific wrapper is stripped. Shared across all ecosystems —
+// the outer `block.number` / `block.height` / `slot` unwrap lives on each
+// ecosystem's `onBlockFilterSchema`, and the inner range fields are the
+// same everywhere.
+type blockRange = {
+  _gte: option<int>,
+  _lte: option<int>,
+  _every: int,
+}
+
+// `S.strict` rejects unknown fields so typos like `_gt` / `_evry` surface
+// with a readable schema error pointing at the offending key, instead of
+// silently registering a broken filter. `_every` defaults to 1 inside the
+// schema so the caller always sees a plain `int`, and `intMin(1)` rejects
+// zero/negative strides — `(blockNumber - startBlock) % 0` would crash and
+// any negative stride would never match.
+let blockRangeSchema: S.t<blockRange> = S.object(s => {
+  _gte: s.field("_gte", S.option(S.int)),
+  _lte: s.field("_lte", S.option(S.int)),
+  _every: s.field("_every", S.option(S.int->S.intMin(1))->S.Option.getOr(1)),
+})->S.strict
+
+let defaultBlockRange: blockRange = {_gte: None, _lte: None, _every: 1}
+
+// Two-stage parse: first the ecosystem-specific outer schema unwraps the
+// wrapper (`block.number` / `block.height` / `slot`) and surfaces the
+// inner chunk as raw `unknown`; then the shared `blockRangeSchema`
+// validates the `{_gte?, _lte?, _every?}` fields. Keeping the inner
+// validation in one place means typos and shape mismatches surface with
+// the same user-friendly error regardless of ecosystem.
+let extractRange = (filter: unknown, ~name, ~ecosystem: Ecosystem.t): blockRange =>
+  try {
+    switch filter->S.parseOrThrow(ecosystem.onBlockFilterSchema) {
+    | None => defaultBlockRange
+    | Some(inner) => inner->S.parseOrThrow(blockRangeSchema)
+    }
+  } catch {
+  | S.Raised(exn) =>
+    JsError.throwWithMessage(
+      `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` \`where\` returned an invalid filter: ${exn
+        ->Utils.prettifyExn
+        ->(Utils.magic: exn => string)}`,
+    )
+  }
+
+// Mirrors `Envio.onBlockWhereArgs` without depending on the module.
+type onBlockWhereArgs = {chain: unknown}
+
+// `where` is evaluated once per configured chain at registration time.
+// Decoded ranges/stride feed directly into the per-chain registration store
+// so the fetcher's `(blockNumber - handlerStartBlock) % interval === 0`
+// math in `FetchState` stays untouched. Deferred via `withRegistration` so
+// the per-chain loop sees the registration's config, which may be a narrowed
+// version of the generated one (TestIndexer runs with a per-test chain
+// subset). `where` arrives unvalidated (`unknown`) straight from the user's
+// options object.
 let registerOnBlock = (
-  ~name,
-  ~chainId,
-  ~interval,
-  ~startBlock,
-  ~endBlock,
+  ~name: string,
+  ~where: unknown,
   ~handler: Internal.onBlockArgs => promise<unit>,
+  ~getChainsObject: Config.t => dict<unknown>,
 ) => {
   withRegistration(registration => {
-    let chainConfig =
-      registration.config.chainMap
-      ->ChainMap.values
-      ->Array.find(chainConfig => chainConfig.id === chainId)
-    switch chainConfig {
-    | None =>
+    let config = registration.config
+    let ecosystem = config.ecosystem
+    let chainsDict = getChainsObject(config)
+    let logger = Logging.createChild(~params={"onBlock": name})
+
+    // `where` must be a function (unlike onEvent, which also accepts a static
+    // value). A static value would have to be evaluated against every chain
+    // independently, which has no useful semantic for block handlers.
+    // Normalize undefined/null to None up front so the per-chain loop below
+    // can't accidentally call `null` as a predicate.
+    let where = switch where {
+    | w if w === %raw(`undefined`) || w === %raw(`null`) => None
+    | w if typeof(w) === #function => Some(w->(Utils.magic: unknown => onBlockWhereArgs => unknown))
+    | w =>
       JsError.throwWithMessage(
-        `The onBlock handler "${name}" is registered for chain ${chainId->Int.toString} which is not in the config.`,
+        `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` expected \`where\` to be a function or omitted, but got ${(typeof(
+            w,
+          ) :> string)}.`,
       )
-    | Some(chainConfig) =>
-      if startBlock->Option.getOr(chainConfig.startBlock) < chainConfig.startBlock {
+    }
+
+    let matchedAny = ref(false)
+
+    config.chainMap
+    ->ChainMap.values
+    ->Array.forEach(chainConfig => {
+      let chainId = chainConfig.id
+      let chainObj = chainsDict->Dict.getUnsafe(chainId->Int.toString)
+
+      // Predicate returns `true` → match with no filter; `false` → skip;
+      // any plain object → structured filter. `undefined`/`null` returns
+      // are rejected — the TS type excludes `void`, so a missing return is
+      // a user bug we surface early rather than silently match-all.
+      let result = switch where {
+      | None => %raw(`true`)
+      | Some(predicate) => predicate({chain: chainObj})
+      }
+
+      let (shouldRegister, range) = if result === %raw(`true`) {
+        (true, defaultBlockRange)
+      } else if result === %raw(`false`) {
+        (false, defaultBlockRange)
+      } else if typeof(result) === #object && !(result->Array.isArray) && result !== %raw(`null`) {
+        (true, extractRange(result, ~name, ~ecosystem))
+      } else {
+        // Reject numbers, strings, functions, arrays, undefined, null —
+        // anything that isn't bool or a plain object would silently
+        // misregister.
         JsError.throwWithMessage(
-          `The start block for onBlock handler "${name}" is less than the chain start block (${chainConfig.startBlock->Int.toString}). This is not supported yet.`,
+          `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` \`where\` predicate returned an invalid value of type ${(typeof(
+              result,
+            ) :> string)}. Expected boolean or a filter object.`,
         )
       }
-      switch chainConfig.endBlock {
-      | Some(chainEndBlock) =>
-        if endBlock->Option.getOr(chainEndBlock) > chainEndBlock {
+
+      if shouldRegister {
+        matchedAny := true
+        if range._gte->Option.getOr(chainConfig.startBlock) < chainConfig.startBlock {
           JsError.throwWithMessage(
-            `The end block for onBlock handler "${name}" is greater than the chain end block (${chainEndBlock->Int.toString}). This is not supported yet.`,
+            `The start block for onBlock handler "${name}" is less than the chain start block (${chainConfig.startBlock->Int.toString}). This is not supported yet.`,
           )
         }
-      | None => ()
+        switch chainConfig.endBlock {
+        | Some(chainEndBlock) =>
+          if range._lte->Option.getOr(chainEndBlock) > chainEndBlock {
+            JsError.throwWithMessage(
+              `The end block for onBlock handler "${name}" is greater than the chain end block (${chainEndBlock->Int.toString}). This is not supported yet.`,
+            )
+          }
+        | None => ()
+        }
+        let pending = registration->getPendingChainRegistrations(~chainId)
+        pending.onBlockRegistrations
+        ->Array.push(
+          (
+            {
+              index: pending.onBlockRegistrations->Array.length,
+              name,
+              startBlock: range._gte,
+              endBlock: range._lte,
+              interval: range._every,
+              chainId,
+              handler,
+            }: Internal.onBlockRegistration
+          ),
+        )
+        ->ignore
       }
-      let pending = registration->getPendingChainRegistrations(~chainId)
-      pending.onBlockRegistrations
-      ->Array.push(
-        (
-          {
-            index: pending.onBlockRegistrations->Array.length,
-            name,
-            startBlock,
-            endBlock,
-            interval,
-            chainId,
-            handler,
-          }: Internal.onBlockRegistration
-        ),
+    })
+
+    // Catches misconfigured `where` predicates that return `false` for every
+    // configured chain — the handler would otherwise never fire with no hint.
+    // Includes the ecosystem-specific method name so SVM users see "onSlot"
+    // and don't get confused looking for a "Block handler" they never wrote.
+    if !matchedAny.contents {
+      logger->Logging.childWarn(
+        `\`indexer.${ecosystem.onBlockMethodName}\` matched 0 chains. Check the \`where\` predicate.`,
       )
-      ->ignore
     }
   })
 }

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -37,50 +37,11 @@ type activeRegistration = {
   mutable finished: bool,
 }
 
-// Stashed on `globalThis` so a duplicate envio module instance — e.g. when the
-// CLI's `bin.mjs` resolves envio from one path but the user's handlers resolve
-// it from `node_modules/envio` — shares one registry. Without this, each copy
-// keeps its own dict and `finishRegistration` reads empty state.
-//
-// Version-gated: the record shapes below can evolve between envio versions,
-// so the guard uses strict full-version equality. On mismatch we throw with
-// a deduplication hint instead of silently mixing shapes across builds.
-type registryShape = {
-  version: string,
-  eventRegistrations: dict<eventRegistration>,
-  activeRegistration: ref<option<activeRegistration>>,
-  preRegistered: array<activeRegistration => unit>,
-}
-
-// Record type with `mutable` so assignment typechecks; ReScript keeps the
-// field name verbatim in the generated JS so the globalThis slot is
-// `__envioRegistry`.
-type globalThis = {mutable __envioRegistry: Nullable.t<registryShape>}
-@val external globalThis: globalThis = "globalThis"
-
-%%private(
-  let registry: registryShape = {
-    let version = Utils.EnvioPackage.value.version
-    switch globalThis.__envioRegistry->Nullable.toOption {
-    | Some(existing) if existing.version === version => existing
-    | Some(existing) =>
-      JsError.throwWithMessage(
-        `Multiple incompatible envio versions loaded in the same process: ${existing.version} and ${version}. Deduplicate the 'envio' dependency in your project.`,
-      )
-    | None =>
-      let fresh = {
-        version,
-        eventRegistrations: Dict.make(),
-        activeRegistration: ref(None),
-        preRegistered: [],
-      }
-      globalThis.__envioRegistry = Nullable.make(fresh)
-      fresh
-    }
-  }
-)
-
-let eventRegistrations = registry.eventRegistrations
+// Registration state lives in the process-wide `EnvioGlobal` record (shared
+// across duplicate envio module instances); the slots are opaque there, so
+// cast them to the real types once here.
+let eventRegistrations =
+  EnvioGlobal.value.eventRegistrations->(Utils.magic: dict<unknown> => dict<eventRegistration>)
 
 let getKey = (~contractName, ~eventName) => contractName ++ "." ++ eventName
 
@@ -95,7 +56,8 @@ let set = (~contractName, ~eventName, registration) => {
   eventRegistrations->Dict.set(getKey(~contractName, ~eventName), registration)
 }
 
-let activeRegistration = registry.activeRegistration
+let getActiveRegistration = () =>
+  EnvioGlobal.value.activeRegistration->(Utils.magic: option<unknown> => option<activeRegistration>)
 
 // Might happen for tests when the handler file
 // is imported by a non-envio process (eg mocha)
@@ -104,10 +66,13 @@ let activeRegistration = registry.activeRegistration
 // Theoretically we could keep preRegistration without an explicit start
 // but I want it to be this way, so for the actual indexer run
 // an error is thrown with the exact stack trace where the handler was registered.
-let preRegistered = registry.preRegistered
+let preRegistered =
+  EnvioGlobal.value.preRegistered->(
+    Utils.magic: array<unknown> => array<activeRegistration => unit>
+  )
 
 let withRegistration = (fn: activeRegistration => unit) => {
-  switch activeRegistration.contents {
+  switch getActiveRegistration() {
   | None => preRegistered->Array.push(fn)
   | Some(r) =>
     if r.finished {
@@ -126,7 +91,7 @@ let startRegistration = (~config: Config.t) => {
     registrationsByChainId: Dict.make(),
     finished: false,
   }
-  activeRegistration.contents = Some(r)
+  EnvioGlobal.value.activeRegistration = Some(r->(Utils.magic: activeRegistration => unknown))
   while preRegistered->Array.length > 0 {
     // Loop + cleanup in one go
     switch preRegistered->Array.pop {
@@ -624,7 +589,7 @@ let registerOnBlock = (
 }
 
 let finishRegistration = (~config: Config.t): registrationsByChainId => {
-  switch activeRegistration.contents {
+  switch getActiveRegistration() {
   | Some(r) => {
       r.finished = true
       let notRegisteredEventsByContract: dict<Utils.Set.t<string>> = Dict.make()
@@ -759,7 +724,7 @@ let finishRegistration = (~config: Config.t): registrationsByChainId => {
 }
 
 let isPendingRegistration = () => {
-  switch activeRegistration.contents {
+  switch getActiveRegistration() {
   | Some(r) => !r.finished
   | None => false
   }
@@ -769,7 +734,7 @@ let isPendingRegistration = () => {
 // `.onSlot` so the user sees a method-specific error at the call site, instead
 // of hitting the generic `withRegistration` throw deep inside `setHandler` etc.
 let throwIfFinishedRegistration = (~methodName) => {
-  switch activeRegistration.contents {
+  switch getActiveRegistration() {
   | Some({finished: true}) =>
     JsError.throwWithMessage(
       `Cannot call \`indexer.${methodName}\` after the indexer has started. Make sure all handlers are registered at the top level of your handler module.`,

--- a/packages/envio/src/HandlerRegister.resi
+++ b/packages/envio/src/HandlerRegister.resi
@@ -5,7 +5,6 @@ type chainRegistrations = {
 type registrationsByChainId = dict<chainRegistrations>
 
 let startRegistration: (~config: Config.t) => unit
-let withConfig: (Config.t => unit) => unit
 let isPendingRegistration: unit => bool
 let finishRegistration: (~config: Config.t) => registrationsByChainId
 let throwIfFinishedRegistration: (~methodName: string) => unit
@@ -39,11 +38,17 @@ let getContractRegister: (
 let isWildcard: (~contractName: string, ~eventName: string) => bool
 let hasRegistration: (~contractName: string, ~eventName: string) => bool
 
+type blockRange = {
+  _gte: option<int>,
+  _lte: option<int>,
+  _every: int,
+}
+let blockRangeSchema: S.t<blockRange>
+let defaultBlockRange: blockRange
+
 let registerOnBlock: (
   ~name: string,
-  ~chainId: int,
-  ~interval: int,
-  ~startBlock: option<int>,
-  ~endBlock: option<int>,
+  ~where: unknown,
   ~handler: Internal.onBlockArgs => promise<unit>,
+  ~getChainsObject: Config.t => dict<unknown>,
 ) => unit

--- a/packages/envio/src/HandlerRegister.resi
+++ b/packages/envio/src/HandlerRegister.resi
@@ -4,7 +4,8 @@ type chainRegistrations = {
 }
 type registrationsByChainId = dict<chainRegistrations>
 
-let startRegistration: (~ecosystem: Ecosystem.t) => unit
+let startRegistration: (~config: Config.t) => unit
+let withConfig: (Config.t => unit) => unit
 let isPendingRegistration: unit => bool
 let finishRegistration: (~config: Config.t) => registrationsByChainId
 let throwIfFinishedRegistration: (~methodName: string) => unit
@@ -35,7 +36,6 @@ let getContractRegister: (
   ~contractName: string,
   ~eventName: string,
 ) => option<Internal.contractRegister>
-let getOnEventWhere: (~contractName: string, ~eventName: string) => option<JSON.t>
 let isWildcard: (~contractName: string, ~eventName: string) => bool
 let hasRegistration: (~contractName: string, ~eventName: string) => bool
 

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -459,14 +459,33 @@ type topicSelection = {
   topic3: array<EvmTypes.Hex.t>,
 }
 
+// A single topic position of a resolved `where`: either static pre-encoded
+// values, or a marker for "the currently registered addresses of this
+// contract", expanded to topic values when a source query is built.
+type topicFilter =
+  | Values(array<EvmTypes.Hex.t>)
+  | ContractAddresses({contractName: string})
+
+type resolvedTopicSelection = {
+  topic0: array<EvmTypes.Hex.t>,
+  topic1: topicFilter,
+  topic2: topicFilter,
+  topic3: topicFilter,
+}
+
+// The registered `where` fully resolved at registration time for one chain.
+// `topicSelections` is in disjunctive normal form (outer array is OR);
+// an empty array means the `where` returned `false` for this chain.
+type resolvedWhere = {
+  topicSelections: array<resolvedTopicSelection>,
+  startBlock: option<int>,
+}
+
 // Per-event, per-invocation arguments passed to a `where` callback. The
 // concrete `chain` shape (which contract key it exposes) is generated per
 // event in user-project codegen — here it's an open record so codegen'd
 // types subtype-coerce into it cleanly.
 type onEventWhereArgs<'chain> = {chain: 'chain}
-
-type eventFilters =
-  Static(array<topicSelection>) | Dynamic(array<Address.t> => array<topicSelection>)
 
 type evmEventConfig = {
   ...eventConfig,
@@ -557,7 +576,7 @@ type onEventRegistration = {
 
 type evmOnEventRegistration = {
   ...onEventRegistration,
-  getEventFiltersOrThrow: ChainMap.Chain.t => eventFilters,
+  resolvedWhere: resolvedWhere,
 }
 
 // Fuel and SVM registrations add no ecosystem-specific fetch state (their

--- a/packages/envio/src/LogSelection.res
+++ b/packages/envio/src/LogSelection.res
@@ -1,5 +1,8 @@
 exception MissingRequiredTopic0
-let makeTopicSelection = (~topic0, ~topic1=[], ~topic2=[], ~topic3=[]) =>
+let makeTopicSelection = (~topic0, ~topic1=[], ~topic2=[], ~topic3=[]): result<
+  Internal.topicSelection,
+  exn,
+> =>
   if topic0->Utils.Array.isEmpty {
     Error(MissingRequiredTopic0)
   } else {
@@ -37,8 +40,8 @@ let compressTopicSelections = (topicSelections: array<Internal.topicSelection>) 
   switch topic0sOfSelectionsWithoutFilters {
   | [] => selectionsWithFilters
   | topic0 =>
-    let selectionWithoutFilters = {
-      Internal.topic0,
+    let selectionWithoutFilters: Internal.topicSelection = {
+      topic0,
       topic1: [],
       topic2: [],
       topic3: [],
@@ -57,20 +60,33 @@ let make = (~addresses, ~topicSelections) => {
   {addresses, topicSelections}
 }
 
-type parsedEventFilters = {
-  getEventFiltersOrThrow: ChainMap.Chain.t => Internal.eventFilters,
+// Expand a resolved topic selection into concrete topic values for a query:
+// `ContractAddresses` markers become the given partition addresses encoded as
+// topics; `Values` pass through.
+let materializeTopicFilter = (filter: Internal.topicFilter, ~addresses: array<Address.t>) =>
+  switch filter {
+  | Values(values) => values
+  | ContractAddresses(_) => addresses->Array.map(TopicFilter.fromAddress)
+  }
+
+let materializeTopicSelections = (
+  topicSelections: array<Internal.resolvedTopicSelection>,
+  ~addresses: array<Address.t>,
+): array<Internal.topicSelection> =>
+  topicSelections->Array.map(({topic0, topic1, topic2, topic3}): Internal.topicSelection => {
+    topic0,
+    topic1: topic1->materializeTopicFilter(~addresses),
+    topic2: topic2->materializeTopicFilter(~addresses),
+    topic3: topic3->materializeTopicFilter(~addresses),
+  })
+
+type parsedWhere = {
+  resolvedWhere: Internal.resolvedWhere,
   filterByAddresses: bool,
   // Indexed params filtered by `chain.<Contract>.addresses`, in disjunctive
   // normal form (outer array OR of AND-groups). Empty unless `filterByAddresses`.
   // Consumed by the codegen of the event's `clientAddressFilter`.
   addressFilterParamGroups: array<array<string>>,
-  // `_gte` from the top-level `block` filter of the user's `where`,
-  // resolved at build time (per-chain via the `probeChainId`). The
-  // caller uses this to override the per-event `startBlock` — a
-  // `where`-derived startBlock always wins over contract-level
-  // config, so users can widen or narrow individual event ranges
-  // without touching `config.yaml`.
-  startBlock: option<int>,
 }
 
 // Inner schema for the event `block` filter chunk: `{_gte?}`.
@@ -123,24 +139,12 @@ let extractStartBlock = (
   }
 }
 
-// Build the runtime `chain` argument passed into a `where` callback.
-// Exposes `chain.id` and `chain.<ContractName>.addresses` as plain values
-// on a normal (Object.prototype) JS object. `Dict` is used so the
-// contract name can be a dynamic property key without defineProperty
-// ceremony.
-let makeChainArg = (~contractName: string, ~chainId: int, ~addresses: array<Address.t>) => {
-  let chainObj = Dict.make()
-  chainObj->Dict.set("id", chainId->Obj.magic)
-  chainObj->Dict.set(contractName, {"addresses": addresses}->Obj.magic)
-  chainObj
-}
-
-// Build the detection-time `chain` argument. `chain.<ContractName>.addresses`
-// is a getter so the runtime can tell whether the callback actually reads
-// it; the contract sub-object itself is built via `defineProperty` only
-// because its `addresses` field needs the getter — the enclosing chainObj
-// is a plain JS object.
-let makeDetectionChainArg = (
+// Build the `chain` argument passed into a `where` callback.
+// `chain.<ContractName>.addresses` is a getter so the runtime can tell
+// whether the callback actually reads it; the contract sub-object itself is
+// built via `defineProperty` only because its `addresses` field needs the
+// getter — the enclosing chainObj is a plain JS object.
+let makeChainArg = (
   ~contractName: string,
   ~chainId: int,
   ~getAddresses: unit => array<Address.t>,
@@ -155,7 +159,7 @@ let makeDetectionChainArg = (
   chainObj
 }
 
-// Sentinel returned by `chain.<Contract>.addresses` during detection. A Proxy
+// Sentinel returned by `chain.<Contract>.addresses`. A Proxy
 // whose traps throw on any access, so the only non-throwing use is passing it
 // straight through as a param filter value — which `extractAddressFilterGroups`
 // then finds by identity. Misuse (spread/map/index/...) fails loud at the site.
@@ -173,77 +177,45 @@ let makeAddressesProbe: (
   return new Proxy([], {get: trap});
 }`)
 
-// Find which indexed params the probed `where` result assigned the Proxy to
-// (DNF: object => one AND-group, array => OR of groups), neutralizing each match
-// to `[]` so later passes can't touch the throwing Proxy. Throws when the
-// callback read the addresses but didn't use them as a param filter value, since
-// the caller only invokes this once it knows the addresses were read.
-let extractAddressFilterGroupsOrThrow = (
-  result: JSON.t,
-  ~probe: array<Address.t>,
-  ~contractName: string,
-): array<array<string>> => {
-  let groups = []
-  let scanGroup = (paramsObj: dict<JSON.t>) => {
-    let names = []
-    paramsObj->Utils.Dict.forEachWithKey((value, key) => {
-      if value === probe->(Utils.magic: array<Address.t> => JSON.t) {
-        names->Array.push(key)->ignore
-        paramsObj->Dict.set(key, []->(Utils.magic: array<unknown> => JSON.t))
-      }
-    })
-    if names->Utils.Array.isEmpty->not {
-      groups->Array.push(names)->ignore
-    }
-  }
-  switch result {
-  | Object(obj) =>
-    switch obj->Dict.get("params") {
-    | Some(Object(p)) => scanGroup(p)
-    | Some(Array(arr)) =>
-      arr->Array.forEach(item =>
-        switch item {
-        | Object(p) => scanGroup(p)
-        | _ => ()
-        }
-      )
-    | _ => ()
-    }
-  | _ => ()
-  }
-  if groups->Utils.Array.isEmpty {
-    JsError.throwWithMessage(
-      `Invalid where configuration for ${contractName}. The callback reads \`chain.${contractName}.addresses\` but doesn't use it as an indexed-param filter value. Use it directly, e.g. { params: { to: chain.${contractName}.addresses } }.`,
-    )
-  }
-  groups
-}
-
-let parseEventFiltersOrThrow = {
+let parseWhereOrThrow = {
   let emptyTopics = []
   let noopGetter = _ => emptyTopics
 
   (
-    ~eventFilters: option<JSON.t>,
+    ~where: option<JSON.t>,
     ~sighash,
-    ~params,
+    ~params: array<string>,
     ~contractName: string,
-    ~probeChainId: int,
+    ~chainId: int,
     ~onEventBlockFilterSchema: S.t<option<unknown>>,
     ~topic1=noopGetter,
     ~topic2=noopGetter,
     ~topic3=noopGetter,
-  ): parsedEventFilters => {
-    let filterByAddresses = ref(false)
-    let addressFilterParamGroups = ref([])
-    let startBlock = ref(None)
+  ): parsedWhere => {
+    let addressFilterParamGroups = []
+    let readAddresses = ref(false)
+    let addressesSentinel = makeAddressesProbe(~contractName)
+    let sentinelJson = addressesSentinel->(Utils.magic: array<Address.t> => JSON.t)
     let topic0 = [sighash->EvmTypes.Hex.fromStringUnsafe]
     let default = {
       Internal.topic0,
-      topic1: emptyTopics,
-      topic2: emptyTopics,
-      topic3: emptyTopics,
+      topic1: Values(emptyTopics),
+      topic2: Values(emptyTopics),
+      topic3: Values(emptyTopics),
     }
+
+    // Topic positions map 1:1 onto the event's indexed params in declared
+    // order, so the sentinel check keys off `params[index]`. The sentinel must
+    // be detected before the topic getter runs — the getter would otherwise
+    // touch the throwing Proxy while encoding.
+    let topicFilterAt = (paramsFilter: dict<JSON.t>, ~index, ~getter) =>
+      switch params
+      ->Array.get(index)
+      ->Option.flatMap(name => paramsFilter->Utils.Dict.dangerouslyGetNonOption(name)) {
+      | Some(value) if value === sentinelJson =>
+        Internal.ContractAddresses({contractName: contractName})
+      | _ => Values(getter(paramsFilter))
+      }
 
     // Build a single topic selection from one indexed-param record (the
     // inside of `params`). Validates that the keys are actual indexed
@@ -253,18 +225,25 @@ let parseEventFiltersOrThrow = {
       if paramsFilter->Utils.Dict.isEmpty {
         default
       } else {
-        paramsFilter->Utils.Dict.forEachWithKey((_, key) => {
+        let sentinelParamNames = []
+        paramsFilter->Utils.Dict.forEachWithKey((value, key) => {
           if params->Array.includes(key)->not {
             JsError.throwWithMessage(
               `Invalid where configuration. The event doesn't have an indexed parameter "${key}" and can't use it for filtering`,
             )
           }
+          if value === sentinelJson {
+            sentinelParamNames->Array.push(key)->ignore
+          }
         })
+        if sentinelParamNames->Utils.Array.isEmpty->not {
+          addressFilterParamGroups->Array.push(sentinelParamNames)->ignore
+        }
         {
           Internal.topic0,
-          topic1: topic1(paramsFilter),
-          topic2: topic2(paramsFilter),
-          topic3: topic3(paramsFilter),
+          topic1: paramsFilter->topicFilterAt(~index=0, ~getter=topic1),
+          topic2: paramsFilter->topicFilterAt(~index=1, ~getter=topic2),
+          topic3: paramsFilter->topicFilterAt(~index=2, ~getter=topic3),
         }
       }
     }
@@ -289,7 +268,7 @@ let parseEventFiltersOrThrow = {
     //
     // The runtime accepts both the function form (the only form ReScript
     // exposes) and a top-level static object form (TypeScript convenience).
-    let parse = (where: JSON.t): array<Internal.topicSelection> => {
+    let parse = (where: JSON.t): array<Internal.resolvedTopicSelection> => {
       if where === Obj.magic(true) {
         [default]
       } else if where === Obj.magic(false) {
@@ -335,84 +314,42 @@ let parseEventFiltersOrThrow = {
       }
     }
 
-    let getEventFiltersOrThrow = switch eventFilters {
-    | None => {
-        let static: Internal.eventFilters = Static([default])
-        _ => static
-      }
-    | Some(eventFilters) =>
-      if typeof(eventFilters) === #function {
-        let fn = eventFilters->(Utils.magic: JSON.t => Internal.onEventWhereArgs<_> => JSON.t)
-        // Determine whether the callback uses addresses by probing it with
-        // a detection chain arg whose `chain.<ContractName>.addresses` getter
-        // flips a flag. The probe uses this chain's real configured id, so
-        // handlers that branch on `chain.id` are exercised along the path
-        // they take for this chain. Event configs are built per-chain, so
-        // each chain gets a `filterByAddresses` verdict that matches its
-        // own callback behaviour.
-        //
-        // The probe result is also reused to extract the per-event
-        // `startBlock` (from `where.block`) for this chain — a second
-        // invocation would risk observing different state for callbacks
-        // that close over mutable references.
-        // A misused Proxy (or any throw from the callback) propagates as-is —
-        // the Proxy's guidance message surfaces without wrapping.
-        let addressesProbe = makeAddressesProbe(~contractName)
-        let chain = makeDetectionChainArg(
-          ~contractName,
-          ~chainId=probeChainId,
-          ~getAddresses=() => {
-            filterByAddresses := true
-            addressesProbe
-          },
-        )
-        let probedResult = fn({chain: chain->Obj.magic})
-        if filterByAddresses.contents {
-          addressFilterParamGroups :=
-            extractAddressFilterGroupsOrThrow(probedResult, ~probe=addressesProbe, ~contractName)
-        }
-        startBlock := extractStartBlock(~onEventBlockFilterSchema, ~contractName, probedResult)
-        if filterByAddresses.contents {
-          chain => Internal.Dynamic(
-            addresses => {
-              let chainArg = makeChainArg(
-                ~contractName,
-                ~chainId=chain->ChainMap.Chain.toChainId,
-                ~addresses,
-              )
-              fn({chain: chainArg->Obj.magic})->parse
-            },
-          )
-        } else {
-          // No probed chain referenced the contract — cache as Static
-          // per chain to avoid recomputing topic selections each batch.
-          // The addresses getter throws: if a code path the probe didn't
-          // exercise reads `chain.<Contract>.addresses` at runtime, silent
-          // [] would produce wrong topics — throw a user-friendly error
-          // instead so the user rewrites the callback to surface the
-          // dependency up-front.
-          chain => {
-            let chainId = chain->ChainMap.Chain.toChainId
-            let chainArg = makeDetectionChainArg(~contractName, ~chainId, ~getAddresses=() =>
-              JsError.throwWithMessage(
-                `Invalid where configuration. Event callback for contract "${contractName}" read \`chain.${contractName}.addresses\` at runtime but the probe didn't detect the access on chainId ${chainId->Int.toString}. Move the \`chain.${contractName}.addresses\` read above any \`chain.id\` branching so the probe picks up the dependency and switches to the dynamic fetch path.`,
-              )
-            )
-            Internal.Static(fn({chain: chainArg->Obj.magic})->parse)
-          }
-        }
+    // The callback is invoked exactly once per chain, at registration time,
+    // with the chain's real configured id. `chain.<Contract>.addresses` yields
+    // the throwing-Proxy sentinel, which the param parser turns into a
+    // `ContractAddresses` marker; addresses are expanded from the marker only
+    // when a source query is built.
+    // A misused Proxy (or any throw from the callback) propagates as-is —
+    // the Proxy's guidance message surfaces without wrapping.
+    let (topicSelections, startBlock) = switch where {
+    | None => ([default], None)
+    | Some(where) =>
+      let whereValue = if typeof(where) === #function {
+        let fn = where->(Utils.magic: JSON.t => Internal.onEventWhereArgs<_> => JSON.t)
+        let chain = makeChainArg(~contractName, ~chainId, ~getAddresses=() => {
+          readAddresses := true
+          addressesSentinel
+        })
+        fn({chain: chain->Obj.magic})
       } else {
-        startBlock := extractStartBlock(~onEventBlockFilterSchema, ~contractName, eventFilters)
-        let static: Internal.eventFilters = Static(eventFilters->parse)
-        _ => static
+        where
       }
+      let topicSelections = whereValue->parse
+      if readAddresses.contents && addressFilterParamGroups->Utils.Array.isEmpty {
+        JsError.throwWithMessage(
+          `Invalid where configuration for ${contractName}. The callback reads \`chain.${contractName}.addresses\` but doesn't use it as an indexed-param filter value. Use it directly, e.g. { params: { to: chain.${contractName}.addresses } }.`,
+        )
+      }
+      (topicSelections, extractStartBlock(~onEventBlockFilterSchema, ~contractName, whereValue))
     }
 
     {
-      getEventFiltersOrThrow,
-      filterByAddresses: filterByAddresses.contents,
-      addressFilterParamGroups: addressFilterParamGroups.contents,
-      startBlock: startBlock.contents,
+      resolvedWhere: {
+        topicSelections,
+        startBlock,
+      },
+      filterByAddresses: addressFilterParamGroups->Utils.Array.isEmpty->not,
+      addressFilterParamGroups,
     }
   }
 }

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -39,15 +39,24 @@ let stateSchema = S.union([
   })),
 ])
 
-let indexerStateRef: ref<option<IndexerState.t>> = ref(None)
+// Runtime state lives in the process-wide `EnvioGlobal` record (shared
+// across duplicate envio module instances); the slots are opaque there, so
+// cast them to the real types here.
+let getIndexerState = () =>
+  EnvioGlobal.value.indexerState->(Utils.magic: option<unknown> => option<IndexerState.t>)
+let setIndexerState = (state: IndexerState.t) =>
+  EnvioGlobal.value.indexerState = Some(state->(Utils.magic: IndexerState.t => unknown))
 
 // Persistence is set by Main.start before handler modules load, so that
 // the exported indexer value can lazily expose DB state (startBlock,
 // endBlock, isRealtime, dynamic contract addresses) once it's ready.
-let globalPersistenceRef: ref<option<Persistence.t>> = ref(None)
+let getGlobalPersistence = () =>
+  EnvioGlobal.value.persistence->(Utils.magic: option<unknown> => option<Persistence.t>)
+let setGlobalPersistence = (persistence: Persistence.t) =>
+  EnvioGlobal.value.persistence = Some(persistence->(Utils.magic: Persistence.t => unknown))
 
 let getInitialChainState = (~chainId: int): option<Persistence.initialChainState> => {
-  switch globalPersistenceRef.contents {
+  switch getGlobalPersistence() {
   | Some(persistence) =>
     switch persistence.storageStatus {
     | Ready(initialState) => initialState.chains->Array.find(c => c.id === chainId)
@@ -105,7 +114,7 @@ let buildChainsObject = (~config: Config.t) => {
       {
         enumerable: true,
         get: () => {
-          switch indexerStateRef.contents {
+          switch getIndexerState() {
           | Some(state) => state->IndexerState.isRealtime
           // Before the global state is available (eg during handler
           // module load after resume), derive from persistence: every chain
@@ -139,7 +148,7 @@ let buildChainsObject = (~config: Config.t) => {
         {
           enumerable: true,
           get: () => {
-            switch indexerStateRef.contents {
+            switch getIndexerState() {
             | Some(state) => {
                 let chain = ChainMap.Chain.makeUnsafe(~chainId=chainConfig.id)
                 let chainState = state->IndexerState.getChainState(~chain)
@@ -493,7 +502,7 @@ let startServer = (~getState, ~persistence: Persistence.t, ~isDevelopmentMode: b
   app->get("/metrics", (_req, res) => {
     res->set("Content-Type", PromClient.defaultRegister->PromClient.getContentType)
     let _ =
-      Metrics.collect(~state=indexerStateRef.contents)->Promise.thenResolve(metrics =>
+      Metrics.collect(~state=getIndexerState())->Promise.thenResolve(metrics =>
         res->endWithData(metrics)
       )
   })
@@ -586,7 +595,7 @@ let start = async (
   | Some(p) => p
   | None => PgStorage.makePersistenceFromConfig(~config)
   }
-  globalPersistenceRef := Some(persistence)
+  setGlobalPersistence(persistence)
   await persistence->Persistence.init(
     ~reset,
     ~chainConfigs=config.chainMap->ChainMap.values,
@@ -633,7 +642,7 @@ let start = async (
 
   if !isTest {
     startServer(~persistence, ~isDevelopmentMode, ~getState=() =>
-      switch indexerStateRef.contents {
+      switch getIndexerState() {
       | None => Initializing({})
       | Some(state) => {
           let chains =
@@ -663,7 +672,7 @@ let start = async (
   if shouldUseTui {
     let _rerender = Tui.start(~getState=() => state)
   }
-  indexerStateRef := Some(state)
+  setIndexerState(state)
   state->IndexerLoop.start
   await runUntilFatalError
 }

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -372,94 +372,100 @@ let getGlobalIndexer = (): 'indexer => {
   // math at `FetchState.res:619` stays untouched.
   let onBlockFn = (rawOptions: 'a, handler: 'b) => {
     HandlerRegister.throwIfFinishedRegistration(~methodName="onBlock")
-    let config = Config.load()
-    let ecosystem = config.ecosystem
-    let raw =
-      rawOptions->(
-        Utils.magic: 'a => {
-          "name": string,
-          "where": option<Envio.onBlockWhereArgs<unknown> => unknown>,
-        }
-      )
-    let typedHandler = handler->(Utils.magic: 'b => Internal.onBlockArgs => promise<unit>)
-    let (chains, _) = buildChainsObject(~config)
-    let chainsDict = chains->(Utils.magic: {..} => dict<unknown>)
-    let name = raw["name"]
-    let logger = Logging.createChild(~params={"onBlock": name})
+    // Deferred until registration is active so the per-chain loop sees the
+    // registration's config, which may be a narrowed version of the generated
+    // one (TestIndexer runs with a per-test chain subset).
+    HandlerRegister.withConfig(config => {
+      let ecosystem = config.ecosystem
+      let raw =
+        rawOptions->(
+          Utils.magic: 'a => {
+            "name": string,
+            "where": option<Envio.onBlockWhereArgs<unknown> => unknown>,
+          }
+        )
+      let typedHandler = handler->(Utils.magic: 'b => Internal.onBlockArgs => promise<unit>)
+      let (chains, _) = buildChainsObject(~config)
+      let chainsDict = chains->(Utils.magic: {..} => dict<unknown>)
+      let name = raw["name"]
+      let logger = Logging.createChild(~params={"onBlock": name})
 
-    // `where` must be a function (unlike onEvent, which also accepts a static
-    // value). A static value would have to be evaluated against every chain
-    // independently, which has no useful semantic for block handlers.
-    // Normalize undefined/null to None up front so the per-chain loop below
-    // can't accidentally call `null` as a predicate (ReScript treats a JS
-    // `null` value as `Some(null)` when the field is typed as option).
-    let where = switch raw["where"]->(Utils.magic: option<'a> => unknown) {
-    | w if w === %raw(`undefined`) || w === %raw(`null`) => None
-    | w if typeof(w) === #function => Some(raw["where"]->Option.getUnsafe)
-    | w =>
-      JsError.throwWithMessage(
-        `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` expected \`where\` to be a function or omitted, but got ${(typeof(
-            w,
-          ) :> string)}.`,
-      )
-    }
-
-    let matchedAny = ref(false)
-
-    config.chainMap
-    ->ChainMap.values
-    ->Array.forEach(chainConfig => {
-      let chainId = chainConfig.id
-      let chainObj = chainsDict->Dict.getUnsafe(chainId->Int.toString)
-
-      // Predicate returns `true` → match with no filter; `false` → skip;
-      // any plain object → structured filter. `undefined`/`null` returns
-      // are rejected — the TS type excludes `void`, so a missing return is
-      // a user bug we surface early rather than silently match-all.
-      let result = switch where {
-      | None => %raw(`true`)
-      | Some(predicate) => predicate({chain: chainObj})
-      }
-
-      let (shouldRegister, range) = if result === %raw(`true`) {
-        (true, defaultBlockRange)
-      } else if result === %raw(`false`) {
-        (false, defaultBlockRange)
-      } else if typeof(result) === #object && !(result->Array.isArray) && result !== %raw(`null`) {
-        (true, extractRange(result, ~name, ~ecosystem))
-      } else {
-        // Reject numbers, strings, functions, arrays, undefined, null —
-        // anything that isn't bool or a plain object would silently
-        // misregister.
+      // `where` must be a function (unlike onEvent, which also accepts a static
+      // value). A static value would have to be evaluated against every chain
+      // independently, which has no useful semantic for block handlers.
+      // Normalize undefined/null to None up front so the per-chain loop below
+      // can't accidentally call `null` as a predicate (ReScript treats a JS
+      // `null` value as `Some(null)` when the field is typed as option).
+      let where = switch raw["where"]->(Utils.magic: option<'a> => unknown) {
+      | w if w === %raw(`undefined`) || w === %raw(`null`) => None
+      | w if typeof(w) === #function => Some(raw["where"]->Option.getUnsafe)
+      | w =>
         JsError.throwWithMessage(
-          `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` \`where\` predicate returned an invalid value of type ${(typeof(
-              result,
-            ) :> string)}. Expected boolean or a filter object.`,
+          `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` expected \`where\` to be a function or omitted, but got ${(typeof(
+              w,
+            ) :> string)}.`,
         )
       }
 
-      if shouldRegister {
-        matchedAny := true
-        HandlerRegister.registerOnBlock(
-          ~name,
-          ~chainId,
-          ~interval=range._every,
-          ~startBlock=range._gte,
-          ~endBlock=range._lte,
-          ~handler=typedHandler,
+      let matchedAny = ref(false)
+
+      config.chainMap
+      ->ChainMap.values
+      ->Array.forEach(chainConfig => {
+        let chainId = chainConfig.id
+        let chainObj = chainsDict->Dict.getUnsafe(chainId->Int.toString)
+
+        // Predicate returns `true` → match with no filter; `false` → skip;
+        // any plain object → structured filter. `undefined`/`null` returns
+        // are rejected — the TS type excludes `void`, so a missing return is
+        // a user bug we surface early rather than silently match-all.
+        let result = switch where {
+        | None => %raw(`true`)
+        | Some(predicate) => predicate({chain: chainObj})
+        }
+
+        let (shouldRegister, range) = if result === %raw(`true`) {
+          (true, defaultBlockRange)
+        } else if result === %raw(`false`) {
+          (false, defaultBlockRange)
+        } else if (
+          typeof(result) === #object && !(result->Array.isArray) && result !== %raw(`null`)
+        ) {
+          (true, extractRange(result, ~name, ~ecosystem))
+        } else {
+          // Reject numbers, strings, functions, arrays, undefined, null —
+          // anything that isn't bool or a plain object would silently
+          // misregister.
+          JsError.throwWithMessage(
+            `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` \`where\` predicate returned an invalid value of type ${(typeof(
+                result,
+              ) :> string)}. Expected boolean or a filter object.`,
+          )
+        }
+
+        if shouldRegister {
+          matchedAny := true
+          HandlerRegister.registerOnBlock(
+            ~name,
+            ~chainId,
+            ~interval=range._every,
+            ~startBlock=range._gte,
+            ~endBlock=range._lte,
+            ~handler=typedHandler,
+          )
+        }
+      })
+
+      // Catches misconfigured `where` predicates that return `false` for every
+      // configured chain — the handler would otherwise never fire with no hint.
+      // Includes the ecosystem-specific method name so SVM users see "onSlot"
+      // and don't get confused looking for a "Block handler" they never wrote.
+      if !matchedAny.contents {
+        logger->Logging.childWarn(
+          `\`indexer.${ecosystem.onBlockMethodName}\` matched 0 chains. Check the \`where\` predicate.`,
         )
       }
     })
-
-    // Catches misconfigured `where` predicates that return `false` for every
-    // configured chain — the handler would otherwise never fire with no hint.
-    // Includes the ecosystem-specific method name so SVM users see "onSlot"
-    // and don't get confused looking for a "Block handler" they never wrote.
-    if !matchedAny.contents {
-      logger->Logging.childWarn(
-        `\`indexer.${ecosystem.onBlockMethodName}\` matched 0 chains. Check the \`where\` predicate.`,
-      )
-    }
   }
 
   // Ecosystem-specific surface: EVM/Fuel expose event + block handlers; SVM
@@ -506,8 +512,7 @@ let getGlobalIndexer = (): 'indexer => {
   let get = (~prop: string) =>
     switch prop {
     | "name" => Config.load().name->(Utils.magic: string => unknown)
-    | "description" =>
-      Config.load().description->(Utils.magic: option<string> => unknown)
+    | "description" => Config.load().description->(Utils.magic: option<string> => unknown)
     | "chainIds" => {
         let (_, chainIds) = buildChainsObject(~config=Config.load())
         chainIds->(Utils.magic: array<int> => unknown)

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -39,31 +39,6 @@ let stateSchema = S.union([
   })),
 ])
 
-// Shape of the user-returned `{_gte?, _lte?, _every?}` filter chunk after
-// the ecosystem-specific wrapper is stripped. Shared across all ecosystems —
-// the outer `block.number` / `block.height` / `slot` unwrap lives on each
-// ecosystem's `onBlockFilterSchema`, and the inner range fields are the
-// same everywhere.
-type blockRange = {
-  _gte: option<int>,
-  _lte: option<int>,
-  _every: int,
-}
-
-// `S.strict` rejects unknown fields so typos like `_gt` / `_evry` surface
-// with a readable schema error pointing at the offending key, instead of
-// silently registering a broken filter. `_every` defaults to 1 inside the
-// schema so the caller always sees a plain `int`, and `intMin(1)` rejects
-// zero/negative strides — `(blockNumber - startBlock) % 0` would crash and
-// any negative stride would never match.
-let blockRangeSchema: S.t<blockRange> = S.object(s => {
-  _gte: s.field("_gte", S.option(S.int)),
-  _lte: s.field("_lte", S.option(S.int)),
-  _every: s.field("_every", S.option(S.int->S.intMin(1))->S.Option.getOr(1)),
-})->S.strict
-
-let defaultBlockRange: blockRange = {_gte: None, _lte: None, _every: 1}
-
 let indexerStateRef: ref<option<IndexerState.t>> = ref(None)
 
 // Persistence is set by Main.start before handler modules load, so that
@@ -345,127 +320,24 @@ let getGlobalIndexer = (): 'indexer => {
     let _ = RollbackCommit.register(callback->(Utils.magic: 'a => RollbackCommit.callback))
   }
 
-  // Two-stage parse: first the ecosystem-specific outer schema unwraps the
-  // wrapper (`block.number` / `block.height` / `slot`) and surfaces the
-  // inner chunk as raw `unknown`; then the shared `blockRangeSchema`
-  // validates the `{_gte?, _lte?, _every?}` fields. Keeping the inner
-  // validation in one place means typos and shape mismatches surface with
-  // the same user-friendly error regardless of ecosystem.
-  let extractRange = (filter: unknown, ~name, ~ecosystem: Ecosystem.t): blockRange =>
-    try {
-      switch filter->S.parseOrThrow(ecosystem.onBlockFilterSchema) {
-      | None => defaultBlockRange
-      | Some(inner) => inner->S.parseOrThrow(blockRangeSchema)
-      }
-    } catch {
-    | S.Raised(exn) =>
-      JsError.throwWithMessage(
-        `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` \`where\` returned an invalid filter: ${exn
-          ->Utils.prettifyExn
-          ->(Utils.magic: exn => string)}`,
-      )
-    }
-
-  // `where` is evaluated once per configured chain at registration time.
-  // Decoded ranges/stride feed directly into `HandlerRegister.registerOnBlock`
-  // so the fetcher's `(blockNumber - handlerStartBlock) % interval === 0`
-  // math at `FetchState.res:619` stays untouched.
   let onBlockFn = (rawOptions: 'a, handler: 'b) => {
     HandlerRegister.throwIfFinishedRegistration(~methodName="onBlock")
-    // Deferred until registration is active so the per-chain loop sees the
-    // registration's config, which may be a narrowed version of the generated
-    // one (TestIndexer runs with a per-test chain subset).
-    HandlerRegister.withConfig(config => {
-      let ecosystem = config.ecosystem
-      let raw =
-        rawOptions->(
-          Utils.magic: 'a => {
-            "name": string,
-            "where": option<Envio.onBlockWhereArgs<unknown> => unknown>,
-          }
-        )
-      let typedHandler = handler->(Utils.magic: 'b => Internal.onBlockArgs => promise<unit>)
-      let (chains, _) = buildChainsObject(~config)
-      let chainsDict = chains->(Utils.magic: {..} => dict<unknown>)
-      let name = raw["name"]
-      let logger = Logging.createChild(~params={"onBlock": name})
-
-      // `where` must be a function (unlike onEvent, which also accepts a static
-      // value). A static value would have to be evaluated against every chain
-      // independently, which has no useful semantic for block handlers.
-      // Normalize undefined/null to None up front so the per-chain loop below
-      // can't accidentally call `null` as a predicate (ReScript treats a JS
-      // `null` value as `Some(null)` when the field is typed as option).
-      let where = switch raw["where"]->(Utils.magic: option<'a> => unknown) {
-      | w if w === %raw(`undefined`) || w === %raw(`null`) => None
-      | w if typeof(w) === #function => Some(raw["where"]->Option.getUnsafe)
-      | w =>
-        JsError.throwWithMessage(
-          `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` expected \`where\` to be a function or omitted, but got ${(typeof(
-              w,
-            ) :> string)}.`,
-        )
-      }
-
-      let matchedAny = ref(false)
-
-      config.chainMap
-      ->ChainMap.values
-      ->Array.forEach(chainConfig => {
-        let chainId = chainConfig.id
-        let chainObj = chainsDict->Dict.getUnsafe(chainId->Int.toString)
-
-        // Predicate returns `true` → match with no filter; `false` → skip;
-        // any plain object → structured filter. `undefined`/`null` returns
-        // are rejected — the TS type excludes `void`, so a missing return is
-        // a user bug we surface early rather than silently match-all.
-        let result = switch where {
-        | None => %raw(`true`)
-        | Some(predicate) => predicate({chain: chainObj})
+    let raw =
+      rawOptions->(
+        Utils.magic: 'a => {
+          "name": string,
+          "where": unknown,
         }
-
-        let (shouldRegister, range) = if result === %raw(`true`) {
-          (true, defaultBlockRange)
-        } else if result === %raw(`false`) {
-          (false, defaultBlockRange)
-        } else if (
-          typeof(result) === #object && !(result->Array.isArray) && result !== %raw(`null`)
-        ) {
-          (true, extractRange(result, ~name, ~ecosystem))
-        } else {
-          // Reject numbers, strings, functions, arrays, undefined, null —
-          // anything that isn't bool or a plain object would silently
-          // misregister.
-          JsError.throwWithMessage(
-            `\`indexer.${ecosystem.onBlockMethodName}("${name}")\` \`where\` predicate returned an invalid value of type ${(typeof(
-                result,
-              ) :> string)}. Expected boolean or a filter object.`,
-          )
-        }
-
-        if shouldRegister {
-          matchedAny := true
-          HandlerRegister.registerOnBlock(
-            ~name,
-            ~chainId,
-            ~interval=range._every,
-            ~startBlock=range._gte,
-            ~endBlock=range._lte,
-            ~handler=typedHandler,
-          )
-        }
-      })
-
-      // Catches misconfigured `where` predicates that return `false` for every
-      // configured chain — the handler would otherwise never fire with no hint.
-      // Includes the ecosystem-specific method name so SVM users see "onSlot"
-      // and don't get confused looking for a "Block handler" they never wrote.
-      if !matchedAny.contents {
-        logger->Logging.childWarn(
-          `\`indexer.${ecosystem.onBlockMethodName}\` matched 0 chains. Check the \`where\` predicate.`,
-        )
-      }
-    })
+      )
+    HandlerRegister.registerOnBlock(
+      ~name=raw["name"],
+      ~where=raw["where"],
+      ~handler=handler->(Utils.magic: 'b => Internal.onBlockArgs => promise<unit>),
+      ~getChainsObject=config => {
+        let (chains, _) = buildChainsObject(~config)
+        chains->(Utils.magic: {..} => dict<unknown>)
+      },
+    )
   }
 
   // Ecosystem-specific surface: EVM/Fuel expose event + block handlers; SVM

--- a/packages/envio/src/RollbackCommit.res
+++ b/packages/envio/src/RollbackCommit.res
@@ -6,7 +6,10 @@
 type args = {chainId: int, rollbackToBlock: int}
 type callback = args => promise<unit>
 
-let callbacks: array<callback> = []
+// Lives in the process-wide `EnvioGlobal` record so callbacks registered
+// through a duplicate envio module instance still fire.
+let callbacks =
+  EnvioGlobal.value.rollbackCommitCallbacks->(Utils.magic: array<unknown> => array<callback>)
 
 let register = (callback: callback) => {
   callbacks->Array.push(callback)

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -336,7 +336,7 @@ let parse = (~simulateItems: array<JSON.t>, ~config: Config.t, ~chainConfig: Con
       | None => seenCoordinates->Dict.set(coordinate, itemIndex)
       }
 
-      // Build a real registration the same way `HandlerRegister.buildOnEventRegistrations`
+      // Build a real registration the same way `HandlerRegister.finishRegistration`
       // does at startup (not a stub), so the address filter and `where`
       // behave identically to real indexing — the dead-input tracker relies
       // on `clientAddressFilter` actually gating unrouted items.

--- a/packages/envio/src/sources/Evm.res
+++ b/packages/envio/src/sources/Evm.res
@@ -90,8 +90,11 @@ let make = (~logger: Pino.t): Ecosystem.t => {
   // range chunk is validated by `eventBlockRangeSchema` in
   // `LogSelection.res` which rejects `_lte`/`_every` (use `onBlock` for
   // stride- and endBlock-based block handlers).
+  // `S.strict` on the inner object rejects unknown `block` fields (e.g. a
+  // `numbre` typo or `block: {timestamp: ...}`) instead of silently
+  // ignoring them.
   onEventBlockFilterSchema: S.object(s =>
-    s.field("block", S.option(S.object(s2 => s2.field("number", S.unknown))))
+    s.field("block", S.option(S.object(s2 => s2.field("number", S.unknown))->S.strict))
   ),
   logger,
   // The payload carries `transaction` by batch prep (HyperSync) or inline

--- a/packages/envio/src/sources/Fuel.res
+++ b/packages/envio/src/sources/Fuel.res
@@ -35,8 +35,10 @@ let make = (~logger: Pino.t): Ecosystem.t => {
   // Analogous to EVM, but keyed by `block.height` instead of
   // `block.number`. See `Evm.res` for the rationale on the two-stage
   // parse and the `_lte`/`_every` rejection.
+  // `S.strict` on the inner object rejects unknown `block` fields — including
+  // `block.number`, which is EVM-only; Fuel filters by `block.height`.
   onEventBlockFilterSchema: S.object(s =>
-    s.field("block", S.option(S.object(s2 => s2.field("height", S.unknown))))
+    s.field("block", S.option(S.object(s2 => s2.field("height", S.unknown))->S.strict))
   ),
   logger,
   toEvent: eventItem => eventItem.payload->(Utils.magic: Internal.eventPayload => Internal.event),

--- a/packages/envio/src/sources/HyperSyncSource.res
+++ b/packages/envio/src/sources/HyperSyncSource.res
@@ -7,13 +7,12 @@ type selectionConfig = {
   fieldSelection: HyperSyncClient.QueryTypes.fieldSelection,
 }
 
-let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
+let getSelectionConfig = (selection: FetchState.selection) => {
   let capitalizedBlockFields = Utils.Set.make()
   let capitalizedTransactionFields = Utils.Set.make()
 
-  let staticTopicSelectionsByContract = Dict.make()
-  let dynamicEventFiltersByContract = Dict.make()
-  let dynamicWildcardEventFiltersByContract = Dict.make()
+  let topicSelectionsByContract = Dict.make()
+  let wildcardTopicSelectionsByContract = Dict.make()
   let noAddressesTopicSelections = []
   let contractNames = Utils.Set.make()
 
@@ -24,7 +23,7 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
       reg.eventConfig->(Utils.magic: Internal.eventConfig => Internal.evmEventConfig)
     let contractName = eventConfig.contractName
     let {selectedBlockFields, selectedTransactionFields} = eventConfig
-    let {dependsOnAddresses, getEventFiltersOrThrow, isWildcard} = reg
+    let {dependsOnAddresses, resolvedWhere, isWildcard} = reg
     selectedBlockFields
     ->Utils.Set.toArray
     ->Array.forEach(name =>
@@ -44,24 +43,16 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
       }
     })
 
-    let eventFilters = getEventFiltersOrThrow(chain)
     if dependsOnAddresses {
       let _ = contractNames->Utils.Set.add(contractName)
-      switch eventFilters {
-      | Static(topicSelections) =>
-        staticTopicSelectionsByContract->Utils.Dict.pushMany(contractName, topicSelections)
-      | Dynamic(fn) =>
-        (
-          isWildcard ? dynamicWildcardEventFiltersByContract : dynamicEventFiltersByContract
-        )->Utils.Dict.push(contractName, fn)
-      }
+
+      (
+        isWildcard ? wildcardTopicSelectionsByContract : topicSelectionsByContract
+      )->Utils.Dict.pushMany(contractName, resolvedWhere.topicSelections)
     } else {
       noAddressesTopicSelections
       ->Array.pushMany(
-        switch eventFilters {
-        | Static(s) => s
-        | Dynamic(fn) => fn([])
-        },
+        resolvedWhere.topicSelections->LogSelection.materializeTopicSelections(~addresses=[]),
       )
       ->ignore
     }
@@ -92,27 +83,26 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
       | None
       | Some([]) => ()
       | Some(addresses) =>
-        switch staticTopicSelectionsByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
+        switch topicSelectionsByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
         | None => ()
         | Some(topicSelections) =>
-          logSelections->Array.push(LogSelection.make(~addresses, ~topicSelections))
-        }
-        switch dynamicEventFiltersByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
-        | None => ()
-        | Some(fns) =>
           logSelections->Array.push(
-            LogSelection.make(~addresses, ~topicSelections=fns->Array.flatMap(fn => fn(addresses))),
+            LogSelection.make(
+              ~addresses,
+              ~topicSelections=topicSelections->LogSelection.materializeTopicSelections(~addresses),
+            ),
           )
         }
-        switch dynamicWildcardEventFiltersByContract->Utils.Dict.dangerouslyGetNonOption(
-          contractName,
-        ) {
+        // Wildcard events that filter an indexed param by registered addresses:
+        // the addresses fold into the topics, so the query itself stays
+        // address-unbound.
+        switch wildcardTopicSelectionsByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
         | None => ()
-        | Some(fns) =>
+        | Some(topicSelections) =>
           logSelections->Array.push(
             LogSelection.make(
               ~addresses=[],
-              ~topicSelections=fns->Array.flatMap(fn => fn(addresses)),
+              ~topicSelections=topicSelections->LogSelection.materializeTopicSelections(~addresses),
             ),
           )
         }
@@ -127,8 +117,7 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
   }
 }
 
-let memoGetSelectionConfig = (~chain) =>
-  Utils.WeakMap.memoize(selection => selection->getSelectionConfig(~chain))
+let memoGetSelectionConfig = () => Utils.WeakMap.memoize(getSelectionConfig)
 
 // Surfaced by HyperSyncClient.getHeight (Rust) when HyperSync rejects the API
 // token. The corrupted-token test feeds the real server error through this
@@ -164,7 +153,7 @@ let make = (
 ): t => {
   let name = "HyperSync"
 
-  let getSelectionConfig = memoGetSelectionConfig(~chain)
+  let getSelectionConfig = memoGetSelectionConfig()
 
   let apiToken = switch apiToken {
   | Some(token) => token

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -412,7 +412,7 @@ type selectionConfig = {
   ) => array<logSelection>,
 }
 
-let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
+let getSelectionConfig = (selection: FetchState.selection) => {
   let evmOnEventRegistrations =
     selection.onEventRegistrations->(
       Utils.magic: array<Internal.onEventRegistration> => array<Internal.evmOnEventRegistration>
@@ -436,33 +436,23 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
   // re-applies it). Pure-wildcard events carry no address constraint, so they're
   // pooled and resolved once.
   let noAddressTopicSelections = []
-  let staticByContract = Dict.make()
-  let dynamicByContract = Dict.make()
-  let dynamicWildcardByContract = Dict.make()
+  let byContract = Dict.make()
+  let wildcardByContract = Dict.make()
   let contractNames = Utils.Set.make()
 
   evmOnEventRegistrations->Array.forEach(reg => {
     let contractName = reg.eventConfig.contractName
-    let {isWildcard, dependsOnAddresses, getEventFiltersOrThrow} = reg
-    let eventFilters = getEventFiltersOrThrow(chain)
+    let {isWildcard, dependsOnAddresses, resolvedWhere} = reg
     if dependsOnAddresses {
       contractNames->Utils.Set.add(contractName)->ignore
-      switch eventFilters {
-      | Internal.Static(topicSelections) =>
-        staticByContract->Utils.Dict.pushMany(contractName, topicSelections)
-      | Dynamic(fn) =>
-        (isWildcard ? dynamicWildcardByContract : dynamicByContract)->Utils.Dict.push(
-          contractName,
-          fn,
-        )
-      }
+      (isWildcard ? wildcardByContract : byContract)->Utils.Dict.pushMany(
+        contractName,
+        resolvedWhere.topicSelections,
+      )
     } else {
       noAddressTopicSelections
       ->Array.pushMany(
-        switch eventFilters {
-        | Static(s) => s
-        | Dynamic(fn) => fn([])
-        },
+        resolvedWhere.topicSelections->LogSelection.materializeTopicSelections(~addresses=[]),
       )
       ->ignore
     }
@@ -491,30 +481,30 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
         | None
         | Some([]) => ()
         | Some(addresses) =>
-          // Static + dynamic non-wildcard filters, scoped to this contract's addresses.
-          let addressedTopicSelections = []
-          switch staticByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
-          | Some(s) => addressedTopicSelections->Array.pushMany(s)->ignore
-          | None => ()
-          }
-          switch dynamicByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
-          | Some(fns) =>
-            fns->Array.forEach(fn =>
-              addressedTopicSelections->Array.pushMany(fn(addresses))->ignore
-            )
-          | None => ()
-          }
-          logSelections
-          ->Array.pushMany(toLogSelections(~addresses=Some(addresses), addressedTopicSelections))
-          ->ignore
-
-          // Dynamic wildcard-by-address filters fold the address into the topics,
-          // so they still match any address.
-          switch dynamicWildcardByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
-          | Some(fns) =>
+          // Non-wildcard filters, scoped to this contract's addresses.
+          switch byContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
+          | Some(topicSelections) =>
             logSelections
             ->Array.pushMany(
-              toLogSelections(~addresses=None, fns->Array.flatMap(fn => fn(addresses))),
+              toLogSelections(
+                ~addresses=Some(addresses),
+                topicSelections->LogSelection.materializeTopicSelections(~addresses),
+              ),
+            )
+            ->ignore
+          | None => ()
+          }
+
+          // Wildcard-by-address filters fold the address into the topics,
+          // so they still match any address.
+          switch wildcardByContract->Utils.Dict.dangerouslyGetNonOption(contractName) {
+          | Some(topicSelections) =>
+            logSelections
+            ->Array.pushMany(
+              toLogSelections(
+                ~addresses=None,
+                topicSelections->LogSelection.materializeTopicSelections(~addresses),
+              ),
             )
             ->ignore
           | None => ()
@@ -530,8 +520,7 @@ let getSelectionConfig = (selection: FetchState.selection, ~chain) => {
   }
 }
 
-let memoGetSelectionConfig = (~chain) =>
-  Utils.WeakMap.memoize(selection => selection->getSelectionConfig(~chain))
+let memoGetSelectionConfig = () => Utils.WeakMap.memoize(getSelectionConfig)
 
 // Type-erase a schema for storage in the field registry
 external toFieldSchema: S.t<'a> => S.t<JSON.t> = "%identity"
@@ -1021,7 +1010,7 @@ let make = (
   }
   let name = `RPC (${urlHost})`
 
-  let getSelectionConfig = memoGetSelectionConfig(~chain)
+  let getSelectionConfig = memoGetSelectionConfig()
 
   // Per-partition adaptive block interval (AIMD), keyed by partitionId. The
   // `max` key holds a source-wide ceiling that only ever tightens, set by

--- a/scenarios/test_codegen/src/handlers/EventHandlers.ts
+++ b/scenarios/test_codegen/src/handlers/EventHandlers.ts
@@ -464,16 +464,35 @@ indexer.onEvent(
   },
   async (_) => {},
 );
+// Registered a second time with a distinct-but-equal-resolving `where`
+// callback: duplicate registrations compare the resolved filter structure,
+// not the function reference, so this composes instead of throwing.
+indexer.onEvent(
+  {
+    contract: "EventFiltersTest",
+    event: "EmptyFiltersArray",
+    wildcard: true,
+    where: ({ chain }) => {
+      if (chain.id !== 100 && chain.id !== 137) {
+        return false;
+      }
+      return { params: [] };
+    },
+  },
+  async (_) => {},
+);
+// `where` keeps the event on chain 137 but drops it on chain 100 — used to
+// assert that a `false` where removes the chain's registration entirely.
 indexer.onEvent(
   {
     contract: "EventFiltersTest",
     event: "WithExcessField",
     wildcard: true,
     where: ({ chain }) => {
-      if (chain.id !== 100 && chain.id !== 137) {
+      if (chain.id !== 137) {
         return false;
       }
-      return { params: { from: ZERO_ADDRESS, to: ZERO_ADDRESS } };
+      return { params: { from: ZERO_ADDRESS } };
     },
   },
   async (_) => {},

--- a/scenarios/test_codegen/test/ClientAddressFilter_test.res
+++ b/scenarios/test_codegen/test/ClientAddressFilter_test.res
@@ -1,22 +1,22 @@
 open Vitest
 
 // Direct tests for the client-side address filter: the `where`-callback
-// detection (`addressFilterParamGroups`) in `LogSelection.parseEventFiltersOrThrow`
+// detection (`addressFilterParamGroups`) in `LogSelection.parseWhereOrThrow`
 // and the precompiled `clientAddressFilter` built in `EventConfigBuilder`.
 
 let transferSighash = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 
-let parseEvm = (~eventFilters: option<JSON.t>, ~probeChainId=1) =>
-  LogSelection.parseEventFiltersOrThrow(
-    ~eventFilters,
+let parseEvm = (~eventFilters: option<JSON.t>, ~chainId=1) =>
+  LogSelection.parseWhereOrThrow(
+    ~where=eventFilters,
     ~sighash=transferSighash,
     ~params=["from", "to"],
     ~contractName="ERC20",
-    ~probeChainId,
+    ~chainId,
     ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
   )
 
-describe("parseEventFiltersOrThrow — address-param detection", () => {
+describe("parseWhereOrThrow — address-param detection", () => {
   it("collects the address-filtered param (single group)", t => {
     let {filterByAddresses, addressFilterParamGroups} = parseEvm(
       ~eventFilters=Some(%raw(`({chain}) => ({params: {to: chain.ERC20.addresses}})`)),
@@ -83,8 +83,8 @@ describe("clientAddressFilter — precompiled predicate", () => {
       ~isWildcard=true,
       ~handler=None,
       ~contractRegister=None,
-      ~eventFilters=Some(eventFilters),
-      ~probeChainId=1,
+      ~where=Some(eventFilters),
+      ~chainId=1,
       ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
     ).clientAddressFilter
 
@@ -176,8 +176,8 @@ describe("FetchState.handleQueryResult applies clientAddressFilter", () => {
     ~isWildcard=true,
     ~handler=None,
     ~contractRegister=None,
-    ~eventFilters=Some(%raw(`({chain}) => ({params: {to: chain.ERC20.addresses}})`)),
-    ~probeChainId=1,
+    ~where=Some(%raw(`({chain}) => ({params: {to: chain.ERC20.addresses}})`)),
+    ~chainId=1,
     ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
     ~startBlock=5,
   )
@@ -246,8 +246,8 @@ describe("FetchState.handleQueryResult drops over-fetched non-wildcard srcAddres
     ~isWildcard=false,
     ~handler=None,
     ~contractRegister=None,
-    ~eventFilters=None,
-    ~probeChainId=1,
+    ~where=None,
+    ~chainId=1,
     ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
     ~startBlock=5,
   )

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -1,7 +1,7 @@
 open Vitest
 
 // Tests for the per-event `startBlock` extracted from `where.block` on the
-// `onEvent` filter. The parser lives in `LogSelection.parseEventFiltersOrThrow`
+// `onEvent` filter. The parser lives in `LogSelection.parseWhereOrThrow`
 // and composes the ecosystem-specific `onEventBlockFilterSchema` (strips
 // `block.number` on EVM, `block.height` on Fuel) with the shared
 // `eventBlockRangeSchema` (strict, `_gte`-only). These tests drive the parser
@@ -12,22 +12,30 @@ open Vitest
 
 let transferSighash = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 
-let parseEvm = (~eventFilters: option<JSON.t>, ~probeChainId=1) =>
-  LogSelection.parseEventFiltersOrThrow(
-    ~eventFilters,
+type parsed = {startBlock: option<int>, filterByAddresses: bool}
+
+let parse = (~eventFilters: option<JSON.t>, ~probeChainId, ~onEventBlockFilterSchema) => {
+  let p = LogSelection.parseWhereOrThrow(
+    ~where=eventFilters,
     ~sighash=transferSighash,
     ~params=["from", "to"],
     ~contractName="ERC20",
+    ~chainId=probeChainId,
+    ~onEventBlockFilterSchema,
+  )
+  {startBlock: p.resolvedWhere.startBlock, filterByAddresses: p.filterByAddresses}
+}
+
+let parseEvm = (~eventFilters: option<JSON.t>, ~probeChainId=1) =>
+  parse(
+    ~eventFilters,
     ~probeChainId,
     ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
   )
 
 let parseFuel = (~eventFilters: option<JSON.t>, ~probeChainId=1) =>
-  LogSelection.parseEventFiltersOrThrow(
+  parse(
     ~eventFilters,
-    ~sighash=transferSighash,
-    ~params=["from", "to"],
-    ~contractName="ERC20",
     ~probeChainId,
     ~onEventBlockFilterSchema=Fuel.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
   )
@@ -60,7 +68,7 @@ describe("eventBlockRangeSchema (strict, _gte-only)", () => {
   })
 })
 
-describe("parseEventFiltersOrThrow — static `where` with block filter (EVM)", () => {
+describe("parseWhereOrThrow — static `where` with block filter (EVM)", () => {
   it("extracts startBlock from a bare block filter", t => {
     let {startBlock, filterByAddresses} = parseEvm(
       ~eventFilters=Some(%raw(`{block: {number: {_gte: 1000}}}`)),
@@ -122,7 +130,7 @@ describe("parseEventFiltersOrThrow — static `where` with block filter (EVM)", 
   })
 })
 
-describe("parseEventFiltersOrThrow — dynamic `where` callback (EVM)", () => {
+describe("parseWhereOrThrow — dynamic `where` callback (EVM)", () => {
   it("extracts startBlock from the probe result for the configured chain", t => {
     // The callback is evaluated once at build time against `probeChainId`
     // so the probe exercises the branch this event config is built for.
@@ -151,7 +159,7 @@ describe("parseEventFiltersOrThrow — dynamic `where` callback (EVM)", () => {
   })
 })
 
-describe("parseEventFiltersOrThrow — Fuel block.height", () => {
+describe("parseWhereOrThrow — Fuel block.height", () => {
   it("extracts startBlock from `block.height._gte`", t => {
     let {startBlock} = parseFuel(~eventFilters=Some(%raw(`{block: {height: {_gte: 42}}}`)))
     t.expect(startBlock).toEqual(Some(42))
@@ -171,7 +179,7 @@ describe("parseEventFiltersOrThrow — Fuel block.height", () => {
 // real codegen'd event module carries the `block` sibling of `params`.
 // Running this test as a value also verifies that the optional fields'
 // shape is preserved end-to-end — the ReScript record unwrapped to JSON
-// matches exactly what `LogSelection.parseEventFiltersOrThrow` expects.
+// matches exactly what `LogSelection.parseWhereOrThrow` expects.
 describe("Generated onEventWhereFilter — block field exists on EVM events", () => {
   it("compiles a `Filter` with combined params + block.number._gte", t => {
     let fromFilter: Indexer.EventFiltersTest.Transfer.whereParams = {
@@ -231,8 +239,8 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
       ~isWildcard=true,
       ~handler=None,
       ~contractRegister=None,
-      ~eventFilters,
-      ~probeChainId=1,
+      ~where=eventFilters,
+      ~chainId=1,
       ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
       ~startBlock?,
     )
@@ -281,8 +289,8 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
       ~isWildcard=true,
       ~handler=None,
       ~contractRegister=None,
-      ~eventFilters=Some(whereFn),
-      ~probeChainId=137,
+      ~where=Some(whereFn),
+      ~chainId=137,
       ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
       ~startBlock=1,
     )
@@ -296,8 +304,8 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
       ~isWildcard=true,
       ~handler=None,
       ~contractRegister=None,
-      ~eventFilters=Some(whereFn),
-      ~probeChainId=1,
+      ~where=Some(whereFn),
+      ~chainId=1,
       ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
       ~startBlock=1,
     )
@@ -330,8 +338,8 @@ describe("FetchState — where.block._gte drives the first query's fromBlock", (
       ~isWildcard=false,
       ~handler=None,
       ~contractRegister=None,
-      ~eventFilters=Some(%raw(`{block: {number: {_gte: 5000}}}`)),
-      ~probeChainId=1,
+      ~where=Some(%raw(`{block: {number: {_gte: 5000}}}`)),
+      ~chainId=1,
       ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
       ~startBlock?,
     )

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -128,6 +128,12 @@ describe("parseWhereOrThrow — static `where` with block filter (EVM)", () => {
       parseEvm(~eventFilters=Some(%raw(`{blocks: {number: {_gte: 10}}}`)))->ignore
     ).toThrowError(`Unknown field "blocks"`)
   })
+
+  it("rejects unknown fields inside `block` (typo catches)", t => {
+    t.expect(() =>
+      parseEvm(~eventFilters=Some(%raw(`{block: {numbre: {_gte: 10}}}`)))->ignore
+    ).toThrowError("`block` filter is invalid")
+  })
 })
 
 describe("parseWhereOrThrow — dynamic `where` callback (EVM)", () => {
@@ -165,13 +171,10 @@ describe("parseWhereOrThrow — Fuel block.height", () => {
     t.expect(startBlock).toEqual(Some(42))
   })
 
-  it("Fuel ignores `block.number` — typed API forbids it, runtime stays permissive", t => {
-    // `FuelOnEventWhereFilter` types out `block.number`, so typed users
-    // can't reach this path; the runtime still accepts the shape and
-    // surfaces `None` rather than throwing, which keeps untyped or JSON
-    // callers from seeing a cryptic schema error.
-    let {startBlock} = parseFuel(~eventFilters=Some(%raw(`{block: {number: {_gte: 42}}}`)))
-    t.expect(startBlock).toEqual(None)
+  it("Fuel rejects `block.number` — the block filter is keyed by height", t => {
+    t.expect(() =>
+      parseFuel(~eventFilters=Some(%raw(`{block: {number: {_gte: 42}}}`)))->ignore
+    ).toThrowError("`block` filter is invalid")
   })
 })
 

--- a/scenarios/test_codegen/test/EventFilters_test.res
+++ b/scenarios/test_codegen/test/EventFilters_test.res
@@ -1,51 +1,61 @@
 open Vitest
 
-// `registerAllHandlers` loads the handler modules, which register the event
-// filters into the global `HandlerRegister` registry as a side effect — that
-// registry state (not `config`, which never changes) is what
+// `registerAllHandlers` loads the handler modules, which resolve the event
+// filters per chain into the global `HandlerRegister` registry as a side
+// effect — that registry state (not `config`, which never changes) is what
 // `MockConfig.getEvmOnEventRegistration` reads below.
 let config = Config.load()
-let _ = await HandlerLoader.registerAllHandlers(~config)
+let registrationsByChainId = await HandlerLoader.registerAllHandlers(~config)
 
 let getEvmEventConfig = MockConfig.getEvmOnEventRegistration(~config, ...)
 
-// The codegen'd onEventWhereArgs is structurally compatible with
-// Internal.onEventWhereArgs<_> at runtime; runtime parser uses Obj.magic.
-
 describe("Test eventFilters", () => {
-  it("Supports multichain filters", t => {
-    let eventConfig = getEvmEventConfig(~contractName="EventFiltersTest", ~eventName="Transfer")
-
-    t.expect(eventConfig.getEventFiltersOrThrow(ChainMap.Chain.makeUnsafe(~chainId=137))).toEqual(
-      Static([
-        {
-          topic0: [
-            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          ]->EvmTypes.Hex.fromStringsUnsafe,
-          topic1: [
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-          ]->EvmTypes.Hex.fromStringsUnsafe,
-          topic2: [
-            "0x000000000000000000000000f39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-            "0x00000000000000000000000070997970C51812dc3A010C7d01b50e0d17dc79C8",
-          ]->EvmTypes.Hex.fromStringsUnsafe,
-          topic3: [],
-        },
-        {
-          topic0: [
-            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-          ]->EvmTypes.Hex.fromStringsUnsafe,
-          topic1: [
-            "0x000000000000000000000000f39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-            "0x00000000000000000000000070997970C51812dc3A010C7d01b50e0d17dc79C8",
-          ]->EvmTypes.Hex.fromStringsUnsafe,
-          topic2: [
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-          ]->EvmTypes.Hex.fromStringsUnsafe,
-          topic3: [],
-        },
-      ]),
+  it("Supports multichain filters and lowercases mixed-case address values", t => {
+    let eventConfig = getEvmEventConfig(
+      ~contractName="EventFiltersTest",
+      ~eventName="Transfer",
+      ~chainId=137,
     )
+
+    // The whitelisted addresses are checksummed (mixed-case) in the handler
+    // file; the resolved topics must be lowercased so they match the
+    // lowercase hex topics returned by sources.
+    t.expect(eventConfig.resolvedWhere.topicSelections).toEqual([
+      {
+        topic0: [
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+        ]->EvmTypes.Hex.fromStringsUnsafe,
+        topic1: Values(
+          [
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+          ]->EvmTypes.Hex.fromStringsUnsafe,
+        ),
+        topic2: Values(
+          [
+            "0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            "0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8",
+          ]->EvmTypes.Hex.fromStringsUnsafe,
+        ),
+        topic3: Values([]),
+      },
+      {
+        topic0: [
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+        ]->EvmTypes.Hex.fromStringsUnsafe,
+        topic1: Values(
+          [
+            "0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            "0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8",
+          ]->EvmTypes.Hex.fromStringsUnsafe,
+        ),
+        topic2: Values(
+          [
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+          ]->EvmTypes.Hex.fromStringsUnsafe,
+        ),
+        topic3: Values([]),
+      },
+    ])
     t.expect(
       eventConfig.dependsOnAddresses,
       ~message=`Even though event filter has a callback,
@@ -55,23 +65,48 @@ describe("Test eventFilters", () => {
   })
 
   it("Supports filter depending on addresses", t => {
-    // Per-chain where-callback probing: pick the chain 137 event config so
-    // the probe exercises the branch that accesses addresses.
     let eventConfig = getEvmEventConfig(
       ~contractName="EventFiltersTest",
       ~eventName="WildcardWithAddress",
       ~chainId=137,
     )
 
+    t.expect(eventConfig.resolvedWhere.topicSelections).toEqual([
+      {
+        topic0: [
+          "0xf26849ed9bbf448cc2a8d7bcb15203e1e2a68bbbd94550aa4f2f717455c1abed",
+        ]->EvmTypes.Hex.fromStringsUnsafe,
+        topic1: Values(
+          [
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+          ]->EvmTypes.Hex.fromStringsUnsafe,
+        ),
+        topic2: ContractAddresses({contractName: "EventFiltersTest"}),
+        topic3: Values([]),
+      },
+      {
+        topic0: [
+          "0xf26849ed9bbf448cc2a8d7bcb15203e1e2a68bbbd94550aa4f2f717455c1abed",
+        ]->EvmTypes.Hex.fromStringsUnsafe,
+        topic1: ContractAddresses({contractName: "EventFiltersTest"}),
+        topic2: Values(
+          [
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+          ]->EvmTypes.Hex.fromStringsUnsafe,
+        ),
+        topic3: Values([]),
+      },
+    ])
+
+    // Materialization at query build expands the markers into the
+    // partition's addresses encoded as topics.
     t.expect(
-      switch eventConfig.getEventFiltersOrThrow(ChainMap.Chain.makeUnsafe(~chainId=137)) {
-      | Static(_) => JsError.throwWithMessage("Should be dynamic")
-      | Dynamic(fn) =>
-        fn([
+      eventConfig.resolvedWhere.topicSelections->LogSelection.materializeTopicSelections(
+        ~addresses=[
           "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"->Address.unsafeFromString,
           "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"->Address.unsafeFromString,
-        ])
-      },
+        ],
+      ),
     ).toEqual([
       {
         topic0: [
@@ -108,33 +143,66 @@ describe("Test eventFilters", () => {
     let eventConfig = getEvmEventConfig(
       ~contractName="EventFiltersTest",
       ~eventName="EmptyFiltersArray",
+      ~chainId=137,
     )
 
-    t.expect(eventConfig.getEventFiltersOrThrow(ChainMap.Chain.makeUnsafe(~chainId=137))).toEqual(
-      Static([
-        {
-          topic0: [
-            "0x668839194402d721b0cf3fe98a505bd32f7601265985fd3ca34b9ddaaaa06ea5",
-          ]->EvmTypes.Hex.fromStringsUnsafe,
-          topic1: [],
-          topic2: [],
-          topic3: [],
-        },
-      ]),
-    )
+    t.expect(eventConfig.resolvedWhere.topicSelections).toEqual([
+      {
+        topic0: [
+          "0x668839194402d721b0cf3fe98a505bd32f7601265985fd3ca34b9ddaaaa06ea5",
+        ]->EvmTypes.Hex.fromStringsUnsafe,
+        topic1: Values([]),
+        topic2: Values([]),
+        topic3: Values([]),
+      },
+    ])
     t.expect(eventConfig.dependsOnAddresses, ~message="foo").toBe(false)
   })
 
-  it("Fails on filter with excess field", t => {
+  it("Second registration with a distinct-but-equal-resolving where composes handlers", t => {
+    // EmptyFiltersArray is registered twice in EventHandlers.ts with two
+    // different callback instances that resolve identically — the duplicate
+    // guard compares resolved structures, so registration succeeded and the
+    // handlers composed.
     let eventConfig = getEvmEventConfig(
       ~contractName="EventFiltersTest",
-      ~eventName="WithExcessField",
+      ~eventName="EmptyFiltersArray",
+      ~chainId=137,
     )
+    t.expect(eventConfig.handler->Option.isSome).toBe(true)
+  })
 
-    t.expect(
-      () => {
-        eventConfig.getEventFiltersOrThrow(ChainMap.Chain.makeUnsafe(~chainId=137))
-      },
+  it("Where returning false drops the chain's registration entirely", t => {
+    // WithExcessField's where returns `false` for chain 100 and a filter for
+    // chain 137 — the finished registrations must include it only on 137.
+    let hasEvent = chainId =>
+      switch registrationsByChainId->Dict.get(chainId) {
+      | Some({HandlerRegister.onEventRegistrations: regs}) =>
+        regs->Array.some(reg => reg.eventConfig.name === "WithExcessField")
+      | None => false
+      }
+    t.expect((hasEvent("137"), hasEvent("100"))).toEqual((true, false))
+  })
+
+  it("Fails on filter with excess field at registration time", t => {
+    let eventConfig = MockConfig.getEvmEventConfig(
+      ~config,
+      ~contractName="EventFiltersTest",
+      ~eventName="WithExcessField",
+      ~chainId=137,
+    )
+    t.expect(() =>
+      EventConfigBuilder.buildEvmOnEventRegistration(
+        ~eventConfig,
+        ~isWildcard=true,
+        ~handler=None,
+        ~contractRegister=None,
+        ~where=Some(
+          %raw(`{params: {from: "0x0000000000000000000000000000000000000000", to: "0x0000000000000000000000000000000000000000"}}`),
+        ),
+        ~chainId=137,
+        ~onEventBlockFilterSchema=config.ecosystem.onEventBlockFilterSchema,
+      )
     ).toThrowError(`Invalid where configuration. The event doesn't have an indexed parameter "to" and can't use it for filtering`)
   })
 
@@ -144,7 +212,11 @@ describe("Test eventFilters", () => {
       ~eventName="WildcardWithAddress",
       ~chainId=137,
     )
-    let transfer = getEvmEventConfig(~contractName="EventFiltersTest", ~eventName="Transfer")
+    let transfer = getEvmEventConfig(
+      ~contractName="EventFiltersTest",
+      ~eventName="Transfer",
+      ~chainId=137,
+    )
     t.expect((
       wildcardWithAddress.clientAddressFilter->Option.isSome,
       transfer.clientAddressFilter->Option.isNone,

--- a/scenarios/test_codegen/test/HandlerRegisterLifecycle_test.res
+++ b/scenarios/test_codegen/test/HandlerRegisterLifecycle_test.res
@@ -1,0 +1,112 @@
+open Vitest
+
+// Covers the per-chain immediate resolution in `HandlerRegister`: duplicate
+// registrations are compared on the resolved `where` structure (not the
+// callback reference), invalid `where`/onBlock options throw at the user's
+// registration call site, and `preRegistered` callbacks replayed by
+// `startRegistration` run through the same code path.
+//
+// This file must not import the handler fixtures — it drives the global
+// registry lifecycle itself, relying on vitest's per-file isolation.
+
+let config = Config.load()
+
+let noopHandler = async _ => ()
+
+let eventOptions = (~where: JSON.t): option<Internal.eventOptions<JSON.t>> =>
+  Some({wildcard: true, where})
+
+// Registered before `startRegistration` → lands in `preRegistered` and
+// replays inside `startRegistration`, resolving the `where` per chain there.
+HandlerRegister.setHandler(
+  ~contractName="EventFiltersTest",
+  ~eventName="Transfer",
+  noopHandler,
+  ~eventOptions=eventOptions(
+    ~where=%raw(`({chain: _chain}) => ({params: {from: "0x0000000000000000000000000000000000000000"}})`),
+  ),
+)
+HandlerRegister.startRegistration(~config)
+
+describe("HandlerRegister — duplicate registrations compare resolved where", () => {
+  it("a distinct callback with an equal resolution composes instead of throwing", t => {
+    HandlerRegister.setHandler(
+      ~contractName="EventFiltersTest",
+      ~eventName="Transfer",
+      noopHandler,
+      ~eventOptions=eventOptions(
+        ~where=%raw(`({chain: _chain}) => ({params: {from: "0x0000000000000000000000000000000000000000"}})`),
+      ),
+    )
+    t.expect(
+      HandlerRegister.getHandler(
+        ~contractName="EventFiltersTest",
+        ~eventName="Transfer",
+      )->Option.isSome,
+    ).toBe(true)
+  })
+
+  it("a callback with a different resolution throws at the registration call site", t => {
+    t.expect(() =>
+      HandlerRegister.setHandler(
+        ~contractName="EventFiltersTest",
+        ~eventName="Transfer",
+        noopHandler,
+        ~eventOptions=eventOptions(
+          ~where=%raw(`({chain: _chain}) => ({params: {to: "0x0000000000000000000000000000000000000000"}})`),
+        ),
+      )
+    ).toThrowError(
+      "Cannot register a second handler with different options. Make sure all handlers for the same event use identical options (wildcard, where) for EventFiltersTest.Transfer",
+    )
+  })
+
+  it("an invalid where throws at the registration call site", t => {
+    t.expect(() =>
+      HandlerRegister.setHandler(
+        ~contractName="EventFiltersTest",
+        ~eventName="EmptyFiltersArray",
+        noopHandler,
+        ~eventOptions=eventOptions(
+          ~where=%raw(`{params: {nonExistingParam: "0x0000000000000000000000000000000000000000"}}`),
+        ),
+      )
+    ).toThrowError(
+      `Invalid where configuration. The event doesn't have an indexed parameter "nonExistingParam" and can't use it for filtering`,
+    )
+  })
+})
+
+describe("HandlerRegister — onBlock validation at registration", () => {
+  let noopBlockHandler = async (_: Internal.onBlockArgs) => ()
+
+  it("throws for a chainId that is not in the config", t => {
+    t.expect(() =>
+      HandlerRegister.registerOnBlock(
+        ~name="unknownChain",
+        ~chainId=424242,
+        ~interval=1,
+        ~startBlock=None,
+        ~endBlock=None,
+        ~handler=noopBlockHandler,
+      )
+    ).toThrowError(
+      `The onBlock handler "unknownChain" is registered for chain 424242 which is not in the config.`,
+    )
+  })
+
+  it("throws when startBlock is below the chain start block", t => {
+    t.expect(() =>
+      HandlerRegister.registerOnBlock(
+        ~name="tooEarly",
+        ~chainId=137,
+        ~interval=1,
+        ~startBlock=Some(0),
+        ~endBlock=None,
+        ~handler=noopBlockHandler,
+      )
+    ).toThrowError(
+      `The start block for onBlock handler "tooEarly" is less than the chain start block (1). This is not supported yet.`,
+    )
+  })
+})

--- a/scenarios/test_codegen/test/HandlerRegisterLifecycle_test.res
+++ b/scenarios/test_codegen/test/HandlerRegisterLifecycle_test.res
@@ -80,30 +80,47 @@ describe("HandlerRegister — duplicate registrations compare resolved where", (
 describe("HandlerRegister — onBlock validation at registration", () => {
   let noopBlockHandler = async (_: Internal.onBlockArgs) => ()
 
-  it("throws for a chainId that is not in the config", t => {
+  // A minimal chains object: the predicates below only read `chain.id`.
+  let getChainsObject = (config: Config.t) =>
+    config.chainMap
+    ->ChainMap.values
+    ->Array.map(chainConfig => (
+      chainConfig.id->Int.toString,
+      {"id": chainConfig.id}->(Utils.magic: {"id": int} => unknown),
+    ))
+    ->Dict.fromArray
+
+  it("throws when where is not a function", t => {
     t.expect(() =>
       HandlerRegister.registerOnBlock(
-        ~name="unknownChain",
-        ~chainId=424242,
-        ~interval=1,
-        ~startBlock=None,
-        ~endBlock=None,
+        ~name="badWhere",
+        ~where=%raw(`{block: {number: {_gte: 10}}}`),
         ~handler=noopBlockHandler,
+        ~getChainsObject,
       )
     ).toThrowError(
-      `The onBlock handler "unknownChain" is registered for chain 424242 which is not in the config.`,
+      `\`indexer.onBlock("badWhere")\` expected \`where\` to be a function or omitted, but got object.`,
     )
+  })
+
+  it("throws when where returns a filter with unknown fields", t => {
+    t.expect(() =>
+      HandlerRegister.registerOnBlock(
+        ~name="typoFilter",
+        ~where=%raw(`() => ({block: {number: {_gt: 10}}})`),
+        ~handler=noopBlockHandler,
+        ~getChainsObject,
+      )
+    ).toThrowError(`\`indexer.onBlock("typoFilter")\` \`where\` returned an invalid filter`)
   })
 
   it("throws when startBlock is below the chain start block", t => {
     t.expect(() =>
       HandlerRegister.registerOnBlock(
         ~name="tooEarly",
-        ~chainId=137,
-        ~interval=1,
-        ~startBlock=Some(0),
-        ~endBlock=None,
+        ~where=%raw(`({chain}) => chain.id === 137 ? {block: {number: {_gte: 0}}} : false`),
         ~handler=noopBlockHandler,
+        ~getChainsObject,
       )
     ).toThrowError(
       `The start block for onBlock handler "tooEarly" is less than the chain start block (1). This is not supported yet.`,

--- a/scenarios/test_codegen/test/HyperSyncSource_test.res
+++ b/scenarios/test_codegen/test/HyperSyncSource_test.res
@@ -11,7 +11,7 @@ describe("HyperSyncSource - getSelectionConfig", () => {
       let selectionConfig = {
         dependsOnAddresses: true,
         onEventRegistrations: [(MockIndexer.evmOnEventRegistration() :> Internal.onEventRegistration)],
-      }->HyperSyncSource.getSelectionConfig(~chain)
+      }->HyperSyncSource.getSelectionConfig
 
       t.expect(selectionConfig).toEqual({
         fieldSelection: {
@@ -67,7 +67,7 @@ describe("HyperSyncSource - getSelectionConfig", () => {
             ~transactionFieldNames=([Hash, GasPrice]: array<Internal.evmTransactionField>),
           ) :> Internal.onEventRegistration),
         ],
-      }->HyperSyncSource.getSelectionConfig(~chain)
+      }->HyperSyncSource.getSelectionConfig
 
       t.expect(selectionConfig).toEqual({
         fieldSelection: {
@@ -88,7 +88,7 @@ describe("HyperSyncSource - getSelectionConfig", () => {
           ~transactionFieldNames=([TransactionIndex, Hash]: array<Internal.evmTransactionField>),
         ) :> Internal.onEventRegistration),
       ],
-    }->HyperSyncSource.getSelectionConfig(~chain)
+    }->HyperSyncSource.getSelectionConfig
 
     t.expect(selectionConfig.fieldSelection).toEqual({
       block: [],
@@ -112,7 +112,7 @@ describe("HyperSyncSource - getSelectionConfig", () => {
           ~transactionFieldNames=([GasPrice]: array<Internal.evmTransactionField>),
         ) :> Internal.onEventRegistration),
       ],
-    }->HyperSyncSource.getSelectionConfig(~chain)
+    }->HyperSyncSource.getSelectionConfig
 
     t.expect(selectionConfig).toEqual({
       fieldSelection: {
@@ -137,7 +137,7 @@ describe("HyperSyncSource - getSelectionConfig", () => {
           ~isWildcard=true,
         ) :> Internal.onEventRegistration),
       ],
-    }->HyperSyncSource.getSelectionConfig(~chain)
+    }->HyperSyncSource.getSelectionConfig
 
     t.expect(
       selectionConfig.getLogSelectionOrThrow(~addressesByContractName=Dict.make()),
@@ -173,7 +173,7 @@ describe("HyperSyncSource - getSelectionConfig", () => {
             ~dependsOnAddresses=true,
           ) :> Internal.onEventRegistration),
         ],
-      }->HyperSyncSource.getSelectionConfig(~chain)
+      }->HyperSyncSource.getSelectionConfig
 
       t.expect(
         selectionConfig.getLogSelectionOrThrow(
@@ -196,7 +196,7 @@ describe("HyperSyncSource - getSelectionConfig", () => {
           topicSelections: [
             {
               topic0: ["event 2"->EvmTypes.Hex.fromStringUnsafe],
-              topic1: [mockAddress0->Utils.magic],
+              topic1: [mockAddress0->TopicFilter.fromAddress],
               topic2: [],
               topic3: [],
             },

--- a/scenarios/test_codegen/test/OnBlockSchema_test.res
+++ b/scenarios/test_codegen/test/OnBlockSchema_test.res
@@ -9,46 +9,46 @@ open Vitest
 //      to 1, optional bounds stay `None`.
 //
 // These tests drive the schemas directly so we don't have to bring up a
-// runtime indexer; the consumer in `Main.onBlockFn` composes them in the
+// runtime indexer; the consumer in `HandlerRegister.registerOnBlock` composes them in the
 // same order as `extractRange`.
 
 describe("blockRangeSchema (shared inner range validation)", () => {
   it("parses all three fields", t => {
     let parsed =
-      %raw(`{_gte: 100, _lte: 200, _every: 5}`)->S.parseOrThrow(Main.blockRangeSchema)
-    t.expect(parsed).toEqual(({_gte: Some(100), _lte: Some(200), _every: 5}: Main.blockRange))
+      %raw(`{_gte: 100, _lte: 200, _every: 5}`)->S.parseOrThrow(HandlerRegister.blockRangeSchema)
+    t.expect(parsed).toEqual(({_gte: Some(100), _lte: Some(200), _every: 5}: HandlerRegister.blockRange))
   })
 
   it("defaults _every to 1 when omitted", t => {
-    let parsed = %raw(`{_gte: 10}`)->S.parseOrThrow(Main.blockRangeSchema)
-    t.expect(parsed).toEqual(({_gte: Some(10), _lte: None, _every: 1}: Main.blockRange))
+    let parsed = %raw(`{_gte: 10}`)->S.parseOrThrow(HandlerRegister.blockRangeSchema)
+    t.expect(parsed).toEqual(({_gte: Some(10), _lte: None, _every: 1}: HandlerRegister.blockRange))
   })
 
   it("accepts an empty object (all bounds optional, _every defaulted)", t => {
-    let parsed = %raw(`{}`)->S.parseOrThrow(Main.blockRangeSchema)
-    t.expect(parsed).toEqual(Main.defaultBlockRange)
+    let parsed = %raw(`{}`)->S.parseOrThrow(HandlerRegister.blockRangeSchema)
+    t.expect(parsed).toEqual(HandlerRegister.defaultBlockRange)
   })
 
   it("S.strict rejects unknown fields (typo catches)", t => {
     // `_gt` (typo for `_gte`) must not be silently accepted.
-    t.expect(() => %raw(`{_gt: 10}`)->S.parseOrThrow(Main.blockRangeSchema)).toThrow()
+    t.expect(() => %raw(`{_gt: 10}`)->S.parseOrThrow(HandlerRegister.blockRangeSchema)).toThrow()
   })
 
   it("rejects non-int _gte", t => {
-    t.expect(() => %raw(`{_gte: "10"}`)->S.parseOrThrow(Main.blockRangeSchema)).toThrow()
+    t.expect(() => %raw(`{_gte: "10"}`)->S.parseOrThrow(HandlerRegister.blockRangeSchema)).toThrow()
   })
 
   it("rejects _every: 0 (would crash the modulo math downstream)", t => {
-    t.expect(() => %raw(`{_every: 0}`)->S.parseOrThrow(Main.blockRangeSchema)).toThrow()
+    t.expect(() => %raw(`{_every: 0}`)->S.parseOrThrow(HandlerRegister.blockRangeSchema)).toThrow()
   })
 
   it("rejects negative _every", t => {
-    t.expect(() => %raw(`{_every: -1}`)->S.parseOrThrow(Main.blockRangeSchema)).toThrow()
+    t.expect(() => %raw(`{_every: -1}`)->S.parseOrThrow(HandlerRegister.blockRangeSchema)).toThrow()
   })
 
   it("accepts _every: 1 (the minimum / default)", t => {
-    let parsed = %raw(`{_every: 1}`)->S.parseOrThrow(Main.blockRangeSchema)
-    t.expect(parsed).toEqual(({_gte: None, _lte: None, _every: 1}: Main.blockRange))
+    let parsed = %raw(`{_every: 1}`)->S.parseOrThrow(HandlerRegister.blockRangeSchema)
+    t.expect(parsed).toEqual(({_gte: None, _lte: None, _every: 1}: HandlerRegister.blockRange))
   })
 })
 
@@ -59,9 +59,9 @@ describe("Evm ecosystem onBlockFilterSchema", () => {
     let parsed =
       %raw(`{block: {number: {_gte: 10, _every: 2}}}`)->S.parseOrThrow(schema)
     // Feed the inner chunk through the shared range schema (mirrors
-    // `extractRange` in Main.res) to prove it carries the raw payload.
-    let range = parsed->Option.getOrThrow->S.parseOrThrow(Main.blockRangeSchema)
-    t.expect(range).toEqual(({_gte: Some(10), _lte: None, _every: 2}: Main.blockRange))
+    // `extractRange` in HandlerRegister.res) to prove it carries the raw payload.
+    let range = parsed->Option.getOrThrow->S.parseOrThrow(HandlerRegister.blockRangeSchema)
+    t.expect(range).toEqual(({_gte: Some(10), _lte: None, _every: 2}: HandlerRegister.blockRange))
   })
 
   it("returns None when `block` is missing entirely", t => {
@@ -78,12 +78,12 @@ describe("Evm ecosystem onBlockFilterSchema", () => {
     // Semantic change from the old unwrap: `{block: {}}` used to be
     // silently treated as 'no filter'. The outer schema surfaces
     // `Some(undefined)` for this input, and then feeding that through
-    // `blockRangeSchema` (what `extractRange` does in Main.res) throws.
+    // `blockRangeSchema` (what `extractRange` does in HandlerRegister.res) throws.
     // Net effect: the user gets a clear parse error instead of a silent
     // no-filter registration.
     let parsed = %raw(`{block: {}}`)->S.parseOrThrow(schema)
     t.expect(() =>
-      parsed->Option.getOrThrow->S.parseOrThrow(Main.blockRangeSchema)->ignore
+      parsed->Option.getOrThrow->S.parseOrThrow(HandlerRegister.blockRangeSchema)->ignore
     ).toThrow()
   })
 })
@@ -94,8 +94,8 @@ describe("Fuel ecosystem onBlockFilterSchema", () => {
   it("surfaces the inner range chunk from block.height", t => {
     let parsed =
       %raw(`{block: {height: {_gte: 1, _lte: 100}}}`)->S.parseOrThrow(schema)
-    let range = parsed->Option.getOrThrow->S.parseOrThrow(Main.blockRangeSchema)
-    t.expect(range).toEqual(({_gte: Some(1), _lte: Some(100), _every: 1}: Main.blockRange))
+    let range = parsed->Option.getOrThrow->S.parseOrThrow(HandlerRegister.blockRangeSchema)
+    t.expect(range).toEqual(({_gte: Some(1), _lte: Some(100), _every: 1}: HandlerRegister.blockRange))
   })
 
   it("returns None when `block` is missing", t => {
@@ -109,8 +109,8 @@ describe("Svm ecosystem onBlockFilterSchema", () => {
 
   it("surfaces the inner range chunk from the flat `slot` key", t => {
     let parsed = %raw(`{slot: {_gte: 42, _every: 3}}`)->S.parseOrThrow(schema)
-    let range = parsed->Option.getOrThrow->S.parseOrThrow(Main.blockRangeSchema)
-    t.expect(range).toEqual(({_gte: Some(42), _lte: None, _every: 3}: Main.blockRange))
+    let range = parsed->Option.getOrThrow->S.parseOrThrow(HandlerRegister.blockRangeSchema)
+    t.expect(range).toEqual(({_gte: Some(42), _lte: None, _every: 3}: HandlerRegister.blockRange))
   })
 
   it("returns None when `slot` is omitted (no inner object layer)", t => {

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -737,7 +737,7 @@ describe("RpcSource - getSelectionConfig", () => {
     let selectionConfig = {
       dependsOnAddresses: true,
       onEventRegistrations: [(MockIndexer.evmOnEventRegistration() :> Internal.onEventRegistration)],
-    }->RpcSource.getSelectionConfig(~chain)
+    }->RpcSource.getSelectionConfig
 
     t.expect(
       selectionConfig.getLogSelectionsOrThrow(
@@ -759,7 +759,7 @@ describe("RpcSource - getSelectionConfig", () => {
         (MockIndexer.evmOnEventRegistration(~id="1", ~isWildcard=true) :> Internal.onEventRegistration),
         (MockIndexer.evmOnEventRegistration(~id="2", ~isWildcard=true) :> Internal.onEventRegistration),
       ],
-    }->RpcSource.getSelectionConfig(~chain)
+    }->RpcSource.getSelectionConfig
 
     t.expect(
       selectionConfig.getLogSelectionsOrThrow(~addressesByContractName=Dict.make()),
@@ -782,7 +782,7 @@ describe("RpcSource - getSelectionConfig", () => {
           ~dependsOnAddresses=true,
         ) :> Internal.onEventRegistration),
       ],
-    }->RpcSource.getSelectionConfig(~chain)
+    }->RpcSource.getSelectionConfig
 
     t.expect(
       selectionConfig.getLogSelectionsOrThrow(
@@ -791,7 +791,7 @@ describe("RpcSource - getSelectionConfig", () => {
     ).toEqual([
       {
         addresses: None,
-        topicQuery: [Single("event 2"), Single(mockAddress0->Address.toString)],
+        topicQuery: [Single("event 2"), Single(mockAddress0->TopicFilter.fromAddress->EvmTypes.Hex.toString)],
       },
     ])
   })
@@ -806,7 +806,7 @@ describe("RpcSource - getSelectionConfig", () => {
           ~dependsOnAddresses=true,
         ) :> Internal.onEventRegistration),
       ],
-    }->RpcSource.getSelectionConfig(~chain)
+    }->RpcSource.getSelectionConfig
 
     t.expect(
       selectionConfig.getLogSelectionsOrThrow(
@@ -815,7 +815,7 @@ describe("RpcSource - getSelectionConfig", () => {
     ).toEqual([
       {
         addresses: Some([mockAddress0]),
-        topicQuery: [Single("event 2"), Single(mockAddress0->Address.toString)],
+        topicQuery: [Single("event 2"), Single(mockAddress0->TopicFilter.fromAddress->EvmTypes.Hex.toString)],
       },
     ])
   })
@@ -827,29 +827,29 @@ describe("RpcSource - getSelectionConfig", () => {
         (MockIndexer.evmOnEventRegistration(
           ~id="1",
           ~isWildcard=true,
-          ~eventFilters=Static([
+          ~eventFilters=[
             {
               topic0: ["1"->EvmTypes.Hex.fromStringUnsafe],
-              topic1: ["a"->EvmTypes.Hex.fromStringUnsafe],
-              topic2: [],
-              topic3: [],
+              topic1: Values(["a"->EvmTypes.Hex.fromStringUnsafe]),
+              topic2: Values([]),
+              topic3: Values([]),
             },
-          ]),
+          ],
         ) :> Internal.onEventRegistration),
         (MockIndexer.evmOnEventRegistration(
           ~id="2",
           ~isWildcard=true,
-          ~eventFilters=Static([
+          ~eventFilters=[
             {
               topic0: ["2"->EvmTypes.Hex.fromStringUnsafe],
-              topic1: ["b"->EvmTypes.Hex.fromStringUnsafe],
-              topic2: [],
-              topic3: [],
+              topic1: Values(["b"->EvmTypes.Hex.fromStringUnsafe]),
+              topic2: Values([]),
+              topic3: Values([]),
             },
-          ]),
+          ],
         ) :> Internal.onEventRegistration),
       ],
-    }->RpcSource.getSelectionConfig(~chain)
+    }->RpcSource.getSelectionConfig
 
     t.expect(
       selectionConfig.getLogSelectionsOrThrow(~addressesByContractName=Dict.make()),
@@ -872,23 +872,23 @@ describe("RpcSource - getSelectionConfig", () => {
         (MockIndexer.evmOnEventRegistration(
           ~id="w",
           ~isWildcard=true,
-          ~eventFilters=Static([
+          ~eventFilters=[
             {
               topic0: ["w"->EvmTypes.Hex.fromStringUnsafe],
-              topic1: ["a"->EvmTypes.Hex.fromStringUnsafe],
-              topic2: [],
-              topic3: [],
+              topic1: Values(["a"->EvmTypes.Hex.fromStringUnsafe]),
+              topic2: Values([]),
+              topic3: Values([]),
             },
             {
               topic0: ["w"->EvmTypes.Hex.fromStringUnsafe],
-              topic1: [],
-              topic2: ["b"->EvmTypes.Hex.fromStringUnsafe],
-              topic3: [],
+              topic1: Values([]),
+              topic2: Values(["b"->EvmTypes.Hex.fromStringUnsafe]),
+              topic3: Values([]),
             },
-          ]),
+          ],
         ) :> Internal.onEventRegistration),
       ],
-    }->RpcSource.getSelectionConfig(~chain)
+    }->RpcSource.getSelectionConfig
 
     t.expect(
       selectionConfig.getLogSelectionsOrThrow(~addressesByContractName=Dict.make()),
@@ -909,7 +909,7 @@ describe("RpcSource - getSelectionConfig", () => {
       let _ = {
         dependsOnAddresses: true,
         onEventRegistrations: [],
-      }->RpcSource.getSelectionConfig(~chain)
+      }->RpcSource.getSelectionConfig
       JsError.throwWithMessage("Should have thrown")
     } catch {
     | Source.GetItemsError(UnsupportedSelection({message})) =>
@@ -927,7 +927,7 @@ describe("RpcSource - getSelectionConfig", () => {
         (MockIndexer.evmOnEventRegistration(~id="1") :> Internal.onEventRegistration),
         (MockIndexer.evmOnEventRegistration(~id="2", ~dependsOnAddresses=true) :> Internal.onEventRegistration),
       ],
-    }->RpcSource.getSelectionConfig(~chain)
+    }->RpcSource.getSelectionConfig
 
     t.expect(
       selectionConfig.getLogSelectionsOrThrow(
@@ -940,7 +940,7 @@ describe("RpcSource - getSelectionConfig", () => {
       },
       {
         addresses: Some([mockAddress0]),
-        topicQuery: [Single("2"), Single(mockAddress0->Address.toString)],
+        topicQuery: [Single("2"), Single(mockAddress0->TopicFilter.fromAddress->EvmTypes.Hex.toString)],
       },
     ])
   })
@@ -1569,24 +1569,24 @@ describe("RpcSource - getItemsOrThrow fans out multiple selections", () => {
       let eventConfig = MockIndexer.evmOnEventRegistration(
         // `id` must equal the router key derived at lookup — `sighash_topicCount`
         ~id=`${sighash}_1`,
-        ~eventFilters=Static([
+        ~eventFilters=[
           {
             topic0: [sighash->EvmTypes.Hex.fromStringUnsafe],
-            topic1: [
+            topic1: Values([
               "0x0000000000000000000000000000000000000000000000000000000000000001"->EvmTypes.Hex.fromStringUnsafe,
-            ],
-            topic2: [],
-            topic3: [],
+            ]),
+            topic2: Values([]),
+            topic3: Values([]),
           },
           {
             topic0: [sighash->EvmTypes.Hex.fromStringUnsafe],
-            topic1: [],
-            topic2: [
+            topic1: Values([]),
+            topic2: Values([
               "0x0000000000000000000000000000000000000000000000000000000000000002"->EvmTypes.Hex.fromStringUnsafe,
-            ],
-            topic3: [],
+            ]),
+            topic3: Values([]),
           },
-        ]),
+        ],
       )
 
       let logJson = JSON.Object(
@@ -1686,7 +1686,7 @@ describe("RpcSource - getItemsOrThrow with a skip-all event filter", () => {
       let eventConfig = MockIndexer.evmOnEventRegistration(
         ~id=`${sighash}_1`,
         ~isWildcard=true,
-        ~eventFilters=Static([]),
+        ~eventFilters=[],
       )
 
       // Echo the requested block number so `latestFetchedBlockNumber` reflects
@@ -1782,28 +1782,28 @@ describe("RpcSource - getItemsOrThrow scopes filters to each contract's addresse
       let eventA = MockIndexer.evmOnEventRegistration(
         ~contractName="ContractA",
         ~id=`${sighash}_1`,
-        ~eventFilters=Static([
+        ~eventFilters=[
           {
             topic0: [sighash->EvmTypes.Hex.fromStringUnsafe],
-            topic1: [filterTopic1->EvmTypes.Hex.fromStringUnsafe],
-            topic2: [],
-            topic3: [],
+            topic1: Values([filterTopic1->EvmTypes.Hex.fromStringUnsafe]),
+            topic2: Values([]),
+            topic3: Values([]),
           },
-        ]),
+        ],
       )
       // Unfiltered, but pin topic0 to the bare sighash (MockIndexer otherwise
       // derives it from `id`, which we set to the router key `sighash_1`).
       let eventB = MockIndexer.evmOnEventRegistration(
         ~contractName="ContractB",
         ~id=`${sighash}_1`,
-        ~eventFilters=Static([
+        ~eventFilters=[
           {
             topic0: [sighash->EvmTypes.Hex.fromStringUnsafe],
-            topic1: [],
-            topic2: [],
-            topic3: [],
+            topic1: Values([]),
+            topic2: Values([]),
+            topic3: Values([]),
           },
-        ]),
+        ],
       )
 
       // A log emitted by ContractA's address, carrying only topic0 (so it does

--- a/scenarios/test_codegen/test/SourceBlockHashes_test.res
+++ b/scenarios/test_codegen/test/SourceBlockHashes_test.res
@@ -58,15 +58,17 @@ let pairCreatedRegistration: Internal.evmOnEventRegistration = {
   startBlock: None,
   handler: None,
   contractRegister: None,
-  getEventFiltersOrThrow: _ =>
-    Static([
+  resolvedWhere: {
+    topicSelections: [
       {
         topic0: [pairCreatedTopic0->EvmTypes.Hex.fromStringUnsafe],
-        topic1: [],
-        topic2: [],
-        topic3: [],
+        topic1: Values([]),
+        topic2: Values([]),
+        topic3: Values([]),
       },
-    ]),
+    ],
+    startBlock: None,
+  },
 }
 
 // Match the on-chain ABI so the hypersync-client decoder doesn't raise

--- a/scenarios/test_codegen/test/__mocks__/MockConfig.res
+++ b/scenarios/test_codegen/test/__mocks__/MockConfig.res
@@ -18,7 +18,7 @@ let getEvmEventConfig = (~config=?, ~contractName, ~eventName, ~chainId=?) =>
   )
 
 // Build the per-(event, chain) registration from the event definition + the
-// registered handlers, mirroring `HandlerRegister.buildOnEventRegistrations`.
+// registered handlers, mirroring `HandlerRegister.finishRegistration`.
 // Handlers must have been registered (`HandlerLoader.registerAllHandlers`)
 // before calling.
 let getOnEventRegistration = (~config=?, ~contractName, ~eventName, ~chainId=?) => {

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -848,8 +848,10 @@ module Source = {
                                 Internal.contractRegister,
                               >
                             ),
-                            getEventFiltersOrThrow: _ =>
-                              JsError.throwWithMessage("Not implemented"),
+                            resolvedWhere: {
+                              topicSelections: [],
+                              startBlock: None,
+                            },
                           }: Internal.evmOnEventRegistration :> Internal.onEventRegistration),
                           chain,
                           blockNumber: item.blockNumber,
@@ -960,7 +962,7 @@ let evmOnEventRegistration = (
   ~dependsOnAddresses=?,
   ~filterByAddresses=false,
   ~startBlock: option<int>=?,
-  ~eventFilters: option<Internal.eventFilters>=?,
+  ~eventFilters: option<array<Internal.resolvedTopicSelection>>=?,
 ): Internal.evmOnEventRegistration => {
   let selectedTransactionFields =
     Utils.Set.fromArray(transactionFieldNames)->(
@@ -992,38 +994,25 @@ let evmOnEventRegistration = (
     startBlock,
     handler: None,
     contractRegister: None,
-    getEventFiltersOrThrow: _ =>
-      switch eventFilters {
-      | Some(eventFilters) => eventFilters
-      | None =>
-        switch dependsOnAddresses {
-        | Some(true) =>
-          Dynamic(
-            addresses => [
-              {
-                topic0: [
-                  // This is a sighash in the original code
-                  id->EvmTypes.Hex.fromStringUnsafe,
-                ],
-                topic1: addresses->Utils.magic,
-                topic2: [],
-                topic3: [],
-              },
+    resolvedWhere: {
+      topicSelections: switch eventFilters {
+      | Some(topicSelections) => topicSelections
+      | None => [
+          {
+            topic0: [
+              // This is a sighash in the original code
+              id->EvmTypes.Hex.fromStringUnsafe,
             ],
-          )
-        | _ =>
-          Static([
-            {
-              topic0: [
-                // This is a sighash in the original code
-                id->EvmTypes.Hex.fromStringUnsafe,
-              ],
-              topic1: [],
-              topic2: [],
-              topic3: [],
+            topic1: switch dependsOnAddresses {
+            | Some(true) => ContractAddresses({contractName: contractName})
+            | _ => Values([])
             },
-          ])
-        }
+            topic2: Values([]),
+            topic3: Values([]),
+          },
+        ]
       },
+      startBlock: None,
+    },
   }
 }

--- a/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
@@ -24,8 +24,8 @@ let makeReg = (~name, ~params): Internal.evmOnEventRegistration =>
     ~isWildcard=false,
     ~handler=None,
     ~contractRegister=None,
-    ~eventFilters=None,
-    ~probeChainId=1,
+    ~where=None,
+    ~chainId=1,
     ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
   )
 


### PR DESCRIPTION
## Summary

Refactors event filter registration to resolve `where` callbacks per-chain immediately when handlers are registered, rather than deferring resolution until chain startup. This enables duplicate registrations to be detected at the user's call site with proper error context, and simplifies the runtime architecture by eliminating deferred filter parsing.

## Key Changes

- **HandlerRegister**: Restructured registration lifecycle to incrementally build per-chain registrations as handlers are registered:
  - `pendingRegistrations` → `pendingChainRegistrations` (per-chain dict of event registrations + onBlock handlers)
  - New `syncOnEventRegistrations` resolves `where` callbacks for all configured chains immediately and validates against existing registrations
  - `buildOnEventRegistrationWith` extracted to accept pre-resolved `where` and other options, decoupling filter building from handler lookup
  - `startRegistration` now takes `Config.t` instead of `Ecosystem.t` to access chain definitions
  - Removed `buildOnEventRegistrations` (deferred per-chain resolution) — resolution now happens incrementally

- **LogSelection**: Renamed and refactored filter parsing:
  - `parseEventFiltersOrThrow` → `parseWhereOrThrow` (clearer intent)
  - Returns `parsedWhere` with `resolvedWhere` (topic selections + startBlock) instead of `parsedEventFilters`
  - Removed `getEventFiltersOrThrow` callback from registration — filters are now fully resolved at registration time
  - `materializeTopicSelections` added to expand `ContractAddresses` markers to concrete topic values when building queries

- **Internal**: Updated event registration types:
  - `onEventRegistration` now carries `resolvedWhere: resolvedWhere` (pre-resolved topic selections + startBlock)
  - New `topicFilter` type distinguishes static `Values` from `ContractAddresses` markers
  - Removed `getEventFiltersOrThrow` callback field

- **EventConfigBuilder**: Address values in topic filters are now lowercased before encoding to match lowercase hex topics from sources (handles mixed-case checksummed input)

- **RpcSource / HyperSyncSource**: Simplified to work with pre-resolved filters:
  - Removed dynamic filter resolution logic
  - `getSelectionConfig` no longer takes `chain` parameter
  - Directly materialize topic selections from `resolvedWhere`

- **Tests**: Updated to reflect new registration model:
  - New `HandlerRegisterLifecycle_test.res` covers per-chain immediate resolution and duplicate detection
  - `EventFilters_test.res` now accesses `resolvedWhere.topicSelections` directly
  - Mock helpers updated to use `resolvedWhere` structure

## Notable Implementation Details

- Duplicate registrations for the same event are now compared on the resolved `where` structure (topic selections + startBlock), not the callback reference. Two distinct callbacks that resolve to identical filters compose instead of throwing.
- Invalid `where` configurations (e.g., referencing non-existent indexed parameters) now throw at the user's registration call site with proper stack context, rather than during chain startup.
- `preRegistered` callbacks (registered before `startRegistration`) are replayed through the same `syncOnEventRegistrations` code path, ensuring consistent validation.
- The `ContractAddresses` marker in resolved filters allows sources to defer address expansion until query time, supporting dynamic address registration.

https://claude.ai/code/session_01Rr49Jzbmp6CSDnC75rBxkY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `where`-based event/block filtering with per-chain resolved topic selection.
  * Address-based filters now normalize mixed-case inputs consistently.

* **Bug Fixes**
  * Duplicate event handler registrations now dedupe based on the resolved `where` criteria.
  * EVM and Fuel block filter validation now rejects unknown `block` fields.
  * Block handler ranges that exceed a chain’s bounds are no longer rejected at registration.

* **Breaking Changes**
  * Handler registration APIs updated: `startRegistration` now takes full config; `registerOnBlock` now uses a `where` predicate plus a chain resolver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->