### PR TITLE
feat(hypersync): coalesce dynamic contract partitions

### DIFF
--- a/packages/cli/src/evm_hypersync_source/selection.rs
+++ b/packages/cli/src/evm_hypersync_source/selection.rs
@@ -403,6 +403,36 @@ mod tests {
     }
 
     #[test]
+    fn different_contracts_keep_address_topic_pairings() {
+        let builder = SelectionBuilder::from_registrations(&[
+            reg(0, SIGHASH_A, "Token", false, true, Some(vec![])),
+            reg(1, SIGHASH_B, "Pool", false, true, Some(vec![])),
+        ])
+        .unwrap();
+        let pool_address = "0x2222222222222222222222222222222222222222";
+        let built = builder
+            .build(
+                &[0, 1],
+                &addresses(&[("Token", &[ADDR]), ("Pool", &[pool_address])]),
+                &Default::default(),
+            )
+            .unwrap();
+        assert_eq!(
+            built.log_selections,
+            vec![
+                BuiltLogSelection {
+                    addresses: vec![ADDR.to_string()],
+                    topics: vec![vec![SIGHASH_A.to_string()], vec![], vec![], vec![]],
+                },
+                BuiltLogSelection {
+                    addresses: vec![pool_address.to_string()],
+                    topics: vec![vec![SIGHASH_B.to_string()], vec![], vec![], vec![]],
+                },
+            ]
+        );
+    }
+
+    #[test]
     fn wildcard_selection_stays_address_free() {
         let builder = SelectionBuilder::from_registrations(&[reg(
             0,

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -826,19 +826,22 @@ let handleQueryResult = (
   | None => ()
   }
 
-  let fs = switch newItemsWithDcs {
-  | [] => cs.fetchState
+  // Complete the triggering query before registering contracts it discovered.
+  // This gives the optimizer the partition's real scheduled frontier instead
+  // of treating the just-completed query as permanently in flight.
+  let fs =
+    cs.fetchState
+    ->FetchState.handleQueryResult(~query, ~latestFetchedBlock, ~newItems)
+    ->FetchState.updateKnownHeight(~knownHeight)
+
+  cs.fetchState = switch newItemsWithDcs {
+  | [] => fs
   | _ =>
-    cs.fetchState->FetchState.registerDynamicContracts(
+    fs->FetchState.registerDynamicContracts(
       ~indexingAddresses=cs.indexingAddresses,
       newItemsWithDcs,
     )
   }
-
-  cs.fetchState =
-    fs
-    ->FetchState.handleQueryResult(~query, ~latestFetchedBlock, ~newItems)
-    ->FetchState.updateKnownHeight(~knownHeight)
 
   // The query is no longer in flight, so release its reservation.
   cs.pendingBudget = Pervasives.max(0., cs.pendingBudget -. query.itemsEst->Int.toFloat)

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -319,10 +319,10 @@ module OptimizedPartitions = {
   let mergeSelections = (a, b) => {
     let registrations = Dict.make()
     a.onEventRegistrations->Array.forEach(reg =>
-      registrations->Dict.set(`${reg.eventConfig.contractName}:${reg.eventConfig.id}`, reg)
+      registrations->Dict.set(reg.index->Int.toString, reg)
     )
     b.onEventRegistrations->Array.forEach(reg =>
-      registrations->Dict.set(`${reg.eventConfig.contractName}:${reg.eventConfig.id}`, reg)
+      registrations->Dict.set(reg.index->Int.toString, reg)
     )
     {
       dependsOnAddresses: true,

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -51,8 +51,9 @@ type partition = {
   selection: selection,
   addressesByContractName: dict<array<Address.t>>,
   mergeBlock: option<int>,
-  // When set, partition indexes a single dynamic contract type.
-  // The addressesByContractName must contain only addresses for this contract.
+  // Identifies a single dynamic contract type while its partitions are being
+  // aligned. A coalesced address-bound partition may contain additional
+  // dynamic or static contract types and may retain either parent's marker.
   dynamicContract: option<string>,
   // Mutated in place and shared across fetchState versions (updateInternal
   // copies the record, not this array): startFetchingQueries inserts,
@@ -287,12 +288,127 @@ module OptimizedPartitions = {
   let ascSortFn = (a, b) =>
     Int.compare(a.latestFetchedBlock.blockNumber, b.latestFetchedBlock.blockNumber)
 
+  let mergeAddressGroups = (a, b) => {
+    let merged = b->Utils.Dict.shallowCopy
+    a
+    ->Dict.keysToArray
+    ->Array.forEach(contractName => {
+      let addresses = a->Dict.getUnsafe(contractName)
+      switch merged->Utils.Dict.dangerouslyGetNonOption(contractName) {
+      | Some(existing) => merged->Dict.set(contractName, existing->Array.concat(addresses))
+      | None => merged->Dict.set(contractName, addresses)
+      }
+    })
+    merged
+  }
+
+  let mergeDensity = (a, b) =>
+    switch (a->getTrustedDensity, b->getTrustedDensity) {
+    | (Some(aDensity), Some(bDensity)) => Some(aDensity +. bDensity)
+    | (Some(density), None) | (None, Some(density)) => Some(density)
+    | (None, None) => None
+    }
+
+  let addressGroupCount = addressesByContractName =>
+    addressesByContractName
+    ->Dict.keysToArray
+    ->Array.reduce(0, (count, contractName) =>
+      count + addressesByContractName->Dict.getUnsafe(contractName)->Array.length
+    )
+
+  let mergeSelections = (a, b) => {
+    let registrations = Dict.make()
+    a.onEventRegistrations->Array.forEach(reg =>
+      registrations->Dict.set(`${reg.eventConfig.contractName}:${reg.eventConfig.id}`, reg)
+    )
+    b.onEventRegistrations->Array.forEach(reg =>
+      registrations->Dict.set(`${reg.eventConfig.contractName}:${reg.eventConfig.id}`, reg)
+    )
+    {
+      dependsOnAddresses: true,
+      onEventRegistrations: registrations->Dict.valuesToArray,
+    }
+  }
+
+  // A partition can join another partition after every query it has already
+  // scheduled is complete. Query values snapshot their selection and address
+  // map, so extending the partition record only affects future queries.
+  let potentialJoinBlock = p =>
+    switch p.mutPendingQueries->Utils.Array.last {
+    | Some({toBlock: Some(toBlock)}) => Some(toBlock)
+    | Some({toBlock: None}) => None
+    | None => Some(p.latestFetchedBlock.blockNumber)
+    }
+
+  let coalesceAddressBoundPartitions = (~partitions, ~maxAddrInPartition) => {
+    let stable = []
+    let candidates: array<(partition, int)> = []
+    partitions->Array.forEach(p =>
+      switch p {
+      | {
+          selection: {dependsOnAddresses: true},
+          mergeBlock: None,
+        } if p.selection.clientFilteredContracts->Option.isNone =>
+        switch p->potentialJoinBlock {
+        | Some(joinBlock) => candidates->Array.push((p, joinBlock))->ignore
+        | None => stable->Array.push(p)->ignore
+        }
+      | _ => stable->Array.push(p)->ignore
+      }
+    )
+
+    if candidates->Array.length === 0 {
+      stable
+    } else {
+      candidates->Array.sort(((_, a), (_, b)) => Int.compare(a, b))->ignore
+      let currentRef = ref(candidates->Utils.Array.firstUnsafe)
+      for idx in 1 to candidates->Array.length - 1 {
+        let (current, currentJoinBlock) = currentRef.contents
+        let (next, nextJoinBlock) = candidates->Array.getUnsafe(idx)
+        let combinedAddressCount =
+          current.addressesByContractName->addressGroupCount +
+            next.addressesByContractName->addressGroupCount
+
+        if combinedAddressCount > maxAddrInPartition {
+          stable->Array.push(current)->ignore
+          currentRef := (next, nextJoinBlock)
+        } else {
+          let mergedAddresses =
+            current.addressesByContractName->mergeAddressGroups(next.addressesByContractName)
+          let minRange = getMinQueryRange([current, next])
+          if currentJoinBlock < nextJoinBlock {
+            stable->Array.push({...current, mergeBlock: Some(nextJoinBlock)})->ignore
+          } else if current.mutPendingQueries->Array.length > 0 {
+            // Both partitions have already scheduled through the same block.
+            // Keep the current one only long enough to consume its response.
+            stable->Array.push({...current, mergeBlock: Some(nextJoinBlock)})->ignore
+          }
+          currentRef := (
+            {
+                ...next,
+                selection: mergeSelections(current.selection, next.selection),
+                addressesByContractName: mergedAddresses,
+                sourceRangeCapacity: minRange,
+                prevSourceRangeCapacity: minRange,
+                eventDensity: mergeDensity(current, next),
+                latestSourceRangeCapacityUpdateBlock: 0,
+              },
+            nextJoinBlock,
+          )
+        }
+      }
+      let (current, _) = currentRef.contents
+      stable->Array.push(current)->ignore
+      stable
+    }
+  }
+
   /**
    * Optimizes partitions by finding opportunities to merge partitions that
-   * are behind other partitions with same/superset of contract names.
+   * are behind other partitions with compatible address-bound selections.
    *
-   * Only partitions with dynamicContract set are eligible for optimization.
-   * This way we don't have optimization overhead when partitions are stable.
+   * Same-contract dynamic partitions are aligned first, then compatible
+   * address-bound partitions are coalesced across contract types.
    */
   let make = (
     ~partitions: array<partition>,
@@ -320,41 +436,47 @@ module OptimizedPartitions = {
       {mergeBlock: Some(_)} =>
         newPartitions->Array.push(p)->ignore
       | {dynamicContract: Some(contractName)} =>
-        let pAddressesCount = p.addressesByContractName->Dict.getUnsafe(contractName)->Array.length
-        // Compute merge block: last pending query's toBlock, or lfb if idle
-        let potentialMergeBlock = switch p.mutPendingQueries->Utils.Array.last {
-        | Some({isChunk: true, toBlock: Some(toBlock)}) => Some(toBlock)
-        | Some(_) => None // unbounded query -- can't merge
-        | None => Some(p.latestFetchedBlock.blockNumber)
-        }
-        switch potentialMergeBlock {
-        | None => newPartitions->Array.push(p)->ignore
-        | Some(potentialMergeBlock) =>
-          if pAddressesCount >= maxAddrInPartition {
-            newPartitions->Array.push(p)->ignore
-          } else {
-            let partitionsByMergeBlock =
-              mergingPartitions->Utils.Dict.getOrInsertEmptyDict(contractName)
-            switch partitionsByMergeBlock->Utils.Dict.dangerouslyGetByIntNonOption(
-              potentialMergeBlock,
-            ) {
-            | Some(existingPartition) =>
-              let result = mergePartitionsAtBlock(
-                ~p1=existingPartition,
-                ~p2=p,
-                ~potentialMergeBlock,
-                ~contractName,
-                ~maxAddrInPartition,
-                ~nextPartitionIndexRef,
-              )
-              for i in 0 to result->Array.length - 2 {
-                newPartitions->Array.push(result->Array.getUnsafe(i))->ignore
-              }
-              partitionsByMergeBlock->Utils.Dict.setByInt(
+        let contractNames = p.addressesByContractName->Dict.keysToArray
+        if contractNames->Array.length !== 1 || contractNames->Array.getUnsafe(0) !== contractName {
+          newPartitions->Array.push(p)->ignore
+        } else {
+          let pAddressesCount =
+            p.addressesByContractName->Dict.getUnsafe(contractName)->Array.length
+          // Compute merge block: last pending query's toBlock, or lfb if idle
+          let potentialMergeBlock = switch p.mutPendingQueries->Utils.Array.last {
+          | Some({isChunk: true, toBlock: Some(toBlock)}) => Some(toBlock)
+          | Some(_) => None // unbounded query -- can't merge
+          | None => Some(p.latestFetchedBlock.blockNumber)
+          }
+          switch potentialMergeBlock {
+          | None => newPartitions->Array.push(p)->ignore
+          | Some(potentialMergeBlock) =>
+            if pAddressesCount >= maxAddrInPartition {
+              newPartitions->Array.push(p)->ignore
+            } else {
+              let partitionsByMergeBlock =
+                mergingPartitions->Utils.Dict.getOrInsertEmptyDict(contractName)
+              switch partitionsByMergeBlock->Utils.Dict.dangerouslyGetByIntNonOption(
                 potentialMergeBlock,
-                result->Utils.Array.lastUnsafe,
-              )
-            | None => partitionsByMergeBlock->Utils.Dict.setByInt(potentialMergeBlock, p)
+              ) {
+              | Some(existingPartition) =>
+                let result = mergePartitionsAtBlock(
+                  ~p1=existingPartition,
+                  ~p2=p,
+                  ~potentialMergeBlock,
+                  ~contractName,
+                  ~maxAddrInPartition,
+                  ~nextPartitionIndexRef,
+                )
+                for i in 0 to result->Array.length - 2 {
+                  newPartitions->Array.push(result->Array.getUnsafe(i))->ignore
+                }
+                partitionsByMergeBlock->Utils.Dict.setByInt(
+                  potentialMergeBlock,
+                  result->Utils.Array.lastUnsafe,
+                )
+              | None => partitionsByMergeBlock->Utils.Dict.setByInt(potentialMergeBlock, p)
+              }
             }
           }
         }
@@ -414,6 +536,9 @@ module OptimizedPartitions = {
 
       newPartitions->Array.push(currentPRef.contents)->ignore
     }
+
+    let newPartitions =
+      coalesceAddressBoundPartitions(~partitions=newPartitions, ~maxAddrInPartition)
 
     // Sort partitions by latestFetchedBlock ascending
     let _ = newPartitions->Array.sort(ascSortFn)
@@ -1583,8 +1708,8 @@ let registerDynamicContracts = (
         // Walks through existing partitions that have addresses for this contract name
         // - If partition has ONLY this contract's addresses -> sets dynamicContract field
         // - If partition has this contract's addresses AND other contracts -> splits them
-        // For the sake of merging simplicity we want to make sure that
-        // partition has addresses of only one contract
+        // Temporarily isolate the newly dynamic contract. The optimizer can
+        // coalesce it again once the resulting partitions have compatible frontiers.
         if !(dynamicContractsRef.contents->Utils.Set.has(contractName)) {
           dynamicContractsRef := dynamicContractsRef.contents->Utils.Set.immutableAdd(contractName)
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1631,6 +1631,10 @@ describe("FetchState.registerDynamicContracts", () => {
         ->Dict.valuesToArray
         ->Array.some(addresses => addresses->Array.includes(address))
       )
+    let continuingAddresses =
+      partitions
+      ->Array.find(p => p.mergeBlock === None)
+      ->Option.map(p => p.addressesByContractName)
 
     t.expect(
       {
@@ -1645,6 +1649,7 @@ describe("FetchState.registerDynamicContracts", () => {
         ),
         "staticAddressCovered": coversAddress(mockAddress0),
         "childAddressCovered": coversAddress(mockAddress1),
+        "continuingAddresses": continuingAddresses,
       },
       ~message=`rollback retains the discovered child and rebuilds both address coverages
         without leaving a fetch or merge frontier beyond the valid block`,
@@ -1654,6 +1659,10 @@ describe("FetchState.registerDynamicContracts", () => {
       "allMergeBlocksRolledBack": true,
       "staticAddressCovered": true,
       "childAddressCovered": true,
+      "continuingAddresses": Some(Dict.fromArray([
+        ("Gravatar", [mockAddress1]),
+        ("NftFactory", [mockAddress0]),
+      ])),
     })
   })
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -92,15 +92,15 @@ let dcToItem = (dc: Internal.indexingAddress) => {
   item
 }
 
-let baseEventConfig = (MockIndexer.evmOnEventRegistration(
-  ~id="0",
-  ~contractName="Gravatar",
-) :> Internal.onEventRegistration)
+let baseEventConfig = ({
+  ...MockIndexer.evmOnEventRegistration(~id="0", ~contractName="Gravatar"),
+  index: 0,
+} :> Internal.onEventRegistration)
 
-let baseEventConfig2 = (MockIndexer.evmOnEventRegistration(
-  ~id="0",
-  ~contractName="NftFactory",
-) :> Internal.onEventRegistration)
+let baseEventConfig2 = ({
+  ...MockIndexer.evmOnEventRegistration(~id="0", ~contractName="NftFactory"),
+  index: 1,
+} :> Internal.onEventRegistration)
 
 let makeInitial = (
   ~knownHeight=knownHeight,
@@ -1386,8 +1386,18 @@ describe("FetchState.registerDynamicContracts", () => {
     let (fetchState, indexingAddresses) = makeFs(
       ~onEventRegistrations=[
         baseEventConfig,
-        (MockIndexer.evmOnEventRegistration(~id="pool", ~contractName="NftFactory") :> Internal.onEventRegistration),
-        (MockIndexer.evmOnEventRegistration(~id="child", ~contractName="SimpleNft") :> Internal.onEventRegistration),
+        ({
+          ...MockIndexer.evmOnEventRegistration(~id="0", ~contractName="Gravatar"),
+          index: 1,
+        } :> Internal.onEventRegistration),
+        ({
+          ...MockIndexer.evmOnEventRegistration(~id="pool", ~contractName="NftFactory"),
+          index: 2,
+        } :> Internal.onEventRegistration),
+        ({
+          ...MockIndexer.evmOnEventRegistration(~id="child", ~contractName="SimpleNft"),
+          index: 3,
+        } :> Internal.onEventRegistration),
       ],
       ~addresses=[makeConfigContract("NftFactory", mockAddress0)],
       ~startBlock=0,
@@ -1429,7 +1439,11 @@ describe("FetchState.registerDynamicContracts", () => {
     t.expect(
       aligned.optimizedPartitions.entities
       ->Dict.valuesToArray
-      ->Array.map(p => (p.latestFetchedBlock.blockNumber, p.addressesByContractName)),
+      ->Array.map(p => (
+        p.latestFetchedBlock.blockNumber,
+        p.addressesByContractName,
+        p.selection.onEventRegistrations->Array.map(reg => reg.index),
+      )),
     ).toEqual([
       (
         0,
@@ -1438,6 +1452,7 @@ describe("FetchState.registerDynamicContracts", () => {
           ("NftFactory", [mockAddress0]),
           ("SimpleNft", [mockAddress2]),
         ]),
+        [0, 1, 2, 3],
       ),
     ])
 
@@ -1572,6 +1587,74 @@ describe("FetchState.registerDynamicContracts", () => {
         ("NftFactory", [mockAddress0]),
       ]),
     )
+  })
+
+  it("rebuilds a coalescing backfill safely when rolling back between frontiers", t => {
+    let (fetchState, indexingAddresses) = makeFs(
+      ~onEventRegistrations=[baseEventConfig, baseEventConfig2],
+      ~addresses=[makeConfigContract("NftFactory", mockAddress0)],
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=10,
+      ~maxOnBlockBufferSize=targetBufferSize,
+      ~chainId,
+      ~knownHeight=200,
+    )
+    let leaderQuery: FetchState.query = {
+      partitionId: "0",
+      itemsTarget: None,
+      itemsEst: 100,
+      fromBlock: 0,
+      toBlock: Some(100),
+      isChunk: true,
+      selection: fetchState.normalSelection,
+      addressesByContractName: Dict.fromArray([("NftFactory", [mockAddress0])]),
+    }
+    fetchState->FetchState.startFetchingQueries(~queries=[leaderQuery])
+    let leaderAt100 = fetchState->FetchState.handleQueryResult(
+      ~query=leaderQuery,
+      ~latestFetchedBlock=getBlockData(~blockNumber=100),
+      ~newItems=[],
+    )
+    let withChild = leaderAt100->FetchState.registerDynamicContracts(~indexingAddresses, [
+      makeDynContractRegistration(
+        ~blockNumber=20,
+        ~contractAddress=mockAddress1,
+        ~contractName="Gravatar",
+      )->dcToItem,
+    ])
+    let rolledBack = withChild->FetchState.rollback(~indexingAddresses, ~targetBlockNumber=50)
+    let partitions = rolledBack.optimizedPartitions.entities->Dict.valuesToArray
+    let coversAddress = address =>
+      partitions->Array.some(p =>
+        p.addressesByContractName
+        ->Dict.valuesToArray
+        ->Array.some(addresses => addresses->Array.includes(address))
+      )
+
+    t.expect(
+      {
+        "childRegistrationRetained": indexingAddresses
+          ->IndexingAddresses.get(mockAddress1->Address.toString)
+          ->Option.map(indexingAddress => indexingAddress.registrationBlock),
+        "allFrontiersRolledBack": partitions->Array.every(
+          p => p.latestFetchedBlock.blockNumber <= 50,
+        ),
+        "allMergeBlocksRolledBack": partitions->Array.every(p =>
+          p.mergeBlock->Option.map(block => block <= 50)->Option.getOr(true)
+        ),
+        "staticAddressCovered": coversAddress(mockAddress0),
+        "childAddressCovered": coversAddress(mockAddress1),
+      },
+      ~message=`rollback retains the discovered child and rebuilds both address coverages
+        without leaving a fetch or merge frontier beyond the valid block`,
+    ).toEqual({
+      "childRegistrationRetained": Some(20),
+      "allFrontiersRolledBack": true,
+      "allMergeBlocksRolledBack": true,
+      "staticAddressCovered": true,
+      "childAddressCovered": true,
+    })
   })
 
   it(
@@ -2612,15 +2695,24 @@ describe("FetchState.getNextQuery & integration", () => {
   })
 
   it("Wildcard partition never merges to another one", t => {
-    let wildcard = (MockIndexer.evmOnEventRegistration(
-      ~id="wildcard",
-      ~contractName="ContractA",
-      ~isWildcard=true,
-    ) :> Internal.onEventRegistration)
+    let wildcard = ({
+      ...MockIndexer.evmOnEventRegistration(
+        ~id="wildcard",
+        ~contractName="ContractA",
+        ~isWildcard=true,
+      ),
+      index: 2,
+    } :> Internal.onEventRegistration)
     let (fetchState, indexingAddresses) = makeFs(
       ~onEventRegistrations=[
-        (MockIndexer.evmOnEventRegistration(~id="0", ~contractName="Gravatar") :> Internal.onEventRegistration),
-        (MockIndexer.evmOnEventRegistration(~id="0", ~contractName="ContractA") :> Internal.onEventRegistration),
+        ({
+          ...MockIndexer.evmOnEventRegistration(~id="0", ~contractName="Gravatar"),
+          index: 0,
+        } :> Internal.onEventRegistration),
+        ({
+          ...MockIndexer.evmOnEventRegistration(~id="0", ~contractName="ContractA"),
+          index: 1,
+        } :> Internal.onEventRegistration),
         wildcard,
       ],
       ~addresses=[makeConfigContract("ContractA", mockAddress1)],

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -1382,6 +1382,198 @@ describe("FetchState.registerDynamicContracts", () => {
     ])
   })
 
+  it("Coalesces aligned static and dynamic contract types into one partition", t => {
+    let (fetchState, indexingAddresses) = makeFs(
+      ~onEventRegistrations=[
+        baseEventConfig,
+        (MockIndexer.evmOnEventRegistration(~id="pool", ~contractName="NftFactory") :> Internal.onEventRegistration),
+        (MockIndexer.evmOnEventRegistration(~id="child", ~contractName="SimpleNft") :> Internal.onEventRegistration),
+      ],
+      ~addresses=[makeConfigContract("NftFactory", mockAddress0)],
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=10,
+      ~maxOnBlockBufferSize=targetBufferSize,
+      ~chainId,
+      ~knownHeight,
+    )
+
+    let updated = fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
+      makeDynContractRegistration(
+        ~blockNumber=0,
+        ~contractAddress=mockAddress1,
+        ~contractName="Gravatar",
+      )->dcToItem,
+      makeDynContractRegistration(
+        ~blockNumber=0,
+        ~contractAddress=mockAddress2,
+        ~contractName="SimpleNft",
+      )->dcToItem,
+    ])
+
+    let updated = {...updated, knownHeight: 10}
+    let backfillQuery = switch updated->FetchState.getNextQuery(
+      ~chainTargetBlock=10,
+      ~chainTargetItems=10_000.,
+    ) {
+    | Ready(queries) => queries->Array.find(q => q.toBlock === Some(0))->Option.getUnsafe
+    | _ => JsError.throwWithMessage("Expected dynamic partition backfill")
+    }
+    updated->FetchState.startFetchingQueries(~queries=[backfillQuery])
+    let aligned = updated->FetchState.handleQueryResult(
+      ~query=backfillQuery,
+      ~latestFetchedBlock={blockNumber: 0, blockTimestamp: 0},
+      ~newItems=[],
+    )
+
+    t.expect(
+      aligned.optimizedPartitions.entities
+      ->Dict.valuesToArray
+      ->Array.map(p => (p.latestFetchedBlock.blockNumber, p.addressesByContractName)),
+    ).toEqual([
+      (
+        0,
+        Dict.fromArray([
+          ("Gravatar", [mockAddress1]),
+          ("NftFactory", [mockAddress0]),
+          ("SimpleNft", [mockAddress2]),
+        ]),
+      ),
+    ])
+
+    t.expect(
+      aligned->FetchState.getNextQuery(~chainTargetBlock=10, ~chainTargetItems=10_000.),
+    ).toEqual(
+      Ready([
+        {
+          partitionId: aligned.optimizedPartitions.idsInAscOrder->Utils.Array.firstUnsafe,
+          itemsTarget: Some(10_000),
+          itemsEst: 10_000,
+          fromBlock: 1,
+          toBlock: None,
+          isChunk: false,
+          selection: aligned.normalSelection,
+          addressesByContractName: Dict.fromArray([
+            ("Gravatar", [mockAddress1]),
+            ("NftFactory", [mockAddress0]),
+            ("SimpleNft", [mockAddress2]),
+          ]),
+        },
+      ]),
+    )
+  })
+
+  it("retires a dynamic backfill into a leader with bounded queries in flight", t => {
+    let (fetchState, indexingAddresses) = makeFs(
+      ~onEventRegistrations=[baseEventConfig, baseEventConfig2],
+      ~addresses=[makeConfigContract("NftFactory", mockAddress0)],
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=10,
+      ~maxOnBlockBufferSize=targetBufferSize,
+      ~chainId,
+      ~knownHeight=200,
+    )
+    let leaderQuery: FetchState.query = {
+      partitionId: "0",
+      itemsTarget: None,
+      itemsEst: 100,
+      fromBlock: 0,
+      toBlock: Some(100),
+      isChunk: true,
+      selection: fetchState.normalSelection,
+      addressesByContractName: Dict.fromArray([("NftFactory", [mockAddress0])]),
+    }
+    fetchState->FetchState.startFetchingQueries(~queries=[leaderQuery])
+
+    let withChild = fetchState->FetchState.registerDynamicContracts(~indexingAddresses, [
+      makeDynContractRegistration(
+        ~blockNumber=20,
+        ~contractAddress=mockAddress1,
+        ~contractName="Gravatar",
+      )->dcToItem,
+    ])
+    let leader = withChild.optimizedPartitions.entities->Dict.getUnsafe("0")
+    let backfill =
+      withChild.optimizedPartitions.entities
+      ->Dict.valuesToArray
+      ->Array.find(p => p.id !== "0")
+      ->Option.getOrThrow
+
+    t.expect(
+      (
+        leader.addressesByContractName,
+        leader.mutPendingQueries,
+        backfill.latestFetchedBlock.blockNumber,
+        backfill.mergeBlock,
+      ),
+      ~message=`the leader's already-issued query remains unchanged, future queries include
+        the child address, and the child-only backfill retires at the leader frontier`,
+    ).toEqual((
+      Dict.fromArray([
+        ("Gravatar", [mockAddress1]),
+        ("NftFactory", [mockAddress0]),
+      ]),
+      [
+        {
+          fromBlock: 0,
+          toBlock: Some(100),
+          isChunk: true,
+          itemsTarget: None,
+          itemsEst: 100,
+          fetchedBlock: None,
+        },
+      ],
+      19,
+      Some(100),
+    ))
+    // The query object itself is the immutable source request snapshot.
+    t.expect(leaderQuery.addressesByContractName).toEqual(
+      Dict.fromArray([("NftFactory", [mockAddress0])]),
+    )
+
+    let nextQueries = switch withChild->FetchState.getNextQuery(
+      ~chainTargetBlock=200,
+      ~chainTargetItems=10_000.,
+    ) {
+    | Ready(queries) => queries
+    | _ => JsError.throwWithMessage("Expected child backfill and pipelined leader queries")
+    }
+    let backfillQuery =
+      nextQueries->Array.find(query => query.partitionId === backfill.id)->Option.getOrThrow
+    let futureLeaderQuery =
+      nextQueries->Array.find(query => query.partitionId === leader.id)->Option.getOrThrow
+    t.expect((backfillQuery.fromBlock, backfillQuery.toBlock)).toEqual((20, Some(100)))
+    t.expect(
+      (
+        futureLeaderQuery.fromBlock,
+        futureLeaderQuery.addressesByContractName,
+      ),
+      ~message="the next leader query begins after its snapshot and includes the child",
+    ).toEqual((
+      101,
+      Dict.fromArray([
+        ("Gravatar", [mockAddress1]),
+        ("NftFactory", [mockAddress0]),
+      ]),
+    ))
+    withChild->FetchState.startFetchingQueries(~queries=[backfillQuery])
+    let caughtUp = withChild->FetchState.handleQueryResult(
+      ~query=backfillQuery,
+      ~latestFetchedBlock=getBlockData(~blockNumber=100),
+      ~newItems=[],
+    )
+
+    t.expect(caughtUp.optimizedPartitions.idsInAscOrder).toEqual(["0"])
+    let caughtUpLeader = caughtUp.optimizedPartitions.entities->Dict.getUnsafe("0")
+    t.expect(caughtUpLeader.addressesByContractName).toEqual(
+      Dict.fromArray([
+        ("Gravatar", [mockAddress1]),
+        ("NftFactory", [mockAddress0]),
+      ]),
+    )
+  })
+
   it(
     "Dcs for a contract with event filtering by addresses are grouped like any other contract",
     // The client-side address filter drops events before each dc's registration
@@ -1472,7 +1664,10 @@ describe("FetchState.registerDynamicContracts", () => {
         (
           "0",
           Some("Gravatar"),
-          Dict.fromArray([("Gravatar", [mockAddress0, mockAddress1])]),
+          Dict.fromArray([
+            ("Gravatar", [mockAddress0, mockAddress1]),
+            ("NftFactory", [mockAddress5]),
+          ]),
           None,
           9,
         ),
@@ -1484,7 +1679,13 @@ describe("FetchState.registerDynamicContracts", () => {
           None,
           2,
         ),
-        ("3", Some("NftFactory"), Dict.fromArray([("NftFactory", [mockAddress5])]), None, 5),
+        (
+          "3",
+          Some("NftFactory"),
+          Dict.fromArray([("NftFactory", [mockAddress5])]),
+          Some(9),
+          5,
+        ),
       ])
     },
   )
@@ -2445,9 +2646,8 @@ describe("FetchState.getNextQuery & integration", () => {
 
     t.expect(
       nextQuery,
-      ~message=`Wildcard partition "0" is untouched.
-      Partitions "1" and "2" split in optimized way for further dynamic contract registrations.
-      All queries performed in parallel without locking.`,
+      ~message=`Wildcard partition "0" is untouched while compatible address-bound
+      partitions backfill once and continue as one exact query.`,
     ).toEqual(
       Ready([
         {
@@ -2468,7 +2668,7 @@ describe("FetchState.getNextQuery & integration", () => {
           itemsTarget: Some(3333),
           itemsEst: 3333,
           fromBlock: 0,
-          toBlock: None,
+          toBlock: Some(1),
           isChunk: false,
           selection: fetchState.normalSelection,
           addressesByContractName: Dict.fromArray([("ContractA", [mockAddress1])]),
@@ -2482,7 +2682,10 @@ describe("FetchState.getNextQuery & integration", () => {
           toBlock: None,
           isChunk: false,
           selection: fetchState.normalSelection,
-          addressesByContractName: Dict.fromArray([("Gravatar", [mockAddress2])]),
+          addressesByContractName: Dict.fromArray([
+            ("ContractA", [mockAddress1]),
+            ("Gravatar", [mockAddress2]),
+          ]),
         },
       ]),
     )


### PR DESCRIPTION
## Summary

Coalesce compatible address-bound HyperSync partitions across contract types while preserving exact contract-address/event-topic pairings.

Factory-discovered contracts still receive the required historical backfill from their registration block, but that temporary partition now retires at the existing leader's scheduled frontier. Future leader queries include the discovered address, leaving one shared realtime query stream instead of one permanent stream per dynamic contract group.

## Key changes

- Merge address-bound selections without producing an address × topic cross product.
- Treat bounded in-flight queries as safe join frontiers; their query objects retain immutable address/selection snapshots.
- Complete the query that discovered a contract before optimizing the resulting dynamic registration.
- Bound dynamic backfills at the leader frontier and retire them once caught up.
- Keep wildcard and address-free client-filtered partitions separate.

## Why

Dynamic contracts discovered by factory handlers can otherwise become permanent independent realtime partitions. On HyperSync this duplicates head-range requests and scales source usage with discovered partition history rather than the logical subscription set.

## Test plan

- `cargo fmt --all -- --check`
- `cargo test -p envio evm_hypersync_source::selection::tests` — 11 passed
- `pnpm rescript` in `packages/envio`
- Focused ReScript suites for FetchState, ChainState, CrossChainState, and IndexerState — 137 passed
- Mainnet replay from block 18,550,000 through live head:
  - 53,873 events processed
  - 17 static/dynamic addresses registered
  - final progress 20,449,296 at source height 20,449,298 (configured lag: 2)
  - dynamic backfills were bounded and retired
  - after catch-up, only partition `0` continued querying new head ranges

## Behavioral trace

The final discovered child backfilled once on partition `13` from `20,285,319` through the leader frontier `20,449,019`. Subsequent live ranges (`20,449,020+`) were queried only by partition `0`, whose source request contained all 17 watched addresses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state update sequencing when processing query results, ensuring newly discovered dynamic contracts are registered against the latest known height.
  * Enhanced address-bound partition coalescing and prevented incorrect merges when dynamic contract address mappings are ambiguous.
  * Preserved in-flight query snapshots and enforced backfill query limits during dynamic contract retirement.

* **Tests**
  * Added a unit test to verify separate contract address/topic0 pairings.
  * Added and updated integration tests covering partition coalescing, dynamic backfills, and wildcard partition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->