### PR TITLE
Replace water-fill budget algorithm with greedy fromBlock-sorted pass

### DIFF
--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -372,7 +372,8 @@ let isReadyToEnterReorgThreshold = (cs: t) => cs.fetchState->FetchState.isReadyT
 let startFetchingQueries = (cs: t, ~queries: array<FetchState.query>) => {
   cs.fetchState->FetchState.startFetchingQueries(~queries)
   cs.pendingBudget =
-    cs.pendingBudget +. queries->Array.reduce(0., (acc, query) => acc +. query.itemsEst->Int.toFloat)
+    cs.pendingBudget +.
+    queries->Array.reduce(0., (acc, query) => acc +. query.itemsEst->Int.toFloat)
 }
 
 // Drop every in-flight query and release their reservations together, keeping
@@ -511,6 +512,7 @@ let getNextQuery = (
     ~chainTargetBlock,
     ~chainTargetItems,
     ~chunkItemsMultiplier,
+    ~chainDensity=?cs->effectiveDensity,
   )
 }
 

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -512,7 +512,6 @@ let getNextQuery = (
     ~chainTargetBlock,
     ~chainTargetItems,
     ~chunkItemsMultiplier,
-    ~chainDensity=?cs->effectiveDensity,
   )
 }
 

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1370,6 +1370,13 @@ let startFetchingQueries = ({optimizedPartitions}: t, ~queries: array<query>) =>
 // Most parallel in-flight chunk queries a single partition may have at once.
 let maxPendingChunksPerPartition = 12
 
+// Target size of an open-ended probe. When the fresh budget can't give every
+// probe partition this many items, the water-fill would spray a sub-item
+// allotment across all of them — each floored to a 1-item query — so instead
+// the budget is concentrated onto the neediest ⌈budget / minQueryItems⌉
+// partitions and the rest wait for a tick with more budget.
+let minQueryItems = 100.
+
 // Fills a gap range (a hole left between completed/pending chunks, e.g. from an
 // out-of-order partial response) unconditionally — gaps are already-committed
 // range, not subject to this tick's water-fill budget. Priced by the
@@ -1724,6 +1731,44 @@ let getNextQuery = (
       fs.pendingCount + fs.chunksUsedThisCall < maxPendingChunksPerPartition
 
     let inRangeStates = fillStates->Array.filter(isInRange)
+
+    // Whether a partition's emit will chunk (a full, density-sized query) rather
+    // than fall back to an open-ended probe — mirrors emitQueries' branch.
+    let willChunk = (fs: waterFillState) =>
+      switch (fs.maybeChunkRange, fs.p->getTrustedDensity) {
+      | (Some(_), Some(density)) if density > 0. => true
+      | _ => false
+      }
+
+    // Cap how many open-ended probes this tick's fresh budget fans out to. Only
+    // probes flood: a thin budget split across many of them gives each a
+    // sub-minQueryItems allotment that the emit floors to a 1-item query — a
+    // burst of near-empty fetches. Serve the neediest (lowest current footprint)
+    // ⌈rangeItemsTarget / minQueryItems⌉ probes, always at least one so the
+    // fetch-priority chain still advances, and let the rest wait until freed
+    // reservations grow the budget. Chunk partitions self-limit (each emit is a
+    // full density-sized chunk) so they always run; ample budget leaves every
+    // probe served too, so normal fan-out is untouched.
+    let probeStates = inRangeStates->Array.filter(fs => !(fs->willChunk))
+    let maxProbes = Pervasives.max(1, Js.Math.ceil_int(rangeItemsTarget /. minQueryItems))
+    let inRangeStates = if probeStates->Array.length <= maxProbes {
+      inRangeStates
+    } else {
+      let keptProbeIds =
+        probeStates
+        ->Array.toSorted((a, b) =>
+          Float.compare(
+            reservedByPartition->Dict.getUnsafe(a.partitionId),
+            reservedByPartition->Dict.getUnsafe(b.partitionId),
+          )
+        )
+        ->Array.slice(~start=0, ~end=maxProbes)
+        ->Array.map(fs => fs.partitionId)
+        ->Utils.Set.fromArray
+      inRangeStates->Array.filter(fs =>
+        fs->willChunk || keptProbeIds->Utils.Set.has(fs.partitionId)
+      )
+    }
 
     // Emits this round's queries for one partition, given its water-fill
     // allotment. Mutates fs.cursor/chunksUsedThisCall and returns the

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1370,21 +1370,14 @@ let startFetchingQueries = ({optimizedPartitions}: t, ~queries: array<query>) =>
 // Most parallel in-flight chunk queries a single partition may have at once.
 let maxPendingChunksPerPartition = 12
 
-// Target size of an open-ended probe. When the fresh budget can't give every
-// probe partition this many items, the water-fill would spray a sub-item
-// allotment across all of them — each floored to a 1-item query — so instead
-// the budget is concentrated onto the neediest ⌈budget / minQueryItems⌉
-// partitions and the rest wait for a tick with more budget.
-let minQueryItems = 100.
-
-// Fills a gap range (a hole left between completed/pending chunks, e.g. from an
-// out-of-order partial response) unconditionally — gaps are already-committed
-// range, not subject to this tick's water-fill budget. Priced by the
-// partition's trusted density when it has one; otherwise by the "available
-// density" — the partition's equal-divide budget spread over its remaining
-// range this tick — so a small gap reserves proportionally little instead of a
-// noisy one-sample estimate. Chunks only on a trusted POSITIVE density, same
-// rule as the water-fill. Returns the created queries' total itemsEst.
+// Generates candidate queries for a gap range (a hole left between
+// completed/pending chunks, e.g. from an out-of-order partial response). Gaps
+// carry the range's low fromBlock, so the acceptance pass takes them before
+// forward progress. Priced by the partition's trusted density when it has one;
+// otherwise by the "available density" — the partition's equal-divide budget
+// spread over its remaining range this tick — so a small gap reserves
+// proportionally little instead of a noisy one-sample estimate. Chunks only on
+// a trusted POSITIVE density. Returns the created queries' total itemsEst.
 let pushGapFillQueries = (
   queries: array<query>,
   ~partitionId: string,
@@ -1488,46 +1481,19 @@ let pushGapFillQueries = (
   cost.contents
 }
 
-// The level every partition ends at when `budget` is poured across partitions
-// already holding `footprints`: the unique L with Σ max(0, L - fᵢ) = budget.
-// Partitions above L get nothing (their head start is their share); the rest
-// are topped up exactly to L, so the pour equals the budget no matter how
-// uneven the footprints are.
-let waterLevel = (~budget: float, ~footprints: array<float>) => {
-  let sorted = footprints->Array.toSorted(Float.compare)
-  let n = sorted->Array.length
-  let prefix = ref(0.)
-  let level = ref(None)
-  let idx = ref(0)
-  while level.contents == None && idx.contents < n {
-    let i = idx.contents
-    prefix := prefix.contents +. sorted->Array.getUnsafe(i)
-    // The level if only the i+1 lowest footprints receive water — correct once
-    // it doesn't reach the next footprint up.
-    let candidate = (budget +. prefix.contents) /. (i + 1)->Int.toFloat
-    if i == n - 1 || candidate <= sorted->Array.getUnsafe(i + 1) {
-      level := Some(candidate)
-    }
-    idx := idx.contents + 1
-  }
-  level.contents->Option.getOr(0.)
-}
-
-// Per-partition mutable state threaded through the water-fill rounds below.
+// Per-partition state carried from the gap-fill/cursor walk to candidate
+// generation.
 type waterFillState = {
   partitionId: string,
   p: partition,
-  mutable cursor: int,
-  mutable chunksUsedThisCall: int,
-  // Existing mutPendingQueries count before this call — fixed for the call,
-  // used with chunksUsedThisCall against maxPendingChunksPerPartition.
+  cursor: int,
+  // Chunks already generated for this partition during gap-fill — used with
+  // pendingCount against maxPendingChunksPerPartition.
+  chunksUsedThisCall: int,
+  // Existing mutPendingQueries count before this call — fixed for the call.
   pendingCount: int,
   queryEndBlock: option<int>,
   maybeChunkRange: option<int>,
-  // This partition's own slot in queriesByPartitionIndex — gap-fill and every
-  // water-fill round push here directly, so query order falls out of
-  // idsInAscOrder for free (see getNextQuery) instead of a final sort pass.
-  bucket: array<query>,
 }
 
 // Candidate queries are sized against chainTargetBlock, the soft querying
@@ -1538,24 +1504,23 @@ type waterFillState = {
 // query with no other ceiling: the true hard bounds stay
 // endBlock/mergeBlock/the lagged head.
 //
-// In-range partitions share chainTargetItems (this chain's target total
-// footprint — in-flight plus new) by water-fill: each round pours exactly the
-// remaining fresh budget at the level computed by waterLevel, so a partition
-// already holding more than the level (from earlier ticks' in-flight queries)
-// gets nothing and its implicit share flows to the others, while totals stay
-// even and the pour never exceeds the budget. Rounds repeat only because
-// emits are quantized: a partition may consume less than its allotment (range
-// or chunk-cap runs out) or slightly more (min one chunk), and the leftover
-// re-pours over whoever still has range left.
+// The tick's budget is chainTargetItems minus what's already in flight. Every
+// candidate query — gap-fill holes, plus each in-range partition's chunks or
+// open-ended probe toward the target — is generated with no budget check, then
+// the candidates are sorted by fromBlock and accepted in that order while the
+// budget stays positive. The query that tips it negative is still accepted (a
+// single overshoot); everything after it waits for a tick with more budget.
+// Sorting by fromBlock spends the budget on the earliest blocks across all
+// partitions first, so no partition is starved by generation order and the
+// frontier advances evenly. In-flight reservations release as responses land,
+// so acceptance redistributes across ticks.
 //
 // A partition with a trusted positive density (two or more responses — see
-// getMinHistoryRange) always emits at least one full-size chunk/query once
-// given an allotment, sized by its real density — may overshoot the
-// allotment by at most one chunk (the server also enforces itemsTarget via a
-// maxNumLogs-style cap, so an overshoot truncates the response rather than
-// the buffer). Any other partition (no signal, one noisy sample, or a
-// density-0 estimate) emits one open-ended probe sized exactly at its
-// allotment instead.
+// getMinHistoryRange) generates real, density-sized chunks toward the target.
+// Any other partition (no signal, one noisy sample, or a density-0 estimate)
+// generates one open-ended probe sized to its even share of the budget
+// (freshBudget / inRangeCount), so several unknown-density partitions
+// still probe in parallel within one budget.
 let getNextQuery = (
   {optimizedPartitions, blockLag, latestOnBlockBlockNumber, knownHeight, endBlock}: t,
   ~chainTargetBlock: int,
@@ -1595,8 +1560,8 @@ let getNextQuery = (
       }
     }
 
-    // One bucket per partition, in idsInAscOrder order — gap-fill and
-    // water-fill both push into a partition's own bucket, so flattening at
+    // One bucket per partition, in idsInAscOrder order — gap-fill and the
+    // budget pass both push into a partition's own bucket, so flattening at
     // the end (see below) reproduces idsInAscOrder without a sort.
     let queriesByPartitionIndex: array<
       array<query>,
@@ -1614,35 +1579,46 @@ let getNextQuery = (
       }
     }
 
-    // Each partition's existing in-flight itemsEst, summed once and reused
-    // both for chainReserved (the call-wide fresh-budget ceiling below) and to
-    // seed each partition's water-fill footprint — so a partition already
-    // holding in-flight queries is counted toward its even share and doesn't
-    // get topped up past the others.
-    let existingReservedByPartition = Dict.make()
+    // Existing in-flight itemsEst across all partitions — already spent against
+    // this chain's budget, so the fresh budget for new queries is what's left
+    // of chainTargetItems after it.
     let chainReserved = ref(0.)
     for idx in 0 to partitionsCount - 1 {
       let partitionId = optimizedPartitions.idsInAscOrder->Array.getUnsafe(idx)
       let p = optimizedPartitions.entities->Dict.getUnsafe(partitionId)
-      let cost = ref(0.)
       for pqIdx in 0 to p.mutPendingQueries->Array.length - 1 {
-        cost := cost.contents +. (p.mutPendingQueries->Array.getUnsafe(pqIdx)).itemsEst->Int.toFloat
+        chainReserved :=
+          chainReserved.contents +.
+          (p.mutPendingQueries->Array.getUnsafe(pqIdx)).itemsEst->Int.toFloat
       }
-      existingReservedByPartition->Dict.set(partitionId, cost.contents)
-      chainReserved := chainReserved.contents +. cost.contents
     }
 
-    // Phase A: gap-fill. Walk each partition's pending queries once,
-    // unconditionally filling any hole (e.g. from an out-of-order partial
-    // chunk response) — uncapped, same as before this tick's water-fill was
-    // introduced. This also determines each partition's post-gap cursor and
+    // The tick's fresh budget: chainTargetItems minus what's already in flight.
+    let freshBudget = Pervasives.max(0., chainTargetItems -. chainReserved.contents)
+
+    // Position of each partition in idsInAscOrder, so an accepted query routes
+    // back to its bucket and the output stays in idsInAscOrder.
+    let partitionIndexById = Dict.make()
+    for idx in 0 to partitionsCount - 1 {
+      partitionIndexById->Dict.set(optimizedPartitions.idsInAscOrder->Array.getUnsafe(idx), idx)
+    }
+
+    // Every candidate query for this tick — gap-fill holes (Phase A) plus each
+    // in-range partition's chunks/probe toward the target (Phase B) — generated
+    // with no budget check, then sorted by fromBlock and accepted while the
+    // budget lasts (acceptance pass). Selecting by fromBlock spends the budget
+    // on the earliest blocks across all partitions first, so no partition is
+    // starved by iteration order and the frontier advances evenly.
+    let candidates = []
+
+    // Phase A: gap-fill. Walk each partition's pending queries once, generating
+    // a candidate for any hole (e.g. from an out-of-order partial chunk
+    // response). This also determines each partition's post-gap cursor and
     // whether it's blocked on an unresolved single-shot query.
     let fillStates = []
-    let gapFillCost = ref(0.)
     for idx in 0 to partitionsCount - 1 {
       let partitionId = optimizedPartitions.idsInAscOrder->Array.getUnsafe(idx)
       let p = optimizedPartitions.entities->Dict.getUnsafe(partitionId)
-      let bucket = queriesByPartitionIndex->Array.getUnsafe(idx)
       let pendingCount = p.mutPendingQueries->Array.length
       let queryEndBlock = computeQueryEndBlock(p)
       let maybeChunkRange = getMinHistoryRange(p)
@@ -1655,9 +1631,9 @@ let getNextQuery = (
         let pq = p.mutPendingQueries->Array.getUnsafe(pqIdx.contents)
 
         if pq.fromBlock > cursor.contents {
-          let beforeLen = bucket->Array.length
-          let cost = pushGapFillQueries(
-            bucket,
+          let beforeLen = candidates->Array.length
+          pushGapFillQueries(
+            candidates,
             ~partitionId,
             ~rangeFromBlock=cursor.contents,
             ~rangeEndBlock=Utils.Math.minOptInt(Some(pq.fromBlock - 1), queryEndBlock),
@@ -1670,9 +1646,8 @@ let getNextQuery = (
             ~chunkItemsMultiplier,
             ~selection=p.selection,
             ~addressesByContractName=p.addressesByContractName,
-          )
-          chunksUsedThisCall := chunksUsedThisCall.contents + (bucket->Array.length - beforeLen)
-          gapFillCost := gapFillCost.contents +. cost
+          )->ignore
+          chunksUsedThisCall := chunksUsedThisCall.contents + (candidates->Array.length - beforeLen)
         }
         switch pq {
         | {isChunk: true, toBlock: Some(toBlock), fetchedBlock: Some({blockNumber})}
@@ -1694,33 +1669,10 @@ let getNextQuery = (
           pendingCount,
           queryEndBlock,
           maybeChunkRange,
-          bucket,
         })
         ->ignore
       }
     }
-
-    // Fresh budget for this call — what's left of chainTargetItems after
-    // existing in-flight queries and this tick's gap-fill. The water-fill
-    // rounds below hand it out; a partition already holding a large share
-    // (seeded below) gets proportionally less so totals stay even.
-    let rangeItemsTarget = Pervasives.max(
-      0.,
-      chainTargetItems -. chainReserved.contents -. gapFillCost.contents,
-    )
-
-    // Each in-range partition's running footprint: existing in-flight plus any
-    // gap-fill just pushed into its bucket. The water-fill levels every
-    // partition up toward a shared line, so this seed is what a partition
-    // starts the fill already holding.
-    let reservedByPartition = Dict.make()
-    fillStates->Array.forEach(fs => {
-      let cost = ref(existingReservedByPartition->Dict.getUnsafe(fs.partitionId))
-      for i in 0 to fs.bucket->Array.length - 1 {
-        cost := cost.contents +. (fs.bucket->Array.getUnsafe(i)).itemsEst->Int.toFloat
-      }
-      reservedByPartition->Dict.set(fs.partitionId, cost.contents)
-    })
 
     let isInRange = (fs: waterFillState) =>
       fs.cursor <= chainTargetBlock &&
@@ -1731,54 +1683,22 @@ let getNextQuery = (
       fs.pendingCount + fs.chunksUsedThisCall < maxPendingChunksPerPartition
 
     let inRangeStates = fillStates->Array.filter(isInRange)
+    // Each open-ended probe reserves an even share of the fresh budget, divided
+    // by the partitions actually fetching this tick (not every partition — so
+    // budget isn't stranded on ones below the head, waiting, or already done).
+    let inRangeCount = inRangeStates->Array.length
+    let probeShare = inRangeCount == 0 ? 0. : freshBudget /. inRangeCount->Int.toFloat
 
-    // Whether a partition's emit will chunk (a full, density-sized query) rather
-    // than fall back to an open-ended probe — mirrors emitQueries' branch.
-    let willChunk = (fs: waterFillState) =>
-      switch (fs.maybeChunkRange, fs.p->getTrustedDensity) {
-      | (Some(_), Some(density)) if density > 0. => true
-      | _ => false
-      }
-
-    // Cap how many open-ended probes this tick's fresh budget fans out to. Only
-    // probes flood: a thin budget split across many of them gives each a
-    // sub-minQueryItems allotment that the emit floors to a 1-item query — a
-    // burst of near-empty fetches. Serve the neediest (lowest current footprint)
-    // ⌈rangeItemsTarget / minQueryItems⌉ probes, always at least one so the
-    // fetch-priority chain still advances, and let the rest wait until freed
-    // reservations grow the budget. Chunk partitions self-limit (each emit is a
-    // full density-sized chunk) so they always run; ample budget leaves every
-    // probe served too, so normal fan-out is untouched.
-    let probeStates = inRangeStates->Array.filter(fs => !(fs->willChunk))
-    let maxProbes = Pervasives.max(1, Js.Math.ceil_int(rangeItemsTarget /. minQueryItems))
-    let inRangeStates = if probeStates->Array.length <= maxProbes {
-      inRangeStates
-    } else {
-      let keptProbeIds =
-        probeStates
-        ->Array.toSorted((a, b) =>
-          Float.compare(
-            reservedByPartition->Dict.getUnsafe(a.partitionId),
-            reservedByPartition->Dict.getUnsafe(b.partitionId),
-          )
-        )
-        ->Array.slice(~start=0, ~end=maxProbes)
-        ->Array.map(fs => fs.partitionId)
-        ->Utils.Set.fromArray
-      inRangeStates->Array.filter(fs =>
-        fs->willChunk || keptProbeIds->Utils.Set.has(fs.partitionId)
-      )
-    }
-
-    // Emits this round's queries for one partition, given its water-fill
-    // allotment. Mutates fs.cursor/chunksUsedThisCall and returns the
-    // itemsEst consumed.
+    // Phase B: generate each in-range partition's candidates — strict chunks
+    // toward the target sized by real density (up to the pending-chunk cap), or,
+    // for a partition without a trusted positive density, a single open-ended
+    // probe at its even share of the budget. No budget check here; the
+    // acceptance pass below decides which candidates make the cut.
     //
-    // Chunks require a POSITIVE trusted density: density 0 prices every chunk
-    // at ~nothing, letting a partition flood its full chunk pipeline with
-    // hard-bounded queries that crawl 1.8× per two responses — an open-ended
-    // probe instead gets the server's full scan range in one response.
-    let emitQueries = (fs: waterFillState, ~budget: float) => {
+    // Chunks require a POSITIVE trusted density: density 0 prices every chunk at
+    // ~nothing, so an open-ended probe (full server scan range in one response)
+    // beats a pipeline of hard-bounded chunks that crawl 1.8× per two responses.
+    inRangeStates->Array.forEach(fs => {
       let p = fs.p
       let maxBlock = switch fs.queryEndBlock {
       | Some(eb) => eb
@@ -1786,23 +1706,17 @@ let getNextQuery = (
       }
       switch (fs.maybeChunkRange, p->getTrustedDensity) {
       | (Some(minHistoryRange), Some(density)) if density > 0. =>
-        // Chunking active: strict chunks with a hard endBlock, sized by real
-        // density with the chunk headroom multiplier — at least one full
-        // chunk this round even if the allotment falls short.
         let chunkSize = Js.Math.ceil_int(minHistoryRange->Int.toFloat *. 1.8)
         let maxChunksRemaining =
           maxPendingChunksPerPartition - fs.pendingCount - fs.chunksUsedThisCall
-        let consumed = ref(0.)
         let created = ref(0)
         let chunkFromBlock = ref(fs.cursor)
-        let budgetLeft = ref(true)
         // No chunk starts past chainTargetBlock; an emitted chunk still keeps
         // its full span (chunkToBlock may exceed the target — only
         // endBlock/mergeBlock are hard bounds).
         while (
-          budgetLeft.contents &&
           created.contents < maxChunksRemaining &&
-          chunkFromBlock.contents <= Pervasives.min(maxBlock, chainTargetBlock)
+            chunkFromBlock.contents <= Pervasives.min(maxBlock, chainTargetBlock)
         ) {
           let chunkToBlock = Pervasives.min(chunkFromBlock.contents + chunkSize - 1, maxBlock)
           let rawEst = density *. (chunkToBlock - chunkFromBlock.contents + 1)->Int.toFloat
@@ -1811,89 +1725,54 @@ let getNextQuery = (
             1,
             (rawEst *. chunkItemsMultiplier)->Math.ceil->Float.toInt,
           )
-          if consumed.contents == 0. || consumed.contents +. itemsEst->Int.toFloat <= budget {
-            fs.bucket->Array.push({
-              partitionId: fs.partitionId,
-              fromBlock: chunkFromBlock.contents,
-              toBlock: Some(chunkToBlock),
-              isChunk: true,
-              selection: p.selection,
-              itemsTarget,
-              itemsEst,
-              addressesByContractName: p.addressesByContractName,
-            })
-            consumed := consumed.contents +. itemsEst->Int.toFloat
-            chunkFromBlock := chunkToBlock + 1
-            created := created.contents + 1
-          } else {
-            budgetLeft := false
-          }
+          candidates
+          ->Array.push({
+            partitionId: fs.partitionId,
+            fromBlock: chunkFromBlock.contents,
+            toBlock: Some(chunkToBlock),
+            isChunk: true,
+            selection: p.selection,
+            itemsTarget,
+            itemsEst,
+            addressesByContractName: p.addressesByContractName,
+          })
+          ->ignore
+          chunkFromBlock := chunkToBlock + 1
+          created := created.contents + 1
         }
-        fs.cursor = chunkFromBlock.contents
-        fs.chunksUsedThisCall = fs.chunksUsedThisCall + created.contents
-        consumed.contents
       | _ =>
-        let itemsTarget = Pervasives.max(1, Math.round(budget)->Float.toInt)
-        let itemsEst = itemsTarget
-        fs.bucket->Array.push({
+        let itemsTarget = Pervasives.max(1, Math.round(probeShare)->Float.toInt)
+        candidates
+        ->Array.push({
           partitionId: fs.partitionId,
           fromBlock: fs.cursor,
           toBlock: fs.queryEndBlock,
           isChunk: false,
           selection: p.selection,
           itemsTarget,
-          itemsEst,
+          itemsEst: itemsTarget,
           addressesByContractName: p.addressesByContractName,
         })
-        fs.cursor = maxBlock + 1
-        fs.chunksUsedThisCall = fs.chunksUsedThisCall + 1
-        itemsEst->Int.toFloat
+        ->ignore
       }
-    }
+    })
 
-    // Water-fill. Range membership is fixed by chainTargetBlock/queryEndBlock,
-    // so the in-range partitions are filtered once up front; each round pours
-    // the remaining fresh budget at the waterLevel of the still-not-filled
-    // partitions' footprints and keeps only those still in range for the next
-    // round. Allotments sum to exactly the poured budget, so the outcome is
-    // order-independent and never exceeds it — the only overshoot left is the
-    // min-one-chunk quantization in emitQueries, bounded by one chunk per
-    // partition per round.
-    //
-    // No explicit round cap: every emit advances chunksUsedThisCall (capped at
-    // maxPendingChunksPerPartition) and consumes a positive amount of fresh
-    // budget, so the not-filled set drains on its own and the loop also stops
-    // once the whole budget is poured.
-    let notFilledPartitions = ref(inRangeStates)
-    let remainingBudget = ref(rangeItemsTarget)
-    while notFilledPartitions.contents->Array.length > 0 && remainingBudget.contents > 0. {
-      let level = waterLevel(
-        ~budget=remainingBudget.contents,
-        ~footprints=notFilledPartitions.contents->Array.map(fs =>
-          reservedByPartition->Dict.getUnsafe(fs.partitionId)
-        ),
-      )
-      let next = []
-      notFilledPartitions.contents->Array.forEach(fs => {
-        let reserved = reservedByPartition->Dict.getUnsafe(fs.partitionId)
-        let budget = level -. reserved
-        if budget > 0. {
-          let consumed = emitQueries(fs, ~budget)
-          reservedByPartition->Dict.set(fs.partitionId, reserved +. consumed)
-          remainingBudget := remainingBudget.contents -. consumed
+    // Acceptance: take candidates in fromBlock order while the budget stays
+    // positive. The query that tips the budget negative is still accepted (a
+    // single overshoot); everything after it waits for a tick with more budget.
+    // Accepted queries route back to their partition bucket, so the output stays
+    // in idsInAscOrder with each partition's queries in fromBlock order.
+    let remainingBudget = ref(freshBudget)
+    candidates
+    ->Array.toSorted((a, b) => Int.compare(a.fromBlock, b.fromBlock))
+    ->Array.forEach(query =>
+      if remainingBudget.contents > 0. {
+        let partitionIdx = partitionIndexById->Dict.getUnsafe(query.partitionId)
+        queriesByPartitionIndex->Array.getUnsafe(partitionIdx)->Array.push(query)->ignore
+        remainingBudget := remainingBudget.contents -. query.itemsEst->Int.toFloat
+      }
+    )
 
-          if fs->isInRange {
-            next->Array.push(fs)->ignore
-          }
-        }
-      })
-      notFilledPartitions := next
-    }
-
-    // Each partition pushed only into its own bucket (indexed by its
-    // idsInAscOrder position), so flattening reproduces idsInAscOrder order
-    // directly — no sort needed even though water-fill rounds interleave
-    // across partitions.
     let queries = queriesByPartitionIndex->Array.flat
 
     if queries->Utils.Array.isEmpty {

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1580,10 +1580,18 @@ let getNextQuery = (
       }
     }
 
-    // Existing in-flight itemsEst across all partitions — already spent against
-    // this chain's budget, so the fresh budget for new queries is what's left
-    // of chainTargetItems after it. Summed in the Phase A sweep below.
+    // In-flight itemsEst summed over queries still being fetched
+    // (fetchedBlock === None). A query whose response already landed has had its
+    // reservation released by ChainState even while it lingers in
+    // mutPendingQueries behind an unfilled gap, so counting it here would
+    // understate the budget. Sizes fresh forward work below.
     let chainReserved = ref(0.)
+
+    // (fromBlock, itemsEst) of each still-in-flight query. The acceptance pass
+    // merges these into the candidate stream and draws them down in fromBlock
+    // order, so a gap-fill sitting before an in-flight query claims budget ahead
+    // of it and the buffer unblocks without waiting for that query to return.
+    let reservations = []
 
     // Position of each partition in idsInAscOrder, so an accepted query routes
     // back to its bucket and the output stays in idsInAscOrder. Filled in the
@@ -1592,10 +1600,11 @@ let getNextQuery = (
 
     // Every candidate query for this tick — gap-fill holes (Phase A) plus each
     // in-range partition's chunks/probe toward the target (Phase B) — generated
-    // with no budget check, then sorted by fromBlock and accepted while the
-    // budget lasts (acceptance pass). Selecting by fromBlock spends the budget
-    // on the earliest blocks across all partitions first, so no partition is
-    // starved by iteration order and the frontier advances evenly.
+    // with no budget check, then merged with the in-flight reservations, sorted
+    // by fromBlock, and accepted while the budget lasts (acceptance pass).
+    // Selecting by fromBlock spends the budget on the earliest blocks across all
+    // partitions first, so no partition is starved by iteration order and the
+    // frontier advances evenly.
     let candidates = []
 
     // Phase A: gap-fill. Walk each partition's pending queries once, generating
@@ -1609,9 +1618,11 @@ let getNextQuery = (
       partitionIndexById->Dict.set(partitionId, idx)
       let pendingCount = p.mutPendingQueries->Array.length
       for pqIdx in 0 to pendingCount - 1 {
-        chainReserved :=
-          chainReserved.contents +.
-          (p.mutPendingQueries->Array.getUnsafe(pqIdx)).itemsEst->Int.toFloat
+        let pq = p.mutPendingQueries->Array.getUnsafe(pqIdx)
+        if pq.fetchedBlock === None {
+          chainReserved := chainReserved.contents +. pq.itemsEst->Int.toFloat
+          reservations->Array.push((pq.fromBlock, pq.itemsEst))->ignore
+        }
       }
       let queryEndBlock = computeQueryEndBlock(p)
       let maybeChunkRange = getMinHistoryRange(p)
@@ -1667,7 +1678,9 @@ let getNextQuery = (
       }
     }
 
-    // The tick's fresh budget: chainTargetItems minus what's already in flight.
+    // Budget for fresh forward work: chainTargetItems minus what's still in
+    // flight. Sizes probes and bounds chunk generation below; the acceptance
+    // pass does the final budgeting against the full chainTargetItems.
     let freshBudget = Pervasives.max(0., chainTargetItems -. chainReserved.contents)
 
     let isInRange = (fs: partitionFillState) =>
@@ -1789,20 +1802,51 @@ let getNextQuery = (
       }
     })
 
-    // Acceptance: take candidates in fromBlock order while the budget stays
-    // positive. The query that tips the budget negative is still accepted (a
-    // single overshoot); everything after it waits for a tick with more budget.
-    // Accepted queries route back to their partition bucket, so the output stays
-    // in idsInAscOrder with each partition's queries in fromBlock order.
-    candidates->Array.sort((a, b) => Int.compare(a.fromBlock, b.fromBlock))
-    let candidatesCount = candidates->Array.length
-    let remainingBudget = ref(freshBudget)
+    // Acceptance: merge fresh candidates (Some) with the in-flight reservations
+    // (None) and walk them in fromBlock order, starting from the full
+    // chainTargetItems. A reservation just draws down the budget — its query is
+    // already sent — while a candidate draws down the budget and is emitted.
+    // Because a gap-fill's fromBlock precedes the in-flight query it unblocks,
+    // it claims budget ahead of that reservation, so the buffer never deadlocks
+    // waiting on a hole it can't fund. The candidate that tips the budget
+    // negative is still emitted (a single overshoot); everything after it waits
+    // for a tick with more budget. Accepted queries route back to their
+    // partition bucket, so the output stays in idsInAscOrder with each
+    // partition's queries in fromBlock order.
+    let acceptanceStream = []
+    candidates->Array.forEach(query =>
+      acceptanceStream->Array.push((query.fromBlock, query.itemsEst, Some(query)))->ignore
+    )
+    reservations->Array.forEach(((fromBlock, itemsEst)) =>
+      acceptanceStream->Array.push((fromBlock, itemsEst, None))->ignore
+    )
+    // Sort by fromBlock; on a tie charge the in-flight reservation (None) before
+    // a fresh candidate (Some), so a same-block candidate can't overshoot the
+    // target buffer. Only a strictly-earlier candidate — a gap-fill, whose
+    // fromBlock precedes the query it unblocks — borrows ahead of a reservation.
+    acceptanceStream->Array.sort(((aFrom, _, aQuery), (bFrom, _, bQuery)) =>
+      if aFrom !== bFrom {
+        Int.compare(aFrom, bFrom)
+      } else {
+        switch (aQuery, bQuery) {
+        | (None, Some(_)) => Ordering.less
+        | (Some(_), None) => Ordering.greater
+        | (None, None) | (Some(_), Some(_)) => Ordering.equal
+        }
+      }
+    )
+    let streamCount = acceptanceStream->Array.length
+    let remainingBudget = ref(chainTargetItems)
     let acceptIdx = ref(0)
-    while remainingBudget.contents > 0. && acceptIdx.contents < candidatesCount {
-      let query = candidates->Array.getUnsafe(acceptIdx.contents)
-      let partitionIdx = partitionIndexById->Dict.getUnsafe(query.partitionId)
-      queriesByPartitionIndex->Array.getUnsafe(partitionIdx)->Array.push(query)->ignore
-      remainingBudget := remainingBudget.contents -. query.itemsEst->Int.toFloat
+    while remainingBudget.contents > 0. && acceptIdx.contents < streamCount {
+      let (_, itemsEst, maybeQuery) = acceptanceStream->Array.getUnsafe(acceptIdx.contents)
+      switch maybeQuery {
+      | Some(query) =>
+        let partitionIdx = partitionIndexById->Dict.getUnsafe(query.partitionId)
+        queriesByPartitionIndex->Array.getUnsafe(partitionIdx)->Array.push(query)->ignore
+      | None => ()
+      }
+      remainingBudget := remainingBudget.contents -. itemsEst->Int.toFloat
       acceptIdx := acceptIdx.contents + 1
     }
 

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1518,18 +1518,15 @@ type waterFillState = {
 // A partition with a trusted positive density (two or more responses — see
 // getMinHistoryRange) generates real, density-sized chunks toward the target.
 // Any other partition (no signal, one noisy sample, or a density-0 estimate)
-// generates one open-ended probe sized to its even share of the budget
-// (freshBudget / inRangeCount), so several unknown-density partitions
-// still probe in parallel within one budget.
+// generates one open-ended probe sized to the events its range to the target is
+// expected to hold — rangeTargetDensity × (chainTargetBlock − fromBlock + 1) /
+// inRangeCount — so several unknown-density partitions probe in parallel within
+// one budget, each scaled by how much of the range it still has to cover.
 let getNextQuery = (
   {optimizedPartitions, blockLag, latestOnBlockBlockNumber, knownHeight, endBlock}: t,
   ~chainTargetBlock: int,
   ~chainTargetItems: float,
   ~chunkItemsMultiplier: float=1.,
-  // Chain-level event density (items/block), when known. Sizes an open-ended
-  // probe by the events its range to the target is expected to hold; falls back
-  // to an even budget share when the chain is cold or already at the target.
-  ~chainDensity: option<float>=?,
 ) => {
   let headBlockNumber = knownHeight - blockLag
   if headBlockNumber <= 0 {
@@ -1687,11 +1684,22 @@ let getNextQuery = (
       fs.pendingCount + fs.chunksUsedThisCall < maxPendingChunksPerPartition
 
     let inRangeStates = fillStates->Array.filter(isInRange)
-    // Each open-ended probe reserves an even share of the fresh budget, divided
-    // by the partitions actually fetching this tick (not every partition — so
-    // budget isn't stranded on ones below the head, waiting, or already done).
     let inRangeCount = inRangeStates->Array.length
+    // Even share of the fresh budget across the partitions actually fetching
+    // this tick (not every partition — so budget isn't stranded on ones below
+    // the head, waiting, or already done). The fallback when there's no range to
+    // the target.
     let probeShare = inRangeCount == 0 ? 0. : freshBudget /. inRangeCount->Int.toFloat
+    // Items/block the budget implies over the range those partitions cover this
+    // tick — from the furthest-behind in-range cursor to the target. A probe
+    // covering less of that range (its partition sits further ahead) gets
+    // proportionally fewer items; one starting at the frontier gets the full
+    // even share.
+    let frontierCursor =
+      inRangeStates->Array.reduce(chainTargetBlock, (min, fs) => fs.cursor < min ? fs.cursor : min)
+    let rangeToTarget = chainTargetBlock - frontierCursor + 1
+    let rangeTargetDensity =
+      inRangeCount > 0 && rangeToTarget > 0 ? freshBudget /. rangeToTarget->Int.toFloat : 0.
 
     // Phase B: generate each in-range partition's candidates — strict chunks
     // toward the target sized by real density (up to the pending-chunk cap), or,
@@ -1746,22 +1754,21 @@ let getNextQuery = (
         }
       | _ =>
         // Size the probe by the events its range to the target is expected to
-        // hold — chainDensity × (chainTargetBlock − fromBlock + 1), split across
-        // all partitions. When the chain has no density, or the partition is
-        // already at the target (no range), fall back to an even share of the
-        // fresh budget so several unknown-density partitions still probe in
-        // parallel.
-        let itemsTarget = switch chainDensity {
-        | Some(density) if density > 0. && chainTargetBlock > fs.cursor =>
+        // hold — rangeTargetDensity × (chainTargetBlock − fromBlock + 1), split
+        // across the partitions fetching this tick. With no range to the target
+        // fall back to an even share of the fresh budget, so cold chains and
+        // caught-up partitions still probe.
+        let itemsTarget = if rangeToTarget > 0 {
           Pervasives.max(
             1,
             Math.round(
-              density *.
+              rangeTargetDensity *.
               (chainTargetBlock - fs.cursor + 1)->Int.toFloat /.
-              partitionsCount->Int.toFloat,
+              inRangeCount->Int.toFloat,
             )->Float.toInt,
           )
-        | _ => Pervasives.max(1, Math.round(probeShare)->Float.toInt)
+        } else {
+          Pervasives.max(1, Math.round(probeShare)->Float.toInt)
         }
         candidates
         ->Array.push({

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1483,7 +1483,7 @@ let pushGapFillQueries = (
 
 // Per-partition state carried from the gap-fill/cursor walk to candidate
 // generation.
-type waterFillState = {
+type partitionFillState = {
   partitionId: string,
   p: partition,
   cursor: int,
@@ -1582,27 +1582,13 @@ let getNextQuery = (
 
     // Existing in-flight itemsEst across all partitions — already spent against
     // this chain's budget, so the fresh budget for new queries is what's left
-    // of chainTargetItems after it.
+    // of chainTargetItems after it. Summed in the Phase A sweep below.
     let chainReserved = ref(0.)
-    for idx in 0 to partitionsCount - 1 {
-      let partitionId = optimizedPartitions.idsInAscOrder->Array.getUnsafe(idx)
-      let p = optimizedPartitions.entities->Dict.getUnsafe(partitionId)
-      for pqIdx in 0 to p.mutPendingQueries->Array.length - 1 {
-        chainReserved :=
-          chainReserved.contents +.
-          (p.mutPendingQueries->Array.getUnsafe(pqIdx)).itemsEst->Int.toFloat
-      }
-    }
-
-    // The tick's fresh budget: chainTargetItems minus what's already in flight.
-    let freshBudget = Pervasives.max(0., chainTargetItems -. chainReserved.contents)
 
     // Position of each partition in idsInAscOrder, so an accepted query routes
-    // back to its bucket and the output stays in idsInAscOrder.
+    // back to its bucket and the output stays in idsInAscOrder. Filled in the
+    // Phase A sweep below.
     let partitionIndexById = Dict.make()
-    for idx in 0 to partitionsCount - 1 {
-      partitionIndexById->Dict.set(optimizedPartitions.idsInAscOrder->Array.getUnsafe(idx), idx)
-    }
 
     // Every candidate query for this tick — gap-fill holes (Phase A) plus each
     // in-range partition's chunks/probe toward the target (Phase B) — generated
@@ -1620,7 +1606,13 @@ let getNextQuery = (
     for idx in 0 to partitionsCount - 1 {
       let partitionId = optimizedPartitions.idsInAscOrder->Array.getUnsafe(idx)
       let p = optimizedPartitions.entities->Dict.getUnsafe(partitionId)
+      partitionIndexById->Dict.set(partitionId, idx)
       let pendingCount = p.mutPendingQueries->Array.length
+      for pqIdx in 0 to pendingCount - 1 {
+        chainReserved :=
+          chainReserved.contents +.
+          (p.mutPendingQueries->Array.getUnsafe(pqIdx)).itemsEst->Int.toFloat
+      }
       let queryEndBlock = computeQueryEndBlock(p)
       let maybeChunkRange = getMinHistoryRange(p)
 
@@ -1675,7 +1667,10 @@ let getNextQuery = (
       }
     }
 
-    let isInRange = (fs: waterFillState) =>
+    // The tick's fresh budget: chainTargetItems minus what's already in flight.
+    let freshBudget = Pervasives.max(0., chainTargetItems -. chainReserved.contents)
+
+    let isInRange = (fs: partitionFillState) =>
       fs.cursor <= chainTargetBlock &&
       switch fs.queryEndBlock {
       | Some(eb) => fs.cursor <= eb
@@ -1721,14 +1716,22 @@ let getNextQuery = (
         let chunkSize = Js.Math.ceil_int(minHistoryRange->Int.toFloat *. 1.8)
         let maxChunksRemaining =
           maxPendingChunksPerPartition - fs.pendingCount - fs.chunksUsedThisCall
-        let created = ref(0)
-        let chunkFromBlock = ref(fs.cursor)
         // No chunk starts past chainTargetBlock; an emitted chunk still keeps
         // its full span (chunkToBlock may exceed the target — only
         // endBlock/mergeBlock are hard bounds).
+        let chunkStartCeiling = Pervasives.min(maxBlock, chainTargetBlock)
+        let created = ref(0)
+        let chunkFromBlock = ref(fs.cursor)
+        // Stop once this partition alone has generated more than the whole fresh
+        // budget: the acceptance pass can hand a single partition at most the
+        // budget plus one overshoot query, so further chunks could never be
+        // accepted. Bounds generation (and the candidate sort) when the budget
+        // is small relative to the pending-chunk cap.
+        let generatedItems = ref(0.)
         while (
           created.contents < maxChunksRemaining &&
-            chunkFromBlock.contents <= Pervasives.min(maxBlock, chainTargetBlock)
+          chunkFromBlock.contents <= chunkStartCeiling &&
+          generatedItems.contents <= freshBudget
         ) {
           let chunkToBlock = Pervasives.min(chunkFromBlock.contents + chunkSize - 1, maxBlock)
           let rawEst = density *. (chunkToBlock - chunkFromBlock.contents + 1)->Int.toFloat
@@ -1749,6 +1752,7 @@ let getNextQuery = (
             addressesByContractName: p.addressesByContractName,
           })
           ->ignore
+          generatedItems := generatedItems.contents +. itemsEst->Int.toFloat
           chunkFromBlock := chunkToBlock + 1
           created := created.contents + 1
         }
@@ -1790,16 +1794,17 @@ let getNextQuery = (
     // single overshoot); everything after it waits for a tick with more budget.
     // Accepted queries route back to their partition bucket, so the output stays
     // in idsInAscOrder with each partition's queries in fromBlock order.
+    candidates->Array.sort((a, b) => Int.compare(a.fromBlock, b.fromBlock))
+    let candidatesCount = candidates->Array.length
     let remainingBudget = ref(freshBudget)
-    candidates
-    ->Array.toSorted((a, b) => Int.compare(a.fromBlock, b.fromBlock))
-    ->Array.forEach(query =>
-      if remainingBudget.contents > 0. {
-        let partitionIdx = partitionIndexById->Dict.getUnsafe(query.partitionId)
-        queriesByPartitionIndex->Array.getUnsafe(partitionIdx)->Array.push(query)->ignore
-        remainingBudget := remainingBudget.contents -. query.itemsEst->Int.toFloat
-      }
-    )
+    let acceptIdx = ref(0)
+    while remainingBudget.contents > 0. && acceptIdx.contents < candidatesCount {
+      let query = candidates->Array.getUnsafe(acceptIdx.contents)
+      let partitionIdx = partitionIndexById->Dict.getUnsafe(query.partitionId)
+      queriesByPartitionIndex->Array.getUnsafe(partitionIdx)->Array.push(query)->ignore
+      remainingBudget := remainingBudget.contents -. query.itemsEst->Int.toFloat
+      acceptIdx := acceptIdx.contents + 1
+    }
 
     let queries = queriesByPartitionIndex->Array.flat
 

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1526,6 +1526,10 @@ let getNextQuery = (
   ~chainTargetBlock: int,
   ~chainTargetItems: float,
   ~chunkItemsMultiplier: float=1.,
+  // Chain-level event density (items/block), when known. Sizes an open-ended
+  // probe by the events its range to the target is expected to hold; falls back
+  // to an even budget share when the chain is cold or already at the target.
+  ~chainDensity: option<float>=?,
 ) => {
   let headBlockNumber = knownHeight - blockLag
   if headBlockNumber <= 0 {
@@ -1741,7 +1745,24 @@ let getNextQuery = (
           created := created.contents + 1
         }
       | _ =>
-        let itemsTarget = Pervasives.max(1, Math.round(probeShare)->Float.toInt)
+        // Size the probe by the events its range to the target is expected to
+        // hold — chainDensity × (chainTargetBlock − fromBlock + 1), split across
+        // all partitions. When the chain has no density, or the partition is
+        // already at the target (no range), fall back to an even share of the
+        // fresh budget so several unknown-density partitions still probe in
+        // parallel.
+        let itemsTarget = switch chainDensity {
+        | Some(density) if density > 0. && chainTargetBlock > fs.cursor =>
+          Pervasives.max(
+            1,
+            Math.round(
+              density *.
+              (chainTargetBlock - fs.cursor + 1)->Int.toFloat /.
+              partitionsCount->Int.toFloat,
+            )->Float.toInt,
+          )
+        | _ => Pervasives.max(1, Math.round(probeShare)->Float.toInt)
+        }
         candidates
         ->Array.push({
           partitionId: fs.partitionId,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -4342,6 +4342,46 @@ describe("FetchState.getNextQuery water-fill with uneven in-flight reservations"
       ]),
     )
   })
+
+  it("concentrates a thin budget onto a few probes instead of spraying a 1-item query per partition", t => {
+    let fetchState = makeFetchState(
+      [
+        mockAddress0,
+        mockAddress1,
+        mockAddress2,
+        mockAddress3,
+        mockAddress4,
+        mockAddress5,
+        mockAddress6,
+      ]->Array.mapWithIndex((address, i) =>
+        makePartition(~id=i->Int.toString, ~address, ~knownDensity=false, ~pendingItemsTarget=None)
+      ),
+    )
+
+    // Fresh budget 300 across 7 unknown-density partitions would water-fill to
+    // ~43 each — 7 near-empty probes. Cap at ⌈300 / minQueryItems⌉ = 3 neediest
+    // partitions, each taking a full 100-item probe; the rest wait for a later
+    // tick.
+    let makeProbe = (~id, ~address): FetchState.query => {
+      partitionId: id,
+      fromBlock: 1,
+      toBlock: None,
+      isChunk: false,
+      itemsTarget: 100,
+      itemsEst: 100,
+      selection: normalSelection,
+      addressesByContractName: Dict.fromArray([("MockContract", [address])]),
+    }
+    t.expect(
+      fetchState->FetchState.getNextQuery(~chainTargetBlock=10000, ~chainTargetItems=300.),
+    ).toEqual(
+      FetchState.Ready([
+        makeProbe(~id="0", ~address=mockAddress0),
+        makeProbe(~id="1", ~address=mockAddress1),
+        makeProbe(~id="2", ~address=mockAddress2),
+      ]),
+    )
+  })
 })
 
 describe("FetchState.getNextQuery target containment", () => {

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -4373,6 +4373,36 @@ describe("FetchState.getNextQuery with uneven in-flight reservations", () => {
       ]),
     )
   })
+
+  it("sizes an open-ended probe by chain density over its range to the target", t => {
+    let fetchState = makeFetchState([
+      makePartition(~id="0", ~address=mockAddress0, ~knownDensity=false, ~pendingItemsTarget=None),
+    ])
+
+    // Given a chain density, the probe is sized to the events its range holds:
+    // density 10 × (100 - 1 + 1) blocks / 1 partition = 1000 items — instead of
+    // the whole 5000 budget share.
+    t.expect(
+      fetchState->FetchState.getNextQuery(
+        ~chainTargetBlock=100,
+        ~chainTargetItems=5000.,
+        ~chainDensity=10.,
+      ),
+    ).toEqual(
+      FetchState.Ready([
+        {
+          partitionId: "0",
+          fromBlock: 1,
+          toBlock: None,
+          isChunk: false,
+          itemsTarget: 1000,
+          itemsEst: 1000,
+          selection: normalSelection,
+          addressesByContractName: Dict.fromArray([("MockContract", [mockAddress0])]),
+        },
+      ]),
+    )
+  })
 })
 
 describe("FetchState.getNextQuery target containment", () => {

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -2119,8 +2119,10 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          itemsTarget: 5000,
-          itemsEst: 5000,
+          // Sits one block ahead of partition "1", so 9/10 of the range to the
+          // target -> 4500 vs 5000.
+          itemsTarget: 4500,
+          itemsEst: 4500,
           fromBlock: 2,
           toBlock: None,
           isChunk: false,
@@ -2199,7 +2201,9 @@ describe("FetchState.getNextQuery & integration", () => {
       there's no point to continue merging partitions,
       so we have two queries concurrently`,
     ).toEqual(
-      Ready([makePartition2Query(~itemsTarget=5000), makePartition0Query(~itemsTarget=5000)]),
+      // Partition "0" sits at block 11 (the head), covering only the last block
+      // of the range to the target -> a small probe next to "2"'s 5000.
+      Ready([makePartition2Query(~itemsTarget=5000), makePartition0Query(~itemsTarget=556)]),
     )
     // Partition "0" is above the target block, so it's the only eligible
     // unknown-density partition here and gets the whole budget.
@@ -2250,8 +2254,10 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           FetchState.partitionId: "0",
-          itemsTarget: 5000,
-          itemsEst: 5000,
+          // At block 11 (the head), it covers only the last block of the range
+          // to the target, so a small probe next to partition "2"'s 5000.
+          itemsTarget: 556,
+          itemsEst: 556,
           toBlock: None,
           selection: originalFetchState.normalSelection,
           addressesByContractName: Dict.fromArray([
@@ -2286,8 +2292,8 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           FetchState.partitionId: "0",
-          itemsTarget: 5000,
-          itemsEst: 5000,
+          itemsTarget: 556,
+          itemsEst: 556,
           toBlock: None,
           selection: originalFetchState.normalSelection,
           addressesByContractName: Dict.fromArray([
@@ -2367,8 +2373,8 @@ describe("FetchState.getNextQuery & integration", () => {
                 fromBlock: 11,
                 toBlock: None,
                 isChunk: false,
-                itemsTarget: 5000,
-                itemsEst: 5000,
+                itemsTarget: 2500,
+                itemsEst: 2500,
                 fetchedBlock: None,
               },
             ],
@@ -2462,8 +2468,9 @@ describe("FetchState.getNextQuery & integration", () => {
         {
           ...defaultQuery,
           partitionId: "2",
-          itemsTarget: 3333,
-          itemsEst: 3333,
+          // Starts at block 2, so 9 of the 11-block range to the target -> 2727.
+          itemsTarget: 2727,
+          itemsEst: 2727,
           fromBlock: 2,
           toBlock: None,
           isChunk: false,
@@ -3311,21 +3318,22 @@ describe("FetchState unit tests for specific cases", () => {
           },
           {
             // Partition responded with no items, so it still has only one
-            // response (not two) — density isn't trusted yet, so it's sized
-            // as an even 3-way split like the others, not real (zero) density.
+            // response (not two) — density isn't trusted yet, so it probes. It
+            // starts further ahead (block 401) than partition "2", so it covers
+            // less of the range to the target and gets a smaller probe.
             ...queryA,
             partitionId: "1",
-            itemsTarget: 3333,
-            itemsEst: 3333,
+            itemsTarget: 1663,
+            itemsEst: 1663,
             toBlock: Some(500),
             fromBlock: 401,
           },
           {
-            // Partition "0" also still has only one response, so it's also
-            // an even 3-way split here vs. the 2-way split it got above.
+            // Partition "0" starts even further ahead (block 501), so it covers
+            // the least range and gets the smallest probe.
             ...queries->Array.getUnsafe(1),
-            itemsTarget: 3333,
-            itemsEst: 3333,
+            itemsTarget: 831,
+            itemsEst: 831,
           },
         ]),
       )
@@ -4211,9 +4219,15 @@ describe("FetchState.getNextQuery with uneven in-flight reservations", () => {
   // from what's left, not the full target.
   let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
 
-  let makePartition = (~id, ~address, ~knownDensity, ~pendingItemsTarget): FetchState.partition => {
+  let makePartition = (
+    ~id,
+    ~address,
+    ~knownDensity,
+    ~pendingItemsTarget,
+    ~latestFetchedBlock=0,
+  ): FetchState.partition => {
     id,
-    latestFetchedBlock: {blockNumber: 0, blockTimestamp: 0},
+    latestFetchedBlock: {blockNumber: latestFetchedBlock, blockTimestamp: 0},
     selection: normalSelection,
     addressesByContractName: Dict.fromArray([("MockContract", [address])]),
     mergeBlock: None,
@@ -4374,20 +4388,25 @@ describe("FetchState.getNextQuery with uneven in-flight reservations", () => {
     )
   })
 
-  it("sizes an open-ended probe by chain density over its range to the target", t => {
+  it("scales each open-ended probe by how much of the range to the target it still covers", t => {
     let fetchState = makeFetchState([
+      // Frontier partition: covers the whole range to the target.
       makePartition(~id="0", ~address=mockAddress0, ~knownDensity=false, ~pendingItemsTarget=None),
+      // Sits at block 50, so it covers only half the range and gets half as much.
+      makePartition(
+        ~id="1",
+        ~address=mockAddress1,
+        ~knownDensity=false,
+        ~pendingItemsTarget=None,
+        ~latestFetchedBlock=50,
+      ),
     ])
 
-    // Given a chain density, the probe is sized to the events its range holds:
-    // density 10 × (100 - 1 + 1) blocks / 1 partition = 1000 items — instead of
-    // the whole 5000 budget share.
+    // rangeToTarget = 100 - 0 = 100, rangeTargetDensity = 1000 / 100 = 10.
+    // Probe "0" (from block 1): 10 × (100 - 1 + 1) / 2 = 500.
+    // Probe "1" (from block 51): 10 × (100 - 51 + 1) / 2 = 250.
     t.expect(
-      fetchState->FetchState.getNextQuery(
-        ~chainTargetBlock=100,
-        ~chainTargetItems=5000.,
-        ~chainDensity=10.,
-      ),
+      fetchState->FetchState.getNextQuery(~chainTargetBlock=100, ~chainTargetItems=1000.),
     ).toEqual(
       FetchState.Ready([
         {
@@ -4395,10 +4414,20 @@ describe("FetchState.getNextQuery with uneven in-flight reservations", () => {
           fromBlock: 1,
           toBlock: None,
           isChunk: false,
-          itemsTarget: 1000,
-          itemsEst: 1000,
+          itemsTarget: 500,
+          itemsEst: 500,
           selection: normalSelection,
           addressesByContractName: Dict.fromArray([("MockContract", [mockAddress0])]),
+        },
+        {
+          partitionId: "1",
+          fromBlock: 51,
+          toBlock: None,
+          isChunk: false,
+          itemsTarget: 250,
+          itemsEst: 250,
+          selection: normalSelection,
+          addressesByContractName: Dict.fromArray([("MockContract", [mockAddress1])]),
         },
       ]),
     )

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -4134,15 +4134,11 @@ describe("FetchState.getNextQuery water-fill round is order-independent", () => 
   })
 })
 
-describe("FetchState.getNextQuery water-fill redistributes a filled partition's leftover", () => {
+describe("FetchState.getNextQuery greedy budget pass fills partitions toward the target", () => {
   // Two equal-density partitions, chunk cost 180 (density 10 × chunkSize 18).
-  // "capped" can only fetch one chunk (mergeBlock caps its range), so it fills
-  // after a single 180-item chunk and leaves the rest of its share behind;
-  // "deep" has unbounded range. The freed budget must flow to "deep" across
-  // rounds. Before the water-fill line accounted for each partition's own
-  // already-emitted footprint, "deep" was dropped the moment its running
-  // reservation passed a round's fresh share — so it stopped at 2 chunks and
-  // a third of the 900-item budget went unused.
+  // "capped" can only fetch one chunk (mergeBlock caps its range); "deep" has
+  // unbounded range but stops at the shared target. The greedy pass walks both,
+  // spending budget as it fills each toward the target and its range end.
   let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
 
   let makeChunkPartition = (~id, ~address, ~mergeBlock): FetchState.partition => {
@@ -4183,9 +4179,13 @@ describe("FetchState.getNextQuery water-fill redistributes a filled partition's 
     firstEventBlock: Some(0),
   }
 
-  it("keeps topping up the partition with range left until the whole budget is spent", t => {
+  it("fills each partition toward the shared target, then stops at its range end", t => {
     let byPartition = Dict.make()
-    switch fetchState->FetchState.getNextQuery(~chainTargetBlock=100000, ~chainTargetItems=900.) {
+    // Target block 45 is reachable within the 900 budget, so "deep" stops at 45
+    // (last chunk trimmed to blocks 37-45 = 90 items) and "capped" fills its
+    // single chunk — both served, unlike an unreachable far target where the
+    // first partition would spend the whole budget alone.
+    switch fetchState->FetchState.getNextQuery(~chainTargetBlock=45, ~chainTargetItems=900.) {
     | Ready(queries) =>
       queries->Array.forEach((q: FetchState.query) =>
         switch byPartition->Dict.get(q.partitionId) {
@@ -4196,43 +4196,19 @@ describe("FetchState.getNextQuery water-fill redistributes a filled partition's 
     | _ => ()
     }
 
-    t.expect(
-      byPartition,
-      ~message="deep absorbs capped's freed budget: 4 chunks (720 items) vs capped's single 180-item chunk",
-    ).toEqual(
+    t.expect(byPartition).toEqual(
       Dict.fromArray([
-        ("deep", [(1, 180), (19, 180), (37, 180), (55, 180)]),
+        ("deep", [(1, 180), (19, 180), (37, 90)]),
         ("capped", [(1, 180)]),
       ]),
     )
   })
 })
 
-describe("FetchState.waterLevel", () => {
-  it("finds the level where top-ups sum exactly to the budget", t => {
-    t.expect({
-      "evenSplitWhenEqual": FetchState.waterLevel(~budget=900., ~footprints=[0., 0., 0.]),
-      // 1500 sits above the level, so the whole 500 goes to the empty glass.
-      "unevenSkipsTheFullGlass": FetchState.waterLevel(~budget=500., ~footprints=[0., 1500.]),
-      // Both below the final level: (1000 + 100 + 200) / 2.
-      "floodsAll": FetchState.waterLevel(~budget=1000., ~footprints=[100., 200.]),
-      "single": FetchState.waterLevel(~budget=5., ~footprints=[45.]),
-    }).toEqual({
-      "evenSplitWhenEqual": 300.,
-      "unevenSkipsTheFullGlass": 500.,
-      "floodsAll": 650.,
-      "single": 50.,
-    })
-  })
-})
-
-describe("FetchState.getNextQuery water-fill with uneven in-flight reservations", () => {
-  // Partition "1" already holds a 1500-item in-flight chunk — far above this
-  // tick's 500-item fresh budget. Its footprint must not inflate the level
-  // handed to partition "0": before the exact waterLevel, the round's line
-  // was the mean ((500 + 1500) / 2 = 1000), so "0" was handed twice the
-  // fresh budget and the chain overshot what CrossChainState subtracts from
-  // the shared pool.
+describe("FetchState.getNextQuery with uneven in-flight reservations", () => {
+  // Partition "1" already holds a 1500-item in-flight chunk, so the fresh
+  // budget is only chainTargetItems minus that reservation — new queries draw
+  // from what's left, not the full target.
   let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
 
   let makePartition = (~id, ~address, ~knownDensity, ~pendingItemsTarget): FetchState.partition => {
@@ -4311,57 +4287,72 @@ describe("FetchState.getNextQuery water-fill with uneven in-flight reservations"
     t.expect(byPartition).toEqual(Dict.fromArray([("0", [(1, 180), (19, 180), (37, 180)])]))
   })
 
-  it("sizes an unknown-density probe to the whole leftover instead of a diluted even split", t => {
-    let fetchState = makeFetchState([
-      makePartition(~id="0", ~address=mockAddress0, ~knownDensity=false, ~pendingItemsTarget=None),
-      makePartition(
-        ~id="1",
-        ~address=mockAddress1,
-        ~knownDensity=true,
-        ~pendingItemsTarget=Some(1500),
-      ),
-    ])
+  it(
+    "sizes an unknown-density probe to its even budget share, then fills chunks by fromBlock until the budget is spent",
+    t => {
+      let fetchState = makeFetchState([
+        makePartition(~id="0", ~address=mockAddress0, ~knownDensity=false, ~pendingItemsTarget=None),
+        makePartition(
+          ~id="1",
+          ~address=mockAddress1,
+          ~knownDensity=true,
+          ~pendingItemsTarget=Some(1500),
+        ),
+      ])
 
-    // Fresh budget = 500, level = 500: the probe takes all of it. Before
-    // probes were sized by their allotment, this was 500 / 2 in-range
-    // partitions = 250, stranding the other half.
-    t.expect(
-      fetchState->FetchState.getNextQuery(~chainTargetBlock=10000, ~chainTargetItems=2000.),
-    ).toEqual(
-      FetchState.Ready([
-        {
-          partitionId: "0",
-          fromBlock: 1,
-          toBlock: None,
-          isChunk: false,
-          itemsTarget: 500,
-          itemsEst: 500,
-          selection: normalSelection,
-          addressesByContractName: Dict.fromArray([("MockContract", [mockAddress0])]),
-        },
-      ]),
-    )
-  })
+      // Fresh budget = 2000 - 1500 reserved = 500, split across the 2 in-range
+      // partitions -> probe share 250. Candidates sort by fromBlock: partition
+      // "0"'s probe (block 1) is accepted first, then partition "1"'s chunks
+      // from block 101 — the second chunk tips the budget negative and ends the
+      // pass.
+      t.expect(
+        fetchState->FetchState.getNextQuery(~chainTargetBlock=10000, ~chainTargetItems=2000.),
+      ).toEqual(
+        FetchState.Ready([
+          {
+            partitionId: "0",
+            fromBlock: 1,
+            toBlock: None,
+            isChunk: false,
+            itemsTarget: 250,
+            itemsEst: 250,
+            selection: normalSelection,
+            addressesByContractName: Dict.fromArray([("MockContract", [mockAddress0])]),
+          },
+          {
+            partitionId: "1",
+            fromBlock: 101,
+            toBlock: Some(118),
+            isChunk: true,
+            itemsTarget: 180,
+            itemsEst: 180,
+            selection: normalSelection,
+            addressesByContractName: Dict.fromArray([("MockContract", [mockAddress1])]),
+          },
+          {
+            partitionId: "1",
+            fromBlock: 119,
+            toBlock: Some(136),
+            isChunk: true,
+            itemsTarget: 180,
+            itemsEst: 180,
+            selection: normalSelection,
+            addressesByContractName: Dict.fromArray([("MockContract", [mockAddress1])]),
+          },
+        ]),
+      )
+    },
+  )
 
-  it("concentrates a thin budget onto a few probes instead of spraying a 1-item query per partition", t => {
+  it("spreads a thin budget across unknown-density partitions as equal parallel probes", t => {
     let fetchState = makeFetchState(
-      [
-        mockAddress0,
-        mockAddress1,
-        mockAddress2,
-        mockAddress3,
-        mockAddress4,
-        mockAddress5,
-        mockAddress6,
-      ]->Array.mapWithIndex((address, i) =>
+      [mockAddress0, mockAddress1, mockAddress2]->Array.mapWithIndex((address, i) =>
         makePartition(~id=i->Int.toString, ~address, ~knownDensity=false, ~pendingItemsTarget=None)
       ),
     )
 
-    // Fresh budget 300 across 7 unknown-density partitions would water-fill to
-    // ~43 each — 7 near-empty probes. Cap at ⌈300 / minQueryItems⌉ = 3 neediest
-    // partitions, each taking a full 100-item probe; the rest wait for a later
-    // tick.
+    // Fresh budget 300 across 3 unknown-density partitions -> each probes with
+    // its even share (100), all three in parallel this tick.
     let makeProbe = (~id, ~address): FetchState.query => {
       partitionId: id,
       fromBlock: 1,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -4523,6 +4523,40 @@ describe("FetchState.getNextQuery target containment", () => {
       ~message="Target below the gap defers it; target inside the gap fills it",
     ).toEqual((None, Some([(101, Some(199))])))
   })
+
+  it("fills a gap behind a returned-but-unconsumed query even when its reservation would exhaust the budget", t => {
+    // Chunk [101, 200] already returned (fetchedBlock set) but is stuck behind
+    // the [51, 100] hole, so it lingers in mutPendingQueries. Its reservation
+    // was released on return, so counting it against the budget would starve the
+    // very gap-fill that lets it be consumed — a deadlock. itemsEst 1500 exceeds
+    // chainTargetItems 1000, so the old up-front subtraction zeroed the budget
+    // and dropped the gap; the fromBlock-ordered acceptance funds it instead.
+    let fetchState = makeFetchState(
+      makePartition(
+        ~latestFetchedBlock=50,
+        ~knownDensity=false,
+        ~mutPendingQueries=[
+          {
+            fromBlock: 101,
+            toBlock: Some(200),
+            isChunk: true,
+            itemsTarget: 1500,
+            itemsEst: 1500,
+            fetchedBlock: Some({blockNumber: 200, blockTimestamp: 0}),
+          },
+        ],
+      ),
+    )
+    let emitted = switch fetchState->FetchState.getNextQuery(
+      ~chainTargetBlock=100,
+      ~chainTargetItems=1000.,
+    ) {
+    | Ready(queries) => queries->Array.map((q: FetchState.query) => (q.fromBlock, q.toBlock))
+    | NothingToQuery => []
+    | WaitingForNewBlock => [(-1, None)]
+    }
+    t.expect(emitted).toEqual([(51, Some(100))])
+  })
 })
 
 describe("FetchState.getNextQuery chunk headroom and budget-driven emit", () => {

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -561,8 +561,10 @@ describe("SourceManager fetchNext", () => {
         {
           ...defaultQuery,
           partitionId: "0",
-          itemsTarget: 16_667,
-          itemsEst: 16_667,
+          // Starts at block 5 vs partition "2"'s block 2, so it covers less of
+          // the range to the target and gets a smaller probe.
+          itemsTarget: 11_111,
+          itemsEst: 11_111,
           fromBlock: 5,
           toBlock: None,
           isChunk: false,
@@ -572,10 +574,9 @@ describe("SourceManager fetchNext", () => {
         {
           ...defaultQuery,
           partitionId: "1",
-          // Every unknown-density probe gets the same even split of the fresh
-          // budget (round(50_000 / 3)), regardless of processing order.
-          itemsTarget: 16_667,
-          itemsEst: 16_667,
+          // Starts furthest ahead (block 6), so it gets the smallest probe.
+          itemsTarget: 9_259,
+          itemsEst: 9_259,
           fromBlock: 6,
           toBlock: None,
           isChunk: false,


### PR DESCRIPTION
## Summary

Replaces the water-fill budget distribution algorithm with a simpler greedy approach that generates all candidate queries (gap-fill holes and partition chunks/probes) without budget constraints, then accepts them in fromBlock order while the budget lasts. This ensures the frontier advances evenly across partitions and no partition is starved by generation order.

## Key Changes

- **Removed water-fill algorithm**: Deleted `waterLevel` function and multi-round water-fill loop that computed a shared level and topped up partitions iteratively. This was complex and order-dependent in subtle ways.

- **New candidate generation + acceptance pass**:
  - Phase A (gap-fill): Generates candidates for holes between pending queries unconditionally
  - Phase B (chunk/probe generation): Each in-range partition generates either density-sized chunks (if trusted positive density) or an open-ended probe sized by its share of the budget
  - Acceptance: Sorts all candidates by `fromBlock` and accepts them while `remainingBudget > 0`, ensuring early blocks are served first across all partitions

- **Simplified probe sizing**:
  - Unknown-density partitions now get an even share of fresh budget split across in-range partitions
  - Probes are further scaled by how much of the range to the target they still cover: `rangeTargetDensity × (chainTargetBlock − fromBlock + 1) / inRangeCount`
  - This prevents partitions sitting ahead of the frontier from consuming disproportionate budget

- **Removed mutable state from `waterFillState`**: Changed `cursor` and `chunksUsedThisCall` from mutable refs to immutable fields since they're no longer mutated during the algorithm.

- **Updated comments**: Rewrote algorithm documentation to reflect the new greedy approach instead of water-fill semantics.

## Notable Implementation Details

- The acceptance pass allows a single overshoot: the query that tips the budget negative is still accepted, then everything after waits for the next tick.
- Candidates are routed back to their partition's bucket via `partitionIndexById` lookup, so the output naturally stays in `idsInAscOrder` without a final sort.
- Fresh budget is computed once as `chainTargetItems - chainReserved` (existing in-flight reservations), then distributed greedily rather than iteratively.
- Test expectations updated to reflect new probe sizing: partitions further ahead of the frontier now get smaller probes proportional to their remaining range.

https://claude.ai/code/session_01Keqij8JHea79B2rqJX4ApZ