### PR TITLE
Add indexer-local-parallel to template directory list

### DIFF
--- a/packages/cli/src/template_dirs.rs
+++ b/packages/cli/src/template_dirs.rs
@@ -417,6 +417,7 @@ mod test {
                 "indexer-factory",
                 "indexer-filters",
                 "indexer-handlers",
+                "indexer-local-parallel",
                 "indexer-multichain",
                 "indexer-performance",
                 "indexer-schema",


### PR DESCRIPTION
Adds the `indexer-local-parallel` template to the list of available indexer templates in the CLI's template directory test.

## Changes
- Added `"indexer-local-parallel"` to the template directory list in `packages/cli/src/template_dirs.rs`

This enables the local parallel indexer template to be recognized and available for use when generating new indexer projects.

https://claude.ai/code/session_013gQBfTW2Mw4b8tGvvQPxVi