### PR TITLE
Test handler errors and improve TestIndexer error messages

### DIFF
--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -369,8 +369,9 @@ let parseBlockRange = (
 // The store owns its entities. Copy on the boundary with user code — both when
 // handing one out (get/getAll/getOrThrow) and when taking one in (set) — so a
 // user mutating a returned entity, or an object they passed to `set`, can't
-// corrupt the in-memory store. Shallow is enough: entity fields are immutable
-// scalar values (string/bigint/BigDecimal), matching InMemoryTable.
+// corrupt the in-memory store. The copy is shallow (matching InMemoryTable):
+// scalar fields (string/bigint/BigDecimal) are immutable, but array-valued
+// fields still share the backing array, so in-place mutation of those leaks.
 let copyEntity = (entity: Internal.entity): Internal.entity =>
   entity
   ->(Utils.magic: Internal.entity => dict<unknown>)
@@ -505,15 +506,15 @@ let makeInMemoryStorage = (~state: testIndexerState): Persistence.storage => {
     (),
   getRollbackTargetCheckpoint: async (~reorgChainId as _, ~lastKnownValidBlockNumber as _) =>
     JsError.throwWithMessage(
-      "TestIndexer: Rollback is not supported. Set rollbackOnReorg to false in config.",
+      "TestIndexer: Rollback is not supported. The runner forces rollbackOnReorg off, so this should be unreachable.",
     ),
   getRollbackProgressDiff: async (~rollbackTargetCheckpointId as _) =>
     JsError.throwWithMessage(
-      "TestIndexer: Rollback is not supported. Set rollbackOnReorg to false in config.",
+      "TestIndexer: Rollback is not supported. The runner forces rollbackOnReorg off, so this should be unreachable.",
     ),
   getRollbackData: async (~entityConfig as _, ~rollbackTargetCheckpointId as _) =>
     JsError.throwWithMessage(
-      "TestIndexer: Rollback is not supported. Set rollbackOnReorg to false in config.",
+      "TestIndexer: Rollback is not supported. The runner forces rollbackOnReorg off, so this should be unreachable.",
     ),
   close: async () => (),
 }
@@ -740,12 +741,10 @@ let makeCreateTestIndexer = (~config: Config.t): (unit => t<'processConfig>) => 
             Int.compare(aId, bId)
           })
 
-          // Parse and validate the block ranges upfront before starting any workers.
+          // Parse and validate the block ranges upfront before running any chain.
           let chainEntries = sortedChainKeys->Array.map(chainIdStr => {
             let rawChainConfig = rawChains->Dict.getUnsafe(chainIdStr)
-            let chainId = switch chainIdStr->Int.fromString {
-            | Some(id) => id
-            | None =>
+            if chainIdStr->Int.fromString->Option.isNone {
               JsError.throwWithMessage(
                 `Invalid chain ID "${chainIdStr}": expected a numeric chain ID`,
               )
@@ -756,7 +755,7 @@ let makeCreateTestIndexer = (~config: Config.t): (unit => t<'processConfig>) => 
               ~rawChainConfig,
               ~progressBlock=state.progressBlockByChain->Dict.get(chainIdStr),
             )
-            (chainIdStr, chainId, rawChainConfig, processChainConfig)
+            (chainIdStr, rawChainConfig, processChainConfig)
           })
 
           // Reset processChanges for this run
@@ -764,7 +763,6 @@ let makeCreateTestIndexer = (~config: Config.t): (unit => t<'processConfig>) => 
 
           let runChainInProcess = async ((
             chainIdStr,
-            _chainId,
             rawChainConfig: rawChainConfig,
             processChainConfig,
           )) => {

--- a/scenarios/test_codegen/src/handlers/EventHandlers.ts
+++ b/scenarios/test_codegen/src/handlers/EventHandlers.ts
@@ -868,6 +868,10 @@ indexer.onEvent({ contract: "Gravatar", event: "FactoryEvent" }, async ({ event,
       fail("Should have thrown");
     }
 
+    case "throwInHandler": {
+      throw new Error("Error from handler");
+    }
+
     // Reproduction for https://github.com/enviodev/hyperindex/issues/1199:
     // getWhere on a linkedEntity field (db column name `<field>_id`) must
     // resolve the field schema in the in-memory TestIndexer. Production

--- a/scenarios/test_codegen/test/EventHandler.test.ts
+++ b/scenarios/test_codegen/test/EventHandler.test.ts
@@ -965,6 +965,30 @@ describe("Use Envio test framework to test event handlers", () => {
     );
   });
 
+  it("propagates a handler throw to the process() call site with its message", async () => {
+    const indexer = createTestIndexer();
+    const dcAddress = "0x1234567890123456789012345678901234567890";
+
+    await assert.rejects(
+      indexer.process({
+        chains: {
+          1337: {
+            startBlock: 1,
+            endBlock: 100,
+            simulate: [
+              {
+                contract: "Gravatar",
+                event: "FactoryEvent",
+                params: { contract: dcAddress, testCase: "throwInHandler" },
+              },
+            ],
+          },
+        },
+      }),
+      /Error from handler/,
+    );
+  });
+
   it("Should throw when registering a handler after the indexer has finished initializing", async () => {
     const indexer = createTestIndexer();
     const dcAddress = "0x1234567890123456789012345678901234567890";


### PR DESCRIPTION
## Summary
Add test coverage for handler exceptions and improve error messages in the TestIndexer to be more accurate and helpful.

## Key Changes
- **Test coverage**: Add test case verifying that exceptions thrown in event handlers propagate to the `process()` call site with their original message
- **Error message improvements**: Update TestIndexer rollback error messages to clarify that rollback is unsupported because the runner forces `rollbackOnReorg` off, rather than suggesting users configure it
- **Code clarity**: Improve comments explaining entity copying behavior and block range validation timing
- **Refactoring**: Simplify chain ID parsing logic by removing unnecessary intermediate variable

## Implementation Details
- New test in `EventHandler.test.ts` simulates a handler throwing "Error from handler" and verifies the exception propagates correctly
- Handler test case added to `EventHandlers.ts` to support the new test scenario
- Comment in `TestIndexer.res` clarified to explain that shallow copying is sufficient because scalar fields are immutable, but array-valued fields still share backing arrays
- Chain ID validation refactored to fail fast without storing the parsed ID when it's invalid

https://claude.ai/code/session_01NCpLSmKU3MZaAyGRjmcAVc