### PR TITLE
Fix future end block progress alignment

### DIFF
--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -445,16 +445,12 @@ let targetBlock = (cs: t, ~chainTargetItems: float) => {
 }
 
 // Block range that cross-chain progress alignment maps fractions over: from
-// the first block that can hold this chain's events to the last block it will
-// fetch.
+// the first block that can hold this chain's events to the last block it can
+// fetch right now.
 let progressRange = (cs: t) => {
   let fetchState = cs.fetchState
   let lower = fetchState.firstEventBlock->Option.getOr(fetchState.startBlock)
-  let upper = switch fetchState.endBlock {
-  | Some(endBlock) => endBlock
-  | None => fetchState.knownHeight
-  }
-  (lower, upper)
+  (lower, cs->fetchCeiling)
 }
 
 // A degenerate range (chain already at or past its last block) maps to 1 so it

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -403,6 +403,47 @@ describe("CrossChainState fetch control", () => {
     },
   )
 
+  Async.it(
+    "checkAndFetch aligns progress against the currently reachable end block",
+    async t => {
+      let leader = makeFetchingChainState(
+        ~chainId=1,
+        ~knownHeight=1000,
+        ~latestFetchedBlock=0,
+        ~endBlock=Some(1_000_000_000),
+        ~chainDensity=Some(1.),
+      )
+      let follower = makeFetchingChainState(
+        ~chainId=2,
+        ~knownHeight=1000,
+        ~latestFetchedBlock=0,
+        ~chainDensity=Some(1.),
+      )
+      let cm = makeCrossChainState(
+        ~chainStatesList=[leader, follower],
+        ~targetBufferSize=3000,
+      )
+
+      let estimatesByChain = Dict.make()
+      await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
+        estimatesByChain->Utils.Dict.setByInt(
+          chain->ChainMap.Chain.toChainId,
+          switch action {
+          | Ready(queries) =>
+            queries->Array.reduce(0, (total, query: FetchState.query) => total + query.itemsEst)
+          | _ => 0
+          },
+        )
+        Promise.resolve()
+      })
+
+      t.expect(
+        estimatesByChain,
+        ~message="A future endBlock must not clamp the follower near its starting frontier",
+      ).toEqual(Dict.fromArray([("1", 1000), ("2", 1000)]))
+    },
+  )
+
   it("getNextQuery caps the budget at the plain range cost regardless of caught-up status", t => {
     let makeChain = (~caughtUpOnce) =>
       makeFetchingChainState(


### PR DESCRIPTION
## Summary

- align cross-chain progress against the current reachable height when `endBlock` is in the future
- add regression coverage for the two-chain waterfall budget

## Why

A future `endBlock` was used as the alignment denominator even though the chain could only fetch through `knownHeight`. That mapped the leader near zero progress and unnecessarily clamped following chains.

## Validation

- `pnpm rescript`
- `pnpm vitest run test/lib_tests/CrossChainState_test.res`