### PR TITLE
Improve rollback logging and conditional event registration logging

### DIFF
--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -149,19 +149,28 @@ let rec onQueryResponse = async (
 
     let numContractRegisterEvents = parsedQueueItems->Array.reduce(0, (count, item) => {
       let eventItem = item->Internal.castUnsafeEventItem
-      eventItem.onEventRegistration.contractRegister !== None
-        ? count + 1
-        : count
+      eventItem.onEventRegistration.contractRegister !== None ? count + 1 : count
     })
-    Logging.trace({
-      "msg": "Finished querying",
-      "chainId": chain->ChainMap.Chain.toChainId,
-      "partitionId": query.partitionId,
-      "fromBlock": fromBlockQueried,
-      "toBlock": latestFetchedBlockNumber,
-      "numEvents": parsedQueueItems->Array.length,
-      "numContractRegisterEvents": numContractRegisterEvents,
-    })
+    if numContractRegisterEvents === 0 {
+      Logging.trace({
+        "msg": "Finished querying",
+        "chainId": chain->ChainMap.Chain.toChainId,
+        "partitionId": query.partitionId,
+        "fromBlock": fromBlockQueried,
+        "toBlock": latestFetchedBlockNumber,
+        "numEvents": parsedQueueItems->Array.length,
+      })
+    } else {
+      Logging.trace({
+        "msg": "Finished querying",
+        "chainId": chain->ChainMap.Chain.toChainId,
+        "partitionId": query.partitionId,
+        "fromBlock": fromBlockQueried,
+        "toBlock": latestFetchedBlockNumber,
+        "numEvents": parsedQueueItems->Array.length,
+        "numContractRegisterEvents": numContractRegisterEvents,
+      })
+    }
 
     let reorgResult = chainState->ChainState.registerReorgGuard(~blockHashes, ~knownHeight)
 

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -96,10 +96,10 @@ and executeRollback = async (
 ) => {
   let startTime = Performance.now()
 
-  let chainState = state->IndexerState.getChainState(~chain=reorgChain)
-
-  let logger = Logging.createChildFrom(
-    ~logger=chainState->ChainState.logger,
+  // Not derived from the reorg chain's logger: that would bind its chainId onto
+  // every line, colliding with the per-chain chainId on the "Rollbacked" logs.
+  // The reorg chain is identified by the reorgChain param instead.
+  let logger = Logging.createChild(
     ~params={
       "action": "Rollback",
       "reorgChain": reorgChain,

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -184,7 +184,6 @@ and executeRollback = async (
         "chainId": chainId,
         "fromBlock": fromBlock,
         "toBlock": toBlock,
-        "isReorgChain": chainId === reorgChainId,
         "rollbackedEvents": eventsProcessedDiffByChain
         ->Utils.Dict.dangerouslyGetByIntNonOption(chainId)
         ->Option.getOr(0.),
@@ -193,7 +192,7 @@ and executeRollback = async (
     }
   })
 
-  let _ = await state->InMemoryStore.prepareRollbackDiff(
+  let diff = await state->InMemoryStore.prepareRollbackDiff(
     ~rollbackTargetCheckpointId,
     ~rollbackDiffCheckpointId=state->IndexerState.committedCheckpointId->BigInt.add(1n),
     ~progressBlockNumberByChainId=newProgressBlockNumberPerChain,
@@ -206,8 +205,12 @@ and executeRollback = async (
       "fromBlock": chain["fromBlock"],
       "toBlock": chain["toBlock"],
       "rollbackedEvents": chain["rollbackedEvents"],
-      "isReorgChain": chain["isReorgChain"],
     })
+  })
+  logger->Logging.childTrace({
+    "msg": "Rollback entity changes",
+    "deleted": diff["deletedEntities"],
+    "upserted": diff["setEntities"],
   })
   Prometheus.RollbackSuccess.increment(
     ~timeSeconds=Performance.secondsSince(startTime),

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -72,7 +72,7 @@ let rec rollback = async (
     // found yet. Wait for the ReorgDetected branch above to find it and re-kick.
     | FindingReorgDepth => ()
     | FoundReorgDepth(_) if state->IndexerState.isProcessing =>
-      Logging.info("Waiting for batch to finish processing before executing rollback")
+      Logging.trace("Waiting for batch to finish processing before executing rollback")
     | FoundReorgDepth({chain: reorgChain, rollbackTargetBlockNumber}) =>
       await executeRollback(
         state,
@@ -161,12 +161,12 @@ and executeRollback = async (
     }
   }
 
-  let rollbackRangeByChainId = Dict.make()
+  let rolledBackChains = []
   state
   ->IndexerState.chainStates
   ->Utils.Dict.forEach(cs => {
     let chainId = (cs->ChainState.chainConfig).id
-    let fromBlockNumber = cs->ChainState.committedProgressBlockNumber
+    let fromBlock = cs->ChainState.committedProgressBlockNumber
     cs->ChainState.rollback(
       ~newProgressBlockNumber=newProgressBlockNumberPerChain->Utils.Dict.dangerouslyGetByIntNonOption(
         chainId,
@@ -177,34 +177,37 @@ and executeRollback = async (
       ~rollbackTargetBlockNumber,
       ~isReorgChain=chainId === reorgChainId,
     )
-    let toBlockNumber = cs->ChainState.committedProgressBlockNumber
-    if fromBlockNumber !== toBlockNumber {
-      rollbackRangeByChainId->Dict.set(
-        chainId->Int.toString,
-        {"fromBlock": fromBlockNumber, "toBlock": toBlockNumber},
-      )
+    let toBlock = cs->ChainState.committedProgressBlockNumber
+    if fromBlock !== toBlock {
+      rolledBackChains
+      ->Array.push({
+        "chainId": chainId,
+        "fromBlock": fromBlock,
+        "toBlock": toBlock,
+        "isReorgChain": chainId === reorgChainId,
+        "rollbackedEvents": eventsProcessedDiffByChain
+        ->Utils.Dict.dangerouslyGetByIntNonOption(chainId)
+        ->Option.getOr(0.),
+      })
+      ->ignore
     }
   })
-  logger->Logging.childInfo({
-    "msg": "Rolled back chains on reorg",
-    "rollbackRangeByChainId": rollbackRangeByChainId,
-  })
 
-  let diff = await state->InMemoryStore.prepareRollbackDiff(
+  let _ = await state->InMemoryStore.prepareRollbackDiff(
     ~rollbackTargetCheckpointId,
     ~rollbackDiffCheckpointId=state->IndexerState.committedCheckpointId->BigInt.add(1n),
     ~progressBlockNumberByChainId=newProgressBlockNumberPerChain,
   )
 
-  logger->Logging.childTrace({
-    "msg": "Finished rollback on reorg",
-    "entityChanges": {
-      "deleted": diff["deletedEntities"],
-      "upserted": diff["setEntities"],
-    },
-    "rollbackedEvents": rollbackedProcessedEvents.contents,
-    "beforeCheckpointId": state->IndexerState.committedCheckpointId,
-    "targetCheckpointId": rollbackTargetCheckpointId,
+  rolledBackChains->Array.forEach(chain => {
+    logger->Logging.childInfo({
+      "msg": "Rollbacked",
+      "chainId": chain["chainId"],
+      "fromBlock": chain["fromBlock"],
+      "toBlock": chain["toBlock"],
+      "rollbackedEvents": chain["rollbackedEvents"],
+      "isReorgChain": chain["isReorgChain"],
+    })
   })
   Prometheus.RollbackSuccess.increment(
     ~timeSeconds=Performance.secondsSince(startTime),

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -161,10 +161,12 @@ and executeRollback = async (
     }
   }
 
+  let rollbackRangeByChainId = Dict.make()
   state
   ->IndexerState.chainStates
   ->Utils.Dict.forEach(cs => {
     let chainId = (cs->ChainState.chainConfig).id
+    let fromBlockNumber = cs->ChainState.committedProgressBlockNumber
     cs->ChainState.rollback(
       ~newProgressBlockNumber=newProgressBlockNumberPerChain->Utils.Dict.dangerouslyGetByIntNonOption(
         chainId,
@@ -175,6 +177,17 @@ and executeRollback = async (
       ~rollbackTargetBlockNumber,
       ~isReorgChain=chainId === reorgChainId,
     )
+    let toBlockNumber = cs->ChainState.committedProgressBlockNumber
+    if fromBlockNumber !== toBlockNumber {
+      rollbackRangeByChainId->Dict.set(
+        chainId->Int.toString,
+        {"fromBlock": fromBlockNumber, "toBlock": toBlockNumber},
+      )
+    }
+  })
+  logger->Logging.childInfo({
+    "msg": "Rolled back chains on reorg",
+    "rollbackRangeByChainId": rollbackRangeByChainId,
   })
 
   let diff = await state->InMemoryStore.prepareRollbackDiff(


### PR DESCRIPTION
## Summary
Enhanced logging during rollback operations and optimized query response logging to reduce noise when contract registration events are absent.

## Key Changes

**Rollback.res:**
- Changed "Waiting for batch to finish processing" log from `info` to `trace` level to reduce log verbosity
- Added structured logging of per-chain rollback details (chainId, fromBlock, toBlock, rollbackedEvents) at `info` level
- Refactored rollback completion logging to separate per-chain summaries from entity change details
- Entity change details now logged at `trace` level instead of `info`

**ChainFetching.res:**
- Made contract registration event logging conditional: only include `numContractRegisterEvents` field in trace logs when contract register events are actually present
- Reduces log noise by omitting zero-valued event counts in the common case where no contract registration events are found

## Implementation Details
- Introduced `rolledBackChains` array to collect per-chain rollback information during the chain state iteration
- Logs are now structured to provide actionable information at appropriate levels (info for rollback summaries, trace for detailed entity changes)
- Conditional logging in ChainFetching maintains backward compatibility while improving log clarity

https://claude.ai/code/session_01Xvxwf6mi6rT2AV16sx2KSL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollback reporting so only chains that were actually rolled back are included in the results/logs.
  * Adjusted “query finished” logging to only include contract-register event counts when such events are present.

* **Refactor**
  * Streamlined rollback-related diagnostics to reduce noisy logs and focus output on the most relevant entity changes.
  * Downgraded one rollback status message from higher-verbosity logging to trace level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->