### PR TITLE
Replace child logger pattern with context params spread

### DIFF
--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -1716,6 +1716,7 @@ module SingleOrMultiple: {{
         true
       }} else if arr->Array.length == 0 {{
         AmbiguousEmptyNestedArray->ErrorHandling.mkLogAndRaise(
+          ~logger=Env.logger,
           ~msg="The given empty array could be interpreted as a flat array (value) or nested array. Since it's ambiguous,
           please pass in a nested empty array if the intention is to provide an empty array as a value",
         )

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generated_for_svm.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generated_for_svm.snap
@@ -41,6 +41,7 @@ module SingleOrMultiple: {
         true
       } else if arr->Array.length == 0 {
         AmbiguousEmptyNestedArray->ErrorHandling.mkLogAndRaise(
+          ~logger=Env.logger,
           ~msg="The given empty array could be interpreted as a flat array (value) or nested array. Since it's ambiguous,
           please pass in a nested empty array if the intention is to provide an empty array as a value",
         )

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_generates_correct_types_and_values.snap
@@ -159,6 +159,7 @@ module SingleOrMultiple: {
         true
       } else if arr->Array.length == 0 {
         AmbiguousEmptyNestedArray->ErrorHandling.mkLogAndRaise(
+          ~logger=Env.logger,
           ~msg="The given empty array could be interpreted as a flat array (value) or nested array. Since it's ambiguous,
           please pass in a nested empty array if the intention is to provide an empty array as a value",
         )

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__indexer_code_multiple_chains.snap
@@ -159,6 +159,7 @@ module SingleOrMultiple: {
         true
       } else if arr->Array.length == 0 {
         AmbiguousEmptyNestedArray->ErrorHandling.mkLogAndRaise(
+          ~logger=Env.logger,
           ~msg="The given empty array could be interpreted as a flat array (value) or nested array. Since it's ambiguous,
           please pass in a nested empty array if the intention is to provide an empty array as a value",
         )

--- a/packages/envio-tests/test/ClientAddressFilter_test.res
+++ b/packages/envio-tests/test/ClientAddressFilter_test.res
@@ -13,7 +13,7 @@ let parseEvm = (~eventFilters: option<JSON.t>, ~chainId=1) =>
     ~params=["from", "to"],
     ~contractName="ERC20",
     ~chainId,
-    ~onEventBlockFilterSchema=Evm.make(~logger=Env.logger).onEventBlockFilterSchema,
+    ~onEventBlockFilterSchema=Evm.make().onEventBlockFilterSchema,
   )
 
 describe("parseWhereOrThrow — address-param detection", () => {
@@ -85,7 +85,7 @@ describe("clientAddressFilter — precompiled predicate", () => {
       ~contractRegister=None,
       ~where=Some(eventFilters),
       ~chainId=1,
-      ~onEventBlockFilterSchema=Evm.make(~logger=Env.logger).onEventBlockFilterSchema,
+      ~onEventBlockFilterSchema=Evm.make().onEventBlockFilterSchema,
     ).clientAddressFilter
 
   let addr = "0x1111111111111111111111111111111111111111"->Address.unsafeFromString
@@ -178,7 +178,7 @@ describe("filterByClientAddress applies clientAddressFilter", () => {
     ~contractRegister=None,
     ~where=Some(%raw(`({chain}) => ({params: {to: chain.ERC20.addresses}})`)),
     ~chainId=1,
-    ~onEventBlockFilterSchema=Evm.make(~logger=Env.logger).onEventBlockFilterSchema,
+    ~onEventBlockFilterSchema=Evm.make().onEventBlockFilterSchema,
     ~startBlock=5,
   )
 
@@ -231,7 +231,7 @@ describe("filterByClientAddress drops over-fetched non-wildcard srcAddress event
     ~contractRegister=None,
     ~where=None,
     ~chainId=1,
-    ~onEventBlockFilterSchema=Evm.make(~logger=Env.logger).onEventBlockFilterSchema,
+    ~onEventBlockFilterSchema=Evm.make().onEventBlockFilterSchema,
     ~startBlock=5,
   )
 

--- a/packages/envio-tests/test/HandlerRegister_test.res
+++ b/packages/envio-tests/test/HandlerRegister_test.res
@@ -160,7 +160,7 @@ let register = fn => {
   HandlerRegister.resetOnEventRegistrations()
   HandlerRegister.startRegistration(~config)
   fn()
-  HandlerRegister.finishRegistration(~config)
+  HandlerRegister.finishRegistration(~config, ~logger=Env.logger)
 }
 
 describe("HandlerRegister multiple registrations", () => {
@@ -273,8 +273,8 @@ describe("HandlerRegister multiple registrations", () => {
     HandlerRegister.resetOnEventRegistrations()
     HandlerRegister.startRegistration(~config=configMultichain)
     setHandler(h1)
-    let registrations1 = HandlerRegister.finishRegistration(~config)
-    let registrations137 = HandlerRegister.finishRegistration(~config=config137)
+    let registrations1 = HandlerRegister.finishRegistration(~config, ~logger=Env.logger)
+    let registrations137 = HandlerRegister.finishRegistration(~config=config137, ~logger=Env.logger)
     t.expect((
       registrations1->describeRegistrations(~chainKey="1", ~labels=[(h1, "h1")], ~crLabels=[]),
       registrations137->describeRegistrations(~chainKey="137", ~labels=[(h1, "h1")], ~crLabels=[]),
@@ -291,7 +291,7 @@ describe("HandlerRegister multiple registrations", () => {
     setHandler(h1)
     setHandler(h2)
     HandlerRegister.startRegistration(~config)
-    let registrations = HandlerRegister.finishRegistration(~config)
+    let registrations = HandlerRegister.finishRegistration(~config, ~logger=Env.logger)
     t.expect(
       registrations->describeRegistrations(~labels=[(h1, "h1"), (h2, "h2")], ~crLabels=[]),
     ).toEqual([(Some("h1"), None, 0), (Some("h2"), None, 1)])
@@ -310,8 +310,8 @@ describe("HandlerRegister multiple registrations", () => {
     HandlerRegister.resetOnEventRegistrations()
     HandlerRegister.startRegistration(~config)
     setHandler(~eventOptions={where: whereFn->Obj.magic}, h1)
-    let _ = HandlerRegister.finishRegistration(~config)
-    let _ = HandlerRegister.finishRegistration(~config)
+    let _ = HandlerRegister.finishRegistration(~config, ~logger=Env.logger)
+    let _ = HandlerRegister.finishRegistration(~config, ~logger=Env.logger)
     t.expect(calls.contents).toBe(1)
   })
 
@@ -323,7 +323,7 @@ describe("HandlerRegister multiple registrations", () => {
     HandlerRegister.resetOnEventRegistrations()
     HandlerRegister.startRegistration(~config=configWithRawEvents)
     setHandler(~eventName="Transfer", ~eventOptions={where: %raw(`() => false`)}, h1)
-    let registrations = HandlerRegister.finishRegistration(~config=configWithRawEvents)
+    let registrations = HandlerRegister.finishRegistration(~config=configWithRawEvents, ~logger=Env.logger)
     t.expect((
       registrations->describeRegistrations(
         ~eventName="Transfer",

--- a/packages/envio-tests/test/LoggerScope_test.res
+++ b/packages/envio-tests/test/LoggerScope_test.res
@@ -23,6 +23,10 @@ let makeCaptureLogger = () => {
 
 let parse = lines => lines->Array.map(line => line->JSON.parseOrThrow)
 
+let makeTmpPath: unit => string = %raw(`() =>
+  require("path").join(require("os").tmpdir(), "envio-logger-close-" + process.hrtime.bigint() + ".log")`)
+let readFile: string => string = %raw(`(path) => require("fs").readFileSync(path, "utf8")`)
+
 describe("Per-indexer logger scope", () => {
   it("routes each indexer's logs to its own logger only", t => {
     let (loggerA, linesA) = makeCaptureLogger()
@@ -54,14 +58,14 @@ describe("Per-indexer logger scope", () => {
 
   it("writes context params on every line instead of binding a child", t => {
     let (logger, lines) = makeCaptureLogger()
-    let params = {"chainId": 1, "logType": "Block Range Query"}->Internal.toLogParams
+    let params = {"chainId": 1, "partitionId": "0"}->Internal.toLogParams
 
     logger->Logging.trace(params->Logging.withParams({"msg": "first", "fromBlock": 10}))
     logger->Logging.warn(params->Logging.withParams({"msg": "second", "fromBlock": 20}))
 
     t.expect(lines->parse).toEqual([
-      %raw(`{level: 10, chainId: 1, logType: "Block Range Query", msg: "first", fromBlock: 10}`),
-      %raw(`{level: 40, chainId: 1, logType: "Block Range Query", msg: "second", fromBlock: 20}`),
+      %raw(`{level: 10, chainId: 1, partitionId: "0", msg: "first", fromBlock: 10}`),
+      %raw(`{level: 40, chainId: 1, partitionId: "0", msg: "second", fromBlock: 20}`),
     ])
   })
 
@@ -96,10 +100,6 @@ describe("Per-indexer logger scope", () => {
   })
 
   Async.it("flushes and releases a file-backed logger on close", async t => {
-    let makeTmpPath: unit => string = %raw(`() =>
-      require("path").join(require("os").tmpdir(), "envio-logger-close-" + process.hrtime.bigint() + ".log")`)
-    let readFile: string => string = %raw(`(path) => require("fs").readFileSync(path, "utf8")`)
-
     let logFilePath = makeTmpPath()
     let logger = Logging.makeLogger(
       ~logStrategy=Logging.FileOnly,
@@ -113,6 +113,24 @@ describe("Per-indexer logger scope", () => {
     await logger->Logging.close
 
     t.expect(readFile(logFilePath)->String.includes(`"written before close"`)).toBe(true)
+  })
+
+  // `both-prettyconsole` nests a file destination inside a multistream, which
+  // has to be closed through its members — the multistream itself throws on
+  // `end` because its console member is write-only.
+  Async.it("flushes the file nested in a console+file multistream", async t => {
+    let logFilePath = makeTmpPath()
+    let logger = Logging.makeLogger(
+      ~logStrategy=Logging.Both,
+      ~logFilePath,
+      ~defaultFileLogLevel=#trace,
+      ~userLogLevel=#trace,
+    )
+    logger->Logging.error({"msg": "nested destination line"})
+
+    await logger->Logging.close
+
+    t.expect(readFile(logFilePath)->String.includes(`"nested destination line"`)).toBe(true)
   })
 
   // A console multistream has no closable resource and throws on `end`, so

--- a/packages/envio-tests/test/LoggerScope_test.res
+++ b/packages/envio-tests/test/LoggerScope_test.res
@@ -1,0 +1,104 @@
+open Vitest
+
+// A logger that captures its own NDJSON output, so two of them can be compared
+// for cross-talk.
+let makeCaptureLogger = () => {
+  let lines = []
+  let logger = Pino.MultiStreamLogger.makeWithMultiStream(
+    {
+      customLevels: Logging.logLevels,
+      level: #trace,
+      base: %raw("{}"),
+      timestamp: false,
+    },
+    Pino.MultiStreamLogger.multistream([
+      {
+        stream: {write: line => lines->Array.push(line)->ignore},
+        level: #trace,
+      },
+    ]),
+  )
+  (logger, lines)
+}
+
+let parse = lines => lines->Array.map(line => line->JSON.parseOrThrow)
+
+describe("Per-indexer logger scope", () => {
+  it("routes each indexer's logs to its own logger only", t => {
+    let (loggerA, linesA) = makeCaptureLogger()
+    let (loggerB, linesB) = makeCaptureLogger()
+
+    loggerA->Logging.info({"msg": "from A", "chainId": 1})
+    loggerB->Logging.info({"msg": "from B", "chainId": 137})
+
+    t.expect((linesA->parse, linesB->parse)).toEqual((
+      [%raw(`{level: 30, msg: "from A", chainId: 1}`)],
+      [%raw(`{level: 30, msg: "from B", chainId: 137}`)],
+    ))
+  })
+
+  it("silencing one indexer's logger leaves the other untouched", t => {
+    let (loggerA, linesA) = makeCaptureLogger()
+    let (loggerB, linesB) = makeCaptureLogger()
+
+    loggerA->Logging.setLogLevel(#silent)
+    loggerA->Logging.info({"msg": "muted"})
+    loggerB->Logging.info({"msg": "still logged"})
+
+    t.expect((linesA->parse, linesB->parse, loggerB->Pino.getLevel)).toEqual((
+      [],
+      [%raw(`{level: 30, msg: "still logged"}`)],
+      #trace,
+    ))
+  })
+
+  it("writes context params on every line instead of binding a child", t => {
+    let (logger, lines) = makeCaptureLogger()
+    let params = {"chainId": 1, "logType": "Block Range Query"}->Internal.toLogParams
+
+    logger->Logging.trace(params->Logging.withParams({"msg": "first", "fromBlock": 10}))
+    logger->Logging.warn(params->Logging.withParams({"msg": "second", "fromBlock": 20}))
+
+    t.expect(lines->parse).toEqual([
+      %raw(`{level: 10, chainId: 1, logType: "Block Range Query", msg: "first", fromBlock: 10}`),
+      %raw(`{level: 40, chainId: 1, logType: "Block Range Query", msg: "second", fromBlock: 20}`),
+    ])
+  })
+
+  it("merges item params into user logs, with user params winning", t => {
+    let (logger, lines) = makeCaptureLogger()
+    let userLogger =
+      logger->Logging.userLogger(
+        ~params={"contract": "ERC20", "event": "Transfer", "chainId": 1}->Internal.toLogParams,
+      )
+
+    userLogger.info("hello", ~params={"custom": true})
+    userLogger.warn("overridden", ~params={"chainId": 137})
+
+    t.expect(lines->parse).toEqual([
+      %raw(`{level: 34, contract: "ERC20", event: "Transfer", chainId: 1, custom: true, msg: "hello"}`),
+      %raw(`{level: 36, contract: "ERC20", event: "Transfer", chainId: 137, msg: "overridden"}`),
+    ])
+  })
+
+  it("keeps ErrorHandling params on the logged error", t => {
+    let (logger, lines) = makeCaptureLogger()
+
+    Utils.Error.make("boom")
+    ->ErrorHandling.make(~logger, ~msg="Failed", ~params={"entityName": "User"})
+    ->ErrorHandling.log
+
+    let withoutStack = %raw(`(lines) => lines.map(({err: {stack, ...err}, ...line}) => ({...line, err}))`)
+
+    t.expect(lines->parse->withoutStack).toEqual([
+      %raw(`{level: 50, entityName: "User", msg: "Failed", err: {type: "Error", message: "boom"}}`),
+    ])
+  })
+
+  it("builds a silent instance logger without touching the process logger", t => {
+    let processLevel = Env.logger->Pino.getLevel
+    let silent = Env.makeLogger(~userLogLevel=#silent)
+
+    t.expect((silent->Pino.getLevel, Env.logger->Pino.getLevel)).toEqual((#silent, processLevel))
+  })
+})

--- a/packages/envio-tests/test/LoggerScope_test.res
+++ b/packages/envio-tests/test/LoggerScope_test.res
@@ -95,6 +95,41 @@ describe("Per-indexer logger scope", () => {
     ])
   })
 
+  Async.it("flushes and releases a file-backed logger on close", async t => {
+    let makeTmpPath: unit => string = %raw(`() =>
+      require("path").join(require("os").tmpdir(), "envio-logger-close-" + process.hrtime.bigint() + ".log")`)
+    let readFile: string => string = %raw(`(path) => require("fs").readFileSync(path, "utf8")`)
+
+    let logFilePath = makeTmpPath()
+    let logger = Logging.makeLogger(
+      ~logStrategy=Logging.FileOnly,
+      ~logFilePath,
+      ~defaultFileLogLevel=#trace,
+      ~userLogLevel=#trace,
+    )
+    logger->Logging.info({"msg": "written before close"})
+
+    // Resolving proves the transport was ended; the file proves it flushed.
+    await logger->Logging.close
+
+    t.expect(readFile(logFilePath)->String.includes(`"written before close"`)).toBe(true)
+  })
+
+  // A console multistream has no closable resource and throws on `end`, so
+  // closing one must be a no-op rather than a rejected promise.
+  Async.it("closes a console logger without throwing", async t => {
+    let logger = Env.makeLogger(~userLogLevel=#silent)
+
+    let closed = try {
+      await logger->Logging.close
+      true
+    } catch {
+    | _ => false
+    }
+
+    t.expect(closed).toBe(true)
+  })
+
   it("builds a silent instance logger without touching the process logger", t => {
     let processLevel = Env.logger->Pino.getLevel
     let silent = Env.makeLogger(~userLogLevel=#silent)

--- a/packages/envio-tests/test/OnBlockSchema_test.res
+++ b/packages/envio-tests/test/OnBlockSchema_test.res
@@ -53,7 +53,7 @@ describe("blockRangeSchema (shared inner range validation)", () => {
 })
 
 describe("Evm ecosystem onBlockFilterSchema", () => {
-  let schema = Evm.make(~logger=Env.logger).onBlockFilterSchema
+  let schema = Evm.make().onBlockFilterSchema
 
   it("surfaces the inner range chunk as Some(unknown) when block.number is present", t => {
     let parsed =
@@ -89,7 +89,7 @@ describe("Evm ecosystem onBlockFilterSchema", () => {
 })
 
 describe("Fuel ecosystem onBlockFilterSchema", () => {
-  let schema = Fuel.make(~logger=Env.logger).onBlockFilterSchema
+  let schema = Fuel.make().onBlockFilterSchema
 
   it("surfaces the inner range chunk from block.height", t => {
     let parsed =
@@ -105,7 +105,7 @@ describe("Fuel ecosystem onBlockFilterSchema", () => {
 })
 
 describe("Svm ecosystem onBlockFilterSchema", () => {
-  let schema = Svm.make(~logger=Env.logger).onBlockFilterSchema
+  let schema = Svm.make().onBlockFilterSchema
 
   it("surfaces the inner range chunk from the flat `slot` key", t => {
     let parsed = %raw(`{slot: {_gte: 42, _every: 3}}`)->S.parseOrThrow(schema)
@@ -126,12 +126,12 @@ describe("Svm ecosystem onBlockFilterSchema", () => {
 
 describe("Ecosystem.t wires the correct onBlockMethodName", () => {
   it("EVM exposes onBlock", t => {
-    t.expect(Evm.make(~logger=Env.logger).onBlockMethodName).toBe("onBlock")
+    t.expect(Evm.make().onBlockMethodName).toBe("onBlock")
   })
   it("Fuel exposes onBlock", t => {
-    t.expect(Fuel.make(~logger=Env.logger).onBlockMethodName).toBe("onBlock")
+    t.expect(Fuel.make().onBlockMethodName).toBe("onBlock")
   })
   it("SVM exposes onSlot", t => {
-    t.expect(Svm.make(~logger=Env.logger).onBlockMethodName).toBe("onSlot")
+    t.expect(Svm.make().onBlockMethodName).toBe("onSlot")
   })
 })

--- a/packages/envio-tests/test/RateLimit_test.res
+++ b/packages/envio-tests/test/RateLimit_test.res
@@ -49,7 +49,7 @@ describe("SourceManager.getBlockHashes rate limit handling", () => {
   Async.it("recovers after a rate limit and tracks wait time", async t => {
     // 500ms resetMs * 2 rate-limited calls = ~1s minimum total wait
     let source = makeMockSource(~rateLimitedCalls=2, ~resetMs=500)
-    let sourceManager = SourceManager.make(
+    let sourceManager = SourceManager.make(~logger=Env.logger, 
       ~sources=[source],
       ~isRealtime=false,
     )
@@ -67,7 +67,7 @@ describe("SourceManager.getBlockHashes rate limit handling", () => {
 
   Async.it("succeeds immediately when no rate limit", async t => {
     let source = makeMockSource(~rateLimitedCalls=0, ~resetMs=100)
-    let sourceManager = SourceManager.make(
+    let sourceManager = SourceManager.make(~logger=Env.logger, 
       ~sources=[source],
       ~isRealtime=false,
     )
@@ -85,7 +85,7 @@ describe("SourceManager.getBlockHashes rate limit handling", () => {
     "concurrent rate-limited calls only count the overlapping wall-clock window once",
     async t => {
       let source = makeMockSource(~rateLimitedCalls=4, ~resetMs=500)
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~sources=[source],
         ~isRealtime=false,
       )

--- a/packages/envio-tests/test/RateLimit_test.res
+++ b/packages/envio-tests/test/RateLimit_test.res
@@ -14,7 +14,7 @@ let makeMockSource = (~rateLimitedCalls: int, ~resetMs: int): Source.t => {
     chain,
     poweredByHyperSync: true,
     pollingInterval: 100,
-    getBlockHashes: (~blockNumbers, ~logger as _) => {
+    getBlockHashes: (~blockNumbers, ~logger as _, ~params as _) => {
       let current = callCount.contents
       callCount := current + 1
       if current < rateLimitedCalls {
@@ -41,6 +41,7 @@ let makeMockSource = (~rateLimitedCalls: int, ~resetMs: int): Source.t => {
       ~itemsTarget as _,
       ~retry as _,
       ~logger as _,
+      ~params as _,
     ) => JsError.throwWithMessage("Not used by rate limit test"),
   }
 }

--- a/packages/envio-tests/test/RateLimit_test.res
+++ b/packages/envio-tests/test/RateLimit_test.res
@@ -14,7 +14,7 @@ let makeMockSource = (~rateLimitedCalls: int, ~resetMs: int): Source.t => {
     chain,
     poweredByHyperSync: true,
     pollingInterval: 100,
-    getBlockHashes: (~blockNumbers, ~logger as _, ~params as _) => {
+    getBlockHashes: (~blockNumbers, ~logger as _) => {
       let current = callCount.contents
       callCount := current + 1
       if current < rateLimitedCalls {
@@ -41,7 +41,6 @@ let makeMockSource = (~rateLimitedCalls: int, ~resetMs: int): Source.t => {
       ~itemsTarget as _,
       ~retry as _,
       ~logger as _,
-      ~params as _,
     ) => JsError.throwWithMessage("Not used by rate limit test"),
   }
 }

--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -174,7 +174,6 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
         },
         ~retry=0,
         ~logger=Env.logger,
-        ~params=Internal.toLogParams({"test": true}),
       )
 
       let item = switch response.parsedQueueItems {

--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -173,7 +173,7 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
           dependsOnAddresses: true,
         },
         ~retry=0,
-        ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "SvmHyperSyncSource"}),
+        ~logger=Env.logger,
       )
 
       let item = switch response.parsedQueueItems {

--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -174,6 +174,7 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
         },
         ~retry=0,
         ~logger=Env.logger,
+        ~params=Internal.toLogParams({"test": true}),
       )
 
       let item = switch response.parsedQueueItems {

--- a/packages/envio-tests/test/lib_tests/ColumnNameFormat_test.res
+++ b/packages/envio-tests/test/lib_tests/ColumnNameFormat_test.res
@@ -245,7 +245,7 @@ ORDER BY (id, envio_checkpoint_id)`,
   Async.it("initializes, writes and reads back entities from a real Postgres", async t => {
     let pgSchema = "colnaming_test_schema"
     let sql = PgStorage.makeClient()
-    let storage = PgStorage.make(
+    let storage = PgStorage.make(~logger=Env.logger, 
       ~sql,
       ~pgHost=Env.Db.host,
       ~pgSchema,

--- a/packages/envio-tests/test/lib_tests/Throttler_test.res
+++ b/packages/envio-tests/test/lib_tests/Throttler_test.res
@@ -4,7 +4,7 @@ let nextImmediate = () => Promise.make((resolve, _) => NodeJs.setImmediate(() =>
 
 describe("Throttler", () => {
   Async.itWithOptions("Schedules and throttles functions as expected", {retry: 3}, async t => {
-    let throttler = Throttler.make(~intervalMillis=100, ~logger=Env.logger)
+    let throttler = Throttler.make(~intervalMillis=100, ~logger=Env.logger, ~params={"test": "Throttler"}->Internal.toLogParams)
     let actionsCalled = []
 
     throttler->Throttler.schedule(async () => actionsCalled->Array.push(1)->ignore)
@@ -35,7 +35,7 @@ describe("Throttler", () => {
   })
 
   Async.itWithOptions("Does not continuously increase schedule time", {retry: 3}, async t => {
-    let throttler = Throttler.make(~intervalMillis=100, ~logger=Env.logger)
+    let throttler = Throttler.make(~intervalMillis=100, ~logger=Env.logger, ~params={"test": "Throttler"}->Internal.toLogParams)
     let actionsCalled = []
     throttler->Throttler.schedule(async () => actionsCalled->Array.push(1)->ignore)
     await Time.resolvePromiseAfterDelay(~delayMilliseconds=50)
@@ -49,7 +49,7 @@ describe("Throttler", () => {
   })
 
   Async.itWithOptions("Does not run until previous task is finished", {retry: 3}, async t => {
-    let throttler = Throttler.make(~intervalMillis=50, ~logger=Env.logger)
+    let throttler = Throttler.make(~intervalMillis=50, ~logger=Env.logger, ~params={"test": "Throttler"}->Internal.toLogParams)
     let actionsCalled = []
     throttler->Throttler.schedule(
       async () => {
@@ -85,7 +85,7 @@ describe("Throttler", () => {
     "Does not immediately execute after a task has finished if below the interval",
     {retry: 3},
     async t => {
-      let throttler = Throttler.make(~intervalMillis=100, ~logger=Env.logger)
+      let throttler = Throttler.make(~intervalMillis=100, ~logger=Env.logger, ~params={"test": "Throttler"}->Internal.toLogParams)
       let actionsCalled = []
       throttler->Throttler.schedule(
         async () => {

--- a/packages/envio/src/BatchProcessing.res
+++ b/packages/envio/src/BatchProcessing.res
@@ -35,7 +35,13 @@ let rec startProcessing = async (state: IndexerState.t, ~scheduleFetch, ~schedul
       let processedBatchesBefore = state->IndexerState.processedBatchesCount
       switch await processNextBatch(state, ~scheduleFetch) {
       | exception exn =>
-        IndexerState.errorExit(state, exn->ErrorHandling.make(~msg=IndexerState.unexpectedErrorMsg))
+        IndexerState.errorExit(
+        state,
+        exn->ErrorHandling.make(
+          ~logger=state->IndexerState.logger,
+          ~msg=IndexerState.unexpectedErrorMsg,
+        ),
+      )
       | () => hasMoreWork := state->IndexerState.processedBatchesCount > processedBatchesBefore
       }
     }
@@ -176,6 +182,7 @@ and processNextBatch = async (state: IndexerState.t, ~scheduleFetch): unit => {
               Utils.Error.make(
                 "No events found between startBlock and chain head. Cannot auto-detect endBlock.",
               ),
+              ~logger=state->IndexerState.logger,
             ),
           )
         } else {

--- a/packages/envio/src/BatchProcessing.res
+++ b/packages/envio/src/BatchProcessing.res
@@ -90,7 +90,7 @@ and processNextBatch = async (state: IndexerState.t, ~scheduleFetch): unit => {
 
     // When resuming from persisted state, all events may already be processed.
     if EventProcessing.allChainsEventsProcessedToEndblock(state->IndexerState.chainStates) {
-      state->IndexerState.logger->Logging.childInfo("All chains are caught up to end blocks.")
+      state->IndexerState.logger->Logging.info("All chains are caught up to end blocks.")
       if !(state->IndexerState.keepProcessAlive) {
         await ExitOnCaughtUp.run(state)
       }
@@ -156,7 +156,7 @@ and processNextBatch = async (state: IndexerState.t, ~scheduleFetch): unit => {
           state->IndexerState.chainStates,
         )
         if allCaughtUp {
-          state->IndexerState.logger->Logging.childInfo("All chains are caught up to end blocks.")
+          state->IndexerState.logger->Logging.info("All chains are caught up to end blocks.")
         }
 
         if allCaughtUp && !(state->IndexerState.keepProcessAlive) {

--- a/packages/envio/src/Bin.res
+++ b/packages/envio/src/Bin.res
@@ -4,7 +4,7 @@ let setEnvVar: (string, string) => unit = %raw(`(k, v) => { process.env[k] = v; 
 // Crash on unhandled promise rejections with a readable error.
 // ReScript exceptions compile to plain objects, not Error instances, so Node.js prints "#<Object>".
 NodeJs.globalProcess->NodeJs.onUnhandledRejection(reason => {
-  Env.logger->Logging.childErrorWithExn(reason->Utils.prettifyExn, "Unhandled promise rejection")
+  Env.logger->Logging.errorWithExn(reason->Utils.prettifyExn, "Unhandled promise rejection")
   NodeJs.process->NodeJs.exitWithCode(Failure)
 })
 
@@ -82,7 +82,7 @@ let run = async args => {
     | JsExn(e) => e->JsExn.message->Option.getOr("Failed at initialization")
     | _ => "Failed at initialization"
     }
-    Env.logger->Logging.childError(message)
+    Env.logger->Logging.error(message)
     NodeJs.process->NodeJs.exitWithCode(Failure)
   }
 }

--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -9,6 +9,7 @@ type partitionQueryResponse = {
 }
 
 let runContractRegistersOrThrow = async (
+  ~logger: Pino.t,
   ~itemsWithContractRegister: array<Internal.item>,
   ~config: Config.t,
   ~transactionStore: option<TransactionStore.t>,
@@ -62,6 +63,7 @@ let runContractRegistersOrThrow = async (
     try {
       let params: ContractRegisterContext.contractRegisterParams = {
         item,
+        logger,
         onRegister,
         config,
         isResolved: false,
@@ -81,7 +83,8 @@ let runContractRegistersOrThrow = async (
             params.isResolved = true
             exn->ErrorHandling.mkLogAndRaise(
               ~msg=errorMessage,
-              ~logger=Ecosystem.getItemLogger(item, ~ecosystem=config.ecosystem),
+              ~logger,
+              ~params=Ecosystem.getItemLogParams(item, ~ecosystem=config.ecosystem),
             )
           }),
         )
@@ -92,7 +95,8 @@ let runContractRegistersOrThrow = async (
     | exn =>
       exn->ErrorHandling.mkLogAndRaise(
         ~msg=errorMessage,
-        ~logger=Ecosystem.getItemLogger(item, ~ecosystem=config.ecosystem),
+        ~logger,
+        ~params=Ecosystem.getItemLogParams(item, ~ecosystem=config.ecosystem),
       )
     }
   }
@@ -142,8 +146,9 @@ let rec onQueryResponse = async (
     if numContractRegisterEvents === 0 {
       chainState
       ->ChainState.logger
-      ->Logging.childTrace({
+      ->Logging.trace({
         "msg": "Finished querying",
+        "chainId": chain->ChainMap.Chain.toChainId,
         "partitionId": query.partitionId,
         "fromBlock": fromBlockQueried,
         "toBlock": latestFetchedBlockNumber,
@@ -152,8 +157,9 @@ let rec onQueryResponse = async (
     } else {
       chainState
       ->ChainState.logger
-      ->Logging.childTrace({
+      ->Logging.trace({
         "msg": "Finished querying",
+        "chainId": chain->ChainMap.Chain.toChainId,
         "partitionId": query.partitionId,
         "fromBlock": fromBlockQueried,
         "toBlock": latestFetchedBlockNumber,
@@ -168,9 +174,10 @@ let rec onQueryResponse = async (
     | ReorgDetected(reorgDetected) => {
         chainState
         ->ChainState.logger
-        ->Logging.childInfo(
+        ->Logging.info(
           reorgDetected->ReorgDetection.reorgDetectedToLogParams(
             ~shouldRollbackOnReorg=(state->IndexerState.config).shouldRollbackOnReorg,
+            ~chainId=chain->ChainMap.Chain.toChainId,
           ),
         )
         chainState->ChainState.recordReorgDetected(
@@ -252,6 +259,7 @@ let rec onQueryResponse = async (
       | [] => proceed(~newItemsWithDcs=[])
       | _ =>
         switch await runContractRegistersOrThrow(
+          ~logger=state->IndexerState.logger,
           ~itemsWithContractRegister,
           ~config=state->IndexerState.config,
           ~transactionStore,
@@ -303,7 +311,12 @@ and applyQueryResponse = (
     !(chainState->ChainState.isReady) &&
     chainState->ChainState.isFetchingAtHead
   ) {
-    chainState->ChainState.logger->Logging.childInfo("All events have been fetched")
+    chainState
+    ->ChainState.logger
+    ->Logging.info({
+      "msg": "All events have been fetched",
+      "chainId": (chainState->ChainState.chainConfig).id,
+    })
   }
 }
 

--- a/packages/envio/src/ChainFetching.res
+++ b/packages/envio/src/ChainFetching.res
@@ -265,7 +265,8 @@ let rec onQueryResponse = async (
           ~transactionStore,
           ~blockStore,
         ) {
-        | exception exn => IndexerState.errorExit(state, exn->ErrorHandling.make)
+        | exception exn =>
+      IndexerState.errorExit(state, exn->ErrorHandling.make(~logger=state->IndexerState.logger))
         | newItemsWithDcs => proceed(~newItemsWithDcs)
         }
       }
@@ -392,7 +393,7 @@ let fetchChain = async (
               ~scheduleRollback,
             )
           } catch {
-          | exn => IndexerState.errorExit(state, exn->ErrorHandling.make)
+          | exn => IndexerState.errorExit(state, exn->ErrorHandling.make(~logger=state->IndexerState.logger))
           }
         },
         ~action,
@@ -400,7 +401,13 @@ let fetchChain = async (
       )
     } catch {
     | exn =>
-      IndexerState.errorExit(state, exn->ErrorHandling.make(~msg=IndexerState.unexpectedErrorMsg))
+      IndexerState.errorExit(
+        state,
+        exn->ErrorHandling.make(
+          ~logger=state->IndexerState.logger,
+          ~msg=IndexerState.unexpectedErrorMsg,
+        ),
+      )
     }
   }
 }

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -215,6 +215,7 @@ let makeInternal = (
       }
     })
     EvmChain.makeSources(
+      ~logger,
       ~chain,
       ~onEventRegistrations=onEventRegistrations->(
         Utils.magic: array<Internal.onEventRegistration> => array<Internal.evmOnEventRegistration>
@@ -225,6 +226,7 @@ let makeInternal = (
     )
   | Config.FuelSourceConfig({hypersync}) => [
       FuelHyperSyncSource.make({
+        logger,
         chain,
         endpointUrl: hypersync,
         apiToken: Env.envioApiToken,
@@ -300,11 +302,10 @@ let makeInternal = (
 let makeFromConfig = (
   chainConfig: Config.chain,
   ~config: Config.t,
+  ~logger: Pino.t,
   ~registrationsByChainId,
   ~knownHeight,
 ) => {
-  let logger = Logging.createChildFrom(~logger=config.logger, ~params={"chainId": chainConfig.id})
-
   makeInternal(
     ~chainConfig,
     ~config,
@@ -334,12 +335,10 @@ let makeFromDbState = (
   ~isInReorgThreshold,
   ~isRealtime,
   ~config: Config.t,
+  ~logger: Pino.t,
   ~registrationsByChainId,
   ~reducedPollingInterval=?,
 ) => {
-  let chainId = chainConfig.id
-  let logger = Logging.createChildFrom(~logger=config.logger, ~params={"chainId": chainId})
-
   let progressBlockNumber =
     // Can be -1 when not set
     resumedChainState.progressBlockNumber >= 0
@@ -840,6 +839,7 @@ let handleQueryResult = (
   | _ =>
     cs.fetchState->FetchState.registerDynamicContracts(
       ~indexingAddresses=cs.indexingAddresses,
+      ~logger=cs.logger,
       newItemsWithDcs,
     )
   }

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -27,6 +27,7 @@ let make: (
 let makeFromConfig: (
   Config.chain,
   ~config: Config.t,
+  ~logger: Pino.t,
   ~registrationsByChainId: HandlerRegister.registrationsByChainId,
   ~knownHeight: int,
 ) => t
@@ -38,6 +39,7 @@ let makeFromDbState: (
   ~isInReorgThreshold: bool,
   ~isRealtime: bool,
   ~config: Config.t,
+  ~logger: Pino.t,
   ~registrationsByChainId: HandlerRegister.registrationsByChainId,
   ~reducedPollingInterval: int=?,
 ) => t

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -66,10 +66,6 @@ type contractHandler = {
 }
 
 type t = {
-  // Per-indexer logger. Everything that used to reach for the process-global
-  // logger now derives from this (directly, or via per-chain children built off
-  // it). Sources and the ecosystem are constructed with it in `fromPublic`.
-  logger: Pino.t,
   name: string,
   description: option<string>,
   handlers: string,
@@ -589,11 +585,10 @@ let fromPublic = (publicConfigJson: JSON.t) => {
     )
   }
 
-  let logger = Env.logger
   let ecosystem = switch ecosystemName {
-  | Ecosystem.Evm => Evm.make(~logger)
-  | Ecosystem.Fuel => Fuel.make(~logger)
-  | Ecosystem.Svm => Svm.make(~logger)
+  | Ecosystem.Evm => Evm.make()
+  | Ecosystem.Fuel => Fuel.make()
+  | Ecosystem.Svm => Svm.make()
   }
 
   // SVM has no raw-events representation (`Svm.toRawEvent` throws), so reject
@@ -1025,7 +1020,6 @@ let fromPublic = (publicConfigJson: JSON.t) => {
   }
 
   {
-    logger,
     name: publicConfig["name"],
     description: publicConfig["description"],
     handlers: publicConfig["handlers"]->Option.getOr("src/handlers"),

--- a/packages/envio/src/ContractRegisterContext.res
+++ b/packages/envio/src/ContractRegisterContext.res
@@ -4,6 +4,7 @@
 
 type contractRegisterParams = {
   item: Internal.item,
+  logger: Pino.t,
   onRegister: (~item: Internal.item, ~contractAddress: Address.t, ~contractName: string) => unit,
   config: Config.t,
   mutable isResolved: bool,
@@ -19,7 +20,8 @@ let makeAddFunction = (~params: contractRegisterParams, ~contractName: string): 
   (contractAddress: Address.t) => {
     if params.isResolved {
       Utils.Error.make(`Impossible to access context.chain after the contract register is resolved. Make sure you didn't miss an await in the handler.`)->ErrorHandling.mkLogAndRaise(
-        ~logger=Ecosystem.getItemLogger(params.item, ~ecosystem=params.config.ecosystem),
+        ~logger=params.logger,
+        ~params=Ecosystem.getItemLogParams(params.item, ~ecosystem=params.config.ecosystem),
       )
     }
     // The value is passed from user-land, so validate and checksum/lowercase it.
@@ -63,14 +65,17 @@ let contractRegisterTraps: Utils.Proxy.traps<contractRegisterParams> = {
       Utils.Error.make(
         `Impossible to access context.${prop} after the contract register is resolved. Make sure you didn't miss an await in the handler.`,
       )->ErrorHandling.mkLogAndRaise(
-        ~logger=Ecosystem.getItemLogger(params.item, ~ecosystem=params.config.ecosystem),
+        ~logger=params.logger,
+        ~params=Ecosystem.getItemLogParams(params.item, ~ecosystem=params.config.ecosystem),
       )
     }
     switch prop {
     | "log" =>
-      Ecosystem.getItemUserLogger(params.item, ~ecosystem=params.config.ecosystem)->(
-        Utils.magic: Envio.logger => unknown
-      )
+      Ecosystem.getItemUserLogger(
+        params.item,
+        ~ecosystem=params.config.ecosystem,
+        ~logger=params.logger,
+      )->(Utils.magic: Envio.logger => unknown)
 
     | "chain" =>
       params

--- a/packages/envio/src/CrossChainState.res
+++ b/packages/envio/src/CrossChainState.res
@@ -28,7 +28,7 @@ let make = (
   ~isInReorgThreshold,
   ~isRealtime,
   ~targetBufferSize=calculateTargetBufferSize(),
-  ~logger=Env.logger,
+  ~logger: Pino.t,
 ): t => {
   {
     logger,
@@ -121,7 +121,7 @@ let createBatch = (
 // Enter the reorg threshold: shrink each chain's buffer by its configured
 // blockLag and flip the flag.
 let enterReorgThreshold = (crossChainState: t) => {
-  crossChainState.logger->Logging.childInfo("Reorg threshold reached")
+  crossChainState.logger->Logging.info("Reorg threshold reached")
 
   for i in 0 to crossChainState.chainIds->Array.length - 1 {
     crossChainState
@@ -342,8 +342,9 @@ let checkAndFetch = async (
           )
           cs
           ->ChainState.logger
-          ->Logging.childTrace({
+          ->Logging.trace({
             "msg": "Started querying",
+            "chainId": chainId,
             "partitions": partitions,
           })
 

--- a/packages/envio/src/CrossChainState.resi
+++ b/packages/envio/src/CrossChainState.resi
@@ -10,7 +10,7 @@ let make: (
   ~isInReorgThreshold: bool,
   ~isRealtime: bool,
   ~targetBufferSize: int=?,
-  ~logger: Pino.t=?,
+  ~logger: Pino.t,
 ) => t
 
 // Accessors.

--- a/packages/envio/src/Ecosystem.res
+++ b/packages/envio/src/Ecosystem.res
@@ -27,25 +27,21 @@ type t = {
       `LogSelection.res`. SVM does not support event handlers, so its
       schema always surfaces `None`. */
   onEventBlockFilterSchema: S.t<option<unknown>>,
-  /** Base logger injected at construction. Used to build per-item child
-      loggers (see `getItemLogger`). */
-  logger: Pino.t,
   /** Materialise the user-facing event handed to handlers and contract
       registration from an item's opaque payload. `event.transaction` is written
       onto the payload at batch prep (HyperSync) or inline (RPC/simulate). */
   toEvent: Internal.eventItem => Internal.event,
-  /** Build the per-item child logger for an event item, with
-      ecosystem-specific log fields (EVM/Fuel: contract/event/address; SVM:
-      program/instruction/programId). Closes over the injected logger. */
-  toEventLogger: Internal.eventItem => Pino.t,
+  /** Log context fields for an event item, with ecosystem-specific keys
+      (EVM/Fuel: contract/event/address; SVM: program/instruction/programId).
+      Spread into every log line about the item. */
+  toEventLogParams: Internal.eventItem => Internal.logParams,
   /** Build a raw event row for the `raw_events` table. Unsupported on SVM,
       where the implementation throws. */
   toRawEvent: Internal.eventItem => Internal.rawEvent,
 }
 
-// The materialised event and the child logger are both memoised on the item
-// object (an item is processed across preload + execution passes, and logged
-// from several places). Hidden keys mirror each other.
+// The materialised event is memoised on the item object — an item is processed
+// across preload + execution passes.
 let getItemEvent = {
   let cacheKey = "_event"
   (item: Internal.item, ~ecosystem: t): Internal.event => {
@@ -60,33 +56,19 @@ let getItemEvent = {
   }
 }
 
-let getItemLogger = {
-  let cacheKey = "_logger"
-  (item: Internal.item, ~ecosystem: t): Pino.t => {
-    let cache = item->(Utils.magic: Internal.item => dict<Pino.t>)
-    switch cache->Utils.Dict.dangerouslyGetNonOption(cacheKey) {
-    | Some(logger) => logger
-    | None =>
-      let logger = switch item {
-      | Internal.Event(_) => ecosystem.toEventLogger(item->Internal.castUnsafeEventItem)
-      | Block({blockNumber, onBlockRegistration}) =>
-        Logging.createChildFrom(
-          ~logger=ecosystem.logger,
-          ~params={
-            "onBlock": onBlockRegistration.name,
-            "chainId": onBlockRegistration.chainId,
-            "block": blockNumber,
-          },
-        )
-      }
-      cache->Dict.set(cacheKey, logger)
-      logger
-    }
+let getItemLogParams = (item: Internal.item, ~ecosystem: t): Internal.logParams =>
+  switch item {
+  | Internal.Event(_) => ecosystem.toEventLogParams(item->Internal.castUnsafeEventItem)
+  | Block({blockNumber, onBlockRegistration}) =>
+    {
+      "onBlock": onBlockRegistration.name,
+      "chainId": onBlockRegistration.chainId,
+      "block": blockNumber,
+    }->Internal.toLogParams
   }
-}
 
-let getItemUserLogger = (item: Internal.item, ~ecosystem: t): Envio.logger =>
-  getItemLogger(item, ~ecosystem)->Logging.userLogger
+let getItemUserLogger = (item: Internal.item, ~ecosystem: t, ~logger: Pino.t): Envio.logger =>
+  logger->Logging.userLogger(~params=getItemLogParams(item, ~ecosystem))
 
 let makeOnBlockArgs = (~blockNumber: int, ~ecosystem: t, ~context): Internal.onBlockArgs => {
   switch ecosystem.name {

--- a/packages/envio/src/Env.res
+++ b/packages/envio/src/Env.res
@@ -79,16 +79,14 @@ let logStrategy =
     ~fallback=ConsolePretty,
   )
 
-// The process-wide base logger. Indexer code doesn't reach for this directly —
-// it flows through `Config.t.logger` (and per-chain children of it). Kept here
-// as the default sink for bootstrap/process-level logging (Bin process
-// handlers, pre-config errors) and as `ErrorHandling`'s fallback logger.
-let logger = Logging.makeLogger(
-  ~logStrategy,
-  ~logFilePath,
-  ~defaultFileLogLevel,
-  ~userLogLevel=userLogLevel->Option.getOr(#info),
-)
+// Builds a logger from the process env. Each indexer instance gets its own,
+// so a level change on one can't affect another.
+let makeLogger = (~userLogLevel=userLogLevel->Option.getOr(#info)) =>
+  Logging.makeLogger(~logStrategy, ~logFilePath, ~defaultFileLogLevel, ~userLogLevel)
+
+// Sink for process-level logging that happens outside any indexer instance:
+// bootstrap and pre-config errors, and `ErrorHandling`'s fallback logger.
+let logger = makeLogger()
 
 module Db = {
   let host = envSafe->EnvSafe.get("ENVIO_PG_HOST", S.string, ~devFallback="localhost")

--- a/packages/envio/src/ErrorHandling.res
+++ b/packages/envio/src/ErrorHandling.res
@@ -1,6 +1,6 @@
 type t = {logger: Pino.t, exn: exn, msg: option<string>, params: option<Internal.logParams>}
 
-let make = (exn, ~logger=Env.logger, ~msg=?, ~params=?) => {
+let make = (exn, ~logger: Pino.t, ~msg=?, ~params=?) => {
   {logger, msg, exn, params: params->Option.map(Internal.toLogParams)}
 }
 
@@ -30,16 +30,16 @@ let raiseExn = (self: t) => {
   self.exn->Utils.prettifyExn->throw
 }
 
-let mkLogAndRaise = (~logger=?, ~msg=?, ~params=?, exn) => {
+let mkLogAndRaise = (~logger, ~msg=?, ~params=?, exn) => {
   let exn = exn->Utils.prettifyExn
-  exn->make(~logger?, ~msg?, ~params?)->log
+  exn->make(~logger, ~msg?, ~params?)->log
   exn->throw
 }
 
-let unwrapLogAndRaise = (~logger=?, ~msg=?, ~params=?, result) => {
+let unwrapLogAndRaise = (~logger, ~msg=?, ~params=?, result) => {
   switch result {
   | Ok(v) => v
-  | Error(exn) => exn->mkLogAndRaise(~logger?, ~msg?, ~params?)
+  | Error(exn) => exn->mkLogAndRaise(~logger, ~msg?, ~params?)
   }
 }
 

--- a/packages/envio/src/ErrorHandling.res
+++ b/packages/envio/src/ErrorHandling.res
@@ -1,13 +1,28 @@
-type t = {logger: Pino.t, exn: exn, msg: option<string>}
+type t = {logger: Pino.t, exn: exn, msg: option<string>, params: option<Internal.logParams>}
 
-let make = (exn, ~logger=Env.logger, ~msg=?) => {
-  {logger, msg, exn}
+let make = (exn, ~logger=Env.logger, ~msg=?, ~params=?) => {
+  {logger, msg, exn, params: params->Option.map(Internal.toLogParams)}
 }
 
+// Params are merged into the logged object rather than bound to a child
+// logger, so a single logger instance can serve every context.
+let withParams = (message: 'a, params) =>
+  switch params {
+  | Some(params) =>
+    Utils.Dict.merge(
+      params->(Utils.magic: Internal.logParams => dict<unknown>),
+      message->(Utils.magic: 'a => dict<unknown>),
+    )->(Utils.magic: dict<unknown> => 'a)
+  | None => message
+  }
+
 let log = (self: t) => {
-  switch self {
-  | {exn, msg: Some(msg), logger} => logger->Logging.childErrorWithExn(exn->Utils.prettifyExn, msg)
-  | {exn, msg: None, logger} => logger->Logging.childError(exn->Utils.prettifyExn)
+  let {exn, msg, logger, params} = self
+  let err = exn->Utils.prettifyExn
+  switch (msg, params) {
+  | (Some(msg), None) => logger->Logging.errorWithExn(err, msg)
+  | (None, None) => logger->Logging.error(err)
+  | (_, Some(_)) => logger->Logging.error({"msg": msg, "err": err}->withParams(params))
   }
 }
 
@@ -15,16 +30,16 @@ let raiseExn = (self: t) => {
   self.exn->Utils.prettifyExn->throw
 }
 
-let mkLogAndRaise = (~logger=?, ~msg=?, exn) => {
+let mkLogAndRaise = (~logger=?, ~msg=?, ~params=?, exn) => {
   let exn = exn->Utils.prettifyExn
-  exn->make(~logger?, ~msg?)->log
+  exn->make(~logger?, ~msg?, ~params?)->log
   exn->throw
 }
 
-let unwrapLogAndRaise = (~logger=?, ~msg=?, result) => {
+let unwrapLogAndRaise = (~logger=?, ~msg=?, ~params=?, result) => {
   switch result {
   | Ok(v) => v
-  | Error(exn) => exn->mkLogAndRaise(~logger?, ~msg?)
+  | Error(exn) => exn->mkLogAndRaise(~logger?, ~msg?, ~params?)
   }
 }
 

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -278,7 +278,7 @@ let registerProcessEventBatchMetrics = (
   ~handlerDuration,
 ) => {
   batch.progressedChainsById->Dict.forEachWithKey((chainAfterBatch, chainId) => {
-    logger->Logging.childTrace({
+    logger->Logging.trace({
       "msg": "Finished processing",
       "chainId": chainId->Int.fromString->Option.getUnsafe,
       "batchSize": chainAfterBatch.batchSize,
@@ -340,10 +340,10 @@ let processEventBatch = async (
   // Compute chains state for this batch
   let chains: Internal.chains = chainStates->computeChainsState
 
-  let logger = config.logger
+  let logger = indexerState->IndexerState.logger
 
   batch.progressedChainsById->Dict.forEachWithKey((chainAfterBatch, chainId) => {
-    logger->Logging.childTrace({
+    logger->Logging.trace({
       "msg": "Started processing",
       "chainId": chainId->Int.fromString->Option.getUnsafe,
       "batchSize": chainAfterBatch.batchSize,
@@ -396,7 +396,8 @@ let processEventBatch = async (
     exn
     ->ErrorHandling.make(
       ~msg=message,
-      ~logger=Ecosystem.getItemLogger(item, ~ecosystem=config.ecosystem),
+      ~logger,
+      ~params=Ecosystem.getItemLogParams(item, ~ecosystem=config.ecosystem),
     )
     ->Error
   | exn => exn->ErrorHandling.make(~msg="Failed processing batch", ~logger)->Error

--- a/packages/envio/src/ExitOnCaughtUp.res
+++ b/packages/envio/src/ExitOnCaughtUp.res
@@ -13,7 +13,7 @@ let run = async (state: IndexerState.t) => {
       switch state->IndexerState.onExit {
       | Some(onExit) => onExit()
       | None =>
-        state->IndexerState.logger->Logging.childInfo("Exiting with success")
+        state->IndexerState.logger->Logging.info("Exiting with success")
         NodeJs.process->NodeJs.exitWithCode(Success)
       }
     | Some(message) => state->IndexerState.errorExit(ErrorHandling.make(Utils.Error.make(message)))

--- a/packages/envio/src/ExitOnCaughtUp.res
+++ b/packages/envio/src/ExitOnCaughtUp.res
@@ -16,7 +16,10 @@ let run = async (state: IndexerState.t) => {
         state->IndexerState.logger->Logging.info("Exiting with success")
         NodeJs.process->NodeJs.exitWithCode(Success)
       }
-    | Some(message) => state->IndexerState.errorExit(ErrorHandling.make(Utils.Error.make(message)))
+    | Some(message) =>
+      state->IndexerState.errorExit(
+        ErrorHandling.make(Utils.Error.make(message), ~logger=state->IndexerState.logger),
+      )
     }
   }
 }

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -914,19 +914,17 @@ let updateInternal = (
 
 let warnDifferentContractType = (
   fetchState,
+  ~logger,
   ~existingContract: indexingAddress,
   ~dc: indexingAddress,
 ) => {
-  let logger = Logging.createChildFrom(
-    ~logger=Env.logger,
-    ~params={
-      "chainId": fetchState.chainId,
-      "contractAddress": dc.address->Address.toString,
-      "existingContractType": existingContract.contractName,
-      "newContractType": dc.contractName,
-    },
-  )
-  logger->Logging.childWarn(`Skipping contract registration: Contract address is already registered for one contract and cannot be registered for another contract.`)
+  logger->Logging.warn({
+    "msg": `Skipping contract registration: Contract address is already registered for one contract and cannot be registered for another contract.`,
+    "chainId": fetchState.chainId,
+    "contractAddress": dc.address->Address.toString,
+    "existingContractType": existingContract.contractName,
+    "newContractType": dc.contractName,
+  })
 }
 
 let addressesByContractNameCount = (addressesByContractName: dict<array<Address.t>>) => {
@@ -1140,6 +1138,7 @@ OptimizedPartitions.t => {
 let registerDynamicContracts = (
   fetchState: t,
   ~indexingAddresses: IndexingAddresses.t,
+  ~logger: Pino.t,
   // These are raw items which might have dynamic contracts received from contractRegister call.
   // Might contain duplicates which we should filter out
   items: array<Internal.item>,
@@ -1193,18 +1192,15 @@ let registerDynamicContracts = (
             // If new registration with earlier block number
             // we should register it for the missing block range
             if existingContract.contractName != dc.contractName {
-              fetchState->warnDifferentContractType(~existingContract, ~dc=dcWithStartBlock)
+              fetchState->warnDifferentContractType(~logger, ~existingContract, ~dc=dcWithStartBlock)
             } else if existingContract.effectiveStartBlock > dcWithStartBlock.effectiveStartBlock {
-              let logger = Logging.createChildFrom(
-                ~logger=Env.logger,
-                ~params={
-                  "chainId": fetchState.chainId,
-                  "contractAddress": dc.address->Address.toString,
-                  "existingBlockNumber": existingContract.effectiveStartBlock,
-                  "newBlockNumber": dcWithStartBlock.effectiveStartBlock,
-                },
-              )
-              logger->Logging.childWarn(`Skipping contract registration: Contract address is already registered at a later block number. Currently registration of the same contract address is not supported by Envio. Reach out to us if it's a problem for you.`)
+              logger->Logging.warn({
+                "msg": `Skipping contract registration: Contract address is already registered at a later block number. Currently registration of the same contract address is not supported by Envio. Reach out to us if it's a problem for you.`,
+                "chainId": fetchState.chainId,
+                "contractAddress": dc.address->Address.toString,
+                "existingBlockNumber": existingContract.effectiveStartBlock,
+                "newBlockNumber": dcWithStartBlock.effectiveStartBlock,
+              })
             }
             shouldRemove := true
           | None =>
@@ -1213,6 +1209,7 @@ let registerDynamicContracts = (
             ) {
             | Some(registeringContract) if registeringContract.contractName != dc.contractName =>
               fetchState->warnDifferentContractType(
+                ~logger,
                 ~existingContract=registeringContract,
                 ~dc=dcWithStartBlock,
               )
@@ -1253,7 +1250,7 @@ let registerDynamicContracts = (
           switch indexingAddresses->IndexingAddresses.get(dc.address->Address.toString) {
           | Some(existingContract) =>
             if existingContract.contractName != dc.contractName {
-              fetchState->warnDifferentContractType(~existingContract, ~dc=dcAsIndexingAddress)
+              fetchState->warnDifferentContractType(~logger, ~existingContract, ~dc=dcAsIndexingAddress)
             }
             shouldRemove := true
           | None =>
@@ -1262,23 +1259,20 @@ let registerDynamicContracts = (
             ) {
             | Some(existingContract) =>
               if existingContract.contractName != dc.contractName {
-                fetchState->warnDifferentContractType(~existingContract, ~dc=dcAsIndexingAddress)
+                fetchState->warnDifferentContractType(~logger, ~existingContract, ~dc=dcAsIndexingAddress)
               }
               // Otherwise already queued for persistence by an earlier item in this batch.
               shouldRemove := true
             | None =>
-              let logger = Logging.createChildFrom(
-                ~logger=Env.logger,
-                ~params={
-                  "chainId": fetchState.chainId,
-                  "contractAddress": dc.address->Address.toString,
-                  "contractName": dc.contractName,
-                },
-              )
               // Persist the address to the db so a future config change that
               // adds events for this contract can pick it up on restart, but
               // skip partition registration since there's nothing to fetch.
-              logger->Logging.childWarn(`Persisting contract registration without fetching: Contract doesn't have any events to fetch. It'll be picked up on restart if you add events for the contract.`)
+              logger->Logging.warn({
+                "msg": `Persisting contract registration without fetching: Contract doesn't have any events to fetch. It'll be picked up on restart if you add events for the contract.`,
+                "chainId": fetchState.chainId,
+                "contractAddress": dc.address->Address.toString,
+                "contractName": dc.contractName,
+              })
               noEventsAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
               registeringAddresses->Dict.set(dc.address->Address.toString, dcAsIndexingAddress)
             }

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -26,7 +26,7 @@ let registerContractHandlers = async (~contractName, ~handler: option<string>) =
     } catch {
     | exn =>
       let cause = exn->Utils.prettifyExn->Obj.magic
-      Env.logger->Logging.childErrorWithExn(
+      Env.logger->Logging.errorWithExn(
         exn,
         `Failed to load handler file for contract ${contractName}: ${handlerPath}`,
       )
@@ -65,7 +65,7 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
   ->Array.map(file => {
     Utils.importPath(toImportUrl(file))->Promise.catch(exn => {
       let cause = exn->Utils.prettifyExn->Obj.magic
-      Env.logger->Logging.childErrorWithExn(exn, `Failed to auto-load handler file: ${file}`)
+      Env.logger->Logging.errorWithExn(exn, `Failed to auto-load handler file: ${file}`)
       JsError.throwWithMessage(`Failed to auto-load handler file: ${file}. Cause: ${cause}`)
     })
   })
@@ -77,7 +77,10 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
 // `HandlerRegister.finishRegistration`. This loads the user handler files
 // (populating the global `HandlerRegister` registry as a side effect) and
 // returns the resulting per-chain registrations.
-let registerAllHandlers = async (~config: Config.t): HandlerRegister.registrationsByChainId => {
+let registerAllHandlers = async (
+  ~config: Config.t,
+  ~logger: Pino.t,
+): HandlerRegister.registrationsByChainId => {
   HandlerRegister.startRegistration(~config)
 
   // Auto-load all .js files from src/handlers directory
@@ -90,5 +93,5 @@ let registerAllHandlers = async (~config: Config.t): HandlerRegister.registratio
   })
   ->Promise.all
 
-  HandlerRegister.finishRegistration(~config)
+  HandlerRegister.finishRegistration(~config, ~logger)
 }

--- a/packages/envio/src/HandlerLoader.res
+++ b/packages/envio/src/HandlerLoader.res
@@ -17,7 +17,7 @@ let toImportUrl = (relativePath: string) => {
   NodeJs.Url.pathToFileURL(absolutePath)->NodeJs.Url.toString
 }
 
-let registerContractHandlers = async (~contractName, ~handler: option<string>) => {
+let registerContractHandlers = async (~contractName, ~handler: option<string>, ~logger) => {
   switch handler {
   | None => ()
   | Some(handlerPath) =>
@@ -26,7 +26,7 @@ let registerContractHandlers = async (~contractName, ~handler: option<string>) =
     } catch {
     | exn =>
       let cause = exn->Utils.prettifyExn->Obj.magic
-      Env.logger->Logging.errorWithExn(
+      logger->Logging.errorWithExn(
         exn,
         `Failed to load handler file for contract ${contractName}: ${handlerPath}`,
       )
@@ -37,7 +37,7 @@ let registerContractHandlers = async (~contractName, ~handler: option<string>) =
   }
 }
 
-let autoLoadFromSrcHandlers = async (~handlers: string) => {
+let autoLoadFromSrcHandlers = async (~handlers: string, ~logger) => {
   // Relative to cwd (project root)
   let srcPattern = `./${handlers}/**/*.{js,mjs,ts}`
   let handlerFiles = try {
@@ -65,7 +65,7 @@ let autoLoadFromSrcHandlers = async (~handlers: string) => {
   ->Array.map(file => {
     Utils.importPath(toImportUrl(file))->Promise.catch(exn => {
       let cause = exn->Utils.prettifyExn->Obj.magic
-      Env.logger->Logging.errorWithExn(exn, `Failed to auto-load handler file: ${file}`)
+      logger->Logging.errorWithExn(exn, `Failed to auto-load handler file: ${file}`)
       JsError.throwWithMessage(`Failed to auto-load handler file: ${file}. Cause: ${cause}`)
     })
   })
@@ -84,12 +84,12 @@ let registerAllHandlers = async (
   HandlerRegister.startRegistration(~config)
 
   // Auto-load all .js files from src/handlers directory
-  await autoLoadFromSrcHandlers(~handlers=config.handlers)
+  await autoLoadFromSrcHandlers(~handlers=config.handlers, ~logger)
 
   // Load contract-specific handlers
   let _ = await config.contractHandlers
   ->Array.map(({name, handler}) => {
-    registerContractHandlers(~contractName=name, ~handler)
+    registerContractHandlers(~contractName=name, ~handler, ~logger)
   })
   ->Promise.all
 

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -357,7 +357,7 @@ let getSimulateOnEventRegistrations = (
   }
 }
 
-let finishRegistration = (~config: Config.t): registrationsByChainId => {
+let finishRegistration = (~config: Config.t, ~logger: Pino.t): registrationsByChainId => {
   switch getActiveRegistration() {
   | Some(r) => {
       r.finished = true
@@ -468,9 +468,7 @@ let finishRegistration = (~config: Config.t): registrationsByChainId => {
             `${contractName} (${eventNames->Utils.Set.toArray->Array.joinUnsafe(", ")})`
           )
           ->Array.joinUnsafe(", ")
-        config.logger->Logging.childInfo(
-          `Events without a handler, skipped for indexing: ${groups}`,
-        )
+        logger->Logging.info(`Events without a handler, skipped for indexing: ${groups}`)
       }
 
       registrationsByChainId
@@ -569,7 +567,6 @@ let registerOnBlock = (
     let config = registration.config
     let ecosystem = config.ecosystem
     let chainsDict = getChainsObject(config)
-    let logger = Logging.createChildFrom(~logger=config.logger, ~params={"onBlock": name})
 
     // `where` must be a function (unlike onEvent, which also accepts a static
     // value). A static value would have to be evaluated against every chain
@@ -661,9 +658,12 @@ let registerOnBlock = (
     // Includes the ecosystem-specific method name so SVM users see "onSlot"
     // and don't get confused looking for a "Block handler" they never wrote.
     if !matchedAny.contents {
-      logger->Logging.childWarn(
-        `\`indexer.${ecosystem.onBlockMethodName}\` matched 0 chains. Check the \`where\` predicate.`,
-      )
+      // Registration happens before an indexer instance exists, so this is
+      // the process-level logger.
+      Env.logger->Logging.warn({
+        "msg": `\`indexer.${ecosystem.onBlockMethodName}\` matched 0 chains. Check the \`where\` predicate.`,
+        "onBlock": name,
+      })
     }
   })
 }

--- a/packages/envio/src/HandlerRegister.resi
+++ b/packages/envio/src/HandlerRegister.resi
@@ -7,7 +7,7 @@ type registrationsByChainId = dict<chainRegistrations>
 let startRegistration: (~config: Config.t) => unit
 let resetOnEventRegistrations: unit => unit
 let isPendingRegistration: unit => bool
-let finishRegistration: (~config: Config.t) => registrationsByChainId
+let finishRegistration: (~config: Config.t, ~logger: Pino.t) => registrationsByChainId
 let throwIfFinishedRegistration: (~methodName: string) => unit
 
 let setHandler: (

--- a/packages/envio/src/Hasura.res
+++ b/packages/envio/src/Hasura.res
@@ -96,7 +96,7 @@ let sendOperation = async (~endpoint, ~auth, ~operation: JSON.t, ~logger) => {
         await Time.resolvePromiseAfterDelay(~delayMilliseconds=backoffMs)
         await retry(~attempt=attempt + 1)
       } else {
-        logger->Logging.childWarn({
+        logger->Logging.warn({
           "msg": "Hasura configuration request failed. Indexing will still work - but you may have issues querying data via GraphQL.",
           "err": exn->Utils.prettifyExn,
         })
@@ -113,10 +113,10 @@ let clearHasuraMetadata = async (~endpoint, ~auth, ~logger) => {
     | QuerySucceeded => "Hasura metadata cleared"
     | AlreadyDone => "Hasura metadata already cleared"
     }
-    logger->Logging.childTrace(msg)
+    logger->Logging.trace(msg)
   } catch {
   | exn =>
-    logger->Logging.childError({
+    logger->Logging.error({
       "msg": `There was an issue clearing metadata in hasura - indexing may still work - but you may have issues querying the data in hasura.`,
       "err": exn->Utils.prettifyExn,
     })
@@ -138,10 +138,10 @@ let reloadHasuraMetadata = async (~endpoint, ~auth, ~logger) => {
     | QuerySucceeded => "Hasura metadata reloaded"
     | AlreadyDone => "Hasura metadata reload acknowledged"
     }
-    logger->Logging.childTrace(msg)
+    logger->Logging.trace(msg)
   } catch {
   | exn =>
-    logger->Logging.childError({
+    logger->Logging.error({
       "msg": `There was an issue reloading hasura metadata - table tracking may race with schema creation.`,
       "err": exn->Utils.prettifyExn,
     })
@@ -242,13 +242,13 @@ let trackTables = async (
     | QuerySucceeded => "Hasura finished tracking tables"
     | AlreadyDone => "Hasura tables already tracked"
     }
-    logger->Logging.childTrace({
+    logger->Logging.trace({
       "msg": msg,
       "tableNames": tableConfigs->Array.map(c => c.tableName),
     })
   } catch {
   | exn =>
-    logger->Logging.childError({
+    logger->Logging.error({
       "msg": `There was an issue tracking tables in hasura - indexing may still work - but you may have issues querying the data in hasura.`,
       "tableNames": tableConfigs->Array.map(c => c.tableName),
       "err": exn->Utils.prettifyExn,
@@ -376,7 +376,7 @@ let trackDatabase = async (
   let tableConfigs = [exposedInternalTableConfigs, userTableConfigs]->Array.flat
   let tableNames = tableConfigs->Array.map(c => c.tableName)
 
-  logger->Logging.childInfo("Tracking tables in Hasura")
+  logger->Logging.info("Tracking tables in Hasura")
 
   let _ = await clearHasuraMetadata(~endpoint, ~auth, ~logger)
 
@@ -447,5 +447,5 @@ let trackDatabase = async (
     }
   }
 
-  logger->Logging.childInfo("Hasura configuration completed")
+  logger->Logging.info("Hasura configuration completed")
 }

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -18,14 +18,13 @@ module Entity = {
   }
 
   // Helper to extract entity ID from any entity
-  exception UnexpectedIdNotDefinedOnEntity
   let getEntityIdUnsafe = (entity: Internal.entity): string =>
     switch (entity->(Utils.magic: Internal.entity => {"id": option<string>}))["id"] {
     | Some(id) => id
     | None =>
       // Raised, not logged: this runs inside handler processing, whose error
       // boundary logs through the indexer's own logger with item context.
-      throw(UnexpectedIdNotDefinedOnEntity)
+      JsError.throwWithMessage("Property 'id' does not exist on expected entity object")
     }
 
   let getOrCreateEntityFilters = (self: t, ~entityId) =>

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -23,10 +23,9 @@ module Entity = {
     switch (entity->(Utils.magic: Internal.entity => {"id": option<string>}))["id"] {
     | Some(id) => id
     | None =>
-      UnexpectedIdNotDefinedOnEntity->ErrorHandling.mkLogAndRaise(
-        ~logger=Env.logger,
-        ~msg="Property 'id' does not exist on expected entity object",
-      )
+      // Raised, not logged: this runs inside handler processing, whose error
+      // boundary logs through the indexer's own logger with item context.
+      throw(UnexpectedIdNotDefinedOnEntity)
     }
 
   let getOrCreateEntityFilters = (self: t, ~entityId) =>

--- a/packages/envio/src/InMemoryTable.res
+++ b/packages/envio/src/InMemoryTable.res
@@ -24,6 +24,7 @@ module Entity = {
     | Some(id) => id
     | None =>
       UnexpectedIdNotDefinedOnEntity->ErrorHandling.mkLogAndRaise(
+        ~logger=Env.logger,
         ~msg="Property 'id' does not exist on expected entity object",
       )
     }

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -8,7 +8,6 @@ type rollbackState =
 
 module EntityTables = {
   type t = dict<InMemoryTable.Entity.t>
-  exception UndefinedEntity({entityName: string})
   let make = (entities: array<Internal.entityConfig>): t => {
     let init = Dict.make()
     entities->Array.forEach(entityConfig => {
@@ -21,9 +20,10 @@ module EntityTables = {
     switch self->Utils.Dict.dangerouslyGetNonOption(entityName) {
     | Some(table) => table
     | None =>
-      UndefinedEntity({entityName: entityName})->ErrorHandling.mkLogAndRaise(
-        ~logger=Env.logger,
-        ~msg="Unexpected, entity InMemoryTable is undefined",
+      // Raised, not logged: every caller runs inside an instance-scoped error
+      // boundary that logs through the indexer's own logger.
+      JsError.throwWithMessage(
+        `Unexpected, InMemoryTable for entity ${entityName} is undefined`,
       )
     }
   }

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -22,6 +22,7 @@ module EntityTables = {
     | Some(table) => table
     | None =>
       UndefinedEntity({entityName: entityName})->ErrorHandling.mkLogAndRaise(
+        ~logger=Env.logger,
         ~msg="Unexpected, entity InMemoryTable is undefined",
       )
     }
@@ -738,7 +739,9 @@ let beginRollbackDiff = (
 // Stop the write loop and surface the failure; the error itself goes to onError.
 let recordWriteFailure = (state: t, exn) => {
   state.hasFailedWrite = true
-  state.onError(exn->ErrorHandling.make(~msg="Failed writing batch to the database"))
+  state.onError(
+    exn->ErrorHandling.make(~logger=state.logger, ~msg="Failed writing batch to the database"),
+  )
 }
 
 let beginWriteFiber = (state: t, fiber) => state.writeFiber = Some(fiber)

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -73,6 +73,7 @@ type historyPruneStat = {
 
 type t = {
   config: Config.t,
+  logger: Pino.t,
   persistence: Persistence.t,
   // --- In-memory store: entity/effect tables and the pending-write queue. ---
   allEntities: array<Internal.entityConfig>,
@@ -144,6 +145,7 @@ type t = {
 
 let make = (
   ~config: Config.t,
+  ~logger: Pino.t,
   ~persistence: Persistence.t,
   ~chainStates: dict<ChainState.t>,
   ~isInReorgThreshold: bool,
@@ -160,18 +162,17 @@ let make = (
     let intervalMillis = Env.ThrottleWrites.chainMetadataIntervalMillis
     Throttler.make(
       ~intervalMillis,
-      ~logger=Logging.createChildFrom(
-        ~logger=config.logger,
-        ~params={
-          "context": "Throttler for chain metadata writes",
-          "intervalMillis": intervalMillis,
-        },
-      ),
+      ~logger,
+      ~params={
+        "context": "Throttler for chain metadata writes",
+        "intervalMillis": intervalMillis,
+      }->Internal.toLogParams,
     )
   }
 
   {
     config,
+    logger,
     persistence,
     allEntities: persistence.allEntities,
     entities: EntityTables.make(persistence.allEntities),
@@ -193,7 +194,7 @@ let make = (
       ~isInReorgThreshold,
       ~isRealtime,
       ~targetBufferSize,
-      ~logger=config.logger,
+      ~logger,
     ),
     indexerStartTime: Date.make(),
     rollbackState: NoRollback,
@@ -229,6 +230,7 @@ let isProgressInReorgThreshold = (~progressBlockNumber, ~sourceBlockNumber, ~max
 
 let makeFromDbState = (
   ~config: Config.t,
+  ~logger: Pino.t,
   ~persistence: Persistence.t,
   ~initialState: Persistence.initialState,
   ~registrationsByChainId,
@@ -272,6 +274,7 @@ let makeFromDbState = (
         ~isInReorgThreshold,
         ~isRealtime,
         ~config,
+        ~logger,
         ~registrationsByChainId,
         ~reducedPollingInterval?,
       ),
@@ -280,6 +283,7 @@ let makeFromDbState = (
 
   let state = make(
     ~config,
+    ~logger,
     ~persistence,
     ~chainStates,
     ~isInReorgThreshold,
@@ -405,7 +409,7 @@ let recordProcessedBatch = (state: t) =>
 // the container in place (eg insert an entity table). ---
 
 let config = (state: t) => state.config
-let logger = (state: t) => state.config.logger
+let logger = (state: t) => state.logger
 let persistence = (state: t) => state.persistence
 let allEntities = (state: t) => state.allEntities
 let entities = (state: t) => state.entities

--- a/packages/envio/src/IndexerState.resi
+++ b/packages/envio/src/IndexerState.resi
@@ -20,6 +20,7 @@ type t
 
 let make: (
   ~config: Config.t,
+  ~logger: Pino.t,
   ~persistence: Persistence.t,
   ~chainStates: dict<ChainState.t>,
   ~isInReorgThreshold: bool,
@@ -35,6 +36,7 @@ let make: (
 
 let makeFromDbState: (
   ~config: Config.t,
+  ~logger: Pino.t,
   ~persistence: Persistence.t,
   ~initialState: Persistence.initialState,
   ~registrationsByChainId: HandlerRegister.registrationsByChainId,

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -2,6 +2,11 @@ type eventParams
 type eventBlock
 type eventTransaction
 
+// Context fields spread into log lines. Abstract so heterogeneous param
+// objects from different ecosystems share one type.
+type logParams
+let toLogParams = (params: 'a): logParams => params->(Utils.magic: 'a => logParams)
+
 // Field name variants for type-safe field selection.
 // @unboxed compiles to plain strings at runtime, matching JS property names.
 @unboxed

--- a/packages/envio/src/LoadLayer.res
+++ b/packages/envio/src/LoadLayer.res
@@ -31,7 +31,8 @@ let loadById = (
     } catch {
     | Persistence.StorageError({message, reason}) =>
       reason->ErrorHandling.mkLogAndRaise(
-        ~logger=Ecosystem.getItemLogger(item, ~ecosystem),
+        ~logger=indexerState->IndexerState.logger,
+        ~params=Ecosystem.getItemLogParams(item, ~ecosystem),
         ~msg=message,
       )
     }
@@ -256,11 +257,15 @@ let loadEffect = (
         )->(Utils.magic: array<unknown> => array<Internal.effectCacheItem>)
       } catch {
       | exn =>
-        Ecosystem.getItemLogger(item, ~ecosystem)->Logging.childWarn({
-          "msg": `Failed to load cache effect cache. The indexer will continue working, but the effect will not be able to use the cache.`,
-          "err": exn->Utils.prettifyExn,
-          "effect": effectName,
-        })
+        indexerState
+        ->IndexerState.logger
+        ->Logging.warn(
+          Ecosystem.getItemLogParams(item, ~ecosystem)->Logging.withParams({
+            "msg": `Failed to load cache effect cache. The indexer will continue working, but the effect will not be able to use the cache.`,
+            "err": exn->Utils.prettifyExn,
+            "effect": effectName,
+          }),
+        )
         []
       }
 
@@ -272,12 +277,16 @@ let loadEffect = (
         } catch {
         | S.Raised(error) =>
           inMemTable->EffectState.recordInvalidation
-          Ecosystem.getItemLogger(item, ~ecosystem)->Logging.childTrace({
-            "msg": "Invalidated effect cache",
-            "input": dbEntity.id,
-            "effect": effectName,
-            "err": error->S.Error.message,
-          })
+          indexerState
+          ->IndexerState.logger
+          ->Logging.trace(
+            Ecosystem.getItemLogParams(item, ~ecosystem)->Logging.withParams({
+              "msg": "Invalidated effect cache",
+              "input": dbEntity.id,
+              "effect": effectName,
+              "err": error->S.Error.message,
+            }),
+          )
         }
       })
 
@@ -370,17 +379,15 @@ let loadByFilter = (
       } catch {
       | Persistence.StorageError({message, reason}) =>
         reason->ErrorHandling.mkLogAndRaise(
-          ~logger=Logging.createChildFrom(
-            ~logger=Ecosystem.getItemLogger(item, ~ecosystem),
-            // The executed query might be merged from multiple getWhere
-            // calls, so report it as the operation users write with the
-            // values bound to its placeholders, instead of an internal
-            // filter representation they never constructed.
-            ~params={
-              "operation": key,
-              "params": filter->EntityFilter.getParams,
-            },
-          ),
+          ~logger=indexerState->IndexerState.logger,
+          // The executed query might be merged from multiple getWhere
+          // calls, so report it as the operation users write with the
+          // values bound to its placeholders, instead of an internal
+          // filter representation they never constructed.
+          ~params=Ecosystem.getItemLogParams(item, ~ecosystem)->Logging.withParams({
+            "operation": key,
+            "params": filter->EntityFilter.getParams,
+          }),
           ~msg=message,
         )
       }

--- a/packages/envio/src/Logging.res
+++ b/packages/envio/src/Logging.res
@@ -138,6 +138,12 @@ let mergeParams: (Internal.logParams, option<'a>) => 'a = %raw(`(base, params) =
 // written on every line instead of being bound to a child logger.
 let withParams: (Internal.logParams, 'a) => 'a = %raw(`(base, message) => ({...base, ...message})`)
 
+// Binds params for code we hand the logger to rather than call — a `Source.t`
+// implementation logs from inside its own module, where the caller's query
+// context isn't in scope and can't be spread per line. Everywhere the params
+// are in scope, write them on the line instead.
+let createChild = (~logger: t, ~params: 'a) => logger->child(params->createChildParams)
+
 // Wrap a logger as the user-facing `context.log`, routing through the custom
 // `u*` levels. `params` is the item context (built by the ecosystem) and is
 // merged into every line, with the user's own params taking precedence.

--- a/packages/envio/src/Logging.res
+++ b/packages/envio/src/Logging.res
@@ -85,31 +85,27 @@ let setLogLevel = (logger: t, level: Pino.logLevel) => {
   logger->setLevel(level)
 }
 
-let childTrace = (logger, params: 'a) => {
+let trace = (logger, params: 'a) => {
   logger.trace(params->createPinoMessage)
 }
-let childDebug = (logger, params: 'a) => {
+let debug = (logger, params: 'a) => {
   logger.debug(params->createPinoMessage)
 }
-let childInfo = (logger, params: 'a) => {
+let info = (logger, params: 'a) => {
   logger.info(params->createPinoMessage)
 }
-let childWarn = (logger, params: 'a) => {
+let warn = (logger, params: 'a) => {
   logger.warn(params->createPinoMessage)
 }
-let childError = (logger, params: 'a) => {
+let error = (logger, params: 'a) => {
   logger.error(params->createPinoMessage)
 }
-let childErrorWithExn = (logger, error, params: 'a) => {
-  logger->Pino.errorExn(params->createPinoMessageWithError(error))
+let errorWithExn = (logger, err, params: 'a) => {
+  logger->Pino.errorExn(params->createPinoMessageWithError(err))
 }
 
-let childFatal = (logger, params: 'a) => {
+let fatal = (logger, params: 'a) => {
   logger.fatal(params->createPinoMessage)
-}
-
-let createChildFrom = (~logger: t, ~params: 'a) => {
-  logger->child(params->createChildParams)
 }
 
 @inline
@@ -129,13 +125,30 @@ let noopLogger: Envio.logger = {
   errorWithExn: (_message: string, _exn) => (),
 }
 
-// Wrap a (child) logger as the user-facing `context.log`, routing through the
-// custom `u*` levels. The caller builds the per-item logger via the ecosystem.
-let userLogger = (logger: t): Envio.logger => {
-  info: (message: string, ~params=?) => logger->logAtLevel(#uinfo, message, ~params?),
-  debug: (message: string, ~params=?) => logger->logAtLevel(#udebug, message, ~params?),
-  warn: (message: string, ~params=?) => logger->logAtLevel(#uwarn, message, ~params?),
-  error: (message: string, ~params=?) => logger->logAtLevel(#uerror, message, ~params?),
+let mergeParams: (Internal.logParams, option<'a>) => 'a = %raw(`(base, params) =>
+  params === undefined ? base : {...base, ...params}`)
+
+// Spread a shared context object into a log message. Used where a block of
+// code emits several lines about the same subject; the fields are still
+// written on every line instead of being bound to a child logger.
+let withParams: (Internal.logParams, 'a) => 'a = %raw(`(base, message) => ({...base, ...message})`)
+
+// Wrap a logger as the user-facing `context.log`, routing through the custom
+// `u*` levels. `params` is the item context (built by the ecosystem) and is
+// merged into every line, with the user's own params taking precedence.
+let userLogger = (logger: t, ~params as itemParams: Internal.logParams): Envio.logger => {
+  info: (message: string, ~params=?) =>
+    logger->logAtLevel(#uinfo, message, ~params=itemParams->mergeParams(params)),
+  debug: (message: string, ~params=?) =>
+    logger->logAtLevel(#udebug, message, ~params=itemParams->mergeParams(params)),
+  warn: (message: string, ~params=?) =>
+    logger->logAtLevel(#uwarn, message, ~params=itemParams->mergeParams(params)),
+  error: (message: string, ~params=?) =>
+    logger->logAtLevel(#uerror, message, ~params=itemParams->mergeParams(params)),
   errorWithExn: (message: string, exn) =>
-    logger->logAtLevel(#uerror, message, ~params={"err": exn->Utils.prettifyExn}),
+    logger->logAtLevel(
+      #uerror,
+      message,
+      ~params=itemParams->mergeParams(Some({"err": exn->Utils.prettifyExn})),
+    ),
 }

--- a/packages/envio/src/Logging.res
+++ b/packages/envio/src/Logging.res
@@ -81,6 +81,11 @@ let makeLogger = (~logStrategy, ~logFilePath, ~defaultFileLogLevel, ~userLogLeve
   }
 }
 
+// Release the logger's stream. Each indexer instance owns its logger, so an
+// instance that shuts down must not leave a file handle or transport worker
+// behind.
+let close = Pino.close
+
 let setLogLevel = (logger: t, level: Pino.logLevel) => {
   logger->setLevel(level)
 }

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -542,12 +542,12 @@ let startServer = (~getState, ~persistence: Persistence.t, ~isDevelopmentMode: b
   server->Express.onError(err => {
     let code = (err->(Utils.magic: JsExn.t => {..}))["code"]
     if code === "EADDRINUSE" {
-      Env.logger->Logging.childError(
+      Env.logger->Logging.error(
         `Port ${Env.serverPort->Int.toString} is already in use. To fix this either:` ++
         `\n  1. Kill the process using the port: lsof -ti :${Env.serverPort->Int.toString} | xargs kill -9` ++ `\n  2. Use a different port by setting the ENVIO_INDEXER_PORT environment variable: ENVIO_INDEXER_PORT=9899 envio start`,
       )
     } else {
-      Env.logger->Logging.childErrorWithExn(err, "Failed to start indexer server")
+      Env.logger->Logging.errorWithExn(err, "Failed to start indexer server")
     }
     NodeJs.process->NodeJs.exitWithCode(Failure)
   })
@@ -567,7 +567,7 @@ let getEnvioInfo = () => Config.getPublicConfigJson()->Config.stripSensitiveData
 
 let migrate = async (~reset) => {
   let config = Config.load()
-  let persistence = PgStorage.makePersistenceFromConfig(~config)
+  let persistence = PgStorage.makePersistenceFromConfig(~config, ~logger=Env.logger)
   await persistence->Persistence.init(
     ~reset,
     ~chainConfigs=config.chainMap->ChainMap.values,
@@ -580,7 +580,7 @@ let migrate = async (~reset) => {
 
 let dropSchema = async () => {
   let config = Config.load()
-  let persistence = PgStorage.makePersistenceFromConfig(~config)
+  let persistence = PgStorage.makePersistenceFromConfig(~config, ~logger=Env.logger)
   await persistence.storage.reset()
   await persistence.storage.close()
 }
@@ -609,6 +609,9 @@ let start = async (
   // Initialize persistence first so the exported indexer value contains state from the database
   // when handler files are loaded (they may access the indexer at module top level).
   let config = Config.load()
+  // One logger per indexer run. `envio start` runs a single indexer per
+  // process, so this is the process logger; in-process runners build their own.
+  let logger = Env.logger
   // isDevelopmentMode controls whether the indexer stays alive after all
   // chains finish (keepProcessAlive) and whether the console API is exposed.
   // Set by `envio dev` via the public config's `isDev` field; `envio start`
@@ -616,7 +619,7 @@ let start = async (
   let isDevelopmentMode = !isTest && config.isDev
   let persistence = switch persistence {
   | Some(p) => p
-  | None => PgStorage.makePersistenceFromConfig(~config)
+  | None => PgStorage.makePersistenceFromConfig(~config, ~logger)
   }
   setGlobalPersistence(persistence)
   await persistence->Persistence.init(
@@ -631,7 +634,7 @@ let start = async (
   // state into the global `HandlerRegister` registry as a side effect; this
   // returns that state resolved into per-chain registrations. `config` itself
   // is never mutated by registration — it holds only event definitions.
-  let registrationsByChainId = await HandlerLoader.registerAllHandlers(~config)
+  let registrationsByChainId = await HandlerLoader.registerAllHandlers(~config, ~logger)
   let config = if isTest {
     {...config, shouldRollbackOnReorg: false}
   } else {
@@ -680,6 +683,7 @@ let start = async (
 
   let state = IndexerState.makeFromDbState(
     ~config,
+    ~logger,
     ~persistence,
     ~initialState=persistence->Persistence.getInitializedState,
     ~registrationsByChainId,

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -472,7 +472,7 @@ let getGlobalIndexer = (): 'indexer => {
   Utils.Proxy.make(Utils.Object.createNullObject(), traps)->(Utils.magic: {..} => 'indexer)
 }
 
-let startServer = (~getState, ~persistence: Persistence.t, ~isDevelopmentMode: bool) => {
+let startServer = (~getState, ~persistence: Persistence.t, ~isDevelopmentMode: bool, ~logger) => {
   open Express
 
   let app = make()
@@ -542,12 +542,12 @@ let startServer = (~getState, ~persistence: Persistence.t, ~isDevelopmentMode: b
   server->Express.onError(err => {
     let code = (err->(Utils.magic: JsExn.t => {..}))["code"]
     if code === "EADDRINUSE" {
-      Env.logger->Logging.error(
+      logger->Logging.error(
         `Port ${Env.serverPort->Int.toString} is already in use. To fix this either:` ++
         `\n  1. Kill the process using the port: lsof -ti :${Env.serverPort->Int.toString} | xargs kill -9` ++ `\n  2. Use a different port by setting the ENVIO_INDEXER_PORT environment variable: ENVIO_INDEXER_PORT=9899 envio start`,
       )
     } else {
-      Env.logger->Logging.errorWithExn(err, "Failed to start indexer server")
+      logger->Logging.errorWithExn(err, "Failed to start indexer server")
     }
     NodeJs.process->NodeJs.exitWithCode(Failure)
   })
@@ -664,7 +664,7 @@ let start = async (
   let envioVersion = Utils.EnvioPackage.value.version
 
   if !isTest {
-    startServer(~persistence, ~isDevelopmentMode, ~getState=() =>
+    startServer(~persistence, ~isDevelopmentMode, ~logger, ~getState=() =>
       switch getIndexerState() {
       | None => Initializing({})
       | Some(state) => {

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -575,14 +575,14 @@ let migrate = async (~reset) => {
     ~resetCommand="envio local db-migrate setup",
     ~runCommand=None,
   )
-  await persistence.storage.close()
+  await persistence->Persistence.close
 }
 
 let dropSchema = async () => {
   let config = Config.load()
   let persistence = PgStorage.makePersistenceFromConfig(~config, ~logger=Env.logger)
   await persistence.storage.reset()
-  await persistence.storage.close()
+  await persistence->Persistence.close
 }
 
 // Rejection carried by `onError`: the failure is already logged with full

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -179,6 +179,13 @@ let make = (
   }
 }
 
+// Shut the indexer's resources down: the storage, then the logger that was
+// reporting on it.
+let close = async (persistence: t) => {
+  await persistence.storage.close()
+  await persistence.logger->Logging.close
+}
+
 let init = {
   async (persistence, ~chainConfigs, ~envioInfo, ~resetCommand, ~runCommand, ~reset=false) => {
     try {
@@ -253,7 +260,11 @@ let init = {
         resolveRef.contents()
       }
     } catch {
-    | exn => exn->ErrorHandling.mkLogAndRaise(~msg=`Failed to initialize the indexer storage.`)
+    | exn =>
+      exn->ErrorHandling.mkLogAndRaise(
+        ~logger=persistence.logger,
+        ~msg=`Failed to initialize the indexer storage.`,
+      )
     }
   }
 }

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -164,7 +164,7 @@ let make = (
   // TODO: Should only pass userEnums and create internal config in runtime
   ~allEnums,
   ~storage,
-  ~logger=Env.logger,
+  ~logger: Pino.t,
 ) => {
   let allEntities = userEntities->Array.concat([InternalTable.EnvioAddresses.entityConfig])
   let allEnums =
@@ -197,14 +197,14 @@ let init = {
         })
         persistence.storageStatus = Initializing(promise)
         if reset || !(await persistence.storage.isInitialized()) {
-          persistence.logger->Logging.childInfo(`Initializing the indexer storage...`)
+          persistence.logger->Logging.info(`Initializing the indexer storage...`)
           let initialState = await persistence.storage.initialize(
             ~entities=persistence.allEntities,
             ~enums=persistence.allEnums,
             ~chainConfigs,
             ~envioInfo,
           )
-          persistence.logger->Logging.childInfo(`The indexer storage is ready. Starting indexing!`)
+          persistence.logger->Logging.info(`The indexer storage is ready. Starting indexing!`)
           persistence.storageStatus = Ready(initialState)
         } else if (
           // In case of a race condition,
@@ -214,7 +214,7 @@ let init = {
           | _ => false
           }
         ) {
-          persistence.logger->Logging.childInfo(`Found existing indexer storage. Resuming indexing state...`)
+          persistence.logger->Logging.info(`Found existing indexer storage. Resuming indexing state...`)
           let initialState = await persistence.storage.resumeInitialState()
           // Compat-check the running config against what was stored on the
           // last successful initialize. None means the schema pre-dates
@@ -245,7 +245,7 @@ let init = {
           initialState.chains->Array.forEach(c => {
             progress->Utils.Dict.setByInt(c.id, c.progressBlockNumber)
           })
-          persistence.logger->Logging.childInfo({
+          persistence.logger->Logging.info({
             "msg": `Successfully resumed indexing state! Continuing from the last checkpoint.`,
             "progress": progress,
           })

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1247,7 +1247,7 @@ let make = (
   ~sink: option<Sink.t>=?,
   ~onInitialize=?,
   ~onNewTables=?,
-  ~logger=Env.logger,
+  ~logger: Pino.t,
 ): Persistence.storage => {
   // Must match PG_CONTAINER in packages/cli/src/docker_env.rs
   let containerName = "envio-postgres"
@@ -1337,7 +1337,7 @@ let make = (
     if withUpload {
       // Try to restore cache tables from the .envio/cache TSV files
       switch await scanCacheDir() {
-      | [] => logger->Logging.childInfo("No cache found to upload.")
+      | [] => logger->Logging.info("No cache found to upload.")
       | entries =>
         switch await getConnectedPsqlExec(~pgUser, ~pgHost, ~pgDatabase, ~pgPort, ~containerName) {
         | Ok(psqlExec) =>
@@ -1365,9 +1365,9 @@ let make = (
             })
           })
           ->Promise.all
-          logger->Logging.childInfo("Successfully uploaded cache.")
+          logger->Logging.info("Successfully uploaded cache.")
         | Error(message) =>
-          logger->Logging.childError(`Failed to upload cache, continuing without it. ${message}`)
+          logger->Logging.error(`Failed to upload cache, continuing without it. ${message}`)
         }
       }
     }
@@ -1598,7 +1598,7 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
 
         switch await getConnectedPsqlExec(~pgUser, ~pgHost, ~pgDatabase, ~pgPort, ~containerName) {
         | Ok(psqlExec) => {
-            logger->Logging.childInfo(
+            logger->Logging.info(
               `Dumping cache: ${cacheTableInfo
                 ->Array.map(({tableName, count}) =>
                   tableName ++ " (" ++ count->Int.toString ++ " rows)"
@@ -1640,15 +1640,15 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
             })
 
             let _ = await promises->Promise.all
-            logger->Logging.childInfo(
+            logger->Logging.info(
               `Successfully dumped cache to ${cacheDirPath->NodeJs.Path.toString}`,
             )
           }
-        | Error(message) => logger->Logging.childError(`Failed to dump cache. ${message}`)
+        | Error(message) => logger->Logging.error(`Failed to dump cache. ${message}`)
         }
       }
     } catch {
-    | exn => logger->Logging.childErrorWithExn(exn->Utils.prettifyExn, `Failed to dump cache.`)
+    | exn => logger->Logging.errorWithExn(exn->Utils.prettifyExn, `Failed to dump cache.`)
     }
   }
 
@@ -1865,6 +1865,7 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
 
 let makeStorageFromEnv = (
   ~config: Config.t,
+  ~logger: Pino.t,
   ~sql=makeClient(),
   ~pgSchema=Env.Db.publicSchema,
   ~isHasuraEnabled=Env.Hasura.enabled,
@@ -1909,6 +1910,7 @@ let makeStorageFromEnv = (
             ~database=database->Option.getUnsafe,
             ~username=username->Option.getUnsafe,
             ~password=password->Option.getUnsafe,
+            ~logger,
           ),
         )
       } else {
@@ -1930,10 +1932,10 @@ let makeStorageFromEnv = (
               ~responseLimit=Env.Hasura.responseLimit,
               ~schema=Schema.make(config.allEntities->Array.map(e => e.table)),
               ~aggregateEntities=Env.Hasura.aggregateEntities,
-              ~logger=config.logger,
+              ~logger,
             )->Promise.catch(err => {
-              config.logger
-              ->Logging.childErrorWithExn(err->Utils.prettifyExn, `Error tracking tables`)
+              logger
+              ->Logging.errorWithExn(err->Utils.prettifyExn, `Error tracking tables`)
               ->Promise.resolve
             })
           },
@@ -1958,10 +1960,10 @@ let makeStorageFromEnv = (
                 description: None,
                 columnConfigs: dict{},
               }),
-              ~logger=config.logger,
+              ~logger,
             )->Promise.catch(err => {
-              config.logger
-              ->Logging.childErrorWithExn(err->Utils.prettifyExn, `Error tracking new tables`)
+              logger
+              ->Logging.errorWithExn(err->Utils.prettifyExn, `Error tracking new tables`)
               ->Promise.resolve
             })
           },
@@ -1971,15 +1973,19 @@ let makeStorageFromEnv = (
       }
     },
     ~isHasuraEnabled,
-    ~logger=config.logger,
+    ~logger,
   )
 }
 
-let makePersistenceFromConfig = (~config: Config.t, ~storage=makeStorageFromEnv(~config)) => {
+let makePersistenceFromConfig = (
+  ~config: Config.t,
+  ~logger: Pino.t,
+  ~storage=makeStorageFromEnv(~config, ~logger),
+) => {
   Persistence.make(
     ~userEntities=config.userEntities,
     ~allEnums=config.allEnums,
     ~storage,
-    ~logger=config.logger,
+    ~logger,
   )
 }

--- a/packages/envio/src/PruneStaleHistory.res
+++ b/packages/envio/src/PruneStaleHistory.res
@@ -112,13 +112,14 @@ let pruneEntities = async (state: IndexerState.t, ~entities, ~safeCheckpointId) 
       )
     | exception exn =>
       // Pruning is cleanup; a failure must not fail the write loop.
-      Logging.createChildFrom(
-        ~logger=state->IndexerState.logger,
-        ~params={
-          "entityName": entityConfig.name,
-          "safeCheckpointId": safeCheckpointId,
-        },
-      )->Logging.childErrorWithExn(exn->Utils.prettifyExn, `Failed to prune stale entity history`)
+      state
+      ->IndexerState.logger
+      ->Logging.error({
+        "msg": `Failed to prune stale entity history`,
+        "entityName": entityConfig.name,
+        "safeCheckpointId": safeCheckpointId,
+        "err": exn->Utils.prettifyExn,
+      })
     }
   }
 }
@@ -127,10 +128,13 @@ let pruneCheckpoints = async (state: IndexerState.t, ~safeCheckpointId) => {
   switch await (state->IndexerState.persistence).storage.pruneStaleCheckpoints(~safeCheckpointId) {
   | () => ()
   | exception exn =>
-    Logging.createChildFrom(
-      ~logger=state->IndexerState.logger,
-      ~params={"safeCheckpointId": safeCheckpointId},
-    )->Logging.childErrorWithExn(exn->Utils.prettifyExn, `Failed to prune stale checkpoints`)
+    state
+    ->IndexerState.logger
+    ->Logging.error({
+      "msg": `Failed to prune stale checkpoints`,
+      "safeCheckpointId": safeCheckpointId,
+      "err": exn->Utils.prettifyExn,
+    })
   }
 }
 

--- a/packages/envio/src/ReorgDetection.res
+++ b/packages/envio/src/ReorgDetection.res
@@ -17,12 +17,13 @@ type reorgDetected = {
   receivedBlock: blockData,
 }
 
-let reorgDetectedToLogParams = (reorgDetected: reorgDetected, ~shouldRollbackOnReorg) => {
+let reorgDetectedToLogParams = (reorgDetected: reorgDetected, ~shouldRollbackOnReorg, ~chainId) => {
   let {scannedBlock, receivedBlock} = reorgDetected
   {
     "msg": `Blockchain reorg detected. ${shouldRollbackOnReorg
         ? "Initiating indexer rollback"
         : "NOT initiating indexer rollback due to configuration"}.`,
+    "chainId": chainId,
     "blockNumber": scannedBlock.blockNumber,
     "indexedBlockHash": scannedBlock.blockHash,
     "receivedBlockHash": receivedBlock.blockHash,

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -86,7 +86,13 @@ let rec rollback = async (
     }
   } catch {
   | exn =>
-    IndexerState.errorExit(state, exn->ErrorHandling.make(~msg=IndexerState.unexpectedErrorMsg))
+    IndexerState.errorExit(
+        state,
+        exn->ErrorHandling.make(
+          ~logger=state->IndexerState.logger,
+          ~msg=IndexerState.unexpectedErrorMsg,
+        ),
+      )
   }
 
 and executeRollback = async (

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -74,7 +74,7 @@ let rec rollback = async (
     | FoundReorgDepth(_) if state->IndexerState.isProcessing =>
       state
       ->IndexerState.logger
-      ->Logging.childTrace("Waiting for batch to finish processing before executing rollback")
+      ->Logging.trace("Waiting for batch to finish processing before executing rollback")
     | FoundReorgDepth({chain: reorgChain, rollbackTargetBlockNumber}) =>
       await executeRollback(
         state,
@@ -98,18 +98,15 @@ and executeRollback = async (
 ) => {
   let startTime = Performance.now()
 
-  // Not derived from the reorg chain's logger: that would bind its chainId onto
-  // every line, colliding with the per-chain chainId on the "Rollbacked" logs.
-  // The reorg chain is identified by the reorgChain param instead.
-  let logger = Logging.createChildFrom(
-    ~logger=state->IndexerState.logger,
-    ~params={
-      "action": "Rollback",
-      "reorgChain": reorgChain,
-      "targetBlockNumber": rollbackTargetBlockNumber,
-    },
-  )
-  logger->Logging.childInfo("Started rollback on reorg")
+  let logger = state->IndexerState.logger
+  // The reorg chain is reported as `reorgChain`, not `chainId`: the per-chain
+  // `chainId` on the "Rollbacked" logs below refers to a different chain.
+  let rollbackParams = {
+    "action": "Rollback",
+    "reorgChain": reorgChain,
+    "targetBlockNumber": rollbackTargetBlockNumber,
+  }->Internal.toLogParams
+  logger->Logging.info(rollbackParams->Logging.withParams({"msg": "Started rollback on reorg"}))
   state
   ->IndexerState.getChainState(~chain=reorgChain)
   ->ChainState.setRollbackTargetBlock(~blockNumber=rollbackTargetBlockNumber)
@@ -201,19 +198,23 @@ and executeRollback = async (
   )
 
   rolledBackChains->Array.forEach(chain => {
-    logger->Logging.childInfo({
-      "msg": "Rollbacked",
-      "chainId": chain["chainId"],
-      "fromBlock": chain["fromBlock"],
-      "toBlock": chain["toBlock"],
-      "rollbackedEvents": chain["rollbackedEvents"],
-    })
+    logger->Logging.info(
+      rollbackParams->Logging.withParams({
+        "msg": "Rollbacked",
+        "chainId": chain["chainId"],
+        "fromBlock": chain["fromBlock"],
+        "toBlock": chain["toBlock"],
+        "rollbackedEvents": chain["rollbackedEvents"],
+      }),
+    )
   })
-  logger->Logging.childTrace({
-    "msg": "Rollback entity changes",
-    "deleted": diff["deletedEntities"],
-    "upserted": diff["setEntities"],
-  })
+  logger->Logging.trace(
+    rollbackParams->Logging.withParams({
+      "msg": "Rollback entity changes",
+      "deleted": diff["deletedEntities"],
+      "upserted": diff["setEntities"],
+    }),
+  )
   state->IndexerState.recordRollbackSuccess(
     ~timeSeconds=Performance.secondsSince(startTime),
     ~rollbackedProcessedEvents=rollbackedProcessedEvents.contents,

--- a/packages/envio/src/Sink.res
+++ b/packages/envio/src/Sink.res
@@ -12,7 +12,7 @@ type t = {
   ) => promise<unit>,
 }
 
-let makeClickHouse = (~host, ~database, ~username, ~password): t => {
+let makeClickHouse = (~host, ~database, ~username, ~password, ~logger): t => {
   let client = ClickHouse.createClient({
     url: host,
     username,
@@ -27,18 +27,18 @@ let makeClickHouse = (~host, ~database, ~username, ~password): t => {
   {
     name: "clickhouse",
     initialize: (~chainConfigs as _=[], ~entities=[], ~enums=[]) => {
-      ClickHouse.initialize(client, ~database, ~entities, ~enums)
+      ClickHouse.initialize(client, ~database, ~entities, ~enums, ~logger)
     },
     resume: (~checkpointId) => {
-      ClickHouse.resume(client, ~database, ~checkpointId)
+      ClickHouse.resume(client, ~database, ~checkpointId, ~logger)
     },
     writeBatch: async (~batch, ~updatedEntities) => {
       await Promise.all(
         updatedEntities->Array.map(({entityConfig, changes}) => {
-          ClickHouse.setUpdatesOrThrow(client, ~cache, ~changes, ~entityConfig, ~database)
+          ClickHouse.setUpdatesOrThrow(client, ~cache, ~changes, ~entityConfig, ~database, ~logger)
         }),
       )->Utils.Promise.ignoreValue
-      await ClickHouse.setCheckpointsOrThrow(client, ~batch, ~database)
+      await ClickHouse.setCheckpointsOrThrow(client, ~batch, ~database, ~logger)
     },
   }
 }

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -550,17 +550,20 @@ let cloneRegistrations = (
 // module-cached anyway) and reuse them across every createTestIndexer run, so
 // the global registration cycle runs a single time and never races.
 let registrationsRef: ref<option<promise<HandlerRegister.registrationsByChainId>>> = ref(None)
-let getRegistrations = (~config) =>
+let getRegistrations = (~config, ~logger) =>
   switch registrationsRef.contents {
   | Some(promise) => promise
   | None =>
-    let promise = HandlerLoader.registerAllHandlers(~config)
+    let promise = HandlerLoader.registerAllHandlers(~config, ~logger)
     registrationsRef := Some(promise)
     promise
   }
 
 let createTestIndexer = (): t<'processConfig> => {
   let config = Config.load()
+  // A per-instance logger, silent unless LOG_LEVEL is set. Never the process
+  // logger — muting one test indexer must not mute anything else.
+  let logger = Env.makeLogger(~userLogLevel=Env.userLogLevel->Option.getOr(#silent))
   let allEntities = config.allEntities
   let entities = Dict.make()
   let entityConfigs = Dict.make()
@@ -606,14 +609,8 @@ let createTestIndexer = (): t<'processConfig> => {
     ~userEntities=config.userEntities,
     ~allEnums=config.allEnums,
     ~storage,
-    ~logger=config.logger,
+    ~logger,
   )
-
-  // Silence logs by default in test mode unless LOG_LEVEL is explicitly set.
-  switch Env.userLogLevel {
-  | None => config.logger->Logging.setLogLevel(#silent)
-  | Some(_) => ()
-  }
 
   // Build entity operations for each user entity
   let entityOpsDict: dict<entityOperations> = Dict.make()
@@ -809,7 +806,7 @@ let createTestIndexer = (): t<'processConfig> => {
 
           // Each run gets its own copy of the shared base registration so the
           // simulate-source registration it appends stays isolated.
-          let registrationsByChainId = cloneRegistrations(await getRegistrations(~config))
+          let registrationsByChainId = cloneRegistrations(await getRegistrations(~config, ~logger))
           let patchedConfig: Config.t = SimulateItems.patchConfig(
             ~config,
             ~processConfig=processConfigJson,
@@ -848,6 +845,7 @@ let createTestIndexer = (): t<'processConfig> => {
             await Promise.make((resolve, reject) => {
               let indexerState = IndexerState.makeFromDbState(
                 ~config=runConfig,
+                ~logger,
                 ~persistence,
                 ~initialState,
                 ~registrationsByChainId,

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -18,12 +18,7 @@ type chainConfig = {
 
 type processResult = {changes: array<unknown>}
 
-type t<'processConfig> = {
-  process: 'processConfig => promise<processResult>,
-  // Releases the instance's logger. Optional for callers — only matters when
-  // file logging is on, where each instance holds its own handle.
-  close: unit => promise<unit>,
-}
+type t<'processConfig> = {process: 'processConfig => promise<processResult>}
 
 type entityChange = {
   sets: array<unknown>,
@@ -550,6 +545,15 @@ let cloneRegistrations = (
   clone
 }
 
+// Shared by every test indexer in the process: nothing disposes a test
+// indexer, so a logger per instance would leak a handle per instance. Silent
+// unless LOG_LEVEL is set, in which case the process logger already has the
+// requested level.
+let logger = switch Env.userLogLevel {
+| Some(_) => Env.logger
+| None => Env.makeLogger(~userLogLevel=#silent)
+}
+
 // User handlers register into the process-global HandlerRegister as an import
 // side effect. Capture the resolved registrations once per process (imports are
 // module-cached anyway) and reuse them across every createTestIndexer run, so
@@ -566,9 +570,6 @@ let getRegistrations = (~config, ~logger) =>
 
 let createTestIndexer = (): t<'processConfig> => {
   let config = Config.load()
-  // A per-instance logger, silent unless LOG_LEVEL is set. Never the process
-  // logger — muting one test indexer must not mute anything else.
-  let logger = Env.makeLogger(~userLogLevel=Env.userLogLevel->Option.getOr(#silent))
   let allEntities = config.allEntities
   let entities = Dict.make()
   let entityConfigs = Dict.make()
@@ -710,11 +711,6 @@ let createTestIndexer = (): t<'processConfig> => {
     // types declare, matching the handler-context keys.
     result->Dict.set(name->Utils.String.capitalize, ops->(Utils.magic: entityOperations => unknown))
   })
-
-  result->Dict.set(
-    "close",
-    (() => persistence->Persistence.close)->(Utils.magic: (unit => promise<unit>) => unknown),
-  )
 
   result->Dict.set(
     "process",

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -551,7 +551,12 @@ let cloneRegistrations = (
 // requested level.
 let logger = switch Env.userLogLevel {
 | Some(_) => Env.logger
-| None => Env.makeLogger(~userLogLevel=#silent)
+| None =>
+  let logger = Env.makeLogger(~userLogLevel=#silent)
+  // The file-backed strategies build the logger at their own file level and
+  // ignore `userLogLevel`, so silence has to be set on the instance.
+  logger->Logging.setLogLevel(#silent)
+  logger
 }
 
 // User handlers register into the process-global HandlerRegister as an import

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -18,7 +18,12 @@ type chainConfig = {
 
 type processResult = {changes: array<unknown>}
 
-type t<'processConfig> = {process: 'processConfig => promise<processResult>}
+type t<'processConfig> = {
+  process: 'processConfig => promise<processResult>,
+  // Releases the instance's logger. Optional for callers — only matters when
+  // file logging is on, where each instance holds its own handle.
+  close: unit => promise<unit>,
+}
 
 type entityChange = {
   sets: array<unknown>,
@@ -705,6 +710,11 @@ let createTestIndexer = (): t<'processConfig> => {
     // types declare, matching the handler-context keys.
     result->Dict.set(name->Utils.String.capitalize, ops->(Utils.magic: entityOperations => unknown))
   })
+
+  result->Dict.set(
+    "close",
+    (() => persistence->Persistence.close)->(Utils.magic: (unit => promise<unit>) => unknown),
+  )
 
   result->Dict.set(
     "process",

--- a/packages/envio/src/Throttler.res
+++ b/packages/envio/src/Throttler.res
@@ -5,15 +5,17 @@ type t = {
   mutable scheduled: option<unit => promise<unit>>,
   intervalMillis: float,
   logger: Pino.t,
+  params: Internal.logParams,
 }
 
-let make = (~intervalMillis: int, ~logger) => {
+let make = (~intervalMillis: int, ~logger, ~params: Internal.logParams) => {
   lastRunTimeMillis: 0.,
   isRunning: false,
   isAwaitingInterval: false,
   scheduled: None,
   intervalMillis: intervalMillis->Int.toFloat,
   logger,
+  params,
 }
 
 let rec startInternal = (throttler: t) => {
@@ -33,11 +35,11 @@ let rec startInternal = (throttler: t) => {
           async () => {
             switch await fn() {
             | exception exn =>
-              throttler.logger->Pino.errorExn(
-                Pino.createPinoMessageWithError(
-                  "Scheduled action failed in throttler",
-                  exn->Utils.prettifyExn,
-                ),
+              throttler.logger->Logging.error(
+                throttler.params->Logging.withParams({
+                  "msg": "Scheduled action failed in throttler",
+                  "err": exn->Utils.prettifyExn,
+                }),
               )
             | _ => ()
             }

--- a/packages/envio/src/Throttler.resi
+++ b/packages/envio/src/Throttler.resi
@@ -15,7 +15,7 @@ Does NOT queue scheduled functions but rather overwrites them
 The logger will be used to log any errors that occur in the scheduled
 functions.
 */
-let make: (~intervalMillis: int, ~logger: Pino.t) => t
+let make: (~intervalMillis: int, ~logger: Pino.t, ~params: Internal.logParams) => t
 
 /**
 Schedules a function to be run on a throttler, overwriting any

--- a/packages/envio/src/Time.res
+++ b/packages/envio/src/Time.res
@@ -14,7 +14,7 @@ let rec retryAsyncWithExponentialBackOff = async (
   | exn =>
     if retryCount < maxRetries {
       let nextRetryCount = retryCount + 1
-      let log = retryCount === 0 ? Logging.childTrace : Logging.childWarn
+      let log = retryCount === 0 ? Logging.trace : Logging.warn
       logger->log({
         "msg": `Retrying query ${nextRetryCount->Int.toString}/${maxRetries->Int.toString} in ${backOffMillis->Int.toString}ms - waiting for correct result.`,
         "err": exn->Utils.prettifyExn,

--- a/packages/envio/src/UserContext.res
+++ b/packages/envio/src/UserContext.res
@@ -23,7 +23,11 @@ Utils.Object.defineProperty(
     // Wrap with toMethod so `this` binds to the EffectContext instance.
     get: Utils.toMethod(() => {
       let params = paramsByThis->Utils.WeakMap.unsafeGet(%raw(`this`))
-      Ecosystem.getItemUserLogger(params.item, ~ecosystem=params.config.ecosystem)
+      Ecosystem.getItemUserLogger(
+        params.item,
+        ~ecosystem=params.config.ecosystem,
+        ~logger=params.indexerState->IndexerState.logger,
+      )
     }),
   },
 )
@@ -296,7 +300,8 @@ let handlerTraps: Utils.Proxy.traps<contextParams> = {
       Utils.Error.make(
         `Impossible to access context.${prop} after the handler is resolved. Make sure you didn't miss an await in the handler.`,
       )->ErrorHandling.mkLogAndRaise(
-        ~logger=Ecosystem.getItemLogger(params.item, ~ecosystem=params.config.ecosystem),
+        ~logger=params.indexerState->IndexerState.logger,
+        ~params=Ecosystem.getItemLogParams(params.item, ~ecosystem=params.config.ecosystem),
       )
     }
     switch prop {
@@ -304,7 +309,11 @@ let handlerTraps: Utils.Proxy.traps<contextParams> = {
       (
         params.isPreload
           ? Logging.noopLogger
-          : Ecosystem.getItemUserLogger(params.item, ~ecosystem=params.config.ecosystem)
+          : Ecosystem.getItemUserLogger(
+              params.item,
+              ~ecosystem=params.config.ecosystem,
+              ~logger=params.indexerState->IndexerState.logger,
+            )
       )->(Utils.magic: Envio.logger => unknown)
 
     | "effect" =>

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -172,7 +172,7 @@ let rec insertWithRetry = async (
     if Array.length(values) > 1 {
       logger->Logging.warn({
         "msg": "ClickHouse insert failed, splitting batch in half and retrying",
-        "context": "ClickHouse",
+        "storage": "clickhouse",
         "table": table,
         "batchSize": Array.length(values),
         "retriesLeft": retries,
@@ -187,7 +187,7 @@ let rec insertWithRetry = async (
     } else {
       logger->Logging.warn({
         "msg": "ClickHouse insert failed, retrying after delay",
-        "context": "ClickHouse",
+        "storage": "clickhouse",
         "table": table,
         "retriesLeft": retries,
         "err": exn->Utils.prettifyExn,
@@ -549,7 +549,7 @@ let initialize = async (
     if hasReplicatedDatabaseEngine && !envReplicated {
       logger->Logging.info({
         "msg": "ENVIO_CLICKHOUSE_DATABASE_ENGINE is Replicated; enabling replicated mode so tables use the ReplicatedMergeTree engine.",
-        "context": "ClickHouse",
+        "storage": "clickhouse",
       })
     }
     let databaseOnClusterClause = onClusterClause(~onCluster=replicated)
@@ -634,11 +634,15 @@ let initialize = async (
 
     logger->Logging.trace({
       "msg": "ClickHouse storage initialization completed successfully",
-      "context": "ClickHouse",
+      "storage": "clickhouse",
     })
   } catch {
   | exn => {
-      logger->Logging.errorWithExn(exn, "Failed to initialize ClickHouse storage")
+      logger->Logging.error({
+        "msg": "Failed to initialize ClickHouse storage",
+        "storage": "clickhouse",
+        "err": exn->Utils.prettifyExn,
+      })
       JsError.throwWithMessage("ClickHouse initialization failed")
     }
   }
@@ -657,10 +661,11 @@ let resume = async (
       await client->exec({query: `USE ${database}`})
     } catch {
     | exn =>
-      logger->Logging.errorWithExn(
-        exn,
-        `ClickHouse storage database "${database}" not found. Please run 'envio start -r' to reinitialize the indexer (it'll also drop Postgres database).`,
-      )
+      logger->Logging.error({
+        "msg": `ClickHouse storage database "${database}" not found. Please run 'envio start -r' to reinitialize the indexer (it'll also drop Postgres database).`,
+        "storage": "clickhouse",
+        "err": exn->Utils.prettifyExn,
+      })
       JsError.throwWithMessage("ClickHouse resume failed")
     }
 
@@ -687,7 +692,11 @@ let resume = async (
   } catch {
   | Persistence.StorageError(_) as exn => throw(exn)
   | exn => {
-      logger->Logging.errorWithExn(exn, "Failed to resume ClickHouse storage")
+      logger->Logging.error({
+        "msg": "Failed to resume ClickHouse storage",
+        "storage": "clickhouse",
+        "err": exn->Utils.prettifyExn,
+      })
       JsError.throwWithMessage("ClickHouse resume failed")
     }
   }

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -153,8 +153,6 @@ let makeClickHouseEntitySchema = (table: Table.table): S.t<Internal.entity> => {
   })
 }
 
-let logger = Logging.createChildFrom(~logger=Env.logger, ~params={"context": "ClickHouse"})
-
 // On transient failure, split values in half and retry each half.
 // If only 1 row remains, retry with delay.
 // Delay scales from 100ms to 1000ms as retries decrease.
@@ -163,6 +161,7 @@ let rec insertWithRetry = async (
   ~table: string,
   ~values: array<'a>,
   ~format: string,
+  ~logger: Pino.t,
   ~retries=8,
 ) => {
   try {
@@ -171,8 +170,9 @@ let rec insertWithRetry = async (
   | exn if retries > 0 =>
     let delayMs = Math.Int.min(1000, 100 + 900 * (8 - retries) / 7)
     if Array.length(values) > 1 {
-      logger->Logging.childWarn({
+      logger->Logging.warn({
         "msg": "ClickHouse insert failed, splitting batch in half and retrying",
+        "context": "ClickHouse",
         "table": table,
         "batchSize": Array.length(values),
         "retriesLeft": retries,
@@ -182,22 +182,23 @@ let rec insertWithRetry = async (
       let mid = Array.length(values) / 2
       let first = values->Array.slice(~start=0, ~end=mid)
       let second = values->Array.slice(~start=mid)
-      await insertWithRetry(client, ~table, ~values=first, ~format, ~retries=retries - 1)
-      await insertWithRetry(client, ~table, ~values=second, ~format, ~retries=retries - 1)
+      await insertWithRetry(client, ~table, ~values=first, ~format, ~logger, ~retries=retries - 1)
+      await insertWithRetry(client, ~table, ~values=second, ~format, ~logger, ~retries=retries - 1)
     } else {
-      logger->Logging.childWarn({
+      logger->Logging.warn({
         "msg": "ClickHouse insert failed, retrying after delay",
+        "context": "ClickHouse",
         "table": table,
         "retriesLeft": retries,
         "err": exn->Utils.prettifyExn,
       })
       await Utils.delay(delayMs)
-      await insertWithRetry(client, ~table, ~values, ~format, ~retries=retries - 1)
+      await insertWithRetry(client, ~table, ~values, ~format, ~logger, ~retries=retries - 1)
     }
   }
 }
 
-let setCheckpointsOrThrow = async (client, ~batch: Batch.t, ~database: string) => {
+let setCheckpointsOrThrow = async (client, ~batch: Batch.t, ~database: string, ~logger: Pino.t) => {
   let checkpointsCount = batch.checkpointIds->Array.length
   if checkpointsCount === 0 {
     ()
@@ -222,6 +223,7 @@ let setCheckpointsOrThrow = async (client, ~batch: Batch.t, ~database: string) =
         ~table=`${database}.\`${InternalTable.Checkpoints.table.tableName}\``,
         ~values=checkpointRows,
         ~format="JSONCompactEachRow",
+        ~logger,
       )
     } catch {
     | exn =>
@@ -246,6 +248,7 @@ let setUpdatesOrThrow = async (
   ~changes: array<Change.t<Internal.entity>>,
   ~entityConfig: Internal.entityConfig,
   ~database: string,
+  ~logger: Pino.t,
 ) => {
   if changes->Array.length === 0 {
     ()
@@ -294,7 +297,7 @@ let setUpdatesOrThrow = async (
       // intermediate change must be persisted, not only the current value.
       let values = changes->convertOrThrow
 
-      await insertWithRetry(client, ~table=tableName, ~values, ~format="JSONEachRow")
+      await insertWithRetry(client, ~table=tableName, ~values, ~format="JSONEachRow", ~logger)
     } catch {
     | exn =>
       throw(
@@ -526,6 +529,7 @@ let initialize = async (
   ~database: string,
   ~entities: array<Internal.entityConfig>,
   ~enums as _: array<Table.enumConfig<Table.enum>>,
+  ~logger: Pino.t,
 ) => {
   try {
     let databaseEngine = Env.ClickHouse.databaseEngine()
@@ -543,9 +547,10 @@ let initialize = async (
     // ENVIO_CLICKHOUSE_REPLICATED is unset.
     let replicated = envReplicated || hasReplicatedDatabaseEngine
     if hasReplicatedDatabaseEngine && !envReplicated {
-      logger->Logging.childInfo(
-        "ENVIO_CLICKHOUSE_DATABASE_ENGINE is Replicated; enabling replicated mode so tables use the ReplicatedMergeTree engine.",
-      )
+      logger->Logging.info({
+        "msg": "ENVIO_CLICKHOUSE_DATABASE_ENGINE is Replicated; enabling replicated mode so tables use the ReplicatedMergeTree engine.",
+        "context": "ClickHouse",
+      })
     }
     let databaseOnClusterClause = onClusterClause(~onCluster=replicated)
     // DDL that a Replicated database engine propagates itself must not carry
@@ -627,24 +632,32 @@ let initialize = async (
       ),
     )->Utils.Promise.ignoreValue
 
-    logger->Logging.childTrace("ClickHouse storage initialization completed successfully")
+    logger->Logging.trace({
+      "msg": "ClickHouse storage initialization completed successfully",
+      "context": "ClickHouse",
+    })
   } catch {
   | exn => {
-      logger->Logging.childErrorWithExn(exn, "Failed to initialize ClickHouse storage")
+      logger->Logging.errorWithExn(exn, "Failed to initialize ClickHouse storage")
       JsError.throwWithMessage("ClickHouse initialization failed")
     }
   }
 }
 
 // Resume ClickHouse sink after reorg by deleting rows with checkpoint IDs higher than target
-let resume = async (client, ~database: string, ~checkpointId: Internal.checkpointId) => {
+let resume = async (
+  client,
+  ~database: string,
+  ~checkpointId: Internal.checkpointId,
+  ~logger: Pino.t,
+) => {
   try {
     // Try to use the database - will throw if it doesn't exist
     try {
       await client->exec({query: `USE ${database}`})
     } catch {
     | exn =>
-      logger->Logging.childErrorWithExn(
+      logger->Logging.errorWithExn(
         exn,
         `ClickHouse storage database "${database}" not found. Please run 'envio start -r' to reinitialize the indexer (it'll also drop Postgres database).`,
       )
@@ -674,7 +687,7 @@ let resume = async (client, ~database: string, ~checkpointId: Internal.checkpoin
   } catch {
   | Persistence.StorageError(_) as exn => throw(exn)
   | exn => {
-      logger->Logging.childErrorWithExn(exn, "Failed to resume ClickHouse storage")
+      logger->Logging.errorWithExn(exn, "Failed to resume ClickHouse storage")
       JsError.throwWithMessage("ClickHouse resume failed")
     }
   }

--- a/packages/envio/src/bindings/Pino.res
+++ b/packages/envio/src/bindings/Pino.res
@@ -102,10 +102,6 @@ type options = {
 @module("pino") external make: options => t = "pino"
 @module("pino") external makeWithOptionsAndTransport: (options, Transport.t) => t = "pino"
 
-type childParams
-let createChildParams: 'a => childParams = v => v->(Utils.magic: 'a => childParams)
-@send external child: (t, childParams) => t = "child"
-
 module ECS = {
   @module("@elastic/ecs-pino-format")
   external make: 'a => options = "default"

--- a/packages/envio/src/bindings/Pino.res
+++ b/packages/envio/src/bindings/Pino.res
@@ -37,6 +37,30 @@ external levels: t => 'a = "levels"
 // Bind to the 'level' property setter
 @set external setLevel: (t, logLevel) => unit = "level"
 
+// Flush and release the logger's underlying stream. Only a file destination
+// or a worker-backed transport holds a resource, and those are the streams
+// that emit "close" once ended. A console multistream has nothing to release
+// (and throws on `end`, since its console stream is write-only).
+@module("pino") external symbols: {"streamSym": unknown} = "symbols"
+
+let closeStream: (t, unknown) => promise<unit> = %raw(`(logger, streamSym) =>
+  new Promise((resolve) => {
+    const stream = logger[streamSym]
+    if (!stream || typeof stream.end !== "function" || typeof stream.once !== "function") {
+      resolve()
+      return
+    }
+    stream.once("close", resolve)
+    stream.once("error", resolve)
+    try {
+      stream.end()
+    } catch (_) {
+      resolve()
+    }
+  })`)
+
+let close = (logger: t) => logger->closeStream(symbols["streamSym"])
+
 @ocaml.doc(`Identity function to help co-erce any type to a pino log message`)
 let createPinoMessage = (message): pinoMessageBlob => message->(Utils.magic: 'a => pinoMessageBlob)
 let createPinoMessageWithError = (message, err): pinoMessageBlobWithError => {

--- a/packages/envio/src/bindings/Pino.res
+++ b/packages/envio/src/bindings/Pino.res
@@ -61,6 +61,10 @@ let closeStream: (t, unknown) => promise<unit> = %raw(`(logger, streamSym) =>
 
 let close = (logger: t) => logger->closeStream(symbols["streamSym"])
 
+type childParams
+let createChildParams: 'a => childParams = v => v->(Utils.magic: 'a => childParams)
+@send external child: (t, childParams) => t = "child"
+
 @ocaml.doc(`Identity function to help co-erce any type to a pino log message`)
 let createPinoMessage = (message): pinoMessageBlob => message->(Utils.magic: 'a => pinoMessageBlob)
 let createPinoMessageWithError = (message, err): pinoMessageBlobWithError => {

--- a/packages/envio/src/bindings/Pino.res
+++ b/packages/envio/src/bindings/Pino.res
@@ -37,27 +37,41 @@ external levels: t => 'a = "levels"
 // Bind to the 'level' property setter
 @set external setLevel: (t, logLevel) => unit = "level"
 
-// Flush and release the logger's underlying stream. Only a file destination
-// or a worker-backed transport holds a resource, and those are the streams
-// that emit "close" once ended. A console multistream has nothing to release
-// (and throws on `end`, since its console stream is write-only).
+// Flush and release the logger's underlying stream: a file destination or a
+// worker-backed transport holds a resource, a console stream doesn't. A
+// multistream can nest either, so its members are closed individually — it
+// exposes `end` itself but throws when a member is write-only.
 @module("pino") external symbols: {"streamSym": unknown} = "symbols"
 
-let closeStream: (t, unknown) => promise<unit> = %raw(`(logger, streamSym) =>
-  new Promise((resolve) => {
-    const stream = logger[streamSym]
-    if (!stream || typeof stream.end !== "function" || typeof stream.once !== "function") {
-      resolve()
-      return
-    }
-    stream.once("close", resolve)
-    stream.once("error", resolve)
+let closeStream: (t, unknown) => promise<unit> = %raw(`(logger, streamSym) => {
+  const closeOne = (stream) =>
+    new Promise((resolve) => {
+      if (!stream || typeof stream.end !== "function" || typeof stream.once !== "function") {
+        resolve()
+        return
+      }
+      stream.once("close", resolve)
+      stream.once("error", resolve)
+      try {
+        stream.end()
+      } catch (_) {
+        // e.g. a sonic-boom destination ended before it was ready.
+        try {
+          stream.flushSync()
+        } catch (_) {}
+        resolve()
+      }
+    })
+
+  const stream = logger[streamSym]
+  if (stream && Array.isArray(stream.streams)) {
     try {
-      stream.end()
-    } catch (_) {
-      resolve()
-    }
-  })`)
+      stream.flushSync()
+    } catch (_) {}
+    return Promise.all(stream.streams.map((s) => closeOne(s.stream))).then(() => undefined)
+  }
+  return closeOne(stream)
+}`)
 
 let close = (logger: t) => logger->closeStream(symbols["streamSym"])
 

--- a/packages/envio/src/sources/Evm.res
+++ b/packages/envio/src/sources/Evm.res
@@ -71,7 +71,7 @@ let cleanUpRawEventFieldsInPlace: JSON.t => unit = %raw(`fields => {
     delete fields.timestamp
   }`)
 
-let make = (~logger: Pino.t): Ecosystem.t => {
+let make = (): Ecosystem.t => {
   name: Evm,
   blockNumberName: "number",
   blockTimestampName: "timestamp",
@@ -96,22 +96,18 @@ let make = (~logger: Pino.t): Ecosystem.t => {
   onEventBlockFilterSchema: S.object(s =>
     s.field("block", S.option(S.object(s2 => s2.field("number", S.unknown))->S.strict))
   ),
-  logger,
   // The payload carries `transaction` by batch prep (HyperSync) or inline
   // (RPC/simulate), so the event is the payload as-is.
   toEvent: eventItem => eventItem.payload->(Utils.magic: Internal.eventPayload => Internal.event),
-  toEventLogger: eventItem =>
-    Logging.createChildFrom(
-      ~logger,
-      ~params={
-        "contract": eventItem.onEventRegistration.eventConfig.contractName,
-        "event": eventItem.onEventRegistration.eventConfig.name,
-        "chainId": eventItem.chain->ChainMap.Chain.toChainId,
-        "block": eventItem.blockNumber,
-        "logIndex": eventItem.logIndex,
-        "address": (eventItem.payload->toPayload).srcAddress,
-      },
-    ),
+  toEventLogParams: eventItem =>
+    {
+      "contract": eventItem.onEventRegistration.eventConfig.contractName,
+      "event": eventItem.onEventRegistration.eventConfig.name,
+      "chainId": eventItem.chain->ChainMap.Chain.toChainId,
+      "block": eventItem.blockNumber,
+      "logIndex": eventItem.logIndex,
+      "address": (eventItem.payload->toPayload).srcAddress,
+    }->Internal.toLogParams,
   toRawEvent: eventItem => {
     let payload = eventItem.payload->toPayload
     let eventConfig =

--- a/packages/envio/src/sources/EvmChain.res
+++ b/packages/envio/src/sources/EvmChain.res
@@ -40,6 +40,7 @@ let getSyncConfig = (
 }
 
 let makeSources = (
+  ~logger,
   ~chain,
   ~onEventRegistrations: array<Internal.evmOnEventRegistration>,
   ~hyperSync,
@@ -49,6 +50,7 @@ let makeSources = (
   let sources = switch hyperSync {
   | Some(endpointUrl) => [
       EvmHyperSyncSource.make({
+        logger,
         chain,
         endpointUrl,
         onEventRegistrations,
@@ -64,6 +66,7 @@ let makeSources = (
   }
   rpcs->Array.forEach(({?syncConfig, url, sourceFor, ?ws, ?headers}) => {
     let source = RpcSource.make({
+      logger,
       chain,
       sourceFor,
       syncConfig: getSyncConfig(syncConfig->Option.getOr({})),

--- a/packages/envio/src/sources/EvmHyperSyncSource.res
+++ b/packages/envio/src/sources/EvmHyperSyncSource.res
@@ -97,7 +97,6 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     ~itemsTarget,
     ~retry,
     ~logger as _,
-    ~params as _,
   ) => {
     let totalTimeRef = Performance.now()
 
@@ -248,14 +247,13 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     }
   }
 
-  let getBlockHashes = (~blockNumbers, ~logger, ~params) =>
+  let getBlockHashes = (~blockNumbers, ~logger) =>
     HyperSync.queryBlockDataMulti(
       ~client,
       ~blockNumbers,
       ~sourceName=name,
       ~chainId=chain->ChainMap.Chain.toChainId,
       ~logger,
-      ~params,
     )->Promise.thenResolve(((queryRes, requestStats)) => {
       Source.result: queryRes->HyperSync.mapExn,
       requestStats,

--- a/packages/envio/src/sources/EvmHyperSyncSource.res
+++ b/packages/envio/src/sources/EvmHyperSyncSource.res
@@ -6,6 +6,7 @@ open Source
 let isUnauthorizedError = (message: string) => message->String.includes("401 Unauthorized")
 
 type options = {
+  logger: Pino.t,
   chain: ChainMap.Chain.t,
   endpointUrl: string,
   // The chain's registrations, indexed by their sequential `index`.
@@ -20,6 +21,7 @@ type options = {
 
 let make = (
   {
+    logger,
     chain,
     endpointUrl,
     onEventRegistrations,
@@ -271,7 +273,10 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
       | JsExn(e) =>
         switch e->JsExn.message {
         | Some(message) if message->isUnauthorizedError =>
-          Env.logger->Logging.childError(`Your ENVIO_API_TOKEN was rejected by HyperSync (401 Unauthorized). The indexer will not be able to fetch events. Update the token and try again using 'envio start' or 'envio dev'. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens`)
+          logger->Logging.error({
+            "msg": `Your ENVIO_API_TOKEN was rejected by HyperSync (401 Unauthorized). The indexer will not be able to fetch events. Update the token and try again using 'envio start' or 'envio dev'. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens`,
+            "chainId": chain->ChainMap.Chain.toChainId,
+          })
           // Retrying an unauthorized request can never succeed, so block forever
           let _ = await Promise.make((_, _) => ())
           0
@@ -284,6 +289,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     getItemsOrThrow,
     createHeightSubscription: (~onHeight) =>
       HyperSyncHeightStream.subscribe(
+        ~logger,
         ~hyperSyncUrl=endpointUrl,
         ~apiToken,
         ~chainId=chain->ChainMap.Chain.toChainId,

--- a/packages/envio/src/sources/EvmHyperSyncSource.res
+++ b/packages/envio/src/sources/EvmHyperSyncSource.res
@@ -56,6 +56,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
   | client => client
   | exception exn =>
     exn->ErrorHandling.mkLogAndRaise(
+      ~logger,
       ~msg="Failed to instantiate the hypersync client, please double check your ABI",
     )
   }
@@ -96,6 +97,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     ~itemsTarget,
     ~retry,
     ~logger as _,
+    ~params as _,
   ) => {
     let totalTimeRef = Performance.now()
 
@@ -246,13 +248,14 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     }
   }
 
-  let getBlockHashes = (~blockNumbers, ~logger) =>
+  let getBlockHashes = (~blockNumbers, ~logger, ~params) =>
     HyperSync.queryBlockDataMulti(
       ~client,
       ~blockNumbers,
       ~sourceName=name,
       ~chainId=chain->ChainMap.Chain.toChainId,
       ~logger,
+      ~params,
     )->Promise.thenResolve(((queryRes, requestStats)) => {
       Source.result: queryRes->HyperSync.mapExn,
       requestStats,

--- a/packages/envio/src/sources/Fuel.res
+++ b/packages/envio/src/sources/Fuel.res
@@ -19,7 +19,7 @@ let cleanUpRawEventFieldsInPlace: JSON.t => unit = %raw(`fields => {
     delete fields.time
   }`)
 
-let make = (~logger: Pino.t): Ecosystem.t => {
+let make = (): Ecosystem.t => {
   name: Fuel,
   blockNumberName: "height",
   blockTimestampName: "time",
@@ -40,20 +40,16 @@ let make = (~logger: Pino.t): Ecosystem.t => {
   onEventBlockFilterSchema: S.object(s =>
     s.field("block", S.option(S.object(s2 => s2.field("height", S.unknown))->S.strict))
   ),
-  logger,
   toEvent: eventItem => eventItem.payload->(Utils.magic: Internal.eventPayload => Internal.event),
-  toEventLogger: eventItem =>
-    Logging.createChildFrom(
-      ~logger,
-      ~params={
-        "contract": eventItem.onEventRegistration.eventConfig.contractName,
-        "event": eventItem.onEventRegistration.eventConfig.name,
-        "chainId": eventItem.chain->ChainMap.Chain.toChainId,
-        "block": eventItem.blockNumber,
-        "logIndex": eventItem.logIndex,
-        "address": (eventItem.payload->toPayload).srcAddress,
-      },
-    ),
+  toEventLogParams: eventItem =>
+    {
+      "contract": eventItem.onEventRegistration.eventConfig.contractName,
+      "event": eventItem.onEventRegistration.eventConfig.name,
+      "chainId": eventItem.chain->ChainMap.Chain.toChainId,
+      "block": eventItem.blockNumber,
+      "logIndex": eventItem.logIndex,
+      "address": (eventItem.payload->toPayload).srcAddress,
+    }->Internal.toLogParams,
   toRawEvent: eventItem => {
     let payload = eventItem.payload->toPayload
     let header = payload.block->(Utils.magic: Internal.eventBlock => {"id": string, "time": int})

--- a/packages/envio/src/sources/FuelHyperSyncSource.res
+++ b/packages/envio/src/sources/FuelHyperSyncSource.res
@@ -3,6 +3,7 @@ open Source
 let isUnauthorizedError = (message: string) => message->String.includes("401 Unauthorized")
 
 type options = {
+  logger: Pino.t,
   chain: ChainMap.Chain.t,
   endpointUrl: string,
   apiToken: option<string>,
@@ -10,7 +11,7 @@ type options = {
   onEventRegistrations: array<Internal.fuelOnEventRegistration>,
 }
 
-let make = ({chain, endpointUrl, apiToken, onEventRegistrations}: options): t => {
+let make = ({logger, chain, endpointUrl, apiToken, onEventRegistrations}: options): t => {
   let name = "HyperFuel"
 
   let apiToken = switch apiToken {
@@ -139,15 +140,14 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
         let data = item.data->Option.getOr("")
         try decode(data) catch {
         | exn => {
-            let params = {
-              "chainId": chainId,
-              "blockNumber": item.blockHeight,
-              "logIndex": item.receiptIndex,
-            }
-            let logger = Logging.createChildFrom(~logger, ~params)
             exn->ErrorHandling.mkLogAndRaise(
               ~msg="Failed to decode Fuel LogData receipt, please double check your ABI.",
               ~logger,
+              ~params={
+                "chainId": chainId,
+                "blockNumber": item.blockHeight,
+                "logIndex": item.receiptIndex,
+              },
             )
           }
         }
@@ -244,7 +244,10 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
       | JsExn(e) =>
         switch e->JsExn.message {
         | Some(message) if message->isUnauthorizedError =>
-          Env.logger->Logging.childError(`Your ENVIO_API_TOKEN was rejected by HyperFuel (401 Unauthorized). The indexer will not be able to fetch events. Update the token and try again using 'envio start' or 'envio dev'. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens`)
+          logger->Logging.error({
+            "msg": `Your ENVIO_API_TOKEN was rejected by HyperFuel (401 Unauthorized). The indexer will not be able to fetch events. Update the token and try again using 'envio start' or 'envio dev'. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens`,
+            "chainId": chain->ChainMap.Chain.toChainId,
+          })
           // Retrying an unauthorized request can never succeed, so block forever
           let _ = await Promise.make((_, _) => ())
           0

--- a/packages/envio/src/sources/FuelHyperSyncSource.res
+++ b/packages/envio/src/sources/FuelHyperSyncSource.res
@@ -30,7 +30,10 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
   ) {
   | client => client
   | exception exn =>
-    exn->ErrorHandling.mkLogAndRaise(~msg="Failed to instantiate the HyperFuel client")
+    exn->ErrorHandling.mkLogAndRaise(
+      ~logger,
+      ~msg="Failed to instantiate the HyperFuel client",
+    )
   }
 
   let getItemsOrThrow = async (
@@ -44,6 +47,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     ~itemsTarget as _,
     ~retry,
     ~logger,
+    ~params,
   ) => {
     let totalTimeRef = Performance.now()
 
@@ -143,11 +147,11 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
             exn->ErrorHandling.mkLogAndRaise(
               ~msg="Failed to decode Fuel LogData receipt, please double check your ABI.",
               ~logger,
-              ~params={
+              ~params=params->Logging.withParams({
                 "chainId": chainId,
                 "blockNumber": item.blockHeight,
                 "logIndex": item.receiptIndex,
-              },
+              }),
             )
           }
         }
@@ -228,7 +232,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     }
   }
 
-  let getBlockHashes = (~blockNumbers as _, ~logger as _) =>
+  let getBlockHashes = (~blockNumbers as _, ~logger as _, ~params as _) =>
     JsError.throwWithMessage("HyperFuel does not support getting block hashes")
 
   {

--- a/packages/envio/src/sources/FuelHyperSyncSource.res
+++ b/packages/envio/src/sources/FuelHyperSyncSource.res
@@ -47,7 +47,6 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     ~itemsTarget as _,
     ~retry,
     ~logger,
-    ~params,
   ) => {
     let totalTimeRef = Performance.now()
 
@@ -147,11 +146,11 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
             exn->ErrorHandling.mkLogAndRaise(
               ~msg="Failed to decode Fuel LogData receipt, please double check your ABI.",
               ~logger,
-              ~params=params->Logging.withParams({
+              ~params={
                 "chainId": chainId,
                 "blockNumber": item.blockHeight,
                 "logIndex": item.receiptIndex,
-              }),
+              },
             )
           }
         }
@@ -232,7 +231,7 @@ Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
     }
   }
 
-  let getBlockHashes = (~blockNumbers as _, ~logger as _, ~params as _) =>
+  let getBlockHashes = (~blockNumbers as _, ~logger as _) =>
     JsError.throwWithMessage("HyperFuel does not support getting block hashes")
 
   {

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -180,7 +180,6 @@ module BlockData = {
     ~sourceName,
     ~chainId,
     ~logger,
-    ~params: Internal.logParams,
     ~requestStats: array<Source.requestStat>,
   ): queryResponse<array<ReorgDetection.blockDataWithTimestamp>> => {
     let body = makeRequestBody(~fromBlock, ~toBlock)
@@ -201,14 +200,12 @@ module BlockData = {
     switch maybeSuccessfulRes {
     | None => {
         let delayMilliseconds = 100
-        logger->Logging.info(
-          params->Logging.withParams({
-            "msg": `Block #${fromBlock->Int.toString} not found in HyperSync. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${delayMilliseconds->Int.toString}ms.`,
-            "chainId": chainId,
-            "fromBlock": fromBlock,
-            "toBlock": toBlock,
-          }),
-        )
+        logger->Logging.info({
+          "msg": `Block #${fromBlock->Int.toString} not found in HyperSync. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${delayMilliseconds->Int.toString}ms.`,
+          "chainId": chainId,
+          "fromBlock": fromBlock,
+          "toBlock": toBlock,
+        })
         await Time.resolvePromiseAfterDelay(~delayMilliseconds)
         await queryBlockData(
           ~client,
@@ -217,7 +214,6 @@ module BlockData = {
           ~sourceName,
           ~chainId,
           ~logger,
-          ~params,
           ~requestStats,
         )
       }
@@ -232,7 +228,6 @@ module BlockData = {
             ~sourceName,
             ~chainId,
             ~logger,
-            ~params,
             ~requestStats,
           )
           restRes->Result.map(rest => datas->Array.concat(rest))
@@ -248,7 +243,6 @@ module BlockData = {
     ~sourceName,
     ~chainId,
     ~logger,
-    ~params,
   ): (queryResponse<array<ReorgDetection.blockDataWithTimestamp>>, array<Source.requestStat>) => {
     let requestStats = []
     let result = switch blockNumbers->Array.get(0) {
@@ -279,7 +273,6 @@ module BlockData = {
           ~sourceName,
           ~chainId,
           ~logger,
-          ~params,
           ~requestStats,
         )
         let filtered = res->Result.map(datas => {
@@ -299,7 +292,7 @@ module BlockData = {
   }
 }
 
-let queryBlockData = (~client, ~blockNumber, ~sourceName, ~chainId, ~logger, ~params) => {
+let queryBlockData = (~client, ~blockNumber, ~sourceName, ~chainId, ~logger) => {
   let requestStats = []
   BlockData.queryBlockData(
     ~client,
@@ -308,7 +301,6 @@ let queryBlockData = (~client, ~blockNumber, ~sourceName, ~chainId, ~logger, ~pa
     ~sourceName,
     ~chainId,
     ~logger,
-    ~params,
     ~requestStats,
   )->Promise.thenResolve(res => (res->Result.map(res => res->Array.get(0)), requestStats))
 }

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -180,6 +180,7 @@ module BlockData = {
     ~sourceName,
     ~chainId,
     ~logger,
+    ~params: Internal.logParams,
     ~requestStats: array<Source.requestStat>,
   ): queryResponse<array<ReorgDetection.blockDataWithTimestamp>> => {
     let body = makeRequestBody(~fromBlock, ~toBlock)
@@ -200,13 +201,14 @@ module BlockData = {
     switch maybeSuccessfulRes {
     | None => {
         let delayMilliseconds = 100
-        logger->Logging.info({
-          "msg": `Block #${fromBlock->Int.toString} not found in HyperSync. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${delayMilliseconds->Int.toString}ms.`,
-          "logType": "HyperSync get block hash query",
-          "chainId": chainId,
-          "fromBlock": fromBlock,
-          "toBlock": toBlock,
-        })
+        logger->Logging.info(
+          params->Logging.withParams({
+            "msg": `Block #${fromBlock->Int.toString} not found in HyperSync. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${delayMilliseconds->Int.toString}ms.`,
+            "chainId": chainId,
+            "fromBlock": fromBlock,
+            "toBlock": toBlock,
+          }),
+        )
         await Time.resolvePromiseAfterDelay(~delayMilliseconds)
         await queryBlockData(
           ~client,
@@ -215,6 +217,7 @@ module BlockData = {
           ~sourceName,
           ~chainId,
           ~logger,
+          ~params,
           ~requestStats,
         )
       }
@@ -229,6 +232,7 @@ module BlockData = {
             ~sourceName,
             ~chainId,
             ~logger,
+            ~params,
             ~requestStats,
           )
           restRes->Result.map(rest => datas->Array.concat(rest))
@@ -244,6 +248,7 @@ module BlockData = {
     ~sourceName,
     ~chainId,
     ~logger,
+    ~params,
   ): (queryResponse<array<ReorgDetection.blockDataWithTimestamp>>, array<Source.requestStat>) => {
     let requestStats = []
     let result = switch blockNumbers->Array.get(0) {
@@ -274,6 +279,7 @@ module BlockData = {
           ~sourceName,
           ~chainId,
           ~logger,
+          ~params,
           ~requestStats,
         )
         let filtered = res->Result.map(datas => {
@@ -293,7 +299,7 @@ module BlockData = {
   }
 }
 
-let queryBlockData = (~client, ~blockNumber, ~sourceName, ~chainId, ~logger) => {
+let queryBlockData = (~client, ~blockNumber, ~sourceName, ~chainId, ~logger, ~params) => {
   let requestStats = []
   BlockData.queryBlockData(
     ~client,
@@ -302,6 +308,7 @@ let queryBlockData = (~client, ~blockNumber, ~sourceName, ~chainId, ~logger) => 
     ~sourceName,
     ~chainId,
     ~logger,
+    ~params,
     ~requestStats,
   )->Promise.thenResolve(res => (res->Result.map(res => res->Array.get(0)), requestStats))
 }

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -184,15 +184,6 @@ module BlockData = {
   ): queryResponse<array<ReorgDetection.blockDataWithTimestamp>> => {
     let body = makeRequestBody(~fromBlock, ~toBlock)
 
-    let logger = Logging.createChildFrom(
-      ~logger,
-      ~params={
-        "logType": "HyperSync get block hash query",
-        "fromBlock": fromBlock,
-        "toBlock": toBlock,
-      },
-    )
-
     let timerRef = Performance.now()
     let maybeSuccessfulRes = switch await client.get(~query=body) {
     | exception exn =>
@@ -209,9 +200,13 @@ module BlockData = {
     switch maybeSuccessfulRes {
     | None => {
         let delayMilliseconds = 100
-        logger->Logging.childInfo(
-          `Block #${fromBlock->Int.toString} not found in HyperSync. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${delayMilliseconds->Int.toString}ms.`,
-        )
+        logger->Logging.info({
+          "msg": `Block #${fromBlock->Int.toString} not found in HyperSync. HyperSync has multiple instances and it's possible that they drift independently slightly from the head. Indexing should continue correctly after retrying the query in ${delayMilliseconds->Int.toString}ms.`,
+          "logType": "HyperSync get block hash query",
+          "chainId": chainId,
+          "fromBlock": fromBlock,
+          "toBlock": toBlock,
+        })
         await Time.resolvePromiseAfterDelay(~delayMilliseconds)
         await queryBlockData(
           ~client,

--- a/packages/envio/src/sources/HyperSync.resi
+++ b/packages/envio/src/sources/HyperSync.resi
@@ -44,7 +44,6 @@ let queryBlockData: (
   ~sourceName: string,
   ~chainId: int,
   ~logger: Pino.t,
-  ~params: Internal.logParams,
 ) => promise<(
   queryResponse<option<ReorgDetection.blockDataWithTimestamp>>,
   array<Source.requestStat>,
@@ -56,7 +55,6 @@ let queryBlockDataMulti: (
   ~sourceName: string,
   ~chainId: int,
   ~logger: Pino.t,
-  ~params: Internal.logParams,
 ) => promise<(
   queryResponse<array<ReorgDetection.blockDataWithTimestamp>>,
   array<Source.requestStat>,

--- a/packages/envio/src/sources/HyperSync.resi
+++ b/packages/envio/src/sources/HyperSync.resi
@@ -44,6 +44,7 @@ let queryBlockData: (
   ~sourceName: string,
   ~chainId: int,
   ~logger: Pino.t,
+  ~params: Internal.logParams,
 ) => promise<(
   queryResponse<option<ReorgDetection.blockDataWithTimestamp>>,
   array<Source.requestStat>,
@@ -55,6 +56,7 @@ let queryBlockDataMulti: (
   ~sourceName: string,
   ~chainId: int,
   ~logger: Pino.t,
+  ~params: Internal.logParams,
 ) => promise<(
   queryResponse<array<ReorgDetection.blockDataWithTimestamp>>,
   array<Source.requestStat>,

--- a/packages/envio/src/sources/HyperSyncHeightStream.res
+++ b/packages/envio/src/sources/HyperSyncHeightStream.res
@@ -2,7 +2,9 @@
 Pure subscription-based implementation of the HyperSync height stream.
 */
 
-let subscribe = (~hyperSyncUrl, ~apiToken, ~chainId, ~onHeight: int => unit): (unit => unit) => {
+let subscribe = (~logger, ~hyperSyncUrl, ~apiToken, ~chainId, ~onHeight: int => unit): (
+  unit => unit
+) => {
   let eventsourceRef = ref(None)
   let errorCount = ref(0)
   let baseDuration = 50
@@ -18,7 +20,7 @@ let subscribe = (~hyperSyncUrl, ~apiToken, ~chainId, ~onHeight: int => unit): (u
     // for staleness to restart the EventSource connection
     let staleTimeMillis = 15_000
     let newTimeoutId = setTimeout(() => {
-      Env.logger->Logging.childTrace({
+      logger->Logging.trace({
         "msg": "Timeout fired for height stream",
         "chainId": chainId,
         "url": hyperSyncUrl,
@@ -71,7 +73,7 @@ let subscribe = (~hyperSyncUrl, ~apiToken, ~chainId, ~onHeight: int => unit): (u
 
     es->EventSource.onopen(_ => {
       errorCount := 0
-      Env.logger->Logging.childTrace({
+      logger->Logging.trace({
         "msg": "SSE connection opened for height stream",
         "chainId": chainId,
         "url": hyperSyncUrl,
@@ -80,7 +82,7 @@ let subscribe = (~hyperSyncUrl, ~apiToken, ~chainId, ~onHeight: int => unit): (u
 
     es->EventSource.onerror(error => {
       errorCount := errorCount.contents + 1
-      Env.logger->Logging.childTrace({
+      logger->Logging.trace({
         "msg": "EventSource error on height stream, reconnecting",
         "chainId": chainId,
         "url": hyperSyncUrl,
@@ -106,7 +108,7 @@ let subscribe = (~hyperSyncUrl, ~apiToken, ~chainId, ~onHeight: int => unit): (u
         // Call the callback with the new height
         onHeight(height)
       | None =>
-        Env.logger->Logging.childTrace({
+        logger->Logging.trace({
           "msg": "Height was not a number in event.data",
           "chainId": chainId,
           "data": event.data,

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -808,7 +808,6 @@ let make = (
     ~itemsTarget as _,
     ~retry,
     ~logger as _,
-    ~params as _,
   ) => {
     let startFetchingBatchTimeRef = Performance.now()
 
@@ -995,7 +994,7 @@ let make = (
     receiptLoader := makeReceiptLoader()
   }
 
-  let getBlockHashes = (~blockNumbers, ~logger as _, ~params as _) => {
+  let getBlockHashes = (~blockNumbers, ~logger as _) => {
     blockNumbers
     ->Array.map(blockNum => blockLoader.contents->LazyLoader.get(blockNum))
     ->Promise.all

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -808,6 +808,7 @@ let make = (
     ~itemsTarget as _,
     ~retry,
     ~logger as _,
+    ~params as _,
   ) => {
     let startFetchingBatchTimeRef = Performance.now()
 
@@ -994,7 +995,7 @@ let make = (
     receiptLoader := makeReceiptLoader()
   }
 
-  let getBlockHashes = (~blockNumbers, ~logger as _currentlyUnusedLogger) => {
+  let getBlockHashes = (~blockNumbers, ~logger as _, ~params as _) => {
     blockNumbers
     ->Array.map(blockNum => blockLoader.contents->LazyLoader.get(blockNum))
     ->Promise.all

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -41,6 +41,7 @@ let parseBlockInfo = (json: JSON.t): blockInfo => {
 }
 
 let getKnownRawBlockWithBackoff = async (
+  ~logger,
   ~client,
   ~sourceName,
   ~chain,
@@ -56,7 +57,7 @@ let getKnownRawBlockWithBackoff = async (
     switch await getKnownRawBlock(~client, ~blockNumber) {
     | exception err =>
       recordRequest(~method="eth_getBlockByNumber", ~seconds=timerRef->Performance.secondsSince)
-      Env.logger->Logging.childWarn({
+      logger->Logging.warn({
         "err": err->Utils.prettifyExn,
         "msg": `Issue while running fetching batch of events from the RPC. Will wait ${currentBackoff.contents->Int.toString}ms and try again.`,
         "source": sourceName,
@@ -610,6 +611,7 @@ let makeThrowingGetEventTransaction = (
 }
 
 type options = {
+  logger: Pino.t,
   sourceFor: Source.sourceFor,
   syncConfig: Config.sourceSync,
   url: string,
@@ -623,6 +625,7 @@ type options = {
 
 let make = (
   {
+    logger,
     sourceFor,
     syncConfig,
     url,
@@ -685,7 +688,7 @@ let make = (
         })
       },
       ~onError=(am, ~exn) => {
-        Env.logger->Logging.childError({
+        logger->Logging.error({
           "err": exn->Utils.prettifyExn,
           "msg": `Top level promise timeout reached. Please review other errors or warnings in the code. This function will retry in ${(am._retryDelayMillis / 1000)
               ->Int.toString} seconds. It is highly likely that your indexer isn't syncing on one or more chains currently. Also take a look at the "suggestedFix" in the metadata of this command`,
@@ -705,6 +708,7 @@ let make = (
     LazyLoader.make(
       ~loaderFn=blockNumber => {
         getKnownRawBlockWithBackoff(
+          ~logger,
           ~client,
           ~sourceName=name,
           ~chain,
@@ -714,7 +718,7 @@ let make = (
         )
       },
       ~onError=(am, ~exn) => {
-        Env.logger->Logging.childError({
+        logger->Logging.error({
           "err": exn->Utils.prettifyExn,
           "msg": `Top level promise timeout reached. Please review other errors or warnings in the code. This function will retry in ${(am._retryDelayMillis / 1000)
               ->Int.toString} seconds. It is highly likely that your indexer isn't syncing on one or more chains currently. Also take a look at the "suggestedFix" in the metadata of this command`,
@@ -745,7 +749,7 @@ let make = (
         })
       },
       ~onError=(am, ~exn) => {
-        Env.logger->Logging.childError({
+        logger->Logging.error({
           "err": exn->Utils.prettifyExn,
           "msg": `Top level promise timeout reached. Please review other errors or warnings in the code. This function will retry in ${(am._retryDelayMillis / 1000)
               ->Int.toString} seconds. It is highly likely that your indexer isn't syncing on one or more chains currently. Also take a look at the "suggestedFix" in the metadata of this command`,
@@ -1018,7 +1022,7 @@ let make = (
 
   let createHeightSubscription =
     ws->Option.map(wsUrl =>
-      (~onHeight) => RpcWebSocketHeightStream.subscribe(~wsUrl, ~chainId, ~onHeight)
+      (~onHeight) => RpcWebSocketHeightStream.subscribe(~logger, ~wsUrl, ~chainId, ~onHeight)
     )
 
   {

--- a/packages/envio/src/sources/RpcWebSocketHeightStream.res
+++ b/packages/envio/src/sources/RpcWebSocketHeightStream.res
@@ -53,7 +53,7 @@ let wsMessageSchema = S.union([
   }),
 ])
 
-let subscribe = (~wsUrl, ~chainId, ~onHeight: int => unit): (unit => unit) => {
+let subscribe = (~logger, ~wsUrl, ~chainId, ~onHeight: int => unit): (unit => unit) => {
   let wsRef: ref<option<WebSocket.t>> = ref(None)
   let isUnsubscribed = ref(false)
   let errorCount = ref(0)
@@ -121,20 +121,20 @@ let subscribe = (~wsUrl, ~chainId, ~onHeight: int => unit): (unit => unit) => {
           }
         } catch {
         | S.Raised(_) =>
-          Env.logger->Logging.childWarn({
+          logger->Logging.warn({
             "msg": "WebSocket height stream received unrecognized message",
             "chainId": chainId,
             "data": event.data,
           })
         | JsExn(_) as e =>
-          Env.logger->Logging.childWarn({
+          logger->Logging.warn({
             "msg": "WebSocket height stream failed to parse message",
             "chainId": chainId,
             "err": e->Utils.prettifyExn,
             "data": event.data,
           })
         | e =>
-          Env.logger->Logging.childError({
+          logger->Logging.error({
             "msg": "Unexpected error in WebSocket height stream message handler",
             "chainId": chainId,
             "err": e->Utils.prettifyExn,

--- a/packages/envio/src/sources/SimulateSource.res
+++ b/packages/envio/src/sources/SimulateSource.res
@@ -8,7 +8,7 @@ let make = (~items: array<Internal.item>, ~endBlock: int, ~chain: ChainMap.Chain
     chain,
     poweredByHyperSync: false,
     pollingInterval: 0,
-    getBlockHashes: (~blockNumbers as _, ~logger as _) => {
+    getBlockHashes: (~blockNumbers as _, ~logger as _, ~params as _) => {
       Promise.resolve({Source.result: Ok([]), requestStats: []})
     },
     getHeightOrThrow: () => {
@@ -26,6 +26,7 @@ let make = (~items: array<Internal.item>, ~endBlock: int, ~chain: ChainMap.Chain
       ~itemsTarget as _,
       ~retry as _,
       ~logger as _,
+      ~params as _,
     ) => {
       // Mirror a real backend: return only the items this query would match —
       // in the block range, part of the selection, and (for non-wildcard events)

--- a/packages/envio/src/sources/SimulateSource.res
+++ b/packages/envio/src/sources/SimulateSource.res
@@ -8,7 +8,7 @@ let make = (~items: array<Internal.item>, ~endBlock: int, ~chain: ChainMap.Chain
     chain,
     poweredByHyperSync: false,
     pollingInterval: 0,
-    getBlockHashes: (~blockNumbers as _, ~logger as _, ~params as _) => {
+    getBlockHashes: (~blockNumbers as _, ~logger as _) => {
       Promise.resolve({Source.result: Ok([]), requestStats: []})
     },
     getHeightOrThrow: () => {
@@ -26,7 +26,6 @@ let make = (~items: array<Internal.item>, ~endBlock: int, ~chain: ChainMap.Chain
       ~itemsTarget as _,
       ~retry as _,
       ~logger as _,
-      ~params as _,
     ) => {
       // Mirror a real backend: return only the items this query would match —
       // in the block range, part of the selection, and (for non-wildcard events)

--- a/packages/envio/src/sources/Source.res
+++ b/packages/envio/src/sources/Source.res
@@ -68,7 +68,13 @@ type t = {
   poweredByHyperSync: bool,
   /* Frequency (in ms) used when polling for new events on this network. */
   pollingInterval: int,
-  getBlockHashes: (~blockNumbers: array<int>, ~logger: Pino.t) => promise<getBlockHashesResponse>,
+  // `params` carries the caller's query context (chain, source, partition,
+  // retry) so a source can write it on the lines it logs itself.
+  getBlockHashes: (
+    ~blockNumbers: array<int>,
+    ~logger: Pino.t,
+    ~params: Internal.logParams,
+  ) => promise<getBlockHashesResponse>,
   getHeightOrThrow: unit => promise<getHeightResponse>,
   getItemsOrThrow: (
     ~fromBlock: int,
@@ -86,6 +92,7 @@ type t = {
     ~itemsTarget: int,
     ~retry: int,
     ~logger: Pino.t,
+    ~params: Internal.logParams,
   ) => promise<blockRangeFetchResponse>,
   createHeightSubscription?: (~onHeight: int => unit) => unit => unit,
   // Invoked by SourceManager once a rollback target is known so the source can

--- a/packages/envio/src/sources/Source.res
+++ b/packages/envio/src/sources/Source.res
@@ -68,13 +68,9 @@ type t = {
   poweredByHyperSync: bool,
   /* Frequency (in ms) used when polling for new events on this network. */
   pollingInterval: int,
-  // `params` carries the caller's query context (chain, source, partition,
-  // retry) so a source can write it on the lines it logs itself.
-  getBlockHashes: (
-    ~blockNumbers: array<int>,
-    ~logger: Pino.t,
-    ~params: Internal.logParams,
-  ) => promise<getBlockHashesResponse>,
+  // The logger is a child bound with the caller's query context (chain,
+  // source, partition, retry), so lines a source logs itself carry it.
+  getBlockHashes: (~blockNumbers: array<int>, ~logger: Pino.t) => promise<getBlockHashesResponse>,
   getHeightOrThrow: unit => promise<getHeightResponse>,
   getItemsOrThrow: (
     ~fromBlock: int,
@@ -92,7 +88,6 @@ type t = {
     ~itemsTarget: int,
     ~retry: int,
     ~logger: Pino.t,
-    ~params: Internal.logParams,
   ) => promise<blockRangeFetchResponse>,
   createHeightSubscription?: (~onHeight: int => unit) => unit => unit,
   // Invoked by SourceManager once a rollback target is known so the source can

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -756,17 +756,20 @@ let executeQuery = async (
     let toBlock = toBlockRef.contents
     let retry = retryRef.contents
 
-    let logger = sourceManager.logger
-    // Written on every line below instead of bound to a child logger.
-    let queryParams = {
-      "chainId": source.chain->ChainMap.Chain.toChainId,
-      "partitionId": query.partitionId,
-      "source": source.name,
-      "fromBlock": query.fromBlock,
-      "toBlock": toBlock,
-      "addresses": query.addressesByContractName->FetchState.addressesByContractNameCount,
-      "retry": retry,
-    }->Internal.toLogParams
+    // A child: the source logs from inside its own module, where this context
+    // isn't in scope.
+    let logger = Logging.createChild(
+      ~logger=sourceManager.logger,
+      ~params={
+        "chainId": source.chain->ChainMap.Chain.toChainId,
+        "partitionId": query.partitionId,
+        "source": source.name,
+        "fromBlock": query.fromBlock,
+        "toBlock": toBlock,
+        "addresses": query.addressesByContractName->FetchState.addressesByContractNameCount,
+        "retry": retry,
+      },
+    )
 
     try {
       let response = await source.getItemsOrThrow(
@@ -780,7 +783,6 @@ let executeQuery = async (
         ~itemsTarget=query.itemsTarget,
         ~retry,
         ~logger,
-        ~params=queryParams,
       )
       sourceState->recordRequestStats(response.requestStats)
       sourceState.lastFailedAt = None
@@ -815,16 +817,14 @@ let executeQuery = async (
           if notAlreadyDisabled {
             switch error {
             | UnsupportedSelection({message}) =>
-              logger->Logging.error(queryParams->Logging.withParams({"msg": message}))
+              logger->Logging.error({"msg": message})
             | FailedGettingFieldSelection({exn, message, blockNumber, logIndex}) =>
-              logger->Logging.error(
-                queryParams->Logging.withParams({
-                  "msg": message,
-                  "err": exn->Utils.prettifyExn,
-                  "blockNumber": blockNumber,
-                  "logIndex": logIndex,
-                }),
-              )
+              logger->Logging.error({
+                "msg": message,
+                "err": exn->Utils.prettifyExn,
+                "blockNumber": blockNumber,
+                "logIndex": logIndex,
+              })
             | _ => ()
             }
           }
@@ -832,13 +832,11 @@ let executeQuery = async (
           retryRef := 0
         }
       | FailedGettingItems({attemptedToBlock, retry: WithSuggestedToBlock({toBlock})}) =>
-        logger->Logging.trace(
-          queryParams->Logging.withParams({
-            "msg": "Failed getting data for the block range. Immediately retrying with the suggested block range from response.",
-            "toBlock": attemptedToBlock,
-            "suggestedToBlock": toBlock,
-          }),
-        )
+        logger->Logging.trace({
+          "msg": "Failed getting data for the block range. Immediately retrying with the suggested block range from response.",
+          "toBlock": attemptedToBlock,
+          "suggestedToBlock": toBlock,
+        })
         toBlockRef := Some(toBlock)
         retryRef := 0
       | FailedGettingItems({exn, attemptedToBlock, retry: ImpossibleForTheQuery({message})}) =>
@@ -852,27 +850,23 @@ let executeQuery = async (
         }
         excludedSources->Utils.Set.add(sourceState)->ignore
 
-        logger->Logging.warn(
-          queryParams->Logging.withParams({
-            "msg": message ++ " - Attempting another source",
-            "toBlock": attemptedToBlock,
-            "err": exn->Utils.prettifyExn,
-          }),
-        )
+        logger->Logging.warn({
+          "msg": message ++ " - Attempting another source",
+          "toBlock": attemptedToBlock,
+          "err": exn->Utils.prettifyExn,
+        })
         retryRef := 0
 
       | FailedGettingItems({exn, attemptedToBlock, retry: WithBackoff({message, backoffMillis})}) =>
         // Start displaying warnings after 4 failures
         let log = retry >= 4 ? Logging.warn : Logging.trace
-        logger->log(
-          queryParams->Logging.withParams({
-            "msg": message,
-            "toBlock": attemptedToBlock,
-            "backOffMilliseconds": backoffMillis,
-            "retry": retry,
-            "err": exn->Utils.prettifyExn,
-          }),
-        )
+        logger->log({
+          "msg": message,
+          "toBlock": attemptedToBlock,
+          "backOffMilliseconds": backoffMillis,
+          "retry": retry,
+          "err": exn->Utils.prettifyExn,
+        })
 
         let shouldSwitch = switch retry {
         // Don't attempt a switch on first two failures
@@ -909,7 +903,6 @@ let executeQuery = async (
       exn->ErrorHandling.mkLogAndRaise(
         ~logger,
         ~msg="Failed to fetch block Range",
-        ~params=queryParams,
       )
     }
   }
@@ -935,15 +928,17 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
     let source = sourceState.source
     let retry = retryRef.contents
 
-    let logger = sourceManager.logger
-    let queryParams = {
-      "chainId": source.chain->ChainMap.Chain.toChainId,
-      "source": source.name,
-      "retry": retry,
-    }->Internal.toLogParams
+    let logger = Logging.createChild(
+      ~logger=sourceManager.logger,
+      ~params={
+        "chainId": source.chain->ChainMap.Chain.toChainId,
+        "source": source.name,
+        "retry": retry,
+      },
+    )
 
     try {
-      let res = await source.getBlockHashes(~blockNumbers, ~logger, ~params=queryParams)
+      let res = await source.getBlockHashes(~blockNumbers, ~logger)
       sourceState->recordRequestStats(res.requestStats)
       switch res.result {
       | Ok(data) =>
@@ -967,14 +962,12 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
       | _ => 1000 * retry
       }
       let log = retry >= 4 ? Logging.warn : Logging.trace
-      logger->log(
-        queryParams->Logging.withParams({
-          "msg": "Failed to fetch block hashes. Retrying.",
-          "retry": retry,
-          "backOffMilliseconds": backoffMillis,
-          "err": exn->Utils.prettifyExn,
-        }),
-      )
+      logger->log({
+        "msg": "Failed to fetch block hashes. Retrying.",
+        "retry": retry,
+        "backOffMilliseconds": backoffMillis,
+        "err": exn->Utils.prettifyExn,
+      })
 
       let shouldSwitch = switch retry {
       | 0 | 1 => false

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -760,7 +760,6 @@ let executeQuery = async (
     // Written on every line below instead of bound to a child logger.
     let queryParams = {
       "chainId": source.chain->ChainMap.Chain.toChainId,
-      "logType": "Block Range Query",
       "partitionId": query.partitionId,
       "source": source.name,
       "fromBlock": query.fromBlock,
@@ -781,6 +780,7 @@ let executeQuery = async (
         ~itemsTarget=query.itemsTarget,
         ~retry,
         ~logger,
+        ~params=queryParams,
       )
       sourceState->recordRequestStats(response.requestStats)
       sourceState.lastFailedAt = None
@@ -938,13 +938,12 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
     let logger = sourceManager.logger
     let queryParams = {
       "chainId": source.chain->ChainMap.Chain.toChainId,
-      "logType": "Block Hash Query",
       "source": source.name,
       "retry": retry,
     }->Internal.toLogParams
 
     try {
-      let res = await source.getBlockHashes(~blockNumbers, ~logger)
+      let res = await source.getBlockHashes(~blockNumbers, ~logger, ~params=queryParams)
       sourceState->recordRequestStats(res.requestStats)
       switch res.result {
       | Ok(data) =>

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -196,12 +196,13 @@ let stopRateLimitTimeout = sourceManager => {
 // pathologically large server values. Escalates the log from trace to
 // warn after the second consecutive retry so the indexer doesn't go
 // silent under chronic throttling.
-let waitForRateLimitReset = async (sourceManager: t, ~resetMs, ~retry, ~logger) => {
+let waitForRateLimitReset = async (sourceManager: t, ~resetMs, ~retry, ~logger, ~chainId) => {
   let waitMs = Pervasives.min(resetMs, 300_000)
-  let log = retry >= 2 ? Logging.childWarn : Logging.childTrace
+  let log = retry >= 2 ? Logging.warn : Logging.trace
   logger->log({
     "msg": `HyperSync source is rate-limited — not critical, the indexer will retry in ${(waitMs / 1000)
         ->Int.toString}s. For higher limits upgrade your plan at https://envio.dev/app/api-tokens.`,
+    "chainId": chainId,
     "retry": retry,
     "waitMs": waitMs,
   })
@@ -263,7 +264,7 @@ let make = (
     ~backoffMultiplicative=2,
     ~maxRetryInterval=60_000,
   ),
-  ~logger=Env.logger,
+  ~logger: Pino.t,
 ) => {
   let hasRealtime = sources->Array.some(s => s.sourceFor === Realtime)
   let initialActiveSource = switch sources->Array.find(source =>
@@ -425,10 +426,11 @@ let getSourceNewHeight = async (
       let pollingFallback = Utils.delay(
         half + (Math.random() *. half->Int.toFloat)->Float.toInt,
       )->Promise.then(async () => {
-        logger->Logging.childTrace({
+        logger->Logging.trace({
           "msg": "onHeight subscription stale, switching to polling fallback",
           "source": source.name,
           "chainId": source.chain->ChainMap.Chain.toChainId,
+          "knownHeight": knownHeight,
         })
         let h = ref(initialHeight)
         while h.contents <= knownHeight && !(newHeight.contents > initialHeight) {
@@ -496,9 +498,11 @@ let getSourceNewHeight = async (
       } catch {
       | exn =>
         let retryInterval = sourceManager.getHeightRetryInterval(~retry=retry.contents)
-        logger->Logging.childTrace({
+        logger->Logging.trace({
           "msg": `Height retrieval from ${source.name} source failed. Retrying in ${retryInterval->Int.toString}ms.`,
           "source": source.name,
+          "chainId": source.chain->ChainMap.Chain.toChainId,
+          "knownHeight": knownHeight,
           "err": exn->Utils.prettifyExn,
         })
         retry := retry.contents + 1
@@ -586,20 +590,17 @@ let getNextSource = (sourceManager, ~isRealtime, ~excludedSources=?) => {
 let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isRealtime, ~reducedPolling) => {
   let {sourcesState} = sourceManager
 
-  let logger = Logging.createChildFrom(
-    ~logger=sourceManager.logger,
-    ~params={
-      "chainId": sourceManager.activeSource.chain->ChainMap.Chain.toChainId,
-      "knownHeight": knownHeight,
-    },
-  )
+  let logger = sourceManager.logger
+  let chainId = sourceManager.activeSource.chain->ChainMap.Chain.toChainId
   if !sourceManager.waitingLogged {
-    logger->Logging.childTrace(
-      reducedPolling
+    logger->Logging.trace({
+      "msg": reducedPolling
         ? `Waiting for new blocks with reduced polling (${(sourceManager.reducedPollingInterval / 1000)
               ->Int.toString}s). Chain is caught up, waiting for other chains to backfill.`
         : "Initiating check for new blocks.",
-    )
+      "chainId": chainId,
+      "knownHeight": knownHeight,
+    })
     sourceManager.waitingLogged = true
   }
 
@@ -656,15 +657,19 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isRealtime, ~reduc
 
           switch fallbackSources {
           | [] =>
-            logger->Logging.childWarn(
-              `No new blocks detected within ${(stallTimeout / 1000)
+            logger->Logging.warn({
+              "msg": `No new blocks detected within ${(stallTimeout / 1000)
                   ->Int.toString}s. Polling will continue at a reduced rate. For better reliability, refer to our RPC fallback guide: https://docs.envio.dev/docs/HyperIndex/rpc-sync`,
-            )
+              "chainId": chainId,
+              "knownHeight": knownHeight,
+            })
           | _ =>
-            logger->Logging.childWarn(
-              `No new blocks detected within ${(stallTimeout / 1000)
+            logger->Logging.warn({
+              "msg": `No new blocks detected within ${(stallTimeout / 1000)
                   ->Int.toString}s. Continuing polling with secondary RPC sources from the configuration.`,
-            )
+              "chainId": chainId,
+              "knownHeight": knownHeight,
+            })
           }
         }
         // Promise.race will be forever pending if fallbackSources is empty
@@ -692,10 +697,12 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isRealtime, ~reduc
   sourceManager.activeSource = source
 
   // Show a higher level log if we displayed a warning/error after newBlockStallTimeout
-  let log = status.contents === Stalled ? Logging.childInfo : Logging.childTrace
+  let log = status.contents === Stalled ? Logging.info : Logging.trace
   logger->log({
     "msg": `New blocks successfully found.`,
     "source": source.name,
+    "chainId": chainId,
+    "knownHeight": knownHeight,
     "newBlockHeight": newBlockHeight,
   })
   sourceManager.waitingLogged = false
@@ -728,12 +735,9 @@ let executeQuery = async (
     ) {
     | Some(s) =>
       if s.source !== sourceManager.activeSource {
-        let logger = Logging.createChildFrom(
-          ~logger=sourceManager.logger,
-          ~params={"chainId": sourceManager.activeSource.chain->ChainMap.Chain.toChainId},
-        )
-        logger->Logging.childInfo({
+        sourceManager.logger->Logging.info({
           "msg": "Switching data-source",
+          "chainId": sourceManager.activeSource.chain->ChainMap.Chain.toChainId,
           "source": s.source.name,
           "previousSource": sourceManager.activeSource.name,
           "fromBlock": query.fromBlock,
@@ -741,30 +745,29 @@ let executeQuery = async (
       }
       s
     | None =>
-      let logger = Logging.createChildFrom(
+      %raw(`null`)->ErrorHandling.mkLogAndRaise(
         ~logger=sourceManager.logger,
+        ~msg=noSourcesError,
         ~params={"chainId": sourceManager.activeSource.chain->ChainMap.Chain.toChainId},
       )
-      %raw(`null`)->ErrorHandling.mkLogAndRaise(~logger, ~msg=noSourcesError)
     }
     sourceManager.activeSource = sourceState.source
     let source = sourceState.source
     let toBlock = toBlockRef.contents
     let retry = retryRef.contents
 
-    let logger = Logging.createChildFrom(
-      ~logger=sourceManager.logger,
-      ~params={
-        "chainId": source.chain->ChainMap.Chain.toChainId,
-        "logType": "Block Range Query",
-        "partitionId": query.partitionId,
-        "source": source.name,
-        "fromBlock": query.fromBlock,
-        "toBlock": toBlock,
-        "addresses": query.addressesByContractName->FetchState.addressesByContractNameCount,
-        "retry": retry,
-      },
-    )
+    let logger = sourceManager.logger
+    // Written on every line below instead of bound to a child logger.
+    let queryParams = {
+      "chainId": source.chain->ChainMap.Chain.toChainId,
+      "logType": "Block Range Query",
+      "partitionId": query.partitionId,
+      "source": source.name,
+      "fromBlock": query.fromBlock,
+      "toBlock": toBlock,
+      "addresses": query.addressesByContractName->FetchState.addressesByContractNameCount,
+      "retry": retry,
+    }->Internal.toLogParams
 
     try {
       let response = await source.getItemsOrThrow(
@@ -791,7 +794,12 @@ let executeQuery = async (
       responseRef := Some(response)
     } catch {
     | Source.RateLimited({resetMs}) =>
-      await sourceManager->waitForRateLimitReset(~resetMs, ~retry, ~logger)
+      await sourceManager->waitForRateLimitReset(
+        ~resetMs,
+        ~retry,
+        ~logger,
+        ~chainId=source.chain->ChainMap.Chain.toChainId,
+      )
       retryRef := retryRef.contents + 1
 
     | Source.GetItemsError(error) =>
@@ -806,14 +814,17 @@ let executeQuery = async (
           // failing at the same time. Log only once
           if notAlreadyDisabled {
             switch error {
-            | UnsupportedSelection({message}) => logger->Logging.childError(message)
+            | UnsupportedSelection({message}) =>
+              logger->Logging.error(queryParams->Logging.withParams({"msg": message}))
             | FailedGettingFieldSelection({exn, message, blockNumber, logIndex}) =>
-              logger->Logging.childError({
-                "msg": message,
-                "err": exn->Utils.prettifyExn,
-                "blockNumber": blockNumber,
-                "logIndex": logIndex,
-              })
+              logger->Logging.error(
+                queryParams->Logging.withParams({
+                  "msg": message,
+                  "err": exn->Utils.prettifyExn,
+                  "blockNumber": blockNumber,
+                  "logIndex": logIndex,
+                }),
+              )
             | _ => ()
             }
           }
@@ -821,11 +832,13 @@ let executeQuery = async (
           retryRef := 0
         }
       | FailedGettingItems({attemptedToBlock, retry: WithSuggestedToBlock({toBlock})}) =>
-        logger->Logging.childTrace({
-          "msg": "Failed getting data for the block range. Immediately retrying with the suggested block range from response.",
-          "toBlock": attemptedToBlock,
-          "suggestedToBlock": toBlock,
-        })
+        logger->Logging.trace(
+          queryParams->Logging.withParams({
+            "msg": "Failed getting data for the block range. Immediately retrying with the suggested block range from response.",
+            "toBlock": attemptedToBlock,
+            "suggestedToBlock": toBlock,
+          }),
+        )
         toBlockRef := Some(toBlock)
         retryRef := 0
       | FailedGettingItems({exn, attemptedToBlock, retry: ImpossibleForTheQuery({message})}) =>
@@ -839,23 +852,27 @@ let executeQuery = async (
         }
         excludedSources->Utils.Set.add(sourceState)->ignore
 
-        logger->Logging.childWarn({
-          "msg": message ++ " - Attempting another source",
-          "toBlock": attemptedToBlock,
-          "err": exn->Utils.prettifyExn,
-        })
+        logger->Logging.warn(
+          queryParams->Logging.withParams({
+            "msg": message ++ " - Attempting another source",
+            "toBlock": attemptedToBlock,
+            "err": exn->Utils.prettifyExn,
+          }),
+        )
         retryRef := 0
 
       | FailedGettingItems({exn, attemptedToBlock, retry: WithBackoff({message, backoffMillis})}) =>
         // Start displaying warnings after 4 failures
-        let log = retry >= 4 ? Logging.childWarn : Logging.childTrace
-        logger->log({
-          "msg": message,
-          "toBlock": attemptedToBlock,
-          "backOffMilliseconds": backoffMillis,
-          "retry": retry,
-          "err": exn->Utils.prettifyExn,
-        })
+        let log = retry >= 4 ? Logging.warn : Logging.trace
+        logger->log(
+          queryParams->Logging.withParams({
+            "msg": message,
+            "toBlock": attemptedToBlock,
+            "backOffMilliseconds": backoffMillis,
+            "retry": retry,
+            "err": exn->Utils.prettifyExn,
+          }),
+        )
 
         let shouldSwitch = switch retry {
         // Don't attempt a switch on first two failures
@@ -888,7 +905,12 @@ let executeQuery = async (
       }
 
     // TODO: Handle more error cases and hang/retry instead of throwing
-    | exn => exn->ErrorHandling.mkLogAndRaise(~logger, ~msg="Failed to fetch block Range")
+    | exn =>
+      exn->ErrorHandling.mkLogAndRaise(
+        ~logger,
+        ~msg="Failed to fetch block Range",
+        ~params=queryParams,
+      )
     }
   }
 
@@ -903,28 +925,23 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
     let sourceState = switch sourceManager->getNextSource(~isRealtime) {
     | Some(s) => s
     | None =>
-      let logger = Logging.createChildFrom(
-        ~logger=sourceManager.logger,
-        ~params={"chainId": sourceManager.activeSource.chain->ChainMap.Chain.toChainId},
-      )
       %raw(`null`)->ErrorHandling.mkLogAndRaise(
-        ~logger,
+        ~logger=sourceManager.logger,
         ~msg="No data-sources available for fetching block hashes.",
+        ~params={"chainId": sourceManager.activeSource.chain->ChainMap.Chain.toChainId},
       )
     }
     sourceManager.activeSource = sourceState.source
     let source = sourceState.source
     let retry = retryRef.contents
 
-    let logger = Logging.createChildFrom(
-      ~logger=sourceManager.logger,
-      ~params={
-        "chainId": source.chain->ChainMap.Chain.toChainId,
-        "logType": "Block Hash Query",
-        "source": source.name,
-        "retry": retry,
-      },
-    )
+    let logger = sourceManager.logger
+    let queryParams = {
+      "chainId": source.chain->ChainMap.Chain.toChainId,
+      "logType": "Block Hash Query",
+      "source": source.name,
+      "retry": retry,
+    }->Internal.toLogParams
 
     try {
       let res = await source.getBlockHashes(~blockNumbers, ~logger)
@@ -937,7 +954,12 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
       }
     } catch {
     | Source.RateLimited({resetMs}) =>
-      await sourceManager->waitForRateLimitReset(~resetMs, ~retry, ~logger)
+      await sourceManager->waitForRateLimitReset(
+        ~resetMs,
+        ~retry,
+        ~logger,
+        ~chainId=source.chain->ChainMap.Chain.toChainId,
+      )
       retryRef := retryRef.contents + 1
 
     | exn =>
@@ -945,13 +967,15 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
       | 0 => 500
       | _ => 1000 * retry
       }
-      let log = retry >= 4 ? Logging.childWarn : Logging.childTrace
-      logger->log({
-        "msg": "Failed to fetch block hashes. Retrying.",
-        "retry": retry,
-        "backOffMilliseconds": backoffMillis,
-        "err": exn->Utils.prettifyExn,
-      })
+      let log = retry >= 4 ? Logging.warn : Logging.trace
+      logger->log(
+        queryParams->Logging.withParams({
+          "msg": "Failed to fetch block hashes. Retrying.",
+          "retry": retry,
+          "backOffMilliseconds": backoffMillis,
+          "err": exn->Utils.prettifyExn,
+        }),
+      )
 
       let shouldSwitch = switch retry {
       | 0 | 1 => false

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -196,13 +196,12 @@ let stopRateLimitTimeout = sourceManager => {
 // pathologically large server values. Escalates the log from trace to
 // warn after the second consecutive retry so the indexer doesn't go
 // silent under chronic throttling.
-let waitForRateLimitReset = async (sourceManager: t, ~resetMs, ~retry, ~logger, ~chainId) => {
+let waitForRateLimitReset = async (sourceManager: t, ~resetMs, ~retry, ~logger) => {
   let waitMs = Pervasives.min(resetMs, 300_000)
   let log = retry >= 2 ? Logging.warn : Logging.trace
   logger->log({
     "msg": `HyperSync source is rate-limited — not critical, the indexer will retry in ${(waitMs / 1000)
         ->Int.toString}s. For higher limits upgrade your plan at https://envio.dev/app/api-tokens.`,
-    "chainId": chainId,
     "retry": retry,
     "waitMs": waitMs,
   })
@@ -796,12 +795,7 @@ let executeQuery = async (
       responseRef := Some(response)
     } catch {
     | Source.RateLimited({resetMs}) =>
-      await sourceManager->waitForRateLimitReset(
-        ~resetMs,
-        ~retry,
-        ~logger,
-        ~chainId=source.chain->ChainMap.Chain.toChainId,
-      )
+      await sourceManager->waitForRateLimitReset(~resetMs, ~retry, ~logger)
       retryRef := retryRef.contents + 1
 
     | Source.GetItemsError(error) =>
@@ -948,12 +942,7 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
       }
     } catch {
     | Source.RateLimited({resetMs}) =>
-      await sourceManager->waitForRateLimitReset(
-        ~resetMs,
-        ~retry,
-        ~logger,
-        ~chainId=source.chain->ChainMap.Chain.toChainId,
-      )
+      await sourceManager->waitForRateLimitReset(~resetMs, ~retry, ~logger)
       retryRef := retryRef.contents + 1
 
     | exn =>

--- a/packages/envio/src/sources/SourceManager.resi
+++ b/packages/envio/src/sources/SourceManager.resi
@@ -17,7 +17,7 @@ let make: (
   ~reducedPollingInterval: int=?,
   ~recoveryTimeout: float=?,
   ~getHeightRetryInterval: (~retry: int) => int=?,
-  ~logger: Pino.t=?,
+  ~logger: Pino.t,
 ) => t
 
 let getActiveSource: t => Source.t

--- a/packages/envio/src/sources/Svm.res
+++ b/packages/envio/src/sources/Svm.res
@@ -85,7 +85,7 @@ let makeRPCSource = (~chain, ~rpc: string, ~sourceFor: Source.sourceFor=Sync): S
     chain,
     poweredByHyperSync: false,
     pollingInterval: 10_000,
-    getBlockHashes: (~blockNumbers as _, ~logger as _, ~params as _) =>
+    getBlockHashes: (~blockNumbers as _, ~logger as _) =>
       JsError.throwWithMessage("Svm does not support getting block hashes"),
     getHeightOrThrow: async () => {
       let timerRef = Performance.now()
@@ -104,7 +104,6 @@ let makeRPCSource = (~chain, ~rpc: string, ~sourceFor: Source.sourceFor=Sync): S
       ~itemsTarget as _,
       ~retry as _,
       ~logger as _,
-      ~params as _,
     ) => JsError.throwWithMessage("Svm does not support getting items"),
   }
 }

--- a/packages/envio/src/sources/Svm.res
+++ b/packages/envio/src/sources/Svm.res
@@ -27,7 +27,7 @@ let blockFields = ["slot", "time", "hash", "height", "parentSlot", "parentHash"]
 // event at config build and cached on the event config.
 let eventBlockFieldMask = BlockStore.makeMaskFn(blockFields)
 
-let make = (~logger: Pino.t): Ecosystem.t => {
+let make = (): Ecosystem.t => {
   name: Svm,
   blockNumberName: "height",
   blockTimestampName: "time",
@@ -40,21 +40,17 @@ let make = (~logger: Pino.t): Ecosystem.t => {
   // SVM has no event handlers, so there is no `onEvent` `where` value to
   // parse. The schema is a no-op object that always surfaces `None`.
   onEventBlockFilterSchema: S.object(_ => None),
-  logger,
   toEvent: eventItem => eventItem.payload->(Utils.magic: Internal.eventPayload => Internal.event),
-  toEventLogger: eventItem => {
+  toEventLogParams: eventItem => {
     let instruction =
       eventItem.payload->(Utils.magic: Internal.eventPayload => Envio.svmInstruction)
-    Logging.createChildFrom(
-      ~logger,
-      ~params={
-        "program": eventItem.onEventRegistration.eventConfig.contractName,
-        "instruction": eventItem.onEventRegistration.eventConfig.name,
-        "chainId": eventItem.chain->ChainMap.Chain.toChainId,
-        "slot": eventItem.blockNumber,
-        "programId": instruction.programId,
-      },
-    )
+    {
+      "program": eventItem.onEventRegistration.eventConfig.contractName,
+      "instruction": eventItem.onEventRegistration.eventConfig.name,
+      "chainId": eventItem.chain->ChainMap.Chain.toChainId,
+      "slot": eventItem.blockNumber,
+      "programId": instruction.programId,
+    }->Internal.toLogParams
   },
   toRawEvent: _ => JsError.throwWithMessage("Raw events are not supported for SVM"),
 }

--- a/packages/envio/src/sources/Svm.res
+++ b/packages/envio/src/sources/Svm.res
@@ -85,7 +85,7 @@ let makeRPCSource = (~chain, ~rpc: string, ~sourceFor: Source.sourceFor=Sync): S
     chain,
     poweredByHyperSync: false,
     pollingInterval: 10_000,
-    getBlockHashes: (~blockNumbers as _, ~logger as _) =>
+    getBlockHashes: (~blockNumbers as _, ~logger as _, ~params as _) =>
       JsError.throwWithMessage("Svm does not support getting block hashes"),
     getHeightOrThrow: async () => {
       let timerRef = Performance.now()
@@ -104,6 +104,7 @@ let makeRPCSource = (~chain, ~rpc: string, ~sourceFor: Source.sourceFor=Sync): S
       ~itemsTarget as _,
       ~retry as _,
       ~logger as _,
+      ~params as _,
     ) => JsError.throwWithMessage("Svm does not support getting items"),
   }
 }

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -93,7 +93,6 @@ let make = (
     ~itemsTarget,
     ~retry,
     ~logger as _,
-    ~params as _,
   ) => {
     let totalTimeRef = Performance.now()
     let pageFetchRef = Performance.now()
@@ -243,7 +242,7 @@ let make = (
     (blockDatas, requestStats)
   }
 
-  let getBlockHashes = async (~blockNumbers, ~logger as _, ~params as _) =>
+  let getBlockHashes = async (~blockNumbers, ~logger as _) =>
     switch blockNumbers->Array.get(0) {
     | None => {Source.result: Ok([]), requestStats: []}
     | Some(firstSlot) =>

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -93,6 +93,7 @@ let make = (
     ~itemsTarget,
     ~retry,
     ~logger as _,
+    ~params as _,
   ) => {
     let totalTimeRef = Performance.now()
     let pageFetchRef = Performance.now()
@@ -242,7 +243,7 @@ let make = (
     (blockDatas, requestStats)
   }
 
-  let getBlockHashes = async (~blockNumbers, ~logger as _) =>
+  let getBlockHashes = async (~blockNumbers, ~logger as _, ~params as _) =>
     switch blockNumbers->Array.get(0) {
     | None => {Source.result: Ok([]), requestStats: []}
     | Some(firstSlot) =>

--- a/packages/envio/src/tui/Tui.res
+++ b/packages/envio/src/tui/Tui.res
@@ -330,7 +330,7 @@ module App = {
         </Box>
       | _ => React.null
       }}
-      <Messages config={state->IndexerState.config} />
+      <Messages config={state->IndexerState.config} logger={state->IndexerState.logger} />
     </Box>
   }
 }

--- a/packages/envio/src/tui/components/CustomHooks.res
+++ b/packages/envio/src/tui/components/CustomHooks.res
@@ -99,7 +99,7 @@ module InitApi = {
 
 type request<'ok, 'err> = Data('ok) | Loading | Err('err)
 
-let useMessages = (~config) => {
+let useMessages = (~config, ~logger) => {
   let (request, setRequest) = React.useState(_ => Loading)
   React.useEffect0(() => {
     InitApi.getMessages(~config)
@@ -107,7 +107,7 @@ let useMessages = (~config) => {
       switch res {
       | Ok(data) => setRequest(_ => Data(data))
       | Error(e) =>
-        config.logger->Logging.childError({
+        logger->Logging.error({
           "msg": "Failed to load messages from envio server",
           "err": e->Utils.prettifyExn,
         })

--- a/packages/envio/src/tui/components/Messages.res
+++ b/packages/envio/src/tui/components/Messages.res
@@ -20,8 +20,8 @@ module Notifications = {
 }
 
 @react.component
-let make = (~config) => {
-  let messages = CustomHooks.useMessages(~config)
+let make = (~config, ~logger) => {
+  let messages = CustomHooks.useMessages(~config, ~logger)
   <>
     {switch messages {
     | Data([]) | Loading => React.null //Don't show anything while loading or no messages

--- a/scenarios/fuel_test/src/Indexer.res
+++ b/scenarios/fuel_test/src/Indexer.res
@@ -43,6 +43,7 @@ module SingleOrMultiple: {
         true
       } else if arr->Array.length == 0 {
         AmbiguousEmptyNestedArray->ErrorHandling.mkLogAndRaise(
+          ~logger=Env.logger,
           ~msg="The given empty array could be interpreted as a flat array (value) or nested array. Since it's ambiguous,
           please pass in a nested empty array if the intention is to provide an empty array as a value",
         )

--- a/scenarios/fuel_test/test/FuelHyperSyncSourceHeight_test.res
+++ b/scenarios/fuel_test/test/FuelHyperSyncSourceHeight_test.res
@@ -51,6 +51,7 @@ describe("FuelHyperSyncSource - getHeightOrThrow", () => {
       res->endWith(`{"height": 123}`)
     }, async endpointUrl => {
       let source = FuelHyperSyncSource.make({
+    logger: Env.logger,
         chain,
         endpointUrl,
         apiToken: Some(apiToken),
@@ -77,6 +78,7 @@ describe("FuelHyperSyncSource - getHeightOrThrow", () => {
       res->endWith("Unauthorized")
     }, async endpointUrl => {
       let source = FuelHyperSyncSource.make({
+    logger: Env.logger,
         chain,
         endpointUrl,
         apiToken: Some(apiToken),

--- a/scenarios/svm_test/src/Indexer.res
+++ b/scenarios/svm_test/src/Indexer.res
@@ -37,6 +37,7 @@ module SingleOrMultiple: {
         true
       } else if arr->Array.length == 0 {
         AmbiguousEmptyNestedArray->ErrorHandling.mkLogAndRaise(
+          ~logger=Env.logger,
           ~msg="The given empty array could be interpreted as a flat array (value) or nested array. Since it's ambiguous,
           please pass in a nested empty array if the intention is to provide an empty array as a value",
         )

--- a/scenarios/test_codegen/src/Indexer.res
+++ b/scenarios/test_codegen/src/Indexer.res
@@ -152,6 +152,7 @@ module SingleOrMultiple: {
         true
       } else if arr->Array.length == 0 {
         AmbiguousEmptyNestedArray->ErrorHandling.mkLogAndRaise(
+          ~logger=Env.logger,
           ~msg="The given empty array could be interpreted as a flat array (value) or nested array. Since it's ambiguous,
           please pass in a nested empty array if the intention is to provide an empty array as a value",
         )

--- a/scenarios/test_codegen/test/ChainMeta_test.res
+++ b/scenarios/test_codegen/test/ChainMeta_test.res
@@ -51,7 +51,7 @@ let makeStore = () => {
     },
   }
   let persistence = {
-    ...PgStorage.makePersistenceFromConfig(~config=MockIndexer.config, ~storage),
+    ...PgStorage.makePersistenceFromConfig(~logger=Env.logger, ~config=MockIndexer.config, ~storage),
     storageStatus: Persistence.Ready({
       cleanRun: false,
       cache: Dict.make(),
@@ -61,7 +61,7 @@ let makeStore = () => {
       envioInfo: None,
     }),
   }
-  let store = IndexerState.make(
+  let store = IndexerState.make(~logger=Env.logger, 
     ~config=MockIndexer.config,
     ~persistence,
     ~chainStates=Dict.make(),

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -30,14 +30,14 @@ let parseEvm = (~eventFilters: option<JSON.t>, ~probeChainId=1) =>
   parse(
     ~eventFilters,
     ~probeChainId,
-    ~onEventBlockFilterSchema=Evm.make(~logger=Env.logger).onEventBlockFilterSchema,
+    ~onEventBlockFilterSchema=Evm.make().onEventBlockFilterSchema,
   )
 
 let parseFuel = (~eventFilters: option<JSON.t>, ~probeChainId=1) =>
   parse(
     ~eventFilters,
     ~probeChainId,
-    ~onEventBlockFilterSchema=Fuel.make(~logger=Env.logger).onEventBlockFilterSchema,
+    ~onEventBlockFilterSchema=Fuel.make().onEventBlockFilterSchema,
   )
 
 describe("eventBlockRangeSchema (strict, _gte-only)", () => {
@@ -244,7 +244,7 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
       ~contractRegister=None,
       ~where=eventFilters,
       ~chainId=1,
-      ~onEventBlockFilterSchema=Evm.make(~logger=Env.logger).onEventBlockFilterSchema,
+      ~onEventBlockFilterSchema=Evm.make().onEventBlockFilterSchema,
       ~startBlock?,
     )
 
@@ -294,7 +294,7 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
       ~contractRegister=None,
       ~where=Some(whereFn),
       ~chainId=137,
-      ~onEventBlockFilterSchema=Evm.make(~logger=Env.logger).onEventBlockFilterSchema,
+      ~onEventBlockFilterSchema=Evm.make().onEventBlockFilterSchema,
       ~startBlock=1,
     )
     let chain1 = EventConfigBuilder.buildEvmOnEventRegistration(
@@ -309,7 +309,7 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
       ~contractRegister=None,
       ~where=Some(whereFn),
       ~chainId=1,
-      ~onEventBlockFilterSchema=Evm.make(~logger=Env.logger).onEventBlockFilterSchema,
+      ~onEventBlockFilterSchema=Evm.make().onEventBlockFilterSchema,
       ~startBlock=1,
     )
     t.expect((chain137.startBlock, chain1.startBlock)).toEqual((Some(5000), Some(250)))
@@ -343,7 +343,7 @@ describe("FetchState — where.block._gte drives the first query's fromBlock", (
       ~contractRegister=None,
       ~where=Some(%raw(`{block: {number: {_gte: 5000}}}`)),
       ~chainId=1,
-      ~onEventBlockFilterSchema=Evm.make(~logger=Env.logger).onEventBlockFilterSchema,
+      ~onEventBlockFilterSchema=Evm.make().onEventBlockFilterSchema,
       ~startBlock?,
     )
 

--- a/scenarios/test_codegen/test/EventFilters_test.res
+++ b/scenarios/test_codegen/test/EventFilters_test.res
@@ -5,7 +5,7 @@ open Vitest
 // effect — that registry state (not `config`, which never changes) is what
 // `MockConfig.getEvmOnEventRegistration` reads below.
 let config = Config.load()
-let registrationsByChainId = await HandlerLoader.registerAllHandlers(~config)
+let registrationsByChainId = await HandlerLoader.registerAllHandlers(~config, ~logger=Env.logger)
 
 let getEvmEventConfig = MockConfig.getEvmOnEventRegistration(~config, ...)
 

--- a/scenarios/test_codegen/test/EventOrigin_test.res
+++ b/scenarios/test_codegen/test/EventOrigin_test.res
@@ -50,7 +50,7 @@ describe("Chains State", () => {
         let handlerContext = UserContext.getHandlerContext({
           item,
           loadManager,
-          persistence: PgStorage.makePersistenceFromConfig(
+          persistence: PgStorage.makePersistenceFromConfig(~logger=Env.logger, 
             ~config=Config.load(),
           ),
           indexerState,

--- a/scenarios/test_codegen/test/IndexerState_test.res
+++ b/scenarios/test_codegen/test/IndexerState_test.res
@@ -129,7 +129,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       ~chainConfig,
       ~fetchState=fetchState.contents,
       ~indexingAddresses,
-      ~sourceManager=SourceManager.make(~sources=[mockSource.source], ~isRealtime=false),
+      ~sourceManager=SourceManager.make(~logger=Env.logger, ~sources=[mockSource.source], ~isRealtime=false),
       // This is quite a hack - but it works!
       ~reorgDetection=ReorgDetection.make(
         ~chainReorgCheckpoints=[],
@@ -143,7 +143,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
     chainStates->Utils.Dict.setByInt(id, mockChainState)
   })
 
-  let state = IndexerState.make(
+  let state = IndexerState.make(~logger=Env.logger, 
     ~config,
     ~persistence=MockIndexer.defaultPersistence(),
     ~chainStates,
@@ -322,7 +322,7 @@ describe("IndexerState", () => {
                 ~chainConfig,
                 ~fetchState,
                 ~indexingAddresses,
-                ~sourceManager=SourceManager.make(~sources=[mockSource.source], ~isRealtime=false),
+                ~sourceManager=SourceManager.make(~logger=Env.logger, ~sources=[mockSource.source], ~isRealtime=false),
                 ~reorgDetection=ReorgDetection.make(
                   ~chainReorgCheckpoints=[],
                   ~maxReorgDepth=200,
@@ -334,7 +334,7 @@ describe("IndexerState", () => {
               chainStates->Utils.Dict.setByInt(chainConfig.id, chainState)
             },
           )
-          IndexerState.make(
+          IndexerState.make(~logger=Env.logger, 
             ~config,
             ~persistence=MockIndexer.defaultPersistence(),
             ~chainStates,

--- a/scenarios/test_codegen/test/OnEventRegistration_test.res
+++ b/scenarios/test_codegen/test/OnEventRegistration_test.res
@@ -7,7 +7,7 @@ open Vitest
 // `Internal.dependsOnAddresses` formula. Filter-parsing behavior is
 // covered separately by `EventFilters_test.res`.
 let config = Config.load()
-let _ = await HandlerLoader.registerAllHandlers(~config)
+let _ = await HandlerLoader.registerAllHandlers(~config, ~logger=Env.logger)
 
 let getEvmEventConfig = MockConfig.getEvmOnEventRegistration(~config, ...)
 

--- a/scenarios/test_codegen/test/RpcSourceContract_test.res
+++ b/scenarios/test_codegen/test/RpcSourceContract_test.res
@@ -99,6 +99,7 @@ let invoke = (source: Source.t, ~registration: Internal.evmOnEventRegistration, 
     ~itemsTarget=5_000,
     ~retry,
     ~logger=Env.logger,
+    ~params=Internal.toLogParams({"test": true}),
   )
 }
 
@@ -449,6 +450,7 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
                 ~itemsTarget=5_000,
                 ~retry=0,
                 ~logger=Env.logger,
+                ~params=Internal.toLogParams({"test": true}),
               )
             )
           (await call(), await call())
@@ -590,6 +592,7 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
               ~itemsTarget=5_000,
               ~retry=0,
               ~logger=Env.logger,
+              ~params=Internal.toLogParams({"test": true}),
             )
           ) {
           | Ok(page) => page
@@ -713,6 +716,7 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
               ~itemsTarget=5_000,
               ~retry=0,
               ~logger=Env.logger,
+              ~params=Internal.toLogParams({"test": true}),
             )
           ) {
           | Ok(page) => page

--- a/scenarios/test_codegen/test/RpcSourceContract_test.res
+++ b/scenarios/test_codegen/test/RpcSourceContract_test.res
@@ -70,6 +70,7 @@ let syncConfig = EvmChain.getSyncConfig({
 
 let makeSource = (~factory, ~url, ~registration: Internal.evmOnEventRegistration) => {
   let options: RpcSource.options = {
+    logger: Env.logger,
     url,
     chain,
     onEventRegistrations: [registration],
@@ -97,7 +98,7 @@ let invoke = (source: Source.t, ~registration: Internal.evmOnEventRegistration, 
     },
     ~itemsTarget=5_000,
     ~retry,
-    ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RPC source contract pin"}),
+    ~logger=Env.logger,
   )
 }
 
@@ -418,6 +419,7 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
         async mock => {
           let registration = makeRegistration()
           let options: RpcSource.options = {
+            logger: Env.logger,
             url: mock.url,
             chain,
             onEventRegistrations: [registration],
@@ -446,7 +448,7 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
                 },
                 ~itemsTarget=5_000,
                 ~retry=0,
-                ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RPC interval pin"}),
+                ~logger=Env.logger,
               )
             )
           (await call(), await call())
@@ -587,7 +589,7 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
               },
               ~itemsTarget=5_000,
               ~retry=0,
-              ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RPC skip-all pin"}),
+              ~logger=Env.logger,
             )
           ) {
           | Ok(page) => page
@@ -678,6 +680,7 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
         ],
         async mock => {
           let options: RpcSource.options = {
+            logger: Env.logger,
             url: mock.url,
             chain,
             onEventRegistrations: [eventA, eventB],
@@ -709,7 +712,7 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
               },
               ~itemsTarget=5_000,
               ~retry=0,
-              ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RPC contract scoping pin"}),
+              ~logger=Env.logger,
             )
           ) {
           | Ok(page) => page

--- a/scenarios/test_codegen/test/RpcSourceContract_test.res
+++ b/scenarios/test_codegen/test/RpcSourceContract_test.res
@@ -99,7 +99,6 @@ let invoke = (source: Source.t, ~registration: Internal.evmOnEventRegistration, 
     ~itemsTarget=5_000,
     ~retry,
     ~logger=Env.logger,
-    ~params=Internal.toLogParams({"test": true}),
   )
 }
 
@@ -450,7 +449,6 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
                 ~itemsTarget=5_000,
                 ~retry=0,
                 ~logger=Env.logger,
-                ~params=Internal.toLogParams({"test": true}),
               )
             )
           (await call(), await call())
@@ -592,7 +590,6 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
               ~itemsTarget=5_000,
               ~retry=0,
               ~logger=Env.logger,
-              ~params=Internal.toLogParams({"test": true}),
             )
           ) {
           | Ok(page) => page
@@ -716,7 +713,6 @@ let registerContractTests = (~name, ~factory: sourceFactory) => {
               ~itemsTarget=5_000,
               ~retry=0,
               ~logger=Env.logger,
-              ~params=Internal.toLogParams({"test": true}),
             )
           ) {
           | Ok(page) => page

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -24,6 +24,7 @@ let mockLog = (
 describe("RpcSource - name", () => {
   it("Returns the name of the source including sanitized rpc url", t => {
     let source = RpcSource.make({
+    logger: Env.logger,
       url: "https://eth.rpc.hypersync.xyz?api_key=123",
       chain: MockConfig.chain1337,
       onEventRegistrations: [],
@@ -38,6 +39,7 @@ describe("RpcSource - name", () => {
 describe("RpcSource - getHeightOrThrow", () => {
   Async.it("Returns the current height of the chain", async t => {
     let source = RpcSource.make({
+    logger: Env.logger,
       url: `https://eth.rpc.hypersync.xyz/${testApiToken}`,
       chain: MockConfig.chain1337,
       onEventRegistrations: [],
@@ -731,6 +733,7 @@ let chain = ChainMap.Chain.makeUnsafe(~chainId=1)
 describe("RpcSource - empty selection", () => {
   Async.it("Throws UnsupportedSelection when the selection has no event configs", async t => {
     let source = RpcSource.make({
+    logger: Env.logger,
       url: "http://localhost:1",
       chain,
       onEventRegistrations: [],
@@ -750,7 +753,7 @@ describe("RpcSource - empty selection", () => {
         ~selection={dependsOnAddresses: true, onEventRegistrations: []},
         ~itemsTarget=5000,
         ~retry=0,
-        ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RpcSource empty selection"}),
+        ~logger=Env.logger,
       )
       None
     } catch {
@@ -814,6 +817,7 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
       })
 
       let source = RpcSource.make({
+    logger: Env.logger,
         url: mock.url,
         chain,
         onEventRegistrations: [eventConfig],
@@ -840,7 +844,7 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
             },
             ~itemsTarget=5000,
             ~retry=0,
-            ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RpcSource response too large"}),
+            ~logger=Env.logger,
           )
           None
         } catch {
@@ -943,6 +947,7 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
       })
 
       let source = RpcSource.make({
+    logger: Env.logger,
         url: mock.url,
         chain,
         onEventRegistrations: [eventConfig],
@@ -969,7 +974,7 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
             },
             ~itemsTarget=5000,
             ~retry=0,
-            ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RpcSource re-grow"}),
+            ~logger=Env.logger,
           )
           ()
         } catch {
@@ -1093,6 +1098,7 @@ describe("RpcSource - getItemsOrThrow classifies real provider block-range error
       })
 
       let source = RpcSource.make({
+    logger: Env.logger,
         url: mock.url,
         chain,
         onEventRegistrations: [eventConfig],
@@ -1118,7 +1124,7 @@ describe("RpcSource - getItemsOrThrow classifies real provider block-range error
             },
             ~itemsTarget=5000,
             ~retry=0,
-            ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RpcSource classify " ++ name}),
+            ~logger=Env.logger,
           )
           None
         } catch {
@@ -1187,6 +1193,7 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
       )
 
       let source = RpcSource.make({
+    logger: Env.logger,
         url: mock.url,
         chain,
         onEventRegistrations: [eventConfig],
@@ -1213,7 +1220,7 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
               },
               ~itemsTarget=5000,
               ~retry,
-              ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RpcSource missing transaction data"}),
+              ~logger=Env.logger,
             )
             None
           } catch {
@@ -1339,6 +1346,7 @@ describe("RpcSource - getItemsOrThrow fans out multiple selections", () => {
       )
 
       let source = RpcSource.make({
+    logger: Env.logger,
         url: mock.url,
         chain,
         onEventRegistrations: [eventConfig],
@@ -1363,7 +1371,7 @@ describe("RpcSource - getItemsOrThrow fans out multiple selections", () => {
           },
           ~itemsTarget=5000,
           ~retry=0,
-          ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RpcSource fan-out"}),
+          ~logger=Env.logger,
         )
         mock.close()
         page
@@ -1467,6 +1475,7 @@ describe("RpcSource - builds partition log selections end to end", () => {
         }
       )
       let source = RpcSource.make({
+    logger: Env.logger,
         url: mock.url,
         chain,
         onEventRegistrations: allRegistrations,
@@ -1491,7 +1500,7 @@ describe("RpcSource - builds partition log selections end to end", () => {
           },
           ~itemsTarget=5000,
           ~retry=0,
-          ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RpcSource selection e2e"}),
+          ~logger=Env.logger,
         )
         let filters =
           mock.requests
@@ -1557,6 +1566,7 @@ describe("RpcSource - getItemsOrThrow with a skip-all event filter", () => {
       )
 
       let source = RpcSource.make({
+    logger: Env.logger,
         url: mock.url,
         chain,
         onEventRegistrations: [eventConfig],
@@ -1579,7 +1589,7 @@ describe("RpcSource - getItemsOrThrow with a skip-all event filter", () => {
           },
           ~itemsTarget=5000,
           ~retry=0,
-          ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RpcSource skip-all"}),
+          ~logger=Env.logger,
         )
         mock.close()
         page
@@ -1718,6 +1728,7 @@ describe("RpcSource - getItemsOrThrow scopes filters to each contract's addresse
 
       let addressesByContractName = Dict.fromArray([("ContractA", [addrA]), ("ContractB", [addrB])])
       let source = RpcSource.make({
+    logger: Env.logger,
         url: mock.url,
         chain,
         onEventRegistrations: [eventA, eventB],
@@ -1740,7 +1751,7 @@ describe("RpcSource - getItemsOrThrow scopes filters to each contract's addresse
           },
           ~itemsTarget=5000,
           ~retry=0,
-          ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "RpcSource pooled leak"}),
+          ~logger=Env.logger,
         )
         mock.close()
         page

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -754,6 +754,7 @@ describe("RpcSource - empty selection", () => {
         ~itemsTarget=5000,
         ~retry=0,
         ~logger=Env.logger,
+        ~params=Internal.toLogParams({"test": true}),
       )
       None
     } catch {
@@ -845,6 +846,7 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
             ~itemsTarget=5000,
             ~retry=0,
             ~logger=Env.logger,
+            ~params=Internal.toLogParams({"test": true}),
           )
           None
         } catch {
@@ -975,6 +977,7 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
             ~itemsTarget=5000,
             ~retry=0,
             ~logger=Env.logger,
+            ~params=Internal.toLogParams({"test": true}),
           )
           ()
         } catch {
@@ -1125,6 +1128,7 @@ describe("RpcSource - getItemsOrThrow classifies real provider block-range error
             ~itemsTarget=5000,
             ~retry=0,
             ~logger=Env.logger,
+            ~params=Internal.toLogParams({"test": true}),
           )
           None
         } catch {
@@ -1221,6 +1225,7 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
               ~itemsTarget=5000,
               ~retry,
               ~logger=Env.logger,
+              ~params=Internal.toLogParams({"test": true}),
             )
             None
           } catch {
@@ -1372,6 +1377,7 @@ describe("RpcSource - getItemsOrThrow fans out multiple selections", () => {
           ~itemsTarget=5000,
           ~retry=0,
           ~logger=Env.logger,
+          ~params=Internal.toLogParams({"test": true}),
         )
         mock.close()
         page
@@ -1501,6 +1507,7 @@ describe("RpcSource - builds partition log selections end to end", () => {
           ~itemsTarget=5000,
           ~retry=0,
           ~logger=Env.logger,
+          ~params=Internal.toLogParams({"test": true}),
         )
         let filters =
           mock.requests
@@ -1590,6 +1597,7 @@ describe("RpcSource - getItemsOrThrow with a skip-all event filter", () => {
           ~itemsTarget=5000,
           ~retry=0,
           ~logger=Env.logger,
+          ~params=Internal.toLogParams({"test": true}),
         )
         mock.close()
         page
@@ -1752,6 +1760,7 @@ describe("RpcSource - getItemsOrThrow scopes filters to each contract's addresse
           ~itemsTarget=5000,
           ~retry=0,
           ~logger=Env.logger,
+          ~params=Internal.toLogParams({"test": true}),
         )
         mock.close()
         page

--- a/scenarios/test_codegen/test/RpcSource_test.res
+++ b/scenarios/test_codegen/test/RpcSource_test.res
@@ -754,7 +754,6 @@ describe("RpcSource - empty selection", () => {
         ~itemsTarget=5000,
         ~retry=0,
         ~logger=Env.logger,
-        ~params=Internal.toLogParams({"test": true}),
       )
       None
     } catch {
@@ -846,7 +845,6 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
             ~itemsTarget=5000,
             ~retry=0,
             ~logger=Env.logger,
-            ~params=Internal.toLogParams({"test": true}),
           )
           None
         } catch {
@@ -977,7 +975,6 @@ describe("RpcSource - getItemsOrThrow on response-too-large", () => {
             ~itemsTarget=5000,
             ~retry=0,
             ~logger=Env.logger,
-            ~params=Internal.toLogParams({"test": true}),
           )
           ()
         } catch {
@@ -1128,7 +1125,6 @@ describe("RpcSource - getItemsOrThrow classifies real provider block-range error
             ~itemsTarget=5000,
             ~retry=0,
             ~logger=Env.logger,
-            ~params=Internal.toLogParams({"test": true}),
           )
           None
         } catch {
@@ -1225,7 +1221,6 @@ describe("RpcSource - getItemsOrThrow with missing transaction data", () => {
               ~itemsTarget=5000,
               ~retry,
               ~logger=Env.logger,
-              ~params=Internal.toLogParams({"test": true}),
             )
             None
           } catch {
@@ -1377,7 +1372,6 @@ describe("RpcSource - getItemsOrThrow fans out multiple selections", () => {
           ~itemsTarget=5000,
           ~retry=0,
           ~logger=Env.logger,
-          ~params=Internal.toLogParams({"test": true}),
         )
         mock.close()
         page
@@ -1507,7 +1501,6 @@ describe("RpcSource - builds partition log selections end to end", () => {
           ~itemsTarget=5000,
           ~retry=0,
           ~logger=Env.logger,
-          ~params=Internal.toLogParams({"test": true}),
         )
         let filters =
           mock.requests
@@ -1597,7 +1590,6 @@ describe("RpcSource - getItemsOrThrow with a skip-all event filter", () => {
           ~itemsTarget=5000,
           ~retry=0,
           ~logger=Env.logger,
-          ~params=Internal.toLogParams({"test": true}),
         )
         mock.close()
         page
@@ -1760,7 +1752,6 @@ describe("RpcSource - getItemsOrThrow scopes filters to each contract's addresse
           ~itemsTarget=5000,
           ~retry=0,
           ~logger=Env.logger,
-          ~params=Internal.toLogParams({"test": true}),
         )
         mock.close()
         page

--- a/scenarios/test_codegen/test/SourceBlockHashes_test.res
+++ b/scenarios/test_codegen/test/SourceBlockHashes_test.res
@@ -127,7 +127,6 @@ let invoke = async (source: Source.t, ~fromBlock, ~toBlock) => {
     ~itemsTarget=5000,
     ~retry=0,
     ~logger=Env.logger,
-    ~params=Internal.toLogParams({"test": true}),
   ) catch {
   | Source.GetItemsError(err) =>
     let detail = switch err {

--- a/scenarios/test_codegen/test/SourceBlockHashes_test.res
+++ b/scenarios/test_codegen/test/SourceBlockHashes_test.res
@@ -92,6 +92,7 @@ let makeSelection = (): FetchState.selection => {
 
 let makeHyperSyncSource = () =>
   EvmHyperSyncSource.make({
+    logger: Env.logger,
     chain,
     endpointUrl: "https://eth.hypersync.xyz",
     onEventRegistrations: [pairCreatedRegistration],
@@ -105,6 +106,7 @@ let makeHyperSyncSource = () =>
 
 let makeRpcSource = () =>
   RpcSource.make({
+    logger: Env.logger,
     url: `https://eth.rpc.hypersync.xyz/${testApiToken}`,
     chain,
     onEventRegistrations: [pairCreatedRegistration],
@@ -124,7 +126,7 @@ let invoke = async (source: Source.t, ~fromBlock, ~toBlock) => {
     ~selection=makeSelection(),
     ~itemsTarget=5000,
     ~retry=0,
-    ~logger=Logging.createChildFrom(~logger=Env.logger, ~params={"test": "SourceBlockHashes"}),
+    ~logger=Env.logger,
   ) catch {
   | Source.GetItemsError(err) =>
     let detail = switch err {

--- a/scenarios/test_codegen/test/SourceBlockHashes_test.res
+++ b/scenarios/test_codegen/test/SourceBlockHashes_test.res
@@ -127,6 +127,7 @@ let invoke = async (source: Source.t, ~fromBlock, ~toBlock) => {
     ~itemsTarget=5000,
     ~retry=0,
     ~logger=Env.logger,
+    ~params=Internal.toLogParams({"test": true}),
   ) catch {
   | Source.GetItemsError(err) =>
     let detail = switch err {

--- a/scenarios/test_codegen/test/fixtures/LogTesting.res
+++ b/scenarios/test_codegen/test/fixtures/LogTesting.res
@@ -13,59 +13,57 @@ open Logging
 // The process base logger, built from LOG_STRATEGY/LOG_LEVEL env vars by Env.
 let logger = Env.logger
 
-// Per-item loggers are built by the ecosystem (the runtime gets it from
-// `config.ecosystem`); this standalone fixture constructs one directly.
-let ecosystem = Evm.make(~logger)
+let ecosystem = Evm.make()
 
 // Testing usage:
-logger->childTrace("By default - This trace message should only be seen in the log file.")
-logger->childDebug("By default - This debug message should only be seen in the log file.")
+logger->trace("By default - This trace message should only be seen in the log file.")
+logger->debug("By default - This debug message should only be seen in the log file.")
 
 exception SomethingWrong({myMessage: string})
 
-logger->childInfo(`##Current log level: ${(logger->getLevel :> string)}`)
-logger->childTrace("This is an trace message.")
-logger->childDebug("This is a debug message.")
-logger->childInfo("This is an info message.")
-logger->childWarn("This is a warning message.")
-logger->childErrorWithExn(SomethingWrong({myMessage: "example exception"}), "This is an error message.")
-logger->childFatal(("This is a fatal message.", "another"))
+logger->info(`##Current log level: ${(logger->getLevel :> string)}`)
+logger->trace("This is an trace message.")
+logger->debug("This is a debug message.")
+logger->info("This is an info message.")
+logger->warn("This is a warning message.")
+logger->errorWithExn(SomethingWrong({myMessage: "example exception"}), "This is an error message.")
+logger->fatal(("This is a fatal message.", "another"))
 
 logger->setLogLevel(#debug)
-logger->childInfo(`##Current log level: ${(logger->getLevel :> string)}`)
-logger->childTrace("This is an trace message. (should not be printed)")
-logger->childDebug("This is a debug message.")
-logger->childInfo("This is an info message.")
-logger->childWarn("This is a warning message.")
-logger->childErrorWithExn(SomethingWrong({myMessage: "example exception"}), "This is an error message.")
-logger->childFatal("This is a fatal message.")
+logger->info(`##Current log level: ${(logger->getLevel :> string)}`)
+logger->trace("This is an trace message. (should not be printed)")
+logger->debug("This is a debug message.")
+logger->info("This is an info message.")
+logger->warn("This is a warning message.")
+logger->errorWithExn(SomethingWrong({myMessage: "example exception"}), "This is an error message.")
+logger->fatal("This is a fatal message.")
 
 logger->setLogLevel(#info)
-logger->childInfo(`##Current log level: ${(logger->getLevel :> string)}`)
-logger->childTrace("This is an trace message. (should not be printed)")
-logger->childDebug("This is a debug message. (should not be printed)")
-logger->childInfo("This is an info message.")
-logger->childWarn("This is a warning message.")
-logger->childErrorWithExn(SomethingWrong({myMessage: "example exception"}), "This is an error message.")
-logger->childFatal("This is a fatal message.")
+logger->info(`##Current log level: ${(logger->getLevel :> string)}`)
+logger->trace("This is an trace message. (should not be printed)")
+logger->debug("This is a debug message. (should not be printed)")
+logger->info("This is an info message.")
+logger->warn("This is a warning message.")
+logger->errorWithExn(SomethingWrong({myMessage: "example exception"}), "This is an error message.")
+logger->fatal("This is a fatal message.")
 
 @send external udebug: (Pino.t, 'a) => unit = "udebug"
 @send external uinfo: (Pino.t, 'a) => unit = "uinfo"
 @send external uwarn: (Pino.t, 'a) => unit = "uwarn"
 @send external uerror: (Pino.t, 'a) => unit = "uerror"
 logger->setLogLevel(#udebug)
-logger->childInfo(`##Current log level: ${(logger->getLevel :> string)}`)
+logger->info(`##Current log level: ${(logger->getLevel :> string)}`)
 
 let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem
 
-let userLogger = Ecosystem.getItemUserLogger(item, ~ecosystem)
+let userLogger = Ecosystem.getItemUserLogger(item, ~ecosystem, ~logger)
 userLogger.debug("This is a user debug message.", ~params={"child": "userLogs debug"})
 userLogger.info("This is a user info message.", ~params={"child": "userLogs debug"})
 userLogger.warn("This is a user warn message.", ~params={"child": "userLogs debug"})
 userLogger.error("This is a user error message.", ~params={"child": "userLogs debug"})
 
 logger->setLogLevel(#uinfo)
-logger->childInfo(`##Current log level: ${(logger->getLevel :> string)}`)
+logger->info(`##Current log level: ${(logger->getLevel :> string)}`)
 
 userLogger.debug("This is a user debug message.", ~params={"child": "userLogs info"})
 userLogger.info("This is a user info message.", ~params={"child": "userLogs info"})
@@ -79,39 +77,39 @@ userLogger.errorWithExn(
   SomethingWrong({myMessage: "example exception"}),
 )
 logger->setLogLevel(#uwarn)
-logger->childInfo(`##Current log level: ${(logger->getLevel :> string)}`)
+logger->info(`##Current log level: ${(logger->getLevel :> string)}`)
 userLogger.debug("This is a user debug message.", ~params={"child": "userLogs warn"})
 userLogger.info("This is a user info message.", ~params={"child": "userLogs warn"})
 userLogger.warn("This is a user warn message.", ~params={"child": "userLogs warn"})
 userLogger.error("This is a user error message.", ~params={"child": "userLogs warn"})
 
 logger->setLogLevel(#uerror)
-logger->childInfo(`##Current log level: ${(logger->getLevel :> string)}`)
+logger->info(`##Current log level: ${(logger->getLevel :> string)}`)
 userLogger.debug("This is a user debug message.", ~params={"child": "userLogs error"})
 userLogger.info("This is a user info message.", ~params={"child": "userLogs error"})
 userLogger.warn("This is a user warn message.", ~params={"child": "userLogs error"})
 userLogger.error("This is a user error message.", ~params={"child": "userLogs error"})
 
 logger->setLogLevel(#warn)
-logger->childInfo(`##Current log level: ${(logger->getLevel :> string)}`)
-logger->childTrace("This is an trace message. (should not be printed)")
-logger->childDebug("This is a debug message. (should not be printed)")
-logger->childInfo("This is an info message. (should not be printed)")
-logger->childWarn("This is a warning message.")
-logger->childErrorWithExn(SomethingWrong({myMessage: "example exception"}), "This is an error message.")
-logger->childFatal("This is a fatal message.")
+logger->info(`##Current log level: ${(logger->getLevel :> string)}`)
+logger->trace("This is an trace message. (should not be printed)")
+logger->debug("This is a debug message. (should not be printed)")
+logger->info("This is an info message. (should not be printed)")
+logger->warn("This is a warning message.")
+logger->errorWithExn(SomethingWrong({myMessage: "example exception"}), "This is an error message.")
+logger->fatal("This is a fatal message.")
 
 logger->setLogLevel(#error)
-logger->childInfo(`##Current log level: ${(logger->getLevel :> string)}`)
-logger->childTrace("This is an trace message. (should not be printed)")
-logger->childDebug("This is a debug message. (should not be printed)")
-logger->childInfo("This is an info message. (should not be printed)")
-logger->childWarn("This is a warning message. (should not be printed)")
-logger->childErrorWithExn(SomethingWrong({myMessage: "example exception"}), "This is an error message.")
-logger->childFatal("This is a fatal message.")
+logger->info(`##Current log level: ${(logger->getLevel :> string)}`)
+logger->trace("This is an trace message. (should not be printed)")
+logger->debug("This is a debug message. (should not be printed)")
+logger->info("This is an info message. (should not be printed)")
+logger->warn("This is a warning message. (should not be printed)")
+logger->errorWithExn(SomethingWrong({myMessage: "example exception"}), "This is an error message.")
+logger->fatal("This is a fatal message.")
 
 // Logging also works with objects of all shapes and sizes
-logger->childFatal({
+logger->fatal({
   "this": "is",
   "a": "fatal",
   "message": "object",

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -375,6 +375,14 @@ let installMockSourceRegistrations = (
     }
   })
 
+// Shared by every mock indexer: nothing disposes one, so a logger per instance
+// would leak a handle per instance. Silent unless LOG_LEVEL is set, in which
+// case the process logger already has the requested level.
+let logger = switch Env.userLogLevel {
+| Some(_) => Env.logger
+| None => Env.makeLogger(~userLogLevel=#silent)
+}
+
 module Indexer = {
   type metric = {
     value: string,
@@ -395,8 +403,6 @@ module Indexer = {
     metric: string => promise<array<metric>>,
     restart: unit => promise<t>,
     graphql: 'data. string => promise<graphqlResponse<'data>>,
-    // Releases this instance's logger.
-    close: unit => promise<unit>,
   }
 
   type chainConfig = {
@@ -431,9 +437,6 @@ module Indexer = {
     // exercise races between in-flight writes and the indexer loop.
     ~mapStorage: Persistence.storage => Persistence.storage=storage => storage,
   ) => {
-    // A per-instance logger, silent unless LOG_LEVEL is set. Never the process
-    // logger — muting one mock indexer must not mute anything else.
-    let logger = Env.makeLogger(~userLogLevel=Env.userLogLevel->Option.getOr(#silent))
 
     // The full (un-narrowed) config. Handlers register against this so every
     // chain resolves once; `finishRegistration` then narrows to the per-test
@@ -714,7 +717,6 @@ module Indexer = {
           }
         )
       },
-      close: () => logger->Logging.close,
       restart: async () => {
         // Persist before restarting, else the resumed indexer loses uncommitted state.
         await state->Writing.flush
@@ -727,7 +729,6 @@ module Indexer = {
         while state->IndexerState.isProcessing || state->IndexerState.writeFiber->Option.isSome {
           await Utils.delay(1)
         }
-        await logger->Logging.close
         await make(
           ~chains,
           ~config=?customConfig,
@@ -930,7 +931,7 @@ module Source = {
           poweredByHyperSync: false,
           chain,
           pollingInterval,
-          getBlockHashes: implement(#getBlockHashes, (~blockNumbers, ~logger as _, ~params as _) => {
+          getBlockHashes: implement(#getBlockHashes, (~blockNumbers, ~logger as _) => {
             getBlockHashesCalls->Array.push(blockNumbers)->ignore
             Promise.make((resolve, _reject) => {
               getBlockHashesResolveFns->Array.push(resolve)->ignore
@@ -954,7 +955,6 @@ module Source = {
             ~itemsTarget as _,
             ~retry,
             ~logger as _,
-            ~params as _,
           ) => {
             keepOnlyPendingCalls(~array=getItemsOrThrowCalls, ~fn=(~resolve, ~reject) => {
               let payload = {

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -380,7 +380,12 @@ let installMockSourceRegistrations = (
 // case the process logger already has the requested level.
 let logger = switch Env.userLogLevel {
 | Some(_) => Env.logger
-| None => Env.makeLogger(~userLogLevel=#silent)
+| None =>
+  let logger = Env.makeLogger(~userLogLevel=#silent)
+  // The file-backed strategies build the logger at their own file level and
+  // ignore `userLogLevel`, so silence has to be set on the instance.
+  logger->Logging.setLogLevel(#silent)
+  logger
 }
 
 module Indexer = {
@@ -496,7 +501,7 @@ module Indexer = {
     let storage = mapStorage(
       PgStorage.makeStorageFromEnv(~logger, ~config, ~sql, ~pgSchema, ~isHasuraEnabled=enableHasura),
     )
-    let persistence = PgStorage.makePersistenceFromConfig(~logger=Env.logger, ~config, ~storage)
+    let persistence = PgStorage.makePersistenceFromConfig(~logger, ~config, ~storage)
 
     let onError = switch onError {
     | Some(onError) => onError

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -395,6 +395,8 @@ module Indexer = {
     metric: string => promise<array<metric>>,
     restart: unit => promise<t>,
     graphql: 'data. string => promise<graphqlResponse<'data>>,
+    // Releases this instance's logger.
+    close: unit => promise<unit>,
   }
 
   type chainConfig = {
@@ -712,6 +714,7 @@ module Indexer = {
           }
         )
       },
+      close: () => logger->Logging.close,
       restart: async () => {
         // Persist before restarting, else the resumed indexer loses uncommitted state.
         await state->Writing.flush
@@ -724,6 +727,7 @@ module Indexer = {
         while state->IndexerState.isProcessing || state->IndexerState.writeFiber->Option.isSome {
           await Utils.delay(1)
         }
+        await logger->Logging.close
         await make(
           ~chains,
           ~config=?customConfig,
@@ -926,7 +930,7 @@ module Source = {
           poweredByHyperSync: false,
           chain,
           pollingInterval,
-          getBlockHashes: implement(#getBlockHashes, (~blockNumbers, ~logger as _) => {
+          getBlockHashes: implement(#getBlockHashes, (~blockNumbers, ~logger as _, ~params as _) => {
             getBlockHashesCalls->Array.push(blockNumbers)->ignore
             Promise.make((resolve, _reject) => {
               getBlockHashesResolveFns->Array.push(resolve)->ignore
@@ -950,6 +954,7 @@ module Source = {
             ~itemsTarget as _,
             ~retry,
             ~logger as _,
+            ~params as _,
           ) => {
             keepOnlyPendingCalls(~array=getItemsOrThrowCalls, ~fn=(~resolve, ~reject) => {
               let payload = {

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -17,9 +17,9 @@ let defaultPersistence = () =>
   | Some(persistence) => persistence
   | None =>
     let config = Config.load()
-    let persistence = PgStorage.makePersistenceFromConfig(
+    let persistence = PgStorage.makePersistenceFromConfig(~logger=Env.logger, 
       ~config,
-      ~storage=PgStorage.makeStorageFromEnv(
+      ~storage=PgStorage.makeStorageFromEnv(~logger=Env.logger, 
         ~config,
         ~sql=PgStorage.makeClient(),
         ~pgSchema=Env.Db.publicSchema,
@@ -49,7 +49,7 @@ module InMemoryStore = {
     | Some(config) => config
     | None => Config.load()
     }
-    let indexerState = IndexerState.make(
+    let indexerState = IndexerState.make(~logger=Env.logger, 
       ~config,
       ~persistence=defaultPersistence(),
       // A trivial chain state map for store-only tests that never run the loop.
@@ -229,7 +229,7 @@ module Storage = {
     | None => Config.load()
     }
     {
-      ...PgStorage.makePersistenceFromConfig(~config, ~storage=storageMock.storage),
+      ...PgStorage.makePersistenceFromConfig(~logger=Env.logger, ~config, ~storage=storageMock.storage),
       storageStatus: Ready({
         cleanRun: false,
         cache: Dict.make(),
@@ -429,11 +429,9 @@ module Indexer = {
     // exercise races between in-flight writes and the indexer loop.
     ~mapStorage: Persistence.storage => Persistence.storage=storage => storage,
   ) => {
-    // Silence logs by default in test mode unless LOG_LEVEL is explicitly set
-    switch Env.userLogLevel {
-    | None => Env.logger->Logging.setLogLevel(#silent)
-    | Some(_) => ()
-    }
+    // A per-instance logger, silent unless LOG_LEVEL is set. Never the process
+    // logger — muting one mock indexer must not mute anything else.
+    let logger = Env.makeLogger(~userLogLevel=Env.userLogLevel->Option.getOr(#silent))
 
     // The full (un-narrowed) config. Handlers register against this so every
     // chain resolves once; `finishRegistration` then narrows to the per-test
@@ -479,21 +477,21 @@ module Indexer = {
     // Register handlers once against the full chain set (idempotent +
     // import-cached, so re-`make` reuses), then narrow to this run's chains.
     switch customConfig {
-    | None => let _ = await HandlerLoader.registerAllHandlers(~config=baseConfig)
+    | None => let _ = await HandlerLoader.registerAllHandlers(~config=baseConfig, ~logger)
     | Some(_) =>
       // A supplied config has no handler files on disk; register inline
       // handlers (if any) through the same public registry lifecycle.
       HandlerRegister.startRegistration(~config=baseConfig)
     }
-    let registrationsByChainId = HandlerRegister.finishRegistration(~config)
+    let registrationsByChainId = HandlerRegister.finishRegistration(~config, ~logger)
     installMockSourceRegistrations(~config, ~registrationsByChainId)
 
     let sql = PgStorage.makeClient()
     let pgSchema = Env.Db.publicSchema
     let storage = mapStorage(
-      PgStorage.makeStorageFromEnv(~config, ~sql, ~pgSchema, ~isHasuraEnabled=enableHasura),
+      PgStorage.makeStorageFromEnv(~logger, ~config, ~sql, ~pgSchema, ~isHasuraEnabled=enableHasura),
     )
-    let persistence = PgStorage.makePersistenceFromConfig(~config, ~storage)
+    let persistence = PgStorage.makePersistenceFromConfig(~logger=Env.logger, ~config, ~storage)
 
     let onError = switch onError {
     | Some(onError) => onError
@@ -519,7 +517,7 @@ module Indexer = {
       ~reset,
     )
 
-    let state = IndexerState.makeFromDbState(
+    let state = IndexerState.makeFromDbState(~logger, 
       ~initialState=persistence->Persistence.getInitializedState,
       ~config,
       ~persistence,

--- a/scenarios/test_codegen/test/lib_tests/ChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ChainState_test.res
@@ -45,7 +45,7 @@ let makeResumedChainState = (
 }
 
 let makeChainState = resumedChainState =>
-  ChainState.makeFromDbState(
+  ChainState.makeFromDbState(~logger=Env.logger, 
     baseChainConfig,
     ~resumedChainState,
     ~reorgCheckpoints=[],

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -67,7 +67,7 @@ let makeChainState = (
     ~fetchState,
     ~onEventRegistrations,
     ~indexingAddresses,
-    ~sourceManager=SourceManager.make(~sources=[mockSource.source], ~isRealtime=false),
+    ~sourceManager=SourceManager.make(~logger=Env.logger, ~sources=[mockSource.source], ~isRealtime=false),
     ~reorgDetection=ReorgDetection.make(
       ~chainReorgCheckpoints=[],
       ~maxReorgDepth=200,
@@ -141,7 +141,7 @@ let makeFetchingChainState = (
     ~chainConfig={...baseChainConfig, id: chainId},
     ~fetchState,
     ~indexingAddresses,
-    ~sourceManager=SourceManager.make(~sources=[mockSource.source], ~isRealtime=false),
+    ~sourceManager=SourceManager.make(~logger=Env.logger, ~sources=[mockSource.source], ~isRealtime=false),
     ~reorgDetection=ReorgDetection.make(
       ~chainReorgCheckpoints=[],
       ~maxReorgDepth=200,
@@ -171,7 +171,7 @@ let makeCrossChainState = (~chainStatesList, ~isRealtime=false, ~targetBufferSiz
   chainStatesList->Array.forEach(cs =>
     chainStates->Utils.Dict.setByInt((cs->ChainState.chainConfig).id, cs)
   )
-  CrossChainState.make(~chainStates, ~isInReorgThreshold=false, ~isRealtime, ~targetBufferSize)
+  CrossChainState.make(~logger=Env.logger, ~chainStates, ~isInReorgThreshold=false, ~isRealtime, ~targetBufferSize)
 }
 
 let makeRegistration = (~contractName, ~index): Internal.onEventRegistration =>
@@ -477,7 +477,7 @@ describe("CrossChainState fetch control", () => {
         ~chainConfig={...baseChainConfig, id: 1},
         ~fetchState=fetchState1,
         ~indexingAddresses=indexingAddresses1,
-        ~sourceManager=SourceManager.make(~sources=[mockSource1.source], ~isRealtime=false),
+        ~sourceManager=SourceManager.make(~logger=Env.logger, ~sources=[mockSource1.source], ~isRealtime=false),
         ~reorgDetection=ReorgDetection.make(
           ~chainReorgCheckpoints=[],
           ~maxReorgDepth=200,

--- a/scenarios/test_codegen/test/lib_tests/EntityHistory_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EntityHistory_test.res
@@ -138,7 +138,7 @@
 //   })
 
 //   Async.it("Creating tables and functions works", async () => {
-//     let storage = PgStorage.make(
+//     let storage = PgStorage.make(~logger=Env.logger, 
 //       ~sql=Db.sql,
 //       ~pgSchema=Env.Db.publicSchema,
 //       ~pgUser=Env.Db.user,
@@ -540,7 +540,7 @@
 //   Async.beforeEach(async () => {
 //     try {
 //       let _ = DbHelpers.resetPostgresClient()
-//       let storage = PgStorage.make(
+//       let storage = PgStorage.make(~logger=Env.logger, 
 //         ~sql=Db.sql,
 //         ~pgSchema=Env.Db.publicSchema,
 //         ~pgUser=Env.Db.user,
@@ -718,7 +718,7 @@
 //   Async.beforeEach(async () => {
 //     try {
 //       let _ = DbHelpers.resetPostgresClient()
-//       let storage = PgStorage.make(
+//       let storage = PgStorage.make(~logger=Env.logger, 
 //         ~sql=Db.sql,
 //         ~pgSchema=Env.Db.publicSchema,
 //         ~pgUser=Env.Db.user,
@@ -854,7 +854,7 @@
 // describe_skip("Prune performance test", () => {
 //   Async.it("Print benchmark of prune function", async () => {
 //     let _ = DbHelpers.resetPostgresClient()
-//     let storage = PgStorage.make(
+//     let storage = PgStorage.make(~logger=Env.logger, 
 //       ~sql=Db.sql,
 //       ~pgSchema=Env.Db.publicSchema,
 //       ~pgUser=Env.Db.user,

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -855,7 +855,7 @@ describe("FetchState.registerDynamicContracts", () => {
     let (fetchState, indexingAddresses) = makeInitial()
 
     t.expect(
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, []),
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, []),
       ~message="Should return fetchState without updating it",
     ).toBe(fetchState)
   })
@@ -864,7 +864,7 @@ describe("FetchState.registerDynamicContracts", () => {
     let (fetchState, indexingAddresses) = makeInitial()
 
     t.expect(
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [
         makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress0)->dcToItem,
       ]),
       ~message="Should return fetchState without updating it",
@@ -884,7 +884,7 @@ describe("FetchState.registerDynamicContracts", () => {
       let item = dc->dcToItem
 
       let updatedFetchState =
-        fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [item])
+        fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [item])
 
       t.expect(
         (
@@ -923,7 +923,7 @@ describe("FetchState.registerDynamicContracts", () => {
         ~contractName="UnknownContract",
       )
       let item1 = dc1->dcToItem
-      let afterFirst = fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [item1])
+      let afterFirst = fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [item1])
 
       // Register the SAME address for a DIFFERENT contract name that also has
       // no events. This should be spliced out of the item (already tracked)
@@ -934,7 +934,7 @@ describe("FetchState.registerDynamicContracts", () => {
         ~contractName="AnotherUnknownContract",
       )
       let item2 = dc2->dcToItem
-      let afterSecond = afterFirst->FetchState.registerDynamicContracts(~indexingAddresses, [item2])
+      let afterSecond = afterFirst->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [item2])
 
       // Register the same address a third time for the same "UnknownContract"
       // - should dedup silently (no duplicate db write).
@@ -944,7 +944,7 @@ describe("FetchState.registerDynamicContracts", () => {
         ~contractName="UnknownContract",
       )
       let item3 = dc3->dcToItem
-      let afterThird = afterSecond->FetchState.registerDynamicContracts(~indexingAddresses, [item3])
+      let afterThird = afterSecond->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [item3])
 
       t.expect(
         (
@@ -984,6 +984,7 @@ describe("FetchState.registerDynamicContracts", () => {
 
       let updatedFetchState =
         fetchState->FetchState.registerDynamicContracts(
+          ~logger=Env.logger,
           ~indexingAddresses,
           [noEventsDc->dcToItem, regularDc->dcToItem],
         )
@@ -1037,7 +1038,7 @@ describe("FetchState.registerDynamicContracts", () => {
       let item = conflictingDc->dcToItem
 
       let updatedFetchState =
-        fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [item])
+        fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [item])
 
       t.expect(
         (
@@ -1072,7 +1073,7 @@ describe("FetchState.registerDynamicContracts", () => {
     let item2 = dc2->dcToItem
 
     let updatedFetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dc1->dcToItem, item2])
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [dc1->dcToItem, item2])
 
     t.expect(
       (
@@ -1115,6 +1116,7 @@ describe("FetchState.registerDynamicContracts", () => {
 
       let _updatedFetchState =
         fetchState->FetchState.registerDynamicContracts(
+          ~logger=Env.logger,
           ~indexingAddresses,
           [eventsDc->dcToItem, noEventsItem],
         )
@@ -1150,6 +1152,7 @@ describe("FetchState.registerDynamicContracts", () => {
 
       let updatedFetchState =
         fetchState->FetchState.registerDynamicContracts(
+          ~logger=Env.logger,
           ~indexingAddresses,
           [noEventsDc->dcToItem, eventsItem],
         )
@@ -1190,7 +1193,7 @@ describe("FetchState.registerDynamicContracts", () => {
     event->Internal.setItemDcs([dc1, dc2, dc3])
 
     let _updatedFetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [event])
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [event])
 
     // Verify that both DC2 and DC3 were registered correctly
     let hasAddress1 =
@@ -1213,7 +1216,7 @@ describe("FetchState.registerDynamicContracts", () => {
       let dc1 = makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress1)
 
       let fetchStateWithDc1 =
-        fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dc1->dcToItem])
+        fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [dc1->dcToItem])
 
       t.expect(
         (
@@ -1224,14 +1227,14 @@ describe("FetchState.registerDynamicContracts", () => {
       ).toEqual((1, 2))
 
       t.expect(
-        fetchStateWithDc1->FetchState.registerDynamicContracts(~indexingAddresses, [dc1->dcToItem]),
+        fetchStateWithDc1->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [dc1->dcToItem]),
         ~message="Calling it with the same dc for the second time shouldn't change anything",
       ).toBe(fetchStateWithDc1)
 
       // This is an edge case we currently don't cover
       // But show a warning in the logs
       t.expect(
-        fetchStateWithDc1->FetchState.registerDynamicContracts(~indexingAddresses, [
+        fetchStateWithDc1->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [
           makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress1)->dcToItem,
         ]),
         ~message=`BROKEN: Calling it with the same dc
@@ -1250,7 +1253,7 @@ describe("FetchState.registerDynamicContracts", () => {
     let dc4 = makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress4)
 
     let updatedFetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [
         dc1->dcToItem,
         dc2->dcToItem,
         dc3->dcToItem,
@@ -1317,7 +1320,7 @@ describe("FetchState.registerDynamicContracts", () => {
     // the one already populated by the registration above.
     let (fetchState, indexingAddresses) = makeInitial()
     let updatedFetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [
         dc1FromAnotherContract->dcToItem,
         dc2->dcToItem,
         dc3->dcToItem,
@@ -1437,7 +1440,7 @@ describe("FetchState.registerDynamicContracts", () => {
       )
 
       let updatedFetchState =
-        fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
+        fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [
           dc1->dcToItem,
           dc2->dcToItem,
           dc3->dcToItem,
@@ -1487,7 +1490,7 @@ describe("FetchState.registerDynamicContracts", () => {
     let dcItem1 = dc1->dcToItem
     let dcItem2 = dc2->dcToItem
 
-    let updatedFetchState = fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dcItem2, dcItem1])
+    let updatedFetchState = fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [dcItem2, dcItem1])
 
     t.expect(
       (dcItem1->Internal.getItemDcs, dcItem2->Internal.getItemDcs),
@@ -1554,7 +1557,7 @@ describe("FetchState.registerDynamicContracts", () => {
     let dc3 = makeDynContractRegistration(~blockNumber=300_000, ~contractAddress=mockAddress3)
 
     let updatedFetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, // Order of dcs doesn't matter
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, // Order of dcs doesn't matter
       // but they are not sorted in fetch state
       [dc1->dcToItem, dc3->dcToItem, dc2->dcToItem])
     t.expect(indexingAddresses->IndexingAddresses.size).toBe(4)
@@ -1735,6 +1738,7 @@ describe("FetchState.getNextQuery & integration", () => {
     let (fs, indexingAddresses) = makeInitial()
     let _ =
       fs->FetchState.registerDynamicContracts(
+        ~logger=Env.logger,
         ~indexingAddresses,
         [dc1->dcToItem, dc2->dcToItem, dc3->dcToItem],
       )
@@ -2057,8 +2061,8 @@ describe("FetchState.getNextQuery & integration", () => {
 
     let fetchStateWithDcs =
       fetchState
-      ->FetchState.registerDynamicContracts(~indexingAddresses, [dc2->dcToItem, dc1->dcToItem])
-      ->FetchState.registerDynamicContracts(~indexingAddresses, [dc3->dcToItem])
+      ->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [dc2->dcToItem, dc1->dcToItem])
+      ->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [dc3->dcToItem])
 
     t.expect(
       fetchStateWithDcs.optimizedPartitions.entities->Dict.valuesToArray,
@@ -2414,7 +2418,7 @@ describe("FetchState.getNextQuery & integration", () => {
       ~knownHeight,
     )
     let fetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [
         makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress2)->dcToItem,
       ])
 
@@ -2623,7 +2627,7 @@ describe("FetchState.getNextQuery & integration", () => {
       ~knownHeight,
     )
     let fetchState =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [
         makeDynContractRegistration(~blockNumber=2, ~contractAddress=mockAddress2)->dcToItem,
       ])
 
@@ -2950,7 +2954,7 @@ describe("FetchState unit tests for specific cases", () => {
     )
 
     let fetchStateWithDc =
-      fetchStateWithEvents->FetchState.registerDynamicContracts(~indexingAddresses, [
+      fetchStateWithEvents->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [
         makeDynContractRegistration(
           ~contractAddress=mockAddress1,
           ~blockNumber=registeringBlockNumber,
@@ -3069,7 +3073,7 @@ describe("FetchState unit tests for specific cases", () => {
 
     t.expect(
       fetchState
-      ->FetchState.registerDynamicContracts(~indexingAddresses, [
+      ->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [
         makeDynContractRegistration(~contractAddress=mockAddress1, ~blockNumber=2)->dcToItem,
       ])
       ->getEarliestEvent,
@@ -3210,7 +3214,7 @@ describe("FetchState unit tests for specific cases", () => {
 
       //Dynamic contract A registered at block 100
       let dcA = makeDynContractRegistration(~contractAddress=mockAddress2, ~blockNumber=100)
-      let fetchStateWithDcA = fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dcA->dcToItem])
+      let fetchStateWithDcA = fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [dcA->dcToItem])
 
       let queries = switch fetchStateWithDcA->FetchState.getNextQuery(
         ~chainTargetBlock=knownHeight,
@@ -3243,7 +3247,7 @@ describe("FetchState unit tests for specific cases", () => {
       //Next registration happens at block 200, between the first register and the upperbound of it's query
       let dc3 = makeDynContractRegistration(~contractAddress=mockAddress3, ~blockNumber=200)
       let fetchStateWithDcB =
-        fetchStateWithDcA->FetchState.registerDynamicContracts(~indexingAddresses, [dc3->dcToItem])
+        fetchStateWithDcA->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [dc3->dcToItem])
 
       let queries = switch fetchStateWithDcB->FetchState.getNextQuery(
         ~chainTargetBlock=knownHeight,
@@ -3623,7 +3627,7 @@ describe("Dynamic contracts with start blocks", () => {
 
     // Register the contract at block 100 (before its startBlock)
     let _ =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dynamicContract->dcToItem])
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [dynamicContract->dcToItem])
 
     // The contract should be registered in indexingAddresses
     t.expect(
@@ -3660,7 +3664,7 @@ describe("Dynamic contracts with start blocks", () => {
     )
 
     let _ =
-      fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [contract1->dcToItem, contract2->dcToItem])
+      fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [contract1->dcToItem, contract2->dcToItem])
 
     // Verify both contracts are registered with correct startBlocks
     let contract1Registered =
@@ -3754,7 +3758,7 @@ describe("FetchState proposes queries against the natural ceiling", () => {
       // affect this partition's own proposal.
       let dc = makeDynContractRegistration(~blockNumber=0, ~contractAddress=mockAddress1)
       let fetchStateWithTwoPartitions =
-        fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [dc->dcToItem])
+        fetchState->FetchState.registerDynamicContracts(~logger=Env.logger, ~indexingAddresses, [dc->dcToItem])
 
       // Buffer 15 items (blocks 6..20), far more than targetBufferSize=10. Admission
       // against the shared budget happens in CrossChainState, not here — getNextQuery

--- a/scenarios/test_codegen/test/lib_tests/IndexerLoop_test.res
+++ b/scenarios/test_codegen/test/lib_tests/IndexerLoop_test.res
@@ -33,7 +33,7 @@ let makeState = (~onError=errHandler => errHandler->ErrorHandling.raiseExn, ()) 
       ~chainConfig,
       ~fetchState,
       ~indexingAddresses,
-      ~sourceManager=SourceManager.make(
+      ~sourceManager=SourceManager.make(~logger=Env.logger, 
         ~sources=[mockSource.source],
         ~isRealtime=false,
       ),
@@ -48,7 +48,7 @@ let makeState = (~onError=errHandler => errHandler->ErrorHandling.raiseExn, ()) 
     chainStates->Utils.Dict.setByInt(chainConfig.id, chainState)
   })
 
-  IndexerState.make(
+  IndexerState.make(~logger=Env.logger, 
     ~config,
     ~persistence=MockIndexer.defaultPersistence(),
     ~chainStates,

--- a/scenarios/test_codegen/test/lib_tests/IndexerLoop_test.res
+++ b/scenarios/test_codegen/test/lib_tests/IndexerLoop_test.res
@@ -100,7 +100,7 @@ describe("Indexer loop", () => {
     let reportedErrors = ref(0)
     let state = makeState(~onError=_ => reportedErrors := reportedErrors.contents + 1, ())
 
-    state->IndexerState.errorExit(ErrorHandling.make(Utils.Error.make("boom")))
+    state->IndexerState.errorExit(ErrorHandling.make(Utils.Error.make("boom"), ~logger=Env.logger))
 
     t.expect(
       {"isStopped": state->IndexerState.isStopped, "reportedErrors": reportedErrors.contents},

--- a/scenarios/test_codegen/test/lib_tests/Persistence_test.res
+++ b/scenarios/test_codegen/test/lib_tests/Persistence_test.res
@@ -7,7 +7,7 @@ describe("Test Persistence layer init", () => {
   Async.it("Should initialize the persistence layer without the user entities", async t => {
     let storageMock = MockIndexer.Storage.make([#isInitialized, #resumeInitialState, #initialize])
 
-    let persistence = Persistence.make(~userEntities=[], ~allEnums=[], ~storage=storageMock.storage)
+    let persistence = Persistence.make(~logger=Env.logger, ~userEntities=[], ~allEnums=[], ~storage=storageMock.storage)
 
     t.expect(
       persistence.allEntities,
@@ -131,7 +131,7 @@ describe("Test Persistence layer init", () => {
   Async.it("Should skip initialization when storage is already initialized", async t => {
     let storageMock = MockIndexer.Storage.make([#isInitialized, #resumeInitialState])
 
-    let persistence = Persistence.make(~userEntities=[], ~allEnums=[], ~storage=storageMock.storage)
+    let persistence = Persistence.make(~logger=Env.logger, ~userEntities=[], ~allEnums=[], ~storage=storageMock.storage)
 
     let envioInfo = JSON.Encode.object(Dict.make())
 
@@ -181,7 +181,7 @@ Although it should load effect caches metadata.`,
     ~runCommand=runCmd,
   ) => {
     let storageMock = MockIndexer.Storage.make([#isInitialized, #resumeInitialState])
-    let persistence = Persistence.make(~userEntities=[], ~allEnums=[], ~storage=storageMock.storage)
+    let persistence = Persistence.make(~logger=Env.logger, ~userEntities=[], ~allEnums=[], ~storage=storageMock.storage)
     let resumePromise =
       persistence->Persistence.init(
         ~chainConfigs=[],

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -946,7 +946,7 @@ describe("PgStorage.makeStorageFromEnv ClickHouse env var validation", () => {
         storage: ({postgres: true, clickhouse: true}: Config.storage),
       }
       let message = switch try {
-        let _ = PgStorage.makeStorageFromEnv(~config)
+        let _ = PgStorage.makeStorageFromEnv(~logger=Env.logger, ~config)
         None
       } catch {
       | JsExn(e) => Some(e->JsExn.message->Option.getOr(""))
@@ -972,7 +972,7 @@ describe("PgStorage.makeStorageFromEnv ClickHouse env var validation", () => {
         storage: ({postgres: true, clickhouse: false}: Config.storage),
       }
       // Just ensure construction succeeds without touching ClickHouse env vars.
-      let _ = PgStorage.makeStorageFromEnv(~config)
+      let _ = PgStorage.makeStorageFromEnv(~logger=Env.logger, ~config)
       t.expect(true, ~message="Expected no throw when clickhouse is disabled").toBe(true)
     },
   )
@@ -996,7 +996,7 @@ describe("PgStorage.makeStorageFromEnv ClickHouse env var validation", () => {
         storage: ({postgres: true, clickhouse: true}: Config.storage),
       }
       let result = try {
-        let _ = PgStorage.makeStorageFromEnv(~config)
+        let _ = PgStorage.makeStorageFromEnv(~logger=Env.logger, ~config)
         Ok()
       } catch {
       | JsExn(e) => Error(e->JsExn.message->Option.getOr(""))

--- a/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
@@ -26,7 +26,7 @@ let makeReg = (~name, ~params): Internal.evmOnEventRegistration =>
     ~contractRegister=None,
     ~where=None,
     ~chainId=1,
-    ~onEventBlockFilterSchema=Evm.make(~logger=Env.logger).onEventBlockFilterSchema,
+    ~onEventBlockFilterSchema=Evm.make().onEventBlockFilterSchema,
   )
 
 let tokenA = makeReg(

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -88,7 +88,7 @@ let onNewBlockMock = () => {
 describe("SourceManager creation", () => {
   it("Successfully creates with a sync source", t => {
     let source = MockIndexer.Source.make([]).source
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[source])
     t.expect(sourceManager->SourceManager.getActiveSource).toBe(source)
   })
 
@@ -96,14 +96,14 @@ describe("SourceManager creation", () => {
     let fallback = MockIndexer.Source.make([], ~sourceFor=Fallback).source
     let sync0 = MockIndexer.Source.make([]).source
     let sync1 = MockIndexer.Source.make([]).source
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[fallback, sync0, sync1])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[fallback, sync0, sync1])
     t.expect(sourceManager->SourceManager.getActiveSource).toBe(sync0)
   })
 
   it("Prefers sync source over live source as initial active source", t => {
     let live = MockIndexer.Source.make([], ~sourceFor=Realtime).source
     let sync = MockIndexer.Source.make([]).source
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[live, sync])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[live, sync])
     // Sync is always preferred as initial active source (backfill mode)
     t.expect(sourceManager->SourceManager.getActiveSource).toBe(sync)
   })
@@ -111,19 +111,19 @@ describe("SourceManager creation", () => {
   it("Prefers live source over sync source as initial active source in live mode", t => {
     let sync = MockIndexer.Source.make([]).source
     let live = MockIndexer.Source.make([], ~sourceFor=Realtime).source
-    let sourceManager = SourceManager.make(~isRealtime=true, ~sources=[sync, live])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=true, ~sources=[sync, live])
     t.expect(sourceManager->SourceManager.getActiveSource).toBe(live)
   })
 
   it("Fails to create without primary sources", t => {
     t.expect(
       () => {
-        SourceManager.make(~isRealtime=false, ~sources=[])
+        SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[])
       },
     ).toThrowError("Invalid configuration, no data-source for historical sync provided")
     t.expect(
       () => {
-        SourceManager.make(
+        SourceManager.make(~logger=Env.logger, 
           ~isRealtime=false,
           ~sources=[MockIndexer.Source.make([], ~sourceFor=Fallback).source],
         )
@@ -196,7 +196,7 @@ describe("SourceManager source priority with Live sources", () => {
       let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Realtime)
       let fallbackMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Fallback)
       let newBlockStallTimeoutRealtime = 5
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[syncMock.source, liveMock.source, fallbackMock.source],
         ~newBlockStallTimeoutRealtime,
@@ -238,7 +238,7 @@ describe("SourceManager source priority with Live sources", () => {
       let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Realtime)
       let fallbackMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Fallback)
       let newBlockStallTimeoutRealtime = 5
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[syncMock.source, liveMock.source, fallbackMock.source],
         ~newBlockStallTimeoutRealtime,
@@ -287,7 +287,7 @@ describe("SourceManager source priority with Live sources", () => {
         ~sourceFor=Fallback,
       )
       let newBlockStallTimeoutRealtime = 0
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~newBlockStallTimeoutRealtime,
         ~sources=[syncMock.source, liveMock.source, fallbackMock.source],
@@ -338,7 +338,7 @@ describe("SourceManager source priority with Live sources", () => {
     async t => {
       let syncMock = MockIndexer.Source.make([#getHeightOrThrow])
       let fallbackMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Fallback)
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[syncMock.source, fallbackMock.source],
       )
@@ -523,7 +523,7 @@ describe("SourceManager fetchNext", () => {
   Async.it(
     "Executes full partitions in any order when we didn't reach concurency limit",
     async t => {
-      let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[source])
+      let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[source])
 
       let partition0 = mockFullPartition(~partitionIndex=0, ~latestFetchedBlockNumber=4)
       let partition1 = mockFullPartition(~partitionIndex=1, ~latestFetchedBlockNumber=5)
@@ -595,7 +595,7 @@ describe("SourceManager fetchNext", () => {
   Async.it(
     "Skips full partitions at the chain last block and the ones at the mergeBlock",
     async t => {
-      let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[source])
+      let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[source])
 
       let p0 = mockFullPartition(~partitionIndex=0, ~latestFetchedBlockNumber=4)
       let p1 = mockFullPartition(~partitionIndex=1, ~latestFetchedBlockNumber=5)
@@ -627,7 +627,7 @@ describe("SourceManager fetchNext", () => {
   )
 
   Async.it("Starts indexing from the initial state", async t => {
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[source])
 
     let waitForNewBlockMock = waitForNewBlockMock()
     let onNewBlockMock = onNewBlockMock()
@@ -673,7 +673,7 @@ describe("SourceManager fetchNext", () => {
   })
 
   Async.it("Waits for new block with knownHeight=0 even when all partitions are done", async t => {
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[source])
 
     let waitForNewBlockMock = waitForNewBlockMock()
     let onNewBlockMock = onNewBlockMock()
@@ -700,7 +700,7 @@ describe("SourceManager fetchNext", () => {
   })
 
   Async.it("Waits for new block when all partitions are at the knownHeight", async t => {
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[source])
 
     let p0 = mockFullPartition(~partitionIndex=0, ~latestFetchedBlockNumber=5)
     let p1 = mockFullPartition(~partitionIndex=1, ~latestFetchedBlockNumber=5)
@@ -741,7 +741,7 @@ describe("SourceManager fetchNext", () => {
   })
 
   Async.it("Restarts waiting for new block after a rollback", async t => {
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[source])
 
     let p0 = mockFullPartition(~partitionIndex=0, ~latestFetchedBlockNumber=5)
 
@@ -798,7 +798,7 @@ describe("SourceManager fetchNext", () => {
   })
 
   Async.it("Filters out partitions at the endBlock and at the head", async t => {
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[source])
 
     let executeQueryMock = executeQueryMock()
 
@@ -838,7 +838,7 @@ describe("SourceManager wait for new blocks", () => {
       let {source, getHeightOrThrowCalls, resolveGetHeightOrThrow} = MockIndexer.Source.make([
         #getHeightOrThrow,
       ])
-      let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[source])
+      let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[source])
 
       let p =
         sourceManager->SourceManager.waitForNewBlock(
@@ -859,7 +859,7 @@ describe("SourceManager wait for new blocks", () => {
     async t => {
       let mock0 = MockIndexer.Source.make([#getHeightOrThrow])
       let mock1 = MockIndexer.Source.make([#getHeightOrThrow])
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[mock0.source, mock1.source],
       )
@@ -899,7 +899,7 @@ describe("SourceManager wait for new blocks", () => {
   Async.it("Excludes live source from height fetch when isRealtime is false", async t => {
     let syncMock = MockIndexer.Source.make([#getHeightOrThrow])
     let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Realtime)
-    let sourceManager = SourceManager.make(
+    let sourceManager = SourceManager.make(~logger=Env.logger, 
       ~isRealtime=false,
       ~sources=[syncMock.source, liveMock.source],
     )
@@ -931,7 +931,7 @@ describe("SourceManager wait for new blocks", () => {
   Async.it("Includes live source in height fetch when isRealtime is true", async t => {
     let syncMock = MockIndexer.Source.make([#getHeightOrThrow])
     let liveMock = MockIndexer.Source.make([#getHeightOrThrow], ~sourceFor=Realtime)
-    let sourceManager = SourceManager.make(
+    let sourceManager = SourceManager.make(~logger=Env.logger, 
       ~isRealtime=false,
       ~sources=[syncMock.source, liveMock.source],
     )
@@ -968,7 +968,7 @@ describe("SourceManager wait for new blocks", () => {
       let pollingInterval1 = 2
       let mock0 = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval=pollingInterval0)
       let mock1 = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval=pollingInterval1)
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[mock0.source, mock1.source],
       )
@@ -1060,7 +1060,7 @@ describe("SourceManager wait for new blocks", () => {
       let initialRetryInterval = 4
       let mock0 = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval=pollingInterval0)
       let mock1 = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval=pollingInterval1)
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[mock0.source, mock1.source],
         ~getHeightRetryInterval=SourceManager.makeGetHeightRetryInterval(
@@ -1202,7 +1202,7 @@ describe("SourceManager wait for new blocks", () => {
         [#getHeightOrThrow],
         ~pollingInterval,
       )
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[sync.source, fallback.source],
         ~newBlockStallTimeout,
@@ -1335,7 +1335,7 @@ describe("SourceManager wait for new blocks", () => {
       let newBlockStallTimeout = 8
       let sync = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval)
 
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[sync.source],
         ~newBlockStallTimeout,
@@ -1394,7 +1394,7 @@ describe("SourceManager wait for new blocks", () => {
       let reducedPollingInterval = 10
       let sync = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval)
 
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[sync.source],
         ~stalledPollingInterval,
@@ -1451,7 +1451,7 @@ describe("SourceManager.executeQuery", () => {
     let {source, getItemsOrThrowCalls, resolveGetItemsOrThrow} = MockIndexer.Source.make([
       #getItemsOrThrow,
     ])
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[source])
     let p =
       sourceManager->SourceManager.executeQuery(
         ~query=mockQuery(),
@@ -1467,7 +1467,7 @@ describe("SourceManager.executeQuery", () => {
 
   Async.it("Rethrows unknown errors", async t => {
     let sourceMock = MockIndexer.Source.make([#getItemsOrThrow])
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[sourceMock.source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[sourceMock.source])
     let p =
       sourceManager->SourceManager.executeQuery(
         ~query=mockQuery(),
@@ -1488,7 +1488,7 @@ describe("SourceManager.executeQuery", () => {
 
   Async.it("Immediately retries with the suggested toBlock", async t => {
     let sourceMock = MockIndexer.Source.make([#getItemsOrThrow])
-    let sourceManager = SourceManager.make(
+    let sourceManager = SourceManager.make(~logger=Env.logger, 
       ~isRealtime=false,
       ~sources=[
         sourceMock.source,
@@ -1541,7 +1541,7 @@ describe("SourceManager.executeQuery", () => {
     async t => {
       let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
       let fallbackMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Fallback)
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[syncMock.source, fallbackMock.source],
       )
@@ -1657,7 +1657,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         ~sourceFor=Fallback,
       )
       let newBlockStallTimeout = 0
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~newBlockStallTimeout,
         ~sources=[syncMock.source, fallbackMock.source],
@@ -1715,7 +1715,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         ~sourceFor=Fallback,
       )
       let recoveryTimeout = 5.0
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~recoveryTimeout,
         ~sources=[syncMock.source, fallbackMock.source],
@@ -1814,7 +1814,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
   Async.it("Does not attempt recovery when active source is already a sync source", async t => {
     let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
     let recoveryTimeout = 0.0
-    let sourceManager = SourceManager.make(
+    let sourceManager = SourceManager.make(~logger=Env.logger, 
       ~isRealtime=false,
       ~sources=[syncMock.source],
       ~recoveryTimeout,
@@ -1846,7 +1846,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     async t => {
       let liveMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Realtime)
       let recoveryTimeout = 0.0
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=true,
         ~sources=[liveMock.source],
         ~recoveryTimeout,
@@ -1887,7 +1887,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         ~sourceFor=Fallback,
       )
       let newBlockStallTimeoutRealtime = 0
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~newBlockStallTimeoutRealtime,
         ~sources=[syncMock.source, liveMock.source, fallbackMock.source],
@@ -1941,7 +1941,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
       let fallbackMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Fallback)
       let recoveryTimeout = 5.0
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~recoveryTimeout,
         ~sources=[syncMock.source, fallbackMock.source],
@@ -2080,7 +2080,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
       let liveMock0 = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Realtime)
       let liveMock1 = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Realtime)
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[syncMock.source, liveMock0.source, liveMock1.source],
       )
@@ -2132,7 +2132,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     let syncMock0 = MockIndexer.Source.make([#getHeightOrThrow, #getItemsOrThrow])
     let syncMock1 = MockIndexer.Source.make([#getHeightOrThrow, #getItemsOrThrow])
     let newBlockStallTimeout = 0
-    let sourceManager = SourceManager.make(
+    let sourceManager = SourceManager.make(~logger=Env.logger, 
       ~isRealtime=false,
       ~newBlockStallTimeout,
       ~sources=[syncMock0.source, syncMock1.source],
@@ -2184,7 +2184,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     async t => {
       let syncMock0 = MockIndexer.Source.make([#getItemsOrThrow])
       let syncMock1 = MockIndexer.Source.make([#getItemsOrThrow])
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[syncMock0.source, syncMock1.source],
       )
@@ -2267,7 +2267,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let syncMock0 = MockIndexer.Source.make([#getItemsOrThrow])
       let syncMock1 = MockIndexer.Source.make([#getItemsOrThrow])
       let syncMock2 = MockIndexer.Source.make([#getItemsOrThrow])
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[syncMock0.source, syncMock1.source, syncMock2.source],
       )
@@ -2334,7 +2334,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
       let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
       let fallbackMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Fallback)
       let recoveryTimeout = 50.0
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[syncMock.source, fallbackMock.source],
         ~recoveryTimeout,
@@ -2427,7 +2427,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     let syncMock0 = MockIndexer.Source.make([#getItemsOrThrow])
     let syncMock1 = MockIndexer.Source.make([#getItemsOrThrow])
     let fallbackMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Fallback)
-    let sourceManager = SourceManager.make(
+    let sourceManager = SourceManager.make(~logger=Env.logger, 
       ~isRealtime=false,
       ~sources=[syncMock0.source, syncMock1.source, fallbackMock.source],
     )
@@ -2487,7 +2487,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
 
   Async.it("WithBackoff with single source retries with delay, no crash", async t => {
     let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
-    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[syncMock.source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[syncMock.source])
 
     let p =
       sourceManager->SourceManager.executeQuery(
@@ -2531,7 +2531,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     async t => {
       let syncMock0 = MockIndexer.Source.make([#getItemsOrThrow])
       let syncMock1 = MockIndexer.Source.make([#getItemsOrThrow])
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[syncMock0.source, syncMock1.source],
       )
@@ -2610,7 +2610,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
     let syncMock = MockIndexer.Source.make([#getItemsOrThrow])
     let liveMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Realtime)
     let fallbackMock = MockIndexer.Source.make([#getItemsOrThrow], ~sourceFor=Fallback)
-    let sourceManager = SourceManager.make(
+    let sourceManager = SourceManager.make(~logger=Env.logger, 
       ~isRealtime=false,
       ~sources=[syncMock.source, liveMock.source, fallbackMock.source],
     )
@@ -2682,7 +2682,7 @@ Retries 2 times on fallback, switches back to sync (oldest lastFailedAt).
         ~sourceFor=Realtime,
       )
       let newBlockStallTimeoutRealtime = 5
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=false,
         ~sources=[syncMock.source, liveMock.source],
         ~newBlockStallTimeoutRealtime,
@@ -2736,7 +2736,7 @@ describe("SourceManager height subscription", () => {
     "Creates subscription when getHeightOrThrow returns same height as knownHeight",
     async t => {
       let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
-      let sourceManager = SourceManager.make(~isRealtime=true, ~sources=[mock.source])
+      let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=true, ~sources=[mock.source])
 
       let p =
         sourceManager->SourceManager.waitForNewBlock(
@@ -2767,7 +2767,7 @@ describe("SourceManager height subscription", () => {
 
   Async.it("Uses cached height from subscription if higher than knownHeight", async t => {
     let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
-    let sourceManager = SourceManager.make(~isRealtime=true, ~sources=[mock.source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=true, ~sources=[mock.source])
 
     // First call - create subscription
     let p1 =
@@ -2799,7 +2799,7 @@ describe("SourceManager height subscription", () => {
     "Waits for next height event when subscription exists but height <= knownHeight",
     async t => {
       let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
-      let sourceManager = SourceManager.make(~isRealtime=true, ~sources=[mock.source])
+      let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=true, ~sources=[mock.source])
 
       // First call - create subscription and set initial height
       let p1 =
@@ -2837,7 +2837,7 @@ describe("SourceManager height subscription", () => {
     async t => {
       let pollingInterval = 1
       let mock = MockIndexer.Source.make([#getHeightOrThrow], ~pollingInterval)
-      let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[mock.source])
+      let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=false, ~sources=[mock.source])
 
       let p =
         sourceManager->SourceManager.waitForNewBlock(
@@ -2865,7 +2865,7 @@ describe("SourceManager height subscription", () => {
     async t => {
       let stallTimeout = 20
       let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
-      let sourceManager = SourceManager.make(
+      let sourceManager = SourceManager.make(~logger=Env.logger, 
         ~isRealtime=true,
         ~sources=[mock.source],
         ~newBlockStallTimeoutRealtime=stallTimeout,
@@ -2913,7 +2913,7 @@ describe("SourceManager height subscription", () => {
       [#getHeightOrThrow, #createHeightSubscription],
       ~pollingInterval,
     )
-    let sourceManager = SourceManager.make(
+    let sourceManager = SourceManager.make(~logger=Env.logger, 
       ~isRealtime=true,
       ~sources=[mock.source],
       ~newBlockStallTimeoutRealtime=stallTimeout,
@@ -2973,7 +2973,7 @@ describe("SourceManager height subscription", () => {
 
   Async.it("Ignores subscription heights lower than or equal to knownHeight", async t => {
     let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
-    let sourceManager = SourceManager.make(~isRealtime=true, ~sources=[mock.source])
+    let sourceManager = SourceManager.make(~logger=Env.logger, ~isRealtime=true, ~sources=[mock.source])
 
     // First call - create subscription
     let p1 =


### PR DESCRIPTION
## Summary

Refactors the logging system to eliminate the child logger pattern (`Logging.createChildFrom`) in favor of spreading context parameters directly into log lines. This simplifies logger management by using a single logger instance per indexer while maintaining full context in every log entry.

## Key Changes

- **Logging API simplification**: Renamed `childTrace`, `childDebug`, `childInfo`, `childWarn`, `childError`, `childErrorWithExn`, `childFatal` to `trace`, `debug`, `info`, `warn`, `error`, `errorWithExn`, `fatal` respectively. Removed `createChildFrom` entirely.

- **Context parameter spreading**: Instead of binding context to a child logger, context fields (chainId, contractAddress, etc.) are now spread directly into each log call via a `withParams` helper that merges parameters into the logged object.

- **Logger propagation**: Added explicit `~logger: Pino.t` parameters throughout the codebase where loggers were previously derived from child creation:
  - `SourceManager.make`, `SourceManager.waitForRateLimitReset`
  - `FetchState.registerDynamicContracts`
  - `IndexerState.make`
  - `ChainState.make`, `ChainState.makeFromConfig`
  - `RpcSource.make`, `FuelHyperSyncSource.make`, `EvmHyperSyncSource.make`
  - `PgStorage.make`, `Persistence.make`
  - `ErrorHandling.make`
  - And many others

- **Ecosystem refactoring**: Removed `logger` field from `Ecosystem.t` and replaced `toEventLogger` with `toEventLogParams` that returns context fields instead of a bound logger instance.

- **Test updates**: Updated all test files to pass `~logger=Env.logger` where required by the new signatures.

- **New test coverage**: Added `LoggerScope_test.res` to verify that per-indexer loggers remain isolated and that context parameters are correctly merged into log output.

## Notable Implementation Details

- The `Internal.logParams` type abstracts heterogeneous parameter objects from different ecosystems (EVM, Fuel, SVM) into a single type for spreading.
- `ErrorHandling` now accepts optional `~params` and merges them into error logs rather than creating a child logger.
- `Throttler` now stores `params: Internal.logParams` to spread context on every throttled operation.
- `Logging.withParams` merges user-provided parameters with context parameters, with user params taking precedence.
- All log calls now explicitly include context fields (chainId, knownHeight, contractAddress, etc.) in the logged object rather than relying on logger hierarchy.

https://claude.ai/code/session_01M6zjvEptC39Ej4RAK6zpUC