### PR TITLE
Cap per-chain query concurrency to 100

### DIFF
--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1465,6 +1465,11 @@ let startFetchingQueries = ({optimizedPartitions}: t, ~queries: array<query>) =>
 // Most parallel in-flight chunk queries a single partition may have at once.
 let maxPendingChunksPerPartition = 12
 
+// Most parallel in-flight queries a single chain may have at once, across all
+// its partitions. Bounds source load on chains with many partitions, where the
+// per-partition cap alone would admit thousands of concurrent queries.
+let maxChainConcurrency = 100
+
 // Generates candidate queries for a gap range (a hole left between
 // completed/pending chunks, e.g. from an out-of-order partial response). Gaps
 // carry the range's low fromBlock, so the acceptance pass takes them before
@@ -1939,12 +1944,21 @@ let getNextQuery = (
     let streamCount = acceptanceStream->Array.length
     let remainingBudget = ref(chainTargetItems)
     let acceptIdx = ref(0)
-    while remainingBudget.contents > 0. && acceptIdx.contents < streamCount {
+    // In-flight queries count against the chain's concurrency cap alongside the
+    // ones accepted this tick; once the cap is reached no later candidate can be
+    // accepted (they're only later in fromBlock order), so the walk stops.
+    let usedConcurrency = ref(reservations->Array.length)
+    while (
+      remainingBudget.contents > 0. &&
+      acceptIdx.contents < streamCount &&
+      usedConcurrency.contents < maxChainConcurrency
+    ) {
       let (_, itemsEst, maybeQuery) = acceptanceStream->Array.getUnsafe(acceptIdx.contents)
       switch maybeQuery {
       | Some(query) =>
         let partitionIdx = partitionIndexById->Dict.getUnsafe(query.partitionId)
         queriesByPartitionIndex->Array.getUnsafe(partitionIdx)->Array.push(query)->ignore
+        usedConcurrency := usedConcurrency.contents + 1
       | None => ()
       }
       remainingBudget := remainingBudget.contents -. itemsEst->Int.toFloat

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -4746,3 +4746,77 @@ describe("mergeIntoBuffer", () => {
     ])
   })
 })
+
+describe("FetchState.getNextQuery caps per-chain concurrency", () => {
+  let normalSelection = {FetchState.dependsOnAddresses: false, onEventRegistrations: []}
+  let addressesByContractName = Dict.fromArray([("MockContract", [mockAddress0])])
+
+  let makePartition = (~idx, ~inFlight): FetchState.partition => {
+    id: idx->Int.toString,
+    latestFetchedBlock: {blockNumber: 0, blockTimestamp: 0},
+    selection: normalSelection,
+    addressesByContractName,
+    mergeBlock: None,
+    dynamicContract: None,
+    mutPendingQueries: inFlight
+      ? [
+          {
+            fromBlock: 1,
+            toBlock: None,
+            isChunk: false,
+            itemsTarget: 1,
+            itemsEst: 1,
+            fetchedBlock: None,
+          },
+        ]
+      : [],
+    sourceRangeCapacity: 0,
+    prevSourceRangeCapacity: 0,
+    eventDensity: None,
+    latestSourceRangeCapacityUpdateBlock: 0,
+  }
+
+  let makeFetchState = (~partitionsCount, ~inFlightCount): FetchState.t => {
+    optimizedPartitions: FetchState.OptimizedPartitions.make(
+      ~partitions=Array.fromInitializer(~length=partitionsCount, idx =>
+        makePartition(~idx, ~inFlight=idx < inFlightCount)
+      ),
+      ~maxAddrInPartition=1,
+      ~nextPartitionIndex=partitionsCount,
+      ~dynamicContracts=Utils.Set.make(),
+    ),
+    startBlock: 0,
+    endBlock: None,
+    buffer: [],
+    normalSelection,
+    latestOnBlockBlockNumber: 0,
+    maxOnBlockBufferSize: 10000,
+    chainId,
+    contractConfigs: Dict.make(),
+    blockLag: 0,
+    onBlockRegistrations: [],
+    knownHeight: 100000,
+    firstEventBlock: Some(0),
+  }
+
+  let countQueries = (fetchState: FetchState.t) =>
+    switch fetchState->FetchState.getNextQuery(
+      ~chainTargetBlock=100000,
+      ~chainTargetItems=1_000_000.,
+    ) {
+    | Ready(queries) => queries->Array.length
+    | _ => 0
+    }
+
+  it("accepts at most 100 queries counting in-flight ones", t => {
+    t.expect({
+      "freshOnly": makeFetchState(~partitionsCount=120, ~inFlightCount=0)->countQueries,
+      "withInFlight": makeFetchState(~partitionsCount=120, ~inFlightCount=30)->countQueries,
+      "underCap": makeFetchState(~partitionsCount=50, ~inFlightCount=0)->countQueries,
+    }).toEqual({
+      "freshOnly": 100,
+      "withInFlight": 70,
+      "underCap": 50,
+    })
+  })
+})


### PR DESCRIPTION
Adds a global concurrency limit for in-flight queries across all partitions on a single chain to prevent source load spikes on chains with many partitions.

## Changes

- Introduce `maxChainConcurrency` constant set to 100, limiting total parallel queries per chain across all partitions
- Track `usedConcurrency` during query acceptance to count both in-flight queries (from `reservations`) and newly accepted queries
- Stop accepting new queries once the concurrency cap is reached, since candidates are ordered by `fromBlock` and later ones can wait
- Add comprehensive test covering three scenarios: fresh queries only, queries with in-flight ones, and under-capacity cases

## Implementation Details

The per-partition cap (`maxPendingChunksPerPartition = 12`) alone could admit thousands of concurrent queries on chains with many partitions. The new chain-level cap bounds this by rejecting candidates once `usedConcurrency >= maxChainConcurrency`, which is safe because the acceptance stream is ordered by `fromBlock` — later candidates can be deferred to subsequent ticks.

https://claude.ai/code/session_01NfCa3PhypeqQTWSLK1tYhr