### PR TITLE
Increase cross-chain alignment margin from 5% to 10%

### DIFF
--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -307,11 +307,11 @@ let checkAndFetch = async (
         (isCold ? Pervasives.min(remaining.contents, coldChainBudget) : remaining.contents) +.
         cs->ChainState.pendingBudget
       let maxTargetBlock = switch alignment {
-      // 5% margin past the anchor's line: chains whose progress tracks the
+      // 10% margin past the anchor's line: chains whose progress tracks the
       // anchor closely would otherwise flap in and out of the clamp on every
       // small frontier move, stalling their pipeline every other tick.
       | Some((anchorChainId, progress)) if anchorChainId !== chainId =>
-        Some(cs->ChainState.blockAtProgress(~progress=progress +. 0.05))
+        Some(cs->ChainState.blockAtProgress(~progress=progress +. 0.1))
       | _ => None
       }
       switch cs->ChainState.getNextQuery(

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -612,8 +612,8 @@ describe("CrossChainState fetch control", () => {
 
       t.expect(
         estimatesByChain,
-        ~message="The follower fetches up to the anchor's 50% line (+5% margin = block 550), not to nothing",
-      ).toEqual(Dict.fromArray([("1", 500), ("2", 30)]))
+        ~message="The follower fetches up to the anchor's 50% line (+10% margin = block 600), not to nothing",
+      ).toEqual(Dict.fromArray([("1", 500), ("2", 80)]))
     },
   )
 
@@ -751,7 +751,7 @@ describe("ChainState cold start", () => {
     // Chain 1 is most behind but produces no new query this tick (its buffer
     // holds a ready item that batch processing will drain). Before frontier
     // anchoring, such a tick left the line unset and chain 2 ran unclamped to
-    // its head; now chain 2 stays held at chain 1's frontier (+5% margin).
+    // its head; now chain 2 stays held at chain 1's frontier (+10% margin).
     let a = makeChainState(
       ~chainId=1,
       ~knownHeight=1000,
@@ -786,7 +786,7 @@ describe("ChainState cold start", () => {
 
     t.expect(
       actionsByChain->Dict.get("2"),
-      ~message="Chain 2's frontier (500) is past chain 1's line (10% + 5% margin = block 150), so it waits instead of fetching to head",
+      ~message="Chain 2's frontier (500) is past chain 1's line (10% + 10% margin = block 200), so it waits instead of fetching to head",
     ).toEqual(Some("waitingForNewBlock"))
   })
 


### PR DESCRIPTION
## Summary
Increases the progress margin used for cross-chain state alignment from 5% to 10% to reduce flapping behavior when chains track the anchor closely.

## Changes
- Updated `CrossChainState.res` to use 10% margin instead of 5% when calculating the maximum target block for non-anchor chains
- Updated corresponding test expectations in `CrossChainState_test.res` to reflect the new margin:
  - Test case expecting block 550 (50% + 5%) now expects block 600 (50% + 10%)
  - Test case expecting block 150 (10% + 5%) now expects block 200 (10% + 10%)
  - Updated comment references from "5% margin" to "10% margin"

## Implementation Details
The margin is applied when a chain has an anchor for alignment. The increased margin prevents chains whose progress closely tracks the anchor from repeatedly entering and exiting the clamp on small frontier movements, which was causing unnecessary pipeline stalls on alternating ticks.

https://claude.ai/code/session_012c95hdFAGTHj1b7aT6tZ64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-chain synchronization by allowing non-anchor chains to progress up to 10% beyond the anchor chain’s progress.
  * Updated alignment behavior to reduce unnecessary waiting when follower chains are slightly behind.

* **Tests**
  * Updated alignment scenarios to validate the expanded progress margin and revised fetch estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->