### PR TITLE
Support numeric entity IDs (Int!, BigInt!) in codegen

### DIFF
--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -1,6 +1,6 @@
 use super::{
     chain_helpers::get_max_reorg_depth_from_id,
-    entity_parsing::{Entity, GraphQLEnum, Schema},
+    entity_parsing::{Entity, GqlScalar, GraphQLEnum, Schema},
     env_interpolation::interpolate_config_variables,
     human_config::{
         self,
@@ -380,6 +380,11 @@ impl Storage {
     }
 }
 
+/// Largest BigInt precision ClickHouse still stores as a numeric `Decimal`;
+/// above this (or with no precision) it falls back to `String`. Kept in sync
+/// with the BigInt branch of `getClickHouseFieldType` in ClickHouse.res.
+const CLICKHOUSE_DECIMAL_MAX_PRECISION: u32 = 38;
+
 /// Check per-entity `@storage` directives against the resolved global storage.
 /// Malformed directives are raised earlier, during schema parsing.
 pub fn validate_entity_storage(storage: &Storage, schema: &Schema) -> anyhow::Result<()> {
@@ -418,6 +423,35 @@ pub fn validate_entity_storage(storage: &Storage, schema: &Schema) -> anyhow::Re
                  - Or add @storage(postgres: true) and/or @storage(clickhouse: true) to the entities listed above. Example:\n      \
                  type {example} @storage(postgres: true) {{ ... }}"
             ));
+        }
+    }
+
+    // ClickHouse stores a BigInt whose precision is unset (or above its Decimal
+    // ceiling) as a String, which sorts lexicographically. `id` is ClickHouse's
+    // mandatory default sort key, so an id like that would order wrong. Reject
+    // it up front, mirroring `validate_clickhouse_order_by_fields`. See the
+    // BigInt branch of `getClickHouseFieldType` in ClickHouse.res.
+    for entity in &entities {
+        let uses_clickhouse = if entity.has_storage_directive() {
+            entity.clickhouse.as_ref().is_some_and(|c| c.is_enabled())
+        } else {
+            clickhouse_default
+        };
+        if !uses_clickhouse {
+            continue;
+        }
+        if let Ok(GqlScalar::BigInt(precision)) = entity.get_id_scalar() {
+            let stored_as_numeric =
+                precision.is_some_and(|p| p <= CLICKHOUSE_DECIMAL_MAX_PRECISION);
+            if !stored_as_numeric {
+                return Err(anyhow!(
+                    "Invalid storage for `{}`. Its `id` is a BigInt, which ClickHouse stores as a \
+                     String (sorted lexicographically, not numerically) unless a precision is set. \
+                     Since `id` is ClickHouse's sorting key, add `@config(precision: N)` with \
+                     N <= {CLICKHOUSE_DECIMAL_MAX_PRECISION} so the id stores as a numeric Decimal.",
+                    entity.name
+                ));
+            }
         }
     }
 

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -85,6 +85,21 @@ fn generate_enums_code(gql_enums: &[GraphQlEnumTypeTemplate]) -> String {
     code
 }
 
+/// An entity's `id` rescript type and whether it is the default `string`.
+/// Foreign keys and id-keyed operations adopt this type; `ID!`/`String!` keep
+/// `string`, `Int!` is `int`, `BigInt!` is `bigint`.
+fn entity_id_type(entity: &EntityRecordTypeTemplate) -> (bool, String) {
+    entity
+        .params
+        .iter()
+        .find(|param| param.field_name.uncapitalized == "id")
+        .map(|param| match &param.field_type {
+            TypeIdent::ID | TypeIdent::String => (true, "string".to_string()),
+            other => (false, other.to_string()),
+        })
+        .unwrap_or((true, "string".to_string()))
+}
+
 fn generate_entities_code(entities: &[EntityRecordTypeTemplate]) -> String {
     let mut code = String::new();
 
@@ -93,23 +108,12 @@ fn generate_entities_code(entities: &[EntityRecordTypeTemplate]) -> String {
     writeln!(code, "type id = string").unwrap();
 
     for entity in entities {
-        // Each entity exposes its own id type so handler/test-indexer operations
-        // (get/getOrThrow/deleteUnsafe) are keyed by the real scalar. `ID!`/
-        // `String!` reuse the `string` default; numeric ids are int/bigint.
-        let id_type = entity
-            .params
-            .iter()
-            .find(|param| param.field_name.uncapitalized == "id")
-            .map(|param| match &param.field_type {
-                TypeIdent::ID => "string".to_string(),
-                other => other.to_string(),
-            })
-            .unwrap_or_else(|| "string".to_string());
+        let (_, id_type) = entity_id_type(entity);
 
         writeln!(code).unwrap();
         writeln!(code, "module {} = {{", entity.name.capitalized).unwrap();
-        writeln!(code, "  type t = {}", entity.type_code).unwrap();
         writeln!(code, "  type id = {}", id_type).unwrap();
+        writeln!(code, "  type t = {}", entity.type_code).unwrap();
         writeln!(code).unwrap();
         writeln!(
             code,
@@ -1494,39 +1498,58 @@ switch chainId {{
         let enums_module_code = indent(&generate_enums_code(&gql_enums));
         let entities_module_code = indent(&generate_entities_code(&entities));
 
-        // Generate handlerContext types
+        // Generate handlerContext types. String ids use the plain
+        // `handlerEntityOperations`; numeric ids use the custom-id variant.
+        let has_custom_id_entity = entities.iter().any(|entity| !entity_id_type(entity).0);
         let handler_context_entity_fields = entities
             .iter()
             .map(|entity| {
-                format!(
-                    "  \\\"{}\": handlerEntityOperations<Entities.{}.t, Entities.{}.id, Entities.{}.getWhereFilter>,",
-                    entity.name.capitalized,
-                    entity.name.capitalized,
-                    entity.name.capitalized,
-                    entity.name.capitalized,
-                )
+                let name = &entity.name.capitalized;
+                if entity_id_type(entity).0 {
+                    format!(
+                        "  \\\"{name}\": handlerEntityOperations<Entities.{name}.t, Entities.{name}.getWhereFilter>,",
+                    )
+                } else {
+                    format!(
+                        "  \\\"{name}\": handlerEntityOperationsWithCustomId<Entities.{name}.t, Entities.{name}.id, Entities.{name}.getWhereFilter>,",
+                    )
+                }
             })
             .collect::<Vec<_>>()
             .join("\n");
 
-        let handler_context_code = format!(
-            r#"type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {{
+        let custom_id_handler_ops_code = if has_custom_id_entity {
+            r#"
+
+type handlerEntityOperationsWithCustomId<'entity, 'id, 'getWhereFilter> = {
   get: 'id => promise<option<'entity>>,
   getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
   deleteUnsafe: 'id => unit,
-}}
+}"#
+        } else {
+            ""
+        };
+
+        let handler_context_code = format!(
+            r#"type handlerEntityOperations<'entity, 'getWhereFilter> = {{
+  get: string => promise<option<'entity>>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  getWhere: 'getWhereFilter => promise<array<'entity>>,
+  getOrCreate: 'entity => promise<'entity>,
+  set: 'entity => unit,
+  deleteUnsafe: string => unit,
+}}{custom_id_handler_ops_code}
 
 type handlerContext = {{
   log: Envio.logger,
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-{}
+{handler_context_entity_fields}
 }}"#,
-            handler_context_entity_fields
         );
 
         // Generate contract modules with event sub-modules
@@ -1817,9 +1840,22 @@ type contractRegisterContext = {{
             .collect::<Vec<_>>()
             .join("\n");
 
-        // Generate entity ops fields for the testIndexer type
-        let test_indexer_entity_ops_type = r#"/** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity, 'id> = {
+        // Generate entity ops fields for the testIndexer type. String ids use
+        // the plain type; numeric ids use the custom-id variant.
+        let test_indexer_entity_ops_type = if has_custom_id_entity {
+            r#"/** Entity operations for direct access outside handlers. */
+type testIndexerEntityOperations<'entity> = {
+  /** Get an entity by ID. */
+  get: string => promise<option<'entity>>,
+  /** Get all entities. */
+  getAll: unit => promise<array<'entity>>,
+  /** Get an entity by ID or throw if not found. */
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  /** Set (create or update) an entity. */
+  set: 'entity => unit,
+}
+
+type testIndexerEntityOperationsWithCustomId<'entity, 'id> = {
   /** Get an entity by ID. */
   get: 'id => promise<option<'entity>>,
   /** Get all entities. */
@@ -1828,15 +1864,32 @@ type testIndexerEntityOperations<'entity, 'id> = {
   getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
-}"#;
+}"#
+        } else {
+            r#"/** Entity operations for direct access outside handlers. */
+type testIndexerEntityOperations<'entity> = {
+  /** Get an entity by ID. */
+  get: string => promise<option<'entity>>,
+  /** Get all entities. */
+  getAll: unit => promise<array<'entity>>,
+  /** Get an entity by ID or throw if not found. */
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  /** Set (create or update) an entity. */
+  set: 'entity => unit,
+}"#
+        };
 
         let test_indexer_entity_fields = entities
             .iter()
             .map(|entity| {
-                format!(
-                    "  \\\"{}\": testIndexerEntityOperations<Entities.{}.t, Entities.{}.id>,",
-                    entity.name.capitalized, entity.name.capitalized, entity.name.capitalized,
-                )
+                let name = &entity.name.capitalized;
+                if entity_id_type(entity).0 {
+                    format!("  \\\"{name}\": testIndexerEntityOperations<Entities.{name}.t>,")
+                } else {
+                    format!(
+                        "  \\\"{name}\": testIndexerEntityOperationsWithCustomId<Entities.{name}.t, Entities.{name}.id>,",
+                    )
+                }
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -1871,7 +1924,7 @@ type testIndexer = {{
         // The GADT name value compiles to a string at runtime via @as decorators,
         // so @get_index can use Entities.name directly as a dictionary key
         if !entities.is_empty() {
-            let get_entity_operations = r#"@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = """#;
+            let get_entity_operations = r#"@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = """#;
 
             indexer_code = format!("{}\n\n{}", indexer_code, get_entity_operations);
         }
@@ -3420,12 +3473,17 @@ type Vault {
             .indexer_code;
 
         let expectations = [
-            "module Chain = {\n    type t = {id: int}\n    type id = int",
-            "module BigThing = {\n    type t = {id: bigint}\n    type id = bigint",
+            // `type id` is emitted before `type t`.
+            "module Chain = {\n    type id = int\n    type t = {id: int}",
+            "module BigThing = {\n    type id = bigint\n    type t = {id: bigint}",
             // The FK columns adopt the referenced entity's id type.
-            "module Vault = {\n    type t = {id: id, chain_id: int, big_id: bigint}\n    type id = string",
-            "handlerEntityOperations<Entities.Chain.t, Entities.Chain.id, Entities.Chain.getWhereFilter>",
-            "testIndexerEntityOperations<Entities.BigThing.t, Entities.BigThing.id>",
+            "module Vault = {\n    type id = string\n    type t = {id: id, chain_id: int, big_id: bigint}",
+            // Numeric ids use the custom-id operation variants...
+            "handlerEntityOperationsWithCustomId<Entities.Chain.t, Entities.Chain.id, Entities.Chain.getWhereFilter>",
+            "testIndexerEntityOperationsWithCustomId<Entities.BigThing.t, Entities.BigThing.id>",
+            // ...while string ids stay on the plain, id-argument-free variants.
+            "handlerEntityOperations<Entities.Vault.t, Entities.Vault.getWhereFilter>",
+            "testIndexerEntityOperations<Entities.Vault.t>",
         ];
         for expected in expectations {
             assert!(

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -93,9 +93,23 @@ fn generate_entities_code(entities: &[EntityRecordTypeTemplate]) -> String {
     writeln!(code, "type id = string").unwrap();
 
     for entity in entities {
+        // Each entity exposes its own id type so handler/test-indexer operations
+        // (get/getOrThrow/deleteUnsafe) are keyed by the real scalar. `ID!`/
+        // `String!` reuse the `string` default; numeric ids are int/bigint.
+        let id_type = entity
+            .params
+            .iter()
+            .find(|param| param.field_name.uncapitalized == "id")
+            .map(|param| match &param.field_type {
+                TypeIdent::ID => "string".to_string(),
+                other => other.to_string(),
+            })
+            .unwrap_or_else(|| "string".to_string());
+
         writeln!(code).unwrap();
         writeln!(code, "module {} = {{", entity.name.capitalized).unwrap();
         writeln!(code, "  type t = {}", entity.type_code).unwrap();
+        writeln!(code, "  type id = {}", id_type).unwrap();
         writeln!(code).unwrap();
         writeln!(
             code,
@@ -1485,7 +1499,8 @@ switch chainId {{
             .iter()
             .map(|entity| {
                 format!(
-                    "  \\\"{}\": handlerEntityOperations<Entities.{}.t, Entities.{}.getWhereFilter>,",
+                    "  \\\"{}\": handlerEntityOperations<Entities.{}.t, Entities.{}.id, Entities.{}.getWhereFilter>,",
+                    entity.name.capitalized,
                     entity.name.capitalized,
                     entity.name.capitalized,
                     entity.name.capitalized,
@@ -1495,13 +1510,13 @@ switch chainId {{
             .join("\n");
 
         let handler_context_code = format!(
-            r#"type handlerEntityOperations<'entity, 'getWhereFilter> = {{
-  get: string => promise<option<'entity>>,
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+            r#"type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {{
+  get: 'id => promise<option<'entity>>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: string => unit,
+  deleteUnsafe: 'id => unit,
 }}
 
 type handlerContext = {{
@@ -1804,13 +1819,13 @@ type contractRegisterContext = {{
 
         // Generate entity ops fields for the testIndexer type
         let test_indexer_entity_ops_type = r#"/** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity> = {
+type testIndexerEntityOperations<'entity, 'id> = {
   /** Get an entity by ID. */
-  get: string => promise<option<'entity>>,
+  get: 'id => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }"#;
@@ -1819,8 +1834,8 @@ type testIndexerEntityOperations<'entity> = {
             .iter()
             .map(|entity| {
                 format!(
-                    "  \\\"{}\": testIndexerEntityOperations<Entities.{}.t>,",
-                    entity.name.capitalized, entity.name.capitalized,
+                    "  \\\"{}\": testIndexerEntityOperations<Entities.{}.t, Entities.{}.id>,",
+                    entity.name.capitalized, entity.name.capitalized, entity.name.capitalized,
                 )
             })
             .collect::<Vec<_>>()
@@ -1856,7 +1871,7 @@ type testIndexer = {{
         // The GADT name value compiles to a string at runtime via @as decorators,
         // so @get_index can use Entities.name directly as a dictionary key
         if !entities.is_empty() {
-            let get_entity_operations = r#"@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = """#;
+            let get_entity_operations = r#"@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = """#;
 
             indexer_code = format!("{}\n\n{}", indexer_code, get_entity_operations);
         }
@@ -2825,6 +2840,7 @@ mod test {
         utils::text::Capitalize,
     };
     use pretty_assertions::assert_eq;
+    use std::collections::HashMap;
     use std::vec;
     use system_config::FieldSelection;
 
@@ -3362,6 +3378,61 @@ mod test {
         // config2.yaml has chain IDs 1 (known: ethereum-mainnet) and 2 (unknown)
         let project_template = get_project_template_helper("config2.yaml");
         insta::assert_snapshot!(project_template.indexer_code);
+    }
+
+    #[test]
+    fn indexer_code_exposes_numeric_entity_id_types() {
+        // Each entity module exposes its id scalar so handler/test-indexer
+        // operations are keyed by the real type: `ID!` reuses `string`, while
+        // `Int!`/`BigInt!` render as `int`/`bigint`.
+        let yaml = r#"
+name: numeric-ids
+chains:
+  - id: 1
+    rpc:
+      url: https://rpc.example.test
+      for: sync
+    start_block: 0
+    contracts:
+      - name: Token
+        address: "0x0000000000000000000000000000000000000001"
+        events:
+          - event: Transfer()
+"#;
+        let schema = r#"
+type Chain {
+  id: Int!
+}
+type BigThing {
+  id: BigInt!
+}
+type Vault {
+  id: ID!
+  chain: Chain!
+  big: BigThing!
+}
+"#;
+        let config =
+            SystemConfig::parse_yaml(yaml, Some(schema), &HashMap::new(), &HashMap::new(), false)
+                .expect("numeric-id config should parse");
+        let indexer_code = super::ProjectTemplate::from_config(&config)
+            .expect("project template")
+            .indexer_code;
+
+        let expectations = [
+            "module Chain = {\n    type t = {id: int}\n    type id = int",
+            "module BigThing = {\n    type t = {id: bigint}\n    type id = bigint",
+            // The FK columns adopt the referenced entity's id type.
+            "module Vault = {\n    type t = {id: id, chain_id: int, big_id: bigint}\n    type id = string",
+            "handlerEntityOperations<Entities.Chain.t, Entities.Chain.id, Entities.Chain.getWhereFilter>",
+            "testIndexerEntityOperations<Entities.BigThing.t, Entities.BigThing.id>",
+        ];
+        for expected in expectations {
+            assert!(
+                indexer_code.contains(expected),
+                "generated indexer code missing:\n{expected}\n\n--- got ---\n{indexer_code}"
+            );
+        }
     }
 
     #[test]

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generated_for_svm.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generated_for_svm.snap
@@ -1,6 +1,6 @@
 ---
 source: packages/cli/src/hbs_templating/codegen_templates.rs
-assertion_line: 3557
+assertion_line: 3671
 expression: project_template.indexer_code
 ---
 /**
@@ -80,8 +80,8 @@ module Entities = {
   type id = string
 
   module EmptyEntity = {
-    type t = {id: id, emptyField: id}
     type id = string
+    type t = {id: id, emptyField: id}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("emptyField") emptyField?: Envio.whereOperator<id>}
   }
@@ -90,13 +90,13 @@ module Entities = {
     | @as("EmptyEntity") EmptyEntity: name<EmptyEntity.t>
 }
 
-type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
-  get: 'id => promise<option<'entity>>,
-  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'getWhereFilter> = {
+  get: string => promise<option<'entity>>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: 'id => unit,
+  deleteUnsafe: string => unit,
 }
 
 type handlerContext = {
@@ -104,7 +104,7 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id, Entities.EmptyEntity.getWhereFilter>,
+  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.getWhereFilter>,
 }
 
 type chainId = [#0]
@@ -240,13 +240,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity, 'id> = {
+type testIndexerEntityOperations<'entity> = {
   /** Get an entity by ID. */
-  get: 'id => promise<option<'entity>>,
+  get: string => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -259,10 +259,10 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id>,
+  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generated_for_svm.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generated_for_svm.snap
@@ -1,5 +1,6 @@
 ---
 source: packages/cli/src/hbs_templating/codegen_templates.rs
+assertion_line: 3557
 expression: project_template.indexer_code
 ---
 /**
@@ -80,6 +81,7 @@ module Entities = {
 
   module EmptyEntity = {
     type t = {id: id, emptyField: id}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("emptyField") emptyField?: Envio.whereOperator<id>}
   }
@@ -88,13 +90,13 @@ module Entities = {
     | @as("EmptyEntity") EmptyEntity: name<EmptyEntity.t>
 }
 
-type handlerEntityOperations<'entity, 'getWhereFilter> = {
-  get: string => promise<option<'entity>>,
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
+  get: 'id => promise<option<'entity>>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: string => unit,
+  deleteUnsafe: 'id => unit,
 }
 
 type handlerContext = {
@@ -102,7 +104,7 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.getWhereFilter>,
+  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id, Entities.EmptyEntity.getWhereFilter>,
 }
 
 type chainId = [#0]
@@ -238,13 +240,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity> = {
+type testIndexerEntityOperations<'entity, 'id> = {
   /** Get an entity by ID. */
-  get: string => promise<option<'entity>>,
+  get: 'id => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -257,10 +259,10 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t>,
+  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
@@ -1,5 +1,6 @@
 ---
 source: packages/cli/src/hbs_templating/codegen_templates.rs
+assertion_line: 3372
 expression: project_template.indexer_code
 ---
 /**
@@ -201,12 +202,14 @@ module Entities = {
 
   module EmptyEntity = {
     type t = {id: id, emptyField: id, status: Enums.Status.t, optionalStatus: option<Enums.Status.t>, related_id: id, optionalRelated_id: option<id>, tags: array<string>, optionalTags: option<array<string>>}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("emptyField") emptyField?: Envio.whereOperator<id>, @as("status") status?: Envio.whereOperator<Enums.Status.t>, @as("optionalStatus") optionalStatus?: Envio.whereOperator<option<Enums.Status.t>>, @as("related_id") related?: Envio.whereOperator<id>, @as("optionalRelated_id") optionalRelated?: Envio.whereOperator<option<id>>, @as("tags") tags?: Envio.whereOperator<array<string>>, @as("optionalTags") optionalTags?: Envio.whereOperator<option<array<string>>>}
   }
 
   module RelatedEntity = {
     type t = {id: id, name: string}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("name") name?: Envio.whereOperator<string>}
   }
@@ -216,13 +219,13 @@ module Entities = {
     | @as("RelatedEntity") RelatedEntity: name<RelatedEntity.t>
 }
 
-type handlerEntityOperations<'entity, 'getWhereFilter> = {
-  get: string => promise<option<'entity>>,
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
+  get: 'id => promise<option<'entity>>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: string => unit,
+  deleteUnsafe: 'id => unit,
 }
 
 type handlerContext = {
@@ -230,8 +233,8 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.getWhereFilter>,
-  \"RelatedEntity": handlerEntityOperations<Entities.RelatedEntity.t, Entities.RelatedEntity.getWhereFilter>,
+  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id, Entities.EmptyEntity.getWhereFilter>,
+  \"RelatedEntity": handlerEntityOperations<Entities.RelatedEntity.t, Entities.RelatedEntity.id, Entities.RelatedEntity.getWhereFilter>,
 }
 
 type chainId = [#1]
@@ -421,13 +424,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity> = {
+type testIndexerEntityOperations<'entity, 'id> = {
   /** Get an entity by ID. */
-  get: string => promise<option<'entity>>,
+  get: 'id => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -440,11 +443,11 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t>,
-  \"RelatedEntity": testIndexerEntityOperations<Entities.RelatedEntity.t>,
+  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id>,
+  \"RelatedEntity": testIndexerEntityOperations<Entities.RelatedEntity.t, Entities.RelatedEntity.id>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
@@ -1,6 +1,6 @@
 ---
 source: packages/cli/src/hbs_templating/codegen_templates.rs
-assertion_line: 3372
+assertion_line: 3426
 expression: project_template.indexer_code
 ---
 /**
@@ -201,15 +201,15 @@ module Entities = {
   type id = string
 
   module EmptyEntity = {
-    type t = {id: id, emptyField: id, status: Enums.Status.t, optionalStatus: option<Enums.Status.t>, related_id: id, optionalRelated_id: option<id>, tags: array<string>, optionalTags: option<array<string>>}
     type id = string
+    type t = {id: id, emptyField: id, status: Enums.Status.t, optionalStatus: option<Enums.Status.t>, related_id: id, optionalRelated_id: option<id>, tags: array<string>, optionalTags: option<array<string>>}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("emptyField") emptyField?: Envio.whereOperator<id>, @as("status") status?: Envio.whereOperator<Enums.Status.t>, @as("optionalStatus") optionalStatus?: Envio.whereOperator<option<Enums.Status.t>>, @as("related_id") related?: Envio.whereOperator<id>, @as("optionalRelated_id") optionalRelated?: Envio.whereOperator<option<id>>, @as("tags") tags?: Envio.whereOperator<array<string>>, @as("optionalTags") optionalTags?: Envio.whereOperator<option<array<string>>>}
   }
 
   module RelatedEntity = {
-    type t = {id: id, name: string}
     type id = string
+    type t = {id: id, name: string}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("name") name?: Envio.whereOperator<string>}
   }
@@ -219,13 +219,13 @@ module Entities = {
     | @as("RelatedEntity") RelatedEntity: name<RelatedEntity.t>
 }
 
-type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
-  get: 'id => promise<option<'entity>>,
-  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'getWhereFilter> = {
+  get: string => promise<option<'entity>>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: 'id => unit,
+  deleteUnsafe: string => unit,
 }
 
 type handlerContext = {
@@ -233,8 +233,8 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id, Entities.EmptyEntity.getWhereFilter>,
-  \"RelatedEntity": handlerEntityOperations<Entities.RelatedEntity.t, Entities.RelatedEntity.id, Entities.RelatedEntity.getWhereFilter>,
+  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.getWhereFilter>,
+  \"RelatedEntity": handlerEntityOperations<Entities.RelatedEntity.t, Entities.RelatedEntity.getWhereFilter>,
 }
 
 type chainId = [#1]
@@ -424,13 +424,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity, 'id> = {
+type testIndexerEntityOperations<'entity> = {
   /** Get an entity by ID. */
-  get: 'id => promise<option<'entity>>,
+  get: string => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -443,11 +443,11 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id>,
-  \"RelatedEntity": testIndexerEntityOperations<Entities.RelatedEntity.t, Entities.RelatedEntity.id>,
+  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t>,
+  \"RelatedEntity": testIndexerEntityOperations<Entities.RelatedEntity.t>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
@@ -1,5 +1,6 @@
 ---
 source: packages/cli/src/hbs_templating/codegen_templates.rs
+assertion_line: 3379
 expression: project_template.indexer_code
 ---
 /**
@@ -197,6 +198,7 @@ module Entities = {
 
   module EmptyEntity = {
     type t = {id: id, emptyField: id}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("emptyField") emptyField?: Envio.whereOperator<id>}
   }
@@ -205,13 +207,13 @@ module Entities = {
     | @as("EmptyEntity") EmptyEntity: name<EmptyEntity.t>
 }
 
-type handlerEntityOperations<'entity, 'getWhereFilter> = {
-  get: string => promise<option<'entity>>,
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
+  get: 'id => promise<option<'entity>>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: string => unit,
+  deleteUnsafe: 'id => unit,
 }
 
 type handlerContext = {
@@ -219,7 +221,7 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.getWhereFilter>,
+  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id, Entities.EmptyEntity.getWhereFilter>,
 }
 
 type chainId = [#1 | #2]
@@ -491,13 +493,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity> = {
+type testIndexerEntityOperations<'entity, 'id> = {
   /** Get an entity by ID. */
-  get: string => promise<option<'entity>>,
+  get: 'id => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -510,10 +512,10 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t>,
+  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
@@ -1,6 +1,6 @@
 ---
 source: packages/cli/src/hbs_templating/codegen_templates.rs
-assertion_line: 3379
+assertion_line: 3433
 expression: project_template.indexer_code
 ---
 /**
@@ -197,8 +197,8 @@ module Entities = {
   type id = string
 
   module EmptyEntity = {
-    type t = {id: id, emptyField: id}
     type id = string
+    type t = {id: id, emptyField: id}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("emptyField") emptyField?: Envio.whereOperator<id>}
   }
@@ -207,13 +207,13 @@ module Entities = {
     | @as("EmptyEntity") EmptyEntity: name<EmptyEntity.t>
 }
 
-type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
-  get: 'id => promise<option<'entity>>,
-  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'getWhereFilter> = {
+  get: string => promise<option<'entity>>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: 'id => unit,
+  deleteUnsafe: string => unit,
 }
 
 type handlerContext = {
@@ -221,7 +221,7 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id, Entities.EmptyEntity.getWhereFilter>,
+  \"EmptyEntity": handlerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.getWhereFilter>,
 }
 
 type chainId = [#1 | #2]
@@ -493,13 +493,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity, 'id> = {
+type testIndexerEntityOperations<'entity> = {
   /** Get an entity by ID. */
-  get: 'id => promise<option<'entity>>,
+  get: string => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -512,10 +512,10 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t, Entities.EmptyEntity.id>,
+  \"EmptyEntity": testIndexerEntityOperations<Entities.EmptyEntity.t>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexer-handlers/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-handlers/SKILL.md
@@ -108,24 +108,13 @@ indexer.chains[1].MyContract.abi;    // [...]
 
 ## Common Pitfalls
 
-**Entity IDs** — prefer `${chainId}_${blockNumber}_${logIndex}` as a unique ID:
+**Entity IDs** — default to a string `${chainId}_${blockNumber}_${logIndex}`, globally unique across chains and blocks, unless the entity is a singleton keyed by address:
 ```ts
 const id = `${event.chainId}_${event.block.number}_${event.logIndex}`;
 ```
-This is globally unique across chains and blocks. Use it as the default unless the entity is a singleton (e.g., a Token or Pool keyed by address).
+Ids may also be `Int!`/`BigInt!` (see `indexer-schema`); `get`/`getOrThrow`/`deleteUnsafe` then take that type (`number`/`bigint`) instead of `string`.
 
-**Entity relationships** — schema uses entity references; handlers use the `_id` suffix that codegen adds:
-```ts
-// Schema:   token0: Token!       ← entity reference, field name is "token0"
-// Handler:  { token0_id: token0.id }  ← codegen adds _id; NEVER write "token0" here
-
-// Schema:   collection: NftCollection!
-// Handler:  { collection_id: collectionEntity.id }
-
-// WRONG:  { token0: token0.id }  ← "token0" is not a valid TypeScript field
-// WRONG:  { collection_id: String! } in schema  ← _id belongs in handlers, not schema
-// CORRECT: { token0_id: token0.id }  in handler
-```
+**Entity relationships** — schema uses the entity reference (`token0: Token!`); handlers use the `_id` suffix codegen adds (`token0_id: token0.id`), typed as the referenced entity's id. Never write the bare name (`token0`) in the handler, and never put `_id` in the schema.
 
 **Optionals** — `string | undefined`, not `string | null`
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexer-handlers/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-handlers/SKILL.md
@@ -108,11 +108,10 @@ indexer.chains[1].MyContract.abi;    // [...]
 
 ## Common Pitfalls
 
-**Entity IDs** — default to a string `${chainId}_${blockNumber}_${logIndex}`, globally unique across chains and blocks, unless the entity is a singleton keyed by address:
+**Entity IDs** — for a string id, `${chainId}_${blockNumber}_${logIndex}` is globally unique across chains and blocks; use it unless the entity is a singleton keyed by address:
 ```ts
 const id = `${event.chainId}_${event.block.number}_${event.logIndex}`;
 ```
-Ids may also be `Int!`/`BigInt!` (see `indexer-schema`); `get`/`getOrThrow`/`deleteUnsafe` then take that type (`number`/`bigint`) instead of `string`.
 
 **Entity relationships** — schema uses the entity reference (`token0: Token!`); handlers use the `_id` suffix codegen adds (`token0_id: token0.id`), typed as the referenced entity's id. Never write the bare name (`token0`) in the handler, and never put `_id` in the schema.
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexer-schema/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-schema/SKILL.md
@@ -13,16 +13,16 @@ metadata:
 ## Entity Rules
 
 - Every type is an entity — **no `@entity` decorator** (unlike TheGraph)
-- Must have an `id` field first — `ID!` (default), or `String!`, `Int!`, `BigInt!`
+- Must have an `id` field first — `ID!` (recommended), or `String!`, `Int!`, `BigInt!`
 - Names: 1-63 chars, alphanumeric + underscore, no reserved words
 - Relationship fields use the **entity type directly**: `collection: NftCollection!` — **never** add `_id` in the schema field name
-- The `_id` suffix only appears in TypeScript handlers (added by codegen): schema field `collection` → handler field `collection_id`, typed as the referenced entity's id (`string` for `ID!`/`String!`, `number` for `Int!`, `bigint` for `BigInt!`)
+- The `_id` suffix only appears in TypeScript handlers (added by codegen): schema field `collection` → handler field `collection_id`, typed as the referenced entity's id
 
 ## Scalar Types
 
 | Schema Type | TypeScript Type | Notes |
 |-------------|----------------|-------|
-| `ID!` | `string` | Default entity id; `String!`/`Int!`/`BigInt!` also allowed as id |
+| `ID!` | `string` | Recommended entity id; `String!`/`Int!`/`BigInt!` also allowed as id |
 | `String!` | `string` | |
 | `Int!` | `number` | |
 | `Float!` | `number` | |
@@ -161,6 +161,6 @@ type Swap {
 | `token0` | `Token!` | `token0_id: string` |
 | `collection` | `NftCollection!` | `collection_id: string` |
 
-Codegen appends `_id` to entity reference fields (never add it in the schema) and types the column as the referenced entity's id — `string` here, but `number`/`bigint` when the target has an `Int!`/`BigInt!` id.
+Codegen appends `_id` to entity reference fields (never add it in the schema), typed as the referenced entity's id.
 
 > If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/packages/cli/templates/static/shared/.claude/skills/indexer-schema/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-schema/SKILL.md
@@ -13,16 +13,16 @@ metadata:
 ## Entity Rules
 
 - Every type is an entity — **no `@entity` decorator** (unlike TheGraph)
-- Must have `id: ID!` as first field
+- Must have an `id` field first — `ID!` (default), or `String!`, `Int!`, `BigInt!`
 - Names: 1-63 chars, alphanumeric + underscore, no reserved words
 - Relationship fields use the **entity type directly**: `collection: NftCollection!` — **never** add `_id` in the schema field name
-- The `_id` suffix only appears in TypeScript handlers (added by codegen): schema field `collection` → handler field `collection_id`
+- The `_id` suffix only appears in TypeScript handlers (added by codegen): schema field `collection` → handler field `collection_id`, typed as the referenced entity's id (`string` for `ID!`/`String!`, `number` for `Int!`, `bigint` for `BigInt!`)
 
 ## Scalar Types
 
 | Schema Type | TypeScript Type | Notes |
 |-------------|----------------|-------|
-| `ID!` | `string` | Required on every entity |
+| `ID!` | `string` | Default entity id; `String!`/`Int!`/`BigInt!` also allowed as id |
 | `String!` | `string` | |
 | `Int!` | `number` | |
 | `Float!` | `number` | |
@@ -153,7 +153,7 @@ type Swap {
 }
 ```
 
-**Schema vs handler field names:**
+**Schema vs handler field names** (entity refs to `ID!`-keyed entities):
 
 | Schema field | Schema type | TypeScript handler field |
 |---|---|---|
@@ -161,6 +161,6 @@ type Swap {
 | `token0` | `Token!` | `token0_id: string` |
 | `collection` | `NftCollection!` | `collection_id: string` |
 
-Codegen always appends `_id` to entity reference field names in the TypeScript types. Do **not** add `_id` yourself in the schema.
+Codegen appends `_id` to entity reference fields (never add it in the schema) and types the column as the referenced entity's id — `string` here, but `number`/`bigint` when the target has an `Int!`/`BigInt!` id.
 
 > If something is unclear, use the `envio-docs` skill to search and read the latest documentation.

--- a/packages/envio-tests/test/ClientAddressFilter_test.res
+++ b/packages/envio-tests/test/ClientAddressFilter_test.res
@@ -53,7 +53,9 @@ describe("parseWhereOrThrow — address-param detection", () => {
       parseEvm(
         ~eventFilters=Some(%raw(`({chain}) => ({params: {to: [...chain.ERC20.addresses]}})`)),
       )->ignore
-    ).toThrowError("must be passed directly as an indexed-param filter value")
+    ).toThrowErrorEqual(
+      "Invalid where configuration for \"ERC20\": chain.ERC20.addresses must be passed directly as an indexed-param filter value (e.g. { params: { to: chain.ERC20.addresses } }). It cannot be spread, mapped, indexed, or otherwise transformed.",
+    )
   })
 
   it("throws when addresses are read but not used as a param filter", t => {
@@ -61,7 +63,9 @@ describe("parseWhereOrThrow — address-param detection", () => {
       parseEvm(
         ~eventFilters=Some(%raw(`({chain}) => { const _a = chain.ERC20.addresses; return true }`)),
       )->ignore
-    ).toThrowError("doesn't use it as an indexed-param filter value")
+    ).toThrowErrorEqual(
+      "Invalid where configuration for ERC20. The callback reads `chain.ERC20.addresses` but doesn't use it as an indexed-param filter value. Use it directly, e.g. { params: { to: chain.ERC20.addresses } }.",
+    )
   })
 })
 

--- a/packages/envio-tests/test/Config_test.res
+++ b/packages/envio-tests/test/Config_test.res
@@ -271,7 +271,7 @@ describe("EventConfigBuilder", () => {
   })
 
   it("abiTypeToSchema throws on unsupported types", t => {
-    t.expect(() => EventConfigBuilder.abiTypeToSchema("function")).toThrowError(
+    t.expect(() => EventConfigBuilder.abiTypeToSchema("function")).toThrowErrorEqual(
       "Unsupported ABI type: function",
     )
   })

--- a/packages/envio-tests/test/EntityFilter_test.res
+++ b/packages/envio-tests/test/EntityFilter_test.res
@@ -237,7 +237,7 @@ describe("EntityFilter.merge", () => {
         EntityFilter.Eq({fieldName: "a", fieldValue: v(1)}),
         EntityFilter.And({filters: [EntityFilter.Eq({fieldName: "a", fieldValue: v(2)})]}),
       ]->EntityFilter.merge
-    ).toThrowError(
+    ).toThrowErrorEqual(
       "Unexpected filter And(a:Eq:2) in a merged batch. Filters batched into a single query must use the same operator and field.",
     )
   })

--- a/packages/envio-tests/test/MockIndexerHandlers_test.res
+++ b/packages/envio-tests/test/MockIndexerHandlers_test.res
@@ -107,6 +107,8 @@ indexer.onEvent({ contract: "Token", event: "Nonexistent" }, async () => {});
 `,
           ~configYaml=yaml,
         )->ignore,
-    ).toThrowError(`Type '"Nonexistent"' is not assignable to type '"Transfer"'`)
+    ).toThrowErrorEqual(
+      "Handler type errors:\n__mock_indexer_handlers.ts(3,38): error TS2322: Type '\"Nonexistent\"' is not assignable to type '\"Transfer\"'.",
+    )
   })
 })

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -144,8 +144,8 @@ describe("EVM config YAML", () => {
 
   ["checksum", "lowercase"]->Array.forEach(addressFormat => {
     it(`rejects invalid addresses with address_format: ${addressFormat}`, t => {
-      t.expect(() => parseAddressConfig(~addressFormat, "0xfoo")->ignore).toThrowError(
-        `Contract "ERC20" on chain 1 has invalid address "0xfoo"`,
+      t.expect(() => parseAddressConfig(~addressFormat, "0xfoo")->ignore).toThrowErrorEqual(
+        `Config parse error: Contract "ERC20" on chain 1 has invalid address "0xfoo". Expected a 20-byte hex string starting with 0x.`,
       )
     })
   })

--- a/packages/envio-tests/test/Utils_test.res
+++ b/packages/envio-tests/test/Utils_test.res
@@ -117,7 +117,7 @@ describe("Hash", () => {
       () => {
         Utils.Hash.makeOrThrow(Utils.Set.fromArray(["1", "2"]))
       },
-    ).toThrowError(`Failed to get hash for Set. If you're using a custom Sury schema make it based on the string type with a decoder: const myTypeSchema = S.transform(S.string, undefined, (yourType) => yourType.toString())`)
+    ).toThrowErrorEqual(`Failed to get hash for Set. If you're using a custom Sury schema make it based on the string type with a decoder: const myTypeSchema = S.transform(S.string, undefined, (yourType) => yourType.toString())`)
   })
 
   it("symbol", t => {

--- a/packages/envio-tests/test/setup.ts
+++ b/packages/envio-tests/test/setup.ts
@@ -1,3 +1,45 @@
 // Importing Env triggers Logging.setLogger as a side effect,
 // ensuring the logger is available for all tests.
 import "envio/src/Env.res.mjs";
+
+import { expect } from "vitest";
+
+// Strict counterpart to the built-in `toThrowError`, which only checks that the
+// thrown message *contains* the expected string. `toThrowErrorEqual` requires
+// the whole message to match, so a test can pin the complete error text.
+expect.extend({
+  toThrowErrorEqual(received: unknown, expected: string) {
+    if (typeof received !== "function") {
+      return {
+        pass: false,
+        message: () =>
+          `toThrowErrorEqual expects a function to invoke, received ${typeof received}.`,
+      };
+    }
+    let thrown: unknown;
+    let didThrow = false;
+    try {
+      received();
+    } catch (error) {
+      didThrow = true;
+      thrown = error;
+    }
+    if (!didThrow) {
+      return {
+        pass: false,
+        message: () => "expected the function to throw, but it did not.",
+      };
+    }
+    const actual = thrown instanceof Error ? thrown.message : String(thrown);
+    const pass = actual === expected;
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected the thrown message not to equal:\n${JSON.stringify(expected)}`
+          : `expected the thrown message to equal:\n${JSON.stringify(
+              expected,
+            )}\nreceived:\n${JSON.stringify(actual)}`,
+    };
+  },
+});

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -585,14 +585,18 @@ export type SvmOnSlotContext<Config extends IndexerConfigTypes = GlobalConfig> =
   BaseHandlerContext<Config, SvmChainIds<Config>>
 >;
 
+/** The entity's `id` type. `ID!`/`String!` ids are `string`; `Int!` is `number`
+ * and `BigInt!` is `bigint`, so id-keyed operations accept the real scalar. */
+type EntityId<Entity> = Entity extends { readonly id: infer Id } ? Id : string;
+
 /** Entity operations available in handler contexts. */
 type EntityOperations<Entity> = {
-  readonly get: (id: string) => Promise<Entity | undefined>;
-  readonly getOrThrow: (id: string, message?: string) => Promise<Entity>;
+  readonly get: (id: EntityId<Entity>) => Promise<Entity | undefined>;
+  readonly getOrThrow: (id: EntityId<Entity>, message?: string) => Promise<Entity>;
   readonly getWhere: (filter: GetWhereFilter<Entity>) => Promise<Entity[]>;
   readonly getOrCreate: (entity: Entity) => Promise<Entity>;
   readonly set: (entity: Entity) => void;
-  readonly deleteUnsafe: (id: string) => void;
+  readonly deleteUnsafe: (id: EntityId<Entity>) => void;
 };
 
 /** Contract registration handle. */
@@ -1528,9 +1532,9 @@ type ConfigEntities<Config extends IndexerConfigTypes = GlobalConfig> =
 /** Entity operations available on test indexer for direct entity manipulation. */
 type TestIndexerEntityOperations<Entity> = {
   /** Get an entity by ID. Returns undefined if not found. */
-  readonly get: (id: string) => Promise<Entity | undefined>;
+  readonly get: (id: EntityId<Entity>) => Promise<Entity | undefined>;
   /** Get an entity by ID or throw if not found. */
-  readonly getOrThrow: (id: string, message?: string) => Promise<Entity>;
+  readonly getOrThrow: (id: EntityId<Entity>, message?: string) => Promise<Entity>;
   /** Get all entities. */
   readonly getAll: () => Promise<Entity[]>;
   /** Set (create or update) an entity. */

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -356,8 +356,8 @@ type genericHandlerArgs<'event, 'context> = {
 type genericHandler<'args> = 'args => promise<unit>
 
 type entityHandlerContext<'entity> = {
-  get: string => promise<option<'entity>>,
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  get: EntityId.t => promise<option<'entity>>,
+  getOrThrow: (EntityId.t, ~message: string=?) => promise<'entity>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
   deleteUnsafe: EntityId.t => unit,

--- a/packages/envio/src/bindings/Vitest.res
+++ b/packages/envio/src/bindings/Vitest.res
@@ -35,6 +35,10 @@ type rec expectation<'a> = {
   // Exception matchers
   toThrow: unit => unit,
   toThrowError: string => unit,
+  // Strict variant of `toThrowError`: the thrown message must equal the
+  // argument exactly, not merely contain it. Registered in each package's
+  // vitest setup via `expect.extend`.
+  toThrowErrorEqual: string => unit,
   // Snapshot matchers
   toMatchSnapshot: unit => unit,
   // Negation

--- a/packages/envio/src/bindings/Vitest.res
+++ b/packages/envio/src/bindings/Vitest.res
@@ -34,10 +34,8 @@ type rec expectation<'a> = {
   toHavePropertyValue: 'b. (string, 'b) => unit,
   // Exception matchers
   toThrow: unit => unit,
-  toThrowError: string => unit,
-  // Strict variant of `toThrowError`: the thrown message must equal the
-  // argument exactly, not merely contain it. Registered in each package's
-  // vitest setup via `expect.extend`.
+  // The thrown message must equal the argument exactly. Registered in each
+  // package's vitest setup via `expect.extend`.
   toThrowErrorEqual: string => unit,
   // Snapshot matchers
   toMatchSnapshot: unit => unit,

--- a/scenarios/fuel_test/src/Indexer.res
+++ b/scenarios/fuel_test/src/Indexer.res
@@ -82,6 +82,7 @@ module Entities = {
 
   module User = {
     type t = {id: id, greetings: array<string>, latestGreeting: string, numberOfGreetings: int}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("greetings") greetings?: Envio.whereOperator<array<string>>, @as("latestGreeting") latestGreeting?: Envio.whereOperator<string>, @as("numberOfGreetings") numberOfGreetings?: Envio.whereOperator<int>}
   }
@@ -90,13 +91,13 @@ module Entities = {
     | @as("User") User: name<User.t>
 }
 
-type handlerEntityOperations<'entity, 'getWhereFilter> = {
-  get: string => promise<option<'entity>>,
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
+  get: 'id => promise<option<'entity>>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: string => unit,
+  deleteUnsafe: 'id => unit,
 }
 
 type handlerContext = {
@@ -104,7 +105,7 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"User": handlerEntityOperations<Entities.User.t, Entities.User.getWhereFilter>,
+  \"User": handlerEntityOperations<Entities.User.t, Entities.User.id, Entities.User.getWhereFilter>,
 }
 
 type chainId = [#0]
@@ -1186,13 +1187,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity> = {
+type testIndexerEntityOperations<'entity, 'id> = {
   /** Get an entity by ID. */
-  get: string => promise<option<'entity>>,
+  get: 'id => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -1205,10 +1206,10 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"User": testIndexerEntityOperations<Entities.User.t>,
+  \"User": testIndexerEntityOperations<Entities.User.t, Entities.User.id>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/scenarios/fuel_test/src/Indexer.res
+++ b/scenarios/fuel_test/src/Indexer.res
@@ -81,8 +81,8 @@ module Entities = {
   type id = string
 
   module User = {
-    type t = {id: id, greetings: array<string>, latestGreeting: string, numberOfGreetings: int}
     type id = string
+    type t = {id: id, greetings: array<string>, latestGreeting: string, numberOfGreetings: int}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("greetings") greetings?: Envio.whereOperator<array<string>>, @as("latestGreeting") latestGreeting?: Envio.whereOperator<string>, @as("numberOfGreetings") numberOfGreetings?: Envio.whereOperator<int>}
   }
@@ -91,13 +91,13 @@ module Entities = {
     | @as("User") User: name<User.t>
 }
 
-type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
-  get: 'id => promise<option<'entity>>,
-  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'getWhereFilter> = {
+  get: string => promise<option<'entity>>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: 'id => unit,
+  deleteUnsafe: string => unit,
 }
 
 type handlerContext = {
@@ -105,7 +105,7 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"User": handlerEntityOperations<Entities.User.t, Entities.User.id, Entities.User.getWhereFilter>,
+  \"User": handlerEntityOperations<Entities.User.t, Entities.User.getWhereFilter>,
 }
 
 type chainId = [#0]
@@ -1187,13 +1187,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity, 'id> = {
+type testIndexerEntityOperations<'entity> = {
   /** Get an entity by ID. */
-  get: 'id => promise<option<'entity>>,
+  get: string => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -1206,10 +1206,10 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"User": testIndexerEntityOperations<Entities.User.t, Entities.User.id>,
+  \"User": testIndexerEntityOperations<Entities.User.t>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/scenarios/svm_test/src/Indexer.res
+++ b/scenarios/svm_test/src/Indexer.res
@@ -76,6 +76,7 @@ module Entities = {
 
   module SlotPing = {
     type t = {id: id, slot: int}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("slot") slot?: Envio.whereOperator<int>}
   }
@@ -84,13 +85,13 @@ module Entities = {
     | @as("SlotPing") SlotPing: name<SlotPing.t>
 }
 
-type handlerEntityOperations<'entity, 'getWhereFilter> = {
-  get: string => promise<option<'entity>>,
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
+  get: 'id => promise<option<'entity>>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: string => unit,
+  deleteUnsafe: 'id => unit,
 }
 
 type handlerContext = {
@@ -98,7 +99,7 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"SlotPing": handlerEntityOperations<Entities.SlotPing.t, Entities.SlotPing.getWhereFilter>,
+  \"SlotPing": handlerEntityOperations<Entities.SlotPing.t, Entities.SlotPing.id, Entities.SlotPing.getWhereFilter>,
 }
 
 type chainId = [#0]
@@ -186,13 +187,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity> = {
+type testIndexerEntityOperations<'entity, 'id> = {
   /** Get an entity by ID. */
-  get: string => promise<option<'entity>>,
+  get: 'id => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -205,10 +206,10 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"SlotPing": testIndexerEntityOperations<Entities.SlotPing.t>,
+  \"SlotPing": testIndexerEntityOperations<Entities.SlotPing.t, Entities.SlotPing.id>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/scenarios/svm_test/src/Indexer.res
+++ b/scenarios/svm_test/src/Indexer.res
@@ -75,8 +75,8 @@ module Entities = {
   type id = string
 
   module SlotPing = {
-    type t = {id: id, slot: int}
     type id = string
+    type t = {id: id, slot: int}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("slot") slot?: Envio.whereOperator<int>}
   }
@@ -85,13 +85,13 @@ module Entities = {
     | @as("SlotPing") SlotPing: name<SlotPing.t>
 }
 
-type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
-  get: 'id => promise<option<'entity>>,
-  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'getWhereFilter> = {
+  get: string => promise<option<'entity>>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: 'id => unit,
+  deleteUnsafe: string => unit,
 }
 
 type handlerContext = {
@@ -99,7 +99,7 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"SlotPing": handlerEntityOperations<Entities.SlotPing.t, Entities.SlotPing.id, Entities.SlotPing.getWhereFilter>,
+  \"SlotPing": handlerEntityOperations<Entities.SlotPing.t, Entities.SlotPing.getWhereFilter>,
 }
 
 type chainId = [#0]
@@ -187,13 +187,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity, 'id> = {
+type testIndexerEntityOperations<'entity> = {
   /** Get an entity by ID. */
-  get: 'id => promise<option<'entity>>,
+  get: string => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -206,10 +206,10 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"SlotPing": testIndexerEntityOperations<Entities.SlotPing.t, Entities.SlotPing.id>,
+  \"SlotPing": testIndexerEntityOperations<Entities.SlotPing.t>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/scenarios/test_codegen/schema.graphql
+++ b/scenarios/test_codegen/schema.graphql
@@ -176,3 +176,15 @@ type SimpleEntity {
   id: ID!
   value: String!
 }
+
+# Non-string entity ids: the id column and any foreign key referencing it adopt
+# the id's scalar, and the generated get/getOrThrow/deleteUnsafe are keyed by it.
+type IntIdEntity {
+  id: Int!
+  value: String!
+}
+
+type BigIntIdEntity {
+  id: BigInt!
+  numericRef: IntIdEntity!
+}

--- a/scenarios/test_codegen/src/Indexer.res
+++ b/scenarios/test_codegen/src/Indexer.res
@@ -200,148 +200,148 @@ module Entities = {
   type id = string
 
   module A = {
-    type t = {id: id, b_id: id, optionalStringToTestLinkedEntities: option<string>}
     type id = string
+    type t = {id: id, b_id: id, optionalStringToTestLinkedEntities: option<string>}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("b_id") b?: Envio.whereOperator<id>, @as("optionalStringToTestLinkedEntities") optionalStringToTestLinkedEntities?: Envio.whereOperator<option<string>>}
   }
 
   module B = {
-    type t = {id: id, c_id: option<id>}
     type id = string
+    type t = {id: id, c_id: option<id>}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("c_id") c?: Envio.whereOperator<option<id>>}
   }
 
   module BigIntIdEntity = {
-    type t = {id: bigint, numericRef_id: int}
     type id = bigint
+    type t = {id: bigint, numericRef_id: int}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<bigint>, @as("numericRef_id") numericRef?: Envio.whereOperator<int>}
   }
 
   module C = {
-    type t = {id: id, a_id: id, stringThatIsMirroredToA: string}
     type id = string
+    type t = {id: id, a_id: id, stringThatIsMirroredToA: string}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("a_id") a?: Envio.whereOperator<id>, @as("stringThatIsMirroredToA") stringThatIsMirroredToA?: Envio.whereOperator<string>}
   }
 
   module CustomSelectionTestPass = {
-    type t = {id: id}
     type id = string
+    type t = {id: id}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>}
   }
 
   module D = {
-    type t = {id: id, c: id}
     type id = string
+    type t = {id: id, c: id}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("c") c?: Envio.whereOperator<id>}
   }
 
   module EntityWith63LenghtName______________________________________one = {
-    type t = {id: id}
     type id = string
+    type t = {id: id}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>}
   }
 
   module EntityWith63LenghtName______________________________________two = {
-    type t = {id: id}
     type id = string
+    type t = {id: id}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>}
   }
 
   module EntityWithAllNonArrayTypes = {
-    type t = {id: id, string: string, optString: option<string>, int_: int, optInt: option<int>, float_: float, optFloat: option<float>, bool: bool, optBool: option<bool>, bigInt: bigint, optBigInt: option<bigint>, bigDecimal: BigDecimal.t, optBigDecimal: option<BigDecimal.t>, bigDecimalWithConfig: BigDecimal.t, enumField: Enums.AccountType.t, optEnumField: option<Enums.AccountType.t>, timestamp: Date.t, optTimestamp: option<Date.t>}
     type id = string
+    type t = {id: id, string: string, optString: option<string>, int_: int, optInt: option<int>, float_: float, optFloat: option<float>, bool: bool, optBool: option<bool>, bigInt: bigint, optBigInt: option<bigint>, bigDecimal: BigDecimal.t, optBigDecimal: option<BigDecimal.t>, bigDecimalWithConfig: BigDecimal.t, enumField: Enums.AccountType.t, optEnumField: option<Enums.AccountType.t>, timestamp: Date.t, optTimestamp: option<Date.t>}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("string") string?: Envio.whereOperator<string>, @as("optString") optString?: Envio.whereOperator<option<string>>, @as("int_") int_?: Envio.whereOperator<int>, @as("optInt") optInt?: Envio.whereOperator<option<int>>, @as("float_") float_?: Envio.whereOperator<float>, @as("optFloat") optFloat?: Envio.whereOperator<option<float>>, @as("bool") bool?: Envio.whereOperator<bool>, @as("optBool") optBool?: Envio.whereOperator<option<bool>>, @as("bigInt") bigInt?: Envio.whereOperator<bigint>, @as("optBigInt") optBigInt?: Envio.whereOperator<option<bigint>>, @as("bigDecimal") bigDecimal?: Envio.whereOperator<BigDecimal.t>, @as("optBigDecimal") optBigDecimal?: Envio.whereOperator<option<BigDecimal.t>>, @as("bigDecimalWithConfig") bigDecimalWithConfig?: Envio.whereOperator<BigDecimal.t>, @as("enumField") enumField?: Envio.whereOperator<Enums.AccountType.t>, @as("optEnumField") optEnumField?: Envio.whereOperator<option<Enums.AccountType.t>>, @as("timestamp") timestamp?: Envio.whereOperator<Date.t>, @as("optTimestamp") optTimestamp?: Envio.whereOperator<option<Date.t>>}
   }
 
   module EntityWithAllTypes = {
-    type t = {id: id, string: string, optString: option<string>, arrayOfStrings: array<string>, int_: int, optInt: option<int>, arrayOfInts: array<int>, float_: float, optFloat: option<float>, arrayOfFloats: array<float>, bool: bool, optBool: option<bool>, bigInt: bigint, optBigInt: option<bigint>, arrayOfBigInts: array<bigint>, bigDecimal: BigDecimal.t, optBigDecimal: option<BigDecimal.t>, bigDecimalWithConfig: BigDecimal.t, arrayOfBigDecimals: array<BigDecimal.t>, timestamp: Date.t, optTimestamp: option<Date.t>, json: JSON.t, enumField: Enums.AccountType.t, optEnumField: option<Enums.AccountType.t>}
     type id = string
+    type t = {id: id, string: string, optString: option<string>, arrayOfStrings: array<string>, int_: int, optInt: option<int>, arrayOfInts: array<int>, float_: float, optFloat: option<float>, arrayOfFloats: array<float>, bool: bool, optBool: option<bool>, bigInt: bigint, optBigInt: option<bigint>, arrayOfBigInts: array<bigint>, bigDecimal: BigDecimal.t, optBigDecimal: option<BigDecimal.t>, bigDecimalWithConfig: BigDecimal.t, arrayOfBigDecimals: array<BigDecimal.t>, timestamp: Date.t, optTimestamp: option<Date.t>, json: JSON.t, enumField: Enums.AccountType.t, optEnumField: option<Enums.AccountType.t>}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("string") string?: Envio.whereOperator<string>, @as("optString") optString?: Envio.whereOperator<option<string>>, @as("arrayOfStrings") arrayOfStrings?: Envio.whereOperator<array<string>>, @as("int_") int_?: Envio.whereOperator<int>, @as("optInt") optInt?: Envio.whereOperator<option<int>>, @as("arrayOfInts") arrayOfInts?: Envio.whereOperator<array<int>>, @as("float_") float_?: Envio.whereOperator<float>, @as("optFloat") optFloat?: Envio.whereOperator<option<float>>, @as("arrayOfFloats") arrayOfFloats?: Envio.whereOperator<array<float>>, @as("bool") bool?: Envio.whereOperator<bool>, @as("optBool") optBool?: Envio.whereOperator<option<bool>>, @as("bigInt") bigInt?: Envio.whereOperator<bigint>, @as("optBigInt") optBigInt?: Envio.whereOperator<option<bigint>>, @as("arrayOfBigInts") arrayOfBigInts?: Envio.whereOperator<array<bigint>>, @as("bigDecimal") bigDecimal?: Envio.whereOperator<BigDecimal.t>, @as("optBigDecimal") optBigDecimal?: Envio.whereOperator<option<BigDecimal.t>>, @as("bigDecimalWithConfig") bigDecimalWithConfig?: Envio.whereOperator<BigDecimal.t>, @as("arrayOfBigDecimals") arrayOfBigDecimals?: Envio.whereOperator<array<BigDecimal.t>>, @as("timestamp") timestamp?: Envio.whereOperator<Date.t>, @as("optTimestamp") optTimestamp?: Envio.whereOperator<option<Date.t>>, @as("json") json?: Envio.whereOperator<JSON.t>, @as("enumField") enumField?: Envio.whereOperator<Enums.AccountType.t>, @as("optEnumField") optEnumField?: Envio.whereOperator<option<Enums.AccountType.t>>}
   }
 
   module EntityWithBigDecimal = {
-    type t = {id: id, bigDecimal: BigDecimal.t}
     type id = string
+    type t = {id: id, bigDecimal: BigDecimal.t}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("bigDecimal") bigDecimal?: Envio.whereOperator<BigDecimal.t>}
   }
 
   module EntityWithRestrictedReScriptField = {
-    type t = {id: id, @as("type") type_: string}
     type id = string
+    type t = {id: id, @as("type") type_: string}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("type") type_?: Envio.whereOperator<string>}
   }
 
   module EntityWithTimestamp = {
-    type t = {id: id, timestamp: Date.t}
     type id = string
+    type t = {id: id, timestamp: Date.t}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("timestamp") timestamp?: Envio.whereOperator<Date.t>}
   }
 
   module Gravatar = {
-    type t = {id: id, owner_id: id, displayName: string, imageUrl: string, updatesCount: bigint, size: Enums.GravatarSize.t}
     type id = string
+    type t = {id: id, owner_id: id, displayName: string, imageUrl: string, updatesCount: bigint, size: Enums.GravatarSize.t}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("owner_id") owner?: Envio.whereOperator<id>, @as("displayName") displayName?: Envio.whereOperator<string>, @as("imageUrl") imageUrl?: Envio.whereOperator<string>, @as("updatesCount") updatesCount?: Envio.whereOperator<bigint>, @as("size") size?: Envio.whereOperator<Enums.GravatarSize.t>}
   }
 
   module IntIdEntity = {
-    type t = {id: int, value: string}
     type id = int
+    type t = {id: int, value: string}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<int>, @as("value") value?: Envio.whereOperator<string>}
   }
 
   module NftCollection = {
-    type t = {id: id, contractAddress: string, name: string, symbol: string, maxSupply: bigint, currentSupply: int}
     type id = string
+    type t = {id: id, contractAddress: string, name: string, symbol: string, maxSupply: bigint, currentSupply: int}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("contractAddress") contractAddress?: Envio.whereOperator<string>, @as("name") name?: Envio.whereOperator<string>, @as("symbol") symbol?: Envio.whereOperator<string>, @as("maxSupply") maxSupply?: Envio.whereOperator<bigint>, @as("currentSupply") currentSupply?: Envio.whereOperator<int>}
   }
 
   module PostgresNumericPrecisionEntityTester = {
-    type t = {id: id, exampleBigInt: option<bigint>, exampleBigIntRequired: bigint, exampleBigIntArray: option<array<bigint>>, exampleBigIntArrayRequired: array<bigint>, exampleBigDecimal: option<BigDecimal.t>, exampleBigDecimalRequired: BigDecimal.t, exampleBigDecimalArray: option<array<BigDecimal.t>>, exampleBigDecimalArrayRequired: array<BigDecimal.t>, exampleBigDecimalOtherOrder: BigDecimal.t}
     type id = string
+    type t = {id: id, exampleBigInt: option<bigint>, exampleBigIntRequired: bigint, exampleBigIntArray: option<array<bigint>>, exampleBigIntArrayRequired: array<bigint>, exampleBigDecimal: option<BigDecimal.t>, exampleBigDecimalRequired: BigDecimal.t, exampleBigDecimalArray: option<array<BigDecimal.t>>, exampleBigDecimalArrayRequired: array<BigDecimal.t>, exampleBigDecimalOtherOrder: BigDecimal.t}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("exampleBigInt") exampleBigInt?: Envio.whereOperator<option<bigint>>, @as("exampleBigIntRequired") exampleBigIntRequired?: Envio.whereOperator<bigint>, @as("exampleBigIntArray") exampleBigIntArray?: Envio.whereOperator<option<array<bigint>>>, @as("exampleBigIntArrayRequired") exampleBigIntArrayRequired?: Envio.whereOperator<array<bigint>>, @as("exampleBigDecimal") exampleBigDecimal?: Envio.whereOperator<option<BigDecimal.t>>, @as("exampleBigDecimalRequired") exampleBigDecimalRequired?: Envio.whereOperator<BigDecimal.t>, @as("exampleBigDecimalArray") exampleBigDecimalArray?: Envio.whereOperator<option<array<BigDecimal.t>>>, @as("exampleBigDecimalArrayRequired") exampleBigDecimalArrayRequired?: Envio.whereOperator<array<BigDecimal.t>>, @as("exampleBigDecimalOtherOrder") exampleBigDecimalOtherOrder?: Envio.whereOperator<BigDecimal.t>}
   }
 
   module SimpleEntity = {
-    type t = {id: id, value: string}
     type id = string
+    type t = {id: id, value: string}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("value") value?: Envio.whereOperator<string>}
   }
 
   module SimulateTestEvent = {
-    type t = {id: id, blockNumber: int, logIndex: int, timestamp: int}
     type id = string
+    type t = {id: id, blockNumber: int, logIndex: int, timestamp: int}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("blockNumber") blockNumber?: Envio.whereOperator<int>, @as("logIndex") logIndex?: Envio.whereOperator<int>, @as("timestamp") timestamp?: Envio.whereOperator<int>}
   }
 
   module Token = {
-    type t = {id: id, tokenId: bigint, collection_id: id, owner_id: id}
     type id = string
+    type t = {id: id, tokenId: bigint, collection_id: id, owner_id: id}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("tokenId") tokenId?: Envio.whereOperator<bigint>, @as("collection_id") collection?: Envio.whereOperator<id>, @as("owner_id") owner?: Envio.whereOperator<id>}
   }
 
   module User = {
-    type t = {id: id, address: string, gravatar_id: option<id>, updatesCountOnUserForTesting: int, accountType: Enums.AccountType.t}
     type id = string
+    type t = {id: id, address: string, gravatar_id: option<id>, updatesCountOnUserForTesting: int, accountType: Enums.AccountType.t}
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("address") address?: Envio.whereOperator<string>, @as("gravatar_id") gravatar?: Envio.whereOperator<option<id>>, @as("updatesCountOnUserForTesting") updatesCountOnUserForTesting?: Envio.whereOperator<int>, @as("accountType") accountType?: Envio.whereOperator<Enums.AccountType.t>}
   }
@@ -370,7 +370,16 @@ module Entities = {
     | @as("User") User: name<User.t>
 }
 
-type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
+type handlerEntityOperations<'entity, 'getWhereFilter> = {
+  get: string => promise<option<'entity>>,
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  getWhere: 'getWhereFilter => promise<array<'entity>>,
+  getOrCreate: 'entity => promise<'entity>,
+  set: 'entity => unit,
+  deleteUnsafe: string => unit,
+}
+
+type handlerEntityOperationsWithCustomId<'entity, 'id, 'getWhereFilter> = {
   get: 'id => promise<option<'entity>>,
   getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
@@ -384,27 +393,27 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"A": handlerEntityOperations<Entities.A.t, Entities.A.id, Entities.A.getWhereFilter>,
-  \"B": handlerEntityOperations<Entities.B.t, Entities.B.id, Entities.B.getWhereFilter>,
-  \"BigIntIdEntity": handlerEntityOperations<Entities.BigIntIdEntity.t, Entities.BigIntIdEntity.id, Entities.BigIntIdEntity.getWhereFilter>,
-  \"C": handlerEntityOperations<Entities.C.t, Entities.C.id, Entities.C.getWhereFilter>,
-  \"CustomSelectionTestPass": handlerEntityOperations<Entities.CustomSelectionTestPass.t, Entities.CustomSelectionTestPass.id, Entities.CustomSelectionTestPass.getWhereFilter>,
-  \"D": handlerEntityOperations<Entities.D.t, Entities.D.id, Entities.D.getWhereFilter>,
-  \"EntityWith63LenghtName______________________________________one": handlerEntityOperations<Entities.EntityWith63LenghtName______________________________________one.t, Entities.EntityWith63LenghtName______________________________________one.id, Entities.EntityWith63LenghtName______________________________________one.getWhereFilter>,
-  \"EntityWith63LenghtName______________________________________two": handlerEntityOperations<Entities.EntityWith63LenghtName______________________________________two.t, Entities.EntityWith63LenghtName______________________________________two.id, Entities.EntityWith63LenghtName______________________________________two.getWhereFilter>,
-  \"EntityWithAllNonArrayTypes": handlerEntityOperations<Entities.EntityWithAllNonArrayTypes.t, Entities.EntityWithAllNonArrayTypes.id, Entities.EntityWithAllNonArrayTypes.getWhereFilter>,
-  \"EntityWithAllTypes": handlerEntityOperations<Entities.EntityWithAllTypes.t, Entities.EntityWithAllTypes.id, Entities.EntityWithAllTypes.getWhereFilter>,
-  \"EntityWithBigDecimal": handlerEntityOperations<Entities.EntityWithBigDecimal.t, Entities.EntityWithBigDecimal.id, Entities.EntityWithBigDecimal.getWhereFilter>,
-  \"EntityWithRestrictedReScriptField": handlerEntityOperations<Entities.EntityWithRestrictedReScriptField.t, Entities.EntityWithRestrictedReScriptField.id, Entities.EntityWithRestrictedReScriptField.getWhereFilter>,
-  \"EntityWithTimestamp": handlerEntityOperations<Entities.EntityWithTimestamp.t, Entities.EntityWithTimestamp.id, Entities.EntityWithTimestamp.getWhereFilter>,
-  \"Gravatar": handlerEntityOperations<Entities.Gravatar.t, Entities.Gravatar.id, Entities.Gravatar.getWhereFilter>,
-  \"IntIdEntity": handlerEntityOperations<Entities.IntIdEntity.t, Entities.IntIdEntity.id, Entities.IntIdEntity.getWhereFilter>,
-  \"NftCollection": handlerEntityOperations<Entities.NftCollection.t, Entities.NftCollection.id, Entities.NftCollection.getWhereFilter>,
-  \"PostgresNumericPrecisionEntityTester": handlerEntityOperations<Entities.PostgresNumericPrecisionEntityTester.t, Entities.PostgresNumericPrecisionEntityTester.id, Entities.PostgresNumericPrecisionEntityTester.getWhereFilter>,
-  \"SimpleEntity": handlerEntityOperations<Entities.SimpleEntity.t, Entities.SimpleEntity.id, Entities.SimpleEntity.getWhereFilter>,
-  \"SimulateTestEvent": handlerEntityOperations<Entities.SimulateTestEvent.t, Entities.SimulateTestEvent.id, Entities.SimulateTestEvent.getWhereFilter>,
-  \"Token": handlerEntityOperations<Entities.Token.t, Entities.Token.id, Entities.Token.getWhereFilter>,
-  \"User": handlerEntityOperations<Entities.User.t, Entities.User.id, Entities.User.getWhereFilter>,
+  \"A": handlerEntityOperations<Entities.A.t, Entities.A.getWhereFilter>,
+  \"B": handlerEntityOperations<Entities.B.t, Entities.B.getWhereFilter>,
+  \"BigIntIdEntity": handlerEntityOperationsWithCustomId<Entities.BigIntIdEntity.t, Entities.BigIntIdEntity.id, Entities.BigIntIdEntity.getWhereFilter>,
+  \"C": handlerEntityOperations<Entities.C.t, Entities.C.getWhereFilter>,
+  \"CustomSelectionTestPass": handlerEntityOperations<Entities.CustomSelectionTestPass.t, Entities.CustomSelectionTestPass.getWhereFilter>,
+  \"D": handlerEntityOperations<Entities.D.t, Entities.D.getWhereFilter>,
+  \"EntityWith63LenghtName______________________________________one": handlerEntityOperations<Entities.EntityWith63LenghtName______________________________________one.t, Entities.EntityWith63LenghtName______________________________________one.getWhereFilter>,
+  \"EntityWith63LenghtName______________________________________two": handlerEntityOperations<Entities.EntityWith63LenghtName______________________________________two.t, Entities.EntityWith63LenghtName______________________________________two.getWhereFilter>,
+  \"EntityWithAllNonArrayTypes": handlerEntityOperations<Entities.EntityWithAllNonArrayTypes.t, Entities.EntityWithAllNonArrayTypes.getWhereFilter>,
+  \"EntityWithAllTypes": handlerEntityOperations<Entities.EntityWithAllTypes.t, Entities.EntityWithAllTypes.getWhereFilter>,
+  \"EntityWithBigDecimal": handlerEntityOperations<Entities.EntityWithBigDecimal.t, Entities.EntityWithBigDecimal.getWhereFilter>,
+  \"EntityWithRestrictedReScriptField": handlerEntityOperations<Entities.EntityWithRestrictedReScriptField.t, Entities.EntityWithRestrictedReScriptField.getWhereFilter>,
+  \"EntityWithTimestamp": handlerEntityOperations<Entities.EntityWithTimestamp.t, Entities.EntityWithTimestamp.getWhereFilter>,
+  \"Gravatar": handlerEntityOperations<Entities.Gravatar.t, Entities.Gravatar.getWhereFilter>,
+  \"IntIdEntity": handlerEntityOperationsWithCustomId<Entities.IntIdEntity.t, Entities.IntIdEntity.id, Entities.IntIdEntity.getWhereFilter>,
+  \"NftCollection": handlerEntityOperations<Entities.NftCollection.t, Entities.NftCollection.getWhereFilter>,
+  \"PostgresNumericPrecisionEntityTester": handlerEntityOperations<Entities.PostgresNumericPrecisionEntityTester.t, Entities.PostgresNumericPrecisionEntityTester.getWhereFilter>,
+  \"SimpleEntity": handlerEntityOperations<Entities.SimpleEntity.t, Entities.SimpleEntity.getWhereFilter>,
+  \"SimulateTestEvent": handlerEntityOperations<Entities.SimulateTestEvent.t, Entities.SimulateTestEvent.getWhereFilter>,
+  \"Token": handlerEntityOperations<Entities.Token.t, Entities.Token.getWhereFilter>,
+  \"User": handlerEntityOperations<Entities.User.t, Entities.User.getWhereFilter>,
 }
 
 type chainId = [#1337 | #1 | #100 | #137]
@@ -2002,7 +2011,18 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity, 'id> = {
+type testIndexerEntityOperations<'entity> = {
+  /** Get an entity by ID. */
+  get: string => promise<option<'entity>>,
+  /** Get all entities. */
+  getAll: unit => promise<array<'entity>>,
+  /** Get an entity by ID or throw if not found. */
+  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  /** Set (create or update) an entity. */
+  set: 'entity => unit,
+}
+
+type testIndexerEntityOperationsWithCustomId<'entity, 'id> = {
   /** Get an entity by ID. */
   get: 'id => promise<option<'entity>>,
   /** Get all entities. */
@@ -2021,30 +2041,30 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"A": testIndexerEntityOperations<Entities.A.t, Entities.A.id>,
-  \"B": testIndexerEntityOperations<Entities.B.t, Entities.B.id>,
-  \"BigIntIdEntity": testIndexerEntityOperations<Entities.BigIntIdEntity.t, Entities.BigIntIdEntity.id>,
-  \"C": testIndexerEntityOperations<Entities.C.t, Entities.C.id>,
-  \"CustomSelectionTestPass": testIndexerEntityOperations<Entities.CustomSelectionTestPass.t, Entities.CustomSelectionTestPass.id>,
-  \"D": testIndexerEntityOperations<Entities.D.t, Entities.D.id>,
-  \"EntityWith63LenghtName______________________________________one": testIndexerEntityOperations<Entities.EntityWith63LenghtName______________________________________one.t, Entities.EntityWith63LenghtName______________________________________one.id>,
-  \"EntityWith63LenghtName______________________________________two": testIndexerEntityOperations<Entities.EntityWith63LenghtName______________________________________two.t, Entities.EntityWith63LenghtName______________________________________two.id>,
-  \"EntityWithAllNonArrayTypes": testIndexerEntityOperations<Entities.EntityWithAllNonArrayTypes.t, Entities.EntityWithAllNonArrayTypes.id>,
-  \"EntityWithAllTypes": testIndexerEntityOperations<Entities.EntityWithAllTypes.t, Entities.EntityWithAllTypes.id>,
-  \"EntityWithBigDecimal": testIndexerEntityOperations<Entities.EntityWithBigDecimal.t, Entities.EntityWithBigDecimal.id>,
-  \"EntityWithRestrictedReScriptField": testIndexerEntityOperations<Entities.EntityWithRestrictedReScriptField.t, Entities.EntityWithRestrictedReScriptField.id>,
-  \"EntityWithTimestamp": testIndexerEntityOperations<Entities.EntityWithTimestamp.t, Entities.EntityWithTimestamp.id>,
-  \"Gravatar": testIndexerEntityOperations<Entities.Gravatar.t, Entities.Gravatar.id>,
-  \"IntIdEntity": testIndexerEntityOperations<Entities.IntIdEntity.t, Entities.IntIdEntity.id>,
-  \"NftCollection": testIndexerEntityOperations<Entities.NftCollection.t, Entities.NftCollection.id>,
-  \"PostgresNumericPrecisionEntityTester": testIndexerEntityOperations<Entities.PostgresNumericPrecisionEntityTester.t, Entities.PostgresNumericPrecisionEntityTester.id>,
-  \"SimpleEntity": testIndexerEntityOperations<Entities.SimpleEntity.t, Entities.SimpleEntity.id>,
-  \"SimulateTestEvent": testIndexerEntityOperations<Entities.SimulateTestEvent.t, Entities.SimulateTestEvent.id>,
-  \"Token": testIndexerEntityOperations<Entities.Token.t, Entities.Token.id>,
-  \"User": testIndexerEntityOperations<Entities.User.t, Entities.User.id>,
+  \"A": testIndexerEntityOperations<Entities.A.t>,
+  \"B": testIndexerEntityOperations<Entities.B.t>,
+  \"BigIntIdEntity": testIndexerEntityOperationsWithCustomId<Entities.BigIntIdEntity.t, Entities.BigIntIdEntity.id>,
+  \"C": testIndexerEntityOperations<Entities.C.t>,
+  \"CustomSelectionTestPass": testIndexerEntityOperations<Entities.CustomSelectionTestPass.t>,
+  \"D": testIndexerEntityOperations<Entities.D.t>,
+  \"EntityWith63LenghtName______________________________________one": testIndexerEntityOperations<Entities.EntityWith63LenghtName______________________________________one.t>,
+  \"EntityWith63LenghtName______________________________________two": testIndexerEntityOperations<Entities.EntityWith63LenghtName______________________________________two.t>,
+  \"EntityWithAllNonArrayTypes": testIndexerEntityOperations<Entities.EntityWithAllNonArrayTypes.t>,
+  \"EntityWithAllTypes": testIndexerEntityOperations<Entities.EntityWithAllTypes.t>,
+  \"EntityWithBigDecimal": testIndexerEntityOperations<Entities.EntityWithBigDecimal.t>,
+  \"EntityWithRestrictedReScriptField": testIndexerEntityOperations<Entities.EntityWithRestrictedReScriptField.t>,
+  \"EntityWithTimestamp": testIndexerEntityOperations<Entities.EntityWithTimestamp.t>,
+  \"Gravatar": testIndexerEntityOperations<Entities.Gravatar.t>,
+  \"IntIdEntity": testIndexerEntityOperationsWithCustomId<Entities.IntIdEntity.t, Entities.IntIdEntity.id>,
+  \"NftCollection": testIndexerEntityOperations<Entities.NftCollection.t>,
+  \"PostgresNumericPrecisionEntityTester": testIndexerEntityOperations<Entities.PostgresNumericPrecisionEntityTester.t>,
+  \"SimpleEntity": testIndexerEntityOperations<Entities.SimpleEntity.t>,
+  \"SimulateTestEvent": testIndexerEntityOperations<Entities.SimulateTestEvent.t>,
+  \"Token": testIndexerEntityOperations<Entities.Token.t>,
+  \"User": testIndexerEntityOperations<Entities.User.t>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/scenarios/test_codegen/src/Indexer.res
+++ b/scenarios/test_codegen/src/Indexer.res
@@ -201,114 +201,147 @@ module Entities = {
 
   module A = {
     type t = {id: id, b_id: id, optionalStringToTestLinkedEntities: option<string>}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("b_id") b?: Envio.whereOperator<id>, @as("optionalStringToTestLinkedEntities") optionalStringToTestLinkedEntities?: Envio.whereOperator<option<string>>}
   }
 
   module B = {
     type t = {id: id, c_id: option<id>}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("c_id") c?: Envio.whereOperator<option<id>>}
   }
 
+  module BigIntIdEntity = {
+    type t = {id: bigint, numericRef_id: int}
+    type id = bigint
+
+    type getWhereFilter = {@as("id") id?: Envio.whereOperator<bigint>, @as("numericRef_id") numericRef?: Envio.whereOperator<int>}
+  }
+
   module C = {
     type t = {id: id, a_id: id, stringThatIsMirroredToA: string}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("a_id") a?: Envio.whereOperator<id>, @as("stringThatIsMirroredToA") stringThatIsMirroredToA?: Envio.whereOperator<string>}
   }
 
   module CustomSelectionTestPass = {
     type t = {id: id}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>}
   }
 
   module D = {
     type t = {id: id, c: id}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("c") c?: Envio.whereOperator<id>}
   }
 
   module EntityWith63LenghtName______________________________________one = {
     type t = {id: id}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>}
   }
 
   module EntityWith63LenghtName______________________________________two = {
     type t = {id: id}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>}
   }
 
   module EntityWithAllNonArrayTypes = {
     type t = {id: id, string: string, optString: option<string>, int_: int, optInt: option<int>, float_: float, optFloat: option<float>, bool: bool, optBool: option<bool>, bigInt: bigint, optBigInt: option<bigint>, bigDecimal: BigDecimal.t, optBigDecimal: option<BigDecimal.t>, bigDecimalWithConfig: BigDecimal.t, enumField: Enums.AccountType.t, optEnumField: option<Enums.AccountType.t>, timestamp: Date.t, optTimestamp: option<Date.t>}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("string") string?: Envio.whereOperator<string>, @as("optString") optString?: Envio.whereOperator<option<string>>, @as("int_") int_?: Envio.whereOperator<int>, @as("optInt") optInt?: Envio.whereOperator<option<int>>, @as("float_") float_?: Envio.whereOperator<float>, @as("optFloat") optFloat?: Envio.whereOperator<option<float>>, @as("bool") bool?: Envio.whereOperator<bool>, @as("optBool") optBool?: Envio.whereOperator<option<bool>>, @as("bigInt") bigInt?: Envio.whereOperator<bigint>, @as("optBigInt") optBigInt?: Envio.whereOperator<option<bigint>>, @as("bigDecimal") bigDecimal?: Envio.whereOperator<BigDecimal.t>, @as("optBigDecimal") optBigDecimal?: Envio.whereOperator<option<BigDecimal.t>>, @as("bigDecimalWithConfig") bigDecimalWithConfig?: Envio.whereOperator<BigDecimal.t>, @as("enumField") enumField?: Envio.whereOperator<Enums.AccountType.t>, @as("optEnumField") optEnumField?: Envio.whereOperator<option<Enums.AccountType.t>>, @as("timestamp") timestamp?: Envio.whereOperator<Date.t>, @as("optTimestamp") optTimestamp?: Envio.whereOperator<option<Date.t>>}
   }
 
   module EntityWithAllTypes = {
     type t = {id: id, string: string, optString: option<string>, arrayOfStrings: array<string>, int_: int, optInt: option<int>, arrayOfInts: array<int>, float_: float, optFloat: option<float>, arrayOfFloats: array<float>, bool: bool, optBool: option<bool>, bigInt: bigint, optBigInt: option<bigint>, arrayOfBigInts: array<bigint>, bigDecimal: BigDecimal.t, optBigDecimal: option<BigDecimal.t>, bigDecimalWithConfig: BigDecimal.t, arrayOfBigDecimals: array<BigDecimal.t>, timestamp: Date.t, optTimestamp: option<Date.t>, json: JSON.t, enumField: Enums.AccountType.t, optEnumField: option<Enums.AccountType.t>}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("string") string?: Envio.whereOperator<string>, @as("optString") optString?: Envio.whereOperator<option<string>>, @as("arrayOfStrings") arrayOfStrings?: Envio.whereOperator<array<string>>, @as("int_") int_?: Envio.whereOperator<int>, @as("optInt") optInt?: Envio.whereOperator<option<int>>, @as("arrayOfInts") arrayOfInts?: Envio.whereOperator<array<int>>, @as("float_") float_?: Envio.whereOperator<float>, @as("optFloat") optFloat?: Envio.whereOperator<option<float>>, @as("arrayOfFloats") arrayOfFloats?: Envio.whereOperator<array<float>>, @as("bool") bool?: Envio.whereOperator<bool>, @as("optBool") optBool?: Envio.whereOperator<option<bool>>, @as("bigInt") bigInt?: Envio.whereOperator<bigint>, @as("optBigInt") optBigInt?: Envio.whereOperator<option<bigint>>, @as("arrayOfBigInts") arrayOfBigInts?: Envio.whereOperator<array<bigint>>, @as("bigDecimal") bigDecimal?: Envio.whereOperator<BigDecimal.t>, @as("optBigDecimal") optBigDecimal?: Envio.whereOperator<option<BigDecimal.t>>, @as("bigDecimalWithConfig") bigDecimalWithConfig?: Envio.whereOperator<BigDecimal.t>, @as("arrayOfBigDecimals") arrayOfBigDecimals?: Envio.whereOperator<array<BigDecimal.t>>, @as("timestamp") timestamp?: Envio.whereOperator<Date.t>, @as("optTimestamp") optTimestamp?: Envio.whereOperator<option<Date.t>>, @as("json") json?: Envio.whereOperator<JSON.t>, @as("enumField") enumField?: Envio.whereOperator<Enums.AccountType.t>, @as("optEnumField") optEnumField?: Envio.whereOperator<option<Enums.AccountType.t>>}
   }
 
   module EntityWithBigDecimal = {
     type t = {id: id, bigDecimal: BigDecimal.t}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("bigDecimal") bigDecimal?: Envio.whereOperator<BigDecimal.t>}
   }
 
   module EntityWithRestrictedReScriptField = {
     type t = {id: id, @as("type") type_: string}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("type") type_?: Envio.whereOperator<string>}
   }
 
   module EntityWithTimestamp = {
     type t = {id: id, timestamp: Date.t}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("timestamp") timestamp?: Envio.whereOperator<Date.t>}
   }
 
   module Gravatar = {
     type t = {id: id, owner_id: id, displayName: string, imageUrl: string, updatesCount: bigint, size: Enums.GravatarSize.t}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("owner_id") owner?: Envio.whereOperator<id>, @as("displayName") displayName?: Envio.whereOperator<string>, @as("imageUrl") imageUrl?: Envio.whereOperator<string>, @as("updatesCount") updatesCount?: Envio.whereOperator<bigint>, @as("size") size?: Envio.whereOperator<Enums.GravatarSize.t>}
   }
 
+  module IntIdEntity = {
+    type t = {id: int, value: string}
+    type id = int
+
+    type getWhereFilter = {@as("id") id?: Envio.whereOperator<int>, @as("value") value?: Envio.whereOperator<string>}
+  }
+
   module NftCollection = {
     type t = {id: id, contractAddress: string, name: string, symbol: string, maxSupply: bigint, currentSupply: int}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("contractAddress") contractAddress?: Envio.whereOperator<string>, @as("name") name?: Envio.whereOperator<string>, @as("symbol") symbol?: Envio.whereOperator<string>, @as("maxSupply") maxSupply?: Envio.whereOperator<bigint>, @as("currentSupply") currentSupply?: Envio.whereOperator<int>}
   }
 
   module PostgresNumericPrecisionEntityTester = {
     type t = {id: id, exampleBigInt: option<bigint>, exampleBigIntRequired: bigint, exampleBigIntArray: option<array<bigint>>, exampleBigIntArrayRequired: array<bigint>, exampleBigDecimal: option<BigDecimal.t>, exampleBigDecimalRequired: BigDecimal.t, exampleBigDecimalArray: option<array<BigDecimal.t>>, exampleBigDecimalArrayRequired: array<BigDecimal.t>, exampleBigDecimalOtherOrder: BigDecimal.t}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("exampleBigInt") exampleBigInt?: Envio.whereOperator<option<bigint>>, @as("exampleBigIntRequired") exampleBigIntRequired?: Envio.whereOperator<bigint>, @as("exampleBigIntArray") exampleBigIntArray?: Envio.whereOperator<option<array<bigint>>>, @as("exampleBigIntArrayRequired") exampleBigIntArrayRequired?: Envio.whereOperator<array<bigint>>, @as("exampleBigDecimal") exampleBigDecimal?: Envio.whereOperator<option<BigDecimal.t>>, @as("exampleBigDecimalRequired") exampleBigDecimalRequired?: Envio.whereOperator<BigDecimal.t>, @as("exampleBigDecimalArray") exampleBigDecimalArray?: Envio.whereOperator<option<array<BigDecimal.t>>>, @as("exampleBigDecimalArrayRequired") exampleBigDecimalArrayRequired?: Envio.whereOperator<array<BigDecimal.t>>, @as("exampleBigDecimalOtherOrder") exampleBigDecimalOtherOrder?: Envio.whereOperator<BigDecimal.t>}
   }
 
   module SimpleEntity = {
     type t = {id: id, value: string}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("value") value?: Envio.whereOperator<string>}
   }
 
   module SimulateTestEvent = {
     type t = {id: id, blockNumber: int, logIndex: int, timestamp: int}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("blockNumber") blockNumber?: Envio.whereOperator<int>, @as("logIndex") logIndex?: Envio.whereOperator<int>, @as("timestamp") timestamp?: Envio.whereOperator<int>}
   }
 
   module Token = {
     type t = {id: id, tokenId: bigint, collection_id: id, owner_id: id}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("tokenId") tokenId?: Envio.whereOperator<bigint>, @as("collection_id") collection?: Envio.whereOperator<id>, @as("owner_id") owner?: Envio.whereOperator<id>}
   }
 
   module User = {
     type t = {id: id, address: string, gravatar_id: option<id>, updatesCountOnUserForTesting: int, accountType: Enums.AccountType.t}
+    type id = string
 
     type getWhereFilter = {@as("id") id?: Envio.whereOperator<id>, @as("address") address?: Envio.whereOperator<string>, @as("gravatar_id") gravatar?: Envio.whereOperator<option<id>>, @as("updatesCountOnUserForTesting") updatesCountOnUserForTesting?: Envio.whereOperator<int>, @as("accountType") accountType?: Envio.whereOperator<Enums.AccountType.t>}
   }
@@ -316,6 +349,7 @@ module Entities = {
   type rec name<'entity> =
     | @as("A") A: name<A.t>
     | @as("B") B: name<B.t>
+    | @as("BigIntIdEntity") BigIntIdEntity: name<BigIntIdEntity.t>
     | @as("C") C: name<C.t>
     | @as("CustomSelectionTestPass") CustomSelectionTestPass: name<CustomSelectionTestPass.t>
     | @as("D") D: name<D.t>
@@ -327,6 +361,7 @@ module Entities = {
     | @as("EntityWithRestrictedReScriptField") EntityWithRestrictedReScriptField: name<EntityWithRestrictedReScriptField.t>
     | @as("EntityWithTimestamp") EntityWithTimestamp: name<EntityWithTimestamp.t>
     | @as("Gravatar") Gravatar: name<Gravatar.t>
+    | @as("IntIdEntity") IntIdEntity: name<IntIdEntity.t>
     | @as("NftCollection") NftCollection: name<NftCollection.t>
     | @as("PostgresNumericPrecisionEntityTester") PostgresNumericPrecisionEntityTester: name<PostgresNumericPrecisionEntityTester.t>
     | @as("SimpleEntity") SimpleEntity: name<SimpleEntity.t>
@@ -335,13 +370,13 @@ module Entities = {
     | @as("User") User: name<User.t>
 }
 
-type handlerEntityOperations<'entity, 'getWhereFilter> = {
-  get: string => promise<option<'entity>>,
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+type handlerEntityOperations<'entity, 'id, 'getWhereFilter> = {
+  get: 'id => promise<option<'entity>>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   getWhere: 'getWhereFilter => promise<array<'entity>>,
   getOrCreate: 'entity => promise<'entity>,
   set: 'entity => unit,
-  deleteUnsafe: string => unit,
+  deleteUnsafe: 'id => unit,
 }
 
 type handlerContext = {
@@ -349,25 +384,27 @@ type handlerContext = {
   effect: 'input 'output. (Envio.effect<'input, 'output>, 'input) => promise<'output>,
   isPreload: bool,
   chain: Internal.chainInfo,
-  \"A": handlerEntityOperations<Entities.A.t, Entities.A.getWhereFilter>,
-  \"B": handlerEntityOperations<Entities.B.t, Entities.B.getWhereFilter>,
-  \"C": handlerEntityOperations<Entities.C.t, Entities.C.getWhereFilter>,
-  \"CustomSelectionTestPass": handlerEntityOperations<Entities.CustomSelectionTestPass.t, Entities.CustomSelectionTestPass.getWhereFilter>,
-  \"D": handlerEntityOperations<Entities.D.t, Entities.D.getWhereFilter>,
-  \"EntityWith63LenghtName______________________________________one": handlerEntityOperations<Entities.EntityWith63LenghtName______________________________________one.t, Entities.EntityWith63LenghtName______________________________________one.getWhereFilter>,
-  \"EntityWith63LenghtName______________________________________two": handlerEntityOperations<Entities.EntityWith63LenghtName______________________________________two.t, Entities.EntityWith63LenghtName______________________________________two.getWhereFilter>,
-  \"EntityWithAllNonArrayTypes": handlerEntityOperations<Entities.EntityWithAllNonArrayTypes.t, Entities.EntityWithAllNonArrayTypes.getWhereFilter>,
-  \"EntityWithAllTypes": handlerEntityOperations<Entities.EntityWithAllTypes.t, Entities.EntityWithAllTypes.getWhereFilter>,
-  \"EntityWithBigDecimal": handlerEntityOperations<Entities.EntityWithBigDecimal.t, Entities.EntityWithBigDecimal.getWhereFilter>,
-  \"EntityWithRestrictedReScriptField": handlerEntityOperations<Entities.EntityWithRestrictedReScriptField.t, Entities.EntityWithRestrictedReScriptField.getWhereFilter>,
-  \"EntityWithTimestamp": handlerEntityOperations<Entities.EntityWithTimestamp.t, Entities.EntityWithTimestamp.getWhereFilter>,
-  \"Gravatar": handlerEntityOperations<Entities.Gravatar.t, Entities.Gravatar.getWhereFilter>,
-  \"NftCollection": handlerEntityOperations<Entities.NftCollection.t, Entities.NftCollection.getWhereFilter>,
-  \"PostgresNumericPrecisionEntityTester": handlerEntityOperations<Entities.PostgresNumericPrecisionEntityTester.t, Entities.PostgresNumericPrecisionEntityTester.getWhereFilter>,
-  \"SimpleEntity": handlerEntityOperations<Entities.SimpleEntity.t, Entities.SimpleEntity.getWhereFilter>,
-  \"SimulateTestEvent": handlerEntityOperations<Entities.SimulateTestEvent.t, Entities.SimulateTestEvent.getWhereFilter>,
-  \"Token": handlerEntityOperations<Entities.Token.t, Entities.Token.getWhereFilter>,
-  \"User": handlerEntityOperations<Entities.User.t, Entities.User.getWhereFilter>,
+  \"A": handlerEntityOperations<Entities.A.t, Entities.A.id, Entities.A.getWhereFilter>,
+  \"B": handlerEntityOperations<Entities.B.t, Entities.B.id, Entities.B.getWhereFilter>,
+  \"BigIntIdEntity": handlerEntityOperations<Entities.BigIntIdEntity.t, Entities.BigIntIdEntity.id, Entities.BigIntIdEntity.getWhereFilter>,
+  \"C": handlerEntityOperations<Entities.C.t, Entities.C.id, Entities.C.getWhereFilter>,
+  \"CustomSelectionTestPass": handlerEntityOperations<Entities.CustomSelectionTestPass.t, Entities.CustomSelectionTestPass.id, Entities.CustomSelectionTestPass.getWhereFilter>,
+  \"D": handlerEntityOperations<Entities.D.t, Entities.D.id, Entities.D.getWhereFilter>,
+  \"EntityWith63LenghtName______________________________________one": handlerEntityOperations<Entities.EntityWith63LenghtName______________________________________one.t, Entities.EntityWith63LenghtName______________________________________one.id, Entities.EntityWith63LenghtName______________________________________one.getWhereFilter>,
+  \"EntityWith63LenghtName______________________________________two": handlerEntityOperations<Entities.EntityWith63LenghtName______________________________________two.t, Entities.EntityWith63LenghtName______________________________________two.id, Entities.EntityWith63LenghtName______________________________________two.getWhereFilter>,
+  \"EntityWithAllNonArrayTypes": handlerEntityOperations<Entities.EntityWithAllNonArrayTypes.t, Entities.EntityWithAllNonArrayTypes.id, Entities.EntityWithAllNonArrayTypes.getWhereFilter>,
+  \"EntityWithAllTypes": handlerEntityOperations<Entities.EntityWithAllTypes.t, Entities.EntityWithAllTypes.id, Entities.EntityWithAllTypes.getWhereFilter>,
+  \"EntityWithBigDecimal": handlerEntityOperations<Entities.EntityWithBigDecimal.t, Entities.EntityWithBigDecimal.id, Entities.EntityWithBigDecimal.getWhereFilter>,
+  \"EntityWithRestrictedReScriptField": handlerEntityOperations<Entities.EntityWithRestrictedReScriptField.t, Entities.EntityWithRestrictedReScriptField.id, Entities.EntityWithRestrictedReScriptField.getWhereFilter>,
+  \"EntityWithTimestamp": handlerEntityOperations<Entities.EntityWithTimestamp.t, Entities.EntityWithTimestamp.id, Entities.EntityWithTimestamp.getWhereFilter>,
+  \"Gravatar": handlerEntityOperations<Entities.Gravatar.t, Entities.Gravatar.id, Entities.Gravatar.getWhereFilter>,
+  \"IntIdEntity": handlerEntityOperations<Entities.IntIdEntity.t, Entities.IntIdEntity.id, Entities.IntIdEntity.getWhereFilter>,
+  \"NftCollection": handlerEntityOperations<Entities.NftCollection.t, Entities.NftCollection.id, Entities.NftCollection.getWhereFilter>,
+  \"PostgresNumericPrecisionEntityTester": handlerEntityOperations<Entities.PostgresNumericPrecisionEntityTester.t, Entities.PostgresNumericPrecisionEntityTester.id, Entities.PostgresNumericPrecisionEntityTester.getWhereFilter>,
+  \"SimpleEntity": handlerEntityOperations<Entities.SimpleEntity.t, Entities.SimpleEntity.id, Entities.SimpleEntity.getWhereFilter>,
+  \"SimulateTestEvent": handlerEntityOperations<Entities.SimulateTestEvent.t, Entities.SimulateTestEvent.id, Entities.SimulateTestEvent.getWhereFilter>,
+  \"Token": handlerEntityOperations<Entities.Token.t, Entities.Token.id, Entities.Token.getWhereFilter>,
+  \"User": handlerEntityOperations<Entities.User.t, Entities.User.id, Entities.User.getWhereFilter>,
 }
 
 type chainId = [#1337 | #1 | #100 | #137]
@@ -1965,13 +2002,13 @@ type testIndexerProcessConfig = {
 }
 
 /** Entity operations for direct access outside handlers. */
-type testIndexerEntityOperations<'entity> = {
+type testIndexerEntityOperations<'entity, 'id> = {
   /** Get an entity by ID. */
-  get: string => promise<option<'entity>>,
+  get: 'id => promise<option<'entity>>,
   /** Get all entities. */
   getAll: unit => promise<array<'entity>>,
   /** Get an entity by ID or throw if not found. */
-  getOrThrow: (string, ~message: string=?) => promise<'entity>,
+  getOrThrow: ('id, ~message: string=?) => promise<'entity>,
   /** Set (create or update) an entity. */
   set: 'entity => unit,
 }
@@ -1984,28 +2021,30 @@ type testIndexer = {
   chainIds: array<chainId>,
   /** Per-chain configuration keyed by chain ID. */
   chains: indexerChains,
-  \"A": testIndexerEntityOperations<Entities.A.t>,
-  \"B": testIndexerEntityOperations<Entities.B.t>,
-  \"C": testIndexerEntityOperations<Entities.C.t>,
-  \"CustomSelectionTestPass": testIndexerEntityOperations<Entities.CustomSelectionTestPass.t>,
-  \"D": testIndexerEntityOperations<Entities.D.t>,
-  \"EntityWith63LenghtName______________________________________one": testIndexerEntityOperations<Entities.EntityWith63LenghtName______________________________________one.t>,
-  \"EntityWith63LenghtName______________________________________two": testIndexerEntityOperations<Entities.EntityWith63LenghtName______________________________________two.t>,
-  \"EntityWithAllNonArrayTypes": testIndexerEntityOperations<Entities.EntityWithAllNonArrayTypes.t>,
-  \"EntityWithAllTypes": testIndexerEntityOperations<Entities.EntityWithAllTypes.t>,
-  \"EntityWithBigDecimal": testIndexerEntityOperations<Entities.EntityWithBigDecimal.t>,
-  \"EntityWithRestrictedReScriptField": testIndexerEntityOperations<Entities.EntityWithRestrictedReScriptField.t>,
-  \"EntityWithTimestamp": testIndexerEntityOperations<Entities.EntityWithTimestamp.t>,
-  \"Gravatar": testIndexerEntityOperations<Entities.Gravatar.t>,
-  \"NftCollection": testIndexerEntityOperations<Entities.NftCollection.t>,
-  \"PostgresNumericPrecisionEntityTester": testIndexerEntityOperations<Entities.PostgresNumericPrecisionEntityTester.t>,
-  \"SimpleEntity": testIndexerEntityOperations<Entities.SimpleEntity.t>,
-  \"SimulateTestEvent": testIndexerEntityOperations<Entities.SimulateTestEvent.t>,
-  \"Token": testIndexerEntityOperations<Entities.Token.t>,
-  \"User": testIndexerEntityOperations<Entities.User.t>,
+  \"A": testIndexerEntityOperations<Entities.A.t, Entities.A.id>,
+  \"B": testIndexerEntityOperations<Entities.B.t, Entities.B.id>,
+  \"BigIntIdEntity": testIndexerEntityOperations<Entities.BigIntIdEntity.t, Entities.BigIntIdEntity.id>,
+  \"C": testIndexerEntityOperations<Entities.C.t, Entities.C.id>,
+  \"CustomSelectionTestPass": testIndexerEntityOperations<Entities.CustomSelectionTestPass.t, Entities.CustomSelectionTestPass.id>,
+  \"D": testIndexerEntityOperations<Entities.D.t, Entities.D.id>,
+  \"EntityWith63LenghtName______________________________________one": testIndexerEntityOperations<Entities.EntityWith63LenghtName______________________________________one.t, Entities.EntityWith63LenghtName______________________________________one.id>,
+  \"EntityWith63LenghtName______________________________________two": testIndexerEntityOperations<Entities.EntityWith63LenghtName______________________________________two.t, Entities.EntityWith63LenghtName______________________________________two.id>,
+  \"EntityWithAllNonArrayTypes": testIndexerEntityOperations<Entities.EntityWithAllNonArrayTypes.t, Entities.EntityWithAllNonArrayTypes.id>,
+  \"EntityWithAllTypes": testIndexerEntityOperations<Entities.EntityWithAllTypes.t, Entities.EntityWithAllTypes.id>,
+  \"EntityWithBigDecimal": testIndexerEntityOperations<Entities.EntityWithBigDecimal.t, Entities.EntityWithBigDecimal.id>,
+  \"EntityWithRestrictedReScriptField": testIndexerEntityOperations<Entities.EntityWithRestrictedReScriptField.t, Entities.EntityWithRestrictedReScriptField.id>,
+  \"EntityWithTimestamp": testIndexerEntityOperations<Entities.EntityWithTimestamp.t, Entities.EntityWithTimestamp.id>,
+  \"Gravatar": testIndexerEntityOperations<Entities.Gravatar.t, Entities.Gravatar.id>,
+  \"IntIdEntity": testIndexerEntityOperations<Entities.IntIdEntity.t, Entities.IntIdEntity.id>,
+  \"NftCollection": testIndexerEntityOperations<Entities.NftCollection.t, Entities.NftCollection.id>,
+  \"PostgresNumericPrecisionEntityTester": testIndexerEntityOperations<Entities.PostgresNumericPrecisionEntityTester.t, Entities.PostgresNumericPrecisionEntityTester.id>,
+  \"SimpleEntity": testIndexerEntityOperations<Entities.SimpleEntity.t, Entities.SimpleEntity.id>,
+  \"SimulateTestEvent": testIndexerEntityOperations<Entities.SimulateTestEvent.t, Entities.SimulateTestEvent.id>,
+  \"Token": testIndexerEntityOperations<Entities.Token.t, Entities.Token.id>,
+  \"User": testIndexerEntityOperations<Entities.User.t, Entities.User.id>,
 }
 
-@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity> = ""
+@get_index external getTestIndexerEntityOperations: (testIndexer, Entities.name<'entity>) => testIndexerEntityOperations<'entity, 'id> = ""
 
 @module("envio") external indexer: indexer = "indexer"
 

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -112,7 +112,9 @@ describe("parseWhereOrThrow — static `where` with block filter (EVM)", () => {
       parseEvm(
         ~eventFilters=Some(%raw(`{block: {number: {_gte: 10, _lte: 200}}}`)),
       )->ignore
-    ).toThrowError("Only `_gte` is supported on event filters")
+    ).toThrowErrorEqual(
+      "Invalid where configuration for ERC20. `block` filter is invalid: RescriptSchemaError: Failed parsing at root. Reason: Encountered disallowed excess key \"_lte\" on an object. Only `_gte` is supported on event filters — use `indexer.onBlock` for `_lte` or `_every`.",
+    )
   })
 
   it("rejects `_every` on event filters", t => {
@@ -120,19 +122,25 @@ describe("parseWhereOrThrow — static `where` with block filter (EVM)", () => {
       parseEvm(
         ~eventFilters=Some(%raw(`{block: {number: {_gte: 10, _every: 5}}}`)),
       )->ignore
-    ).toThrowError("Only `_gte` is supported on event filters")
+    ).toThrowErrorEqual(
+      "Invalid where configuration for ERC20. `block` filter is invalid: RescriptSchemaError: Failed parsing at root. Reason: Encountered disallowed excess key \"_every\" on an object. Only `_gte` is supported on event filters — use `indexer.onBlock` for `_lte` or `_every`.",
+    )
   })
 
   it("rejects unknown top-level keys (typo catches)", t => {
     t.expect(() =>
       parseEvm(~eventFilters=Some(%raw(`{blocks: {number: {_gte: 10}}}`)))->ignore
-    ).toThrowError(`Unknown field "blocks"`)
+    ).toThrowErrorEqual(
+      `Invalid where configuration. Unknown field "blocks". Indexed parameter filters must be nested under \`params\` and block-range filters under \`block\``,
+    )
   })
 
   it("rejects unknown fields inside `block` (typo catches)", t => {
     t.expect(() =>
       parseEvm(~eventFilters=Some(%raw(`{block: {numbre: {_gte: 10}}}`)))->ignore
-    ).toThrowError("`block` filter is invalid")
+    ).toThrowErrorEqual(
+      "Invalid where configuration for ERC20. `block` filter is invalid: RescriptSchemaError: Failed parsing at [\"block\"]. Reason: Encountered disallowed excess key \"numbre\" on an object. Only `_gte` is supported on event filters — use `indexer.onBlock` for `_lte` or `_every`.",
+    )
   })
 })
 
@@ -174,7 +182,9 @@ describe("parseWhereOrThrow — Fuel block.height", () => {
   it("Fuel rejects `block.number` — the block filter is keyed by height", t => {
     t.expect(() =>
       parseFuel(~eventFilters=Some(%raw(`{block: {number: {_gte: 42}}}`)))->ignore
-    ).toThrowError("`block` filter is invalid")
+    ).toThrowErrorEqual(
+      "Invalid where configuration for ERC20. `block` filter is invalid: RescriptSchemaError: Failed parsing at [\"block\"]. Reason: Encountered disallowed excess key \"number\" on an object. Only `_gte` is supported on event filters — use `indexer.onBlock` for `_lte` or `_every`.",
+    )
   })
 })
 

--- a/scenarios/test_codegen/test/EventFilters_test.res
+++ b/scenarios/test_codegen/test/EventFilters_test.res
@@ -513,7 +513,7 @@ describe("Test eventFilters", () => {
         ~chainId=137,
         ~onEventBlockFilterSchema=config.ecosystem.onEventBlockFilterSchema,
       )
-    ).toThrowError(`Invalid where configuration. The event doesn't have an indexed parameter "to" and can't use it for filtering`)
+    ).toThrowErrorEqual(`Invalid where configuration. The event doesn't have an indexed parameter "to" and can't use it for filtering`)
   })
 
   it("Registration path builds clientAddressFilter for address-filtered events only", t => {

--- a/scenarios/test_codegen/test/HandlerRegisterLifecycle_test.res
+++ b/scenarios/test_codegen/test/HandlerRegisterLifecycle_test.res
@@ -65,7 +65,7 @@ describe("HandlerRegister — every onEvent registers separately", () => {
           ~where=%raw(`{params: {nonExistingParam: "0x0000000000000000000000000000000000000000"}}`),
         ),
       )
-    ).toThrowError(
+    ).toThrowErrorEqual(
       `Invalid where configuration. The event doesn't have an indexed parameter "nonExistingParam" and can't use it for filtering`,
     )
   })
@@ -92,7 +92,7 @@ describe("HandlerRegister — onBlock validation at registration", () => {
         ~handler=noopBlockHandler,
         ~getChainsObject,
       )
-    ).toThrowError(
+    ).toThrowErrorEqual(
       `\`indexer.onBlock("badWhere")\` expected \`where\` to be a function or omitted, but got object.`,
     )
   })
@@ -105,7 +105,9 @@ describe("HandlerRegister — onBlock validation at registration", () => {
         ~handler=noopBlockHandler,
         ~getChainsObject,
       )
-    ).toThrowError(`\`indexer.onBlock("typoFilter")\` \`where\` returned an invalid filter`)
+    ).toThrowErrorEqual(
+      `\`indexer.onBlock("typoFilter")\` \`where\` returned an invalid filter: RescriptSchemaError: Failed parsing at root. Reason: Encountered disallowed excess key "_gt" on an object`,
+    )
   })
 
   it("throws when startBlock is below the chain start block", t => {
@@ -116,7 +118,7 @@ describe("HandlerRegister — onBlock validation at registration", () => {
         ~handler=noopBlockHandler,
         ~getChainsObject,
       )
-    ).toThrowError(
+    ).toThrowErrorEqual(
       `The start block for onBlock handler "tooEarly" is less than the chain start block (1). This is not supported yet.`,
     )
   })

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -190,7 +190,7 @@ describe("ChainState event registration ownership", () => {
         ~firstEventBlock=0,
         ~onEventRegistrations=[makeRegistration(~contractName="ContractA", ~index=4)],
       )->ignore
-    ).toThrowError(
+    ).toThrowErrorEqual(
       "Invalid onEvent registration index for chain 1: ContractA.EventWithoutFields has index 4, but its ChainState position is 0.",
     )
   })

--- a/scenarios/test_codegen/test/lib_tests/EntityIdType_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EntityIdType_test.res
@@ -250,31 +250,42 @@ chains:
 
   let bothBackends = "  postgres:\n    default: true\n  clickhouse: true"
 
+  // The full error a rejected parse throws, so each negative case asserts the
+  // exact message (not a substring). The entity is named "Thing" in every case.
+  let expectedError = "Config parse error: Invalid storage for `Thing`. Its `id` is a BigInt, which ClickHouse stores as a String (sorted lexicographically, not numerically) unless a precision is set. Since `id` is ClickHouse's sorting key, add `@config(precision: N)` with N <= 38 so the id stores as a numeric Decimal."
+
+  // Returns the thrown message, so the assertion pins the whole error rather
+  // than a substring (vitest's `toThrowError(string)` only checks containment).
+  let parseError = (~schema, ~storage) =>
+    try {
+      parseWithStorage(~schema, ~storage)->ignore
+      "Expected config parsing to throw, but it succeeded."
+    } catch {
+    | JsExn(e) => e->JsExn.message->Option.getOr("Thrown value had no message.")
+    }
+
   it("rejects an unbounded BigInt id on a clickhouse entity", t => {
-    t.expect(() =>
-      parseWithStorage(
-        ~schema=`type Thing @storage(clickhouse: true) { id: BigInt! }`,
-        ~storage=bothBackends,
-      )->ignore
-    ).toThrowError("ClickHouse stores as a String")
+    t.expect(
+      parseError(~schema=`type Thing @storage(clickhouse: true) { id: BigInt! }`, ~storage=bothBackends),
+    ).toBe(expectedError)
   })
 
   it("rejects a BigInt id whose precision exceeds the ClickHouse Decimal ceiling", t => {
-    t.expect(() =>
-      parseWithStorage(
+    t.expect(
+      parseError(
         ~schema=`type Thing @storage(clickhouse: true) { id: BigInt! @config(precision: 100) }`,
         ~storage=bothBackends,
-      )->ignore
-    ).toThrowError("ClickHouse stores as a String")
+      ),
+    ).toBe(expectedError)
   })
 
   it("rejects an unbounded BigInt id when clickhouse is the default backend", t => {
-    t.expect(() =>
-      parseWithStorage(
+    t.expect(
+      parseError(
         ~schema=`type Thing { id: BigInt! }`,
         ~storage="  postgres:\n    default: true\n  clickhouse:\n    default: true",
-      )->ignore
-    ).toThrowError("ClickHouse stores as a String")
+      ),
+    ).toBe(expectedError)
   })
 
   it("accepts a BigInt id with a numeric precision on a clickhouse entity", t => {

--- a/scenarios/test_codegen/test/lib_tests/EntityIdType_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EntityIdType_test.res
@@ -250,42 +250,35 @@ chains:
 
   let bothBackends = "  postgres:\n    default: true\n  clickhouse: true"
 
-  // The full error a rejected parse throws, so each negative case asserts the
-  // exact message (not a substring). The entity is named "Thing" in every case.
+  // The full error a rejected parse throws. `toThrowErrorEqual` asserts the
+  // whole message (not a substring). The entity is named "Thing" in every case.
   let expectedError = "Config parse error: Invalid storage for `Thing`. Its `id` is a BigInt, which ClickHouse stores as a String (sorted lexicographically, not numerically) unless a precision is set. Since `id` is ClickHouse's sorting key, add `@config(precision: N)` with N <= 38 so the id stores as a numeric Decimal."
 
-  // Returns the thrown message, so the assertion pins the whole error rather
-  // than a substring (vitest's `toThrowError(string)` only checks containment).
-  let parseError = (~schema, ~storage) =>
-    try {
-      parseWithStorage(~schema, ~storage)->ignore
-      "Expected config parsing to throw, but it succeeded."
-    } catch {
-    | JsExn(e) => e->JsExn.message->Option.getOr("Thrown value had no message.")
-    }
-
   it("rejects an unbounded BigInt id on a clickhouse entity", t => {
-    t.expect(
-      parseError(~schema=`type Thing @storage(clickhouse: true) { id: BigInt! }`, ~storage=bothBackends),
-    ).toBe(expectedError)
+    t.expect(() =>
+      parseWithStorage(
+        ~schema=`type Thing @storage(clickhouse: true) { id: BigInt! }`,
+        ~storage=bothBackends,
+      )->ignore
+    ).toThrowErrorEqual(expectedError)
   })
 
   it("rejects a BigInt id whose precision exceeds the ClickHouse Decimal ceiling", t => {
-    t.expect(
-      parseError(
+    t.expect(() =>
+      parseWithStorage(
         ~schema=`type Thing @storage(clickhouse: true) { id: BigInt! @config(precision: 100) }`,
         ~storage=bothBackends,
-      ),
-    ).toBe(expectedError)
+      )->ignore
+    ).toThrowErrorEqual(expectedError)
   })
 
   it("rejects an unbounded BigInt id when clickhouse is the default backend", t => {
-    t.expect(
-      parseError(
+    t.expect(() =>
+      parseWithStorage(
         ~schema=`type Thing { id: BigInt! }`,
         ~storage="  postgres:\n    default: true\n  clickhouse:\n    default: true",
-      ),
-    ).toBe(expectedError)
+      )->ignore
+    ).toThrowErrorEqual(expectedError)
   })
 
   it("accepts a BigInt id with a numeric precision on a clickhouse entity", t => {

--- a/scenarios/test_codegen/test/lib_tests/EntityIdType_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EntityIdType_test.res
@@ -227,3 +227,77 @@ chains:
     ))
   })
 })
+
+// A ClickHouse entity keyed by a BigInt id must set a numeric precision:
+// ClickHouse stores an unbounded (or over-precision) BigInt as a String, and an
+// id is the mandatory sort key, so it would order lexicographically.
+describe("ClickHouse BigInt id precision validation", () => {
+  let parseWithStorage = (~schema, ~storage) =>
+    InternalTestIndexer.fromUserApi(
+      ~schema,
+      ~configYaml=`
+name: ch-bigint-id
+storage:
+${storage}
+chains:
+  - id: 1
+    rpc:
+      url: https://eth.com
+      for: sync
+    start_block: 0
+`,
+    )
+
+  let bothBackends = "  postgres:\n    default: true\n  clickhouse: true"
+
+  it("rejects an unbounded BigInt id on a clickhouse entity", t => {
+    t.expect(() =>
+      parseWithStorage(
+        ~schema=`type Thing @storage(clickhouse: true) { id: BigInt! }`,
+        ~storage=bothBackends,
+      )->ignore
+    ).toThrowError("ClickHouse stores as a String")
+  })
+
+  it("rejects a BigInt id whose precision exceeds the ClickHouse Decimal ceiling", t => {
+    t.expect(() =>
+      parseWithStorage(
+        ~schema=`type Thing @storage(clickhouse: true) { id: BigInt! @config(precision: 100) }`,
+        ~storage=bothBackends,
+      )->ignore
+    ).toThrowError("ClickHouse stores as a String")
+  })
+
+  it("rejects an unbounded BigInt id when clickhouse is the default backend", t => {
+    t.expect(() =>
+      parseWithStorage(
+        ~schema=`type Thing { id: BigInt! }`,
+        ~storage="  postgres:\n    default: true\n  clickhouse:\n    default: true",
+      )->ignore
+    ).toThrowError("ClickHouse stores as a String")
+  })
+
+  it("accepts a BigInt id with a numeric precision on a clickhouse entity", t => {
+    let {config} = parseWithStorage(
+      ~schema=`type Thing @storage(clickhouse: true) { id: BigInt! @config(precision: 20) }`,
+      ~storage=bothBackends,
+    )
+    t.expect(config.userEntitiesByName->Dict.get("Thing")->Option.isSome).toBe(true)
+  })
+
+  it("accepts an Int id on a clickhouse entity", t => {
+    let {config} = parseWithStorage(
+      ~schema=`type Thing @storage(clickhouse: true) { id: Int! }`,
+      ~storage=bothBackends,
+    )
+    t.expect(config.userEntitiesByName->Dict.get("Thing")->Option.isSome).toBe(true)
+  })
+
+  it("accepts an unbounded BigInt id on a postgres-only entity", t => {
+    let {config} = parseWithStorage(
+      ~schema=`type Thing { id: BigInt! }`,
+      ~storage="  postgres:\n    default: true",
+    )
+    t.expect(config.userEntitiesByName->Dict.get("Thing")->Option.isSome).toBe(true)
+  })
+})

--- a/scenarios/test_codegen/test/lib_tests/EntityIdType_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EntityIdType_test.res
@@ -71,6 +71,15 @@ describe("Non-string entity id support", () => {
     )).toEqual(("Int32", "Decimal(20,0)"))
   })
 
+  it("degrades an unbounded BigInt id to a ClickHouse String column", t => {
+    // A BigInt without precision has no Decimal width, so ClickHouse falls back
+    // to String. This is expected (lexicographic ORDER BY) — pin it so the
+    // fallback isn't silently changed.
+    t.expect(
+      ClickHouse.getClickHouseFieldType(~fieldType=BigInt({}), ~isNullable=false, ~isArray=false),
+    ).toBe("String")
+  })
+
   it("serializes a history set update keeping the numeric id value", t => {
     let entitySchema =
       S.object(s =>
@@ -99,6 +108,29 @@ describe("Non-string entity id support", () => {
     )
   })
 })
+
+// Compile-time proof that the generated user-facing API keys each entity's
+// operations by its real id scalar. These functions are type-checked, never
+// run: `IntIdEntity` id is `int`, `BigIntIdEntity` id is `bigint`, and its
+// foreign key `numericRef_id` adopts the referenced `Int` id. Passing a string
+// where a numeric id is expected would fail to compile.
+let _handlerContextKeysOpsByIdScalar = async (context: Indexer.handlerContext) => {
+  context.\"IntIdEntity".set({id: 1, value: "x"})
+  let _: option<Indexer.Entities.IntIdEntity.t> = await context.\"IntIdEntity".get(1)
+  let _ = await context.\"IntIdEntity".getOrThrow(1)
+  context.\"IntIdEntity".deleteUnsafe(1)
+
+  context.\"BigIntIdEntity".set({id: 1n, numericRef_id: 2})
+  let _ = await context.\"BigIntIdEntity".get(1n)
+  context.\"BigIntIdEntity".deleteUnsafe(1n)
+}
+
+let _testIndexerKeysOpsByIdScalar = async (indexer: Indexer.testIndexer) => {
+  let _: option<Indexer.Entities.IntIdEntity.t> = await indexer.\"IntIdEntity".get(1)
+  let _ = await indexer.\"IntIdEntity".getOrThrow(1)
+  indexer.\"IntIdEntity".set({id: 1, value: "x"})
+  let _ = await indexer.\"BigIntIdEntity".get(1n)
+}
 
 // End-to-end coverage through the in-process test indexer + Postgres: a schema
 // with Int!/BigInt! ids and foreign keys referencing them, driven by a real

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -275,7 +275,9 @@ describe("FetchState.make", () => {
         )
       },
       ~message=`Should panic if there's nothing to fetch`,
-    ).toThrowError("Invalid configuration: Nothing to fetch on chain")
+    ).toThrowErrorEqual(
+      "Invalid configuration: Nothing to fetch on chain 0. addresses=0, onEventRegistrations=1, normalRegistrations=1. Make sure that you provided at least one contract address to index, or have events with Wildcard mode enabled, or have onBlock handlers.",
+    )
   })
 
   it(

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -120,7 +120,7 @@ describe("SourceManager creation", () => {
       () => {
         SourceManager.make(~isRealtime=false, ~sources=[])
       },
-    ).toThrowError("Invalid configuration, no data-source for historical sync provided")
+    ).toThrowErrorEqual("Invalid configuration, no data-source for historical sync provided")
     t.expect(
       () => {
         SourceManager.make(
@@ -128,7 +128,7 @@ describe("SourceManager creation", () => {
           ~sources=[MockIndexer.Source.make([], ~sourceFor=Fallback).source],
         )
       },
-    ).toThrowError("Invalid configuration, no data-source for historical sync provided")
+    ).toThrowErrorEqual("Invalid configuration, no data-source for historical sync provided")
   })
 })
 

--- a/scenarios/test_codegen/test/setup.ts
+++ b/scenarios/test_codegen/test/setup.ts
@@ -1,3 +1,45 @@
 // Importing Env triggers Logging.setLogger as a side effect,
 // ensuring the logger is available for all tests.
 import "envio/src/Env.res.mjs";
+
+import { expect } from "vitest";
+
+// Strict counterpart to the built-in `toThrowError`, which only checks that the
+// thrown message *contains* the expected string. `toThrowErrorEqual` requires
+// the whole message to match, so a test can pin the complete error text.
+expect.extend({
+  toThrowErrorEqual(received: unknown, expected: string) {
+    if (typeof received !== "function") {
+      return {
+        pass: false,
+        message: () =>
+          `toThrowErrorEqual expects a function to invoke, received ${typeof received}.`,
+      };
+    }
+    let thrown: unknown;
+    let didThrow = false;
+    try {
+      received();
+    } catch (error) {
+      didThrow = true;
+      thrown = error;
+    }
+    if (!didThrow) {
+      return {
+        pass: false,
+        message: () => "expected the function to throw, but it did not.",
+      };
+    }
+    const actual = thrown instanceof Error ? thrown.message : String(thrown);
+    const pass = actual === expected;
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected the thrown message not to equal:\n${JSON.stringify(expected)}`
+          : `expected the thrown message to equal:\n${JSON.stringify(
+              expected,
+            )}\nreceived:\n${JSON.stringify(actual)}`,
+    };
+  },
+});


### PR DESCRIPTION
## Summary

Extends entity ID support beyond the default `string` (from `ID!`/`String!`) to allow `Int!` and `BigInt!` as entity id scalars. Entity operations (get, getOrThrow, deleteUnsafe) and foreign key references now adopt the real id type, enabling type-safe numeric id handling in handlers and test indexers.

## Key Changes

- **Entity ID type detection** (`entity_id_type` function): Inspects each entity's `id` field and returns a tuple `(is_default: bool, type_string: String)`. Defaults to `string` for `ID!`/`String!`, maps `Int!` → `int`, `BigInt!` → `bigint`.

- **Entity module id type exposure**: Each `Entities.{Name}` module now declares `type id = <actual_type>`, allowing foreign keys and operations to reference the correct scalar.

- **Handler context operations**: Generates `handlerEntityOperationsWithCustomId<'entity, 'id, 'getWhereFilter>` for numeric ids (where `get`/`getOrThrow`/`deleteUnsafe` accept `'id` instead of `string`), while string ids continue using the plain `handlerEntityOperations`.

- **Test indexer operations**: Similarly generates `testIndexerEntityOperationsWithCustomId<'entity, 'id>` for numeric ids, keeping the plain variant for strings.

- **Foreign key typing**: FK columns (e.g., `chain_id: int`) adopt the referenced entity's id type, ensuring type safety across relationships.

- **TypeScript/ReScript type definitions**: Updated `EntityId<Entity>` helper in `packages/envio/index.d.ts` and `packages/envio/src/Internal.res` to extract the real id scalar from entity types, making operation signatures polymorphic over the id type.

- **Documentation updates**: Clarified in skill guides that `Int!` and `BigInt!` are valid entity id choices, and that foreign key handler fields are typed as the referenced entity's id.

## Notable Implementation Details

- The `entity_id_type` function is called once per entity during codegen to determine which operation variant to use, avoiding runtime overhead.
- Conditional code generation: `has_custom_id_entity` flag determines whether to emit the custom-id operation type definitions at all, keeping output minimal when all ids are strings.
- Test coverage added: `indexer_code_exposes_numeric_entity_id_types` verifies that numeric ids generate correct operation signatures and FK types.
- Compile-time proof in test file: Functions that use numeric ids with handlers and test indexers are type-checked but never executed, ensuring the generated API is correct.

https://claude.ai/code/session_01KDdTB5oid2AvSy2D1k1Jqr