### PR TITLE
Format source request seconds metric to 3 decimal places

### DIFF
--- a/packages/envio/src/Metrics.res
+++ b/packages/envio/src/Metrics.res
@@ -47,7 +47,7 @@ let renderSourceRequests = (~samples: array<SourceManager.requestStatSample>) =>
       if sample.seconds !== 0. {
         secondsOut :=
           secondsOut.contents ++
-          `\n${sourceRequestSecondsTotalName}${labels} ${sample.seconds->Float.toString}`
+          `\n${sourceRequestSecondsTotalName}${labels} ${sample.seconds->Float.toFixed(~digits=3)}`
       }
     })
     countOut.contents ++ secondsOut.contents

--- a/scenarios/test_codegen/test/lib_tests/Metrics_test.res
+++ b/scenarios/test_codegen/test/lib_tests/Metrics_test.res
@@ -41,7 +41,7 @@ describe("Metrics.renderSourceRequests", () => {
             chainId: 1,
             method: "getLogs",
             count: 3,
-            seconds: 1.5,
+            seconds: 816.8360346669994,
           },
           {
             SourceManager.sourceName: "RPC (host)",
@@ -61,7 +61,7 @@ envio_source_request_total{source="HyperSync",chainId="1",method="getLogs"} 3
 envio_source_request_total{source="RPC (host)",chainId="137",method="heightSubscription"} 1
 # HELP envio_source_request_seconds_total Cumulative time spent on data source requests.
 # TYPE envio_source_request_seconds_total counter
-envio_source_request_seconds_total{source="HyperSync",chainId="1",method="getLogs"} 1.5`,
+envio_source_request_seconds_total{source="HyperSync",chainId="1",method="getLogs"} 816.836`,
       )
     },
   )


### PR DESCRIPTION
## Summary
Updates the source request seconds metric output to use fixed-point formatting with 3 decimal places instead of full floating-point precision.

## Changes
- Modified `Metrics.renderSourceRequests` to format `sample.seconds` using `Float.toFixed(~digits=3)` instead of `Float.toString`
- Updated corresponding test expectations to reflect the new formatting (e.g., `1.5` → `816.836`)

## Details
This change improves the readability of Prometheus metrics by limiting the seconds metric to 3 decimal places, providing sufficient precision while avoiding excessive decimal output in the metrics output.

https://claude.ai/code/session_01HXLm9MMGewb4nVbBPXHdW6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for source request timing metrics by limiting values to three decimal places.
  * Ensures more consistent and readable metric output for monitoring integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->