### PR TITLE
fix: SVM account_filters fails config parse at runtime

### DIFF
--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -200,14 +200,18 @@ let svmEventDescriptorSchema = S.schema(s =>
     "transactionFields": s.matches(S.array(Internal.svmTransactionFieldSchema)),
     "blockFields": s.matches(S.option(S.array(Internal.svmBlockFieldSchema))),
     "includeLogs": s.matches(S.bool),
+    // An array of AND-groups OR-ed together: the CLI normalizes both the flat
+    // and `any_of` YAML shapes to `Vec<Vec<SvmAccountFilterJson>>`.
     "accountFilters": s.matches(
       S.option(
         S.array(
-          S.schema(s =>
-            {
-              "position": s.matches(S.int),
-              "values": s.matches(S.array(S.string)),
-            }
+          S.array(
+            S.schema(s =>
+              {
+                "position": s.matches(S.int),
+                "values": s.matches(S.array(S.string)),
+              }
+            ),
           ),
         ),
       ),

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -192,6 +192,30 @@ describe("svmEventDescriptorSchema", () => {
     let expected: option<array<Internal.svmBlockField>> = Some([Height, ParentSlot, ParentHash])
     t.expect(parsed["blockFields"]).toEqual(expected)
   })
+
+  // Regression: the CLI emits `accountFilters` as an array of AND-groups
+  // (`Vec<Vec<SvmAccountFilterJson>>`, OR-ed together). The schema used to
+  // declare a flat array, so any config using `account_filters` failed to
+  // load with `Failed parsing at ["accountFilters"]["0"]["position"].
+  // Reason: Expected int32, received undefined`.
+  it("parses accountFilters as an array of AND-groups", t => {
+    let json: JSON.t = %raw(`{
+      "discriminator": "0x0c",
+      "discriminatorByteLen": 1,
+      "transactionFields": ["signatures"],
+      "includeLogs": false,
+      "accountFilters": [
+        [{"position": 1, "values": ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"]}],
+        [{"position": 0, "values": ["So11111111111111111111111111111111111111112"]}]
+      ]
+    }`)
+    let parsed = json->S.parseOrThrow(Config.svmEventDescriptorSchema)
+    let expected = Some([
+      [{"position": 1, "values": ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"]}],
+      [{"position": 0, "values": ["So11111111111111111111111111111111111111112"]}],
+    ])
+    t.expect(parsed["accountFilters"]).toEqual(expected)
+  })
 })
 
 describe("EventConfigBuilder", () => {


### PR DESCRIPTION
## Problem

Any SVM config using `account_filters` fails at indexer startup (and in `createTestIndexer`) with:

```
Invalid indexer config: Failed parsing at ["svm"]["programs"]["<Program>"]["events"]["0"]["svm"]["accountFilters"]["0"]["position"]. Reason: Expected int32, received undefined
```

The CLI emits `accountFilters` as `Vec<Vec<SvmAccountFilterJson>>` (an array of AND-groups OR-ed together; both the flat and `any_of` YAML shapes are normalized to this), and the consumer in `Config.fromPublic` already maps it as nested groups. But `svmEventDescriptorSchema` declared a flat `array<{position, values}>`, so the parse throws before the consumer ever runs.

Reproduced against `envio@3.3.0-alpha.10` with a minimal SPL Token `TransferChecked` config filtering on the USDC/USDT mint at position 1.

## Fix

Wrap the schema in one more `S.array` so it matches what the CLI emits and what the consumer expects. Added a regression test next to the existing `svmEventDescriptorSchema` blockFields test.

## Testing

- `scenarios/test_codegen`: `Config_test` passes (24/24, including the new regression test). The handful of failing files in the full suite (HyperSyncClient/HyperSync/RpcSource/SourceBlockHashes/EventHandler-createTestIndexer) fail identically on clean `main` in my environment (network/Postgres dependent).
- Verified end-to-end by applying the same one-line change as a pnpm patch to `envio@3.3.0-alpha.10` in a real SVM indexer using `account_filters`; config loads and the indexer processes the filtered instructions correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)