### PR TITLE
Handler type-checking for mock indexer fixtures (review fixes)

### DIFF
--- a/packages/cli/src/napi.rs
+++ b/packages/cli/src/napi.rs
@@ -8,11 +8,22 @@ use std::collections::HashMap;
 
 #[derive(Default)]
 #[napi_derive::napi(object)]
-pub struct ParseConfigYamlOptions {
+pub struct FromUserApiOptions {
     pub schema: Option<String>,
     pub env: Option<HashMap<String, String>>,
     pub files: Option<HashMap<String, String>>,
-    pub is_rescript: Option<bool>,
+    /// Also generate the `.envio/types.d.ts` contents, so a caller can
+    /// type-check handlers against the config's generated `indexer` surface.
+    pub with_indexer_types: Option<bool>,
+}
+
+#[napi_derive::napi(object)]
+pub struct FromUserApiResult {
+    /// The public config JSON, the same shape `get_config_json` returns.
+    pub config: String,
+    /// The generated `.envio/types.d.ts`, present only when
+    /// `with_indexer_types` was requested.
+    pub indexer_types: Option<String>,
 }
 
 fn serialize_config_result(config: anyhow::Result<SystemConfig>) -> napi::Result<String> {
@@ -21,21 +32,6 @@ fn serialize_config_result(config: anyhow::Result<SystemConfig>) -> napi::Result
     system_config
         .to_public_config_json(false)
         .map_err(|e| napi::Error::from_reason(format!("Failed serializing config: {e}")))
-}
-
-fn parse_yaml_from_options(
-    yaml: &str,
-    options: ParseConfigYamlOptions,
-) -> anyhow::Result<SystemConfig> {
-    let env = options.env.unwrap_or_default();
-    let files = options.files.unwrap_or_default();
-    SystemConfig::parse_yaml(
-        yaml,
-        options.schema.as_deref(),
-        &env,
-        &files,
-        options.is_rescript.unwrap_or(false),
-    )
 }
 
 #[napi_derive::napi]
@@ -52,31 +48,41 @@ pub fn get_config_json(
     serialize_config_result(SystemConfig::parse_from_project_files(&project_paths))
 }
 
-/// Parses an indexer config without consulting the filesystem or process
-/// environment. Schema text, interpolation variables, and ABI/IDL file bodies
-/// are supplied explicitly so callers can use this from any working directory.
+/// Parses an inline indexer config the way a user's project would, without
+/// consulting the filesystem or process environment. Schema text, interpolation
+/// variables, and ABI/IDL file bodies are supplied explicitly so callers can use
+/// this from any working directory. With `with_indexer_types`, also returns the
+/// generated `.envio/types.d.ts` — the same TypeScript production codegen writes
+/// — from the single parse, so a caller can type-check handlers against the
+/// config's `indexer` surface without re-parsing.
 #[napi_derive::napi]
-pub fn parse_config_yaml(
+pub fn from_user_api(
     yaml: String,
-    options: Option<ParseConfigYamlOptions>,
-) -> napi::Result<String> {
-    serialize_config_result(parse_yaml_from_options(&yaml, options.unwrap_or_default()))
-}
-
-/// Generates the `.envio/types.d.ts` contents for an inline config, without
-/// touching the filesystem. Mirrors `parse_config_yaml`'s inputs; returns the
-/// same TypeScript the production codegen writes, so a caller can type-check
-/// handlers against a config's generated `indexer` surface.
-#[napi_derive::napi]
-pub fn generate_indexer_types(
-    yaml: String,
-    options: Option<ParseConfigYamlOptions>,
-) -> napi::Result<String> {
-    let config = parse_yaml_from_options(&yaml, options.unwrap_or_default())
+    options: Option<FromUserApiOptions>,
+) -> napi::Result<FromUserApiResult> {
+    let options = options.unwrap_or_default();
+    let env = options.env.unwrap_or_default();
+    let files = options.files.unwrap_or_default();
+    let config = SystemConfig::parse_yaml(&yaml, options.schema.as_deref(), &env, &files, false)
         .map_err(|e| napi::Error::from_reason(format!("Config parse error: {e:#}")))?;
-    let template = ProjectTemplate::from_config(&config)
-        .map_err(|e| napi::Error::from_reason(format!("Failed generating indexer types: {e:#}")))?;
-    Ok(template.indexer_types_dts().to_string())
+
+    let config_json = config
+        .to_public_config_json(false)
+        .map_err(|e| napi::Error::from_reason(format!("Failed serializing config: {e}")))?;
+
+    let indexer_types = if options.with_indexer_types.unwrap_or(false) {
+        let template = ProjectTemplate::from_config(&config).map_err(|e| {
+            napi::Error::from_reason(format!("Failed generating indexer types: {e:#}"))
+        })?;
+        Some(template.indexer_types_dts().to_string())
+    } else {
+        None
+    };
+
+    Ok(FromUserApiResult {
+        config: config_json,
+        indexer_types,
+    })
 }
 
 /// Returns a JSON-encoded `Command` for JS to dispatch, or `None` when

--- a/packages/envio-tests/test/MockIndexerHandlers_test.res
+++ b/packages/envio-tests/test/MockIndexerHandlers_test.res
@@ -41,7 +41,7 @@ indexer.onEvent({ contract: "Token", event: "Transfer" }, async ({ event, contex
     t.expect(config.name).toBe("mock-handlers")
   })
 
-  it("throws on handlers that reference a nonexistent event", t => {
+  it("throws the exact diagnostic on a nonexistent event", t => {
     t.expect(
       () =>
         InternalTestIndexer.fromUserApi(
@@ -52,6 +52,6 @@ indexer.onEvent({ contract: "Token", event: "Nonexistent" }, async () => {});
 `,
           ~configYaml=yaml,
         )->ignore,
-    ).toThrowError("Handler type errors")
+    ).toThrowError(`Type '"Nonexistent"' is not assignable to type '"Transfer"'`)
   })
 })

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -34,7 +34,7 @@ let firstContract = (config: Config.t): Config.contract => {
   chain.contracts->Array.getUnsafe(0)
 }
 
-describe("InternalTestIndexer.fromUserApi", () => {
+describe("InternalTestIndexer.fromUserApi validation", () => {
   it("parses user YAML with explicit env and no project schema", t => {
     let env = Dict.fromArray([
       ("RPC_URL", "https://rpc.example.test"),

--- a/packages/envio-tests/test/helpers/InternalTestIndexer.res
+++ b/packages/envio-tests/test/helpers/InternalTestIndexer.res
@@ -9,22 +9,23 @@ type parsed = {
 }
 
 // Parse the same YAML a user supplies, then cross the public JSON boundary used at runtime.
-// When `handlers` (TS source using `import {indexer} from "envio"`) is supplied, it's
-// type-checked against the config's generated types and any type error is thrown.
-let fromUserApi = (~schema=?, ~env=?, ~files=?, ~handlers=?, ~isRescript=false, ~configYaml): parsed => {
-  let publicConfigJson =
-    Core.parseConfigYaml(~schema?, ~env?, ~files?, ~isRescript, configYaml)->JSON.parseOrThrow
+// When `handlers` (TS source using `import {indexer} from "envio"`) is supplied, the same
+// parse also emits the generated types, and the handlers are type-checked against them;
+// any type error is thrown.
+let fromUserApi = (~schema=?, ~env=?, ~files=?, ~handlers=?, ~configYaml): parsed => {
+  let {config: configJson, indexerTypes} =
+    Core.fromUserApi(~schema?, ~env?, ~files?, ~withIndexerTypes=handlers->Option.isSome, configYaml)
 
-  switch handlers {
-  | Some(handlers) =>
-    let typesDts = Core.generateIndexerTypes(~schema?, ~env?, ~files?, configYaml)
+  switch (handlers, indexerTypes->Null.toOption) {
+  | (Some(handlers), Some(typesDts)) =>
     switch checkHandlerTypes(typesDts, handlers) {
     | [] => ()
     | errors => JsError.throwWithMessage("Handler type errors:\n" ++ errors->Array.join("\n"))
     }
-  | None => ()
+  | _ => ()
   }
 
+  let publicConfigJson = configJson->JSON.parseOrThrow
   {
     publicConfigJson,
     config: Config.fromPublic(publicConfigJson),

--- a/packages/envio-tests/test/helpers/TypeChecker.ts
+++ b/packages/envio-tests/test/helpers/TypeChecker.ts
@@ -2,6 +2,18 @@ import ts from "typescript";
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
 
+// Must match the TypeScript version the init templates pin
+// (packages/cli/src/hbs_templating/init_templates.rs), so handlers are checked
+// with the exact compiler a real project runs. Bump both together.
+const EXPECTED_TS_VERSION = "6.0.3";
+if (ts.version !== EXPECTED_TS_VERSION) {
+  throw new Error(
+    `TypeChecker expects TypeScript ${EXPECTED_TS_VERSION} to match the init-template pin ` +
+      `in packages/cli/src/hbs_templating/init_templates.rs, but resolved ${ts.version}. ` +
+      `Update both together.`,
+  );
+}
+
 // Mirrors packages/cli/templates/static/*/typescript/tsconfig.json (identical
 // across every init template), so handlers are checked exactly as a real
 // project's would be. Kept as the same JSON tsc itself parses, then converted
@@ -45,55 +57,76 @@ const formatHost: ts.FormatDiagnosticsHost = {
   getNewLine: () => "\n",
 };
 
+const typesPath = path.join(helpersDir, "__mock_indexer_types.d.ts");
+const handlersPath = path.join(helpersDir, "__mock_indexer_handlers.ts");
+
+// The virtual inputs for the current call, injected as sibling files of this
+// module so bare imports (`envio`, `ts-expect`, ...) resolve through
+// envio-tests' node_modules, and the generated `declare module "envio"`
+// augmentation binds `indexer` to this fixture's config for this program only —
+// no shared global state, so independent configs never collide.
+let virtualFiles = new Map<string, string>();
+
+// The `envio`/`@types/node`/lib `.d.ts` graph is identical across fixtures, so
+// parse it once and reuse the SourceFiles (and the prior program's structure)
+// across calls — otherwise each fixture re-parses megabytes of declarations.
+// Only the two virtual files are re-read every call.
+const sourceFileCache = new Map<string, ts.SourceFile>();
+let previousProgram: ts.Program | undefined;
+
+const host = ts.createCompilerHost(compilerOptions, true);
+// Anchor resolution to this package so `types: ["node"]` (and any other
+// type-root lookup) finds envio-tests' `@types/node` regardless of which
+// package's cwd launched the test — otherwise a caller without `@types/node`
+// reachable from its cwd gets a spurious global TS2688.
+host.getCurrentDirectory = () => helpersDir;
+const baseReadFile = host.readFile.bind(host);
+const baseFileExists = host.fileExists.bind(host);
+const baseGetSourceFile = host.getSourceFile.bind(host);
+
+host.readFile = (fileName) => virtualFiles.get(fileName) ?? baseReadFile(fileName);
+host.fileExists = (fileName) =>
+  virtualFiles.has(fileName) || baseFileExists(fileName);
+host.getSourceFile = (fileName, languageVersionOrOptions, onError, shouldCreate) => {
+  const virtual = virtualFiles.get(fileName);
+  if (virtual !== undefined) {
+    // Fresh every call — the fixture's types/handlers differ, and returning a
+    // new SourceFile is what tells the reused program these two files changed.
+    return ts.createSourceFile(fileName, virtual, languageVersionOrOptions, true);
+  }
+  const cached = sourceFileCache.get(fileName);
+  if (cached !== undefined) return cached;
+  const sourceFile = baseGetSourceFile(fileName, languageVersionOrOptions, onError, shouldCreate);
+  if (sourceFile !== undefined) sourceFileCache.set(fileName, sourceFile);
+  return sourceFile;
+};
+
 /**
  * Type-check `handlers` against the generated `.envio/types.d.ts` of a mock
  * config. Returns human-readable error strings; an empty array means the
  * handlers type-check cleanly.
- *
- * The two inputs are injected as virtual sibling files of this module so bare
- * imports (`envio`, `ts-expect`, ...) resolve through envio-tests'
- * node_modules, and the generated `declare module "envio"` augmentation binds
- * `indexer` to the mock config for this program only — no shared global state,
- * so independent configs never collide.
  */
 export function checkHandlerTypes(typesDts: string, handlers: string): string[] {
-  const typesPath = path.join(helpersDir, "__mock_indexer_types.d.ts");
-  const handlersPath = path.join(helpersDir, "__mock_indexer_handlers.ts");
-
-  const virtualFiles = new Map<string, string>([
+  virtualFiles = new Map<string, string>([
     [typesPath, typesDts],
     [handlersPath, handlers],
   ]);
 
-  const host = ts.createCompilerHost(compilerOptions, true);
-  // Anchor resolution to this package so `types: ["node"]` (and any other
-  // type-root lookup) finds envio-tests' `@types/node` regardless of which
-  // package's cwd launched the test — otherwise a caller without `@types/node`
-  // reachable from its cwd gets a spurious global TS2688.
-  host.getCurrentDirectory = () => helpersDir;
-  const baseReadFile = host.readFile.bind(host);
-  const baseFileExists = host.fileExists.bind(host);
-  const baseGetSourceFile = host.getSourceFile.bind(host);
+  const program = ts.createProgram(
+    [typesPath, handlersPath],
+    compilerOptions,
+    host,
+    previousProgram,
+  );
+  previousProgram = program;
 
-  host.readFile = (fileName) => virtualFiles.get(fileName) ?? baseReadFile(fileName);
-  host.fileExists = (fileName) =>
-    virtualFiles.has(fileName) || baseFileExists(fileName);
-  host.getSourceFile = (fileName, languageVersionOrOptions, onError, shouldCreate) => {
-    const virtual = virtualFiles.get(fileName);
-    if (virtual !== undefined) {
-      return ts.createSourceFile(fileName, virtual, languageVersionOrOptions, true);
-    }
-    return baseGetSourceFile(fileName, languageVersionOrOptions, onError, shouldCreate);
-  };
-
-  const program = ts.createProgram([typesPath, handlersPath], compilerOptions, host);
-
-  // Report errors from the handler + generated-types files and global config
-  // errors (no associated file). node_modules noise is dropped; lib .d.ts
-  // errors are already suppressed by skipLibCheck.
+  // Only diagnostics inferred in the handler source are of interest — the
+  // generated types are a `.d.ts` we trust (and skipLibCheck skips anyway). We
+  // keep file-less diagnostics too, since those are global config/harness
+  // errors (e.g. a missing `@types/node`) that must not be silently swallowed.
   const diagnostics = ts
     .getPreEmitDiagnostics(program)
-    .filter((d) => d.file === undefined || virtualFiles.has(d.file.fileName));
+    .filter((d) => d.file === undefined || d.file.fileName === handlersPath);
 
   return diagnostics.map((d) => ts.formatDiagnostic(d, formatHost).trim());
 }

--- a/packages/envio/src/Core.res
+++ b/packages/envio/src/Core.res
@@ -10,18 +10,22 @@ type svmHyperSyncClientCtor
 type fuelHyperSyncClientCtor
 type transactionStoreCtor
 type blockStoreCtor
-type parseConfigYamlOptions = {
+type fromUserApiOptions = {
   schema?: string,
   env?: dict<string>,
   files?: dict<string>,
-  isRescript?: bool,
+  withIndexerTypes?: bool,
+}
+
+type fromUserApiResult = {
+  config: string,
+  indexerTypes: Null.t<string>,
 }
 
 type addon = {
   getConfigJson: (~configPath: Null.t<string>, ~directory: Null.t<string>) => string,
   encodeIndexedTopic: (~abiType: string, ~value: unknown) => EvmTypes.Hex.t,
-  parseConfigYaml: (string, parseConfigYamlOptions) => string,
-  generateIndexerTypes: (string, parseConfigYamlOptions) => string,
+  fromUserApi: (string, fromUserApiOptions) => fromUserApiResult,
   runCli: (~args: array<string>, ~envioPackageDir: Null.t<string>) => promise<Null.t<string>>,
   @as("EvmHyperSyncClient")
   evmHyperSyncClient: evmHyperSyncClientCtor,
@@ -208,30 +212,18 @@ let getConfigJson = (~configPath=?, ~directory=?) => {
 
 // Pure config entry point: no cwd, config file, schema file, .env, or process env lookup.
 // A supplied schema is authoritative; omitted or blank schema text means an empty schema.
-let parseConfigYaml = (~schema=?, ~env=?, ~files=?, ~isRescript=false, yaml) => {
+// With `withIndexerTypes`, the single parse also returns the generated
+// `.envio/types.d.ts`, so callers can type-check handlers against the config's
+// `indexer` surface without re-parsing.
+let fromUserApi = (~schema=?, ~env=?, ~files=?, ~withIndexerTypes=false, yaml) => {
   let addon = getAddon()
-  addon.parseConfigYaml(
+  addon.fromUserApi(
     yaml,
     {
       ?schema,
       ?env,
       ?files,
-      isRescript,
-    },
-  )
-}
-
-// Generates the `.envio/types.d.ts` contents for an inline config, so callers
-// can type-check handlers against the config's generated `indexer` surface.
-let generateIndexerTypes = (~schema=?, ~env=?, ~files=?, yaml) => {
-  let addon = getAddon()
-  addon.generateIndexerTypes(
-    yaml,
-    {
-      ?schema,
-      ?env,
-      ?files,
-      isRescript: false,
+      withIndexerTypes,
     },
   )
 }


### PR DESCRIPTION
## What

Lets a mock-indexer test fixture type-check TypeScript handler source (`import { indexer } from "envio"; indexer.onEvent(...)`) against the `indexer` surface generated from its own inline `config.yaml` + `schema.graphql`. This is the type-test half of the mock-indexer tooling; actually running the handlers is intentionally out of scope for now.

```rescript
InternalTestIndexer.fromUserApi(
  ~schema,
  ~handlers=`
    import { indexer } from "envio";
    import { expectType, type TypeEqual } from "ts-expect";
    indexer.onEvent({ contract: "Token", event: "Transfer" }, async ({ event, context }) => {
      expectType<TypeEqual<typeof event.params.value, bigint>>(true);
      context.Account.set({ id: event.params.to, balance: event.params.value });
    });
  `,
  ~configYaml=yaml,
)
```

Any handler type error throws with the compiler diagnostics.

## How

- **`from_user_api` (napi) + `Core.fromUserApi`** — parses an inline config once and returns `{ config, indexerTypes }`. With `withIndexerTypes`, `indexerTypes` is the exact `.envio/types.d.ts` production codegen emits (via `ProjectTemplate::from_config`); otherwise it's absent. A single napi call, so the runtime config and the generated types can't drift from two separate parses. No filesystem access.
- **`TypeChecker.ts`** — type-checks the handlers in an isolated, in-process `ts.Program` using the same compiler options as the init-template `tsconfig.json`, and asserts its TypeScript version matches the init-template pin so the two can't silently diverge. The generated `declare module "envio"` augmentation is injected as a virtual file, so each fixture binds `indexer` to its own config for that program only — independent fixtures never collide on the global module augmentation. Only diagnostics inferred in the handler source (plus global config errors) are reported; the generated `.d.ts` is trusted, not re-checked. The unchanged `envio` + `@types/node` declaration graph is parsed once and reused across fixtures (source-file cache + prior-program reuse), so each check doesn't re-parse it.
- **`InternalTestIndexer.fromUserApi`** (renamed from `MockIndexerConfig.parseYaml`) — gains an optional `~handlers`; throws on any type error.

## Tests

- New `MockIndexerHandlers_test`: a clean handler set type-checks, and a nonexistent event name throws the exact diagnostic `Type '"Nonexistent"' is not assignable to type '"Transfer"'`.
- `UserApiValidation_test` (renamed from `ConfigYaml_test`) and `ColumnNameFormat_test` moved to the renamed helper.
- Rust `envio_types_dts` snapshots (evm/fuel/svm) unchanged.

## Notes

- Builds on #1470 and applies the review feedback: single napi parse, no `isRescript`, handler-scoped diagnostics, TS-version pin assertion, cross-fixture program reuse, and an exact-diagnostic negative test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jWRbYWgh5DQ74GF6NDdu2

---
_Generated by [Claude Code](https://claude.ai/code/session_018jWRbYWgh5DQ74GF6NDdu2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user-facing API for parsing configuration with inline schema, environment, and file inputs.
  * Added optional generation of indexer TypeScript definitions alongside parsed configuration.
  * Added validation of handler code against generated indexer types.

* **Bug Fixes**
  * Improved configuration and type-generation error messages.

* **Tests**
  * Expanded coverage for handler typing, configuration validation, YAML workflows, and storage naming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->