### PR TITLE
Implement cold-chain targeting and density-aware query sizing

### DIFF
--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -23,9 +23,6 @@ type t = {
   // then smoothed with an EMA on every batch (see applyBatchProgress). None
   // until the chain has processed at least one event.
   mutable chainDensity: option<float>,
-  // A chain with no density signal targets frontier + coldTargetRange;
-  // whenever it has no pending queries and still no signal, the range doubles.
-  mutable coldTargetRange: int,
   mutable reorgDetection: ReorgDetection.t,
   mutable safeCheckpointTracking: option<SafeCheckpointTracking.t>,
   // Holds this chain's transactions (kept in Rust) keyed by (blockNumber,
@@ -96,7 +93,6 @@ let make = (
   numEventsProcessed,
   pendingBudget: 0.,
   chainDensity,
-  coldTargetRange: 20_000,
   reorgDetection,
   safeCheckpointTracking,
   transactionStore,
@@ -422,6 +418,10 @@ let effectiveDensity = (cs: t) =>
   | (None, None) => None
   }
 
+// How far past the frontier a chain with no density signal targets while it
+// takes its first measurements.
+let coldTargetRange = 20_000
+
 // This chain's share of the indexer-wide buffer budget turned into a soft
 // target block: via density, or frontier + coldTargetRange when there's no
 // density signal yet.
@@ -435,7 +435,7 @@ let targetBlock = (cs: t, ~chainTargetItems: float) => {
       fetchCeiling,
       bufferBlockNumber + Math.ceil(chainTargetItems /. density)->Float.toInt,
     )
-  | _ => Pervasives.min(bufferBlockNumber + cs.coldTargetRange, fetchCeiling)
+  | _ => Pervasives.min(bufferBlockNumber + coldTargetRange, fetchCeiling)
   }
 }
 
@@ -477,19 +477,6 @@ let blockAtProgress = (cs: t, ~progress) => {
 // chain, so a chain with budget can't run further ahead than the chain the
 // whole pool is prioritizing.
 let getNextQuery = (cs: t, ~chainTargetItems: float, ~maxTargetBlock=?) => {
-  // A cold chain that went idle (queries all resolved) without producing a
-  // density signal found nothing in its window — widen it so the next probe
-  // covers more ground per round trip. Ignored once a signal exists; no reset.
-  if cs->effectiveDensity === None {
-    let fetchState = cs.fetchState
-    let frontier = fetchState->FetchState.bufferBlockNumber
-    if frontier >= fetchState.startBlock && !(fetchState->FetchState.hasPendingQueries) {
-      cs.coldTargetRange = Pervasives.min(
-        cs.coldTargetRange * 2,
-        Pervasives.max(cs->fetchCeiling - frontier, 1),
-      )
-    }
-  }
   let chainTargetBlock = cs->targetBlock(~chainTargetItems)
   let chainTargetBlock = switch maxTargetBlock {
   | Some(maxTargetBlock) => Pervasives.min(chainTargetBlock, maxTargetBlock)

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -13,6 +13,11 @@ type t = {
   mutable isProgressAtHead: bool,
   mutable timestampCaughtUpToHeadOrEndblock: option<Date.t>,
   mutable committedProgressBlockNumber: int,
+  // Progress of the batch currently being processed. The buffer is consumed at
+  // batch creation (see advanceAfterBatch), so this runs ahead of
+  // committedProgressBlockNumber until the batch commits — it's the true lower
+  // boundary of the remaining buffer's block span.
+  mutable processingBlockNumber: int,
   mutable numEventsProcessed: float,
   // Running sum of in-flight queries' itemsTarget, kept here so the
   // scheduler doesn't re-sum pending queries on every tick. Incremented when
@@ -90,6 +95,7 @@ let make = (
   isProgressAtHead,
   timestampCaughtUpToHeadOrEndblock,
   committedProgressBlockNumber,
+  processingBlockNumber: committedProgressBlockNumber,
   numEventsProcessed,
   pendingBudget: 0.,
   chainDensity,
@@ -399,7 +405,7 @@ let fetchCeiling = (cs: t) => {
 // batches commit.
 let readyBufferDensity = (cs: t) => {
   let readyCount = cs.fetchState->FetchState.bufferReadyCount
-  let span = cs.fetchState->FetchState.bufferBlockNumber - cs.committedProgressBlockNumber
+  let span = cs.fetchState->FetchState.bufferBlockNumber - cs.processingBlockNumber
   if readyCount > 0 && span > 0 {
     Some(readyCount->Int.toFloat /. span->Int.toFloat)
   } else {
@@ -881,6 +887,10 @@ let advanceAfterBatch = (cs: t, ~batch: Batch.t, ~enteringReorgThreshold) =>
     cs.fetchState = enteringReorgThreshold
       ? chainAfterBatch.fetchState->FetchState.updateInternal(~blockLag=cs.chainConfig.blockLag)
       : chainAfterBatch.fetchState
+
+    // The batch's items just left the buffer, so the remaining buffer's span
+    // starts at the batch's progress.
+    cs.processingBlockNumber = chainAfterBatch.progressBlockNumber
   | None => ()
   }
 
@@ -967,6 +977,13 @@ let applyBatchProgress = (cs: t, ~batch: Batch.t, ~blockTimestampName: string) =
       }
 
       cs.committedProgressBlockNumber = chainAfterBatch.progressBlockNumber
+
+      // Normally already set by advanceAfterBatch at batch creation; catch up
+      // here for paths that commit progress without it.
+      cs.processingBlockNumber = Pervasives.max(
+        cs.processingBlockNumber,
+        chainAfterBatch.progressBlockNumber,
+      )
       cs.numEventsProcessed = chainAfterBatch.totalEventsProcessed
       // Processed blocks' transactions and blocks are no longer needed.
       cs.transactionStore->TransactionStore.prune(chainAfterBatch.progressBlockNumber)
@@ -1051,6 +1068,7 @@ let rollback = (
     cs.transactionStore->TransactionStore.rollback(newProgressBlockNumber)
     cs.blockStore->BlockStore.rollback(newProgressBlockNumber)
     cs.committedProgressBlockNumber = newProgressBlockNumber
+    cs.processingBlockNumber = newProgressBlockNumber
     cs.numEventsProcessed = newTotalEventsProcessed
   | None =>
     if isReorgChain {
@@ -1069,6 +1087,7 @@ let rollback = (
         cs.committedProgressBlockNumber,
         rollbackTargetBlockNumber,
       )
+      cs.processingBlockNumber = Pervasives.min(cs.processingBlockNumber, rollbackTargetBlockNumber)
     }
   }
 }

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -23,6 +23,9 @@ type t = {
   // then smoothed with an EMA on every batch (see applyBatchProgress). None
   // until the chain has processed at least one event.
   mutable chainDensity: option<float>,
+  // A chain with no density signal targets frontier + coldTargetRange;
+  // whenever it has no pending queries and still no signal, the range doubles.
+  mutable coldTargetRange: int,
   mutable reorgDetection: ReorgDetection.t,
   mutable safeCheckpointTracking: option<SafeCheckpointTracking.t>,
   // Holds this chain's transactions (kept in Rust) keyed by (blockNumber,
@@ -93,6 +96,7 @@ let make = (
   numEventsProcessed,
   pendingBudget: 0.,
   chainDensity,
+  coldTargetRange: 20_000,
   reorgDetection,
   safeCheckpointTracking,
   transactionStore,
@@ -394,20 +398,44 @@ let fetchCeiling = (cs: t) => {
   }
 }
 
+// Events/block over the ready part of the buffer — a live signal that reacts
+// to what fetching just found, unlike the processing EMA which only moves as
+// batches commit.
+let readyBufferDensity = (cs: t) => {
+  let readyCount = cs.fetchState->FetchState.bufferReadyCount
+  let span = cs.fetchState->FetchState.bufferBlockNumber - cs.committedProgressBlockNumber
+  if readyCount > 0 && span > 0 {
+    Some(readyCount->Int.toFloat /. span->Int.toFloat)
+  } else {
+    None
+  }
+}
+
+// Density used for query sizing: the higher of the processing EMA and the
+// ready-buffer density, so a stale-low EMA can't undersize queries while the
+// buffer proves the range is dense. None means the chain is cold — no density
+// signal at all.
+let effectiveDensity = (cs: t) =>
+  switch (cs.chainDensity, cs->readyBufferDensity) {
+  | (Some(ema), Some(buffer)) => Some(Pervasives.max(ema, buffer))
+  | (Some(_) as density, None) | (None, Some(_) as density) => density
+  | (None, None) => None
+  }
+
 // This chain's share of the indexer-wide buffer budget turned into a soft
-// target block: via chain density, or the fetch ceiling when density isn't
-// known yet.
+// target block: via density, or frontier + coldTargetRange when there's no
+// density signal yet.
 let targetBlock = (cs: t, ~chainTargetItems: float) => {
   let fetchState = cs.fetchState
   let fetchCeiling = cs->fetchCeiling
   let bufferBlockNumber = fetchState->FetchState.bufferBlockNumber
-  switch cs.chainDensity {
+  switch cs->effectiveDensity {
   | Some(density) if density > 0. =>
     Pervasives.min(
       fetchCeiling,
       bufferBlockNumber + Math.ceil(chainTargetItems /. density)->Float.toInt,
     )
-  | _ => fetchCeiling
+  | _ => Pervasives.min(bufferBlockNumber + cs.coldTargetRange, fetchCeiling)
   }
 }
 
@@ -449,6 +477,19 @@ let blockAtProgress = (cs: t, ~progress) => {
 // chain, so a chain with budget can't run further ahead than the chain the
 // whole pool is prioritizing.
 let getNextQuery = (cs: t, ~chainTargetItems: float, ~maxTargetBlock=?) => {
+  // A cold chain that went idle (queries all resolved) without producing a
+  // density signal found nothing in its window — widen it so the next probe
+  // covers more ground per round trip. Ignored once a signal exists; no reset.
+  if cs->effectiveDensity === None {
+    let fetchState = cs.fetchState
+    let frontier = fetchState->FetchState.bufferBlockNumber
+    if frontier >= fetchState.startBlock && !(fetchState->FetchState.hasPendingQueries) {
+      cs.coldTargetRange = Pervasives.min(
+        cs.coldTargetRange * 2,
+        Pervasives.max(cs->fetchCeiling - frontier, 1),
+      )
+    }
+  }
   let chainTargetBlock = cs->targetBlock(~chainTargetItems)
   let chainTargetBlock = switch maxTargetBlock {
   | Some(maxTargetBlock) => Pervasives.min(chainTargetBlock, maxTargetBlock)
@@ -460,7 +501,7 @@ let getNextQuery = (cs: t, ~chainTargetItems: float, ~maxTargetBlock=?) => {
   // top: they're already accounted and shouldn't crowd out new partitions), so
   // the waterfall's leftover flows to the next chain in the same tick instead
   // of being held by an oversized probe.
-  let chainTargetItems = switch cs.chainDensity {
+  let chainTargetItems = switch cs->effectiveDensity {
   | Some(density) if density > 0. =>
     let rangeCost =
       density *. (chainTargetBlock - cs.fetchState->FetchState.bufferBlockNumber)->Int.toFloat
@@ -473,10 +514,9 @@ let getNextQuery = (cs: t, ~chainTargetItems: float, ~maxTargetBlock=?) => {
     let rangeCost =
       chainTargetBlock >= cs->fetchCeiling && cs->isReady ? rangeCost *. 3. : rangeCost
     Pervasives.min(chainTargetItems, Math.ceil(rangeCost) +. cs.pendingBudget)
-  | _ =>
-    // No density signal yet: bound the probe so one unknown chain doesn't
-    // hold the whole pool while it takes its first measurements.
-    Pervasives.min(chainTargetItems, 5_000. +. cs.pendingBudget)
+  // No density signal: the cross-chain waterfall already clamped the handed
+  // budget to the cold-chain cap, so it's used as-is.
+  | _ => chainTargetItems
   }
   cs.fetchState->FetchState.getNextQuery(~chainTargetBlock, ~chainTargetItems)
 }

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -60,6 +60,7 @@ let bufferSize: t => int
 let bufferReadyCount: t => int
 let getProgressPercentage: t => float
 let chainDensity: t => option<float>
+let effectiveDensity: t => option<float>
 let hasReadyItem: t => bool
 let isReadyToEnterReorgThreshold: t => bool
 

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -217,6 +217,11 @@ let checkAndFetch = async (
     ),
   )
 
+  // A chain with no density signal probes blind, so it only gets a bounded
+  // slice of the pool — one unknown chain shouldn't hold the whole budget
+  // while it takes its first measurements.
+  let coldChainBudget = Pervasives.min(5_000., crossChainState.targetBufferSize->Int.toFloat)
+
   let actionByChain = Dict.make()
   let maxProgress = ref(None)
   crossChainState
@@ -229,8 +234,15 @@ let checkAndFetch = async (
       // chain whose source hasn't reported doesn't unconstrain everyone else.
       actionByChain->Utils.Dict.setByInt(chainId, FetchState.WaitingForNewBlock)
     } else {
-      let chainTargetItems = remaining.contents +. cs->ChainState.pendingBudget
+      let isCold = cs->ChainState.effectiveDensity === None
+      let chainTargetItems =
+        (isCold ? Pervasives.min(remaining.contents, coldChainBudget) : remaining.contents) +.
+        cs->ChainState.pendingBudget
       let maxTargetBlock = switch maxProgress.contents {
+      | None if isCold =>
+        // A cold chain's target is a guess — it doesn't set the alignment
+        // line; the first density-bearing chain after it does.
+        None
       | None =>
         // The most-behind chain sets the alignment line for everyone after it.
         maxProgress :=

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1381,7 +1381,10 @@ let pushGapFillQueries = (
   ~addressesByContractName: dict<array<Address.t>>,
 ) => {
   let cost = ref(0.)
-  if rangeFromBlock <= knownHeight && maxChunks > 0 {
+
+  // Gaps past the chain's target block wait: they regenerate from the
+  // pending-walk each tick and fill once the target reaches them.
+  if rangeFromBlock <= Pervasives.min(knownHeight, chainTargetBlock) && maxChunks > 0 {
     switch rangeEndBlock {
     | Some(endBlock) if rangeFromBlock > endBlock => ()
     | _ =>
@@ -1722,7 +1725,13 @@ let getNextQuery = (
         let consumed = ref(0.)
         let created = ref(0)
         let chunkFromBlock = ref(fs.cursor)
-        while created.contents < numChunks && chunkFromBlock.contents <= maxBlock {
+        // No chunk starts past chainTargetBlock; an emitted chunk still keeps
+        // its full span (chunkToBlock may exceed the target — only
+        // endBlock/mergeBlock are hard bounds).
+        while (
+          created.contents < numChunks &&
+            chunkFromBlock.contents <= Pervasives.min(maxBlock, chainTargetBlock)
+        ) {
           let chunkToBlock = Pervasives.min(chunkFromBlock.contents + chunkSize - 1, maxBlock)
           let itemsTarget = Pervasives.max(
             1,
@@ -1819,6 +1828,11 @@ let getNextQuery = (
     }
   }
 }
+
+let hasPendingQueries = ({optimizedPartitions}: t) =>
+  optimizedPartitions.idsInAscOrder->Array.some(partitionId =>
+    (optimizedPartitions.entities->Dict.getUnsafe(partitionId)).mutPendingQueries->Array.length > 0
+  )
 
 let hasReadyItem = ({buffer} as fetchState: t) => {
   switch buffer->Array.get(0) {

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1829,11 +1829,6 @@ let getNextQuery = (
   }
 }
 
-let hasPendingQueries = ({optimizedPartitions}: t) =>
-  optimizedPartitions.idsInAscOrder->Array.some(partitionId =>
-    (optimizedPartitions.entities->Dict.getUnsafe(partitionId)).mutPendingQueries->Array.length > 0
-  )
-
 let hasReadyItem = ({buffer} as fetchState: t) => {
   switch buffer->Array.get(0) {
   | Some(item) => item->Internal.getItemBlockNumber <= fetchState->bufferBlockNumber

--- a/scenarios/test_codegen/test/E2E_test.res
+++ b/scenarios/test_codegen/test/E2E_test.res
@@ -1348,8 +1348,18 @@ describe("E2E tests", () => {
 
     // Step 2: Register DC1 at block 5000, DC2 at block 25100
     // Gap = 25099 - 4999 = 20100 > tooFarBlockRange(20000) → separate partitions
+    // The 100 plain events at blocks 3000-3099 give the chain a density signal
+    // (ready-buffer density immediately, the processing EMA once the batch
+    // commits). Without one the chain is cold and its target block is capped at
+    // frontier + 20k, which would gate the far partitions this merge
+    // choreography relies on fetching in parallel — and the density must be
+    // high enough that the chain-level range-cost budget affords DC2's full
+    // 10-chunk pipeline below.
     sourceMock.resolveGetItemsOrThrow(
       [
+        ...Array.fromInitializer(~length=100, i => (
+          {blockNumber: 3000 + i, logIndex: 0}: MockIndexer.Source.itemMock
+        )),
         {
           blockNumber: 5000,
           logIndex: 0,
@@ -1371,7 +1381,7 @@ describe("E2E tests", () => {
       ],
       ~latestFetchedBlockNumber=25100,
     )
-    // Batch writes because P0 advances and items at blocks 5000,25100 are processable
+    // Batch writes because P0 advances and the items at blocks 3000-3099 are processable
     await indexerMock.getBatchWritePromise()
 
     // DC1 = partition "2" at lfb=4999, DC2 = partition "3" at lfb=25099

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -571,6 +571,38 @@ describe("ChainState density from the ready buffer", () => {
     t.expect(cs->ChainState.effectiveDensity).toEqual(Some(0.5))
   })
 
+  it("mid-batch, the span starts at the processing block, not the committed one", t => {
+    // A batch was created up to block 100, consuming the buffer's head; its
+    // progress commits only after processing. The remaining 2 ready items span
+    // the 100 blocks since the batch's progress — not the 201 since the still
+    // uncommitted progress (-1).
+    let cs = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=1_000_000,
+      ~latestFetchedBlock=200,
+      ~bufferBlocks=[150, 160],
+    )
+    let progressedChainsById = Dict.make()
+    progressedChainsById->Utils.Dict.setByInt(
+      1,
+      (
+        {
+          batchSize: 5,
+          progressBlockNumber: 100,
+          sourceBlockNumber: 1_000_000,
+          totalEventsProcessed: 5.,
+          fetchState: (cs->ChainState.toChainBeforeBatch).fetchState,
+          isProgressAtHeadWhenBatchCreated: false,
+        }: Batch.chainAfterBatch
+      ),
+    )
+    cs->ChainState.advanceAfterBatch(
+      ~batch={...emptyBatch, progressedChainsById},
+      ~enteringReorgThreshold=false,
+    )
+    t.expect(cs->ChainState.effectiveDensity).toEqual(Some(2. /. 100.))
+  })
+
   it("ready items alone take the chain out of cold mode before the first batch commits", t => {
     let cs = makeFetchingChainState(
       ~chainId=1,

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -474,14 +474,9 @@ describe("CrossChainState readiness", () => {
 })
 
 describe("ChainState cold start", () => {
-  it("targets frontier + 20k with no density signal, doubling while idle without one", t => {
-    let cs = makeFetchingChainState(~chainId=1, ~knownHeight=1_000_000, ~latestFetchedBlock=0)
-    let before = cs->ChainState.targetBlock(~chainTargetItems=1000.)
-    // Idle (no pending queries) and still no signal at tick start -> the
-    // window doubles before the target is derived.
-    let _ = cs->ChainState.getNextQuery(~chainTargetItems=1000.)
-    let after = cs->ChainState.targetBlock(~chainTargetItems=1000.)
-    t.expect((before, after)).toEqual((20_000, 40_000))
+  it("targets frontier + 20k with no density signal", t => {
+    let cs = makeFetchingChainState(~chainId=1, ~knownHeight=1_000_000, ~latestFetchedBlock=5_000)
+    t.expect(cs->ChainState.targetBlock(~chainTargetItems=1000.)).toBe(25_000)
   })
 
   it("caps the cold target at an endBlock inside the horizon", t => {

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -85,6 +85,7 @@ let makeFetchingChainState = (
   ~endBlock=None,
   ~chainDensity=None,
   ~caughtUpOnce=false,
+  ~bufferBlocks=[],
 ) => {
   let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
   let address = "0x1234567890123456789012345678901234567890"->Address.unsafeFromString
@@ -117,7 +118,7 @@ let makeFetchingChainState = (
     ),
     startBlock: 0,
     endBlock,
-    buffer: [],
+    buffer: bufferBlocks->Array.map(blockNumber => mockEvent(~blockNumber)),
     normalSelection,
     latestOnBlockBlockNumber: latestFetchedBlock,
     maxOnBlockBufferSize: 10000,
@@ -472,3 +473,116 @@ describe("CrossChainState readiness", () => {
   })
 })
 
+describe("ChainState cold start", () => {
+  it("targets frontier + 20k with no density signal, doubling while idle without one", t => {
+    let cs = makeFetchingChainState(~chainId=1, ~knownHeight=1_000_000, ~latestFetchedBlock=0)
+    let before = cs->ChainState.targetBlock(~chainTargetItems=1000.)
+    // Idle (no pending queries) and still no signal at tick start -> the
+    // window doubles before the target is derived.
+    let _ = cs->ChainState.getNextQuery(~chainTargetItems=1000.)
+    let after = cs->ChainState.targetBlock(~chainTargetItems=1000.)
+    t.expect((before, after)).toEqual((20_000, 40_000))
+  })
+
+  it("caps the cold target at an endBlock inside the horizon", t => {
+    let cs = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=1_000_000,
+      ~latestFetchedBlock=0,
+      ~endBlock=Some(5_000),
+    )
+    t.expect(cs->ChainState.targetBlock(~chainTargetItems=1000.)).toBe(5_000)
+  })
+
+  Async.it("cold leader doesn't set the alignment line", async t => {
+    // Chain 1 is cold and most behind: its 20k guess-window on a 1M-block
+    // chain maps to ~2% progress, which would cap chain 2 near block 20 if a
+    // cold chain could claim leadership. Instead chain 2 (density-bearing)
+    // sets the line and drains the rest of the pool.
+    let a = makeFetchingChainState(~chainId=1, ~knownHeight=1_000_000, ~latestFetchedBlock=0)
+    let b = makeFetchingChainState(
+      ~chainId=2,
+      ~knownHeight=1000,
+      ~latestFetchedBlock=500,
+      ~chainDensity=Some(10.),
+    )
+    let cm = makeCrossChainState(~chainStatesList=[a, b], ~targetBufferSize=10_000)
+
+    let dispatchedItemsByChain = Dict.make()
+    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
+      dispatchedItemsByChain->Utils.Dict.setByInt(
+        chain->ChainMap.Chain.toChainId,
+        switch action {
+        | Ready(queries) =>
+          queries->Array.reduce(0., (acc, q: FetchState.query) => acc +. q.itemsTarget->Int.toFloat)
+        | _ => 0.
+        },
+      )
+      Promise.resolve()
+    })
+
+    t.expect(
+      dispatchedItemsByChain,
+      ~message="Cold chain 1 gets its bounded probe; chain 2 is unconstrained by chain 1's guess",
+    ).toEqual(Dict.fromArray([("1", 5000.), ("2", 5000.)]))
+  })
+
+  Async.it("clamps a cold chain to min(5k, targetBufferSize)", async t => {
+    let probeSize = async (~targetBufferSize) => {
+      let cs = makeFetchingChainState(~chainId=1, ~knownHeight=1_000_000, ~latestFetchedBlock=0)
+      let cm = makeCrossChainState(~chainStatesList=[cs], ~targetBufferSize)
+      let dispatched = ref(0.)
+      await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain as _, ~action) => {
+        switch action {
+        | Ready(queries) =>
+          dispatched :=
+            queries->Array.reduce(0., (acc, q: FetchState.query) =>
+              acc +. q.itemsTarget->Int.toFloat
+            )
+        | _ => ()
+        }
+        Promise.resolve()
+      })
+      dispatched.contents
+    }
+    t.expect(
+      (await probeSize(~targetBufferSize=10_000), await probeSize(~targetBufferSize=2_000)),
+      ~message="The cold probe never exceeds 5k, nor the whole pool when it's smaller",
+    ).toEqual((5000., 2000.))
+  })
+})
+
+describe("ChainState density from the ready buffer", () => {
+  it("a dense ready buffer overrides a stale-low processing EMA", t => {
+    // 100 ready items over the 101-block span (-1 committed progress ->
+    // frontier 100) prove ~1 item/block even though the EMA says 0.001.
+    let cs = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=1_000_000,
+      ~latestFetchedBlock=100,
+      ~chainDensity=Some(0.001),
+      ~bufferBlocks=Array.make(~length=100, 50),
+    )
+    t.expect(cs->ChainState.effectiveDensity).toEqual(Some(100. /. 101.))
+  })
+
+  it("falls back to the processing EMA when the buffer is empty", t => {
+    let cs = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=1_000_000,
+      ~latestFetchedBlock=100,
+      ~chainDensity=Some(0.5),
+    )
+    t.expect(cs->ChainState.effectiveDensity).toEqual(Some(0.5))
+  })
+
+  it("ready items alone take the chain out of cold mode before the first batch commits", t => {
+    let cs = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=1_000_000,
+      ~latestFetchedBlock=100,
+      ~bufferBlocks=[50],
+    )
+    t.expect(cs->ChainState.effectiveDensity).toEqual(Some(1. /. 101.))
+  })
+})

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -4307,3 +4307,94 @@ describe("FetchState.getNextQuery water-fill with uneven in-flight reservations"
     )
   })
 })
+
+describe("FetchState.getNextQuery target containment", () => {
+  let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
+
+  let makePartition = (
+    ~latestFetchedBlock,
+    ~knownDensity,
+    ~mergeBlock=None,
+    ~mutPendingQueries=[],
+  ): FetchState.partition => {
+    id: "0",
+    latestFetchedBlock: {blockNumber: latestFetchedBlock, blockTimestamp: 0},
+    selection: normalSelection,
+    addressesByContractName: Dict.fromArray([("MockContract", [mockAddress0])]),
+    mergeBlock,
+    dynamicContract: None,
+    mutPendingQueries,
+    prevQueryRange: knownDensity ? 10 : 0,
+    prevPrevQueryRange: knownDensity ? 10 : 0,
+    prevRangeSize: knownDensity ? 100 : 0, // density = 100 / 10 = 10 items/block
+    latestBlockRangeUpdateBlock: 0,
+  }
+
+  let makeFetchState = (partition): FetchState.t => {
+    optimizedPartitions: FetchState.OptimizedPartitions.make(
+      ~partitions=[partition],
+      ~maxAddrInPartition=2,
+      ~nextPartitionIndex=1,
+      ~dynamicContracts=Utils.Set.make(),
+    ),
+    startBlock: 0,
+    endBlock: None,
+    buffer: [],
+    normalSelection,
+    latestOnBlockBlockNumber: partition.latestFetchedBlock.blockNumber,
+    maxOnBlockBufferSize: 10000,
+    chainId,
+    contractConfigs: Dict.make(),
+    blockLag: 0,
+    onBlockRegistrations: [],
+    knownHeight: 10000,
+    firstEventBlock: Some(0),
+  }
+
+  it("gates chunk starts at the target block even when a far mergeBlock allows more", t => {
+    // mergeBlock=1000 gives the partition a 1000-block hard range; the budget
+    // affords 10 chunks. Only chunks STARTING at or below chainTargetBlock=50
+    // may be emitted (chunkSize = ceil(10 * 1.8) = 18 -> starts 1, 19, 37);
+    // the last chunk keeps its full span past the target.
+    let fetchState = makeFetchState(
+      makePartition(~latestFetchedBlock=0, ~knownDensity=true, ~mergeBlock=Some(1000)),
+    )
+    let emitted = switch fetchState->FetchState.getNextQuery(
+      ~chainTargetBlock=50,
+      ~chainTargetItems=10_000.,
+    ) {
+    | Ready(queries) => queries->Array.map((q: FetchState.query) => (q.fromBlock, q.toBlock))
+    | _ => []
+    }
+    t.expect(emitted).toEqual([(1, Some(18)), (19, Some(36)), (37, Some(54))])
+  })
+
+  it("defers a gap past the target block, then fills it once the target reaches it", t => {
+    // Gap [101, 199] sits between the fetched frontier (100) and a pending
+    // chunk starting at 200.
+    let makeGappedFetchState = () =>
+      makeFetchState(
+        makePartition(
+          ~latestFetchedBlock=100,
+          ~knownDensity=false,
+          ~mutPendingQueries=[
+            {fromBlock: 200, toBlock: Some(219), isChunk: true, itemsTarget: 100, fetchedBlock: None},
+          ],
+        ),
+      )
+    let emitted = (~chainTargetBlock) =>
+      switch makeGappedFetchState()->FetchState.getNextQuery(
+        ~chainTargetBlock,
+        ~chainTargetItems=10_000.,
+      ) {
+      | Ready(queries) =>
+        Some(queries->Array.map((q: FetchState.query) => (q.fromBlock, q.toBlock)))
+      | NothingToQuery => None
+      | WaitingForNewBlock => Some([(-1, None)])
+      }
+    t.expect(
+      (emitted(~chainTargetBlock=50), emitted(~chainTargetBlock=150)),
+      ~message="Target below the gap defers it; target inside the gap fills it",
+    ).toEqual((None, Some([(101, Some(199))])))
+  })
+})


### PR DESCRIPTION
## Summary

This change improves how the indexer handles chains with no density signal (cold chains) during their initial sync phase. It introduces a bounded probe strategy for cold chains and makes query sizing responsive to live buffer density, preventing a single unknown chain from monopolizing the fetch budget while it takes its first measurements.

## Key Changes

- **Cold chain targeting**: Chains without density signal now target `frontier + 20k` blocks instead of relying on the fetch ceiling, providing a reasonable initial guess window. This target is capped by any configured `endBlock`.

- **Effective density calculation**: Introduced `effectiveDensity` that combines the processing EMA with live ready-buffer density, taking the maximum of both. This allows stale-low EMAs to be overridden by what the buffer actually contains, improving query sizing responsiveness.

- **Processing block tracking**: Added `processingBlockNumber` to `ChainState` to track the lower boundary of the remaining buffer's block span. This runs ahead of `committedProgressBlockNumber` until a batch commits, enabling accurate density calculations mid-batch.

- **Cold chain budget clamping**: Cold chains are now limited to `min(5k, targetBufferSize)` items per tick in the cross-chain waterfall. This prevents one unknown chain from holding the entire pool budget while it measures density.

- **Cold chain alignment**: Cold chains no longer set the alignment line for other chains; the first density-bearing chain after them does. This prevents a cold chain's blind guess from constraining chains with actual density signals.

- **Target-aware gap filling**: Gap-fill queries now respect the chain's target block—gaps past the target are deferred and regenerate each tick, filling once the target reaches them. Chunk emission is also gated to not start past the target block.

## Implementation Details

- `readyBufferDensity` calculates events/block over the ready portion of the buffer, providing a live signal that reacts immediately to fetching results.
- The `coldTargetRange` constant (20k blocks) is used as the probe window for chains taking initial measurements.
- `processingBlockNumber` is updated at batch creation (in `advanceAfterBatch`) and batch commit (in `applyBatchProgress`), with rollback support.
- Tests verify cold-start behavior, density override mechanics, and gap-fill deferral logic.

https://claude.ai/code/session_018CiEziFbVe1P3Y6iuyfT5Z