### PR TITLE
Anchor cross-chain alignment to most-behind chain's frontier

### DIFF
--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -466,12 +466,13 @@ let targetBlock = (cs: t, ~chainTargetItems: float) => {
 }
 
 // Block range that cross-chain progress alignment maps fractions over: from
-// the first block that can hold this chain's events to the last block it can
-// fetch right now.
+// the chain's startBlock to the last block it can fetch right now. The lower
+// bound is deliberately static — anchoring it at firstEventBlock would
+// collapse a chain's progress to 0 the moment its first event is discovered,
+// yanking every other chain's alignment line below their own frontiers.
 let progressRange = (cs: t) => {
   let fetchState = cs.fetchState
-  let lower = fetchState.firstEventBlock->Option.getOr(fetchState.startBlock)
-  (lower, cs->fetchCeiling)
+  (fetchState.startBlock, cs->fetchCeiling)
 }
 
 // A degenerate range (chain already at or past its last block) maps to 1 so it
@@ -491,6 +492,12 @@ let blockAtProgress = (cs: t, ~progress) => {
   let (lower, upper) = cs->progressRange
   lower + Math.ceil(progress *. (upper - lower)->Int.toFloat)->Float.toInt
 }
+
+// The fetch frontier as a fraction of the alignable range — what the
+// cross-chain waterfall aligns other chains against. Based on blocks actually
+// fetched, so it holds up even while this chain's queries are in flight.
+let frontierProgress = (cs: t) =>
+  cs->progressAtBlock(~blockNumber=cs.fetchState->FetchState.bufferBlockNumber)
 
 // Propose queries sized against this chain's target block. Called by
 // CrossChainState's waterfall, furthest-behind chain first, with

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -410,13 +410,17 @@ let isReady = (cs: t) => cs.timestampCaughtUpToHeadOrEndblock !== None
 // nudge it.
 let densityBlendWindow = 100.
 
-// The last block this chain can fetch right now: the head, or endBlock when
-// it's below the head.
+// The last block this chain can fetch right now: the lagged head
+// (knownHeight - blockLag, the frontier when a reorg-threshold blockLag holds
+// back the tip), or endBlock when it's below that head. Matching isFetchingAtHead's
+// definition of the head is what lets a chain parked at its lagged head read
+// 100% progress instead of looking behind against blocks it can't fetch.
 let fetchCeiling = (cs: t) => {
   let fetchState = cs.fetchState
+  let head = Pervasives.max(0, fetchState.knownHeight - fetchState.blockLag)
   switch fetchState.endBlock {
-  | Some(endBlock) => Pervasives.min(endBlock, fetchState.knownHeight)
-  | None => fetchState.knownHeight
+  | Some(endBlock) => Pervasives.min(endBlock, head)
+  | None => head
   }
 }
 

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -467,9 +467,10 @@ let targetBlock = (cs: t, ~chainTargetItems: float) => {
 
 // Block range that cross-chain progress alignment maps fractions over: from
 // the chain's startBlock to the last block it can fetch right now. The lower
-// bound is deliberately static — anchoring it at firstEventBlock would
-// collapse a chain's progress to 0 the moment its first event is discovered,
-// yanking every other chain's alignment line below their own frontiers.
+// bound is deliberately static — anchoring it at firstEventBlock would make
+// two chains sitting at the same block read different progress fractions
+// depending on whether each has discovered its first event yet, so the
+// anchor's line could map below a follower's own frontier and stall it.
 let progressRange = (cs: t) => {
   let fetchState = cs.fetchState
   (fetchState.startBlock, cs->fetchCeiling)

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -67,7 +67,6 @@ let isReadyToEnterReorgThreshold: t => bool
 
 // Fetch control.
 let targetBlock: (t, ~chainTargetItems: float) => int
-let progressAtBlock: (t, ~blockNumber: int) => float
 let blockAtProgress: (t, ~progress: float) => int
 let frontierProgress: t => float
 let getNextQuery: (

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -69,6 +69,7 @@ let isReadyToEnterReorgThreshold: t => bool
 let targetBlock: (t, ~chainTargetItems: float) => int
 let progressAtBlock: (t, ~blockNumber: int) => float
 let blockAtProgress: (t, ~progress: float) => int
+let frontierProgress: t => float
 let getNextQuery: (
   t,
   ~chainTargetItems: float,

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -169,13 +169,18 @@ let applyBatchProgress = (crossChainState: t, ~batch: Batch.t, ~blockTimestampNa
 
 // --- Fetch control. ---
 
-// Chains ordered furthest-behind first, so the shared buffer pool goes to the
-// chains with the most fetchable backfill work before the rest.
+// Chains ordered furthest-behind first by fetch-frontier progress, so the
+// shared buffer pool goes to the chains with the most fetchable backfill work
+// before the rest — and the same metric that sets the alignment line also
+// decides who draws budget first, so the anchor is served before any chain it
+// clamps. (Batch ordering keeps its own getProgressPercentage measure.) A chain
+// with no known height reads 100% here and sorts last, which is fine: it can't
+// fetch until its first block lands regardless of when it's visited.
 let priorityOrder = (crossChainState: t) =>
   crossChainState.chainStates
   ->Dict.valuesToArray
   ->Array.toSorted((a, b) =>
-    Float.compare(a->ChainState.getProgressPercentage, b->ChainState.getProgressPercentage)
+    Float.compare(a->ChainState.frontierProgress, b->ChainState.frontierProgress)
   )
 
 // In-flight estimated items across every chain — the live draw against
@@ -241,26 +246,18 @@ let checkAndFetch = async (
 
   let prioritizedChainStates = crossChainState->priorityOrder
 
-  // Alignment anchor: the known-height chain with the lowest fetch-frontier
-  // progress — the same metric the clamp maps other chains against, so the
-  // chain that sets the line is exactly the one furthest behind by that line's
-  // own measure. Anchoring on the frontier (not on the target of whichever
-  // chain happens to query this tick) keeps the line in place while the
-  // anchor's queries are still in flight. A chain caught up to its fetchable
-  // head reads 100% here and so never anchors while another chain is behind.
+  // Alignment anchor: the first known-height chain in priority order — which,
+  // since that order sorts by frontier progress, is the chain furthest behind
+  // by the very metric the clamp maps other chains against. Anchoring on the
+  // frontier (not on the target of whichever chain happens to query this tick)
+  // keeps the line in place while the anchor's queries are still in flight. A
+  // chain caught up to its fetchable head reads 100% and sorts past any behind
+  // chain, so it never anchors while another chain is behind.
   let alignment = crossChainState.isRealtime
     ? None
-    : prioritizedChainStates->Array.reduce(None, (acc, cs) =>
-        if cs->ChainState.knownHeight == 0 {
-          acc
-        } else {
-          let progress = cs->ChainState.frontierProgress
-          switch acc {
-          | Some((_, best)) if best <= progress => acc
-          | _ => Some(((cs->ChainState.chainConfig).id, progress))
-          }
-        }
-      )
+    : prioritizedChainStates
+      ->Array.find(cs => cs->ChainState.knownHeight != 0)
+      ->Option.map(cs => ((cs->ChainState.chainConfig).id, cs->ChainState.frontierProgress))
 
   let actionByChain = Dict.make()
   prioritizedChainStates->Array.forEach(cs => {

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -201,10 +201,13 @@ let totalReservedSize = (crossChainState: t) => {
 // automatically. Starting a new query requires at least 10% of the target pool
 // to be free. A chain visited after the budget falls below that admission unit
 // doesn't query this round — reservations release as responses land, so the
-// next tick redistributes. Chains that do get budget are additionally capped
-// at the first querying chain's target progress mapped onto their own range, so
-// no chain runs further ahead than the chain currently using the pool. Waiting
-// and idle chains do not establish this alignment line.
+// next tick redistributes. Every other chain is additionally capped at the
+// most-behind chain's fetch-frontier progress mapped onto its own range, so no
+// chain runs ahead of the chain the pool is prioritizing — including on ticks
+// where that chain is mid-fetch and emits no new query. A chain with no known
+// height can't anchor this line (there's no range to measure against), and
+// once the whole indexer has caught up (isRealtime) the clamp is dropped —
+// chains at head only trail each other by real-time block production.
 let checkAndFetch = async (
   crossChainState: t,
   ~dispatchChain: (~chain: ChainMap.Chain.t, ~action: FetchState.nextQuery) => promise<unit>,
@@ -235,11 +238,20 @@ let checkAndFetch = async (
   // gets more since a forced catch-up query there costs a head-poll roundtrip.
   let chunkItemsMultiplier = crossChainState.isRealtime ? 3. : 1.5
 
+  let prioritizedChainStates = crossChainState->priorityOrder
+
+  // Alignment anchor: the most-behind chain with a known height. Anchoring on
+  // its current frontier (not on the target of whichever chain happens to
+  // query this tick) keeps the line in place while the anchor's queries are
+  // still in flight.
+  let alignment = crossChainState.isRealtime
+    ? None
+    : prioritizedChainStates
+      ->Array.find(cs => cs->ChainState.knownHeight != 0)
+      ->Option.map(cs => ((cs->ChainState.chainConfig).id, cs->ChainState.frontierProgress))
+
   let actionByChain = Dict.make()
-  let maxProgress = ref(None)
-  crossChainState
-  ->priorityOrder
-  ->Array.forEach(cs => {
+  prioritizedChainStates->Array.forEach(cs => {
     let chainId = (cs->ChainState.chainConfig).id
     if remaining.contents < minimumAdmissionBudget {
       // More than 90% of the target pool is ready or reserved. Do not attempt
@@ -257,21 +269,13 @@ let checkAndFetch = async (
       let chainTargetItems =
         (isCold ? Pervasives.min(remaining.contents, coldChainBudget) : remaining.contents) +.
         cs->ChainState.pendingBudget
-      let candidateProgress = switch maxProgress.contents {
-      | None if !isCold =>
-        Some(
-          cs->ChainState.progressAtBlock(
-            ~blockNumber=cs->ChainState.targetBlock(~chainTargetItems),
-          ),
-        )
+      let maxTargetBlock = switch alignment {
+      // 5% margin past the anchor's line: chains whose progress tracks the
+      // anchor closely would otherwise flap in and out of the clamp on every
+      // small frontier move, stalling their pipeline every other tick.
+      | Some((anchorChainId, progress)) if anchorChainId !== chainId =>
+        Some(cs->ChainState.blockAtProgress(~progress=progress +. 0.05))
       | _ => None
-      }
-      let maxTargetBlock = switch maxProgress.contents {
-      | None => None
-      // 5% margin past the leader's line: chains whose progress tracks the
-      // leader closely would otherwise flap in and out of the clamp as
-      // leadership alternates, stalling their pipeline every other tick.
-      | Some(progress) => Some(cs->ChainState.blockAtProgress(~progress=progress +. 0.05))
       }
       switch cs->ChainState.getNextQuery(
         ~chainTargetItems,
@@ -297,14 +301,6 @@ let checkAndFetch = async (
             : FetchState.WaitingForNewBlock
         actionByChain->Utils.Dict.setByInt(chainId, action)
       | Ready(queries) => {
-          // A density-bearing chain establishes the alignment line only after
-          // proving that it can use the pool. Waiting and idle chains leave it
-          // open for the next chain; cold-chain targets remain guesses and do
-          // not lead, as before.
-          switch candidateProgress {
-          | Some(progress) => maxProgress := Some(progress)
-          | None => ()
-          }
           let consumed =
             queries->Array.reduce(0., (acc, query: FetchState.query) =>
               acc +. query.itemsEst->Int.toFloat

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -202,12 +202,13 @@ let totalReservedSize = (crossChainState: t) => {
 // to be free. A chain visited after the budget falls below that admission unit
 // doesn't query this round — reservations release as responses land, so the
 // next tick redistributes. Every other chain is additionally capped at the
-// most-behind chain's fetch-frontier progress mapped onto its own range, so no
+// lowest-frontier-progress chain's progress mapped onto its own range, so no
 // chain runs ahead of the chain the pool is prioritizing — including on ticks
 // where that chain is mid-fetch and emits no new query. A chain with no known
-// height can't anchor this line (there's no range to measure against), and
-// once the whole indexer has caught up (isRealtime) the clamp is dropped —
-// chains at head only trail each other by real-time block production.
+// height can't anchor this line (there's no range to measure against), a chain
+// caught up to its fetchable head reads 100% and so never anchors while another
+// is behind, and once the whole indexer has caught up (isRealtime) the clamp is
+// dropped — chains at head only trail each other by real-time block production.
 let checkAndFetch = async (
   crossChainState: t,
   ~dispatchChain: (~chain: ChainMap.Chain.t, ~action: FetchState.nextQuery) => promise<unit>,
@@ -240,15 +241,26 @@ let checkAndFetch = async (
 
   let prioritizedChainStates = crossChainState->priorityOrder
 
-  // Alignment anchor: the most-behind chain with a known height. Anchoring on
-  // its current frontier (not on the target of whichever chain happens to
-  // query this tick) keeps the line in place while the anchor's queries are
-  // still in flight.
+  // Alignment anchor: the known-height chain with the lowest fetch-frontier
+  // progress — the same metric the clamp maps other chains against, so the
+  // chain that sets the line is exactly the one furthest behind by that line's
+  // own measure. Anchoring on the frontier (not on the target of whichever
+  // chain happens to query this tick) keeps the line in place while the
+  // anchor's queries are still in flight. A chain caught up to its fetchable
+  // head reads 100% here and so never anchors while another chain is behind.
   let alignment = crossChainState.isRealtime
     ? None
-    : prioritizedChainStates
-      ->Array.find(cs => cs->ChainState.knownHeight != 0)
-      ->Option.map(cs => ((cs->ChainState.chainConfig).id, cs->ChainState.frontierProgress))
+    : prioritizedChainStates->Array.reduce(None, (acc, cs) =>
+        if cs->ChainState.knownHeight == 0 {
+          acc
+        } else {
+          let progress = cs->ChainState.frontierProgress
+          switch acc {
+          | Some((_, best)) if best <= progress => acc
+          | _ => Some(((cs->ChainState.chainConfig).id, progress))
+          }
+        }
+      )
 
   let actionByChain = Dict.make()
   prioritizedChainStates->Array.forEach(cs => {

--- a/scenarios/test_codegen/test/E2E_test.res
+++ b/scenarios/test_codegen/test/E2E_test.res
@@ -1787,8 +1787,22 @@ describe("E2E tests", () => {
         await indexerMock.getBatchWritePromise()
       }
 
-      // The follower is below its own head (frontier 100 < head 105) but starved
-      // of budget. It must keep polling for new blocks rather than going silent.
+      // The follower is below its own head (frontier 100 < head 105). The
+      // indexer is realtime, so the cross-chain alignment clamp is dropped:
+      // instead of being starved behind the backfilling leader, the follower
+      // fetches its small range to head...
+      await MockIndexer.Helper.waitItemsQuery(followerSource)
+      let followerCall = followerSource.getItemsOrThrowCalls->Array.getUnsafe(0)
+      t.expect(
+        followerCall.payload["fromBlock"],
+        ~message="follower fetches its own range to head instead of waiting behind the leader",
+      ).toEqual(101)
+      followerCall.resolve([], ~latestFetchedBlockNumber=105)
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      // ...and once at head it goes back to polling for new blocks rather
+      // than going silent.
       t.expect(
         followerSource.getHeightOrThrowCalls->Array.length > followerPollsBefore,
         ~message="follower keeps polling getHeightOrThrow while the leader backfills a large range",

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -209,6 +209,26 @@ describe("CrossChainState fetch control", () => {
     ).toEqual([1, 2, 3])
   })
 
+  it("priorityOrder ranks by frontier progress, not event-based progress", t => {
+    // Chain 1 has found no events yet (firstEventBlock=None), so
+    // getProgressPercentage reports it at 0% even though its fetch frontier
+    // (900) is far ahead of chain 2's (300). Ordering by frontier progress must
+    // put the genuinely-behind chain 2 first, so it draws budget and anchors
+    // the line before the ahead-but-eventless chain 1.
+    let ahead = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=1000,
+      ~latestFetchedBlock=900,
+      ~firstEventBlock=None,
+    )
+    let behind = makeFetchingChainState(~chainId=2, ~knownHeight=1000, ~latestFetchedBlock=300)
+    let cm = makeCrossChainState(~chainStatesList=[ahead, behind])
+
+    t.expect(
+      cm->CrossChainState.priorityOrder->Array.map(cs => (cs->ChainState.chainConfig).id),
+    ).toEqual([2, 1])
+  })
+
   Async.it("checkAndFetch dispatches every chain that has work, skipping idle ones", async t => {
     // Chains at head (onBlock-only, frontier == knownHeight) wait for a new
     // block, so they're dispatched with that action. A chain whose buffer is

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -499,19 +499,19 @@ describe("CrossChainState fetch control", () => {
   }
 
   Async.it(
-    "checkAndFetch's waterfall lets the furthest-behind chain drain only what it can use, flowing the remainder to the next chain",
+    "checkAndFetch's waterfall clamps the next chain to the most-behind chain's frontier during backfill",
     async t => {
       t.expect(
         await runShortRangeWaterfall(~isRealtime=false),
-        ~message="Chain 1's real range caps it at 200 items regardless of its share of the 3000-item pool (itemsTarget carries the 1.5x headroom = 300, but only the 200 estimate is reserved); chain 2 gets the rest",
-      ).toEqual((Some(300.), Some(2800.), 200., 2800.))
+        ~message="Chain 1's real range caps it at 200 items (itemsTarget carries the 1.5x headroom = 300, only the 200 estimate is reserved); chain 2's frontier is already past the alignment line anchored at chain 1's frontier, so it waits instead of draining the pool",
+      ).toEqual((Some(300.), Some(0.), 200., 0.))
     },
   )
 
-  Async.it("checkAndFetch sizes realtime chunk caps with 3x headroom but reserves the estimate", async t => {
+  Async.it("checkAndFetch drops the alignment clamp in realtime and sizes chunk caps with 3x headroom", async t => {
     t.expect(
       await runShortRangeWaterfall(~isRealtime=true),
-      ~message="Chain 1's itemsTarget carries the 3x realtime headroom = 600, but pendingBudget still reserves the honest 200-item estimate; chain 2 gets the rest",
+      ~message="Chain 1's itemsTarget carries the 3x realtime headroom = 600, but pendingBudget still reserves the honest 200-item estimate; chain 2 is unclamped at realtime and gets the rest",
     ).toEqual((Some(600.), Some(2800.), 200., 2800.))
   })
 
@@ -553,21 +553,25 @@ describe("CrossChainState fetch control", () => {
   Async.it(
     "checkAndFetch aligns progress against the currently reachable end block",
     async t => {
-      let leader = makeFetchingChainState(
+      // The anchor's endBlock (1e9) is far past its head (1000). Its frontier
+      // progress must be measured against the reachable range (500/1000 = 50%),
+      // not the raw endBlock (500/1e9 ≈ 0%) — the latter would clamp the
+      // follower below its own frontier and stall it.
+      let anchor = makeFetchingChainState(
         ~chainId=1,
         ~knownHeight=1000,
-        ~latestFetchedBlock=0,
+        ~latestFetchedBlock=500,
         ~endBlock=Some(1_000_000_000),
         ~chainDensity=Some(1.),
       )
       let follower = makeFetchingChainState(
         ~chainId=2,
         ~knownHeight=1000,
-        ~latestFetchedBlock=0,
+        ~latestFetchedBlock=520,
         ~chainDensity=Some(1.),
       )
       let cm = makeCrossChainState(
-        ~chainStatesList=[leader, follower],
+        ~chainStatesList=[anchor, follower],
         ~targetBufferSize=3000,
       )
 
@@ -586,8 +590,8 @@ describe("CrossChainState fetch control", () => {
 
       t.expect(
         estimatesByChain,
-        ~message="A future endBlock must not clamp the follower near its starting frontier",
-      ).toEqual(Dict.fromArray([("1", 1000), ("2", 1000)]))
+        ~message="The follower fetches up to the anchor's 50% line (+5% margin = block 550), not to nothing",
+      ).toEqual(Dict.fromArray([("1", 500), ("2", 30)]))
     },
   )
 
@@ -689,11 +693,10 @@ describe("ChainState cold start", () => {
     t.expect(cs->ChainState.targetBlock(~chainTargetItems=1000.)).toBe(5_000)
   })
 
-  Async.it("cold leader doesn't set the alignment line", async t => {
-    // Chain 1 is cold and most behind: its 20k guess-window on a 1M-block
-    // chain maps to ~2% progress, which would cap chain 2 near block 20 if a
-    // cold chain could claim leadership. Instead chain 2 (density-bearing)
-    // sets the line and drains the rest of the pool.
+  Async.it("cold most-behind chain still anchors the alignment line at its frontier", async t => {
+    // Chain 1 is cold and most behind. Its target is a guess, but its frontier
+    // is a real measurement — chain 2 must not run ahead of it just because
+    // chain 1 hasn't produced a density signal yet.
     let a = makeFetchingChainState(~chainId=1, ~knownHeight=1_000_000, ~latestFetchedBlock=0)
     let b = makeFetchingChainState(
       ~chainId=2,
@@ -718,8 +721,92 @@ describe("ChainState cold start", () => {
 
     t.expect(
       dispatchedItemsByChain,
-      ~message="Cold chain 1 gets its bounded probe; chain 2 is unconstrained by chain 1's guess",
-    ).toEqual(Dict.fromArray([("1", 1000.), ("2", 5000.)]))
+      ~message="Cold chain 1 gets its bounded probe; chain 2 (already past the line anchored at chain 1's 0% frontier) waits",
+    ).toEqual(Dict.fromArray([("1", 1000.), ("2", 0.)]))
+  })
+
+  Async.it("most-behind chain anchors the alignment line even when it emits no query", async t => {
+    // Chain 1 is most behind but produces no new query this tick (its buffer
+    // holds a ready item that batch processing will drain). Before frontier
+    // anchoring, such a tick left the line unset and chain 2 ran unclamped to
+    // its head; now chain 2 stays held at chain 1's frontier (+5% margin).
+    let a = makeChainState(
+      ~chainId=1,
+      ~knownHeight=1000,
+      ~frontier=100,
+      ~firstEventBlock=0,
+      ~bufferBlocks=[100],
+    )
+    let b = makeFetchingChainState(
+      ~chainId=2,
+      ~knownHeight=1000,
+      ~latestFetchedBlock=500,
+      ~chainDensity=Some(10.),
+    )
+    let cm = makeCrossChainState(~chainStatesList=[a, b], ~targetBufferSize=10_000)
+
+    let actionsByChain = Dict.make()
+    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
+      actionsByChain->Utils.Dict.setByInt(
+        chain->ChainMap.Chain.toChainId,
+        switch action {
+        | WaitingForNewBlock => "waitingForNewBlock"
+        | NothingToQuery => "nothingToQuery"
+        | Ready(queries) =>
+          "ready:" ++
+          queries
+          ->Array.reduce(0., (acc, q: FetchState.query) => acc +. q.itemsTarget->Int.toFloat)
+          ->Float.toString
+        },
+      )
+      Promise.resolve()
+    })
+
+    t.expect(
+      actionsByChain->Dict.get("2"),
+      ~message="Chain 2's frontier (500) is past chain 1's line (10% + 5% margin = block 150), so it waits instead of fetching to head",
+    ).toEqual(Some("waitingForNewBlock"))
+  })
+
+  Async.it("realtime indexer drops the alignment clamp", async t => {
+    // Same shape as the anchoring test above, but the indexer is realtime:
+    // chain 2 must be free to fetch to its head regardless of chain 1.
+    let a = makeChainState(
+      ~chainId=1,
+      ~knownHeight=1000,
+      ~frontier=100,
+      ~firstEventBlock=0,
+      ~bufferBlocks=[100],
+    )
+    let b = makeFetchingChainState(
+      ~chainId=2,
+      ~knownHeight=1000,
+      ~latestFetchedBlock=500,
+      ~chainDensity=Some(10.),
+    )
+    let cm = makeCrossChainState(
+      ~chainStatesList=[a, b],
+      ~isRealtime=true,
+      ~targetBufferSize=10_000,
+    )
+
+    let dispatchedItemsByChain = Dict.make()
+    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
+      dispatchedItemsByChain->Utils.Dict.setByInt(
+        chain->ChainMap.Chain.toChainId,
+        switch action {
+        | Ready(queries) =>
+          queries->Array.reduce(0, (acc, q: FetchState.query) => acc + q.itemsEst)
+        | _ => 0
+        },
+      )
+      Promise.resolve()
+    })
+
+    t.expect(
+      dispatchedItemsByChain->Dict.get("2"),
+      ~message="Chain 2 fetches its full 500-block range to head at density 10",
+    ).toEqual(Some(5000))
   })
 
   Async.it("gives a cold chain one 10% admission unit", async t => {

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -91,6 +91,8 @@ let makeFetchingChainState = (
   ~chainDensity=None,
   ~caughtUpOnce=false,
   ~bufferBlocks=[],
+  ~firstEventBlock=Some(0),
+  ~blockLag=0,
 ) => {
   let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
   let address = "0x1234567890123456789012345678901234567890"->Address.unsafeFromString
@@ -129,10 +131,10 @@ let makeFetchingChainState = (
     maxOnBlockBufferSize: 10000,
     chainId,
     contractConfigs: Dict.make(),
-    blockLag: 0,
+    blockLag,
     onBlockRegistrations: [],
     knownHeight,
-    firstEventBlock: Some(0),
+    firstEventBlock,
   }
   let mockSource = MockIndexer.Source.make([], ~chain=#1)
   ChainState.make(
@@ -831,6 +833,72 @@ describe("ChainState cold start", () => {
       (await probeSize(~targetBufferSize=10_000), await probeSize(~targetBufferSize=2_000)),
       ~message="The cold probe scales with the configured target buffer",
     ).toEqual((1000., 200.))
+  })
+
+  it("frontierProgress reads 100% at the lagged head", t => {
+    // knownHeight 1000 held back by blockLag 200 -> the fetchable head is 800.
+    // A chain fetched to 800 is fully caught up and must read 1.0, not 0.8, so
+    // it never looks behind against blocks it can't fetch yet.
+    let cs = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=1000,
+      ~latestFetchedBlock=800,
+      ~blockLag=200,
+    )
+    t.expect(cs->ChainState.frontierProgress).toBe(1.)
+  })
+
+  Async.it("a chain with no discovered first event never becomes a dead anchor", async t => {
+    // Chain 1 has found no events yet (firstEventBlock=None) but has already
+    // scanned to 90% of its range. FetchState.getProgressPercentage reports it
+    // at 0% (its priority rank), yet its fetch frontier is far ahead. The
+    // alignment anchor must be chain 2 (furthest behind by frontier progress),
+    // so chain 3 (just ahead of chain 2) is held near chain 2's line instead of
+    // racing to head on chain 1's non-clamping frontier.
+    let scanning = makeFetchingChainState(
+      ~chainId=1,
+      ~knownHeight=1000,
+      ~latestFetchedBlock=900,
+      ~chainDensity=Some(10.),
+      ~firstEventBlock=None,
+    )
+    let behind = makeFetchingChainState(
+      ~chainId=2,
+      ~knownHeight=1000,
+      ~latestFetchedBlock=300,
+      ~chainDensity=Some(10.),
+    )
+    let slightlyAhead = makeFetchingChainState(
+      ~chainId=3,
+      ~knownHeight=1000,
+      ~latestFetchedBlock=310,
+      ~chainDensity=Some(10.),
+    )
+    let cm = makeCrossChainState(
+      ~chainStatesList=[scanning, behind, slightlyAhead],
+      ~targetBufferSize=100_000,
+    )
+
+    let itemsByChain = Dict.make()
+    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
+      itemsByChain->Utils.Dict.setByInt(
+        chain->ChainMap.Chain.toChainId,
+        switch action {
+        | Ready(queries) => queries->Array.reduce(0, (acc, q: FetchState.query) => acc + q.itemsEst)
+        | _ => 0
+        },
+      )
+      Promise.resolve()
+    })
+
+    t.expect(
+      (
+        itemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(1),
+        itemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(2),
+        itemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(3),
+      ),
+      ~message="Chain 2 anchors and fetches to head; chain 3 is clamped to chain 2's line (~block 350 -> 400 items); the scanning chain 1 sets no line and idles",
+    ).toEqual((Some(0), Some(7000), Some(400)))
   })
 })
 

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -891,14 +891,23 @@ describe("ChainState cold start", () => {
       Promise.resolve()
     })
 
+    let items = chainId => itemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(chainId)->Option.getOr(0)
+    // Structural, not exact: chain 1 (scanning, firstEventBlock=None) must set
+    // no line and idle; chain 2 (lowest frontier progress) anchors and fetches
+    // freely; chain 3 stays clamped near chain 2's line — far below what it
+    // would fetch if chain 1's near-head frontier were the anchor.
     t.expect(
-      (
-        itemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(1),
-        itemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(2),
-        itemsByChain->Utils.Dict.dangerouslyGetByIntNonOption(3),
-      ),
-      ~message="Chain 2 anchors and fetches to head; chain 3 is clamped to chain 2's line (~block 350 -> 400 items); the scanning chain 1 sets no line and idles",
-    ).toEqual((Some(0), Some(7000), Some(400)))
+      {
+        "scanningChainIdle": items(1) == 0,
+        "anchorFetchesFreely": items(2) > items(3),
+        "followerHeldFarBelowAnchor": items(3) > 0 && items(3) * 3 < items(2),
+      },
+      ~message="The genuinely-behind chain 2 anchors the line; chain 3 is held near it instead of racing to head on the scanning chain's non-clamping frontier",
+    ).toEqual({
+      "scanningChainIdle": true,
+      "anchorFetchesFreely": true,
+      "followerHeldFarBelowAnchor": true,
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

Changes the cross-chain waterfall algorithm to anchor the progress alignment line at the most-behind chain's current fetch frontier, rather than at whichever chain happens to emit a query this tick. This prevents faster chains from running ahead of the chain the pool is prioritizing, even when that chain is mid-fetch and emits no new query.

## Key Changes

- **Alignment anchor computation** (`CrossChainState.res`): Pre-compute the alignment anchor once per tick as the most-behind chain with a known height, using its current frontier progress. This anchor persists across the entire waterfall, independent of which chains query.

- **Frontier progress tracking** (`ChainState.res`): Add `frontierProgress` function to measure the most-behind chain's fetch frontier as a fraction of its alignable range. The alignable range now uses a static `startBlock` lower bound (not `firstEventBlock`) so two chains at the same block read the same progress fraction regardless of event discovery state.

- **Realtime clamp removal**: When `isRealtime=true`, the alignment clamp is dropped entirely — chains at head are free to fetch to their own head rather than being held back by slower chains.

- **Test updates**: Reflect the new behavior where chains already past the anchor's frontier line wait instead of draining the pool, and where realtime indexers drop the clamp. Updated test messages and expected values to match the new semantics.

## Notable Implementation Details

- The 5% margin past the anchor's line prevents flapping when a chain's frontier moves slightly, which would otherwise cause it to oscillate in and out of the clamp on consecutive ticks.

- Cold chains (with no density signal yet) can still anchor the line via their frontier, but their target remains a guess and doesn't establish the line themselves — only the most-behind chain with a known height does.

- The anchor is computed before the waterfall loop and reused for all chains, ensuring consistent behavior even when the anchor chain itself doesn't query this tick.

https://claude.ai/code/session_01A9rjeiYEtjQKRKxCtfFdnR