### PR TITLE
Enable strict warning checks in ReScript configurations

### DIFF
--- a/packages/cli/templates/static/blank_template/rescript/rescript.json
+++ b/packages/cli/templates/static/blank_template/rescript/rescript.json
@@ -14,5 +14,8 @@
     "version": 4
   },
   "suffix": ".res.mjs",
-  "dependencies": ["envio"]
+  "dependencies": ["envio"],
+  "warnings": {
+    "error": "+23"
+  }
 }

--- a/packages/cli/templates/static/blank_template/rescript/rescript.json
+++ b/packages/cli/templates/static/blank_template/rescript/rescript.json
@@ -14,8 +14,5 @@
     "version": 4
   },
   "suffix": ".res.mjs",
-  "dependencies": ["envio"],
-  "warnings": {
-    "error": "+23"
-  }
+  "dependencies": ["envio"]
 }

--- a/scenarios/fuel_test/rescript.json
+++ b/scenarios/fuel_test/rescript.json
@@ -20,6 +20,6 @@
   },
   "dependencies": ["envio"],
   "warnings": {
-    "error": "+23"
+    "error": "+a"
   }
 }

--- a/scenarios/fuel_test/rescript.json
+++ b/scenarios/fuel_test/rescript.json
@@ -18,5 +18,8 @@
     "module": "esmodule",
     "in-source": true
   },
-  "dependencies": ["envio"]
+  "dependencies": ["envio"],
+  "warnings": {
+    "error": "+23"
+  }
 }

--- a/scenarios/svm_test/rescript.json
+++ b/scenarios/svm_test/rescript.json
@@ -20,6 +20,6 @@
   },
   "dependencies": ["envio"],
   "warnings": {
-    "error": "+23"
+    "error": "+a"
   }
 }

--- a/scenarios/svm_test/rescript.json
+++ b/scenarios/svm_test/rescript.json
@@ -18,5 +18,8 @@
     "module": "esmodule",
     "in-source": true
   },
-  "dependencies": ["envio"]
+  "dependencies": ["envio"],
+  "warnings": {
+    "error": "+23"
+  }
 }

--- a/scenarios/test_codegen/rescript.json
+++ b/scenarios/test_codegen/rescript.json
@@ -24,6 +24,6 @@
   ],
   "compiler-flags": ["-open RescriptSchema"],
   "warnings": {
-    "error": "+23"
+    "error": "+a"
   }
 }

--- a/scenarios/test_codegen/rescript.json
+++ b/scenarios/test_codegen/rescript.json
@@ -22,5 +22,8 @@
     "rescript-schema",
     "envio"
   ],
-  "compiler-flags": ["-open RescriptSchema"]
+  "compiler-flags": ["-open RescriptSchema"],
+  "warnings": {
+    "error": "+23"
+  }
 }


### PR DESCRIPTION
Enable the `+a` warning flag (all warnings) as errors across all ReScript scenario configurations to enforce stricter code quality standards.

## Changes

- Added `"warnings": { "error": "+a" }` configuration to `scenarios/fuel_test/rescript.json`
- Added `"warnings": { "error": "+a" }` configuration to `scenarios/svm_test/rescript.json`
- Added `"warnings": { "error": "+a" }` configuration to `scenarios/test_codegen/rescript.json`

## Details

This change configures the ReScript compiler to treat all warnings as errors across the test scenarios. The `+a` flag enables all warnings, and the `"error"` setting promotes them to compilation errors. This ensures consistent code quality standards and prevents warnings from being overlooked during development.

https://claude.ai/code/session_01DGX7HGV5nCwFHHoazo8dCM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compiler settings across test scenarios to treat all warnings as errors.
  * Improved consistency in build validation by enforcing stricter warning handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->