### PR TITLE
Isolate test indexer entity store with defensive copies

### DIFF
--- a/packages/cli/templates/static/shared/.claude/skills/indexer-testing/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-testing/SKILL.md
@@ -101,16 +101,14 @@ await indexer.EntityName.getAll();         // returns all entities of this type
 
 ## Test isolation
 
-Each `createTestIndexer()` gets its own isolated entity store, so independent
-indexers don't share entity state. Within one indexer, entity state and block
-progress persist across `process()` calls (each call continues where the last
-stopped).
+Each `createTestIndexer()` has its own entity store; within one indexer, entity
+state and block progress persist across `process()` calls (each continues where
+the last stopped).
 
-Tests run in-process (no per-test worker), so anything **module-level** in your
-handler code is shared across every indexer and every test in the file — and
-persists between them. This includes top-level `let`/`const` state, memoized
-clients, and effect caches. If a test depends on such state, reset it yourself
-(e.g. in a `beforeEach`); don't rely on `createTestIndexer()` to clear it.
+Tests run in-process, so **module-level** state in your handler code (top-level
+`let`/`const`, memoized clients, effect caches) is shared across every indexer
+and test in the file and persists between them. Reset it yourself (e.g. in a
+`beforeEach`) if a test depends on it.
 
 ## result.changes
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexer-testing/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-testing/SKILL.md
@@ -99,6 +99,19 @@ await indexer.EntityName.getOrThrow("id"); // throws if not found
 await indexer.EntityName.getAll();         // returns all entities of this type
 ```
 
+## Test isolation
+
+Each `createTestIndexer()` gets its own isolated entity store, so independent
+indexers don't share entity state. Within one indexer, entity state and block
+progress persist across `process()` calls (each call continues where the last
+stopped).
+
+Tests run in-process (no per-test worker), so anything **module-level** in your
+handler code is shared across every indexer and every test in the file — and
+persists between them. This includes top-level `let`/`const` state, memoized
+clients, and effect caches. If a test depends on such state, reset it yourself
+(e.g. in a `beforeEach`); don't rely on `createTestIndexer()` to clear it.
+
 ## result.changes
 
 `result.changes` is an array of per-block change objects. Each entry has `block`, `chainId`, `eventsProcessed`, plus entity names as keys with `sets` arrays of created/updated entities. Dynamic contract registrations appear under `addresses.sets`.

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -732,44 +732,15 @@ let isPendingRegistration = () => {
   }
 }
 
-// Drop the finished registration context so the public `indexer.onEvent` /
-// `.contractRegister` API stays callable afterwards. The in-process test runner
-// captures registrations once and reuses them, then clears the context so a
-// test can still exercise the registration API (calls queue as pre-registered
-// and are ignored by the captured run) instead of hitting the "after the
-// indexer has started" guard.
-let clearActiveRegistration = () => {
-  EnvioGlobal.value.activeRegistration = None
-}
-
-// The in-process test runner executes user handlers with the same
-// process-global `indexer` the test itself can reach, so it can't use the
-// global `finished` flag to make a handler's `indexer.onEvent` throw without
-// also breaking test-time registration. Instead it runs each indexer inside an
-// AsyncLocalStorage scope; a handler executing within that scope hits the
-// "after the indexer has started" guard, while test-time calls (and other
-// concurrent runs' scopes) are unaffected.
-type asyncLocalStorage
-@module("node:async_hooks") @new
-external makeAsyncLocalStorage: unit => asyncLocalStorage = "AsyncLocalStorage"
-@send external alsRun: (asyncLocalStorage, {..}, unit => 'a) => 'a = "run"
-@send external alsGetStore: asyncLocalStorage => Nullable.t<{..}> = "getStore"
-
-let handlerScope = makeAsyncLocalStorage()
-let isInHandlerScope = () => handlerScope->alsGetStore->Nullable.toOption->Option.isSome
-let runInHandlerScope = fn => handlerScope->alsRun({"active": true}, fn)
-
 // Early guard called from `indexer.onEvent` / `.contractRegister` / `.onBlock` /
 // `.onSlot` so the user sees a method-specific error at the call site, instead
 // of hitting the generic `withRegistration` throw deep inside `setHandler` etc.
 let throwIfFinishedRegistration = (~methodName) => {
-  let finished = switch getActiveRegistration() {
-  | Some({finished}) => finished
-  | None => false
-  }
-  if finished || isInHandlerScope() {
+  switch getActiveRegistration() {
+  | Some({finished: true}) =>
     JsError.throwWithMessage(
       `Cannot call \`indexer.${methodName}\` after the indexer has started. Make sure all handlers are registered at the top level of your handler module.`,
     )
+  | _ => ()
   }
 }

--- a/packages/envio/src/HandlerRegister.resi
+++ b/packages/envio/src/HandlerRegister.resi
@@ -7,8 +7,6 @@ type registrationsByChainId = dict<chainRegistrations>
 let startRegistration: (~config: Config.t) => unit
 let isPendingRegistration: unit => bool
 let finishRegistration: (~config: Config.t) => registrationsByChainId
-let clearActiveRegistration: unit => unit
-let runInHandlerScope: (unit => 'a) => 'a
 let throwIfFinishedRegistration: (~methodName: string) => unit
 
 let buildOnEventRegistration: (

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -549,12 +549,7 @@ let getRegistrations = (~config) =>
   switch registrationsRef.contents {
   | Some(promise) => promise
   | None =>
-    let promise = HandlerLoader.registerAllHandlers(~config)->Promise.thenResolve(registrations => {
-      // Reopen the registration API for tests that call indexer.onEvent /
-      // contractRegister after a run has captured its registrations.
-      HandlerRegister.clearActiveRegistration()
-      registrations
-    })
+    let promise = HandlerLoader.registerAllHandlers(~config)
     registrationsRef := Some(promise)
     promise
   }
@@ -851,28 +846,23 @@ let makeCreateTestIndexer = (~config: Config.t): (unit => t<'processConfig>) => 
               }
             }
             try {
-              // Run inside the handler scope so a handler that calls
-              // indexer.onEvent throws, as in production, without finishing the
-              // process-global registration the test itself uses.
-              await HandlerRegister.runInHandlerScope(() =>
-                Promise.make((resolve, reject) => {
-                  let indexerState = IndexerState.makeFromDbState(
-                    ~config=runConfig,
-                    ~persistence,
-                    ~initialState,
-                    ~registrationsByChainId,
-                    ~exitAfterFirstEventBlock,
-                    ~onError=errHandler => {
-                      errHandler->ErrorHandling.log
-                      reject(errHandler.exn->Utils.prettifyExn)
-                    },
-                    // Caught up: resolve the run instead of exiting the process.
-                    ~onExit=() => resolve(),
-                  )
-                  indexerStateRef := Some(indexerState)
-                  indexerState->IndexerLoop.start
-                })
-              )
+              await Promise.make((resolve, reject) => {
+                let indexerState = IndexerState.makeFromDbState(
+                  ~config=runConfig,
+                  ~persistence,
+                  ~initialState,
+                  ~registrationsByChainId,
+                  ~exitAfterFirstEventBlock,
+                  ~onError=errHandler => {
+                    errHandler->ErrorHandling.log
+                    reject(errHandler.exn->Utils.prettifyExn)
+                  },
+                  // Caught up: resolve the run instead of exiting the process.
+                  ~onExit=() => resolve(),
+                )
+                indexerStateRef := Some(indexerState)
+                indexerState->IndexerLoop.start
+              })
               await cleanup()
             } catch {
             | exn =>

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -366,6 +366,17 @@ let parseBlockRange = (
   {startBlock, endBlock}
 }
 
+// The store owns its entities. Copy on the boundary with user code — both when
+// handing one out (get/getAll/getOrThrow) and when taking one in (set) — so a
+// user mutating a returned entity, or an object they passed to `set`, can't
+// corrupt the in-memory store. Shallow is enough: entity fields are immutable
+// scalar values (string/bigint/BigDecimal), matching InMemoryTable.
+let copyEntity = (entity: Internal.entity): Internal.entity =>
+  entity
+  ->(Utils.magic: Internal.entity => dict<unknown>)
+  ->Utils.Dict.shallowCopy
+  ->(Utils.magic: dict<unknown> => Internal.entity)
+
 // Entity operations for direct manipulation outside of handlers
 let getEntityFromState = (
   ~state: testIndexerState,
@@ -379,7 +390,7 @@ let getEntityFromState = (
     )
   }
   let entityDict = state.entities->Dict.get(entityConfig.name)->Option.getOr(Dict.make())
-  entityDict->Dict.get(entityId)
+  entityDict->Dict.get(entityId)->Option.map(copyEntity)
 }
 
 let makeEntityGet = (~state: testIndexerState, ~entityConfig: Internal.entityConfig): (
@@ -422,7 +433,7 @@ let makeEntitySet = (~state: testIndexerState, ~entityConfig: Internal.entityCon
       state.entities->Dict.set(entityConfig.name, dict)
       dict
     }
-    entityDict->Dict.set(entity.id, entity)
+    entityDict->Dict.set(entity.id, copyEntity(entity))
   }
 }
 
@@ -436,7 +447,7 @@ let makeEntityGetAll = (~state: testIndexerState, ~entityConfig: Internal.entity
       )
     }
     let entityDict = state.entities->Dict.get(entityConfig.name)->Option.getOr(Dict.make())
-    Promise.resolve(entityDict->Dict.valuesToArray)
+    Promise.resolve(entityDict->Dict.valuesToArray->Array.map(copyEntity))
   }
 }
 
@@ -450,17 +461,20 @@ type entityOperations = {
 // Adapt the real storage interface to the in-memory entity store. In-process
 // there's no worker boundary, so entities are stored and loaded decoded — no
 // JSON serialization round-trip.
-let makeInMemoryStorage = (
-  ~state: testIndexerState,
-  ~getInitialState: unit => Persistence.initialState,
-): Persistence.storage => {
+let makeInMemoryStorage = (~state: testIndexerState): Persistence.storage => {
   name: "test-inmemory",
   isInitialized: async () => true,
+  // The runner injects the config-derived initial state by setting
+  // `persistence.storageStatus = Ready(...)` directly, bypassing `Persistence.init`,
+  // so neither of these is reached.
   initialize: async (~chainConfigs as _=?, ~entities as _=?, ~enums as _=?, ~envioInfo as _) =>
     JsError.throwWithMessage(
       "TestIndexer: initialize should not be called; the initial state is derived from config.",
     ),
-  resumeInitialState: async () => getInitialState(),
+  resumeInitialState: async () =>
+    JsError.throwWithMessage(
+      "TestIndexer: resumeInitialState should not be called; the initial state is derived from config.",
+    ),
   loadOrThrow: async (~filter, ~table: Table.table) =>
     state
     ->handleLoad(~tableName=table.tableName, ~filter)
@@ -584,14 +598,10 @@ let makeCreateTestIndexer = (~config: Config.t): (unit => t<'processConfig>) => 
       processChanges: [],
     }
 
-    // Per-instance in-memory storage over `state.entities`. `process()` runs are
-    // sequential within one indexer, so a single ref carries the current run's
-    // config-derived initial state; separate indexers get separate storages, so
-    // independent indexers run in parallel without shared mutable state.
-    let currentInitialState: ref<option<Persistence.initialState>> = ref(None)
-    let storage = makeInMemoryStorage(~state, ~getInitialState=() =>
-      currentInitialState.contents->Option.getOrThrow
-    )
+    // Per-instance in-memory storage over `state.entities`. Separate indexers
+    // get separate storages, so independent indexers run in parallel without
+    // shared mutable state.
+    let storage = makeInMemoryStorage(~state)
     let persistence = Persistence.make(
       ~userEntities=config.userEntities,
       ~allEnums=config.allEnums,
@@ -817,7 +827,6 @@ let makeCreateTestIndexer = (~config: Config.t): (unit => t<'processConfig>) => 
             // Bypass Persistence.init: hand the loop the config-derived initial
             // state directly (never a real DB) and mark the storage Ready so
             // writes go through.
-            currentInitialState := Some(initialState)
             persistence.storageStatus = Ready(initialState)
 
             let indexerStateRef = ref(None)
@@ -831,7 +840,12 @@ let makeCreateTestIndexer = (~config: Config.t): (unit => t<'processConfig>) => 
                   indexerState->IndexerState.isProcessing ||
                     indexerState->IndexerState.writeFiber->Option.isSome
                 ) {
-                  await Utils.delay(0)
+                  switch indexerState->IndexerState.writeFiber {
+                  // Await the in-flight write directly; only fall back to a tick
+                  // yield while processing hasn't yet spawned a write fiber.
+                  | Some(fiber) => await fiber
+                  | None => await Utils.delay(0)
+                  }
                 }
               | None => ()
               }

--- a/scenarios/test_codegen/src/handlers/EventHandlers.ts
+++ b/scenarios/test_codegen/src/handlers/EventHandlers.ts
@@ -129,6 +129,40 @@ expectType<
   >
 >(true);
 
+// Type-only surface checks for the registration API. Guarded by `if (0)` so
+// tsc validates them but they never execute: invalid contract/event combos must
+// stay compile errors, and these must not register real handlers.
+if (0) {
+  indexer.onEvent(
+    // @ts-expect-error - "BadContract" is not a configured contract
+    { contract: "BadContract", event: "X" },
+    async () => {},
+  );
+  indexer.onEvent(
+    // @ts-expect-error - "BadEvent" is not an event of Gravatar
+    { contract: "Gravatar", event: "BadEvent" },
+    async () => {},
+  );
+  indexer.onEvent(
+    { contract: "Gravatar", event: "NewGravatar" },
+    async ({ event }) => {
+      expectType<TypeEqual<typeof event.params.displayName, string>>(true);
+    },
+  );
+  indexer.contractRegister(
+    { contract: "NftFactory", event: "SimpleNftCreated" },
+    async ({ event, context }) => {
+      expectType<
+        TypeEqual<typeof event.params.contractAddress, `0x${string}`>
+      >(true);
+      context.chain.SimpleNft.add(event.params.contractAddress);
+      context.chain.NftFactory.add(event.params.contractAddress);
+      // @ts-expect-error - UnknownContract is not configured
+      context.chain.UnknownContract.add(event.params.contractAddress);
+    },
+  );
+}
+
 const zeroAddress = "0x0000000000000000000000000000000000000000";
 
 indexer.onEvent({ contract: "Gravatar", event: "CustomSelection" }, async ({ event, context }) => {

--- a/scenarios/test_codegen/test/EventHandler.test.ts
+++ b/scenarios/test_codegen/test/EventHandler.test.ts
@@ -1787,44 +1787,10 @@ describe("onEvent / contractRegister types", () => {
     type _userOnCr = EvmContractRegisterContext["User"];
   });
 
-  it("indexer.onEvent rejects invalid contract/event combinations", () => {
-    indexer.onEvent(
-      // @ts-expect-error - "BadContract" is not a configured contract
-      { contract: "BadContract", event: "X" },
-      async () => {},
-    );
-
-    indexer.onEvent(
-      // @ts-expect-error - "BadEvent" is not an event of Gravatar
-      { contract: "Gravatar", event: "BadEvent" },
-      async () => {},
-    );
-
-    // Valid combination should compile (no @ts-expect-error)
-    indexer.onEvent(
-      { contract: "Gravatar", event: "NewGravatar" },
-      async ({ event }) => {
-        expectType<TypeEqual<typeof event.params.displayName, string>>(true);
-      },
-    );
-  });
-
-  it("indexer.contractRegister exposes context.chain.ContractName.add()", () => {
-    indexer.contractRegister(
-      { contract: "NftFactory", event: "SimpleNftCreated" },
-      async ({ event, context }) => {
-        // event is typed
-        expectType<
-          TypeEqual<typeof event.params.contractAddress, `0x${string}`>
-        >(true);
-        // chain.ContractName.add(address) is available
-        context.chain.SimpleNft.add(event.params.contractAddress);
-        context.chain.NftFactory.add(event.params.contractAddress);
-        // @ts-expect-error - UnknownContract is not configured
-        context.chain.UnknownContract.add(event.params.contractAddress);
-      },
-    );
-  });
+  // `indexer.onEvent` / `indexer.contractRegister` type-surface checks live in
+  // `src/handlers/EventHandlers.ts` (compile-time only): the registration API
+  // throws once handlers are registered, so they can't run as post-registration
+  // test cases here.
 
   it("EvmOnEventHandler defaults to union of all events", () => {
     // Without args, the handler accepts the union of all EVM events

--- a/scenarios/test_codegen/test/EventHandler.test.ts
+++ b/scenarios/test_codegen/test/EventHandler.test.ts
@@ -460,6 +460,36 @@ describe("Use Envio test framework to test event handlers", () => {
     assert.deepEqual(users, [existingUser]);
   });
 
+  it("mutating entities across the set/get boundary doesn't corrupt the store", async () => {
+    const indexer = createTestIndexer();
+
+    const original: User = {
+      id: "0",
+      address: "existing",
+      updatesCountOnUserForTesting: 0,
+      gravatar_id: undefined,
+      accountType: "USER",
+    };
+    indexer.User.set(original);
+
+    // Mutating the object passed to set, or any entity handed back, must not
+    // leak into the in-memory store.
+    Object.assign(original, { address: "mutated-after-set" });
+    Object.assign(await indexer.User.getOrThrow("0"), { address: "mutated-after-getOrThrow" });
+    Object.assign((await indexer.User.get("0"))!, { address: "mutated-after-get" });
+    (await indexer.User.getAll()).forEach((u) => Object.assign(u, { address: "mutated-after-getAll" }));
+
+    assert.deepEqual(await indexer.User.getAll(), [
+      {
+        id: "0",
+        address: "existing",
+        updatesCountOnUserForTesting: 0,
+        gravatar_id: undefined,
+        accountType: "USER",
+      },
+    ]);
+  });
+
   it("entity.getOrThrow throws if entity doesn't exist", async () => {
     const indexer = createTestIndexer();
     const dcAddress = "0x1234567890123456789012345678901234567890";


### PR DESCRIPTION
## Summary

Fixes entity store corruption in the test indexer by making defensive shallow copies of entities at storage boundaries. This prevents user code from mutating entities returned by `get`/`getAll`/`getOrThrow` or passed to `set`, which could corrupt the in-memory store.

## Key Changes

- **Entity copying**: Added `copyEntity` helper that performs shallow copies of entities (sufficient since entity fields are immutable scalars). Applied at all storage boundaries:
  - `getEntityFromState`: copies when returning an entity
  - `makeEntitySet`: copies before storing
  - `makeEntityGetAll`: copies all returned entities

- **Storage initialization simplification**: Removed `getInitialState` callback from `makeInMemoryStorage`. The initial state is now set directly via `persistence.storageStatus = Ready(...)`, making the `initialize` and `resumeInitialState` methods unreachable (both now throw with explanatory messages).

- **Handler scope removal**: Deleted the `AsyncLocalStorage`-based handler scope mechanism (`runInHandlerScope`, `isInHandlerScope`, `clearActiveRegistration`). The test runner no longer needs to distinguish handler execution from test-time registration calls, simplifying the registration guard to a single `finished` flag check.

- **Write fiber optimization**: Changed the indexer loop's wait logic to directly await in-flight write fibers instead of always yielding a tick, reducing latency when waiting for writes to complete.

- **Type-only test checks**: Moved registration API type-surface tests (`indexer.onEvent` / `indexer.contractRegister` validation) from runtime test cases to compile-time-only checks in `EventHandlers.ts` (guarded by `if (0)`), since the registration API throws after handlers are registered.

- **Documentation**: Added test isolation section to the indexer testing skill guide, clarifying that each `createTestIndexer()` gets isolated entity state but module-level code is shared across tests.

## Implementation Details

Entity copying uses `Utils.magic` for type-safe casting between `Internal.entity` and `dict<unknown>`, then calls `Utils.Dict.shallowCopy` on the intermediate dict representation. This approach is safe because entity fields are immutable scalar values (string/bigint/BigDecimal), matching the constraints of `InMemoryTable`.

The removal of `AsyncLocalStorage` simplifies the registration guard: handlers can no longer call `indexer.onEvent` because the `finished` flag is set when the indexer starts, without needing a separate scope mechanism.

https://claude.ai/code/session_01DAwNk4gUT3QV6dh7uBtef1