### PR TITLE
Append envio_checkpoint_id to custom ClickHouse orderBy

### DIFF
--- a/packages/cli/src/config_parsing/entity_parsing.rs
+++ b/packages/cli/src/config_parsing/entity_parsing.rs
@@ -340,8 +340,9 @@ impl GraphQLEnum {
 pub struct ClickHouseTableOptions {
     /// Raw ClickHouse expression emitted as `PARTITION BY <expr>`.
     pub partition_by: Option<String>,
-    /// Entity field names replacing the default `ORDER BY (id,
-    /// envio_checkpoint_id)` sorting key.
+    /// Entity field names that lead the history table's sorting key, replacing
+    /// the default `id` prefix. `envio_checkpoint_id` stays appended, so the key
+    /// becomes `ORDER BY (<order_by...>, envio_checkpoint_id)`.
     pub order_by: Option<Vec<String>>,
     /// Raw ClickHouse expression emitted as `TTL <expr>`.
     pub ttl: Option<String>,

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -337,24 +337,30 @@ let makeCreateHistoryTableQuery = (
 
   let orderByColumns = switch orderBy {
   | Some(fieldNames) =>
-    fieldNames
-    ->Array.map(fieldName =>
-      switch entityConfig.table.fields->Array.findMap(field =>
-        switch field {
-        | Field(f) if f.fieldName === fieldName => Some(f)
-        | _ => None
+    // envio_checkpoint_id stays appended so the sorting key keeps a
+    // deterministic tie-break and the view's checkpoint dedup gets a clean
+    // ascending run per prefix. id is dropped: ClickHouse entities are
+    // read-only, so nothing looks history rows up by id.
+    let userColumns =
+      fieldNames
+      ->Array.map(fieldName =>
+        switch entityConfig.table.fields->Array.findMap(field =>
+          switch field {
+          | Field(f) if f.fieldName === fieldName => Some(f)
+          | _ => None
+          }
+        ) {
+        | Some(f) => `\`${f->Table.getClickHouseDbFieldName}\``
+        | None =>
+          // Validated at codegen, so a miss means the schema and the
+          // persisted config diverged.
+          JsError.throwWithMessage(
+            `ClickHouse orderBy field "${fieldName}" is not defined on entity "${entityConfig.name}"`,
+          )
         }
-      ) {
-      | Some(f) => `\`${f->Table.getClickHouseDbFieldName}\``
-      | None =>
-        // Validated at codegen, so a miss means the schema and the
-        // persisted config diverged.
-        JsError.throwWithMessage(
-          `ClickHouse orderBy field "${fieldName}" is not defined on entity "${entityConfig.name}"`,
-        )
-      }
-    )
-    ->Array.joinUnsafe(", ")
+      )
+      ->Array.joinUnsafe(", ")
+    `${userColumns}, ${EntityHistory.checkpointIdFieldName}`
   | None => `${Table.idFieldName}, ${EntityHistory.checkpointIdFieldName}`
   }
 

--- a/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
@@ -201,7 +201,7 @@ chains:
 )
 ENGINE = MergeTree()
 PARTITION BY toYYYYMM(timestamp)
-ORDER BY (\`timestamp\`)
+ORDER BY (\`timestamp\`, envio_checkpoint_id)
 TTL timestamp + INTERVAL 2 YEAR`,
         })
       },
@@ -252,7 +252,7 @@ chains:
   \`envio_change\` Enum8('SET', 'DELETE')
 )
 ENGINE = MergeTree()
-ORDER BY (\`base_token_id\`, \`trade_time\`)`)
+ORDER BY (\`base_token_id\`, \`trade_time\`, envio_checkpoint_id)`)
       },
     )
   })


### PR DESCRIPTION
Stacked on #1433. Refines how a custom `@storage(clickhouse: {orderBy: [...]})` builds the history table's sorting key.

## What changed

Before, a custom `orderBy` **replaced** the whole sorting key, dropping `envio_checkpoint_id`:

```sql
ORDER BY (`timestamp`)
```

Now `envio_checkpoint_id` stays **appended** — the user's fields lead, the checkpoint id trails:

```sql
ORDER BY (`timestamp`, envio_checkpoint_id)
```

`id` is intentionally *not* re-added.

## Reasoning

For a read-only ClickHouse entity, nothing structurally *requires* `id` or `envio_checkpoint_id` in the key — the current-state view sorts at query time, writes are blind inserts, and rollback (`ALTER … DELETE WHERE envio_checkpoint_id > X`) can't prune on a non-leading column regardless. So the choice is about secondary properties, and on those the trailing checkpoint id is a cheap win over a bare overwrite:

- **Deterministic physical order** — a bare user-field key leaves ties among equal-prefix rows resolved arbitrarily by merge order; the monotonic `envio_checkpoint_id` breaks them reproducibly.
- **Compression** — `envio_checkpoint_id` is monotonic, so within each user-field run it's a clean ascending sequence, compressing well alongside time-correlated columns.
- **Cleaner view dedup** — the current-state view's `ORDER BY envio_checkpoint_id DESC LIMIT 1 BY id` gets a tidy per-prefix ascending run to work against.

**Why drop `id`:** the only thing `id` in the key buys is granule pruning for by-id lookups. All ClickHouse entities are read-only today — no path loads history rows by id — so `id` would be dead weight. If a by-id read path is ever added for ClickHouse, that's the point to reconsider (and to gate custom `orderBy` on read-only/immutable entities).

## Testing

`ClickHouse_test.res` (6 tests) green, including the two custom-`orderBy` DDL assertions updated to expect the appended `envio_checkpoint_id` (plain and snake_case + linked-entity column resolution). `pnpm rescript` clean; the Rust doc-comment update compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX5KpUyG4WHbKTJsHi5b5F

---
_Generated by [Claude Code](https://claude.ai/code/session_01SX5KpUyG4WHbKTJsHi5b5F)_