### PR TITLE
Add chunk headroom multiplier for budget-aware query sizing

### DIFF
--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -448,7 +448,12 @@ let blockAtProgress = (cs: t, ~progress) => {
 // maxTargetBlock set to the most-behind chain's progress mapped onto this
 // chain, so a chain with budget can't run further ahead than the chain the
 // whole pool is prioritizing.
-let getNextQuery = (cs: t, ~chainTargetItems: float, ~maxTargetBlock=?) => {
+let getNextQuery = (
+  cs: t,
+  ~chainTargetItems: float,
+  ~chunkItemsMultiplier=1.,
+  ~maxTargetBlock=?,
+) => {
   let chainTargetBlock = cs->targetBlock(~chainTargetItems)
   let chainTargetBlock = switch maxTargetBlock {
   | Some(maxTargetBlock) => Pervasives.min(chainTargetBlock, maxTargetBlock)
@@ -478,7 +483,11 @@ let getNextQuery = (cs: t, ~chainTargetItems: float, ~maxTargetBlock=?) => {
     // hold the whole pool while it takes its first measurements.
     Pervasives.min(chainTargetItems, 5_000. +. cs.pendingBudget)
   }
-  cs.fetchState->FetchState.getNextQuery(~chainTargetBlock, ~chainTargetItems)
+  cs.fetchState->FetchState.getNextQuery(
+    ~chainTargetBlock,
+    ~chainTargetItems,
+    ~chunkItemsMultiplier,
+  )
 }
 
 // Run a fetch tick for this chain against its sources, feeding the owned fetch

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -67,7 +67,12 @@ let isReadyToEnterReorgThreshold: t => bool
 let targetBlock: (t, ~chainTargetItems: float) => int
 let progressAtBlock: (t, ~blockNumber: int) => float
 let blockAtProgress: (t, ~progress: float) => int
-let getNextQuery: (t, ~chainTargetItems: float, ~maxTargetBlock: int=?) => FetchState.nextQuery
+let getNextQuery: (
+  t,
+  ~chainTargetItems: float,
+  ~chunkItemsMultiplier: float=?,
+  ~maxTargetBlock: int=?,
+) => FetchState.nextQuery
 let dispatch: (
   t,
   ~executeQuery: FetchState.query => promise<unit>,

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -217,6 +217,11 @@ let checkAndFetch = async (
     ),
   )
 
+  // Chunk reservations get headroom over the density estimate so a
+  // denser-than-expected range doesn't truncate at the server cap; realtime
+  // gets more since a forced catch-up query there costs a head-poll roundtrip.
+  let chunkItemsMultiplier = crossChainState.isRealtime ? 3. : 1.5
+
   let actionByChain = Dict.make()
   let maxProgress = ref(None)
   crossChainState
@@ -242,7 +247,11 @@ let checkAndFetch = async (
         None
       | Some(progress) => Some(cs->ChainState.blockAtProgress(~progress))
       }
-      switch cs->ChainState.getNextQuery(~chainTargetItems, ~maxTargetBlock?) {
+      switch cs->ChainState.getNextQuery(
+        ~chainTargetItems,
+        ~chunkItemsMultiplier,
+        ~maxTargetBlock?,
+      ) {
       | (WaitingForNewBlock | NothingToQuery) as action =>
         actionByChain->Utils.Dict.setByInt(chainId, action)
       | Ready(queries) => {

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1490,11 +1490,6 @@ type waterFillState = {
   p: partition,
   mutable cursor: int,
   mutable chunksUsedThisCall: int,
-  // Whether a water-fill round already emitted for this partition this call.
-  // The min-one-chunk force (emit a full chunk even past the allotment) is a
-  // progress guarantee, so it applies only to a partition's first emit — a
-  // later round's leftover re-pour must not force over-budget chunks.
-  mutable emittedThisCall: bool,
   // Existing mutPendingQueries count before this call — fixed for the call,
   // used with chunksUsedThisCall against maxPendingChunksPerPartition.
   pendingCount: int,
@@ -1668,7 +1663,6 @@ let getNextQuery = (
           p,
           cursor: cursor.contents,
           chunksUsedThisCall: chunksUsedThisCall.contents,
-          emittedThisCall: false,
           pendingCount,
           queryEndBlock,
           maybeChunkRange,
@@ -1727,8 +1721,8 @@ let getNextQuery = (
       switch (fs.maybeChunkRange, p->getTrustedDensity) {
       | (Some(minHistoryRange), Some(density)) if density > 0. =>
         // Chunking active: strict chunks with a hard endBlock, sized by real
-        // density with the chunk headroom multiplier — the partition's first
-        // emit this call gets one full chunk even if the budget falls short.
+        // density with the chunk headroom multiplier — at least one full
+        // chunk this round even if the allotment falls short.
         let chunkSize = Js.Math.ceil_int(minHistoryRange->Int.toFloat *. 1.8)
         let maxChunksRemaining =
           maxPendingChunksPerPartition - fs.pendingCount - fs.chunksUsedThisCall
@@ -1750,10 +1744,7 @@ let getNextQuery = (
             ->Math.ceil
             ->Float.toInt,
           )
-          if (
-            (!fs.emittedThisCall && consumed.contents == 0.) ||
-              consumed.contents +. itemsTarget->Int.toFloat <= budget
-          ) {
+          if consumed.contents == 0. || consumed.contents +. itemsTarget->Int.toFloat <= budget {
             fs.bucket->Array.push({
               partitionId: fs.partitionId,
               fromBlock: chunkFromBlock.contents,
@@ -1772,9 +1763,6 @@ let getNextQuery = (
         }
         fs.cursor = chunkFromBlock.contents
         fs.chunksUsedThisCall = fs.chunksUsedThisCall + created.contents
-        if created.contents > 0 {
-          fs.emittedThisCall = true
-        }
         consumed.contents
       | _ =>
         let itemsTarget = Pervasives.max(1, Math.round(budget)->Float.toInt)
@@ -1789,7 +1777,6 @@ let getNextQuery = (
         })
         fs.cursor = maxBlock + 1
         fs.chunksUsedThisCall = fs.chunksUsedThisCall + 1
-        fs.emittedThisCall = true
         itemsTarget->Int.toFloat
       }
     }
@@ -1801,11 +1788,13 @@ let getNextQuery = (
     // round. Allotments sum to exactly the poured budget, so the outcome is
     // order-independent and never exceeds it — the only overshoot left is the
     // min-one-chunk quantization in emitQueries, bounded by one chunk per
-    // partition per call (a partition's first emit only).
+    // partition per round.
     //
-    // No explicit round cap: a partition survives a round only by consuming
-    // fresh budget, so the not-filled set drains on its own and the loop also
-    // stops once the whole budget is poured.
+    // No explicit round cap: a partition survives a round only by advancing
+    // chunksUsedThisCall (capped at maxPendingChunksPerPartition) or by
+    // consuming fresh budget (every emit consumes at least 1), so the
+    // not-filled set drains on its own and the loop also stops once the whole
+    // budget is poured.
     let notFilledPartitions = ref(inRangeStates)
     let remainingBudget = ref(rangeItemsTarget)
     while notFilledPartitions.contents->Array.length > 0 && remainingBudget.contents > 0. {
@@ -1824,10 +1813,7 @@ let getNextQuery = (
           reservedByPartition->Dict.set(fs.partitionId, reserved +. consumed)
           remainingBudget := remainingBudget.contents -. consumed
 
-          // A zero-consumption emit means the allotment can't fit even one
-          // more chunk — re-pouring the same leftover at it would spin
-          // forever, so the partition is done for this call.
-          if consumed > 0. && fs->isInRange {
+          if fs->isInRange {
             next->Array.push(fs)->ignore
           }
         }

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -476,15 +476,21 @@ module OptimizedPartitions = {
         switch query.toBlock {
         | None => latestFetchedBlock.blockNumber < knownHeight - 10 // Don't update block range when very close to the head
         | Some(queryToBlock) =>
-          // Update on partial response (direct capacity evidence),
-          // or when the query's intended range covers at least the partition's
-          // current chunk range — meaning it was a capacity-based split chunk,
-          // not a small gap-fill whose toBlock is an artificial boundary.
-          latestFetchedBlock.blockNumber < queryToBlock ||
+          if latestFetchedBlock.blockNumber < queryToBlock {
+            // Partial response is direct capacity evidence — unless it was
+            // truncated by our own itemsTarget cap: that reflects the
+            // reservation we asked for, not what the server could return.
+            itemsCount < query.itemsTarget
+          } else {
+            // A full response updates only when the query's intended range
+            // covers at least the partition's current chunk range — meaning it
+            // was a capacity-based split chunk, not a small gap-fill whose
+            // toBlock is an artificial boundary.
             switch getMinHistoryRange(p) {
             | None => false // Chunking not active yet, don't update
             | Some(minHistoryRange) => queryToBlock - query.fromBlock + 1 >= minHistoryRange
             }
+          }
         }
     let updatedPrevQueryRange = shouldUpdateBlockRange ? blockRange : p.prevQueryRange
     let updatedPrevPrevQueryRange = shouldUpdateBlockRange ? p.prevQueryRange : p.prevPrevQueryRange
@@ -1377,6 +1383,7 @@ let pushGapFillQueries = (
   ~maxChunks: int,
   ~partition: partition,
   ~partitionBudget: float,
+  ~chunkItemsMultiplier: float,
   ~selection: selection,
   ~addressesByContractName: dict<array<Address.t>>,
 ) => {
@@ -1419,7 +1426,7 @@ let pushGapFillQueries = (
           ) {
             let chunkToBlock = chunkFromBlock.contents + chunkSize - 1
             let itemsTarget = densityItemsTarget(
-              ~density,
+              ~density=density *. chunkItemsMultiplier,
               ~fromBlock=chunkFromBlock.contents,
               ~toBlock=Some(chunkToBlock),
               ~chainTargetBlock,
@@ -1439,9 +1446,10 @@ let pushGapFillQueries = (
           }
         } else {
           // Not enough room for 2 chunks, fall back to a single query
-          pushSingleQuery(~density, ~isChunk=rangeEndBlock !== None)
+          pushSingleQuery(~density=density *. chunkItemsMultiplier, ~isChunk=rangeEndBlock !== None)
         }
-      | (Some(density), _) => pushSingleQuery(~density, ~isChunk=false)
+      | (Some(density), _) =>
+        pushSingleQuery(~density=density *. chunkItemsMultiplier, ~isChunk=false)
       | (None, _) =>
         let remainingRange = Pervasives.max(1, chainTargetBlock - rangeFromBlock + 1)
         pushSingleQuery(~density=partitionBudget /. remainingRange->Int.toFloat, ~isChunk=false)
@@ -1482,6 +1490,11 @@ type waterFillState = {
   p: partition,
   mutable cursor: int,
   mutable chunksUsedThisCall: int,
+  // Whether a water-fill round already emitted for this partition this call.
+  // The min-one-chunk force (emit a full chunk even past the allotment) is a
+  // progress guarantee, so it applies only to a partition's first emit — a
+  // later round's leftover re-pour must not force over-budget chunks.
+  mutable emittedThisCall: bool,
   // Existing mutPendingQueries count before this call — fixed for the call,
   // used with chunksUsedThisCall against maxPendingChunksPerPartition.
   pendingCount: int,
@@ -1523,6 +1536,7 @@ let getNextQuery = (
   {optimizedPartitions, blockLag, latestOnBlockBlockNumber, knownHeight, endBlock}: t,
   ~chainTargetBlock: int,
   ~chainTargetItems: float,
+  ~chunkItemsMultiplier: float=1.,
 ) => {
   let headBlockNumber = knownHeight - blockLag
   if headBlockNumber <= 0 {
@@ -1630,6 +1644,7 @@ let getNextQuery = (
             ~maxChunks=maxPendingChunksPerPartition - pendingCount - chunksUsedThisCall.contents,
             ~partition=p,
             ~partitionBudget=chainTargetItems /. partitionsCount->Int.toFloat,
+            ~chunkItemsMultiplier,
             ~selection=p.selection,
             ~addressesByContractName=p.addressesByContractName,
           )
@@ -1653,6 +1668,7 @@ let getNextQuery = (
           p,
           cursor: cursor.contents,
           chunksUsedThisCall: chunksUsedThisCall.contents,
+          emittedThisCall: false,
           pendingCount,
           queryEndBlock,
           maybeChunkRange,
@@ -1710,41 +1726,55 @@ let getNextQuery = (
       }
       switch (fs.maybeChunkRange, p->getTrustedDensity) {
       | (Some(minHistoryRange), Some(density)) if density > 0. =>
-        // Chunking active: strict chunks with a hard endBlock, uncapped real
-        // density — at least one full chunk this round even if budget falls
-        // short.
+        // Chunking active: strict chunks with a hard endBlock, sized by real
+        // density with the chunk headroom multiplier — the partition's first
+        // emit this call gets one full chunk even if the budget falls short.
         let chunkSize = Js.Math.ceil_int(minHistoryRange->Int.toFloat *. 1.8)
-        let chunkCost = density *. chunkSize->Int.toFloat
         let maxChunksRemaining =
           maxPendingChunksPerPartition - fs.pendingCount - fs.chunksUsedThisCall
-        let affordable = Math.floor(budget /. chunkCost)->Float.toInt
-        let numChunks = Pervasives.max(1, Pervasives.min(affordable, maxChunksRemaining))
         let consumed = ref(0.)
         let created = ref(0)
         let chunkFromBlock = ref(fs.cursor)
-        while created.contents < numChunks && chunkFromBlock.contents <= maxBlock {
+        let budgetLeft = ref(true)
+        while (
+          budgetLeft.contents &&
+          created.contents < maxChunksRemaining &&
+          chunkFromBlock.contents <= maxBlock
+        ) {
           let chunkToBlock = Pervasives.min(chunkFromBlock.contents + chunkSize - 1, maxBlock)
           let itemsTarget = Pervasives.max(
             1,
-            (density *. (chunkToBlock - chunkFromBlock.contents + 1)->Int.toFloat)
+            (density *.
+            (chunkToBlock - chunkFromBlock.contents + 1)->Int.toFloat *.
+            chunkItemsMultiplier)
             ->Math.ceil
             ->Float.toInt,
           )
-          fs.bucket->Array.push({
-            partitionId: fs.partitionId,
-            fromBlock: chunkFromBlock.contents,
-            toBlock: Some(chunkToBlock),
-            isChunk: true,
-            selection: p.selection,
-            itemsTarget,
-            addressesByContractName: p.addressesByContractName,
-          })
-          consumed := consumed.contents +. itemsTarget->Int.toFloat
-          chunkFromBlock := chunkToBlock + 1
-          created := created.contents + 1
+          if (
+            (!fs.emittedThisCall && consumed.contents == 0.) ||
+              consumed.contents +. itemsTarget->Int.toFloat <= budget
+          ) {
+            fs.bucket->Array.push({
+              partitionId: fs.partitionId,
+              fromBlock: chunkFromBlock.contents,
+              toBlock: Some(chunkToBlock),
+              isChunk: true,
+              selection: p.selection,
+              itemsTarget,
+              addressesByContractName: p.addressesByContractName,
+            })
+            consumed := consumed.contents +. itemsTarget->Int.toFloat
+            chunkFromBlock := chunkToBlock + 1
+            created := created.contents + 1
+          } else {
+            budgetLeft := false
+          }
         }
         fs.cursor = chunkFromBlock.contents
         fs.chunksUsedThisCall = fs.chunksUsedThisCall + created.contents
+        if created.contents > 0 {
+          fs.emittedThisCall = true
+        }
         consumed.contents
       | _ =>
         let itemsTarget = Pervasives.max(1, Math.round(budget)->Float.toInt)
@@ -1759,6 +1789,7 @@ let getNextQuery = (
         })
         fs.cursor = maxBlock + 1
         fs.chunksUsedThisCall = fs.chunksUsedThisCall + 1
+        fs.emittedThisCall = true
         itemsTarget->Int.toFloat
       }
     }
@@ -1770,13 +1801,11 @@ let getNextQuery = (
     // round. Allotments sum to exactly the poured budget, so the outcome is
     // order-independent and never exceeds it — the only overshoot left is the
     // min-one-chunk quantization in emitQueries, bounded by one chunk per
-    // partition per round.
+    // partition per call (a partition's first emit only).
     //
-    // No explicit round cap: a partition survives a round only by advancing
-    // chunksUsedThisCall (capped at maxPendingChunksPerPartition) or by
-    // consuming fresh budget (every emit consumes at least 1), so the
-    // not-filled set drains on its own and the loop also stops once the whole
-    // budget is poured.
+    // No explicit round cap: a partition survives a round only by consuming
+    // fresh budget, so the not-filled set drains on its own and the loop also
+    // stops once the whole budget is poured.
     let notFilledPartitions = ref(inRangeStates)
     let remainingBudget = ref(rangeItemsTarget)
     while notFilledPartitions.contents->Array.length > 0 && remainingBudget.contents > 0. {
@@ -1794,7 +1823,11 @@ let getNextQuery = (
           let consumed = emitQueries(fs, ~budget)
           reservedByPartition->Dict.set(fs.partitionId, reserved +. consumed)
           remainingBudget := remainingBudget.contents -. consumed
-          if fs->isInRange {
+
+          // A zero-consumption emit means the allotment can't fit even one
+          // more chunk — re-pouring the same leftover at it would spin
+          // forever, so the partition is done for this call.
+          if consumed > 0. && fs->isInRange {
             next->Array.push(fs)->ignore
           }
         }

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -252,14 +252,14 @@ describe("CrossChainState fetch control", () => {
     t.expect(dispatched).toEqual([(1, 1)])
   })
 
-  Async.it(
-    "checkAndFetch's waterfall lets the furthest-behind chain drain only what it can use, flowing the remainder to the next chain",
-    async t => {
-      // Chain 1 (furthest behind, so priorityOrder visits it first): a single
-      // known-density partition with a short remaining range (endBlock=20 at
-      // density 10 items/block -> 200 items total across 2 chunks). Its real
-      // consumption is capped by that range, far below whatever share of the
-      // 3000-item pool the waterfall would otherwise hand it.
+  // Chain 1 (furthest behind, so priorityOrder visits it first): a single
+  // known-density partition with a short remaining range (endBlock=20 at
+  // density 10 items/block -> 200 items across 2 chunks, reserved at the
+  // chunk headroom multiplier: 1.5x backfill, 3x realtime). Its real
+  // consumption is capped by that range, far below whatever share of the
+  // 3000-item pool the waterfall would otherwise hand it. Returns each
+  // chain's dispatched itemsTarget total and pendingBudget.
+  let runShortRangeWaterfall = async (~isRealtime) => {
       let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
       let address1 = "0x1111111111111111111111111111111111111111"->Address.unsafeFromString
       let partition1: FetchState.partition = {
@@ -327,7 +327,7 @@ describe("CrossChainState fetch control", () => {
       // directly reflects what chain 1 left behind.
       let b = makeFetchingChainState(~chainId=2, ~knownHeight=1000, ~latestFetchedBlock=500)
 
-      let cm = makeCrossChainState(~chainStatesList=[a, b], ~targetBufferSize=3000)
+      let cm = makeCrossChainState(~chainStatesList=[a, b], ~isRealtime, ~targetBufferSize=3000)
 
       let dispatchedItemsByChain = Dict.make()
       await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
@@ -342,20 +342,30 @@ describe("CrossChainState fetch control", () => {
         Promise.resolve()
       })
 
-      t.expect(
-        (
-          dispatchedItemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(1),
-          dispatchedItemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(2),
-        ),
-        ~message="Chain 1's real range caps it at 200 regardless of its share of the 3000-item pool; chain 2 gets the rest",
-      ).toEqual((Some(200.), Some(2800.)))
+      (
+        dispatchedItemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(1),
+        dispatchedItemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(2),
+        a->ChainState.pendingBudget,
+        b->ChainState.pendingBudget,
+      )
+  }
 
+  Async.it(
+    "checkAndFetch's waterfall lets the furthest-behind chain drain only what it can use, flowing the remainder to the next chain",
+    async t => {
       t.expect(
-        (a->ChainState.pendingBudget, b->ChainState.pendingBudget),
-        ~message="Each chain's pendingBudget reflects exactly what it was just dispatched",
-      ).toEqual((200., 2800.))
+        await runShortRangeWaterfall(~isRealtime=false),
+        ~message="Chain 1's real range caps it at 300 (200 items at 1.5x chunk headroom) regardless of its share of the 3000-item pool; chain 2 gets the rest, and each chain's pendingBudget reflects exactly what it was just dispatched",
+      ).toEqual((Some(300.), Some(2700.), 300., 2700.))
     },
   )
+
+  Async.it("checkAndFetch reserves chunks with 3x headroom under realtime", async t => {
+    t.expect(
+      await runShortRangeWaterfall(~isRealtime=true),
+      ~message="Chain 1's 200-item range is reserved at 3x = 600; chain 2 gets the rest",
+    ).toEqual((Some(600.), Some(2400.), 600., 2400.))
+  })
 
   Async.it(
     "checkAndFetch skips a chain with no known height without claiming leadership or budget",

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -4268,10 +4268,10 @@ describe("FetchState.getNextQuery water-fill with uneven in-flight reservations"
     }
 
     // Fresh budget = 2000 - 1500 reserved = 500. Level = 500 (partition "1"
-    // sits above it). Partition "0": 2 chunks fit the 500 budget; the 140-item
-    // leftover can't fit a third chunk and doesn't force one — far from the
-    // reservation-inflated mean.
-    t.expect(byPartition).toEqual(Dict.fromArray([("0", [(1, 180), (19, 180)])]))
+    // sits above it). Partition "0": 2 chunks fit the 500 budget + 1 forced
+    // chunk for the 140-item leftover — the only overshoot is the
+    // min-one-chunk quantization, not the reservation-inflated mean.
+    t.expect(byPartition).toEqual(Dict.fromArray([("0", [(1, 180), (19, 180), (37, 180)])]))
   })
 
   it("sizes an unknown-density probe to the whole leftover instead of a diluted even split", t => {
@@ -4359,24 +4359,24 @@ describe("FetchState.getNextQuery chunk headroom and budget-driven emit", () => 
 
   it("sizes chunk itemsTarget with the chunk headroom multiplier", t => {
     t.expect({
-      "backfill1_5x": makeFetchState()->getChunks(~chainTargetItems=1000., ~chunkItemsMultiplier=1.5),
-      "realtime3x": makeFetchState()->getChunks(~chainTargetItems=1000., ~chunkItemsMultiplier=3.),
+      "backfill1_5x": makeFetchState()->getChunks(~chainTargetItems=270., ~chunkItemsMultiplier=1.5),
+      "realtime3x": makeFetchState()->getChunks(~chainTargetItems=270., ~chunkItemsMultiplier=3.),
     }).toEqual({
-      // ceil(1.5 * 10 * 18) = 270 per chunk: 3 fit the 1000 budget.
-      "backfill1_5x": [(1, 270), (19, 270), (37, 270)],
-      // ceil(3 * 10 * 18) = 540 per chunk: the second one doesn't fit.
+      // ceil(1.5 * 10 * 18) = 270 per chunk.
+      "backfill1_5x": [(1, 270)],
+      // ceil(3 * 10 * 18) = 540 per chunk.
       "realtime3x": [(1, 540)],
     })
   })
 
-  it("emits chunks while the budget lasts, first chunk always full-size", t => {
+  it("emits chunks while the budget lasts, min one chunk per water-fill round", t => {
     t.expect({
       "budget400": makeFetchState()->getChunks(~chainTargetItems=400.),
       "budget50": makeFetchState()->getChunks(~chainTargetItems=50.),
     }).toEqual({
-      // 180 + 180 = 360 <= 400; a third chunk would exceed the budget and the
-      // 40-item leftover doesn't force one.
-      "budget400": [(1, 180), (19, 180)],
+      // 180 + 180 = 360 <= 400 in the first round; the 40-item leftover
+      // re-pours and forces one more full chunk, so no budget strands.
+      "budget400": [(1, 180), (19, 180), (37, 180)],
       // The first chunk emits full-size regardless of budget (overshoot allowed).
       "budget50": [(1, 180)],
     })

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -4268,12 +4268,10 @@ describe("FetchState.getNextQuery water-fill with uneven in-flight reservations"
     }
 
     // Fresh budget = 2000 - 1500 reserved = 500. Level = 500 (partition "1"
-    // sits above it). Partition "0": 2 affordable chunks + 1 forced chunk for
-    // the 140-item leftover — the only overshoot is the min-one-chunk
-    // quantization, not the reservation-inflated mean.
-    t.expect(byPartition).toEqual(
-      Dict.fromArray([("0", [(1, 180), (19, 180), (37, 180)])]),
-    )
+    // sits above it). Partition "0": 2 chunks fit the 500 budget; the 140-item
+    // leftover can't fit a third chunk and doesn't force one — far from the
+    // reservation-inflated mean.
+    t.expect(byPartition).toEqual(Dict.fromArray([("0", [(1, 180), (19, 180)])]))
   })
 
   it("sizes an unknown-density probe to the whole leftover instead of a diluted even split", t => {
@@ -4305,5 +4303,164 @@ describe("FetchState.getNextQuery water-fill with uneven in-flight reservations"
         },
       ]),
     )
+  })
+})
+
+describe("FetchState.getNextQuery chunk headroom and budget-driven emit", () => {
+  // Single partition with density 10 items/block and chunk history 10 ->
+  // chunkSize = ceil(10 * 1.8) = 18, so a chunk costs 180 items at multiplier
+  // 1, 270 at the 1.5x backfill headroom, 540 at the 3x realtime headroom.
+  let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
+
+  let makeFetchState = (): FetchState.t => {
+    optimizedPartitions: FetchState.OptimizedPartitions.make(
+      ~partitions=[
+        {
+          id: "0",
+          latestFetchedBlock: {blockNumber: 0, blockTimestamp: 0},
+          selection: normalSelection,
+          addressesByContractName: Dict.fromArray([("MockContract", [mockAddress0])]),
+          mergeBlock: None,
+          dynamicContract: None,
+          mutPendingQueries: [],
+          prevQueryRange: 10,
+          prevPrevQueryRange: 10,
+          prevRangeSize: 100, // density = 100 / 10 = 10 items/block
+          latestBlockRangeUpdateBlock: 0,
+        },
+      ],
+      ~maxAddrInPartition=2,
+      ~nextPartitionIndex=1,
+      ~dynamicContracts=Utils.Set.make(),
+    ),
+    startBlock: 0,
+    endBlock: None,
+    buffer: [],
+    normalSelection,
+    latestOnBlockBlockNumber: 0,
+    maxOnBlockBufferSize: 10000,
+    chainId,
+    contractConfigs: Dict.make(),
+    blockLag: 0,
+    onBlockRegistrations: [],
+    knownHeight: 100000,
+    firstEventBlock: Some(0),
+  }
+
+  let getChunks = (fetchState: FetchState.t, ~chainTargetItems, ~chunkItemsMultiplier=?) =>
+    switch fetchState->FetchState.getNextQuery(
+      ~chainTargetBlock=100000,
+      ~chainTargetItems,
+      ~chunkItemsMultiplier?,
+    ) {
+    | Ready(queries) => queries->Array.map((q: FetchState.query) => (q.fromBlock, q.itemsTarget))
+    | _ => []
+    }
+
+  it("sizes chunk itemsTarget with the chunk headroom multiplier", t => {
+    t.expect({
+      "backfill1_5x": makeFetchState()->getChunks(~chainTargetItems=1000., ~chunkItemsMultiplier=1.5),
+      "realtime3x": makeFetchState()->getChunks(~chainTargetItems=1000., ~chunkItemsMultiplier=3.),
+    }).toEqual({
+      // ceil(1.5 * 10 * 18) = 270 per chunk: 3 fit the 1000 budget.
+      "backfill1_5x": [(1, 270), (19, 270), (37, 270)],
+      // ceil(3 * 10 * 18) = 540 per chunk: the second one doesn't fit.
+      "realtime3x": [(1, 540)],
+    })
+  })
+
+  it("emits chunks while the budget lasts, first chunk always full-size", t => {
+    t.expect({
+      "budget400": makeFetchState()->getChunks(~chainTargetItems=400.),
+      "budget50": makeFetchState()->getChunks(~chainTargetItems=50.),
+    }).toEqual({
+      // 180 + 180 = 360 <= 400; a third chunk would exceed the budget and the
+      // 40-item leftover doesn't force one.
+      "budget400": [(1, 180), (19, 180)],
+      // The first chunk emits full-size regardless of budget (overshoot allowed).
+      "budget50": [(1, 180)],
+    })
+  })
+})
+
+describe("Cap-hit truncation does not update chunk history", () => {
+  // Chunk history 300 with a pending chunk truncated at block 90: when the
+  // truncation was caused by our own itemsTarget cap it says nothing about
+  // server capacity, so the 300 history must survive. A sub-cap partial is
+  // real capacity evidence and shrinks it to 90.
+  let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
+  let addressesByContractName = Dict.fromArray([("MockContract", [mockAddress0])])
+
+  let makeFetchState = (): FetchState.t => {
+    optimizedPartitions: FetchState.OptimizedPartitions.make(
+      ~partitions=[
+        {
+          id: "0",
+          latestFetchedBlock: {blockNumber: 0, blockTimestamp: 0},
+          selection: normalSelection,
+          addressesByContractName,
+          mergeBlock: None,
+          dynamicContract: None,
+          mutPendingQueries: [],
+          prevQueryRange: 300,
+          prevPrevQueryRange: 300,
+          prevRangeSize: 300,
+          latestBlockRangeUpdateBlock: 0,
+        },
+      ],
+      ~maxAddrInPartition=2,
+      ~nextPartitionIndex=1,
+      ~dynamicContracts=Utils.Set.make(),
+    ),
+    startBlock: 0,
+    endBlock: None,
+    buffer: [],
+    normalSelection,
+    latestOnBlockBlockNumber: 0,
+    maxOnBlockBufferSize: 10000,
+    chainId,
+    contractConfigs: Dict.make(),
+    blockLag: 0,
+    onBlockRegistrations: [],
+    knownHeight: 100000,
+    firstEventBlock: Some(0),
+  }
+
+  let chunkQuery: FetchState.query = {
+    partitionId: "0",
+    fromBlock: 1,
+    toBlock: Some(540),
+    isChunk: true,
+    itemsTarget: 3,
+    selection: normalSelection,
+    addressesByContractName,
+  }
+
+  let runPartialResponse = (~itemsCount) => {
+    let (_, indexingAddresses) = makeInitial()
+    let fetchState = makeFetchState()
+    fetchState->FetchState.startFetchingQueries(~queries=[chunkQuery])
+    let updated =
+      fetchState->FetchState.handleQueryResult(
+        ~indexingAddresses,
+        ~query=chunkQuery,
+        ~latestFetchedBlock={blockNumber: 90, blockTimestamp: 90 * 15},
+        ~newItems=Array.fromInitializer(~length=itemsCount, i =>
+          mockEvent(~blockNumber=10, ~logIndex=i)
+        ),
+      )
+    updated.optimizedPartitions.entities
+    ->Dict.getUnsafe("0")
+    ->FetchState.getMinHistoryRange
+  }
+
+  it("keeps history on a cap-hit partial and updates it on a sub-cap partial", t => {
+    t.expect({
+      "capHit": runPartialResponse(~itemsCount=3),
+      "subCap": runPartialResponse(~itemsCount=2),
+    }).toEqual({
+      "capHit": Some(300),
+      "subCap": Some(90),
+    })
   })
 })


### PR DESCRIPTION
## Summary

Introduces a configurable `chunkItemsMultiplier` parameter to size chunk queries with headroom above the density estimate. This prevents truncation at server capacity limits when actual event density exceeds expectations, with different multipliers for backfill (1.5x) and realtime (3x) modes.

## Key Changes

- **FetchState**: 
  - Added `chunkItemsMultiplier` parameter to `getNextQuery` and `pushGapFillQueries`, applied to density calculations when sizing chunks
  - Changed chunk emission logic from pre-calculating affordable chunks to emitting chunks while budget lasts, guaranteeing at least one full chunk per round
  - Fixed chunk history update logic to distinguish between cap-hit truncations (don't update history) and sub-cap partials (update history as capacity evidence)

- **ChainState**: 
  - Threaded `chunkItemsMultiplier` parameter through `getNextQuery` to FetchState

- **CrossChainState**: 
  - Computed `chunkItemsMultiplier` based on `isRealtime` flag (3.0 for realtime, 1.5 for backfill)
  - Passed multiplier to ChainState's `getNextQuery`

- **Tests**: 
  - Added comprehensive test suite for chunk headroom and budget-driven emission behavior
  - Added test suite for cap-hit truncation not updating chunk history
  - Updated existing waterfall test to verify chunk reservation with headroom multipliers in both backfill and realtime modes

## Implementation Details

The chunk sizing now applies the multiplier to the density estimate: `density * chunkItemsMultiplier`. This increases the `itemsTarget` for each chunk, creating a buffer against denser-than-expected ranges. The budget-aware emission loop ensures at least one chunk is always emitted (even if it overshoots the budget) but stops adding chunks once the budget is exhausted, preventing budget stranding while respecting capacity constraints.

https://claude.ai/code/session_01KpFcYPn8UbQfaEfW6gjant