### PR TITLE
Add scope label to effect metrics for per-scope tracking

### DIFF
--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -232,8 +232,12 @@ let makeFromDbState = (
 
   Prometheus.ProcessingMaxBatchSize.set(~maxBatchSize=config.batchSize)
   Prometheus.ReorgThreshold.set(~isInReorgThreshold)
-  initialState.cache->Utils.Dict.forEach(({effectName, count}) => {
-    Prometheus.EffectCacheCount.set(~count, ~effectName)
+  initialState.cache->Utils.Dict.forEach(({effectName, count, scope}) => {
+    Prometheus.EffectCacheCount.set(
+      ~count,
+      ~effectName,
+      ~scope=scope->Internal.EffectCache.scopeToString,
+    )
   })
 
   // updateSyncTimeOnRestart wipes the saved timestamp so a restart re-enters

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -795,6 +795,21 @@ module EffectCache = {
     | Chain(chainId) => `envio_${chainId->Int.toString}_effect_${effectName}`
     }
 
+  // "crossChain" or the decimal chain id. Used as the `scope` Prometheus label.
+  let scopeToString = scope =>
+    switch scope {
+    | CrossChain => "crossChain"
+    | Chain(chainId) => chainId->Int.toString
+    }
+
+  // Only accepts a canonical decimal chain id ("7", not "007" or "1foo") —
+  // Int.fromString alone follows parseInt semantics and accepts both.
+  let parseChainId = str =>
+    switch Int.fromString(str) {
+    | Some(chainId) if chainId >= 0 && chainId->Int.toString === str => Some(chainId)
+    | _ => None
+    }
+
   let chainScopedRe = /^envio_([0-9]+)_effect_(.+)$/
   let crossChainRe = /^envio_effect_(.+)$/
 
@@ -809,7 +824,7 @@ module EffectCache = {
         RegExp.Result.matches(result)->Array.get(1),
       ) {
       | (Some(Some(chainIdStr)), Some(Some(effectName))) =>
-        switch Int.fromString(chainIdStr) {
+        switch parseChainId(chainIdStr) {
         | Some(chainId) => Some((effectName, Chain(chainId)))
         | None => None
         }

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -77,10 +77,11 @@ let callEffect = (
   ~onError,
 ) => {
   let effectName = effect.name
+  let scopeLabel = inMemTable.scope->Internal.EffectCache.scopeToString
   let hadActiveCalls = inMemTable.activeCallsCount > 0
   inMemTable.activeCallsCount = inMemTable.activeCallsCount + 1
   Prometheus.EffectCalls.activeCallsCount->Prometheus.SafeGauge.handleInt(
-    ~labels=effectName,
+    ~labels={"effect": effectName, "scope": scopeLabel},
     ~value=inMemTable.activeCallsCount,
   )
 
@@ -110,7 +111,7 @@ let callEffect = (
   ->Promise.finally(() => {
     inMemTable.activeCallsCount = inMemTable.activeCallsCount - 1
     Prometheus.EffectCalls.activeCallsCount->Prometheus.SafeGauge.handleInt(
-      ~labels=effectName,
+      ~labels={"effect": effectName, "scope": scopeLabel},
       ~value=inMemTable.activeCallsCount,
     )
     let newTimer = Performance.now()
@@ -193,7 +194,11 @@ let rec executeWithRateLimit = (
     if immediateCount > 0 && isFromQueue {
       // Update queue count metric
       state.queueCount = state.queueCount - immediateCount
-      Prometheus.EffectQueueCount.set(~count=state.queueCount, ~effectName)
+      Prometheus.EffectQueueCount.set(
+        ~count=state.queueCount,
+        ~effectName,
+        ~scope=inMemTable.scope->Internal.EffectCache.scopeToString,
+      )
     }
 
     // Handle queued items
@@ -201,7 +206,11 @@ let rec executeWithRateLimit = (
       if !isFromQueue {
         // Update queue count metric
         state.queueCount = state.queueCount + queuedArgs->Array.length
-        Prometheus.EffectQueueCount.set(~count=state.queueCount, ~effectName)
+        Prometheus.EffectQueueCount.set(
+          ~count=state.queueCount,
+          ~effectName,
+          ~scope=inMemTable.scope->Internal.EffectCache.scopeToString,
+        )
       }
 
       let millisUntilReset = ref(0)

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1260,7 +1260,7 @@ let make = (
       if isDir {
         let subEntries = await NodeJs.Fs.Promises.readdir(entryPath)
         let tsvs = subEntries->Array.filter(sub => sub->String.endsWith(".tsv"))
-        switch Int.fromString(entry) {
+        switch Internal.EffectCache.parseChainId(entry) {
         | Some(chainId) =>
           tsvs->Array.forEach(sub => {
             let effectName = sub->String.slice(~start=0, ~end=-4)

--- a/packages/envio/src/Prometheus.res
+++ b/packages/envio/src/Prometheus.res
@@ -606,6 +606,16 @@ let effectLabelsSchema = S.object(s => {
   s.field("effect", S.string)
 })
 
+// For metrics whose backing state lives per scope ("crossChain" or a chain
+// id) — without the label, scopes of the same effect would clobber each
+// other's gauge value.
+let effectScopeLabelsSchema = S.schema(s =>
+  {
+    "effect": s.matches(S.string),
+    "scope": s.matches(S.string),
+  }
+)
+
 module EffectCalls = {
   let timeCounter = SafeCounter.makeOrThrow(
     ~name="envio_effect_call_seconds",
@@ -628,7 +638,7 @@ module EffectCalls = {
   let activeCallsCount = SafeGauge.makeOrThrow(
     ~name="envio_effect_active_calls",
     ~help="The number of Effect function calls that are currently running.",
-    ~labelSchema=effectLabelsSchema,
+    ~labelSchema=effectScopeLabelsSchema,
   )
 }
 
@@ -636,11 +646,11 @@ module EffectCacheCount = {
   let gauge = SafeGauge.makeOrThrow(
     ~name="envio_effect_cache",
     ~help="The number of items in the effect cache.",
-    ~labelSchema=effectLabelsSchema,
+    ~labelSchema=effectScopeLabelsSchema,
   )
 
-  let set = (~count, ~effectName) => {
-    gauge->SafeGauge.handleInt(~labels=effectName, ~value=count)
+  let set = (~count, ~effectName, ~scope) => {
+    gauge->SafeGauge.handleInt(~labels={"effect": effectName, "scope": scope}, ~value=count)
   }
 }
 
@@ -660,7 +670,7 @@ module EffectQueueCount = {
   let gauge = SafeGauge.makeOrThrow(
     ~name="envio_effect_queue",
     ~help="The number of effect calls waiting in the rate limit queue.",
-    ~labelSchema=effectLabelsSchema,
+    ~labelSchema=effectScopeLabelsSchema,
   )
 
   let timeCounter = SafeCounter.makeOrThrow(
@@ -669,8 +679,8 @@ module EffectQueueCount = {
     ~labelSchema=effectLabelsSchema,
   )
 
-  let set = (~count, ~effectName) => {
-    gauge->SafeGauge.handleInt(~labels=effectName, ~value=count)
+  let set = (~count, ~effectName, ~scope) => {
+    gauge->SafeGauge.handleInt(~labels={"effect": effectName, "scope": scope}, ~value=count)
   }
 }
 

--- a/packages/envio/src/Writing.res
+++ b/packages/envio/src/Writing.res
@@ -61,7 +61,11 @@ let snapshotEffects = (state: IndexerState.t, ~cache): array<Persistence.updated
       }
       let shouldInitialize = effectCacheRecord.count === 0
       effectCacheRecord.count = effectCacheRecord.count + items->Array.length - invalidationsCount
-      Prometheus.EffectCacheCount.set(~count=effectCacheRecord.count, ~effectName)
+      Prometheus.EffectCacheCount.set(
+        ~count=effectCacheRecord.count,
+        ~effectName,
+        ~scope=scope->Internal.EffectCache.scopeToString,
+      )
       acc
       ->Array.push(
         (

--- a/scenarios/test_codegen/test/E2E_test.res
+++ b/scenarios/test_codegen/test/E2E_test.res
@@ -342,7 +342,7 @@ describe("E2E tests", () => {
     ).toEqual([
       {
         value: "2",
-        labels: Dict.fromArray([("effect", "testEffectWithCache")]),
+        labels: Dict.fromArray([("effect", "testEffectWithCache"), ("scope", "crossChain")]),
       },
     ])
     t.expect(
@@ -370,7 +370,7 @@ describe("E2E tests", () => {
     ).toEqual([
       {
         value: "2",
-        labels: Dict.fromArray([("effect", "testEffectWithCache")]),
+        labels: Dict.fromArray([("effect", "testEffectWithCache"), ("scope", "crossChain")]),
       },
     ])
 
@@ -471,7 +471,7 @@ describe("E2E tests", () => {
       [
         {
           value: "2",
-          labels: Dict.fromArray([("effect", "testEffectWithCache")]),
+          labels: Dict.fromArray([("effect", "testEffectWithCache"), ("scope", "crossChain")]),
         },
       ],
     ))
@@ -658,7 +658,7 @@ describe("E2E tests", () => {
         [
           {
             value: "1",
-            labels: Dict.fromArray([("effect", "chainScopedE2E")]),
+            labels: Dict.fromArray([("effect", "chainScopedE2E"), ("scope", "1337")]),
           },
         ],
       ))
@@ -830,17 +830,17 @@ describe("E2E tests", () => {
     t.expect(
       queueMetricDuringExecution.contents->Option.getOrThrow,
       ~message="queue should have 4 items during execution",
-    ).toEqual([{value: "4", labels: Dict.fromArray([("effect", "testEffectMultiWindow")])}])
+    ).toEqual([{value: "4", labels: Dict.fromArray([("effect", "testEffectMultiWindow"), ("scope", "crossChain")])}])
     t.expect(
       activeMetricDuringExecution.contents->Option.getOrThrow,
       ~message="active calls should be at rate limit (2)",
-    ).toEqual([{value: "2", labels: Dict.fromArray([("effect", "testEffectMultiWindow")])}])
+    ).toEqual([{value: "2", labels: Dict.fromArray([("effect", "testEffectMultiWindow"), ("scope", "crossChain")])}])
 
     // Final check - queue should be empty
     t.expect(
       await indexerMock.metric("envio_effect_queue"),
       ~message="queue should be empty after all windows complete",
-    ).toEqual([{value: "0", labels: Dict.fromArray([("effect", "testEffectMultiWindow")])}])
+    ).toEqual([{value: "0", labels: Dict.fromArray([("effect", "testEffectMultiWindow"), ("scope", "crossChain")])}])
   })
 
   Async.it("Effect rate limiting with single call per window", async t => {
@@ -932,11 +932,11 @@ describe("E2E tests", () => {
     t.expect(
       queueMetricDuringExecution.contents->Option.getOrThrow,
       ~message="queue should have 3 items during execution",
-    ).toEqual([{value: "3", labels: Dict.fromArray([("effect", "testEffectNested")])}])
+    ).toEqual([{value: "3", labels: Dict.fromArray([("effect", "testEffectNested"), ("scope", "crossChain")])}])
     t.expect(
       activeMetricDuringExecution.contents->Option.getOrThrow,
       ~message="active calls should be at rate limit (1)",
-    ).toEqual([{value: "1", labels: Dict.fromArray([("effect", "testEffectNested")])}])
+    ).toEqual([{value: "1", labels: Dict.fromArray([("effect", "testEffectNested"), ("scope", "crossChain")])}])
 
     // Check metrics after first window
     let queueMetric2 = queueMetricAfterFirstWindow.contents->Option.getOrThrow
@@ -952,7 +952,7 @@ describe("E2E tests", () => {
     t.expect(
       await indexerMock.metric("envio_effect_queue"),
       ~message="queue should be empty after all batches complete",
-    ).toEqual([{value: "0", labels: Dict.fromArray([("effect", "testEffectNested")])}])
+    ).toEqual([{value: "0", labels: Dict.fromArray([("effect", "testEffectNested"), ("scope", "crossChain")])}])
   })
 
   Async.it("Effect cache can be disabled per-call via context.cache", async t => {

--- a/scenarios/test_codegen/test/lib_tests/EffectCache_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EffectCache_test.res
@@ -52,6 +52,23 @@ describe("Internal.EffectCache address mapping", () => {
     )).toEqual((Some(("1_effect_x", CrossChain)), Some(("x", Chain(1)))))
   })
 
+  it("Parses only canonical decimal chain ids", t => {
+    t.expect(
+      ["1", "137", "007", "1foo", "", "-1", "1.5"]->Array.map(Internal.EffectCache.parseChainId),
+    ).toEqual([Some(1), Some(137), None, None, None, None, None])
+  })
+
+  it("Rejects table names with a non-canonical chain id", t => {
+    t.expect(Internal.EffectCache.fromTableName("envio_007_effect_foo")).toEqual(None)
+  })
+
+  it("Maps scope to its Prometheus label value", t => {
+    t.expect((
+      Internal.EffectCache.scopeToString(CrossChain),
+      Internal.EffectCache.scopeToString(Chain(137)),
+    )).toEqual(("crossChain", "137"))
+  })
+
   it("Returns None for tables that aren't effect caches", t => {
     t.expect(
       ["envio_chains", "envio_checkpoints", "User", "envio_effect_"]->Array.map(


### PR DESCRIPTION
## Summary
Add a `scope` label to effect-related Prometheus metrics to distinguish between cross-chain and chain-specific effect executions. This prevents metrics from different scopes from clobbering each other's gauge values.

## Key Changes
- **Prometheus schema**: Created `effectScopeLabelsSchema` with `effect` and `scope` labels for metrics whose state is per-scope
- **Metric updates**: Updated `EffectCalls.activeCallsCount`, `EffectCacheCount.gauge`, and `EffectQueueCount.gauge` to use the new schema and include scope in label values
- **Helper functions**: Added `scopeToString` to convert scope values to Prometheus label strings ("crossChain" or decimal chain ID) and `parseChainId` to validate canonical decimal chain IDs
- **Call sites**: Updated all metric recording calls in `LoadLayer.res`, `IndexerState.res`, and `Writing.res` to pass the scope label
- **Tests**: Updated E2E and unit tests to expect the new `scope` label in metric assertions

## Implementation Details
- The `parseChainId` function validates that chain IDs are canonical decimal strings (e.g., "137" not "007") to prevent ambiguous table name parsing
- Scope is derived from `inMemTable.scope` or the cache entry's scope and converted to a string at the point of metric recording
- The `effectLabelsSchema` remains unchanged for metrics that don't require per-scope tracking (e.g., `EffectQueueCount.timeCounter`)

https://claude.ai/code/session_011YLPufR6wf9LYFAsNjKz1t