### PR TITLE
Replace prune throttler with smart scheduling in write loop

### DIFF
--- a/packages/envio/src/BatchProcessing.res
+++ b/packages/envio/src/BatchProcessing.res
@@ -180,13 +180,6 @@ and processNextBatch = async (state: IndexerState.t, ~scheduleFetch): unit => {
           )
         } else {
           ChainMetadata.stage(state)
-          if (
-            state
-            ->IndexerState.config
-            ->Config.shouldPruneHistory(~isInReorgThreshold=state->IndexerState.isInReorgThreshold)
-          ) {
-            state->PruneStaleHistory.schedule
-          }
         }
       }
     }

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -6,23 +6,6 @@ type rollbackState =
   | FoundReorgDepth({chain: chain, rollbackTargetBlockNumber: int})
   | RollbackReady({eventsProcessedDiffByChain: dict<float>})
 
-module WriteThrottlers = {
-  type t = {pruneStaleEntityHistory: Throttler.t}
-  let make = (): t => {
-    let pruneStaleEntityHistory = {
-      let intervalMillis = Env.ThrottleWrites.pruneStaleDataIntervalMillis
-      let logger = Logging.createChild(
-        ~params={
-          "context": "Throttler for pruning stale entity history data",
-          "intervalMillis": intervalMillis,
-        },
-      )
-      Throttler.make(~intervalMillis, ~logger)
-    }
-    {pruneStaleEntityHistory: pruneStaleEntityHistory}
-  }
-}
-
 module EntityTables = {
   type t = dict<InMemoryTable.Entity.t>
   exception UndefinedEntity({entityName: string})
@@ -94,7 +77,9 @@ type t = {
   crossChainState: CrossChainState.t,
   mutable rollbackState: rollbackState,
   indexerStartTime: Date.t,
-  writeThrottlers: WriteThrottlers.t,
+  // When an entity's history was last pruned. No key = never pruned yet,
+  // which counts as overdue.
+  lastPrunedAtMillis: dict<float>,
   loadManager: LoadManager.t,
   keepProcessAlive: bool,
   exitAfterFirstEventBlock: bool,
@@ -164,7 +149,7 @@ let make = (
     ),
     indexerStartTime: Date.make(),
     rollbackState: NoRollback,
-    writeThrottlers: WriteThrottlers.make(),
+    lastPrunedAtMillis: Dict.make(),
     loadManager: LoadManager.make(),
     keepProcessAlive: isDevelopmentMode || shouldUseTui,
     exitAfterFirstEventBlock,
@@ -405,7 +390,7 @@ let keepProcessAlive = (state: t) => state.keepProcessAlive
 let exitAfterFirstEventBlock = (state: t) => state.exitAfterFirstEventBlock
 let isStopped = (state: t) => state.isStopped
 let epoch = (state: t) => state.epoch
-let pruneStaleEntityHistoryThrottler = (state: t) => state.writeThrottlers.pruneStaleEntityHistory
+let lastPrunedAtMillis = (state: t) => state.lastPrunedAtMillis
 let simulateDeadInputTracker = (state: t) => state.simulateDeadInputTracker
 
 // --- Store domain operations. ---

--- a/packages/envio/src/IndexerState.resi
+++ b/packages/envio/src/IndexerState.resi
@@ -106,7 +106,7 @@ let keepProcessAlive: t => bool
 let exitAfterFirstEventBlock: t => bool
 let isStopped: t => bool
 let epoch: t => int
-let pruneStaleEntityHistoryThrottler: t => Throttler.t
+let lastPrunedAtMillis: t => dict<float>
 let simulateDeadInputTracker: t => option<SimulateDeadInputTracker.t>
 
 // Store domain operations.

--- a/packages/envio/src/PruneStaleHistory.res
+++ b/packages/envio/src/PruneStaleHistory.res
@@ -1,45 +1,140 @@
-// Throttled prune of stale entity-history rows below the safe checkpoint.
+// Prune of stale entity-history rows below the safe checkpoint.
+//
+// Pruning must never run concurrently with a write to the same entity's history
+// table: the prune's anchor deletion relies on "no history after the safe
+// checkpoint", which a concurrently committing batch can falsify, losing the
+// anchor and breaking a later rollback. The write loop enforces the safety by
+// running the concurrent group only for entities absent from the batch being
+// written (and awaiting it before the next write starts), and the forced group
+// alone after the write.
 
-let runPrune = async (state: IndexerState.t) => {
-  switch state->IndexerState.getSafeCheckpointId {
-  | None => ()
-  | Some(safeCheckpointId) =>
-    let persistence = state->IndexerState.persistence
-    await persistence.storage.pruneStaleCheckpoints(~safeCheckpointId)
+let maxEntitiesPerWrite = 5
+let forcedIntervalMultiplier = 5.
 
-    for idx in 0 to persistence.allEntities->Array.length - 1 {
-      if idx !== 0 {
-        // Add some delay between entities
-        // To unblock the pg client if it's needed for something else
-        await Utils.delay(1000)
-      }
-      let entityConfig = persistence.allEntities->Array.getUnsafe(idx)
-      let timeRef = Performance.now()
-      try {
-        let () = await persistence.storage.pruneStaleEntityHistory(
-          ~entityName=entityConfig.name,
-          ~entityIndex=entityConfig.index,
+type targets = {
+  safeCheckpointId: Internal.checkpointId,
+  concurrent: array<Internal.entityConfig>,
+  forced: array<Internal.entityConfig>,
+}
+
+let selectFrom = (
+  ~allEntities: array<Internal.entityConfig>,
+  ~lastPrunedAtMillis: dict<float>,
+  ~writtenEntityNames: Utils.Set.t<string>,
+  ~isRollback,
+  ~nowMillis,
+  ~intervalMillis,
+  ~safeCheckpointId,
+) => {
+  let lastPrunedAt = (entityConfig: Internal.entityConfig) =>
+    lastPrunedAtMillis
+    ->Utils.Dict.dangerouslyGetNonOption(entityConfig.name)
+    ->Option.getOr(0.)
+  let byOldestPrune = (a, b) => lastPrunedAt(a) -. lastPrunedAt(b)
+
+  let candidates = allEntities->Array.filter(entityConfig => entityConfig.storage.postgres)
+
+  let concurrent = isRollback
+    ? []
+    : candidates
+      ->Array.filter(entityConfig =>
+        !(writtenEntityNames->Utils.Set.has(entityConfig.name)) &&
+        nowMillis -. lastPrunedAt(entityConfig) >= intervalMillis
+      )
+      ->Array.toSorted(byOldestPrune)
+      ->Array.slice(~start=0, ~end=maxEntitiesPerWrite)
+
+  let concurrentNames = Utils.Set.make()
+  concurrent->Array.forEach(entityConfig =>
+    concurrentNames->Utils.Set.add(entityConfig.name)->ignore
+  )
+
+  let forced =
+    candidates
+    ->Array.filter(entityConfig =>
+      !(concurrentNames->Utils.Set.has(entityConfig.name)) &&
+      nowMillis -. lastPrunedAt(entityConfig) >= intervalMillis *. forcedIntervalMultiplier
+    )
+    ->Array.toSorted(byOldestPrune)
+    ->Array.slice(~start=0, ~end=maxEntitiesPerWrite)
+
+  {safeCheckpointId, concurrent, forced}
+}
+
+let select = (state: IndexerState.t, ~writtenEntityNames, ~isRollback) => {
+  let config = state->IndexerState.config
+  if config->Config.shouldPruneHistory(~isInReorgThreshold=state->IndexerState.isInReorgThreshold) {
+    switch state->IndexerState.getSafeCheckpointId {
+    | None => None
+    | Some(safeCheckpointId) =>
+      Some(
+        selectFrom(
+          ~allEntities=(state->IndexerState.persistence).allEntities,
+          ~lastPrunedAtMillis=state->IndexerState.lastPrunedAtMillis,
+          ~writtenEntityNames,
+          ~isRollback,
+          ~nowMillis=Date.now(),
+          ~intervalMillis=Env.ThrottleWrites.pruneStaleDataIntervalMillis->Int.toFloat,
           ~safeCheckpointId,
-        )
-      } catch {
-      | exn =>
-        exn->ErrorHandling.mkLogAndRaise(
-          ~msg=`Failed to prune stale entity history`,
-          ~logger=Logging.createChild(
-            ~params={
-              "entityName": entityConfig.name,
-              "safeCheckpointId": safeCheckpointId,
-            },
-          ),
-        )
-      }
+        ),
+      )
+    }
+  } else {
+    None
+  }
+}
+
+let pruneEntities = async (state: IndexerState.t, ~entities, ~safeCheckpointId) => {
+  let persistence = state->IndexerState.persistence
+  for idx in 0 to entities->Array.length - 1 {
+    let entityConfig: Internal.entityConfig = entities->Array.getUnsafe(idx)
+    let timeRef = Performance.now()
+    switch await persistence.storage.pruneStaleEntityHistory(
+      ~entityName=entityConfig.name,
+      ~entityIndex=entityConfig.index,
+      ~safeCheckpointId,
+    ) {
+    | () =>
+      state->IndexerState.lastPrunedAtMillis->Dict.set(entityConfig.name, Date.now())
       Prometheus.RollbackHistoryPrune.increment(
         ~timeSeconds=Performance.secondsSince(timeRef),
         ~entityName=entityConfig.name,
       )
+    | exception exn =>
+      // Pruning is cleanup; a failure must not fail the write loop.
+      Logging.createChild(
+        ~params={
+          "entityName": entityConfig.name,
+          "safeCheckpointId": safeCheckpointId,
+        },
+      )->Logging.childErrorWithExn(exn->Utils.prettifyExn, `Failed to prune stale entity history`)
     }
   }
 }
 
-let schedule = (state: IndexerState.t) =>
-  state->IndexerState.pruneStaleEntityHistoryThrottler->Throttler.schedule(() => runPrune(state))
+let runConcurrent = async (state: IndexerState.t, ~targets) => {
+  switch targets {
+  | Some({safeCheckpointId, concurrent, forced}) =>
+    if concurrent->Utils.Array.notEmpty || forced->Utils.Array.notEmpty {
+      switch await (state->IndexerState.persistence).storage.pruneStaleCheckpoints(
+        ~safeCheckpointId,
+      ) {
+      | () => ()
+      | exception exn =>
+        Logging.createChild(
+          ~params={"safeCheckpointId": safeCheckpointId},
+        )->Logging.childErrorWithExn(exn->Utils.prettifyExn, `Failed to prune stale checkpoints`)
+      }
+    }
+    await pruneEntities(state, ~entities=concurrent, ~safeCheckpointId)
+  | None => ()
+  }
+}
+
+let runForced = async (state: IndexerState.t, ~targets) => {
+  switch targets {
+  | Some({safeCheckpointId, forced}) =>
+    await pruneEntities(state, ~entities=forced, ~safeCheckpointId)
+  | None => ()
+  }
+}

--- a/packages/envio/src/PruneStaleHistory.res
+++ b/packages/envio/src/PruneStaleHistory.res
@@ -97,13 +97,15 @@ let pruneEntities = async (state: IndexerState.t, ~entities, ~safeCheckpointId) 
   for idx in 0 to entities->Array.length - 1 {
     let entityConfig: Internal.entityConfig = entities->Array.getUnsafe(idx)
     let timeRef = Performance.now()
+    // Recorded for failures too, so a failing prune retries on the same
+    // interval instead of on every write.
+    state->IndexerState.lastPrunedAtMillis->Dict.set(entityConfig.name, Date.now())
     switch await persistence.storage.pruneStaleEntityHistory(
       ~entityName=entityConfig.name,
       ~entityIndex=entityConfig.index,
       ~safeCheckpointId,
     ) {
     | () =>
-      state->IndexerState.lastPrunedAtMillis->Dict.set(entityConfig.name, Date.now())
       Prometheus.RollbackHistoryPrune.increment(
         ~timeSeconds=Performance.secondsSince(timeRef),
         ~entityName=entityConfig.name,
@@ -120,29 +122,35 @@ let pruneEntities = async (state: IndexerState.t, ~entities, ~safeCheckpointId) 
   }
 }
 
+let pruneCheckpoints = async (state: IndexerState.t, ~safeCheckpointId) => {
+  switch await (state->IndexerState.persistence).storage.pruneStaleCheckpoints(~safeCheckpointId) {
+  | () => ()
+  | exception exn =>
+    Logging.createChild(~params={"safeCheckpointId": safeCheckpointId})->Logging.childErrorWithExn(
+      exn->Utils.prettifyExn,
+      `Failed to prune stale checkpoints`,
+    )
+  }
+}
+
 let runConcurrent = async (state: IndexerState.t, ~targets) => {
   switch targets {
-  | Some({safeCheckpointId, concurrent, forced}) =>
-    if concurrent->Utils.Array.notEmpty || forced->Utils.Array.notEmpty {
-      switch await (state->IndexerState.persistence).storage.pruneStaleCheckpoints(
-        ~safeCheckpointId,
-      ) {
-      | () => ()
-      | exception exn =>
-        Logging.createChild(
-          ~params={"safeCheckpointId": safeCheckpointId},
-        )->Logging.childErrorWithExn(exn->Utils.prettifyExn, `Failed to prune stale checkpoints`)
-      }
-    }
+  | Some({safeCheckpointId, concurrent}) if concurrent->Utils.Array.notEmpty =>
+    await pruneCheckpoints(state, ~safeCheckpointId)
     await pruneEntities(state, ~entities=concurrent, ~safeCheckpointId)
-  | None => ()
+  | Some(_) | None => ()
   }
 }
 
 let runForced = async (state: IndexerState.t, ~targets) => {
   switch targets {
-  | Some({safeCheckpointId, forced}) =>
+  | Some({safeCheckpointId, concurrent, forced}) if forced->Utils.Array.notEmpty =>
+    // When nothing ran concurrently (eg a rollback write), checkpoint pruning
+    // lands here, after the write, so it never overlaps a rollback transaction.
+    if concurrent->Utils.Array.isEmpty {
+      await pruneCheckpoints(state, ~safeCheckpointId)
+    }
     await pruneEntities(state, ~entities=forced, ~safeCheckpointId)
-  | None => ()
+  | Some(_) | None => ()
   }
 }

--- a/packages/envio/src/PruneStaleHistory.res
+++ b/packages/envio/src/PruneStaleHistory.res
@@ -26,39 +26,47 @@ let selectFrom = (
   ~intervalMillis,
   ~safeCheckpointId,
 ) => {
-  let lastPrunedAt = (entityConfig: Internal.entityConfig) =>
-    lastPrunedAtMillis
-    ->Utils.Dict.dangerouslyGetNonOption(entityConfig.name)
-    ->Option.getOr(0.)
-  let byOldestPrune = (a, b) => lastPrunedAt(a) -. lastPrunedAt(b)
+  let byOldestPrune = ((a, _), (b, _)) => a -. b
+  let toEntities = candidates => candidates->Array.map(((_, entityConfig)) => entityConfig)
 
-  let candidates = allEntities->Array.filter(entityConfig => entityConfig.storage.postgres)
-
-  let concurrent = isRollback
-    ? []
-    : candidates
-      ->Array.filter(entityConfig =>
+  let concurrentCandidates = []
+  let forcedCandidates = []
+  allEntities->Array.forEach(entityConfig => {
+    if entityConfig.storage.postgres {
+      let lastPrunedAt =
+        lastPrunedAtMillis
+        ->Utils.Dict.dangerouslyGetNonOption(entityConfig.name)
+        ->Option.getOr(0.)
+      if (
+        !isRollback &&
         !(writtenEntityNames->Utils.Set.has(entityConfig.name)) &&
-        nowMillis -. lastPrunedAt(entityConfig) >= intervalMillis
-      )
-      ->Array.toSorted(byOldestPrune)
-      ->Array.slice(~start=0, ~end=maxEntitiesPerWrite)
+        nowMillis -. lastPrunedAt >= intervalMillis
+      ) {
+        concurrentCandidates->Array.push((lastPrunedAt, entityConfig))
+      } else if nowMillis -. lastPrunedAt >= intervalMillis *. forcedIntervalMultiplier {
+        forcedCandidates->Array.push((lastPrunedAt, entityConfig))
+      }
+    }
+  })
 
-  let concurrentNames = Utils.Set.make()
-  concurrent->Array.forEach(entityConfig =>
-    concurrentNames->Utils.Set.add(entityConfig.name)->ignore
-  )
+  let sortedConcurrent = concurrentCandidates->Array.toSorted(byOldestPrune)
+  // Concurrent candidates beyond the cap are not selected, so the starved
+  // ones among them still qualify for the forced group.
+  for idx in maxEntitiesPerWrite to sortedConcurrent->Array.length - 1 {
+    let (lastPrunedAt, _) = sortedConcurrent->Array.getUnsafe(idx)
+    if nowMillis -. lastPrunedAt >= intervalMillis *. forcedIntervalMultiplier {
+      forcedCandidates->Array.push(sortedConcurrent->Array.getUnsafe(idx))
+    }
+  }
 
-  let forced =
-    candidates
-    ->Array.filter(entityConfig =>
-      !(concurrentNames->Utils.Set.has(entityConfig.name)) &&
-      nowMillis -. lastPrunedAt(entityConfig) >= intervalMillis *. forcedIntervalMultiplier
-    )
+  {
+    safeCheckpointId,
+    concurrent: sortedConcurrent->Array.slice(~start=0, ~end=maxEntitiesPerWrite)->toEntities,
+    forced: forcedCandidates
     ->Array.toSorted(byOldestPrune)
     ->Array.slice(~start=0, ~end=maxEntitiesPerWrite)
-
-  {safeCheckpointId, concurrent, forced}
+    ->toEntities,
+  }
 }
 
 let select = (state: IndexerState.t, ~writtenEntityNames, ~isRollback) => {

--- a/packages/envio/src/Writing.res
+++ b/packages/envio/src/Writing.res
@@ -113,16 +113,35 @@ let runOneWrite = async (state: IndexerState.t) => {
     })
     let updatedEffectsCache = snapshotEffects(state, ~cache)
 
-    await persistence.storage.writeBatch(
-      ~batch,
-      ~rollback,
-      ~isInReorgThreshold=batch.isInReorgThreshold,
-      ~config,
-      ~allEntities=persistence.allEntities,
-      ~updatedEntities,
-      ~updatedEffectsCache,
-      ~chainMetaData,
+    let writtenEntityNames = Utils.Set.make()
+    updatedEntities->Array.forEach(({entityConfig}) =>
+      writtenEntityNames->Utils.Set.add(entityConfig.name)->ignore
     )
+    let pruneTargets = PruneStaleHistory.select(
+      state,
+      ~writtenEntityNames,
+      ~isRollback=rollback->Option.isSome,
+    )
+
+    // The prune runs concurrently with the batch write, but only for entities
+    // absent from it, so they never touch the same history table. Both must be
+    // awaited before the next write starts, otherwise a still-running prune
+    // could overlap the next batch's history writes and lose an anchor (which
+    // breaks a later rollback). Rollback writes touch every history table, so
+    // they get no concurrent prune at all.
+    let _ = await Promise.all2((
+      persistence.storage.writeBatch(
+        ~batch,
+        ~rollback,
+        ~isInReorgThreshold=batch.isInReorgThreshold,
+        ~config,
+        ~allEntities=persistence.allEntities,
+        ~updatedEntities,
+        ~updatedEffectsCache,
+        ~chainMetaData,
+      ),
+      PruneStaleHistory.runConcurrent(state, ~targets=pruneTargets),
+    ))
 
     state->IndexerState.markCommitted(~upToCheckpointId)
 
@@ -131,6 +150,10 @@ let runOneWrite = async (state: IndexerState.t) => {
       await RollbackCommit.fire(~progressBlockNumberByChainId)
     | _ => ()
     }
+
+    // Entities starved of the concurrent prune (eg written in every batch) are
+    // pruned here with no other pg writer running.
+    await PruneStaleHistory.runForced(state, ~targets=pruneTargets)
   }
 }
 

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -179,10 +179,12 @@ module Storage = {
         },
         reset: () => JsError.throwWithMessage("Not implemented"),
         setChainMeta: _ => JsError.throwWithMessage("Not implemented"),
-        pruneStaleCheckpoints: (~safeCheckpointId as _) =>
-          JsError.throwWithMessage("Not implemented"),
-        pruneStaleEntityHistory: (~entityName as _, ~entityIndex as _, ~safeCheckpointId as _) =>
-          JsError.throwWithMessage("Not implemented"),
+        pruneStaleCheckpoints: async (~safeCheckpointId as _) => (),
+        pruneStaleEntityHistory: async (
+          ~entityName as _,
+          ~entityIndex as _,
+          ~safeCheckpointId as _,
+        ) => (),
         getRollbackTargetCheckpoint: (~reorgChainId as _, ~lastKnownValidBlockNumber as _) =>
           JsError.throwWithMessage("Not implemented"),
         getRollbackProgressDiff: (~rollbackTargetCheckpointId as _) =>

--- a/scenarios/test_codegen/test/lib_tests/PruneStaleHistory_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PruneStaleHistory_test.res
@@ -1,0 +1,131 @@
+open Vitest
+
+let makeEntityConfig = (~name, ~postgres=true, ~clickhouse=false): Internal.entityConfig =>
+  {
+    "name": name,
+    "index": 0,
+    "storage": {"postgres": postgres, "clickhouse": clickhouse},
+  }->(
+    Utils.magic: {"name": string, "index": int, "storage": {"postgres": bool, "clickhouse": bool}} => Internal.entityConfig
+  )
+
+let toNames = (targets: PruneStaleHistory.targets) => {
+  "concurrent": targets.concurrent->Array.map(entityConfig => entityConfig.name),
+  "forced": targets.forced->Array.map(entityConfig => entityConfig.name),
+}
+
+let intervalMillis = 1000.
+let nowMillis = 100_000.
+
+describe("PruneStaleHistory.selectFrom", () => {
+  it("Selects up to 5 overdue entities oldest-first, excluding ones written in the batch", t => {
+    let lastPrunedAtMillis = Dict.fromArray([
+      ("recent", 99_500.),
+      ("written", 95_500.),
+      ("oldA", 95_000.),
+      ("oldB", 96_000.),
+      ("oldC", 97_000.),
+      ("oldD", 99_000.),
+    ])
+
+    let targets = PruneStaleHistory.selectFrom(
+      ~allEntities=["recent", "written", "never", "oldA", "oldB", "oldC", "oldD"]->Array.map(name =>
+        makeEntityConfig(~name)
+      ),
+      ~lastPrunedAtMillis,
+      ~writtenEntityNames=Utils.Set.fromArray(["written"]),
+      ~isRollback=false,
+      ~nowMillis,
+      ~intervalMillis,
+      ~safeCheckpointId=100n,
+    )
+
+    t.expect({
+      "safeCheckpointId": targets.safeCheckpointId,
+      "concurrent": (targets->toNames)["concurrent"],
+      "forced": (targets->toNames)["forced"],
+    }).toEqual({
+      "safeCheckpointId": 100n,
+      "concurrent": ["never", "oldA", "oldB", "oldC", "oldD"],
+      "forced": [],
+    })
+  })
+
+  it("Caps concurrent at 5 and force-prunes starved entities, even ones written in the batch", t => {
+    let lastPrunedAtMillis = Dict.fromArray([
+      ("e2", 10_000.),
+      ("e3", 20_000.),
+      ("e4", 30_000.),
+      ("e5", 40_000.),
+      ("e6", 50_000.),
+      ("e7", 60_000.),
+      ("e8", 70_000.),
+    ])
+
+    let targets = PruneStaleHistory.selectFrom(
+      ~allEntities=["e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8"]->Array.map(name =>
+        makeEntityConfig(~name)
+      ),
+      ~lastPrunedAtMillis,
+      ~writtenEntityNames=Utils.Set.fromArray(["e1", "e2"]),
+      ~isRollback=false,
+      ~nowMillis,
+      ~intervalMillis,
+      ~safeCheckpointId=100n,
+    )
+
+    t.expect(targets->toNames).toEqual({
+      "concurrent": ["e3", "e4", "e5", "e6", "e7"],
+      "forced": ["e1", "e2", "e8"],
+    })
+  })
+
+  it("Selects no concurrent prunes for a rollback write, but keeps forced ones", t => {
+    let lastPrunedAtMillis = Dict.fromArray([
+      ("e2", 10_000.),
+      ("e3", 20_000.),
+      ("e4", 30_000.),
+      ("e5", 40_000.),
+      ("e6", 50_000.),
+      ("e7", 60_000.),
+      ("e8", 70_000.),
+    ])
+
+    let targets = PruneStaleHistory.selectFrom(
+      ~allEntities=["e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8"]->Array.map(name =>
+        makeEntityConfig(~name)
+      ),
+      ~lastPrunedAtMillis,
+      ~writtenEntityNames=Utils.Set.make(),
+      ~isRollback=true,
+      ~nowMillis,
+      ~intervalMillis,
+      ~safeCheckpointId=100n,
+    )
+
+    t.expect(targets->toNames).toEqual({
+      "concurrent": [],
+      "forced": ["e1", "e2", "e3", "e4", "e5"],
+    })
+  })
+
+  it("Skips entities not stored in postgres", t => {
+    let targets = PruneStaleHistory.selectFrom(
+      ~allEntities=[
+        makeEntityConfig(~name="pg"),
+        makeEntityConfig(~name="chOnly", ~postgres=false, ~clickhouse=true),
+      ],
+      ~lastPrunedAtMillis=Dict.make(),
+      ~writtenEntityNames=Utils.Set.make(),
+      ~isRollback=false,
+      ~nowMillis,
+      ~intervalMillis,
+      ~safeCheckpointId=100n,
+    )
+
+    t.expect(targets->toNames).toEqual({
+      "concurrent": ["pg"],
+      "forced": [],
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Refactors entity history pruning from a throttled background task to an integrated part of the write loop. Pruning now runs concurrently with batch writes (for non-written entities) and sequentially after writes (for starved entities), eliminating the need for a separate throttler while maintaining safety guarantees.

## Key Changes

- **Removed throttler-based pruning**: Deleted `WriteThrottlers` module and `Throttler.schedule` call from batch processing
- **Integrated pruning into write loop**: 
  - `PruneStaleHistory.select()` determines which entities to prune based on write batch contents and staleness
  - `runConcurrent()` prunes non-written entities in parallel with batch writes
  - `runForced()` prunes starved entities (written in every batch) after writes complete
- **Smart entity selection**:
  - Concurrent group: up to 5 oldest-due entities not in the current batch (skipped during rollbacks)
  - Forced group: entities exceeding 5× the normal interval, even if written in batch
  - Only targets PostgreSQL-backed entities
- **Safety enforcement**: Concurrent and forced prunes are awaited before the next write starts, preventing anchor loss during overlapping history writes
- **State tracking**: Replaced throttler with `lastPrunedAtMillis` dict to track per-entity prune timestamps

## Implementation Details

- `selectFrom()` implements the selection logic with configurable intervals and entity filtering
- Pruning failures are logged but don't fail the write loop (cleanup operation)
- Added comprehensive test suite covering selection logic, starvation prevention, and rollback behavior
- Updated mock storage in test helpers to return async no-ops for prune operations

https://claude.ai/code/session_01UjkHvbFKZxk1L3JY6e7HCt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Upgraded stale-history cleanup to a safer two-phase workflow that selects pruning targets before database writes, reducing write conflicts.
  - Added per-entity pruning timing so cleanup is consistently throttled and retries behave predictably.
  - Coordinated cleanup with batch persistence, including rollback handling, ensuring cleanup completes reliably before progressing.
  - Pruning errors are logged and don’t interrupt the overall write flow.

- **Tests**
  - Added a Vitest suite covering target selection limits, deferred/forced pruning behavior, rollback scenarios, and differing storage capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->