### PR TITLE
Refactor effect cache row counting to per-table queries

### DIFF
--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -672,7 +672,12 @@ let makeEffectCacheTableNamesQuery = (~pgSchema) => {
 }
 
 let makeCacheRowCountQuery = (~pgSchema, ~tableName) => {
-  `SELECT COUNT(*)::int AS count FROM "${pgSchema}"."${tableName}";`
+  // The table name comes from information_schema, so anything cache-shaped that
+  // was created out-of-band in the schema reaches here. Splice both identifiers
+  // as quoted identifiers, doubling embedded quotes, so a crafted name can't
+  // break out into raw SQL.
+  let quoteIdent = ident => `"${ident->String.replaceAll("\"", "\"\"")}"`
+  `SELECT COUNT(*)::int AS count FROM ${quoteIdent(pgSchema)}.${quoteIdent(tableName)};`
 }
 
 type psqlExecState =

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1,5 +1,3 @@
-let getCacheRowCountFnName = "get_cache_row_count"
-
 let makeClient = () => {
   Postgres.makeSql(
     ~config={
@@ -267,18 +265,7 @@ GRANT ALL ON SCHEMA "${pgSchema}" TO public;`,
   | None => ()
   }
 
-  [
-    query.contents,
-    `CREATE OR REPLACE FUNCTION ${getCacheRowCountFnName}(table_name text) 
-RETURNS integer AS $$
-DECLARE
-  result integer;
-BEGIN
-  EXECUTE format('SELECT COUNT(*) FROM "${pgSchema}".%I', table_name) INTO result;
-  RETURN result;
-END;
-$$ LANGUAGE plpgsql;`,
-  ]
+  [query.contents]
 }
 
 let makeLoadQuery = (~pgSchema, ~tableName, ~condition) => {
@@ -661,16 +648,19 @@ type schemaCacheTableInfo = {
   count: int,
 }
 
+type cacheRowCount = {
+  @as("count")
+  count: int,
+}
+
 // Matches both the cross-chain (`envio_effect_<name>`) and chain-scoped
 // (`envio_<chainId>_effect_<name>`) cache-table formats. Kept in sync with
 // Internal.EffectCache.
-let makeSchemaCacheTableInfoQuery = (~pgSchema) => {
+let makeEffectCacheTableNamesQuery = (~pgSchema) => {
   // The column guard requires the effect-cache shape (exactly an `id` + `output`
   // pair) so a user entity table that happens to match the name pattern is never
   // mistaken for an effect cache.
-  `SELECT
-    t.table_name,
-    ${getCacheRowCountFnName}(t.table_name) as count
+  `SELECT t.table_name
    FROM information_schema.tables t
    WHERE t.table_schema = '${pgSchema}'
    AND t.table_name ~ '^envio_([0-9]+_)?effect_.+'
@@ -679,6 +669,10 @@ let makeSchemaCacheTableInfoQuery = (~pgSchema) => {
      FROM information_schema.columns c
      WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name
    ) = ARRAY['id', 'output'];`
+}
+
+let makeCacheRowCountQuery = (~pgSchema, ~tableName) => {
+  `SELECT COUNT(*)::int AS count FROM "${pgSchema}"."${tableName}";`
 }
 
 type psqlExecState =
@@ -1301,6 +1295,23 @@ let make = (
     result
   }
 
+  // Each indexer counts the effect-cache tables in its own schema. The counts
+  // are computed here per table rather than through a shared SQL helper so
+  // indexers isolated by schema in one database never touch each other's state.
+  let queryCacheTableInfo = async (): array<schemaCacheTableInfo> => {
+    let tableNames: array<schemaTableName> = await sql->Postgres.unsafe(
+      makeEffectCacheTableNamesQuery(~pgSchema),
+    )
+    await tableNames
+    ->Array.map(async ({tableName}) => {
+      let rows: array<cacheRowCount> = await sql->Postgres.unsafe(
+        makeCacheRowCountQuery(~pgSchema, ~tableName),
+      )
+      ({tableName, count: (rows->Array.getUnsafe(0)).count}: schemaCacheTableInfo)
+    })
+    ->Promise.all
+  }
+
   let restoreEffectCache = async (~withUpload) => {
     if withUpload {
       // Try to restore cache tables from the .envio/cache TSV files
@@ -1340,9 +1351,7 @@ let make = (
       }
     }
 
-    let cacheTableInfo: array<schemaCacheTableInfo> = await sql->Postgres.unsafe(
-      makeSchemaCacheTableInfoQuery(~pgSchema),
-    )
+    let cacheTableInfo = await queryCacheTableInfo()
 
     if withUpload && cacheTableInfo->Utils.Array.notEmpty {
       // Integration with other tools like Hasura
@@ -1551,10 +1560,7 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
 
   let dumpEffectCache = async () => {
     try {
-      let cacheTableInfo: array<schemaCacheTableInfo> =
-        (await sql->Postgres.unsafe(makeSchemaCacheTableInfoQuery(~pgSchema)))->Array.filter(i =>
-          i.count > 0
-        )
+      let cacheTableInfo = (await queryCacheTableInfo())->Array.filter(i => i.count > 0)
 
       if cacheTableInfo->Utils.Array.notEmpty {
         // Create .envio/cache directory if it doesn't exist

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -249,11 +249,10 @@ describe("Test PgStorage SQL generation functions", () => {
           ~isHasuraEnabled=true,
         )
 
-        // Should return exactly 2 queries: main DDL + functions
         t.expect(
           queries->Array.length,
-          ~message="Should return exactly 2 queries for main DDL and functions",
-        ).toBe(2)
+          ~message="Should return a single main DDL query",
+        ).toBe(1)
 
         let mainQuery = queries->Array.get(0)->Option.getOrThrow
 
@@ -327,11 +326,10 @@ VALUES (1, 100, 200, 10, 0, NULL, -1, -1, NULL, 0, false),
           ~isHasuraEnabled=false,
         )
 
-        // Should return exactly 2 query (main DDL, and a function for cache)
         t.expect(
           queries->Array.length,
-          ~message="Should return single query when no entities have functions. And a function needed for cache.",
-        ).toBe(2)
+          ~message="Should return a single main DDL query",
+        ).toBe(1)
 
         let mainQuery = queries->Array.get(0)->Option.getOrThrow
 
@@ -376,19 +374,6 @@ FROM "test_schema"."envio_chains";`
           mainQuery,
           ~message="Minimal configuration should match expected SQL exactly",
         ).toBe(expectedMainQuery)
-
-        t.expect(
-          queries->Array.get(1)->Option.getOrThrow,
-          ~message="A function for cache should be created",
-        ).toBe(`CREATE OR REPLACE FUNCTION get_cache_row_count(table_name text) 
-RETURNS integer AS $$
-DECLARE
-  result integer;
-BEGIN
-  EXECUTE format('SELECT COUNT(*) FROM "test_schema".%I', table_name) INTO result;
-  RETURN result;
-END;
-$$ LANGUAGE plpgsql;`)
       },
     )
 
@@ -408,11 +393,10 @@ $$ LANGUAGE plpgsql;`)
 
         t.expect(
           queries->Array.length,
-          ~message="Should return 2 queries for entity with history function",
-        ).toBe(2)
+          ~message="Should return a single main DDL query",
+        ).toBe(1)
 
         let mainQuery = queries->Array.get(0)->Option.getOrThrow
-        let functionsQuery = queries->Array.get(1)->Option.getOrThrow
 
         let expectedMainQuery = `DROP SCHEMA IF EXISTS "public" CASCADE;
 CREATE SCHEMA "public";
@@ -457,20 +441,6 @@ FROM "public"."envio_chains";`
         t.expect(mainQuery, ~message="Single entity SQL should match expected output exactly").toBe(
           expectedMainQuery,
         )
-
-        // Verify functions query contains the A history function
-        t.expect(
-          functionsQuery,
-          ~message="Should contain cache row count function definition",
-        ).toBe(`CREATE OR REPLACE FUNCTION get_cache_row_count(table_name text) 
-RETURNS integer AS $$
-DECLARE
-  result integer;
-BEGIN
-  EXECUTE format('SELECT COUNT(*) FROM "public".%I', table_name) INTO result;
-  RETURN result;
-END;
-$$ LANGUAGE plpgsql;`)
       },
     )
   })


### PR DESCRIPTION
## Summary
Removes the shared SQL helper function `get_cache_row_count` and refactors cache table row counting to use individual per-table queries instead. This ensures schema-isolated indexers never interfere with each other's state when computing cache statistics.

## Key Changes
- Removed `getCacheRowCountFnName` constant and the `CREATE OR REPLACE FUNCTION` SQL definition from schema initialization
- Renamed `makeSchemaCacheTableInfoQuery` to `makeEffectCacheTableNamesQuery` and simplified it to only fetch table names (removed the function call that counted rows)
- Added new `makeCacheRowCountQuery` function that counts rows for a single table
- Added new `cacheRowCount` type to decode individual row count results
- Introduced `queryCacheTableInfo` function that:
  - Fetches all effect cache table names in the schema
  - Maps over each table name and executes a separate count query
  - Combines results into the `schemaCacheTableInfo` array
- Updated `restoreEffectCache` and `dumpEffectCache` to use the new `queryCacheTableInfo` function

## Implementation Details
The refactoring moves from a single SQL query that uses a helper function to count all cache tables at once, to a pattern where table names are fetched first, then each table is counted individually. This approach is safer for schema-isolated indexers since each indexer only queries tables in its own schema, eliminating any possibility of cross-indexer interference through shared SQL functions.

https://claude.ai/code/session_01ToHxMxkorYGapDr9Jpp4dD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved effect-cache table discovery and row-count handling during initialization and restoration.
  * Ensured only valid cache tables are considered when rebuilding cached data.
  * Excluded empty cache tables from effect-cache dumps for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->