### PR TITLE
MockIndexer: fix dropped-item default and thread envioInfo

### DIFF
--- a/packages/envio/package.json
+++ b/packages/envio/package.json
@@ -74,6 +74,7 @@
     "tsx": "4.21.0"
   },
   "devDependencies": {
-    "rescript": "12.2.0"
+    "rescript": "12.2.0",
+    "vitest": "4.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       rescript:
         specifier: 12.2.0
         version: 12.2.0
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jsdom@16.7.0)(vite@7.3.1(@types/node@24.12.2)(tsx@4.21.0))
 
   packages/envio-tests:
     dependencies:

--- a/scenarios/test_codegen/test/YamlConfigIndexer_test.res
+++ b/scenarios/test_codegen/test/YamlConfigIndexer_test.res
@@ -14,7 +14,7 @@ describe("YAML-driven MockIndexer", () => {
   Async.it(
     "runs the indexer loop with a config parsed from user YAML instead of the generated one",
     async t => {
-      let {config} = MockIndexerConfig.parseYaml(
+      let {config, publicConfigJson} = MockIndexerConfig.parseYaml(
         ~schema=`
 type YamlToken {
   id: ID!
@@ -40,6 +40,7 @@ chains:
       let source = MockIndexer.Source.make([#getHeightOrThrow, #getItemsOrThrow], ~chain=#1337)
       let indexerMock = await MockIndexer.Indexer.make(
         ~config,
+        ~envioInfo=publicConfigJson->Config.stripSensitiveData,
         ~chains=[{chain: #1337, sourceConfig: Config.CustomSources([source.source])}],
         ~shouldRollbackOnReorg=false,
       )
@@ -49,6 +50,9 @@ chains:
       await Utils.delay(0)
       await Utils.delay(0)
 
+      // No explicit ~latestFetchedBlockNumber: the mock defaults it to at least
+      // the highest item block, so the block-5 item is processed rather than
+      // dropped for sitting above the fetched range.
       source.resolveGetItemsOrThrow([
         {
           blockNumber: 5,
@@ -59,7 +63,7 @@ chains:
             context.yamlToken.set({id: "token-1", owner: "0xabc"})
           },
         },
-      ], ~latestFetchedBlockNumber=300)
+      ])
       await indexerMock.getBatchWritePromise()
 
       let tokens: array<yamlToken> = await indexerMock.queryRaw(

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -410,6 +410,9 @@ module Indexer = {
     // A config parsed through the user-facing pipeline (MockIndexerConfig.parseYaml).
     // Defaults to the generated project config.
     ~config as customConfig: option<Config.t>=?,
+    // Recorded as envio_info on init. Supply the stripped public config JSON so
+    // restart/compat-diff scenarios validate against the real value instead of `{}`.
+    ~envioInfo: JSON.t=JSON.Encode.object(Dict.make()),
     ~saveFullHistory=false,
     // Reinit storage without Hasura
     // makes tests ~1.9 seconds faster
@@ -508,7 +511,7 @@ module Indexer = {
 
     await persistence->Persistence.init(
       ~chainConfigs=config.chainMap->ChainMap.values,
-      ~envioInfo=JSON.Encode.object(Dict.make()),
+      ~envioInfo,
       ~resetCommand="envio dev -r",
       ~runCommand=Some("envio dev"),
       ~reset,
@@ -724,6 +727,7 @@ module Indexer = {
         await make(
           ~chains,
           ~config=?customConfig,
+          ~envioInfo,
           ~enableHasura,
           ~enableRawEvents,
           ~saveFullHistory,
@@ -964,8 +968,17 @@ module Source = {
                   ~knownHeight=knownHeight,
                   ~prevRangeLastBlock=?,
                 ) => {
-                  let latestFetchedBlockNumber =
-                    latestFetchedBlockNumber->Option.getOr(toBlock->Option.getOr(fromBlock))
+                  let latestFetchedBlockNumber = switch latestFetchedBlockNumber {
+                  | Some(latestFetchedBlockNumber) => latestFetchedBlockNumber
+                  | None =>
+                    // Never resolve below the highest item block: the indexer only
+                    // processes up to latestFetchedBlockNumber, so an item above the
+                    // fetched range (e.g. toBlock unset ⇒ defaults to fromBlock) would
+                    // otherwise be silently dropped.
+                    items->Array.reduce(toBlock->Option.getOr(fromBlock), (max, item) =>
+                      item.blockNumber > max ? item.blockNumber : max
+                    )
+                  }
 
                   let latestFetchedBlockHash = switch latestFetchedBlockHash {
                   | Some(latestFetchedBlockHash) => latestFetchedBlockHash


### PR DESCRIPTION
Small follow-up to #1445 — DX/correctness fixes in the MockIndexer test harness.

## Changes

**1. `resolveGetItemsOrThrow` no longer silently drops items above the fetched range**

When a caller resolved items without an explicit `~latestFetchedBlockNumber`, the mock defaulted it to `toBlock ?? fromBlock`. If an item's `blockNumber` sat above that (e.g. the first query where `toBlock` is unset ⇒ defaults to `fromBlock`), the indexer — which only processes up to `latestFetchedBlockNumber` — would silently drop it. The default now floors at the highest item block, so the item is processed. The YAML acceptance test drops the `~latestFetchedBlockNumber=300` workaround it previously needed, which demonstrates the fix.

**2. `MockIndexer.make` accepts `~envioInfo`**

Previously `Persistence.init` was always passed `{}` as `envio_info`. `make` now takes `~envioInfo` (defaulting to `{}`, so existing callers are unchanged) and preserves it across `restart`, so custom-config restart/compat-diff scenarios can validate against the real stripped public config JSON. The acceptance test now passes `publicConfigJson->Config.stripSensitiveData`.

**3. Restore `vitest` to envio's devDependencies (bug fix)**

envio's `src/bindings/Vitest.res.mjs` imports `"vitest"`. #1445 removed vitest from envio's devDependencies; this resolves fine in CI (scenarios build against the published artifact and provide vitest) but breaks **local** workspace runs, where `node_modules/envio` symlinks to the package whose `node_modules` no longer has vitest — so any test_codegen suite touching the `Vitest` binding (e.g. `WriteRead_test`) failed locally. Restoring the devDep fixes local dev; it's excluded from the shipped artifact's dependencies, so nothing changes for published envio.

## Verification

`pnpm rescript` in test_codegen, plus vitest on the affected suites: `YamlConfigIndexer_test`, `IndexerLoop_test`, `WriteRead_test`, `StalledPolling_test`, `SourceBlockHashes_test`, `SourceManager_test`, `FetchState_test`, `Rollback_test`, `EventOrigin_test` — all green. Full suite runs on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fb6Yyif9GZG1DWAiCER4Gh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb6Yyif9GZG1DWAiCER4Gh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Improved mock indexer behavior when determining the latest fetched block from returned data.
  * Updated YAML-based indexing tests to validate configuration metadata handling and default block-range behavior.
  * Added Vitest as a development testing tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->