### PR TITLE
Extract client-side address filtering from FetchState

### DIFF
--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -223,17 +223,18 @@ let rec onQueryResponse = async (
       // kick (eg from the processing loop quiescing) collapses into this one.
       scheduleRollback()
     | None =>
+      // Drop over-fetched events (a merged partition returning an address before
+      // its effectiveStartBlock, or a wildcard param referencing an address
+      // registered after the log's block) before contract registration, so they
+      // neither spawn dynamic contracts nor enter the buffer.
+      let newItems = chainState->ChainState.filterByClientAddress(parsedQueueItems)
       let itemsWithContractRegister = []
-      let newItems = []
-      for idx in 0 to parsedQueueItems->Array.length - 1 {
-        let item = parsedQueueItems->Array.getUnsafe(idx)
+      for idx in 0 to newItems->Array.length - 1 {
+        let item = newItems->Array.getUnsafe(idx)
         let eventItem = item->Internal.castUnsafeEventItem
         if eventItem.onEventRegistration.contractRegister !== None {
           itemsWithContractRegister->Array.push(item)
         }
-        // TODO: Don't really need to keep it in the queue
-        // when there's no handler (besides raw_events, processed counter, and dcsToStore consuming)
-        newItems->Array.push(item)
       }
 
       // Re-check staleness: contract registration is async, so the chain state

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -94,8 +94,8 @@ let make = (
   validateOnEventRegistrations(~chainId=chainConfig.id, onEventRegistrations)
   {
     logger,
-    fetchState,
     onEventRegistrations,
+    fetchState,
     indexingAddresses,
     sourceManager,
     chainConfig,
@@ -619,6 +619,9 @@ let materializePageItems = async (
   ))
 }
 
+let filterByClientAddress = (cs: t, items: array<Internal.item>): array<Internal.item> =>
+  items->FetchState.filterByClientAddress(~indexingAddresses=cs.indexingAddresses)
+
 let handleQueryResult = (
   cs: t,
   ~query: FetchState.query,
@@ -651,12 +654,7 @@ let handleQueryResult = (
 
   cs.fetchState =
     fs
-    ->FetchState.handleQueryResult(
-      ~indexingAddresses=cs.indexingAddresses,
-      ~query,
-      ~latestFetchedBlock,
-      ~newItems,
-    )
+    ->FetchState.handleQueryResult(~query, ~latestFetchedBlock, ~newItems)
     ->FetchState.updateKnownHeight(~knownHeight)
 
   // The query is no longer in flight, so release its reservation.

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -103,6 +103,10 @@ let isReady: t => bool
 let isFetchingAtHead: t => bool
 let isAtHeadWithoutEndBlock: t => bool
 
+// Drop over-fetched events an address-param filter rejects, before contract
+// registration runs on them. Uses the chain's current indexing addresses.
+let filterByClientAddress: (t, array<Internal.item>) => array<Internal.item>
+
 // State transitions. The chain state is mutated only through these.
 let handleQueryResult: (
   t,

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -627,13 +627,90 @@ let bufferReadyCount = (fetchState: t) => {
 /*
 Comparitor for two events from the same chain. No need for chain id or timestamp
 */
-let compareBufferItem = (a: Internal.item, b: Internal.item) => {
-  let blockOrdering = Int.compare(a->Internal.getItemBlockNumber, b->Internal.getItemBlockNumber)
-  if blockOrdering === Ordering.equal {
-    Int.compare(a->Internal.getItemLogIndex, b->Internal.getItemLogIndex)
-  } else {
-    blockOrdering
+let getRegistrationIndex = (item: Internal.item): int =>
+  switch item {
+  | Event({onEventRegistration}) => onEventRegistration.index
+  | Block({onBlockRegistration}) => onBlockRegistration.index
   }
+
+// Total order on buffer items: block, then logIndex, then registration index.
+// Returns a plain int (-1/0/1) with explicit field comparisons so it can be
+// called directly from the merge/insertion loops below — no Array.sort callback,
+// no allocated key. `0` means a true duplicate: same log routed to the same
+// registration (two registrations for one log differ by index and are kept).
+let compareBufferItem = (a: Internal.item, b: Internal.item): int => {
+  let ba = a->Internal.getItemBlockNumber
+  let bb = b->Internal.getItemBlockNumber
+  if ba != bb {
+    ba < bb ? -1 : 1
+  } else {
+    let la = a->Internal.getItemLogIndex
+    let lb = b->Internal.getItemLogIndex
+    if la != lb {
+      la < lb ? -1 : 1
+    } else {
+      let ia = a->getRegistrationIndex
+      let ib = b->getRegistrationIndex
+      ia < ib ? -1 : ia > ib ? 1 : 0
+    }
+  }
+}
+
+// Merge a maybe-unsorted `newItems` run into the already-sorted, already-deduped
+// `buffer`, dropping items equal on (blockNumber, logIndex, registration index).
+// Single linear pass over both runs after ordering `newItems` in place; every
+// comparison is a direct `compareBufferItem` call (V8 inlines it) rather than a
+// callback through `Array.sort`.
+let mergeIntoBuffer = (buffer: array<Internal.item>, newItems: array<Internal.item>): array<
+  Internal.item,
+> => {
+  let n = newItems->Array.length
+  // Insertion sort: a source response is small and usually already ascending,
+  // so this is ~O(n) here.
+  for i in 1 to n - 1 {
+    let x = newItems->Array.getUnsafe(i)
+    let j = ref(i - 1)
+    while j.contents >= 0 && compareBufferItem(newItems->Array.getUnsafe(j.contents), x) > 0 {
+      newItems->Array.setUnsafe(j.contents + 1, newItems->Array.getUnsafe(j.contents))
+      j := j.contents - 1
+    }
+    newItems->Array.setUnsafe(j.contents + 1, x)
+  }
+
+  let m = buffer->Array.length
+  let merged = []
+  let last = ref(None)
+  let push = item =>
+    switch last.contents {
+    | Some(l) if compareBufferItem(l, item) === 0 => ()
+    | _ => {
+        merged->Array.push(item)
+        last := Some(item)
+      }
+    }
+
+  let i = ref(0)
+  let j = ref(0)
+  while i.contents < m && j.contents < n {
+    let a = buffer->Array.getUnsafe(i.contents)
+    let b = newItems->Array.getUnsafe(j.contents)
+    if compareBufferItem(a, b) <= 0 {
+      push(a)
+      i := i.contents + 1
+    } else {
+      push(b)
+      j := j.contents + 1
+    }
+  }
+  while i.contents < m {
+    push(buffer->Array.getUnsafe(i.contents))
+    i := i.contents + 1
+  }
+  while j.contents < n {
+    push(newItems->Array.getUnsafe(j.contents))
+    j := j.contents + 1
+  }
+  merged
 }
 
 // Some big number which should be bigger than any log index
@@ -704,48 +781,46 @@ let updateInternal = (
   fetchState: t,
   ~optimizedPartitions=fetchState.optimizedPartitions,
   ~mutItems=?,
+  // Set when the caller already passes a sorted, deduped buffer (hot paths merge
+  // via mergeIntoBuffer or filter the sorted buffer). Otherwise mutItems is
+  // normalized here, so callers can hand over items in any order.
+  ~mutItemsSorted=false,
   ~blockLag=fetchState.blockLag,
   ~knownHeight=fetchState.knownHeight,
 ): t => {
-  let mutItemsRef = ref(mutItems)
+  // The buffer to build on: the caller's items (normalized to sorted if needed),
+  // or the current buffer when only onBlock items change.
+  let base = switch mutItems {
+  | Some(items) => mutItemsSorted ? items : []->mergeIntoBuffer(items)
+  | None => fetchState.buffer
+  }
 
+  // onBlock items are generated as their own ascending (block, logIndex) run and
+  // folded into `base` by the single merge below.
+  let blockItems = []
   let latestOnBlockBlockNumber = switch fetchState.onBlockRegistrations {
   | [] => knownHeight
-  | onBlockRegistrations => {
-      // Calculate the max block number we are going to create items for
-      // Use maxOnBlockBufferSize to get the last target item in the buffer
-      //
-      // mutItems is not very reliable, since it might not be sorted,
-      // but the chances for it happen are very low and not critical
-      //
-      // All this needed to prevent OOM when adding too many block items to the queue
-      let maxBlockNumber = switch switch mutItemsRef.contents {
-      | Some(mutItems) => mutItems
-      | None => fetchState.buffer
-      }->Array.get(fetchState.maxOnBlockBufferSize - 1) {
-      | Some(item) => item->Internal.getItemBlockNumber
-      | None =>
-        switch optimizedPartitions->OptimizedPartitions.getLatestFullyFetchedBlock {
-        | None => knownHeight
-        | Some(latestFullyFetchedBlock) => latestFullyFetchedBlock.blockNumber
-        }
+  | onBlockRegistrations =>
+    // Calculate the max block number we are going to create items for
+    // Use maxOnBlockBufferSize to get the last target item in the buffer
+    // (sorted, so this is the highest-block item within the buffer cap).
+    // All this needed to prevent OOM when adding too many block items to the queue
+    let maxBlockNumber = switch base->Array.get(fetchState.maxOnBlockBufferSize - 1) {
+    | Some(item) => item->Internal.getItemBlockNumber
+    | None =>
+      switch optimizedPartitions->OptimizedPartitions.getLatestFullyFetchedBlock {
+      | None => knownHeight
+      | Some(latestFullyFetchedBlock) => latestFullyFetchedBlock.blockNumber
       }
-
-      let mutItems = switch mutItemsRef.contents {
-      | Some(mutItems) => mutItems
-      | None => fetchState.buffer->Array.copy
-      }
-      mutItemsRef := Some(mutItems)
-
-      appendOnBlockItems(
-        ~mutItems,
-        ~onBlockRegistrations,
-        ~indexerStartBlock=fetchState.startBlock,
-        ~fromBlock=fetchState.latestOnBlockBlockNumber,
-        ~maxBlockNumber,
-        ~maxOnBlockBufferSize=fetchState.maxOnBlockBufferSize,
-      )
     }
+    appendOnBlockItems(
+      ~mutItems=blockItems,
+      ~onBlockRegistrations,
+      ~indexerStartBlock=fetchState.startBlock,
+      ~fromBlock=fetchState.latestOnBlockBlockNumber,
+      ~maxBlockNumber,
+      ~maxOnBlockBufferSize=fetchState.maxOnBlockBufferSize,
+    )
   }
 
   let updatedFetchState = {
@@ -760,15 +835,10 @@ let updateInternal = (
     latestOnBlockBlockNumber,
     blockLag,
     knownHeight,
-    buffer: switch mutItemsRef.contents {
-    // Theoretically it could be faster to asume that
-    // the items are sorted, but there are cases
-    // when the data source returns them unsorted
-    | Some(mutItems) => {
-        mutItems->Array.sort(compareBufferItem)
-        mutItems
-      }
-    | None => fetchState.buffer
+    // Single merge point: fold any onBlock items into the sorted base buffer.
+    buffer: switch blockItems {
+    | [] => base
+    | blockItems => base->mergeIntoBuffer(blockItems)
     },
     firstEventBlock: fetchState.firstEventBlock,
   }
@@ -1285,24 +1355,15 @@ let registerDynamicContracts = (
   }
 }
 
-/*
-Updates fetchState with a response for a given query.
-Returns Error if the partition with given query cannot be found (unexpected)
-
-newItems are ordered earliest to latest (as they are returned from the worker)
-*/
-let handleQueryResult = (
-  fetchState: t,
+// Drop events an address-param filter rejects. A merged partition may
+// over-fetch a wildcard event whose indexed address param references an
+// address registered after the log's block; `clientAddressFilter` is the
+// param-level analogue of EventRouter's srcAddress effectiveStartBlock check.
+let filterByClientAddress = (
+  items: array<Internal.item>,
   ~indexingAddresses: IndexingAddresses.t,
-  ~query: query,
-  ~latestFetchedBlock: blockNumberAndTimestamp,
-  ~newItems,
-): t => {
-  // Drop events an address-param filter rejects. A merged partition may
-  // over-fetch a wildcard event whose indexed address param references an
-  // address registered after the log's block; `clientAddressFilter` is the
-  // param-level analogue of EventRouter's srcAddress effectiveStartBlock check.
-  let newItems = newItems->Array.filter(item =>
+): array<Internal.item> =>
+  items->Array.filter(item =>
     switch item {
     | Internal.Event({payload, blockNumber}) as item =>
       switch (item->Internal.castUnsafeEventItem).onEventRegistration.clientAddressFilter {
@@ -1313,6 +1374,19 @@ let handleQueryResult = (
     | _ => true
     }
   )
+
+/*
+Updates fetchState with a response for a given query.
+Returns Error if the partition with given query cannot be found (unexpected)
+
+newItems are ordered earliest to latest (as they are returned from the worker)
+*/
+let handleQueryResult = (
+  fetchState: t,
+  ~query: query,
+  ~latestFetchedBlock: blockNumberAndTimestamp,
+  ~newItems,
+): t => {
   fetchState->updateInternal(
     ~optimizedPartitions=fetchState.optimizedPartitions->OptimizedPartitions.handleQueryResponse(
       ~query,
@@ -1320,10 +1394,14 @@ let handleQueryResult = (
       ~itemsCount=newItems->Array.length,
       ~latestFetchedBlock,
     ),
+    // Merge the response into the sorted buffer, dropping duplicates an
+    // overlapping query may re-deliver (e.g. an over-fetched log matched by two
+    // partitions). Absorbs sorting too, so updateInternal doesn't re-sort.
+    ~mutItemsSorted=true,
     ~mutItems=?{
       switch newItems {
       | [] => None
-      | _ => Some(fetchState.buffer->Array.concat(newItems))
+      | _ => Some(fetchState.buffer->mergeIntoBuffer(newItems))
       }
     },
   )
@@ -1916,6 +1994,8 @@ let rollback = (fetchState: t, ~indexingAddresses: IndexingAddresses.t, ~targetB
     ),
   }->updateInternal(
     ~optimizedPartitions,
+    // Filtering the sorted buffer keeps it sorted and deduped.
+    ~mutItemsSorted=true,
     ~mutItems=fetchState.buffer->Array.filter(item =>
       switch item {
       | Event({blockNumber})

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -330,6 +330,9 @@ type eventPayload
 @get external getPayloadBlock: eventPayload => Nullable.t<eventBlock> = "block"
 @set external setPayloadBlock: (eventPayload, eventBlock) => unit = "block"
 
+// The log's emitting address (EVM/Fuel; the program id carries it for SVM).
+@get external getPayloadSrcAddress: eventPayload => Address.t = "srcAddress"
+
 type genericLoaderArgs<'event, 'context> = {
   event: 'event,
   context: 'context,

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -419,16 +419,19 @@ let patchConfig = (
             registrationsByChainId->Dict.set(chainIdStr, registrations)
             registrations
           }
+          let startBlock: int = raw["startBlock"]->(Utils.magic: 'a => int)
+          let endBlock: int = raw["endBlock"]->(Utils.magic: 'a => int)
+          // Parse with the process's startBlock so items default into the range
+          // the source will be queried over; the source now filters by range.
+          let chainConfig = {...chainConfig, startBlock, endBlock}
           let items = parse(
             ~simulateItems,
             ~config,
             ~chainConfig,
             ~onEventRegistrations=chainRegistrations.onEventRegistrations,
           )
-          let startBlock: int = raw["startBlock"]->(Utils.magic: 'a => int)
-          let endBlock: int = raw["endBlock"]->(Utils.magic: 'a => int)
           let source = SimulateSource.make(~items, ~endBlock, ~chain)
-          {...chainConfig, startBlock, endBlock, sourceConfig: Config.CustomSources([source])}
+          {...chainConfig, sourceConfig: Config.CustomSources([source])}
         | None => chainConfig
         }
       | None => chainConfig

--- a/packages/envio/src/sources/SimulateSource.res
+++ b/packages/envio/src/sources/SimulateSource.res
@@ -1,12 +1,5 @@
-let make = (
-  ~items: array<Internal.item>,
-  ~endBlock: int,
-  ~chain: ChainMap.Chain.t,
-): Source.t => {
-  // getItemsOrThrow might be called multiple times with different partition ids.
-  // Return all items on the first call and empty on subsequent calls to prevent
-  // duplicate event processing.
-  let delivered = ref(false)
+let make = (~items: array<Internal.item>, ~endBlock: int, ~chain: ChainMap.Chain.t): Source.t => {
+  let reportedHeight = max(endBlock, 1)
 
   {
     name: "SimulateSource",
@@ -20,38 +13,59 @@ let make = (
     },
     getHeightOrThrow: () => {
       // Report at least height 1 so the engine doesn't treat 0 as "no blocks available"
-      Promise.resolve({Source.height: max(endBlock, 1), requestStats: []})
+      Promise.resolve({Source.height: reportedHeight, requestStats: []})
     },
     getItemsOrThrow: (
-      ~fromBlock as _,
-      ~toBlock as _,
+      ~fromBlock,
+      ~toBlock,
       ~addressesByContractName as _,
-      ~contractNameByAddress as _,
+      ~contractNameByAddress,
       ~knownHeight as _,
       ~partitionId as _,
-      ~selection as _,
+      ~selection: FetchState.selection,
       ~itemsTarget as _,
       ~retry as _,
       ~logger as _,
     ) => {
-      // Return all items on the first call, empty on subsequent.
-      let result = if delivered.contents {
-        []
-      } else {
-        delivered := true
-        items
+      // Mirror a real backend: return only the items this query would match —
+      // in the block range, part of the selection, and (for non-wildcard events)
+      // emitted by an address the partition is querying. Wildcard events are
+      // over-fetched regardless of srcAddress, leaving the client-side address
+      // filter to gate them exactly as it does for a HyperSync response. Overlapping
+      // queries may return the same item more than once; the buffer dedups it.
+      let toBlockQueried = switch toBlock {
+      | Some(toBlock) => toBlock
+      | None => reportedHeight
       }
+      let selectionEventIds = Utils.Set.make()
+      selection.onEventRegistrations->Array.forEach(reg =>
+        selectionEventIds->Utils.Set.add(reg.eventConfig.id)->ignore
+      )
 
-      let reportedHeight = max(endBlock, 1)
+      let parsedQueueItems = items->Array.filter(item => {
+        let eventItem = item->Internal.castUnsafeEventItem
+        let {blockNumber, onEventRegistration} = eventItem
+        if blockNumber < fromBlock || blockNumber > toBlockQueried {
+          false
+        } else if !(selectionEventIds->Utils.Set.has(onEventRegistration.eventConfig.id)) {
+          false
+        } else if onEventRegistration.isWildcard {
+          true
+        } else {
+          let sa = eventItem.payload->Internal.getPayloadSrcAddress->Address.toString
+          contractNameByAddress->Utils.Dict.dangerouslyGetNonOption(sa)->Option.isSome
+        }
+      })
+
       Promise.resolve({
         Source.knownHeight: reportedHeight,
         blockHashes: [],
-        parsedQueueItems: result,
+        parsedQueueItems,
         // Simulate keeps the transaction and block inline on the payload; no store pages.
         transactionStore: None,
         blockStore: None,
-        fromBlockQueried: 0,
-        latestFetchedBlockNumber: reportedHeight,
+        fromBlockQueried: fromBlock,
+        latestFetchedBlockNumber: toBlockQueried,
         latestFetchedBlockTimestamp: 0,
         stats: {
           totalTimeElapsed: 0.,

--- a/scenarios/test_codegen/test/ClientAddressFilter_test.res
+++ b/scenarios/test_codegen/test/ClientAddressFilter_test.res
@@ -156,7 +156,7 @@ describe("clientAddressFilter — precompiled predicate", () => {
   })
 })
 
-describe("FetchState.handleQueryResult applies clientAddressFilter", () => {
+describe("filterByClientAddress applies clientAddressFilter", () => {
   let transferParams: array<EventConfigBuilder.paramMeta> = [
     {name: "from", abiType: "address", indexed: true},
     {name: "to", abiType: "address", indexed: true},
@@ -200,35 +200,17 @@ describe("FetchState.handleQueryResult applies clientAddressFilter", () => {
     let addresses = [{Internal.address: registeredAddr, contractName: "ERC20", registrationBlock: -1}]
     let contractConfigs = IndexingAddresses.makeContractConfigs(~onEventRegistrations)
     let indexingAddresses = IndexingAddresses.make(~contractConfigs, ~addresses)
-    let fetchState = FetchState.make(
-      ~onEventRegistrations,
-      ~contractConfigs,
-      ~addresses,
-      ~startBlock=0,
-      ~endBlock=None,
-      ~maxAddrInPartition=10,
-      ~maxOnBlockBufferSize=5000,
-      ~chainId=1,
-      ~knownHeight=1000,
-    )
-    let query = switch fetchState->FetchState.getNextQuery {
-    | Ready([q]) => q
-    | _ => JsError.throwWithMessage("expected a single ready query")
-    }
-    fetchState->FetchState.startFetchingQueries(~queries=[query])
-    let updated =
-      fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
-        ~query,
-        ~latestFetchedBlock={blockNumber: 20, blockTimestamp: 300},
-        // to=registeredAddr (effectiveStartBlock 5): block 10 kept, block 3 dropped.
-        ~newItems=[makeItem(~to=registeredAddr, ~blockNumber=10), makeItem(~to=registeredAddr, ~blockNumber=3)],
-      )
-    t.expect(updated.buffer->Array.map(item => item->Internal.getItemBlockNumber)).toEqual([10])
+    // to=registeredAddr (effectiveStartBlock 5): block 10 kept, block 3 dropped.
+    let filtered =
+      [
+        makeItem(~to=registeredAddr, ~blockNumber=10),
+        makeItem(~to=registeredAddr, ~blockNumber=3),
+      ]->FetchState.filterByClientAddress(~indexingAddresses)
+    t.expect(filtered->Array.map(item => item->Internal.getItemBlockNumber)).toEqual([10])
   })
 })
 
-describe("FetchState.handleQueryResult drops over-fetched non-wildcard srcAddress events", () => {
+describe("filterByClientAddress drops over-fetched non-wildcard srcAddress events", () => {
   // Non-wildcard Transfer for ERC20, effective from block 5 (contract startBlock).
   // A merged partition can over-fetch an address before its effectiveStartBlock;
   // the codegen'd srcAddress check in clientAddressFilter drops those.
@@ -271,33 +253,12 @@ describe("FetchState.handleQueryResult drops over-fetched non-wildcard srcAddres
     let addresses = [{Internal.address: registeredAddr, contractName: "ERC20", registrationBlock: -1}]
     let contractConfigs = IndexingAddresses.makeContractConfigs(~onEventRegistrations)
     let indexingAddresses = IndexingAddresses.make(~contractConfigs, ~addresses)
-    let fetchState = FetchState.make(
-      ~onEventRegistrations,
-      ~contractConfigs,
-      ~addresses,
-      ~startBlock=0,
-      ~endBlock=None,
-      ~maxAddrInPartition=10,
-      ~maxOnBlockBufferSize=5000,
-      ~chainId=1,
-      ~knownHeight=1000,
-    )
-    let query = switch fetchState->FetchState.getNextQuery {
-    | Ready([q]) => q
-    | _ => JsError.throwWithMessage("expected a single ready query")
-    }
-    fetchState->FetchState.startFetchingQueries(~queries=[query])
-    let updated =
-      fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
-        ~query,
-        ~latestFetchedBlock={blockNumber: 20, blockTimestamp: 300},
-        ~newItems=[
-          makeItem(~srcAddress=registeredAddr, ~blockNumber=10),
-          makeItem(~srcAddress=registeredAddr, ~blockNumber=3),
-        ],
-      )
-    t.expect(updated.buffer->Array.map(item => item->Internal.getItemBlockNumber)).toEqual([10])
+    let filtered =
+      [
+        makeItem(~srcAddress=registeredAddr, ~blockNumber=10),
+        makeItem(~srcAddress=registeredAddr, ~blockNumber=3),
+      ]->FetchState.filterByClientAddress(~indexingAddresses)
+    t.expect(filtered->Array.map(item => item->Internal.getItemBlockNumber)).toEqual([10])
   })
 })
 

--- a/scenarios/test_codegen/test/IndexerState_test.res
+++ b/scenarios/test_codegen/test/IndexerState_test.res
@@ -79,10 +79,11 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
           blockNumber: currentBlockNumber.contents,
           logIndex,
           transactionIndex: 0,
-          onEventRegistration:
-            "Mock onEventRegistration in IndexerState test"->(
-              Utils.magic: string => Internal.onEventRegistration
-            ),
+          // Carries an `index` so the buffer's dedup key resolves; the rest of
+          // the registration is unused by this test.
+          onEventRegistration: {"index": 0}->(
+            Utils.magic: {"index": int} => Internal.onEventRegistration
+          ),
           payload: `mock event (chainId)${id->Int.toString} - (blockNumber)${currentBlockNumber.contents->Int.toString} - (logIndex)${logIndex->Int.toString} - (timestamp)${currentTime.contents->Int.toString}`->(
             Utils.magic: string => Internal.eventPayload
           ),
@@ -107,7 +108,6 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
 
         fetchState :=
           fetchState.contents->FetchState.handleQueryResult(
-            ~indexingAddresses,
             ~query,
             ~latestFetchedBlock={
               blockNumber: currentBlockNumber.contents,
@@ -189,10 +189,11 @@ describe("IndexerState", () => {
           blockNumber: 0,
           logIndex: 0,
           transactionIndex: 0,
-          onEventRegistration:
-            "Mock onEventRegistration in IndexerState test"->(
-              Utils.magic: string => Internal.onEventRegistration
-            ),
+          // Carries an `index` so the buffer's dedup key resolves; the rest of
+          // the registration is unused by this test.
+          onEventRegistration: {"index": 0}->(
+            Utils.magic: {"index": int} => Internal.onEventRegistration
+          ),
           payload: `mock initial event`->(Utils.magic: string => Internal.eventPayload),
         })
 
@@ -290,7 +291,6 @@ describe("IndexerState", () => {
               fetchState.contents->FetchState.startFetchingQueries(~queries=[query])
               fetchState :=
                 fetchState.contents->FetchState.handleQueryResult(
-                  ~indexingAddresses,
                   ~query,
                   ~latestFetchedBlock={blockNumber, blockTimestamp: blockNumber * 15},
                   ~newItems=[
@@ -299,10 +299,10 @@ describe("IndexerState", () => {
                       blockNumber,
                       logIndex: 0,
                       transactionIndex: 0,
-                      onEventRegistration:
-                        "Mock onEventRegistration"->(
-                          Utils.magic: string => Internal.onEventRegistration
-                        ),
+                      // Carries an `index` so the buffer's dedup key resolves.
+                      onEventRegistration: {"index": 0}->(
+                        Utils.magic: {"index": int} => Internal.onEventRegistration
+                      ),
                       payload: "Mock event"->(Utils.magic: string => Internal.eventPayload),
                     }),
                   ],
@@ -382,8 +382,10 @@ describe("IndexerState", () => {
               blockNumber: 15,
               logIndex: 0,
               transactionIndex: 0,
-              onEventRegistration:
-                "Mock onEventRegistration"->(Utils.magic: string => Internal.onEventRegistration),
+              // Carries an `index` so the buffer's dedup key resolves.
+              onEventRegistration: {"index": 0}->(
+                Utils.magic: {"index": int} => Internal.onEventRegistration
+              ),
               payload: "Mock event"->(Utils.magic: string => Internal.eventPayload),
             }),
           ],

--- a/scenarios/test_codegen/test/OptionalBlockParams_test.res
+++ b/scenarios/test_codegen/test/OptionalBlockParams_test.res
@@ -34,9 +34,9 @@ Async.it(
     })
 
     let entities = await indexer.\"SimulateTestEvent".getAll()
-    // Event block defaults to config startBlock (1) in SimulateItems.parse,
-    // but the process range is startBlock=5, endBlock=5
-    t.expect(entities).toEqual([{id: "1_0", blockNumber: 1, logIndex: 0, timestamp: 0}])
+    // Event block defaults to the process startBlock (5), which is also the
+    // endBlock, so it lands in the queried range and routes to its handler.
+    t.expect(entities).toEqual([{id: "5_0", blockNumber: 5, logIndex: 0, timestamp: 0}])
   },
 )
 

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -6,10 +6,11 @@ let mockEvent = (~blockNumber): Internal.item =>
   Internal.Event({
     chain: ChainMap.Chain.makeUnsafe(~chainId=1),
     blockNumber,
-    onEventRegistration:
-      "Mock onEventRegistration in CrossChainState test"->(
-        Utils.magic: string => Internal.onEventRegistration
-      ),
+    // Carries an `index` so the buffer's dedup key resolves; the rest of the
+    // registration is unused by these tests.
+    onEventRegistration: {"index": 0}->(
+      Utils.magic: {"index": int} => Internal.onEventRegistration
+    ),
     logIndex: 0,
     transactionIndex: 0,
     payload: "Mock event in CrossChainState test"->(Utils.magic: string => Internal.eventPayload),

--- a/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_onBlock_test.res
@@ -57,8 +57,7 @@ let makeInitialWithOnBlock = (~startBlock=0, ~onBlockRegistrations) => {
     },
   ]
   let contractConfigs = IndexingAddresses.makeContractConfigs(~onEventRegistrations)
-  let indexingAddresses = IndexingAddresses.make(~contractConfigs, ~addresses)
-  let fetchState = FetchState.make(
+  FetchState.make(
     ~onEventRegistrations,
     ~contractConfigs,
     ~addresses,
@@ -70,14 +69,14 @@ let makeInitialWithOnBlock = (~startBlock=0, ~onBlockRegistrations) => {
     ~onBlockRegistrations?,
     ~knownHeight=0,
   )
-  (fetchState, indexingAddresses)
 }
 
 let mockEvent = (~blockNumber, ~logIndex=0): Internal.item => Internal.Event({
   chain: ChainMap.Chain.makeUnsafe(~chainId),
   blockNumber,
-  onEventRegistration:
-    Utils.magic("Mock onEventRegistration in fetchstate test"),
+  // Carries an `index` so the buffer's dedup key (blockNumber, logIndex, index)
+  // resolves; the rest of the registration is unused by these tests.
+  onEventRegistration: Utils.magic({"index": 0}),
   logIndex,
   transactionIndex: 0,
   payload: "Mock event in fetchstate test"->(Utils.magic: string => Internal.eventPayload),
@@ -87,7 +86,7 @@ describe("FetchState onBlock functionality", () => {
   it("should add block items to queue when processing first batch with onBlock config", t => {
     // Create a fetch state with onBlock config
     let onBlockRegistration = makeOnBlockRegistration(~interval=2, ~startBlock=Some(0))
-    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration]))
+    let fetchState = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration]))
 
     // Verify initial state - no items in queue
     t.expect(fetchState->FetchState.bufferSize, ~message="Initial queue should be empty").toBe(0)
@@ -107,7 +106,6 @@ describe("FetchState onBlock functionality", () => {
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     let updatedFetchState =
       fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~latestFetchedBlock={blockNumber: 10, blockTimestamp: 10 * 15},
         ~newItems=[mockEvent(~blockNumber=5)],
@@ -140,7 +138,7 @@ describe("FetchState onBlock functionality", () => {
   it("should respect onBlock startBlock configuration", t => {
     // Create onBlock config with startBlock = 5
     let onBlockRegistration = makeOnBlockRegistration(~interval=1, ~startBlock=Some(5))
-    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration]))
+    let fetchState = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration]))
 
     // Process a batch that goes from block 0 to 10
     let query: FetchState.query = {
@@ -156,7 +154,6 @@ describe("FetchState onBlock functionality", () => {
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     let updatedFetchState =
       fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~latestFetchedBlock={blockNumber: 10, blockTimestamp: 10 * 15},
         ~newItems=[mockEvent(~blockNumber=5)],
@@ -190,7 +187,7 @@ describe("FetchState onBlock functionality", () => {
   it("should respect onBlock endBlock configuration", t => {
     // Create onBlock config with endBlock = 8
     let onBlockRegistration = makeOnBlockRegistration(~interval=1, ~endBlock=Some(8))
-    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration]))
+    let fetchState = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration]))
 
     // Process a batch that goes from block 0 to 10
     let query: FetchState.query = {
@@ -206,7 +203,6 @@ describe("FetchState onBlock functionality", () => {
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     let updatedFetchState =
       fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~latestFetchedBlock={blockNumber: 10, blockTimestamp: 10 * 15},
         ~newItems=[mockEvent(~blockNumber=5)],
@@ -244,7 +240,7 @@ describe("FetchState onBlock functionality", () => {
     // Create two onBlock configs with different intervals
     let onBlockRegistration1 = makeOnBlockRegistration(~name="config1", ~index=0, ~interval=2)
     let onBlockRegistration2 = makeOnBlockRegistration(~name="config2", ~index=1, ~interval=3)
-    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration1, onBlockRegistration2]))
+    let fetchState = makeInitialWithOnBlock(~onBlockRegistrations=Some([onBlockRegistration1, onBlockRegistration2]))
 
     // Process a batch
     let query: FetchState.query = {
@@ -260,7 +256,6 @@ describe("FetchState onBlock functionality", () => {
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     let updatedFetchState =
       fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~latestFetchedBlock={blockNumber: 12, blockTimestamp: 12 * 15},
         ~newItems=[mockEvent(~blockNumber=5)],
@@ -301,7 +296,7 @@ describe("FetchState onBlock functionality", () => {
 
   it("should not add block items when onBlock configs are not provided", t => {
     // Create fetch state without onBlock configs
-    let (fetchState, indexingAddresses) = makeInitialWithOnBlock(~onBlockRegistrations=None)
+    let fetchState = makeInitialWithOnBlock(~onBlockRegistrations=None)
 
     // Process a batch
     let query: FetchState.query = {
@@ -317,7 +312,6 @@ describe("FetchState onBlock functionality", () => {
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     let updatedFetchState =
       fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~latestFetchedBlock={blockNumber: 10, blockTimestamp: 10 * 15},
         ~newItems=[mockEvent(~blockNumber=5)],

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -76,15 +76,17 @@ let makeConfigContract = (contractName, address): Internal.indexingAddress => {
   }
 }
 
-let mockEvent = (~blockNumber, ~logIndex=0, ~chainId=1): Internal.item => Internal.Event({
-  chain: ChainMap.Chain.makeUnsafe(~chainId),
-  blockNumber,
-  onEventRegistration:
-    Utils.magic("Mock onEventRegistration in fetchstate test"),
-  logIndex,
-  transactionIndex: 0,
-  payload: "Mock event in fetchstate test"->(Utils.magic: string => Internal.eventPayload),
-})
+let mockEvent = (~blockNumber, ~logIndex=0, ~chainId=1, ~registrationIndex=0): Internal.item =>
+  Internal.Event({
+    chain: ChainMap.Chain.makeUnsafe(~chainId),
+    blockNumber,
+    // Carries an `index` so the buffer's dedup key (blockNumber, logIndex, index)
+    // resolves; the rest of the registration is unused by these tests.
+    onEventRegistration: Utils.magic({"index": registrationIndex}),
+    logIndex,
+    transactionIndex: 0,
+    payload: "Mock event in fetchstate test"->(Utils.magic: string => Internal.eventPayload),
+  })
 
 let dcToItem = (dc: Internal.indexingAddress) => {
   let item = mockEvent(~blockNumber=dc.registrationBlock)
@@ -1872,7 +1874,7 @@ describe("FetchState.getNextQuery & integration", () => {
     ->FetchState.getNextQuery
 
   it("Emulate first indexer queries with a static event", t => {
-    let (fetchState, indexingAddresses) = makeInitial()
+    let (fetchState, _) = makeInitial()
 
     t.expect(fetchState->getNextQuery(~knownHeight=0)).toEqual(WaitingForNewBlock)
 
@@ -1920,7 +1922,6 @@ describe("FetchState.getNextQuery & integration", () => {
     )
 
     let updatedFetchState = fetchState->FetchState.handleQueryResult(
-      ~indexingAddresses,
       ~query,
       ~latestFetchedBlock={
         blockNumber: 10,
@@ -1983,7 +1984,7 @@ describe("FetchState.getNextQuery & integration", () => {
   })
 
   it("Emulate first indexer queries with block lag configured", t => {
-    let (fetchState, indexingAddresses) = makeInitial(~blockLag=2)
+    let (fetchState, _) = makeInitial(~blockLag=2)
 
     t.expect(fetchState->getNextQuery(~knownHeight=0)).toEqual(WaitingForNewBlock)
 
@@ -2040,7 +2041,6 @@ describe("FetchState.getNextQuery & integration", () => {
     )
 
     let updatedFetchState = fetchState->FetchState.handleQueryResult(
-      ~indexingAddresses,
       ~query,
       ~latestFetchedBlock={
         blockNumber: 8,
@@ -2152,7 +2152,6 @@ describe("FetchState.getNextQuery & integration", () => {
     let updatedFetchState =
       fetchStateWithDcs
       ->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query=queries->Array.getUnsafe(0),
         ~latestFetchedBlock={
           blockNumber: 10,
@@ -2161,7 +2160,6 @@ describe("FetchState.getNextQuery & integration", () => {
         ~newItems=[],
       )
       ->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query=queries->Array.getUnsafe(1),
         ~latestFetchedBlock={
           blockNumber: 2,
@@ -2258,7 +2256,6 @@ describe("FetchState.getNextQuery & integration", () => {
     // Continue with the state from previous test
     // But increase the maxAddrInPartition up to 4
     let fetchState = makeIntermidiateDcMerge(~maxAddrInPartition=4, ~knownHeight=11)
-    let indexingAddresses = makeIntermidiateIndex()
     t.expect(
       fetchState->getNextQuery,
       ~message="Although, if we pass it through partition optimization, it should merge partitions now",
@@ -2300,7 +2297,6 @@ describe("FetchState.getNextQuery & integration", () => {
     // When it didn't finish fetching to the target partition block
     fetchState->FetchState.startFetchingQueries(~queries=[p2Query])
     let fetchStateWithResponse1 = fetchState->FetchState.handleQueryResult(
-      ~indexingAddresses,
       ~query=p2Query,
       ~latestFetchedBlock={
         blockNumber: 9,
@@ -2333,7 +2329,6 @@ describe("FetchState.getNextQuery & integration", () => {
     fetchStateWithResponse1->FetchState.startFetchingQueries(~queries)
 
     let fetchStateWithResponse2 = fetchStateWithResponse1->FetchState.handleQueryResult(
-      ~indexingAddresses,
       ~query=queries->Array.getUnsafe(0),
       ~latestFetchedBlock={
         blockNumber: 10,
@@ -2678,7 +2673,7 @@ describe("FetchState.getNextQuery & integration", () => {
 
 describe("FetchState unit tests for specific cases", () => {
   it("Should merge events in correct order on merging", t => {
-    let (base, indexingAddresses) = makeInitial()
+    let (base, _) = makeInitial()
     let normalSelection = base.normalSelection
     let fetchState = base->FetchState.updateInternal(
       ~optimizedPartitions=FetchState.OptimizedPartitions.make(
@@ -2742,13 +2737,15 @@ describe("FetchState unit tests for specific cases", () => {
 
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     let updatedFetchState = fetchState->FetchState.handleQueryResult(
-      ~indexingAddresses,
       ~query,
       ~latestFetchedBlock={
         blockNumber: 10,
         blockTimestamp: 10,
       },
-      ~newItems=[mockEvent(~blockNumber=4, ~logIndex=1), mockEvent(~blockNumber=4, ~logIndex=1)],
+      ~newItems=[
+        mockEvent(~blockNumber=4, ~logIndex=1, ~registrationIndex=0),
+        mockEvent(~blockNumber=4, ~logIndex=1, ~registrationIndex=1),
+      ],
     )
 
     t.expect(updatedFetchState.buffer, ~message="Should merge events in correct order").toEqual([
@@ -2756,14 +2753,14 @@ describe("FetchState unit tests for specific cases", () => {
       mockEvent(~blockNumber=2),
       mockEvent(~blockNumber=3),
       mockEvent(~blockNumber=4),
-      mockEvent(~blockNumber=4, ~logIndex=1),
-      mockEvent(~blockNumber=4, ~logIndex=1),
+      mockEvent(~blockNumber=4, ~logIndex=1, ~registrationIndex=0),
+      mockEvent(~blockNumber=4, ~logIndex=1, ~registrationIndex=1),
       mockEvent(~blockNumber=4, ~logIndex=2),
     ])
   })
 
   it("Sorts newItems when source returns them unsorted", t => {
-    let (base, indexingAddresses) = makeInitial()
+    let (base, _) = makeInitial()
     let fetchState = base
 
     let unsorted = [
@@ -2787,7 +2784,6 @@ describe("FetchState unit tests for specific cases", () => {
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     let updatedFetchState =
       fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~latestFetchedBlock=getBlockData(~blockNumber=10),
         ~newItems=unsorted,
@@ -2813,7 +2809,7 @@ describe("FetchState unit tests for specific cases", () => {
     // FetchState with 2 partitions,
     // one of them reached the head
     // another reached max queue size
-    let (fetchState, indexingAddresses) = makeFs(
+    let (fetchState, _) = makeFs(
       ~onEventRegistrations=[
         (MockIndexer.evmOnEventRegistration(~id="0", ~contractName="ContractA") :> Internal.onEventRegistration),
         wildcard,
@@ -2855,13 +2851,11 @@ describe("FetchState unit tests for specific cases", () => {
     let fetchState =
       fetchState
       ->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query=query0,
         ~latestFetchedBlock=getBlockData(~blockNumber=1),
         ~newItems=[mockEvent(~blockNumber=1), mockEvent(~blockNumber=0)],
       )
       ->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query=query1,
         ~latestFetchedBlock=getBlockData(~blockNumber=2),
         ~newItems=[],
@@ -2918,7 +2912,6 @@ describe("FetchState unit tests for specific cases", () => {
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     let fetchStateWithEvents =
       fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~newItems=[
           mockEvent(~blockNumber=6, ~logIndex=2),
@@ -2947,7 +2940,7 @@ describe("FetchState unit tests for specific cases", () => {
   })
 
   it("Returns NoItem when there is an empty partition at block 0", t => {
-    let (fetchState, indexingAddresses) = makeFs(
+    let (fetchState, _) = makeFs(
       ~onEventRegistrations=[
         (MockIndexer.evmOnEventRegistration(~id="0", ~contractName="ContractA") :> Internal.onEventRegistration),
       ],
@@ -2985,7 +2978,6 @@ describe("FetchState unit tests for specific cases", () => {
     fetchState->FetchState.startFetchingQueries(~queries=[query])
     let updatedFetchState =
       fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~newItems=[mockEvent(~blockNumber=0, ~logIndex=1)],
         ~latestFetchedBlock=getBlockData(~blockNumber=1),
@@ -3085,7 +3077,6 @@ describe("FetchState unit tests for specific cases", () => {
       {...makeInitialFs(~startBlock=10), endBlock: Some(9)}->FetchState.isActivelyIndexing,
       ~message=`Shouldn't be active if endBlock is less than the startBlock`,
     ).toEqual(false)
-    let (_, indexingAddresses) = makeInitial()
     let fetchState = {
       ...makeInitialFs(),
       endBlock: Some(0),
@@ -3104,7 +3095,6 @@ describe("FetchState unit tests for specific cases", () => {
     t.expect(
       fetchState
       ->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~newItems=[mockEvent(~blockNumber=0)],
         ~latestFetchedBlock={blockNumber: -1, blockTimestamp: 0},
@@ -3115,7 +3105,6 @@ describe("FetchState unit tests for specific cases", () => {
   })
 
   it("isFetchingAtHead", t => {
-    let (_, indexingAddresses) = makeInitial()
     let fetchToHead = (fetchState: FetchState.t, ~latestFetchedBlockNumber) => {
       let query: FetchState.query = {
         ...defaultQuery,
@@ -3129,7 +3118,6 @@ describe("FetchState unit tests for specific cases", () => {
       }
       fetchState->FetchState.startFetchingQueries(~queries=[query])
       fetchState->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~newItems=[],
         ~latestFetchedBlock={blockNumber: latestFetchedBlockNumber, blockTimestamp: 0},
@@ -3187,7 +3175,6 @@ describe("FetchState unit tests for specific cases", () => {
       fetchState->FetchState.startFetchingQueries(~queries=[query])
       let fetchState =
         fetchState->FetchState.handleQueryResult(
-          ~indexingAddresses,
           ~query,
           ~newItems=[
             mockEvent(~blockNumber=6, ~logIndex=2),
@@ -3250,7 +3237,6 @@ describe("FetchState unit tests for specific cases", () => {
       //Response with updated fetch state
       let fetchStateWithBothDcsAndQueryAResponse =
         fetchStateWithDcB->FetchState.handleQueryResult(
-          ~indexingAddresses,
           ~query=queryA,
           ~latestFetchedBlock=getBlockData(~blockNumber=400),
           ~newItems=[],
@@ -3294,12 +3280,11 @@ describe("FetchState.sortForBatch", () => {
 
   // Helper: create a fetch state with desired latestFetchedBlock and queue items via public API
   let makeFsWith = (~latestBlock: int, ~queueBlocks: array<int>): FetchState.t => {
-    let (fs0, indexingAddresses) = makeInitial(~knownHeight=10)
+    let (fs0, _) = makeInitial(~knownHeight=10)
     let query = mkQuery(fs0)
     fs0->FetchState.startFetchingQueries(~queries=[query])
     let fs =
       fs0->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query,
         ~latestFetchedBlock={blockNumber: latestBlock, blockTimestamp: latestBlock},
         ~newItems=queueBlocks->Array.map(b => mockEvent(~blockNumber=b)),
@@ -3594,7 +3579,7 @@ describe("Dynamic contracts with start blocks", () => {
 
 describe("FetchState progress tracking", () => {
   let makeFetchStateWith = (~latestBlock: int, ~queueBlocks: array<(int, int)>): FetchState.t => {
-    let (fs0, indexingAddresses) = makeInitial(~knownHeight=1000)
+    let (fs0, _) = makeInitial(~knownHeight=1000)
     let query = {
       ...defaultQuery,
       FetchState.partitionId: "0",
@@ -3607,7 +3592,6 @@ describe("FetchState progress tracking", () => {
     }
     fs0->FetchState.startFetchingQueries(~queries=[query])
     fs0->FetchState.handleQueryResult(
-      ~indexingAddresses,
       ~query,
       ~latestFetchedBlock={blockNumber: latestBlock, blockTimestamp: latestBlock},
       ~newItems=queueBlocks->Array.map(((b, l)) => mockEvent(~blockNumber=b, ~logIndex=l)),
@@ -3685,7 +3669,6 @@ describe("FetchState proposes queries against the natural ceiling", () => {
       fetchStateWithTwoPartitions->FetchState.startFetchingQueries(~queries=[query0])
       let fetchStateWithLargeQueue =
         fetchStateWithTwoPartitions->FetchState.handleQueryResult(
-          ~indexingAddresses,
           ~query=query0,
           ~latestFetchedBlock={blockNumber: 30, blockTimestamp: 30 * 15},
           ~newItems=largeQueueEvents,
@@ -3733,7 +3716,6 @@ describe("FetchState proposes queries against the natural ceiling", () => {
       let fetchStateSmallQueue =
         fetchState
         ->FetchState.handleQueryResult(
-          ~indexingAddresses,
           ~query=query3,
           ~latestFetchedBlock={blockNumber: 10, blockTimestamp: 10 * 15},
           ~newItems=[mockEvent(~blockNumber=5)],
@@ -3853,7 +3835,7 @@ describe("Stale query response should not overwrite block range", () => {
     fs->FetchState.updateKnownHeight(~knownHeight)->FetchState.getNextQuery
 
   it("Out-of-order parallel query responses should not degrade chunking heuristic", t => {
-    let (fetchState, indexingAddresses) = makeInitial(~knownHeight=100000)
+    let (fetchState, _) = makeInitial(~knownHeight=100000)
 
     // -- Query 1: uncapped query from block 0 --
     let q1 = switch fetchState->getNextQuery {
@@ -3868,7 +3850,6 @@ describe("Stale query response should not overwrite block range", () => {
       fetchState
       ->FetchState.updateKnownHeight(~knownHeight=100000)
       ->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query=q1,
         ~latestFetchedBlock={blockNumber: 500, blockTimestamp: 500 * 15},
         ~newItems=[],
@@ -3896,7 +3877,6 @@ describe("Stale query response should not overwrite block range", () => {
     // shouldUpdateBlockRange: None toBlock => 1000 < 99990 = true
     let fs2 =
       fs1->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query=q2,
         ~latestFetchedBlock={blockNumber: 1000, blockTimestamp: 1000 * 15},
         ~newItems=[],
@@ -3931,7 +3911,6 @@ describe("Stale query response should not overwrite block range", () => {
     // blockRange = 2500 - 1901 + 1 = 600
     let fs3 =
       fs2->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query=chunkB,
         ~latestFetchedBlock={blockNumber: 2500, blockTimestamp: 2500 * 15},
         ~newItems=[],
@@ -3949,7 +3928,6 @@ describe("Stale query response should not overwrite block range", () => {
     // So prevQueryRange should NOT change
     let fs4 =
       fs3->FetchState.handleQueryResult(
-        ~indexingAddresses,
         ~query=chunkA,
         ~latestFetchedBlock={blockNumber: 1500, blockTimestamp: 1500 * 15},
         ~newItems=[],
@@ -3960,5 +3938,35 @@ describe("Stale query response should not overwrite block range", () => {
       (p4.prevQueryRange, p4.prevPrevQueryRange, p4.latestBlockRangeUpdateBlock),
       ~message="Earlier chunk A stale response should not overwrite range bookkeeping (still 600, 500, 2500)",
     ).toEqual((600, 500, 2500))
+  })
+})
+
+describe("mergeIntoBuffer", () => {
+  it("merges an unsorted response into the sorted buffer and drops duplicates", t => {
+    let buffer = [mockEvent(~blockNumber=1), mockEvent(~blockNumber=3), mockEvent(~blockNumber=5)]
+    let newItems = [
+      mockEvent(~blockNumber=4),
+      mockEvent(~blockNumber=2),
+      mockEvent(~blockNumber=3), // duplicate of the buffer's block 3
+      mockEvent(~blockNumber=4), // duplicate within the response
+    ]
+    t.expect(buffer->FetchState.mergeIntoBuffer(newItems)).toEqual([
+      mockEvent(~blockNumber=1),
+      mockEvent(~blockNumber=2),
+      mockEvent(~blockNumber=3),
+      mockEvent(~blockNumber=4),
+      mockEvent(~blockNumber=5),
+    ])
+  })
+
+  it("keeps two registrations for one log (equal block+logIndex, distinct index)", t => {
+    let newItems = [
+      mockEvent(~blockNumber=7, ~logIndex=2, ~registrationIndex=1),
+      mockEvent(~blockNumber=7, ~logIndex=2, ~registrationIndex=0),
+    ]
+    t.expect([]->FetchState.mergeIntoBuffer(newItems)).toEqual([
+      mockEvent(~blockNumber=7, ~logIndex=2, ~registrationIndex=0),
+      mockEvent(~blockNumber=7, ~logIndex=2, ~registrationIndex=1),
+    ])
   })
 })


### PR DESCRIPTION
## Summary

Rebases the change from #1414 directly onto `main`. The original PR was merged into the multichain query-control feature branch rather than the default branch.

- Extracts `FetchState.filterByClientAddress` and applies it before contract registration, so over-fetched events cannot spawn dynamic contracts or enter the buffer.
- Updates `SimulateSource` to mirror backend block-range, event-selection, address, and delivery semantics.
- Replaces repeated whole-buffer sorting with a linear merge that preserves registration-distinct events while dropping true duplicates.
- Updates focused address-filtering, simulation, and buffer-merge coverage for the current `main` APIs.

## Why

Over-fetched events were able to run contract-registration handlers before client-side address filtering removed them. The simulator also returned items more broadly than real sources, which obscured this ordering problem. Buffer accumulation additionally re-sorted the full buffer on each response.

## Impact

Address filtering now gates side effects at the correct boundary, simulation more closely matches production source behavior, and response accumulation avoids repeated full-buffer sorts.

## Validation

- `pnpm --filter envio build`
- `pnpm --dir scenarios/test_codegen build`
- `pnpm exec vitest run test/ClientAddressFilter_test.res.mjs test/lib_tests/FetchState_test.res.mjs` — 84 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client-address filtering so irrelevant events are excluded before processing.
  * Fixed event buffering to maintain deterministic ordering and remove duplicates while preserving distinct registrations.
  * Corrected simulated event queries to respect block ranges, event selections, and source addresses.
  * Fixed simulated item placement when only a start block is specified.

* **Tests**
  * Expanded coverage for address filtering, event ordering, deduplication, and simulated block behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->