### PR TITLE
Fix rollback handling for deleted entities

### DIFF
--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -117,17 +117,17 @@ let prepareRollbackDiff = async (
   ->Array.map(async entityConfig => {
     let entityTable = state->getInMemTable(~entityConfig)
 
-    let (removedIdsResult, restoredEntitiesResult) = await persistence.storage.getRollbackData(
+    let (removedIds, restoredEntitiesResult) = await persistence.storage.getRollbackData(
       ~entityConfig,
       ~rollbackTargetCheckpointId,
     )
 
-    removedIdsResult->Array.forEach(data => {
-      deletedEntities->Utils.Dict.push(entityConfig.name, data["id"])
+    removedIds->Array.forEach(entityId => {
+      deletedEntities->Utils.Dict.push(entityConfig.name, entityId)
       entityTable->InMemoryTable.Entity.set(
         ~committedCheckpointId,
         Delete({
-          entityId: data["id"],
+          entityId,
           checkpointId: rollbackDiffCheckpointId,
         }),
       )

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -112,7 +112,7 @@ type storage = {
   getRollbackData: (
     ~entityConfig: Internal.entityConfig,
     ~rollbackTargetCheckpointId: Internal.checkpointId,
-  ) => promise<(array<{"id": string}>, array<unknown>)>,
+  ) => promise<(array<string>, array<unknown>)>,
   // Write batch to storage
   writeBatch: (
     ~batch: Batch.t,

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1668,7 +1668,7 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
     ~entityConfig: Internal.entityConfig,
     ~rollbackTargetCheckpointId,
   ) => {
-    let (removedIdsResult, rollbackRows) = await Promise.all2((
+    let (removedIdRows, rollbackRows) = await Promise.all2((
       // Get IDs of entities that should be deleted (created after rollback target with no prior history)
       sql
       ->Postgres.preparedUnsafe(
@@ -1685,16 +1685,17 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
       ->(Utils.magic: promise<unknown> => promise<array<unknown>>),
     ))
 
+    let removedIds = removedIdRows->Array.map(row => row["id"])
     let restoredEntitiesResult = []
     rollbackRows->Array.forEach(row => {
       let (entityId, action) = row->S.parseOrThrow(rollbackRowStateSchema)
       switch action {
       | SET => restoredEntitiesResult->Array.push(row)->ignore
-      | DELETE => removedIdsResult->Array.push({"id": entityId})->ignore
+      | DELETE => removedIds->Array.push(entityId)->ignore
       }
     })
 
-    (removedIdsResult, restoredEntitiesResult)
+    (removedIds, restoredEntitiesResult)
   }
 
   let writeBatchMethod = async (

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1157,9 +1157,9 @@ let rec writeBatch = async (
   }
 }
 
-// Returns the most recent entity state for IDs that need to be restored during rollback.
-// For each ID modified after the rollback target, retrieves its latest state at or before the target.
-let makeGetRollbackRestoredEntitiesQuery = (~entityConfig: Internal.entityConfig, ~pgSchema) => {
+// Returns the most recent history row at or before the rollback target for IDs changed after it.
+// envio_change is included so ReScript can turn SET rows into restores and DELETE rows into removals.
+let makeGetRollbackPreTargetRowsQuery = (~entityConfig: Internal.entityConfig, ~pgSchema) => {
   let dataFieldNames = entityConfig.table.fields->Array.filterMap(fieldOrDerived =>
     switch fieldOrDerived {
     | Field(field) => field->Table.getPgDbFieldName->Some
@@ -1175,35 +1175,40 @@ let makeGetRollbackRestoredEntitiesQuery = (~entityConfig: Internal.entityConfig
     ~entityIndex=entityConfig.index,
   )
 
-  `SELECT DISTINCT ON (${Table.idFieldName}) ${dataFieldsCommaSeparated}
-FROM "${pgSchema}"."${historyTableName}"
-WHERE "${EntityHistory.checkpointIdFieldName}" <= $1
-  AND EXISTS (
-    SELECT 1
-    FROM "${pgSchema}"."${historyTableName}" h
-    WHERE h.${Table.idFieldName} = "${historyTableName}".${Table.idFieldName}
-      AND h."${EntityHistory.checkpointIdFieldName}" > $1
-  )
-ORDER BY ${Table.idFieldName}, "${EntityHistory.checkpointIdFieldName}" DESC`
+  `SELECT DISTINCT ON ("${Table.idFieldName}") ${dataFieldsCommaSeparated}, "${EntityHistory.changeFieldName}"
+  FROM "${pgSchema}"."${historyTableName}"
+  WHERE "${EntityHistory.checkpointIdFieldName}" <= $1
+    AND EXISTS (
+      SELECT 1
+      FROM "${pgSchema}"."${historyTableName}" h
+      WHERE h."${Table.idFieldName}" = "${historyTableName}"."${Table.idFieldName}"
+        AND h."${EntityHistory.checkpointIdFieldName}" > $1
+    )
+  ORDER BY "${Table.idFieldName}", "${EntityHistory.checkpointIdFieldName}" DESC`
 }
 
 // Returns entity IDs that were created after the rollback target and have no history before it.
-// These entities should be deleted during rollback.
+// DELETE rows at or before the target are returned by the restore query and classified in ReScript.
 let makeGetRollbackRemovedIdsQuery = (~entityConfig: Internal.entityConfig, ~pgSchema) => {
   let historyTableName = EntityHistory.historyTableName(
     ~entityName=entityConfig.name,
     ~entityIndex=entityConfig.index,
   )
-  `SELECT DISTINCT ${Table.idFieldName}
-FROM "${pgSchema}"."${historyTableName}"
-WHERE "${EntityHistory.checkpointIdFieldName}" > $1
-AND NOT EXISTS (
-  SELECT 1
-  FROM "${pgSchema}"."${historyTableName}" h
-  WHERE h.${Table.idFieldName} = "${historyTableName}".${Table.idFieldName}
-    AND h."${EntityHistory.checkpointIdFieldName}" <= $1
-)`
+  `SELECT DISTINCT "${Table.idFieldName}"
+  FROM "${pgSchema}"."${historyTableName}"
+  WHERE "${EntityHistory.checkpointIdFieldName}" > $1
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "${pgSchema}"."${historyTableName}" h
+      WHERE h."${Table.idFieldName}" = "${historyTableName}"."${Table.idFieldName}"
+        AND h."${EntityHistory.checkpointIdFieldName}" <= $1
+    )`
 }
+
+let rollbackRowStateSchema = S.object(s => (
+  s.field(Table.idFieldName, S.string),
+  s.field(EntityHistory.changeFieldName, EntityHistory.RowAction.schema),
+))
 
 let make = (
   ~sql: Postgres.sql,
@@ -1663,7 +1668,7 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
     ~entityConfig: Internal.entityConfig,
     ~rollbackTargetCheckpointId,
   ) => {
-    await Promise.all2((
+    let (removedIdsResult, rollbackRows) = await Promise.all2((
       // Get IDs of entities that should be deleted (created after rollback target with no prior history)
       sql
       ->Postgres.preparedUnsafe(
@@ -1671,14 +1676,25 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
         [rollbackTargetCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
       )
       ->(Utils.magic: promise<unknown> => promise<array<{"id": string}>>),
-      // Get entities that should be restored to their state at or before rollback target
+      // Get the latest pre-target row, including its SET or DELETE action.
       sql
       ->Postgres.preparedUnsafe(
-        makeGetRollbackRestoredEntitiesQuery(~entityConfig, ~pgSchema),
+        makeGetRollbackPreTargetRowsQuery(~entityConfig, ~pgSchema),
         [rollbackTargetCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
       )
       ->(Utils.magic: promise<unknown> => promise<array<unknown>>),
     ))
+
+    let restoredEntitiesResult = []
+    rollbackRows->Array.forEach(row => {
+      let (entityId, action) = row->S.parseOrThrow(rollbackRowStateSchema)
+      switch action {
+      | SET => restoredEntitiesResult->Array.push(row)->ignore
+      | DELETE => removedIdsResult->Array.push({"id": entityId})->ignore
+      }
+    })
+
+    (removedIdsResult, restoredEntitiesResult)
   }
 
   let writeBatchMethod = async (

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -387,6 +387,8 @@ module Indexer = {
     ~shouldRollbackOnReorg=true,
     ~reducedPollingInterval=?,
     ~targetBufferSize=?,
+    // Lets regression tests surface fatal errors without terminating the Vitest worker.
+    ~onError=?,
     // Lets a test intercept storage methods, e.g. to stall writeBatch and
     // exercise races between in-flight writes and the indexer loop.
     ~mapStorage: Persistence.storage => Persistence.storage=storage => storage,
@@ -445,9 +447,12 @@ module Indexer = {
     )
     let persistence = PgStorage.makePersistenceFromConfig(~config, ~storage)
 
-    let onError = (errHandler: ErrorHandling.t) => {
-      errHandler->ErrorHandling.log
-      NodeJs.process->NodeJs.exitWithCode(NodeJs.Failure)
+    let onError = switch onError {
+    | Some(onError) => onError
+    | None => (errHandler: ErrorHandling.t) => {
+        errHandler->ErrorHandling.log
+        NodeJs.process->NodeJs.exitWithCode(NodeJs.Failure)
+      }
     }
 
     let graphqlClient = Rest.client(`${Env.Hasura.url}/v1/graphql`)

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -653,6 +653,7 @@ module Indexer = {
           ~shouldRollbackOnReorg,
           ~reducedPollingInterval?,
           ~targetBufferSize?,
+          ~onError,
           ~mapStorage,
         )
       },

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -424,6 +424,142 @@ describe("E2E rollback tests", () => {
     await testSingleChainRollback(~t, ~sourceMock, ~indexerMock)
   })
 
+  Async.it("Rolls back SET -> DELETE -> SET to the deleted state", async t => {
+    let sourceMock = MockIndexer.Source.make(
+      [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+      ~chain=#1337,
+    )
+    let resolveIndexerError = ref(None)
+    let indexerErrorPromise = Promise.make((resolve, _reject) => {
+      resolveIndexerError := Some(resolve)
+    })
+    let indexerMock = await MockIndexer.Indexer.make(
+      ~chains=[
+        {
+          chain: #1337,
+          sourceConfig: Config.CustomSources([sourceMock.source]),
+        },
+      ],
+      ~onError=errHandler => {
+        let resolve = resolveIndexerError.contents->Option.getOrThrow(
+          ~message="Indexer error observer was not initialized",
+        )
+        resolve(errHandler)
+      },
+    )
+    await Utils.delay(0)
+    await MockIndexer.Helper.initialEnterReorgThreshold(~t, ~indexerMock, ~sourceMock)
+
+    sourceMock.resolveGetItemsOrThrow(
+      [
+        {
+          blockNumber: 101,
+          logIndex: 0,
+          handler: async ({context}) => {
+            context.\"SimpleEntity".set({id: "1", value: "before-delete"})
+          },
+        },
+        {
+          blockNumber: 102,
+          logIndex: 0,
+          handler: async ({context}) => {
+            context.\"SimpleEntity".deleteUnsafe("1")
+          },
+        },
+      ],
+      ~latestFetchedBlockNumber=102,
+    )
+    await indexerMock.getBatchWritePromise()
+
+    sourceMock.resolveGetItemsOrThrow(
+      [
+        {
+          blockNumber: 103,
+          logIndex: 0,
+          handler: async ({context}) => {
+            context.\"SimpleEntity".set({id: "1", value: "after-recreate"})
+          },
+        },
+      ],
+      ~latestFetchedBlockNumber=103,
+    )
+    await indexerMock.getBatchWritePromise()
+
+    // getBatchWritePromise can observe the loop between the response resolving
+    // and processing starting, so wait until this specific batch is visible.
+    let hasRecreatedEntityHistory = ref(false)
+    while !hasRecreatedEntityHistory.contents {
+      hasRecreatedEntityHistory :=
+        (await indexerMock.queryHistory(SimpleEntity))->Array.length === 3
+      if !hasRecreatedEntityHistory.contents {
+        await Utils.delay(1)
+      }
+    }
+
+    t.expect(
+      await Promise.all2((
+        indexerMock.query(SimpleEntity),
+        indexerMock.queryHistory(SimpleEntity),
+      )),
+      ~message="Should establish SET -> DELETE -> SET history before the rollback",
+    ).toEqual((
+      [{Indexer.Entities.SimpleEntity.id: "1", value: "after-recreate"}],
+      [
+        Set({
+          checkpointId: 2n,
+          entityId: "1",
+          entity: {Indexer.Entities.SimpleEntity.id: "1", value: "before-delete"},
+        }),
+        Delete({checkpointId: 3n, entityId: "1"}),
+        Set({
+          checkpointId: 4n,
+          entityId: "1",
+          entity: {Indexer.Entities.SimpleEntity.id: "1", value: "after-recreate"},
+        }),
+      ],
+    ))
+
+    // Detect a reorg at block 103, then establish block 102 (the DELETE
+    // checkpoint) as the latest valid block.
+    sourceMock.resolveGetItemsOrThrow(
+      [],
+      ~latestFetchedBlockNumber=104,
+      ~prevRangeLastBlock={blockNumber: 103, blockHash: "0x103-reorged"},
+    )
+    await Utils.delay(0)
+    await Utils.delay(0)
+
+    t.expect(
+      sourceMock.getBlockHashesCalls,
+      ~message="Should query the scanned blocks below the reorg",
+    ).toEqual([[100, 102]])
+    sourceMock.resolveGetBlockHashes([
+      {blockNumber: 100, blockHash: "0x100", blockTimestamp: 100},
+      {blockNumber: 102, blockHash: "0x102", blockTimestamp: 102},
+    ])
+
+    switch await Promise.race([
+      indexerMock.getRollbackReadyPromise()->Promise.thenResolve(_ => Ok()),
+      indexerErrorPromise->Promise.thenResolve(errHandler => Error(errHandler)),
+    ]) {
+    | Ok() => ()
+    | Error(errHandler) => errHandler->ErrorHandling.raiseExn
+    }
+
+    // Commit the rollback diff without recreating the entity on the canonical chain.
+    sourceMock.resolveGetItemsOrThrow(
+      [],
+      ~latestFetchedBlockNumber=103,
+      ~latestFetchedBlockHash="0x103-reorged",
+    )
+    await indexerMock.getBatchWritePromise()
+
+    t.expect(
+      await indexerMock.query(SimpleEntity),
+      ~message="The entity should remain deleted at the rollback target",
+    ).toEqual([])
+  })
+
   Async.it("Parks a reorg detected while a batch is still processing", async t => {
     let sourceMock = MockIndexer.Source.make(
       [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -487,13 +487,32 @@ describe("E2E rollback tests", () => {
 
     // getBatchWritePromise can observe the loop between the response resolving
     // and processing starting, so wait until this specific batch is visible.
-    let hasRecreatedEntityHistory = ref(false)
-    while !hasRecreatedEntityHistory.contents {
-      hasRecreatedEntityHistory :=
-        (await indexerMock.queryHistory(SimpleEntity))->Array.length === 3
-      if !hasRecreatedEntityHistory.contents {
-        await Utils.delay(1)
+    let shouldKeepWaitingForHistory = ref(true)
+    let rec waitForRecreatedEntityHistory = async () => {
+      if shouldKeepWaitingForHistory.contents {
+        let hasRecreatedEntityHistory =
+          (await indexerMock.queryHistory(SimpleEntity))->Array.length === 3
+        if shouldKeepWaitingForHistory.contents && !hasRecreatedEntityHistory {
+          await Utils.delay(1)
+          await waitForRecreatedEntityHistory()
+        }
       }
+    }
+    let historyWaitTimeoutId = ref(None)
+    let historyWaitTimeout = Promise.make((resolve, _reject) => {
+      historyWaitTimeoutId := Some(setTimeout(resolve, 5_000))
+    })
+    let historyWaitResult = await Promise.race([
+      waitForRecreatedEntityHistory()->Promise.thenResolve(_ => Ok()),
+      indexerErrorPromise->Promise.thenResolve(errHandler => Error(Some(errHandler))),
+      historyWaitTimeout->Promise.thenResolve(_ => Error(None)),
+    ])
+    shouldKeepWaitingForHistory := false
+    historyWaitTimeoutId.contents->Option.forEach(clearTimeout)
+    switch historyWaitResult {
+    | Ok() => ()
+    | Error(Some(errHandler)) => errHandler->ErrorHandling.raiseExn
+    | Error(None) => JsError.throwWithMessage("Timed out waiting for SET -> DELETE -> SET history")
     }
 
     t.expect(


### PR DESCRIPTION
## Summary

- include `envio_change` when retrieving the latest pre-target entity history row
- classify pre-target `SET` rows as restores and `DELETE` rows as removal diffs in ReScript
- add a mock-indexer regression covering `SET -> DELETE -> SET` followed by rollback to the DELETE checkpoint

## Root cause

Rollback retrieval selected the latest row at or before the target but discarded its change action. A DELETE history row therefore reached normal entity parsing with null data fields, causing required-field parsing failures and allowing nullable-only entities to be restored as phantom rows.

## Validation

- `pnpm exec rescript`
- `pnpm exec vitest run test/rollback/Rollback_test.res.mjs` — 19 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed rollback correctness for entities that go through `SET → DELETE → SET` during reorgs, ensuring history and live state align as expected.
  - Corrected in-memory rollback diff handling to use removed entity identifiers consistently.
  - Updated the rollback storage contract so removed identifiers are returned as plain values.
- **Tests**
  - Added an end-to-end rollback scenario covering `SET/DELETE/SET` reorg behavior.
- **Chores**
  - Enhanced the test indexer helper with an optional custom error handler (defaults to failing the test).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->