### PR TITLE
Address block-store reorg review findings: config authority, test resilience, seam validation

### DIFF
--- a/packages/cli/src/block_store.rs
+++ b/packages/cli/src/block_store.rs
@@ -743,11 +743,19 @@ impl BlockStore {
         if let Some(conflict) = conflict {
             record_conflict(&mut dst.response_conflict, conflict);
         }
+        // The appended keys seed the EVM parent-link check below, which needs
+        // them after the rows have moved into `dst`.
+        let src_keys = matches!(self.ecosystem, Ecosystem::Evm { .. })
+            .then(|| src.table.keys())
+            .unwrap_or_default();
         dst.table.append_from(&mut src.table);
         for range in src.svm_covered_ranges.drain(..) {
             add_svm_covered_range(&mut dst.svm_covered_ranges, range);
         }
         if let Some(conflict) = self.svm_parent_link_conflict(&dst) {
+            record_conflict(&mut dst.response_conflict, conflict);
+        }
+        if let Some(conflict) = self.evm_parent_link_conflict(&dst, &src_keys) {
             record_conflict(&mut dst.response_conflict, conflict);
         }
     }
@@ -958,6 +966,55 @@ impl BlockStore {
         Ok(())
     }
 
+    /// Return the lowest inconsistent EVM parent link touched by `keys`: block
+    /// N's `parentHash` must equal block N-1's `hash` whenever both are stored.
+    /// EVM block numbers are dense, so unlike SVM no cursor coverage is needed
+    /// to know which block is the parent; a neighbour that simply isn't in the
+    /// response is not checked. Fuel has no parent-id field in its header
+    /// (`prev_root` is a merkle root over all ancestors), so this check is
+    /// EVM-only.
+    fn evm_parent_link_conflict(&self, inner: &Inner, keys: &[u64]) -> Option<HashMismatch> {
+        if !matches!(self.ecosystem, Ecosystem::Evm { .. }) {
+            return None;
+        }
+        let hash_field = EvmBlockField::Hash as usize;
+        let parent_field = EvmBlockField::ParentHash as usize;
+        let mut lowest = None;
+        for &key in keys {
+            // This block's parentHash against the previous block's hash.
+            if key > 0 {
+                if let (Some(parent), Some(prev_hash)) = (
+                    inner.table.field_bytes(&key, parent_field),
+                    inner.table.field_bytes(&(key - 1), hash_field),
+                ) {
+                    if parent != prev_hash {
+                        let conflict = HashMismatch {
+                            block_number: (key - 1) as i64,
+                            stored_hash: self.hash_display(prev_hash),
+                            received_hash: self.hash_display(parent),
+                        };
+                        lowest = lowest_conflict(lowest, Some(conflict));
+                    }
+                }
+            }
+            // The next block's parentHash against this block's hash.
+            if let (Some(next_parent), Some(hash)) = (
+                inner.table.field_bytes(&(key + 1), parent_field),
+                inner.table.field_bytes(&key, hash_field),
+            ) {
+                if next_parent != hash {
+                    let conflict = HashMismatch {
+                        block_number: key as i64,
+                        stored_hash: self.hash_display(hash),
+                        received_hash: self.hash_display(next_parent),
+                    };
+                    lowest = lowest_conflict(lowest, Some(conflict));
+                }
+            }
+        }
+        lowest
+    }
+
     /// Return the lowest inconsistent SVM parent link inside cursor-covered
     /// ranges. A parent outside coverage is unknown and therefore not checked.
     fn svm_parent_link_conflict(&self, inner: &Inner) -> Option<HashMismatch> {
@@ -1129,6 +1186,9 @@ impl BlockStore {
         let conflict = inner
             .table
             .detect_field_conflict(&keys, cols[field].as_ref(), field);
+        let batch_keys = matches!(self.ecosystem, Ecosystem::Evm { .. })
+            .then(|| keys.clone())
+            .unwrap_or_default();
         inner.table.merge_batch(keys, cols);
         if let Some((key, stored, received)) = conflict {
             record_conflict(
@@ -1139,6 +1199,9 @@ impl BlockStore {
                     received_hash: self.hash_display(&received),
                 },
             );
+        }
+        if let Some(conflict) = self.evm_parent_link_conflict(&inner, &batch_keys) {
+            record_conflict(&mut inner.response_conflict, conflict);
         }
     }
 
@@ -1802,6 +1865,55 @@ mod tests {
         page.insert_evm_blocks(vec![hashed_evm_block(11, 0x11)]);
         page.insert_evm_blocks(vec![hashed_evm_block(11, 0x11)]);
         assert!(page.response_conflict().is_none());
+    }
+
+    fn linked_evm_block(number: u64, byte: u8, parent_byte: u8) -> simple_types::Block {
+        let mut b = hashed_evm_block(number, byte);
+        b.parent_hash = Some(Hash::from([parent_byte; 32]));
+        b
+    }
+
+    #[test]
+    fn evm_parent_link_conflict_is_a_response_conflict() {
+        // Consistent links: no conflict.
+        let page = evm_page(vec![
+            linked_evm_block(10, 0x10, 0x09),
+            linked_evm_block(11, 0x11, 0x10),
+        ]);
+        assert!(page.response_conflict().is_none());
+
+        // Block 11 names a parent that disagrees with block 10's hash.
+        let page = evm_page(vec![
+            linked_evm_block(10, 0x10, 0x09),
+            linked_evm_block(11, 0x11, 0xaa),
+        ]);
+        let mismatch = page.response_conflict().expect("broken parent link");
+        assert_eq!(
+            (
+                mismatch.block_number,
+                mismatch.stored_hash,
+                mismatch.received_hash
+            ),
+            (
+                10,
+                format!("0x{}", "10".repeat(32)),
+                format!("0x{}", "aa".repeat(32))
+            )
+        );
+
+        // A missing neighbour is not checked (sparse event pages).
+        let page = evm_page(vec![
+            linked_evm_block(10, 0x10, 0x09),
+            linked_evm_block(12, 0x12, 0xbb),
+        ]);
+        assert!(page.response_conflict().is_none());
+
+        // The seam between two backend pages is checked on append.
+        let aggregate = evm_page(vec![linked_evm_block(20, 0x20, 0x19)]);
+        let next = evm_page(vec![linked_evm_block(21, 0x21, 0xcc)]);
+        aggregate.append_page(&next);
+        let mismatch = aggregate.response_conflict().expect("cross-page link");
+        assert_eq!(mismatch.block_number, 20);
     }
 
     #[test]

--- a/packages/cli/src/block_store.rs
+++ b/packages/cli/src/block_store.rs
@@ -743,20 +743,9 @@ impl BlockStore {
         if let Some(conflict) = conflict {
             record_conflict(&mut dst.response_conflict, conflict);
         }
-        // The appended keys seed the EVM parent-link check below, which needs
-        // them after the rows have moved into `dst`.
-        let src_keys = matches!(self.ecosystem, Ecosystem::Evm { .. })
-            .then(|| src.table.keys())
-            .unwrap_or_default();
         dst.table.append_from(&mut src.table);
         for range in src.svm_covered_ranges.drain(..) {
             add_svm_covered_range(&mut dst.svm_covered_ranges, range);
-        }
-        if let Some(conflict) = self.svm_parent_link_conflict(&dst) {
-            record_conflict(&mut dst.response_conflict, conflict);
-        }
-        if let Some(conflict) = self.evm_parent_link_conflict(&dst, &src_keys) {
-            record_conflict(&mut dst.response_conflict, conflict);
         }
     }
 
@@ -940,8 +929,7 @@ impl BlockStore {
 
 impl BlockStore {
     /// Mark a half-open SVM range as completely processed by HyperSync. Missing
-    /// rows inside it are verified skipped slots. Parent links are validated
-    /// independently so cursor coverage cannot hide an omitted or mixed parent.
+    /// rows inside it are verified skipped slots.
     pub(crate) fn mark_svm_coverage(&self, from_slot: i64, to_slot_exclusive: i64) -> Result<()> {
         if !matches!(self.ecosystem, Ecosystem::Svm) {
             anyhow::bail!("SVM coverage can only be recorded on an SVM block store");
@@ -960,186 +948,7 @@ impl BlockStore {
             &mut inner.svm_covered_ranges,
             SvmCoveredRange { from, to_exclusive },
         );
-        if let Some(conflict) = self.svm_parent_link_conflict(&inner) {
-            record_conflict(&mut inner.response_conflict, conflict);
-        }
         Ok(())
-    }
-
-    /// Verify an EVM block-hash page covers `[from, to_exclusive)` densely:
-    /// every block present with a hash, and every non-genesis block carrying a
-    /// `parentHash`. The parent-link check skips absent neighbours (event
-    /// pages are sparse by design), so for an `include_all_blocks` range a gap
-    /// or a missing parent field must be rejected here — otherwise it could
-    /// hide exactly the mixed-fork seam the link check exists to catch.
-    pub(crate) fn validate_evm_dense_range(&self, from: i64, to_exclusive: i64) -> Result<()> {
-        if !matches!(self.ecosystem, Ecosystem::Evm { .. }) {
-            anyhow::bail!("dense-range validation only applies to EVM block stores");
-        }
-        let from = u64::try_from(from).context("range start is negative")?;
-        let to_exclusive = u64::try_from(to_exclusive).context("range end is negative")?;
-        let hash_field = EvmBlockField::Hash as usize;
-        let parent_field = EvmBlockField::ParentHash as usize;
-        let inner = self.inner.lock().unwrap();
-        for key in from..to_exclusive {
-            if inner.table.field_bytes(&key, hash_field).is_none() {
-                anyhow::bail!(
-                    "block #{key} is missing from a response that must cover the complete range"
-                );
-            }
-            if key > 0 && inner.table.field_bytes(&key, parent_field).is_none() {
-                anyhow::bail!("block #{key} is missing its parent hash in the response");
-            }
-        }
-        Ok(())
-    }
-
-    /// Return the lowest inconsistent EVM parent link touched by `keys`: block
-    /// N's `parentHash` must equal block N-1's `hash` whenever both are stored.
-    /// EVM block numbers are dense, so unlike SVM no cursor coverage is needed
-    /// to know which block is the parent; a neighbour that simply isn't in the
-    /// response is not checked. Fuel has no parent-id field in its header
-    /// (`prev_root` is a merkle root over all ancestors), so this check is
-    /// EVM-only.
-    fn evm_parent_link_conflict(&self, inner: &Inner, keys: &[u64]) -> Option<HashMismatch> {
-        if !matches!(self.ecosystem, Ecosystem::Evm { .. }) {
-            return None;
-        }
-        let hash_field = EvmBlockField::Hash as usize;
-        let parent_field = EvmBlockField::ParentHash as usize;
-        let mut lowest = None;
-        for &key in keys {
-            // This block's parentHash against the previous block's hash.
-            if key > 0 {
-                if let (Some(parent), Some(prev_hash)) = (
-                    inner.table.field_bytes(&key, parent_field),
-                    inner.table.field_bytes(&(key - 1), hash_field),
-                ) {
-                    if parent != prev_hash {
-                        let conflict = HashMismatch {
-                            block_number: (key - 1) as i64,
-                            stored_hash: self.hash_display(prev_hash),
-                            received_hash: self.hash_display(parent),
-                        };
-                        lowest = lowest_conflict(lowest, Some(conflict));
-                    }
-                }
-            }
-            // The next block's parentHash against this block's hash.
-            if let (Some(next_parent), Some(hash)) = (
-                inner.table.field_bytes(&(key + 1), parent_field),
-                inner.table.field_bytes(&key, hash_field),
-            ) {
-                if next_parent != hash {
-                    let conflict = HashMismatch {
-                        block_number: key as i64,
-                        stored_hash: self.hash_display(hash),
-                        received_hash: self.hash_display(next_parent),
-                    };
-                    lowest = lowest_conflict(lowest, Some(conflict));
-                }
-            }
-        }
-        lowest
-    }
-
-    /// Return the lowest inconsistent SVM parent link inside cursor-covered
-    /// ranges. A parent outside coverage is unknown and therefore not checked.
-    fn svm_parent_link_conflict(&self, inner: &Inner) -> Option<HashMismatch> {
-        if !matches!(self.ecosystem, Ecosystem::Svm) {
-            return None;
-        }
-        let hash_field = SvmBlockField::Hash as usize;
-        let parent_slot_field = SvmBlockField::ParentSlot as usize;
-        let parent_hash_field = SvmBlockField::ParentHash as usize;
-
-        let mut lowest = None;
-        for range in &inner.svm_covered_ranges {
-            let mut previous_child_slot = None;
-            for child_slot in
-                inner
-                    .table
-                    .keys_with_field(range.from, range.to_exclusive, hash_field)
-            {
-                // Genesis has no parent link.
-                if child_slot == 0 {
-                    continue;
-                }
-                let child_hash = inner.table.field_bytes(&child_slot, hash_field).unwrap();
-                let Some(parent_slot) = inner.table.field_u64(&child_slot, parent_slot_field)
-                else {
-                    let conflict = HashMismatch {
-                        block_number: child_slot as i64,
-                        stored_hash: "<missing parent_slot>".to_string(),
-                        received_hash: self.hash_display(child_hash),
-                    };
-                    lowest = lowest_conflict(lowest, Some(conflict));
-                    previous_child_slot = Some(child_slot);
-                    continue;
-                };
-                let Some(parent_hash) = inner.table.field_bytes(&child_slot, parent_hash_field)
-                else {
-                    let conflict = HashMismatch {
-                        block_number: child_slot as i64,
-                        stored_hash: "<missing parent_blockhash>".to_string(),
-                        received_hash: self.hash_display(child_hash),
-                    };
-                    lowest = lowest_conflict(lowest, Some(conflict));
-                    previous_child_slot = Some(child_slot);
-                    continue;
-                };
-
-                if parent_slot >= child_slot {
-                    let conflict = HashMismatch {
-                        block_number: child_slot as i64,
-                        stored_hash: "<parent slot below child>".to_string(),
-                        received_hash: format!("<parent slot {parent_slot}>"),
-                    };
-                    lowest = lowest_conflict(lowest, Some(conflict));
-                    previous_child_slot = Some(child_slot);
-                    continue;
-                }
-
-                let conflict = if let Some(previous_slot) = previous_child_slot {
-                    if parent_slot != previous_slot {
-                        Some(HashMismatch {
-                            block_number: child_slot as i64,
-                            stored_hash: format!("<expected parent slot {previous_slot}>"),
-                            received_hash: format!("<parent slot {parent_slot}>"),
-                        })
-                    } else {
-                        let previous_hash = inner
-                            .table
-                            .field_bytes(&previous_slot, hash_field)
-                            .expect("previous SVM child carries a block hash");
-                        (previous_hash != parent_hash).then(|| HashMismatch {
-                            block_number: previous_slot as i64,
-                            stored_hash: self.hash_display(previous_hash),
-                            received_hash: self.hash_display(parent_hash),
-                        })
-                    }
-                } else if svm_slot_is_covered(&inner.svm_covered_ranges, parent_slot) {
-                    match inner.table.field_bytes(&parent_slot, hash_field) {
-                        Some(hash) if hash != parent_hash => Some(HashMismatch {
-                            block_number: parent_slot as i64,
-                            stored_hash: self.hash_display(hash),
-                            received_hash: self.hash_display(parent_hash),
-                        }),
-                        None => Some(HashMismatch {
-                            block_number: parent_slot as i64,
-                            stored_hash: "<missing block>".to_string(),
-                            received_hash: self.hash_display(parent_hash),
-                        }),
-                        _ => None,
-                    }
-                } else {
-                    None
-                };
-                lowest = lowest_conflict(lowest, conflict);
-                previous_child_slot = Some(child_slot);
-            }
-        }
-        lowest
     }
 
     fn with_ecosystem(ecosystem: Ecosystem) -> Self {
@@ -1214,9 +1023,6 @@ impl BlockStore {
         let conflict = inner
             .table
             .detect_field_conflict(&keys, cols[field].as_ref(), field);
-        let batch_keys = matches!(self.ecosystem, Ecosystem::Evm { .. })
-            .then(|| keys.clone())
-            .unwrap_or_default();
         inner.table.merge_batch(keys, cols);
         if let Some((key, stored, received)) = conflict {
             record_conflict(
@@ -1227,9 +1033,6 @@ impl BlockStore {
                     received_hash: self.hash_display(&received),
                 },
             );
-        }
-        if let Some(conflict) = self.evm_parent_link_conflict(&inner, &batch_keys) {
-            record_conflict(&mut inner.response_conflict, conflict);
         }
     }
 
@@ -1387,21 +1190,6 @@ mod tests {
             slot,
             blockhash: "hash".to_string(),
             block_time: Some(123),
-            ..Default::default()
-        }
-    }
-
-    fn linked_svm_block(
-        slot: u64,
-        hash: &str,
-        parent_slot: u64,
-        parent_hash: &str,
-    ) -> solana_simple::Block {
-        solana_simple::Block {
-            slot,
-            blockhash: hash.to_string(),
-            parent_slot: Some(parent_slot),
-            parent_blockhash: Some(parent_hash.to_string()),
             ..Default::default()
         }
     }
@@ -1895,80 +1683,6 @@ mod tests {
         assert!(page.response_conflict().is_none());
     }
 
-    fn linked_evm_block(number: u64, byte: u8, parent_byte: u8) -> simple_types::Block {
-        let mut b = hashed_evm_block(number, byte);
-        b.parent_hash = Some(Hash::from([parent_byte; 32]));
-        b
-    }
-
-    #[test]
-    fn evm_parent_link_conflict_is_a_response_conflict() {
-        // Consistent links: no conflict.
-        let page = evm_page(vec![
-            linked_evm_block(10, 0x10, 0x09),
-            linked_evm_block(11, 0x11, 0x10),
-        ]);
-        assert!(page.response_conflict().is_none());
-
-        // Block 11 names a parent that disagrees with block 10's hash.
-        let page = evm_page(vec![
-            linked_evm_block(10, 0x10, 0x09),
-            linked_evm_block(11, 0x11, 0xaa),
-        ]);
-        let mismatch = page.response_conflict().expect("broken parent link");
-        assert_eq!(
-            (
-                mismatch.block_number,
-                mismatch.stored_hash,
-                mismatch.received_hash
-            ),
-            (
-                10,
-                format!("0x{}", "10".repeat(32)),
-                format!("0x{}", "aa".repeat(32))
-            )
-        );
-
-        // A missing neighbour is not checked (sparse event pages).
-        let page = evm_page(vec![
-            linked_evm_block(10, 0x10, 0x09),
-            linked_evm_block(12, 0x12, 0xbb),
-        ]);
-        assert!(page.response_conflict().is_none());
-
-        // The seam between two backend pages is checked on append.
-        let aggregate = evm_page(vec![linked_evm_block(20, 0x20, 0x19)]);
-        let next = evm_page(vec![linked_evm_block(21, 0x21, 0xcc)]);
-        aggregate.append_page(&next);
-        let mismatch = aggregate.response_conflict().expect("cross-page link");
-        assert_eq!(mismatch.block_number, 20);
-    }
-
-    #[test]
-    fn evm_dense_range_validation_rejects_gaps_and_missing_parents() {
-        let page = evm_page(vec![
-            linked_evm_block(10, 0x10, 0x09),
-            linked_evm_block(11, 0x11, 0x10),
-        ]);
-        assert!(page.validate_evm_dense_range(10, 12).is_ok());
-
-        // A gap inside the covered range.
-        let page = evm_page(vec![
-            linked_evm_block(10, 0x10, 0x09),
-            linked_evm_block(12, 0x12, 0x11),
-        ]);
-        let err = page.validate_evm_dense_range(10, 13).unwrap_err();
-        assert!(err.to_string().contains("block #11 is missing"));
-
-        // A block without its parent hash.
-        let page = evm_page(vec![
-            linked_evm_block(10, 0x10, 0x09),
-            hashed_evm_block(11, 0x11),
-        ]);
-        let err = page.validate_evm_dense_range(10, 12).unwrap_err();
-        assert!(err.to_string().contains("parent hash"));
-    }
-
     #[test]
     fn response_store_comparison_and_coverage_stay_in_rust() {
         let persistent = evm_page(vec![
@@ -1992,14 +1706,11 @@ mod tests {
     }
 
     #[test]
-    fn svm_cursor_coverage_accepts_skipped_slots_and_validates_parent_links() {
+    fn svm_cursor_coverage_accepts_skipped_slots() {
         // Cursor coverage proves every slot in [10, 15) was processed, so the
         // missing interior slots and the missing upper slot are valid skips.
         let response = BlockStore::new_svm();
-        response.insert_svm_blocks(vec![
-            linked_svm_block(10, "h10", 9, "h9"),
-            linked_svm_block(13, "h13", 10, "h10"),
-        ]);
+        response.insert_svm_blocks(vec![raw_svm_block(10), raw_svm_block(13)]);
         assert_eq!(
             response.missing_hashes(vec![10, 11, 12, 13, 14]),
             vec![11, 12, 14]
@@ -2007,90 +1718,6 @@ mod tests {
         response.mark_svm_coverage(10, 15).unwrap();
         assert!(response.missing_hashes(vec![10, 11, 12, 13, 14]).is_empty());
         assert!(response.response_conflict().is_none());
-
-        // A parent outside the cursor-covered range is unknown, not missing.
-        let boundary_response = BlockStore::new_svm();
-        boundary_response.insert_svm_blocks(vec![linked_svm_block(13, "h13", 10, "h10")]);
-        boundary_response.mark_svm_coverage(11, 14).unwrap();
-        assert!(boundary_response
-            .missing_hashes(vec![11, 12, 13])
-            .is_empty());
-        assert!(boundary_response.response_conflict().is_none());
-
-        // A child naming an in-range parent that was not returned proves the
-        // response is incomplete even though cursor coverage closes the gap.
-        let omitted_parent = BlockStore::new_svm();
-        omitted_parent.insert_svm_blocks(vec![linked_svm_block(13, "h13", 11, "h11")]);
-        omitted_parent.mark_svm_coverage(11, 14).unwrap();
-        assert!(omitted_parent.missing_hashes(vec![11, 12, 13]).is_empty());
-        let mismatch = omitted_parent.response_conflict().expect("missing parent");
-        assert_eq!(
-            (
-                mismatch.block_number,
-                mismatch.stored_hash,
-                mismatch.received_hash
-            ),
-            (11, "<missing block>".to_string(), "h11".to_string())
-        );
-
-        // If the named parent is in the response, both parts of the link must
-        // agree; mixing blocks from two forks must remain inconsistent.
-        let mixed_fork = BlockStore::new_svm();
-        mixed_fork.insert_svm_blocks(vec![
-            linked_svm_block(10, "other-h10", 9, "h9"),
-            linked_svm_block(13, "h13", 10, "h10"),
-        ]);
-        mixed_fork.mark_svm_coverage(10, 14).unwrap();
-        let mismatch = mixed_fork.response_conflict().expect("mixed fork");
-        assert_eq!(
-            (
-                mismatch.block_number,
-                mismatch.stored_hash,
-                mismatch.received_hash
-            ),
-            (10, "other-h10".to_string(), "h10".to_string())
-        );
-
-        // Parent fields are required for every non-genesis block in coverage.
-        let missing_link = BlockStore::new_svm();
-        missing_link.insert_svm_blocks(vec![raw_svm_block(13)]);
-        missing_link.mark_svm_coverage(10, 14).unwrap();
-        let mismatch = missing_link.response_conflict().expect("missing link");
-        assert_eq!(mismatch.block_number, 13);
-        assert_eq!(mismatch.stored_hash, "<missing parent_slot>");
-
-        // Only the first returned block may name a parent below coverage. A
-        // later block doing so belongs to a disconnected fork.
-        let disconnected_fork = BlockStore::new_svm();
-        disconnected_fork.insert_svm_blocks(vec![
-            linked_svm_block(10, "h10", 9, "h9"),
-            linked_svm_block(13, "h13", 9, "h9"),
-        ]);
-        disconnected_fork.mark_svm_coverage(10, 14).unwrap();
-        let mismatch = disconnected_fork
-            .response_conflict()
-            .expect("disconnected fork");
-        assert_eq!(mismatch.block_number, 13);
-        assert_eq!(mismatch.stored_hash, "<expected parent slot 10>");
-        assert_eq!(mismatch.received_hash, "<parent slot 9>");
-
-        for (name, invalid_parent_slot) in [("self parent", 10), ("forward parent", 11)] {
-            let invalid_order = BlockStore::new_svm();
-            invalid_order.insert_svm_blocks(vec![linked_svm_block(
-                10,
-                "h10",
-                invalid_parent_slot,
-                "parent-hash",
-            )]);
-            invalid_order.mark_svm_coverage(10, 12).unwrap();
-            let mismatch = invalid_order.response_conflict().expect(name);
-            assert_eq!(mismatch.block_number, 10);
-            assert_eq!(mismatch.stored_hash, "<parent slot below child>");
-            assert_eq!(
-                mismatch.received_hash,
-                format!("<parent slot {invalid_parent_slot}>")
-            );
-        }
     }
 
     #[test]

--- a/packages/cli/src/block_store.rs
+++ b/packages/cli/src/block_store.rs
@@ -966,6 +966,34 @@ impl BlockStore {
         Ok(())
     }
 
+    /// Verify an EVM block-hash page covers `[from, to_exclusive)` densely:
+    /// every block present with a hash, and every non-genesis block carrying a
+    /// `parentHash`. The parent-link check skips absent neighbours (event
+    /// pages are sparse by design), so for an `include_all_blocks` range a gap
+    /// or a missing parent field must be rejected here — otherwise it could
+    /// hide exactly the mixed-fork seam the link check exists to catch.
+    pub(crate) fn validate_evm_dense_range(&self, from: i64, to_exclusive: i64) -> Result<()> {
+        if !matches!(self.ecosystem, Ecosystem::Evm { .. }) {
+            anyhow::bail!("dense-range validation only applies to EVM block stores");
+        }
+        let from = u64::try_from(from).context("range start is negative")?;
+        let to_exclusive = u64::try_from(to_exclusive).context("range end is negative")?;
+        let hash_field = EvmBlockField::Hash as usize;
+        let parent_field = EvmBlockField::ParentHash as usize;
+        let inner = self.inner.lock().unwrap();
+        for key in from..to_exclusive {
+            if inner.table.field_bytes(&key, hash_field).is_none() {
+                anyhow::bail!(
+                    "block #{key} is missing from a response that must cover the complete range"
+                );
+            }
+            if key > 0 && inner.table.field_bytes(&key, parent_field).is_none() {
+                anyhow::bail!("block #{key} is missing its parent hash in the response");
+            }
+        }
+        Ok(())
+    }
+
     /// Return the lowest inconsistent EVM parent link touched by `keys`: block
     /// N's `parentHash` must equal block N-1's `hash` whenever both are stored.
     /// EVM block numbers are dense, so unlike SVM no cursor coverage is needed
@@ -1914,6 +1942,31 @@ mod tests {
         aggregate.append_page(&next);
         let mismatch = aggregate.response_conflict().expect("cross-page link");
         assert_eq!(mismatch.block_number, 20);
+    }
+
+    #[test]
+    fn evm_dense_range_validation_rejects_gaps_and_missing_parents() {
+        let page = evm_page(vec![
+            linked_evm_block(10, 0x10, 0x09),
+            linked_evm_block(11, 0x11, 0x10),
+        ]);
+        assert!(page.validate_evm_dense_range(10, 12).is_ok());
+
+        // A gap inside the covered range.
+        let page = evm_page(vec![
+            linked_evm_block(10, 0x10, 0x09),
+            linked_evm_block(12, 0x12, 0x11),
+        ]);
+        let err = page.validate_evm_dense_range(10, 13).unwrap_err();
+        assert!(err.to_string().contains("block #11 is missing"));
+
+        // A block without its parent hash.
+        let page = evm_page(vec![
+            linked_evm_block(10, 0x10, 0x09),
+            hashed_evm_block(11, 0x11),
+        ]);
+        let err = page.validate_evm_dense_range(10, 12).unwrap_err();
+        assert!(err.to_string().contains("parent hash"));
     }
 
     #[test]

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -187,9 +187,8 @@ impl EvmHypersyncClient {
             if next_block <= cursor {
                 let error = map_err(anyhow::anyhow!(
                     "Block #{cursor} is not yet available on the queried HyperSync replica. \
-                     Requests are load-balanced across replicas, which may briefly trail the \
-                     chain head. This is expected behavior and resolves on its own - indexing \
-                     will continue after an automatic retry."
+                     Replicas may briefly trail the chain head - this is expected, and indexing \
+                     continues after an automatic retry."
                 ));
                 return Err(error_with_request_stats(error, &request_stats));
             }

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -186,9 +186,10 @@ impl EvmHypersyncClient {
             // in-process loop could do.
             if next_block <= cursor {
                 let error = map_err(anyhow::anyhow!(
-                    "Block #{cursor} is not found in HyperSync yet. This happens when the request \
-                     is routed to a HyperSync replica that is slightly behind the head. Everything \
-                     is fine - indexing should continue correctly after a retry."
+                    "Block #{cursor} is not yet available on the queried HyperSync replica. \
+                     Requests are load-balanced across replicas, which may briefly trail the \
+                     chain head. This is expected behavior and resolves on its own - indexing \
+                     will continue after an automatic retry."
                 ));
                 return Err(error_with_request_stats(error, &request_stats));
             }

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -181,13 +181,14 @@ impl EvmHypersyncClient {
                 block_hash_page(response, self.enable_checksum_addresses)
                     .map_err(map_err)
                     .map_err(|error| error_with_request_stats(error, &request_stats))?;
-            // Usually a replica lagging behind the requested range. Surfaced
-            // as an error so SourceManager owns the retry: it logs, backs off,
-            // and can fail over to another source, none of which an in-process
-            // loop could do.
+            // Surfaced as an error so SourceManager owns the retry: it logs,
+            // backs off, and can fail over to another source, none of which an
+            // in-process loop could do.
             if next_block <= cursor {
                 let error = map_err(anyhow::anyhow!(
-                    "EVM block hash query made no progress: cursor={cursor}, next_block={next_block}"
+                    "Block #{cursor} is not found in HyperSync yet. This happens when the request \
+                     is routed to a HyperSync replica that is slightly behind the head. Everything \
+                     is fine - indexing should continue correctly after a retry."
                 ));
                 return Err(error_with_request_stats(error, &request_stats));
             }

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::sync::Once;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anyhow::{Context, Result};
 use hypersync_client::{simple_types, RateLimitResponse};
@@ -181,9 +181,15 @@ impl EvmHypersyncClient {
                 block_hash_page(response, self.enable_checksum_addresses)
                     .map_err(map_err)
                     .map_err(|error| error_with_request_stats(error, &request_stats))?;
+            // Usually a replica lagging behind the requested range. Surfaced
+            // as an error so SourceManager owns the retry: it logs, backs off,
+            // and can fail over to another source, none of which an in-process
+            // loop could do.
             if next_block <= cursor {
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                continue;
+                let error = map_err(anyhow::anyhow!(
+                    "EVM block hash query made no progress: cursor={cursor}, next_block={next_block}"
+                ));
+                return Err(error_with_request_stats(error, &request_stats));
             }
             aggregate.append_page(&page_store);
             if next_block > to_block {

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -152,19 +152,22 @@ impl EvmHypersyncClient {
         let mut request_stats = Vec::new();
         let mut cursor = from_block;
         loop {
+            // Follow-up pages re-request the last block of the previous page:
+            // one HyperSync response is internally consistent, so a fork
+            // switch between paginated requests is the only seam — and it
+            // surfaces as a hash collision on the overlapping block when the
+            // page is appended.
+            let request_from = if cursor > from_block {
+                cursor - 1
+            } else {
+                cursor
+            };
             let query = Query {
-                from_block: cursor,
+                from_block: request_from,
                 to_block: Some(to_block_exclusive),
                 include_all_blocks: Some(true),
                 field_selection: query::FieldSelection {
-                    // ParentHash lets the response store validate the chain
-                    // linkage of the contiguous range (the EVM analogue of the
-                    // SVM parent-slot check).
-                    block: Some(vec![
-                        BlockField::Number,
-                        BlockField::Hash,
-                        BlockField::ParentHash,
-                    ]),
+                    block: Some(vec![BlockField::Number, BlockField::Hash]),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -192,11 +195,6 @@ impl EvmHypersyncClient {
                 ));
                 return Err(error_with_request_stats(error, &request_stats));
             }
-            page_store
-                .validate_evm_dense_range(cursor, next_block.min(to_block_exclusive))
-                .context("validate block-hash page")
-                .map_err(map_err)
-                .map_err(|error| error_with_request_stats(error, &request_stats))?;
             aggregate.append_page(&page_store);
             if next_block > to_block {
                 return Ok((aggregate, request_stats));

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -192,6 +192,11 @@ impl EvmHypersyncClient {
                 ));
                 return Err(error_with_request_stats(error, &request_stats));
             }
+            page_store
+                .validate_evm_dense_range(cursor, next_block.min(to_block_exclusive))
+                .context("validate block-hash page")
+                .map_err(map_err)
+                .map_err(|error| error_with_request_stats(error, &request_stats))?;
             aggregate.append_page(&page_store);
             if next_block > to_block {
                 return Ok((aggregate, request_stats));

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -157,7 +157,14 @@ impl EvmHypersyncClient {
                 to_block: Some(to_block_exclusive),
                 include_all_blocks: Some(true),
                 field_selection: query::FieldSelection {
-                    block: Some(vec![BlockField::Number, BlockField::Hash]),
+                    // ParentHash lets the response store validate the chain
+                    // linkage of the contiguous range (the EVM analogue of the
+                    // SVM parent-slot check).
+                    block: Some(vec![
+                        BlockField::Number,
+                        BlockField::Hash,
+                        BlockField::ParentHash,
+                    ]),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/packages/cli/src/field_table.rs
+++ b/packages/cli/src/field_table.rs
@@ -86,7 +86,9 @@ impl FixedCol {
     pub(crate) fn push(&mut self, v: Option<&[u8]>) {
         match v {
             Some(b) => {
-                debug_assert_eq!(b.len(), self.width);
+                // A hard check: a wrong-width cell would silently shift every
+                // subsequent row's offset in release builds.
+                assert_eq!(b.len(), self.width, "fixed column cell width mismatch");
                 self.data.extend_from_slice(b);
             }
             None => self.data.resize(self.data.len() + self.width, 0),
@@ -400,7 +402,7 @@ impl StoreCol {
             (StoreCol::Bool(v), AnyCol::Bool(s)) => v[slot] = s.get(row).unwrap(),
             (StoreCol::Fixed { width, data }, AnyCol::Fixed(s)) => {
                 let b = s.get(row).unwrap();
-                debug_assert_eq!(b.len(), *width);
+                assert_eq!(b.len(), *width, "fixed column cell width mismatch");
                 data[slot * *width..(slot + 1) * *width].copy_from_slice(b);
             }
             (StoreCol::Var(v), AnyCol::Var(s)) => {
@@ -499,6 +501,9 @@ pub(crate) struct Table<K> {
 
 impl<K: Ord + Clone + std::hash::Hash> Table<K> {
     pub(crate) fn new(n_fields: usize) -> Self {
+        // Field masks are single u64 bitsets; a 65th field would silently
+        // corrupt them in release builds.
+        assert!(n_fields <= 64, "Table supports at most 64 fields");
         Self {
             by_key: HashMap::new(),
             order: BTreeMap::new(),
@@ -694,6 +699,11 @@ impl<K: Ord + Clone + std::hash::Hash> Table<K> {
                 self.free_slot(slot);
             }
         }
+    }
+
+    /// Every stored key, ascending.
+    pub(crate) fn keys(&self) -> Vec<K> {
+        self.order.keys().cloned().collect()
     }
 
     /// Keys in `[from, below)` whose row carries `field`, ascending.

--- a/packages/cli/src/field_table.rs
+++ b/packages/cli/src/field_table.rs
@@ -475,14 +475,6 @@ impl StoreCol {
         }
     }
 
-    /// Raw unsigned integer cell. The caller must have checked the row's mask
-    /// bit, because primitive store columns do not carry per-slot validity.
-    fn cell_u64(&self, slot: usize) -> u64 {
-        match self {
-            StoreCol::U64(v) => v[slot],
-            _ => panic!("expected a u64 column"),
-        }
-    }
 }
 
 /// Merge-on-insert columnar table: one slot per distinct key. `by_key` backs
@@ -617,14 +609,6 @@ impl<K: Ord + Clone + std::hash::Hash> Table<K> {
             .and_then(|c| c.cell_bytes(slot as usize))
     }
 
-    /// Unsigned integer value of `field` for `key`, if the row carries it.
-    pub(crate) fn field_u64(&self, key: &K, field: usize) -> Option<u64> {
-        let &slot = self.by_key.get(key)?;
-        if self.masks[slot as usize] & (1u64 << field) == 0 {
-            return None;
-        }
-        self.cols[field].as_ref().map(|c| c.cell_u64(slot as usize))
-    }
 
     /// Lowest key `>= from` carrying `field` in both tables whose cells differ.
     pub(crate) fn first_field_mismatch(
@@ -699,11 +683,6 @@ impl<K: Ord + Clone + std::hash::Hash> Table<K> {
                 self.free_slot(slot);
             }
         }
-    }
-
-    /// Every stored key, ascending.
-    pub(crate) fn keys(&self) -> Vec<K> {
-        self.order.keys().cloned().collect()
     }
 
     /// Keys in `[from, below)` whose row carries `field`, ascending.

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -241,7 +241,9 @@ impl SvmHypersyncClient {
                 .map_err(|error| error_with_request_stats(error, &request_stats))?;
             if next_slot <= cursor {
                 let error = map_err(anyhow::anyhow!(
-                    "SVM block hash query made no progress: cursor={cursor}, next_slot={next_slot}"
+                    "Slot #{cursor} is not found in HyperSync yet. This happens when the request \
+                     is routed to a HyperSync replica that is slightly behind the head. Everything \
+                     is fine - indexing should continue correctly after a retry."
                 ));
                 return Err(error_with_request_stats(error, &request_stats));
             }

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -241,9 +241,10 @@ impl SvmHypersyncClient {
                 .map_err(|error| error_with_request_stats(error, &request_stats))?;
             if next_slot <= cursor {
                 let error = map_err(anyhow::anyhow!(
-                    "Slot #{cursor} is not found in HyperSync yet. This happens when the request \
-                     is routed to a HyperSync replica that is slightly behind the head. Everything \
-                     is fine - indexing should continue correctly after a retry."
+                    "Slot #{cursor} is not yet available on the queried HyperSync replica. \
+                     Requests are load-balanced across replicas, which may briefly trail the \
+                     chain head. This is expected behavior and resolves on its own - indexing \
+                     will continue after an automatic retry."
                 ));
                 return Err(error_with_request_stats(error, &request_stats));
             }

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -242,9 +242,8 @@ impl SvmHypersyncClient {
             if next_slot <= cursor {
                 let error = map_err(anyhow::anyhow!(
                     "Slot #{cursor} is not yet available on the queried HyperSync replica. \
-                     Requests are load-balanced across replicas, which may briefly trail the \
-                     chain head. This is expected behavior and resolves on its own - indexing \
-                     will continue after an automatic retry."
+                     Replicas may briefly trail the chain head - this is expected, and indexing \
+                     continues after an automatic retry."
                 ));
                 return Err(error_with_request_stats(error, &request_stats));
             }

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -209,20 +209,21 @@ impl SvmHypersyncClient {
             .map_err(map_err)?;
 
         let fields = query::FieldSelection {
-            block: Some(vec![
-                "slot".to_string(),
-                "blockhash".to_string(),
-                "parent_slot".to_string(),
-                "parent_blockhash".to_string(),
-            ]),
+            block: Some(vec!["slot".to_string(), "blockhash".to_string()]),
             ..Default::default()
         };
         let aggregate = BlockStore::new_svm();
         let mut request_stats = Vec::new();
         let mut cursor = from_slot;
+        // Follow-up pages re-request the last returned block: one HyperSync
+        // response is internally consistent, so a fork switch between
+        // paginated requests is the only seam — and it surfaces as a hash
+        // collision on the overlapping slot when the page is appended.
+        let mut overlap_slot = None;
         loop {
+            let request_from = overlap_slot.unwrap_or(cursor);
             let query = SvmQuery {
-                from_slot: cursor,
+                from_slot: request_from,
                 to_slot: Some(to_slot_exclusive),
                 include_all_blocks: Some(true),
                 fields: Some(fields.clone()),
@@ -236,7 +237,7 @@ impl SvmHypersyncClient {
             });
             let response =
                 response.map_err(|error| error_with_request_stats(error, &request_stats))?;
-            let (next_slot, page_store) = block_hash_page(response)
+            let (next_slot, last_slot, page_store) = block_hash_page(response)
                 .map_err(map_err)
                 .map_err(|error| error_with_request_stats(error, &request_stats))?;
             if next_slot <= cursor {
@@ -249,23 +250,33 @@ impl SvmHypersyncClient {
             }
             aggregate.append_page(&page_store);
             aggregate
-                .mark_svm_coverage(cursor, next_slot.min(to_slot_exclusive))
+                .mark_svm_coverage(request_from, next_slot.min(to_slot_exclusive))
                 .map_err(map_err)
                 .map_err(|error| error_with_request_stats(error, &request_stats))?;
             if next_slot >= to_slot_exclusive {
                 return Ok((aggregate, request_stats));
             }
             cursor = next_slot;
+            overlap_slot = last_slot.or(overlap_slot);
         }
     }
 }
 
-/// Convert only the cursor and raw blocks needed for rollback-depth checks.
-fn block_hash_page(mut response: simple::SolanaResponse) -> Result<(i64, BlockStore)> {
+/// Convert only the values needed by the block-hash paginator: the advancing
+/// cursor, the highest returned slot (the next page's overlap anchor), and the
+/// page store.
+fn block_hash_page(mut response: simple::SolanaResponse) -> Result<(i64, Option<i64>, BlockStore)> {
     let next_slot = i64::try_from(response.next_slot).context("convert next_slot")?;
+    let last_slot = response
+        .blocks
+        .iter()
+        .map(|b| i64::try_from(b.slot).context("convert slot"))
+        .try_fold(None, |acc: Option<i64>, slot| {
+            slot.map(|s| Some(acc.map_or(s, |a: i64| a.max(s))))
+        })?;
     let block_store = BlockStore::new_svm();
     block_store.insert_svm_blocks(std::mem::take(&mut response.blocks));
-    Ok((next_slot, block_store))
+    Ok((next_slot, last_slot, block_store))
 }
 
 pub(crate) fn map_err(e: anyhow::Error) -> napi::Error {

--- a/packages/cli/templates/dynamic/init_templates/shared/package.json.hbs
+++ b/packages/cli/templates/dynamic/init_templates/shared/package.json.hbs
@@ -11,7 +11,7 @@
     "codegen": "envio codegen",
     "dev": "{{#if is_rescript}}pnpm build && {{/if}}envio dev",
     "start": "{{#if is_rescript}}pnpm build && {{/if}}envio start",
-    "test": "{{#if is_rescript}}pnpm build && {{/if}}vitest run --test-timeout=20000"
+    "test": "{{#if is_rescript}}pnpm build && {{/if}}vitest run --test-timeout=60000"
   },
   "devDependencies": {
   {{#if is_rescript}}

--- a/packages/cli/templates/dynamic/init_templates/shared/package.json.hbs
+++ b/packages/cli/templates/dynamic/init_templates/shared/package.json.hbs
@@ -11,7 +11,7 @@
     "codegen": "envio codegen",
     "dev": "{{#if is_rescript}}pnpm build && {{/if}}envio dev",
     "start": "{{#if is_rescript}}pnpm build && {{/if}}envio start",
-    "test": "{{#if is_rescript}}pnpm build && {{/if}}vitest run --test-timeout=60000"
+    "test": "{{#if is_rescript}}pnpm build && {{/if}}vitest run --test-timeout=30000"
   },
   "devDependencies": {
   {{#if is_rescript}}

--- a/packages/e2e-tests/src/template-tests/templates.test.ts
+++ b/packages/e2e-tests/src/template-tests/templates.test.ts
@@ -182,13 +182,23 @@ function templateTest({ name, initArgs, hasTests }: TemplateConfig) {
   }, config.timeouts.codegen + 10_000);
 
   it.skipIf(!hasTests)("runs tests successfully", async () => {
-    const result = await runCommand("pnpm", ["test"], {
+    let result = await runCommand("pnpm", ["test"], {
       cwd: projectDir,
       timeout: config.timeouts.test,
     });
 
+    // Template smoke tests index a couple of real blocks through live
+    // HyperSync; a single hung connection on the runner shouldn't fail the
+    // job, so give the whole suite one more attempt.
+    if (result.exitCode !== 0) {
+      result = await runCommand("pnpm", ["test"], {
+        cwd: projectDir,
+        timeout: config.timeouts.test,
+      });
+    }
+
     expect(result.exitCode, `[${name}] test failed (exit ${result.exitCode}):\n${result.stderr}\n${result.stdout}`).toBe(0);
-  }, config.timeouts.test + 10_000);
+  }, config.timeouts.test * 2 + 10_000);
 }
 
 for (const template of TEMPLATES) {

--- a/packages/e2e-tests/src/template-tests/templates.test.ts
+++ b/packages/e2e-tests/src/template-tests/templates.test.ts
@@ -182,23 +182,13 @@ function templateTest({ name, initArgs, hasTests }: TemplateConfig) {
   }, config.timeouts.codegen + 30_000);
 
   it.skipIf(!hasTests)("runs tests successfully", async () => {
-    let result = await runCommand("pnpm", ["test"], {
+    const result = await runCommand("pnpm", ["test"], {
       cwd: projectDir,
       timeout: config.timeouts.test,
     });
 
-    // Template smoke tests index a couple of real blocks through live
-    // HyperSync; a single hung connection on the runner shouldn't fail the
-    // job, so give the whole suite one more attempt.
-    if (result.exitCode !== 0) {
-      result = await runCommand("pnpm", ["test"], {
-        cwd: projectDir,
-        timeout: config.timeouts.test,
-      });
-    }
-
     expect(result.exitCode, `[${name}] test failed (exit ${result.exitCode}):\n${result.stderr}\n${result.stdout}`).toBe(0);
-  }, config.timeouts.test * 2 + 30_000);
+  }, config.timeouts.test);
 }
 
 for (const template of TEMPLATES) {

--- a/packages/e2e-tests/src/template-tests/templates.test.ts
+++ b/packages/e2e-tests/src/template-tests/templates.test.ts
@@ -161,7 +161,7 @@ function templateTest({ name, initArgs, hasTests }: TemplateConfig) {
     );
 
     expect(result.exitCode, `[${name}] init failed (exit ${result.exitCode}):\n${result.stderr}\n${result.stdout}`).toBe(0);
-  }, config.timeouts.install + 10_000);
+  }, config.timeouts.install + 30_000);
 
   it("installs dependencies", async () => {
     const result = await runCommand("pnpm", ["install"], {
@@ -170,7 +170,7 @@ function templateTest({ name, initArgs, hasTests }: TemplateConfig) {
     });
 
     expect(result.exitCode, `[${name}] pnpm install failed (exit ${result.exitCode}):\n${result.stderr}`).toBe(0);
-  }, config.timeouts.install + 10_000);
+  }, config.timeouts.install + 30_000);
 
   it("runs codegen successfully", async () => {
     const result = await runCommand(config.envioCommand, [...config.envioArgs, "codegen"], {
@@ -179,7 +179,7 @@ function templateTest({ name, initArgs, hasTests }: TemplateConfig) {
     });
 
     expect(result.exitCode, `[${name}] codegen failed (exit ${result.exitCode}):\n${result.stderr}`).toBe(0);
-  }, config.timeouts.codegen + 10_000);
+  }, config.timeouts.codegen + 30_000);
 
   it.skipIf(!hasTests)("runs tests successfully", async () => {
     let result = await runCommand("pnpm", ["test"], {
@@ -198,7 +198,7 @@ function templateTest({ name, initArgs, hasTests }: TemplateConfig) {
     }
 
     expect(result.exitCode, `[${name}] test failed (exit ${result.exitCode}):\n${result.stderr}\n${result.stdout}`).toBe(0);
-  }, config.timeouts.test * 2 + 10_000);
+  }, config.timeouts.test * 2 + 30_000);
 }
 
 for (const template of TEMPLATES) {

--- a/packages/e2e-tests/vitest.config.ts
+++ b/packages/e2e-tests/vitest.config.ts
@@ -3,5 +3,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     testTimeout: 120_000,
+    // The smoke tests index real blocks through live HyperSync; a failed
+    // attempt surfaces quickly with a real error, so one retry on CI absorbs
+    // a hung connection on the runner without hiding deterministic failures.
+    retry: process.env.CI ? 1 : 0,
   },
 });

--- a/packages/e2e-tests/vitest.config.ts
+++ b/packages/e2e-tests/vitest.config.ts
@@ -3,9 +3,5 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     testTimeout: 120_000,
-    // The smoke tests index real blocks through live HyperSync; a failed
-    // attempt surfaces quickly with a real error, so one retry on CI absorbs
-    // a hung connection on the runner without hiding deterministic failures.
-    retry: process.env.CI ? 1 : 0,
   },
 });

--- a/packages/envio/src/Batch.res
+++ b/packages/envio/src/Batch.res
@@ -16,6 +16,9 @@ type chainBeforeBatch = {
   // for reorg detection.
   blockStore: BlockStore.t,
   shouldRollbackOnReorg: bool,
+  // The resumed-from-DB reorg depth (may differ from the config value after a
+  // restart) — the same authority the store used when retaining hashes.
+  maxReorgDepth: int,
   progressBlockNumber: int,
   sourceBlockNumber: int,
   totalEventsProcessed: float,
@@ -139,7 +142,10 @@ let addReorgCheckpoints = (
 ) => {
   if shouldRollbackOnReorg {
     let prevCheckpointId = ref(prevCheckpointId)
-    for blockNumber in Pervasives.max(fromBlockExclusive + 1, thresholdBlockNumber) to toBlockExclusive - 1 {
+    for blockNumber in Pervasives.max(
+      fromBlockExclusive + 1,
+      thresholdBlockNumber,
+    ) to toBlockExclusive - 1 {
       switch blockStore->BlockStore.getHash(blockNumber) {
       | Null.Value(hash) =>
         let checkpointId = prevCheckpointId.contents->BigInt.add(1n)
@@ -206,7 +212,7 @@ let prepareBatch = (
     // threshold; below it checkpoints stay hashless (matching what the store
     // retains after pruning).
     let chainThresholdBlockNumber =
-      chainBeforeBatch.sourceBlockNumber - chainBeforeBatch.chainConfig.maxReorgDepth
+      chainBeforeBatch.sourceBlockNumber - chainBeforeBatch.maxReorgDepth
     if chainBatchSize > 0 {
       for idx in 0 to chainBatchSize - 1 {
         let item = fetchState.buffer->Array.getUnsafe(idx)

--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -179,7 +179,7 @@ let rec onQueryResponse = async (
         ->ChainState.logger
         ->Logging.childInfo(
           reorgDetected->ReorgDetection.reorgDetectedToLogParams(
-            ~shouldRollbackOnReorg=(state->IndexerState.config).shouldRollbackOnReorg,
+            ~shouldRollbackOnReorg=chainState->ChainState.shouldRollbackOnReorg,
           ),
         )
         Prometheus.ReorgCount.increment(~chain)
@@ -187,7 +187,11 @@ let rec onQueryResponse = async (
           ~blockNumber=reorgDetected.scannedBlock.blockNumber,
           ~chain,
         )
-        if (state->IndexerState.config).shouldRollbackOnReorg {
+
+        // Must agree with the `reportOnly` flag registerReorgGuard passed to
+        // the merge: a discarded page (rollback mode) needs the rollback to
+        // actually happen, or the stale stored hash re-reports forever.
+        if chainState->ChainState.shouldRollbackOnReorg {
           Some(reorgDetected.scannedBlock.blockNumber)
         } else {
           None

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -87,8 +87,8 @@ let make = (
   ~sourceManager: SourceManager.t,
   ~committedProgressBlockNumber: int,
   ~safeCheckpointTracking=None,
-  ~shouldRollbackOnReorg=false,
-  ~maxReorgDepth=0,
+  ~shouldRollbackOnReorg,
+  ~maxReorgDepth,
   ~numEventsProcessed=0.,
   ~timestampCaughtUpToHeadOrEndblock=None,
   ~isProgressAtHead=false,
@@ -369,6 +369,7 @@ let logger = (cs: t) => cs.logger
 let blockStore = (cs: t) => cs.blockStore
 let sourceManager = (cs: t) => cs.sourceManager
 let chainConfig = (cs: t) => cs.chainConfig
+let shouldRollbackOnReorg = (cs: t) => cs.shouldRollbackOnReorg
 // Reorg-scan reads over the block store, for the rollback flow: the scanned
 // block numbers still inside the reorg threshold, and the highest of them whose
 // re-fetched hash still matches.
@@ -378,16 +379,9 @@ let getReorgThresholdBlockNumbersBelow = (cs: t, ~blockNumber) =>
     ~belowBlock=blockNumber,
   )
 
-let getLatestValidScannedBlock = (
-  cs: t,
-  ~blockStore: BlockStore.t,
-  ~blockNumbers: array<int>,
-) =>
+let getLatestValidScannedBlock = (cs: t, ~blockStore: BlockStore.t, ~blockNumbers: array<int>) =>
   cs.blockStore
-  ->BlockStore.latestValidBlockFromStore(
-    blockStore,
-    blockNumbers,
-  )
+  ->BlockStore.latestValidBlockFromStore(blockStore, blockNumbers)
   ->Null.toOption
 let safeCheckpointTracking = (cs: t) => cs.safeCheckpointTracking
 let isProgressAtHead = (cs: t) => cs.isProgressAtHead
@@ -461,7 +455,7 @@ let hasProcessedToEndblock = (cs: t) => {
 }
 
 let getHighestBlockBelowThreshold = (cs: t): int => {
-  let highestBlockBelowThreshold = cs.fetchState.knownHeight - cs.chainConfig.maxReorgDepth
+  let highestBlockBelowThreshold = cs.fetchState.knownHeight - cs.maxReorgDepth
   highestBlockBelowThreshold < 0 ? 0 : highestBlockBelowThreshold
 }
 
@@ -768,6 +762,7 @@ let toChainBeforeBatch = (cs: t): Batch.chainBeforeBatch => {
   sourceBlockNumber: cs.fetchState.knownHeight,
   blockStore: cs.blockStore,
   shouldRollbackOnReorg: cs.shouldRollbackOnReorg,
+  maxReorgDepth: cs.maxReorgDepth,
   chainConfig: cs.chainConfig,
 }
 

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -169,8 +169,11 @@ let makeInternal = (
     ~knownHeight,
     ~chainId=chainConfig.id,
     // FIXME: Shouldn't set with full history
+    // The resumed depth, not the config one: the pre-threshold lag must match
+    // the window reorg detection compares, or a reduced config depth would let
+    // fetching enter the stored rollback window without history.
     ~blockLag=Pervasives.max(
-      !config.shouldRollbackOnReorg || isInReorgThreshold ? 0 : chainConfig.maxReorgDepth,
+      !config.shouldRollbackOnReorg || isInReorgThreshold ? 0 : maxReorgDepth,
       chainConfig.blockLag,
     ),
     ~onBlockRegistrations,

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -13,8 +13,8 @@ let make: (
   ~sourceManager: SourceManager.t,
   ~committedProgressBlockNumber: int,
   ~safeCheckpointTracking: option<SafeCheckpointTracking.t>=?,
-  ~shouldRollbackOnReorg: bool=?,
-  ~maxReorgDepth: int=?,
+  ~shouldRollbackOnReorg: bool,
+  ~maxReorgDepth: int,
   ~numEventsProcessed: float=?,
   ~timestampCaughtUpToHeadOrEndblock: option<Date.t>=?,
   ~isProgressAtHead: bool=?,
@@ -46,6 +46,7 @@ let logger: t => Pino.t
 let blockStore: t => BlockStore.t
 let sourceManager: t => SourceManager.t
 let chainConfig: t => Config.chain
+let shouldRollbackOnReorg: t => bool
 // Reorg-scan reads over the chain's block store, for the rollback flow.
 let getReorgThresholdBlockNumbersBelow: (t, ~blockNumber: int) => array<int>
 let getLatestValidScannedBlock: (

--- a/packages/envio/src/Env.res
+++ b/packages/envio/src/Env.res
@@ -7,6 +7,11 @@
 let updateSyncTimeOnRestart =
   envSafe->EnvSafe.get("UPDATE_SYNC_TIME_ON_RESTART", S.bool, ~fallback=true)
 let targetBufferSize = envSafe->EnvSafe.get("ENVIO_INDEXING_MAX_BUFFER_SIZE", S.option(S.int))
+// Caps consecutive failed retries of one source operation before the run fails
+// with the underlying error. Unset means retry indefinitely (production
+// default); the test indexer sets a small cap so an unreachable source fails
+// the test with a real error instead of hanging until the test timeout.
+let maxSourceRetries = envSafe->EnvSafe.get("ENVIO_MAX_SOURCE_RETRIES", S.option(S.int))
 let maxAddrInPartition = envSafe->EnvSafe.get("MAX_PARTITION_SIZE", S.int, ~fallback=5_000)
 
 // Target number of in-memory objects (uncommitted entity/effect changes plus

--- a/packages/envio/src/ReorgDetection.res
+++ b/packages/envio/src/ReorgDetection.res
@@ -1,9 +1,4 @@
-// Reorg detection lives in the Rust `BlockStore`. A validated response is
-// compared with the persistent store and only that cross-store mismatch is a
-// reorg signal; response-internal conflicts are retried by SourceManager.
-
 type blockData = {
-  // Block hash is used for actual comparison to test for reorg
   blockHash: string,
   blockNumber: int,
 }

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -724,8 +724,11 @@ let makeCreateTestIndexer = (~config: Config.t, ~workerPath: string): (
                     workerData: workerData->(Utils.magic: workerData => JSON.t),
                     // Explicitly forward parent env so handlers running in
                     // the worker observe the same environment as the test
-                    // process (e.g. E2E_EXPECTED_END_BLOCK).
-                    env: %raw(`process.env`),
+                    // process (e.g. E2E_EXPECTED_END_BLOCK). A test run should
+                    // fail with the source's error rather than retry until the
+                    // test-runner timeout, so cap source retries unless the
+                    // user overrides the cap.
+                    env: %raw(`{ENVIO_MAX_SOURCE_RETRIES: "1", ...process.env}`),
                   },
                 )
               } catch {

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -726,14 +726,10 @@ let makeCreateTestIndexer = (~config: Config.t, ~workerPath: string): (
                     // the worker observe the same environment as the test
                     // process (e.g. E2E_EXPECTED_END_BLOCK). A test run should
                     // fail with the source's error rather than retry until the
-                    // test-runner timeout, so unless the user overrides them,
-                    // cap source retries and shorten the HyperSync request
-                    // timeout (the production 120s default outlives any test
-                    // timeout, turning a hung connection into a context-free
-                    // test failure instead of a quick retry on a fresh one).
+                    // test-runner timeout, so cap source retries unless the
+                    // user overrides the cap.
                     env: %raw(`{
-                      ENVIO_MAX_SOURCE_RETRIES: "1",
-                      ENVIO_HYPERSYNC_CLIENT_TIMEOUT_MILLIS: "30000",
+                      ENVIO_MAX_SOURCE_RETRIES: "3",
                       ...process.env,
                     }`),
                   },

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -733,7 +733,7 @@ let makeCreateTestIndexer = (~config: Config.t, ~workerPath: string): (
                     // test failure instead of a quick retry on a fresh one).
                     env: %raw(`{
                       ENVIO_MAX_SOURCE_RETRIES: "1",
-                      ENVIO_HYPERSYNC_CLIENT_TIMEOUT_MILLIS: "10000",
+                      ENVIO_HYPERSYNC_CLIENT_TIMEOUT_MILLIS: "30000",
                       ...process.env,
                     }`),
                   },

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -726,9 +726,16 @@ let makeCreateTestIndexer = (~config: Config.t, ~workerPath: string): (
                     // the worker observe the same environment as the test
                     // process (e.g. E2E_EXPECTED_END_BLOCK). A test run should
                     // fail with the source's error rather than retry until the
-                    // test-runner timeout, so cap source retries unless the
-                    // user overrides the cap.
-                    env: %raw(`{ENVIO_MAX_SOURCE_RETRIES: "1", ...process.env}`),
+                    // test-runner timeout, so unless the user overrides them,
+                    // cap source retries and shorten the HyperSync request
+                    // timeout (the production 120s default outlives any test
+                    // timeout, turning a hung connection into a context-free
+                    // test failure instead of a quick retry on a fresh one).
+                    env: %raw(`{
+                      ENVIO_MAX_SOURCE_RETRIES: "1",
+                      ENVIO_HYPERSYNC_CLIENT_TIMEOUT_MILLIS: "10000",
+                      ...process.env,
+                    }`),
                   },
                 )
               } catch {

--- a/packages/envio/src/bindings/Vitest.res
+++ b/packages/envio/src/bindings/Vitest.res
@@ -99,7 +99,7 @@ external afterEach: (unit => unit) => unit = "afterEach"
 // Async Module
 // ============================================================================
 
-type options = {retry?: int}
+type options = {retry?: int, timeout?: int}
 
 module Async = {
   @module("vitest")

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -1,16 +1,17 @@
-let mapRateLimitedExn = exn => {
-  let failure = exn->Source.unpackNativeRequestFailure
+let mapRateLimitedFailure = (failure: Source.nativeRequestFailure) => {
   switch failure.message {
   | Some(msg) if msg->String.startsWith("RATE_LIMITED:") =>
-      let resetMs =
-        msg
-        ->String.slice(~start=13, ~end=msg->String.length)
-        ->Int.fromString
-        ->Option.getOr(1000)
+    let resetMs =
+      msg
+      ->String.slice(~start=13, ~end=msg->String.length)
+      ->Int.fromString
+      ->Option.getOr(1000)
     Source.RateLimited({resetMs: resetMs})
   | _ => failure.cause
   }
 }
+
+let mapRateLimitedExn = exn => exn->Source.unpackNativeRequestFailure->mapRateLimitedFailure
 
 let reraiseIfRateLimited = exn =>
   switch exn->mapRateLimitedExn {

--- a/packages/envio/src/sources/HyperSync.resi
+++ b/packages/envio/src/sources/HyperSync.resi
@@ -9,6 +9,7 @@ type logsQueryPage = {
 }
 
 let reraiseIfRateLimited: exn => unit
+let mapRateLimitedFailure: Source.nativeRequestFailure => exn
 let mapRateLimitedExn: exn => exn
 
 module GetLogs: {

--- a/packages/envio/src/sources/HyperSyncSource.res
+++ b/packages/envio/src/sources/HyperSyncSource.res
@@ -1,6 +1,5 @@
 open Source
 
-
 // Surfaced by HyperSyncClient.getHeight (Rust) when HyperSync rejects the API
 // token. The corrupted-token test feeds the real server error through this
 // check so it can't silently drift away from what getHeightOrThrow guards on.
@@ -46,9 +45,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     ~url=endpointUrl,
     ~apiToken,
     ~httpReqTimeoutMillis=clientTimeoutMillis,
-    ~eventRegistrations=HyperSyncClient.Registration.fromOnEventRegistrations(
-      onEventRegistrations,
-    ),
+    ~eventRegistrations=HyperSyncClient.Registration.fromOnEventRegistrations(onEventRegistrations),
     ~enableChecksumAddresses=!lowercaseAddresses,
     ~serializationFormat,
     ~enableQueryCaching,
@@ -180,8 +177,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     let getBlock = blockNumber => blocksByNumber->Utils.Map.unsafeGet(blockNumber)
 
     pageUnsafe.items->Array.forEach(item => {
-      let onEventRegistration =
-        onEventRegistrations->Array.getUnsafe(item.onEventRegistrationIndex)
+      let onEventRegistration = onEventRegistrations->Array.getUnsafe(item.onEventRegistrationIndex)
       parsedQueueItems
       ->Array.push(makeEventBatchQueueItem(item, ~onEventRegistration))
       ->ignore
@@ -233,7 +229,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     } catch {
     | exn => {
         let failure = exn->Source.unpackNativeRequestFailure
-        (Error(exn->HyperSync.mapRateLimitedExn), failure.requestStats)
+        (Error(failure->HyperSync.mapRateLimitedFailure), failure.requestStats)
       }
     }
     {Source.result, requestStats}

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -97,7 +97,6 @@ let getErrorMessage = (exn: exn): option<string> =>
   | _ => None
   }
 
-
 // `EvmRpcClient.getNextPage` throws a napi error whose message is a JSON
 // payload describing the retry decision:
 // `{"kind":"Retry","attemptedToBlock":int,"errorMessage":string|null,
@@ -647,9 +646,7 @@ let make = (
   let client = Rpc.makeClient(url, ~headers?)
   let rpcClient = EvmRpcClient.make(
     ~url,
-    ~eventRegistrations=HyperSyncClient.Registration.fromOnEventRegistrations(
-      onEventRegistrations,
-    ),
+    ~eventRegistrations=HyperSyncClient.Registration.fromOnEventRegistrations(onEventRegistrations),
     ~checksumAddresses=!lowercaseAddresses,
     ~syncConfig,
     ~headers?,
@@ -885,63 +882,64 @@ let make = (
         onEventRegistration.eventConfig->(
           Utils.magic: Internal.eventConfig => Internal.evmEventConfig
         )
+
       (
         async () => {
-                let (block, transaction) = try await Promise.all2((
-                  log->getEventBlockOrThrow(~selectedBlockFields=eventConfig.selectedBlockFields),
-                  log->getEventTransactionOrThrow(
-                    ~selectedTransactionFields=eventConfig.selectedTransactionFields->(
-                      Utils.magic: Utils.Set.t<string> => Utils.Set.t<Internal.evmTransactionField>
-                    ),
-                  ),
-                )) catch {
-                | TransactionDataNotFound({message}) =>
-                  let backoffMillis = switch retry {
-                  | 0 => 100
-                  | _ => 500 * retry
-                  }
-                  throw(
-                    Source.GetItemsError(
-                      FailedGettingItems({
-                        exn: %raw(`null`),
-                        attemptedToBlock: toBlock,
-                        retry: WithBackoff({
-                          message: `${message}. The RPC provider might be load-balanced between nodes that drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${backoffMillis->Int.toString}ms.`,
-                          backoffMillis,
-                        }),
-                      }),
-                    ),
-                  )
-                | exn =>
-                  throw(
-                    Source.GetItemsError(
-                      FailedGettingFieldSelection({
-                        message: "Failed getting selected fields. Please double-check your RPC provider returns correct data.",
-                        exn,
-                        blockNumber: log.blockNumber,
-                        logIndex: log.logIndex,
-                      }),
-                    ),
-                  )
-                }
-
-                Internal.Event({
-                  onEventRegistration: (onEventRegistration :> Internal.onEventRegistration),
-                  blockNumber: block->getBlockNumber,
-                  chain,
+          let (block, transaction) = try await Promise.all2((
+            log->getEventBlockOrThrow(~selectedBlockFields=eventConfig.selectedBlockFields),
+            log->getEventTransactionOrThrow(
+              ~selectedTransactionFields=eventConfig.selectedTransactionFields->(
+                Utils.magic: Utils.Set.t<string> => Utils.Set.t<Internal.evmTransactionField>
+              ),
+            ),
+          )) catch {
+          | TransactionDataNotFound({message}) =>
+            let backoffMillis = switch retry {
+            | 0 => 100
+            | _ => 500 * retry
+            }
+            throw(
+              Source.GetItemsError(
+                FailedGettingItems({
+                  exn: %raw(`null`),
+                  attemptedToBlock: toBlock,
+                  retry: WithBackoff({
+                    message: `${message}. The RPC provider might be load-balanced between nodes that drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${backoffMillis->Int.toString}ms.`,
+                    backoffMillis,
+                  }),
+                }),
+              ),
+            )
+          | exn =>
+            throw(
+              Source.GetItemsError(
+                FailedGettingFieldSelection({
+                  message: "Failed getting selected fields. Please double-check your RPC provider returns correct data.",
+                  exn,
+                  blockNumber: log.blockNumber,
                   logIndex: log.logIndex,
-                  transactionIndex: log.transactionIndex,
-                  payload: {
-                    contractName: eventConfig.contractName,
-                    eventName: eventConfig.name,
-                    chainId: chain->ChainMap.Chain.toChainId,
-                    params: decoded,
-                    block,
-                    transaction,
-                    srcAddress: log.address,
-                    logIndex: log.logIndex,
-                  }->Evm.fromPayload,
-                })
+                }),
+              ),
+            )
+          }
+
+          Internal.Event({
+            onEventRegistration: (onEventRegistration :> Internal.onEventRegistration),
+            blockNumber: block->getBlockNumber,
+            chain,
+            logIndex: log.logIndex,
+            transactionIndex: log.transactionIndex,
+            payload: {
+              contractName: eventConfig.contractName,
+              eventName: eventConfig.name,
+              chainId: chain->ChainMap.Chain.toChainId,
+              params: decoded,
+              block,
+              transaction,
+              srcAddress: log.address,
+              logIndex: log.logIndex,
+            }->Evm.fromPayload,
+          })
         }
       )()
     })
@@ -1013,16 +1011,28 @@ let make = (
     ->Array.map(blockNum => blockLoader.contents->LazyLoader.get(blockNum))
     ->Promise.all
     ->Promise.thenResolve(rawBlocks => {
-      let blockStore = rawBlocks
-      ->Array.map(json => {
+      // Each block is fetched in its own request, so responses can mix forks.
+      // The parent hash becomes a minimal extra row: when consecutive blocks
+      // are requested, the page's own hash-collision check cross-validates the
+      // separately fetched responses.
+      let observedBlocks: array<BlockStore.inputBlock> = []
+      rawBlocks->Array.forEach(json => {
         let b = parseBlockInfo(json)
-        {
+        observedBlocks
+        ->Array.push({
           BlockStore.blockNumber: b.number,
           blockHash: b.hash,
           blockTimestamp: b.timestamp,
+        })
+        ->ignore
+        if b.number > 0 {
+          observedBlocks
+          ->Array.push({BlockStore.blockNumber: b.number - 1, blockHash: b.parentHash})
+          ->ignore
         }
       })
-      ->BlockStore.fromJs(~ecosystem=Evm, ~shouldChecksum=!lowercaseAddresses)
+      let blockStore =
+        observedBlocks->BlockStore.fromJs(~ecosystem=Evm, ~shouldChecksum=!lowercaseAddresses)
       {Source.result: Ok(blockStore), requestStats: drainRequestStats()}
     })
     ->Promise.catch(exn =>

--- a/packages/envio/src/sources/Source.res
+++ b/packages/envio/src/sources/Source.res
@@ -12,11 +12,9 @@ type blockRangeFetchStats = {
 // per (source, method) into the envio_source_request_* metrics.
 type requestStat = {method: string, seconds: float}
 
-// Native clients use this structured error when one logical operation owns
-// multiple backend requests. It lets the source return timings even when the
-// operation ultimately fails and SourceManager retries it.
-exception NativeRequestFailed(string)
-
+// Native clients wrap a failure of a multi-request operation in a structured
+// payload, so the source can still return timings when SourceManager retries
+// it. `cause` carries the inner message as a plain error, ready for logging.
 type nativeRequestFailure = {
   cause: exn,
   message: option<string>,
@@ -59,7 +57,7 @@ let unpackNativeRequestFailure = (exn: exn): nativeRequestFailure => {
   }
   switch decoded {
   | Some((message, requestStats)) => {
-      cause: NativeRequestFailed(message),
+      cause: JsError.make(message)->(Utils.magic: JsError.t => exn),
       message: Some(message),
       requestStats,
     }

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -465,13 +465,22 @@ let getSourceNewHeight = async (
           "chainId": source.chain->ChainMap.Chain.toChainId,
         })
         let h = ref(initialHeight)
+        let fallbackRetry = ref(0)
         while h.contents <= knownHeight && !(newHeight.contents > initialHeight) {
           try {
             let res = await source.getHeightOrThrow()
             sourceState->recordRequestStats(res.requestStats)
             h := res.height
+            fallbackRetry := 0
           } catch {
-          | _ => ()
+          | exn =>
+            sourceManager->raiseIfRetriesExhausted(
+              ~retry=fallbackRetry.contents,
+              ~logger,
+              ~err=exn,
+              ~msg=`Failed to fetch the chain height from the ${source.name} source. Make sure the endpoint is reachable.`,
+            )
+            fallbackRetry := fallbackRetry.contents + 1
           }
           if h.contents <= knownHeight && !(newHeight.contents > initialHeight) {
             await Utils.delay(source.pollingInterval)
@@ -479,6 +488,10 @@ let getSourceNewHeight = async (
         }
         h.contents
       })
+      // With a retry cap the fallback can reject after losing the race;
+      // observe that rejection so it doesn't surface as unhandled. The race
+      // still rejects normally when the fallback fails first.
+      pollingFallback->Promise.catch(_ => Promise.resolve(initialHeight))->ignore
       let height = await Promise.race([subscriptionPromise, pollingFallback])
 
       // Only accept heights greater than initialHeight

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -944,7 +944,6 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
     let logger = Logging.createChild(
       ~params={
         "chainId": source.chain->ChainMap.Chain.toChainId,
-        "logType": "Block Hash Query",
         "source": source.name,
         "retry": retry,
       },
@@ -985,18 +984,27 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
 
     | exn =>
       // A short first retry covers the common transient case (e.g. a request
-      // routed to a HyperSync replica slightly behind the head).
-      let backoffMillis = switch retry {
-      | 0 => 100
-      | _ => 1000 * retry
-      }
+      // routed to a HyperSync replica slightly behind the head), doubling from
+      // there.
+      let backoffMillis = Pervasives.min(100. *. 2. ** retry->Int.toFloat, 60_000.)->Float.toInt
       let log = retry >= 4 ? Logging.childWarn : Logging.childTrace
-      logger->log({
-        "msg": "Failed to fetch block hashes. Retrying.",
-        "retry": retry,
-        "backOffMilliseconds": backoffMillis,
-        "err": exn->Utils.prettifyExn,
-      })
+      // A native failure's message is self-explanatory, so it becomes the log
+      // message itself; anything else keeps the generic message with details.
+      switch exn->JsExn.anyToExnInternal {
+      | JsExn(e) =>
+        logger->log({
+          "msg": e->JsExn.message->Option.getOr("Failed to fetch block hashes. Retrying."),
+          "retry": retry,
+          "backOffMilliseconds": backoffMillis,
+        })
+      | exn =>
+        logger->log({
+          "msg": "Failed to fetch block hashes. Retrying.",
+          "retry": retry,
+          "backOffMilliseconds": backoffMillis,
+          "err": exn->Utils.prettifyExn,
+        })
+      }
 
       let shouldSwitch = switch retry {
       | 0 | 1 => false
@@ -1006,7 +1014,7 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
       if shouldSwitch {
         sourceState.lastFailedAt = Some(Date.now())
       }
-      await Utils.delay(Pervasives.min(backoffMillis, 60_000))
+      await Utils.delay(backoffMillis)
       retryRef := retryRef.contents + 1
     }
   }

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -171,21 +171,25 @@ let validateResponseBlockStore = (
   let missingBlockNumbers = blockStore->BlockStore.missingHashes(requiredBlockNumbers)
   switch conflict {
   | Some({blockNumber, storedHash, receivedHash}) =>
-    throw(Source.InconsistentResponse({
-      method,
-      blockNumber: Some(blockNumber),
-      storedHash: Some(storedHash),
-      receivedHash: Some(receivedHash),
-      missingBlockNumbers,
-    }))
+    throw(
+      Source.InconsistentResponse({
+        method,
+        blockNumber: Some(blockNumber),
+        storedHash: Some(storedHash),
+        receivedHash: Some(receivedHash),
+        missingBlockNumbers,
+      }),
+    )
   | None if missingBlockNumbers->Array.length > 0 =>
-    throw(Source.InconsistentResponse({
-      method,
-      blockNumber: None,
-      storedHash: None,
-      receivedHash: None,
-      missingBlockNumbers,
-    }))
+    throw(
+      Source.InconsistentResponse({
+        method,
+        blockNumber: None,
+        storedHash: None,
+        receivedHash: None,
+        missingBlockNumbers,
+      }),
+    )
   | None => ()
   }
 }
@@ -802,10 +806,7 @@ let executeQuery = async (
         ~logger,
       )
       sourceState->recordRequestStats(response.requestStats)
-      validateResponseBlockStore(
-        ~method="getItems",
-        ~blockStore=response.blockStore,
-      )
+      validateResponseBlockStore(~method="getItems", ~blockStore=response.blockStore)
       sourceState.lastFailedAt = None
       responseRef := Some(response)
     } catch {
@@ -814,13 +815,7 @@ let executeQuery = async (
       retryRef := retryRef.contents + 1
 
     | Source.InconsistentResponse(_) as err => {
-        await retryInconsistentResponse(
-          sourceState,
-          ~retry,
-          ~logger,
-          ~method="getItems",
-          ~err,
-        )
+        await retryInconsistentResponse(sourceState, ~retry, ~logger, ~method="getItems", ~err)
         source.onReorg->Option.forEach(cb => cb(~rollbackTargetBlock=query.fromBlock - 1))
         retryRef := retryRef.contents + 1
       }
@@ -982,17 +977,17 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
           ~method="getBlockHashes",
           ~err,
         )
-        let lowestRequestedBlock = blockNumbers->Array.reduce(
-          blockNumbers->Array.get(0)->Option.getOr(0),
-          Pervasives.min,
-        )
+        let lowestRequestedBlock =
+          blockNumbers->Array.reduce(blockNumbers->Array.get(0)->Option.getOr(0), Pervasives.min)
         source.onReorg->Option.forEach(cb => cb(~rollbackTargetBlock=lowestRequestedBlock - 1))
         retryRef := retryRef.contents + 1
       }
 
     | exn =>
+      // A short first retry covers the common transient case (e.g. a request
+      // routed to a HyperSync replica slightly behind the head).
       let backoffMillis = switch retry {
-      | 0 => 500
+      | 0 => 100
       | _ => 1000 * retry
       }
       let log = retry >= 4 ? Logging.childWarn : Logging.childTrace

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -49,6 +49,7 @@ type t = {
   stalledPollingInterval: int,
   reducedPollingInterval: int,
   getHeightRetryInterval: (~retry: int) => int,
+  maxRetries: option<int>,
   mutable activeSource: Source.t,
   mutable waitingForNewBlockStateId: option<int>,
   // Dedupes the "waiting for new blocks" trace so it fires once per contiguous
@@ -194,6 +195,18 @@ let validateResponseBlockStore = (
   }
 }
 
+// In production a failing source is retried indefinitely (backoff and failover
+// keep the indexer alive through outages). With `maxRetries` set — the test
+// indexer caps it via ENVIO_MAX_SOURCE_RETRIES — the operation gives up once
+// the cap is reached and fails the run with the underlying error, so a test
+// against an unreachable source reports the real cause instead of hanging
+// until the test-runner timeout.
+let raiseIfRetriesExhausted = (sourceManager: t, ~retry, ~logger, ~err, ~msg) =>
+  switch sourceManager.maxRetries {
+  | Some(max) if retry >= max => err->ErrorHandling.mkLogAndRaise(~logger, ~msg)
+  | _ => ()
+  }
+
 let retryInconsistentResponse = async (
   sourceState: sourceState,
   ~retry: int,
@@ -273,6 +286,7 @@ let make = (
     ~backoffMultiplicative=2,
     ~maxRetryInterval=60_000,
   ),
+  ~maxRetries=Env.maxSourceRetries,
 ) => {
   let hasRealtime = sources->Array.some(s => s.sourceFor === Realtime)
   let initialActiveSource = switch sources->Array.find(source =>
@@ -305,6 +319,7 @@ let make = (
     stalledPollingInterval,
     reducedPollingInterval,
     getHeightRetryInterval,
+    maxRetries,
     recoveryTimeout,
     statusStart: Performance.now(),
     status: Idle,
@@ -514,6 +529,12 @@ let getSourceNewHeight = async (
         }
       } catch {
       | exn =>
+        sourceManager->raiseIfRetriesExhausted(
+          ~retry=retry.contents,
+          ~logger,
+          ~err=exn,
+          ~msg=`Failed to fetch the chain height from the ${source.name} source. Make sure the endpoint is reachable.`,
+        )
         let retryInterval = sourceManager.getHeightRetryInterval(~retry=retry.contents)
         logger->Logging.childTrace({
           "msg": `Height retrieval from ${source.name} source failed. Retrying in ${retryInterval->Int.toString}ms.`,
@@ -810,11 +831,23 @@ let executeQuery = async (
       sourceState.lastFailedAt = None
       responseRef := Some(response)
     } catch {
-    | Source.RateLimited({resetMs}) =>
+    | Source.RateLimited({resetMs}) as err =>
+      sourceManager->raiseIfRetriesExhausted(
+        ~retry,
+        ~logger,
+        ~err,
+        ~msg=`The ${source.name} source keeps rate-limiting item requests.`,
+      )
       await sourceManager->waitForRateLimitReset(~resetMs, ~retry, ~logger)
       retryRef := retryRef.contents + 1
 
     | Source.InconsistentResponse(_) as err => {
+        sourceManager->raiseIfRetriesExhausted(
+          ~retry,
+          ~logger,
+          ~err,
+          ~msg=`The ${source.name} source keeps returning internally inconsistent item responses.`,
+        )
         await retryInconsistentResponse(sourceState, ~retry, ~logger, ~method="getItems", ~err)
         source.onReorg->Option.forEach(cb => cb(~rollbackTargetBlock=query.fromBlock - 1))
         retryRef := retryRef.contents + 1
@@ -873,6 +906,12 @@ let executeQuery = async (
         retryRef := 0
 
       | FailedGettingItems({exn, attemptedToBlock, retry: WithBackoff({message, backoffMillis})}) =>
+        sourceManager->raiseIfRetriesExhausted(
+          ~retry,
+          ~logger,
+          ~err=exn,
+          ~msg=`Failed to fetch items from the ${source.name} source. Make sure the endpoint is reachable.`,
+        )
         // Start displaying warnings after 4 failures
         let log = retry >= 4 ? Logging.childWarn : Logging.childTrace
         logger->log({
@@ -964,11 +1003,23 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
       | Error(exn) => throw(exn)
       }
     } catch {
-    | Source.RateLimited({resetMs}) =>
+    | Source.RateLimited({resetMs}) as err =>
+      sourceManager->raiseIfRetriesExhausted(
+        ~retry,
+        ~logger,
+        ~err,
+        ~msg=`The ${source.name} source keeps rate-limiting block-hash requests.`,
+      )
       await sourceManager->waitForRateLimitReset(~resetMs, ~retry, ~logger)
       retryRef := retryRef.contents + 1
 
     | Source.InconsistentResponse(_) as err => {
+        sourceManager->raiseIfRetriesExhausted(
+          ~retry,
+          ~logger,
+          ~err,
+          ~msg=`The ${source.name} source keeps returning internally inconsistent block-hash responses.`,
+        )
         await retryInconsistentResponse(
           sourceState,
           ~retry,
@@ -983,6 +1034,12 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
       }
 
     | exn =>
+      sourceManager->raiseIfRetriesExhausted(
+        ~retry,
+        ~logger,
+        ~err=exn,
+        ~msg=`Failed to fetch block hashes from the ${source.name} source. Make sure the endpoint is reachable.`,
+      )
       // A short first retry covers the common transient case (e.g. a request
       // routed to a HyperSync replica slightly behind the head), doubling from
       // there.

--- a/packages/envio/src/sources/SourceManager.resi
+++ b/packages/envio/src/sources/SourceManager.resi
@@ -17,6 +17,7 @@ let make: (
   ~reducedPollingInterval: int=?,
   ~recoveryTimeout: float=?,
   ~getHeightRetryInterval: (~retry: int) => int=?,
+  ~maxRetries: option<int>=?,
 ) => t
 
 let getActiveSource: t => Source.t
@@ -65,11 +66,7 @@ let makeGetHeightRetryInterval: (
   ~maxRetryInterval: int,
 ) => (~retry: int) => int
 
-let getBlockHashes: (
-  t,
-  ~blockNumbers: array<int>,
-  ~isRealtime: bool,
-) => promise<BlockStore.t>
+let getBlockHashes: (t, ~blockNumbers: array<int>, ~isRealtime: bool) => promise<BlockStore.t>
 
 // Total time the indexer spent waiting on rate limits, including any
 // currently-in-progress window measured against Date.now() at call time.

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -578,7 +578,7 @@ let make = (
     } catch {
     | exn => {
         let failure = exn->Source.unpackNativeRequestFailure
-        (Error(failure.cause), failure.requestStats)
+        (Error(failure->HyperSync.mapRateLimitedFailure), failure.requestStats)
       }
     }
     {Source.result, requestStats}

--- a/scenarios/e2e_test/src/indexer.test.ts
+++ b/scenarios/e2e_test/src/indexer.test.ts
@@ -8,6 +8,7 @@ import { createTestIndexer } from "envio";
 describe("Indexer smoke test", () => {
   it(
     "processes the first block with events on chain 1",
+    { retry: 3, timeout: 60_000 },
     async (t) => {
       const indexer = createTestIndexer();
 
@@ -54,7 +55,6 @@ describe("Indexer smoke test", () => {
           ],
         }
       `);
-    },
-    60_000
+    }
   );
 });

--- a/scenarios/test_codegen/test/EventHandler.test.ts
+++ b/scenarios/test_codegen/test/EventHandler.test.ts
@@ -1023,7 +1023,7 @@ describe("Use Envio test framework to test event handlers", () => {
     });
   });
 
-  it("createTestIndexer works", async () => {
+  it("createTestIndexer works", { retry: 3 }, async () => {
     const indexer = createTestIndexer();
 
     const result = await indexer.process({
@@ -1150,7 +1150,7 @@ describe("Use Envio test framework to test event handlers", () => {
     });
   });
 
-  it("createTestIndexer throws when process is called while already running", async () => {
+  it("createTestIndexer throws when process is called while already running", { retry: 3 }, async () => {
     const indexer = createTestIndexer();
 
     // Start first process (don't await)
@@ -1228,7 +1228,7 @@ describe("Use Envio test framework to test event handlers", () => {
     );
   });
 
-  it("TestIndexer result type is properly typed", async () => {
+  it("TestIndexer result type is properly typed", { retry: 3 }, async () => {
     const testIndexer = createTestIndexer();
 
     // Verify TestIndexer type matches createTestIndexer return type

--- a/scenarios/test_codegen/test/HyperSyncClient_test.res
+++ b/scenarios/test_codegen/test/HyperSyncClient_test.res
@@ -69,7 +69,7 @@ let runQuery = async (~client: HyperSyncClient.t, ~registrationIndexes=[42]) => 
 }
 
 describe("HyperSync client getEventItems (live)", () => {
-  Async.it("returns decoded event items for a real block range", async t => {
+  Async.itWithOptions("returns decoded event items for a real block range", {retry: 3}, async t => {
     let client = makeClient(~eventRegistrations=[transferEventRegistration])
     let res = await runQuery(~client)
 
@@ -107,14 +107,14 @@ describe("HyperSync client getEventItems (live)", () => {
       })
   })
 
-  Async.it("getHeight returns a height past the queried range", async t => {
+  Async.itWithOptions("getHeight returns a height past the queried range", {retry: 3}, async t => {
     let client = makeClient(~eventRegistrations=[transferEventRegistration])
     let height = await client.getHeight()
 
     t.expect(height > toBlock).toEqual(true)
   })
 
-  Async.it("drops items whose topic0 doesn't match any registered sig", async t => {
+  Async.itWithOptions("drops items whose topic0 doesn't match any registered sig", {retry: 3}, async t => {
     // A wildcard registration whose topic0 is the Transfer sighash, so the
     // query fetches Transfer logs, but the decoder is only registered for an
     // unrelated 1-topic signature — every fetched log routes nowhere.
@@ -149,8 +149,9 @@ describe("HyperSync client getHeight with corrupted token", () => {
   // A corrupted token makes the server reply 401, so getHeight throws. The error
   // must keep matching HyperSyncSource.isUnauthorizedError, otherwise
   // getHeightOrThrow's block-forever guard silently stops working.
-  Async.it(
+  Async.itWithOptions(
     "is detected by HyperSyncSource.isUnauthorizedError",
+    {retry: 3, timeout: 60000},
     async t => {
       let client = HyperSyncClient.make(
         ~url="https://eth.hypersync.xyz",
@@ -170,7 +171,6 @@ describe("HyperSync client getHeight with corrupted token", () => {
 
       t.expect(detected).toEqual(true)
     },
-    ~timeout=60000,
   )
 })
 

--- a/scenarios/test_codegen/test/IndexerState_test.res
+++ b/scenarios/test_codegen/test/IndexerState_test.res
@@ -134,6 +134,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       ~sourceManager=SourceManager.make(~sources=[mockSource.source], ~isRealtime=false),
       // This is quite a hack - but it works!
       ~maxReorgDepth=200,
+      ~shouldRollbackOnReorg=false,
       ~committedProgressBlockNumber=-1,
       ~logger=Logging.getLogger(),
     )
@@ -315,13 +316,17 @@ describe("IndexerState", () => {
           ->Array.forEach(
             chainConfig => {
               let mockSource = MockIndexer.Source.make([], ~chain=#1)
-              let (fetchState, indexingAddresses) = makeFetchState(~chainId=chainConfig.id, ~eventBlocks)
+              let (fetchState, indexingAddresses) = makeFetchState(
+                ~chainId=chainConfig.id,
+                ~eventBlocks,
+              )
               let chainState = ChainState.make(
                 ~chainConfig,
                 ~fetchState,
                 ~indexingAddresses,
                 ~sourceManager=SourceManager.make(~sources=[mockSource.source], ~isRealtime=false),
                 ~maxReorgDepth=200,
+                ~shouldRollbackOnReorg=false,
                 ~committedProgressBlockNumber=-1,
                 ~logger=Logging.getLogger(),
               )

--- a/scenarios/test_codegen/test/ReorgDetection_test.res
+++ b/scenarios/test_codegen/test/ReorgDetection_test.res
@@ -1,8 +1,5 @@
 open Vitest
 
-// Reorg detection now lives in the Rust BlockStore: merging a page compares
-// block hashes and reports the lowest in-threshold mismatch; pruning keeps
-// in-threshold hashes; rollback reads find the last valid block.
 describe("Block store reorg detection", () => {
   let scannedHashesFixture = [(1, "0x123"), (50, "0x456"), (300, "0x789"), (500, "0x5432")]
 
@@ -47,10 +44,12 @@ describe("Block store reorg detection", () => {
       ~message="Returns blocks below 500 that are in threshold",
     ).toEqual([300])
     t.expect(
-      mock([(300, "0x789"), (50, "0x456"), (500, "0x5432"), (1, "0x123")])->BlockStore.getHashedBlockNumbers(
-        ~fromBlock=500 - 200,
-        ~belowBlock=501,
-      ),
+      mock([
+        (300, "0x789"),
+        (50, "0x456"),
+        (500, "0x5432"),
+        (1, "0x123"),
+      ])->BlockStore.getHashedBlockNumbers(~fromBlock=500 - 200, ~belowBlock=501),
       ~message="The order of merged blocks doesn't matter",
     ).toEqual([300, 500])
     t.expect(
@@ -184,10 +183,7 @@ describe("Block store reorg detection", () => {
   it("Correctly finds the latest valid scanned block", t => {
     let store = mock(scannedHashesFixture)
     let latestValid = pairs =>
-      store->BlockStore.latestValidBlockFromStore(
-        makePage(pairs),
-        pairs->Array.map(((n, _)) => n),
-      )
+      store->BlockStore.latestValidBlockFromStore(makePage(pairs), pairs->Array.map(((n, _)) => n))
 
     t.expect(
       latestValid([(1, "0x123"), (50, "0x456"), (300, "0x789differnt"), (500, "0x5432differnt")]),
@@ -209,5 +205,158 @@ describe("Block store reorg detection", () => {
       latestValid([(1, "0x123"), (99, "0x99")]),
       ~message="A block the store no longer holds counts as a mismatch",
     ).toEqual(Null.Value(1))
+  })
+})
+
+// The production threshold arithmetic: ChainState derives merge/read/prune
+// boundaries from (knownHeight, maxReorgDepth), where maxReorgDepth is the
+// resumed-from-DB value and may differ from the config after a restart.
+describe("ChainState reorg threshold", () => {
+  let baseChainConfig = Config.load().chainMap->ChainMap.values->Utils.Array.firstUnsafe
+
+  let makeChainState = (~knownHeight, ~maxReorgDepth, ~scannedHashes) => {
+    let contractConfigs = IndexingAddresses.makeContractConfigs(~onEventRegistrations=[])
+    let indexingAddresses = IndexingAddresses.make(~contractConfigs, ~addresses=[])
+    let base = FetchState.make(
+      ~onEventRegistrations=[],
+      ~contractConfigs,
+      ~addresses=[],
+      ~onBlockRegistrations=[
+        {
+          Internal.index: 0,
+          name: "reorg-threshold-test",
+          chainId: baseChainConfig.id,
+          startBlock: None,
+          endBlock: None,
+          interval: 1,
+          handler: "mock onBlock handler"->(
+            Utils.magic: string => Internal.onBlockArgs => promise<unit>
+          ),
+        },
+      ],
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=3,
+      ~maxOnBlockBufferSize=10000,
+      ~chainId=baseChainConfig.id,
+      ~knownHeight=0,
+    )
+    let blockStore = BlockStore.make(~ecosystem=Svm, ~shouldChecksum=false)
+    let seedPage = BlockStore.fromJs(
+      scannedHashes->Array.map(((blockNumber, blockHash)): BlockStore.inputBlock => {
+        blockNumber,
+        blockHash,
+      }),
+      ~ecosystem=Svm,
+      ~shouldChecksum=false,
+    )
+    switch blockStore->BlockStore.merge(seedPage, ~fromBlock=0, ~reportOnly=false) {
+    | Null.Value(_) => JsError.throwWithMessage("Unexpected reorg detected in test setup")
+    | Null.Null => ()
+    }
+    let fetchState = {...base, FetchState.knownHeight}
+    let mockSource = MockIndexer.Source.make([], ~chain=#1)
+    let cs = ChainState.make(
+      ~chainConfig=baseChainConfig,
+      ~fetchState,
+      ~indexingAddresses,
+      ~sourceManager=SourceManager.make(~sources=[mockSource.source], ~isRealtime=false),
+      ~shouldRollbackOnReorg=true,
+      ~maxReorgDepth,
+      ~committedProgressBlockNumber=-1,
+      ~blockStore,
+      ~logger=Logging.getLogger(),
+    )
+    (cs, fetchState)
+  }
+
+  let scannedHashes = [(1, "0x1"), (50, "0x50"), (300, "0x300"), (500, "0x500")]
+
+  it("getReorgThresholdBlockNumbersBelow derives the threshold from knownHeight and depth", t => {
+    let thresholdBlocks = (~knownHeight, ~maxReorgDepth) => {
+      let (cs, _) = makeChainState(~knownHeight, ~maxReorgDepth, ~scannedHashes)
+      cs->ChainState.getReorgThresholdBlockNumbersBelow(~blockNumber=501)
+    }
+
+    t.expect({
+      "sameDepth": thresholdBlocks(~knownHeight=500, ~maxReorgDepth=200),
+      // The store was seeded with checkpoints scanned under depth 200; resuming
+      // with a smaller or larger depth must re-derive the threshold, not reuse
+      // the one the checkpoints were saved with.
+      "shrunkDepth": thresholdBlocks(~knownHeight=500, ~maxReorgDepth=199),
+      "grownDepth": thresholdBlocks(~knownHeight=500, ~maxReorgDepth=450),
+      "clampedToZero": thresholdBlocks(~knownHeight=100, ~maxReorgDepth=200),
+    }).toEqual({
+      "sameDepth": [300, 500],
+      "shrunkDepth": [500],
+      "grownDepth": [50, 300, 500],
+      "clampedToZero": [1, 50, 300, 500],
+    })
+  })
+
+  it("registerReorgGuard compares hashes only at or above knownHeight - maxReorgDepth", t => {
+    let registerConflictAt300 = (~knownHeight) => {
+      let (cs, _) = makeChainState(~knownHeight=500, ~maxReorgDepth=200, ~scannedHashes)
+      cs->ChainState.registerReorgGuard(
+        ~blockStore=BlockStore.fromJs(
+          [{BlockStore.blockNumber: 300, blockHash: "0x300-different"}],
+          ~ecosystem=Svm,
+          ~shouldChecksum=false,
+        ),
+        ~knownHeight,
+      )
+    }
+
+    t.expect(
+      registerConflictAt300(~knownHeight=500),
+      ~message="Block 300 is exactly at the threshold, so the conflict is a reorg",
+    ).toEqual(
+      ReorgDetection.ReorgDetected({
+        scannedBlock: {blockNumber: 300, blockHash: "0x300"},
+        receivedBlock: {blockNumber: 300, blockHash: "0x300-different"},
+      }),
+    )
+    t.expect(
+      registerConflictAt300(~knownHeight=501),
+      ~message="One block later 300 leaves the threshold and the conflict is ignored",
+    ).toEqual(ReorgDetection.NoReorg)
+  })
+
+  it("applyBatchProgress prunes processed blocks but keeps in-threshold hashes", t => {
+    let (cs, fetchState) = makeChainState(~knownHeight=500, ~maxReorgDepth=200, ~scannedHashes)
+    let progressedChainsById = Dict.make()
+    progressedChainsById->Utils.Dict.setByInt(
+      baseChainConfig.id,
+      (
+        {
+          batchSize: 0,
+          progressBlockNumber: 500,
+          sourceBlockNumber: 500,
+          totalEventsProcessed: 0.,
+          fetchState,
+          isProgressAtHeadWhenBatchCreated: false,
+        }: Batch.chainAfterBatch
+      ),
+    )
+    let batch: Batch.t = {
+      totalBatchSize: 0,
+      items: [],
+      progressedChainsById,
+      isInReorgThreshold: true,
+      checkpointIds: [],
+      checkpointChainIds: [],
+      checkpointBlockNumbers: [],
+      checkpointBlockHashes: [],
+      checkpointEventsProcessed: [],
+    }
+
+    cs->ChainState.applyBatchProgress(~batch, ~blockTimestampName="timestamp")
+
+    t.expect(
+      cs
+      ->ChainState.blockStore
+      ->BlockStore.getHashedBlockNumbers(~fromBlock=0, ~belowBlock=1000),
+      ~message="Processed blocks below knownHeight - maxReorgDepth lose their hashes; in-threshold ones stay",
+    ).toEqual([300, 500])
   })
 })

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -36,7 +36,7 @@ describe("RpcSource - name", () => {
 })
 
 describe("RpcSource - getHeightOrThrow", () => {
-  Async.it("Returns the current height of the chain", async t => {
+  Async.itWithOptions("Returns the current height of the chain", {retry: 3}, async t => {
     let source = RpcSource.make({
       url: `https://eth.rpc.hypersync.xyz/${testApiToken}`,
       chain: MockConfig.chain1337,

--- a/scenarios/test_codegen/test/SvmHyperSyncSource_test.res
+++ b/scenarios/test_codegen/test/SvmHyperSyncSource_test.res
@@ -306,8 +306,8 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
           dependsOnAddresses: true,
         },
         ~itemsTarget=5000,
-      ~retry=0,
-      ~logger=Logging.createChild(~params={"test": "SvmHyperSyncSource"}),
+        ~retry=0,
+        ~logger=Logging.createChild(~params={"test": "SvmHyperSyncSource"}),
       )
 
       let query = capturedQueries->Array.getUnsafe(capturedQueries->Array.length - 1)
@@ -367,21 +367,15 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
           dependsOnAddresses: true,
         },
         ~itemsTarget=5000,
-      ~retry=0,
-      ~logger=Logging.createChild(~params={"test": "SvmHyperSyncSource"}),
+        ~retry=0,
+        ~logger=Logging.createChild(~params={"test": "SvmHyperSyncSource"}),
       )
 
       let query = capturedQueries->Array.getUnsafe(capturedQueries->Array.length - 1)
       let fields: SvmHyperSyncClient.QueryTypes.fieldSelection = query.fields->Option.getUnsafe
-      let expectedTokenBalance: option<array<SvmHyperSyncClient.QueryTypes.tokenBalanceField>> = Some([
-        Slot,
-        TransactionIndex,
-        Account,
-        Mint,
-        Owner,
-        PreAmount,
-        PostAmount,
-      ])
+      let expectedTokenBalance: option<
+        array<SvmHyperSyncClient.QueryTypes.tokenBalanceField>,
+      > = Some([Slot, TransactionIndex, Account, Mint, Owner, PreAmount, PostAmount])
       t.expect({
         "tokenBalance": fields.tokenBalance,
         "transaction": fields.transaction,

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -2,19 +2,16 @@ open Vitest
 
 let baseChainConfig = Config.load().chainMap->ChainMap.values->Utils.Array.firstUnsafe
 
-let mockEvent = (~blockNumber): Internal.item =>
-  Internal.Event({
-    chain: ChainMap.Chain.makeUnsafe(~chainId=1),
-    blockNumber,
-    // Carries an `index` so the buffer's dedup key resolves; the rest of the
-    // registration is unused by these tests.
-    onEventRegistration: {"index": 0}->(
-      Utils.magic: {"index": int} => Internal.onEventRegistration
-    ),
-    logIndex: 0,
-    transactionIndex: 0,
-    payload: "Mock event in CrossChainState test"->(Utils.magic: string => Internal.eventPayload),
-  })
+let mockEvent = (~blockNumber): Internal.item => Internal.Event({
+  chain: ChainMap.Chain.makeUnsafe(~chainId=1),
+  blockNumber,
+  // Carries an `index` so the buffer's dedup key resolves; the rest of the
+  // registration is unused by these tests.
+  onEventRegistration: {"index": 0}->(Utils.magic: {"index": int} => Internal.onEventRegistration),
+  logIndex: 0,
+  transactionIndex: 0,
+  payload: "Mock event in CrossChainState test"->(Utils.magic: string => Internal.eventPayload),
+})
 
 // A chain state with no partitions, so bufferBlockNumber is latestOnBlockBlockNumber
 // (the fetch frontier) and every derived value used by the scheduler is set directly.
@@ -44,7 +41,9 @@ let makeChainState = (
         startBlock: None,
         endBlock: None,
         interval: 1,
-        handler: "mock onBlock handler"->(Utils.magic: string => Internal.onBlockArgs => promise<unit>),
+        handler: "mock onBlock handler"->(
+          Utils.magic: string => Internal.onBlockArgs => promise<unit>
+        ),
       },
     ],
     ~startBlock=0,
@@ -69,6 +68,7 @@ let makeChainState = (
     ~indexingAddresses,
     ~sourceManager=SourceManager.make(~sources=[mockSource.source], ~isRealtime=false),
     ~maxReorgDepth=200,
+    ~shouldRollbackOnReorg=false,
     ~committedProgressBlockNumber=-1,
     ~isProgressAtHead,
     ~logger=Logging.getLogger(),
@@ -99,7 +99,14 @@ let makeFetchingChainState = (~chainId, ~knownHeight, ~latestFetchedBlock) => {
     Dict.fromArray([
       (
         address->Address.toString,
-        ({contractName: "MockContract", address, registrationBlock: -1, effectiveStartBlock: 0}: Internal.indexingContract),
+        (
+          {
+            contractName: "MockContract",
+            address,
+            registrationBlock: -1,
+            effectiveStartBlock: 0,
+          }: Internal.indexingContract
+        ),
       ),
     ])->(Utils.magic: dict<Internal.indexingContract> => IndexingAddresses.t)
   let fetchState: FetchState.t = {
@@ -129,6 +136,7 @@ let makeFetchingChainState = (~chainId, ~knownHeight, ~latestFetchedBlock) => {
     ~indexingAddresses,
     ~sourceManager=SourceManager.make(~sources=[mockSource.source], ~isRealtime=false),
     ~maxReorgDepth=200,
+    ~shouldRollbackOnReorg=false,
     ~committedProgressBlockNumber=-1,
     ~logger=Logging.getLogger(),
   )
@@ -162,14 +170,15 @@ let makeRegistration = (~contractName, ~index): Internal.onEventRegistration =>
 
 describe("ChainState event registration ownership", () => {
   it("rejects a registration whose index differs from its ChainState position", t => {
-    t.expect(() =>
-      makeChainState(
-        ~chainId=1,
-        ~knownHeight=10,
-        ~frontier=10,
-        ~firstEventBlock=0,
-        ~onEventRegistrations=[makeRegistration(~contractName="ContractA", ~index=4)],
-      )->ignore
+    t.expect(
+      () =>
+        makeChainState(
+          ~chainId=1,
+          ~knownHeight=10,
+          ~frontier=10,
+          ~firstEventBlock=0,
+          ~onEventRegistrations=[makeRegistration(~contractName="ContractA", ~index=4)],
+        )->ignore,
     ).toThrowError(
       "Invalid onEvent registration index for chain 1: ContractA.EventWithoutFields has index 4, but its ChainState position is 0.",
     )
@@ -178,9 +187,27 @@ describe("ChainState event registration ownership", () => {
 
 describe("CrossChainState fetch control", () => {
   it("priorityOrder visits the furthest-behind chain first", t => {
-    let a = makeChainState(~chainId=1, ~knownHeight=1000, ~frontier=100, ~firstEventBlock=0, ~bufferBlocks=[100])
-    let b = makeChainState(~chainId=2, ~knownHeight=1000, ~frontier=500, ~firstEventBlock=0, ~bufferBlocks=[500])
-    let cHead = makeChainState(~chainId=3, ~knownHeight=1000, ~frontier=1000, ~firstEventBlock=0, ~bufferBlocks=[950])
+    let a = makeChainState(
+      ~chainId=1,
+      ~knownHeight=1000,
+      ~frontier=100,
+      ~firstEventBlock=0,
+      ~bufferBlocks=[100],
+    )
+    let b = makeChainState(
+      ~chainId=2,
+      ~knownHeight=1000,
+      ~frontier=500,
+      ~firstEventBlock=0,
+      ~bufferBlocks=[500],
+    )
+    let cHead = makeChainState(
+      ~chainId=3,
+      ~knownHeight=1000,
+      ~frontier=1000,
+      ~firstEventBlock=0,
+      ~bufferBlocks=[950],
+    )
 
     let cm = makeCrossChainState(~chainStatesList=[cHead, a, b])
 
@@ -200,10 +227,12 @@ describe("CrossChainState fetch control", () => {
     let cm = makeCrossChainState(~chainStatesList=[a, b], ~isRealtime=true)
 
     let dispatched = []
-    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
-      dispatched->Array.push((chain->ChainMap.Chain.toChainId, action))->ignore
-      Promise.resolve()
-    })
+    await cm->CrossChainState.checkAndFetch(
+      ~dispatchChain=(~chain, ~action) => {
+        dispatched->Array.push((chain->ChainMap.Chain.toChainId, action))->ignore
+        Promise.resolve()
+      },
+    )
 
     t.expect(
       dispatched->Array.map(((chainId, action)) => (chainId, action === WaitingForNewBlock)),
@@ -230,10 +259,12 @@ describe("CrossChainState fetch control", () => {
     let cm = makeCrossChainState(~chainStatesList=[a, b], ~targetBufferSize=100)
 
     let dispatched = []
-    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action as _) => {
-      dispatched->Array.push(chain->ChainMap.Chain.toChainId)->ignore
-      Promise.resolve()
-    })
+    await cm->CrossChainState.checkAndFetch(
+      ~dispatchChain=(~chain, ~action as _) => {
+        dispatched->Array.push(chain->ChainMap.Chain.toChainId)->ignore
+        Promise.resolve()
+      },
+    )
 
     t.expect(dispatched).toEqual([])
   })
@@ -246,18 +277,20 @@ describe("CrossChainState fetch control", () => {
     let cm = makeCrossChainState(~chainStatesList=[cs], ~targetBufferSize=1)
 
     let dispatched = []
-    await cm->CrossChainState.checkAndFetch(~dispatchChain=(~chain, ~action) => {
-      dispatched
-      ->Array.push((
-        chain->ChainMap.Chain.toChainId,
-        switch action {
-        | Ready(queries) => queries->Array.length
-        | _ => 0
-        },
-      ))
-      ->ignore
-      Promise.resolve()
-    })
+    await cm->CrossChainState.checkAndFetch(
+      ~dispatchChain=(~chain, ~action) => {
+        dispatched
+        ->Array.push((
+          chain->ChainMap.Chain.toChainId,
+          switch action {
+          | Ready(queries) => queries->Array.length
+          | _ => 0
+          },
+        ))
+        ->ignore
+        Promise.resolve()
+      },
+    )
 
     t.expect(dispatched).toEqual([(1, 1)])
   })

--- a/scenarios/test_codegen/test/lib_tests/IndexerLoop_test.res
+++ b/scenarios/test_codegen/test/lib_tests/IndexerLoop_test.res
@@ -33,11 +33,9 @@ let makeState = (~onError=errHandler => errHandler->ErrorHandling.raiseExn, ()) 
       ~chainConfig,
       ~fetchState,
       ~indexingAddresses,
-      ~sourceManager=SourceManager.make(
-        ~sources=[mockSource.source],
-        ~isRealtime=false,
-      ),
+      ~sourceManager=SourceManager.make(~sources=[mockSource.source], ~isRealtime=false),
       ~maxReorgDepth=200,
+      ~shouldRollbackOnReorg=false,
       ~committedProgressBlockNumber=-1,
       ~logger=Logging.getLogger(),
     )
@@ -71,7 +69,11 @@ describe("Indexer loop", () => {
   Async.it("startProcessing releases the flag once there is no work", async t => {
     let state = makeState()
 
-    await BatchProcessing.startProcessing(state, ~scheduleFetch=() => (), ~scheduleRollback=() => ())
+    await BatchProcessing.startProcessing(
+      state,
+      ~scheduleFetch=() => (),
+      ~scheduleRollback=() => (),
+    )
 
     t.expect(
       state->IndexerState.isProcessing,
@@ -84,7 +86,11 @@ describe("Indexer loop", () => {
     // Simulate an in-flight loop instance.
     state->IndexerState.beginProcessing
 
-    await BatchProcessing.startProcessing(state, ~scheduleFetch=() => (), ~scheduleRollback=() => ())
+    await BatchProcessing.startProcessing(
+      state,
+      ~scheduleFetch=() => (),
+      ~scheduleRollback=() => (),
+    )
 
     t.expect(
       state->IndexerState.isProcessing,

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -1504,6 +1504,39 @@ describe("SourceManager.executeQuery", () => {
     t.expect((await p).parsedQueueItems).toEqual([])
   })
 
+  Async.it("Gives up with the source error once maxRetries is exhausted", async t => {
+    let sourceMock = MockIndexer.Source.make([#getItemsOrThrow])
+    let sourceManager = SourceManager.make(
+      ~isRealtime=false,
+      ~sources=[sourceMock.source],
+      ~maxRetries=Some(1),
+    )
+    let p = sourceManager->SourceManager.executeQuery(
+      ~query=mockQuery(),
+      ~isRealtime=false,
+      ~knownHeight=100,
+    )
+    let failure = Source.GetItemsError(
+      FailedGettingItems({
+        exn: JsError.make("Connection refused")->(Utils.magic: JsError.t => exn),
+        attemptedToBlock: 100,
+        retry: WithBackoff({message: "Failed to fetch", backoffMillis: 0}),
+      }),
+    )
+    (sourceMock.getItemsOrThrowCalls->Utils.Array.firstUnsafe).reject(failure)
+    await Utils.delay(50)
+    switch sourceMock.getItemsOrThrowCalls {
+    | [call] => call.reject(failure)
+    | _ => JsError.throwWithMessage("Expected a retry call after the first failure")
+    }
+    try {
+      let _ = await p
+      JsError.throwWithMessage("Should not have resolved")
+    } catch {
+    | JsExn(e) => t.expect(e->JsExn.message).toEqual(Some("Connection refused"))
+    }
+  })
+
   Async.it("Rethrows unknown errors", async t => {
     let sourceMock = MockIndexer.Source.make([#getItemsOrThrow])
     let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[sourceMock.source])

--- a/scenarios/test_codegen/vitest.config.ts
+++ b/scenarios/test_codegen/vitest.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
     maxWorkers: 1,
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    // Some tests hit live HyperSync/RPC endpoints; on CI a single hung
+    // connection shouldn't fail the run. Tests run sequentially with a fresh
+    // indexer per test, so a retry starts from a clean slate.
+    retry: process.env.CI ? 1 : 0,
     setupFiles: ["test/setup.ts"],
     passWithNoTests: true,
     server: {

--- a/scenarios/test_codegen/vitest.config.ts
+++ b/scenarios/test_codegen/vitest.config.ts
@@ -22,10 +22,6 @@ export default defineConfig({
     maxWorkers: 1,
     testTimeout: 30_000,
     hookTimeout: 30_000,
-    // Some tests hit live HyperSync/RPC endpoints; on CI a single hung
-    // connection shouldn't fail the run. Tests run sequentially with a fresh
-    // indexer per test, so a retry starts from a clean slate.
-    retry: process.env.CI ? 1 : 0,
     setupFiles: ["test/setup.ts"],
     passWithNoTests: true,
     server: {


### PR DESCRIPTION
## Summary

Follow-up to the block-store reorg PR addressing review findings: a single authority for reorg configuration, fail-fast behavior for test runs against unreachable sources, restored reorg-threshold test coverage, and hash-collision-based seam validation for paginated block-hash fetches.

## Key Changes

**Reorg config authority (ReScript)**
- `maxReorgDepth` and `shouldRollbackOnReorg` now come from a single authority — the resumed-from-DB chain state — everywhere: batch checkpoint gating, `getHighestBlockBelowThreshold`, the reorg log/rollback decision, and the pre-threshold `blockLag`
- Both are required parameters of `ChainState.make` (previously silently defaulted)

**Seam validation for block-hash fetches**
- A single HyperSync response is internally consistent, so paginated block-hash requests re-request the last returned block: a fork switch between requests surfaces as a hash collision on the overlapping block via the existing duplicate detection
- RPC fetches every block separately, so each block's `parentHash` becomes a minimal `(number-1, hash)` row and the page's existing collision check cross-validates separately fetched blocks
- Block-hash queries select only number + hash; parent-link validation and its parent-field selections are removed

**Fail-fast test runs**
- `SourceManager` accepts a retry cap (`ENVIO_MAX_SOURCE_RETRIES`) enforced across the height, `getItems`, and `getBlockHashes` retry loops, including the subscription fallback poller; when exhausted, the run fails with the underlying source error
- The test-indexer worker caps retries at 3, so a test against an unreachable endpoint reports the real cause instead of hanging until the test-runner timeout
- The EVM block-hash paginator surfaces no-progress as a retryable error (matching SVM) instead of silently sleeping in-process; SourceManager owns backoff, logging, and failover
- Rate-limit mapping applies uniformly to EVM and SVM native failures; retry logs use the error's own message

**Tests**
- New `ChainState reorg threshold` suite: threshold derivation from `(knownHeight, maxReorgDepth)` including depth changes across restarts and clamping, `registerReorgGuard` boundary behavior, and hash retention through `applyBatchProgress`
- Live-endpoint tests (HyperSync client, RPC height, mainnet-fetching `createTestIndexer` tests, e2e smoke test) retry up to 3 times; deterministic tests fail on the first attempt
- Templates run their suites with a 30s per-test vitest timeout

**Robustness**
- `field_table`: hard width checks on fixed columns, 64-field cap on masks

https://claude.ai/code/session_019RcUijSCoEY19MCEbdh6fL