### PR TITLE
Filter stores to only routed items' blocks and transactions

### DIFF
--- a/packages/cli/src/evm_hypersync_source/decode.rs
+++ b/packages/cli/src/evm_hypersync_source/decode.rs
@@ -39,7 +39,7 @@ pub(crate) struct LogAddress<'a> {
 /// The 20 address bytes of a padded indexed topic, or `None` when the topic's
 /// upper bytes aren't zero — then it isn't an address at all.
 fn topic_address(topic: &LogArgument) -> Option<&[u8]> {
-    let bytes: &[u8; 32] = &***topic;
+    let bytes: &[u8; 32] = topic;
     bytes[..12].iter().all(|b| *b == 0).then(|| &bytes[12..])
 }
 

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -458,13 +458,17 @@ fn process_response(
     if !requested_transaction_fields.is_empty() {
         let mut kept: Vec<simple_types::Transaction> = Vec::new();
         for tx in transactions.into_iter().flatten() {
-            let key = match (tx.block_number, tx.transaction_index) {
-                (Some(block_number), Some(transaction_index)) => {
-                    Some(transaction_key(block_number, transaction_index))
-                }
-                _ => None,
+            // A row the source returned without its key backs no item — there
+            // is nothing to join it to — so it is dropped unjudged. If a routed
+            // item did want it, the coverage check below still reports the
+            // transaction as missing.
+            let (Some(block_number), Some(transaction_index)) =
+                (tx.block_number, tx.transaction_index)
+            else {
+                continue;
             };
-            if key.is_some_and(|key| !referenced_transactions.contains(&key)) {
+            let key = transaction_key(block_number, transaction_index);
+            if !referenced_transactions.contains(&key) {
                 continue;
             }
             for &field in requested_transaction_fields {
@@ -472,10 +476,8 @@ fn process_response(
                     push_unique(&mut missing, format!("transaction.{}", name));
                 }
             }
-            if let Some(key) = key {
-                transaction_keys.insert(key);
-                kept.push(tx);
-            }
+            transaction_keys.insert(key);
+            kept.push(tx);
         }
         transaction_store.insert_evm_txs(kept);
     }
@@ -488,10 +490,19 @@ fn process_response(
     let present_block_numbers: HashSet<u64> =
         response_blocks.iter().filter_map(|b| b.number).collect();
 
-    // Validate every block field we requested — the user's selection plus the
-    // always-required number/timestamp/hash — once per distinct block.
+    // Validate the requested block fields once per distinct block. The
+    // always-required number/timestamp/hash back every header, so they are
+    // checked on every returned block; the rest of the user's selection is only
+    // ever read through the store, so it is checked only where an item can
+    // reach it — same rule as transactions.
     for block in &response_blocks {
+        let referenced = block
+            .number
+            .is_some_and(|number| referenced_blocks.contains(&number));
         for &field in validated_block_fields {
+            if !referenced && !REQUIRED_BLOCK_FIELDS.contains(&field) {
+                continue;
+            }
             if let Some(name) = block_field_missing(block, field) {
                 push_unique(&mut missing, format!("block.{}", name));
             }
@@ -1138,6 +1149,84 @@ mod tests {
         .expect("an unrouted log's absent block and transaction are not missing fields");
 
         assert_eq!((items.len(), blocks.len()), (0, 0));
+    }
+
+    #[test]
+    fn unreferenced_block_is_judged_only_on_its_header_fields() {
+        // Block 2 backs no item, so its absent `gasUsed` can't fail the page —
+        // nothing can read it. The header trio is still required of it, since
+        // every returned block yields a header.
+        let block = |number: u64| simple_types::Block {
+            number: Some(number),
+            hash: Some(Default::default()),
+            timestamp: Some(Default::default()),
+            gas_used: (number == 1).then(Default::default),
+            ..Default::default()
+        };
+        let (items, blocks) = process_response(
+            vec![vec![block(1), block(2)]],
+            vec![],
+            vec![vec![full_log(1), unrouted_log(2)]],
+            &zero_event_decoder(),
+            false,
+            &[
+                BlockField::Number,
+                BlockField::Hash,
+                BlockField::Timestamp,
+                BlockField::GasUsed,
+            ],
+            &[],
+            &TransactionStore::new_evm(false),
+            &BlockStore::new_evm(false),
+            empty_set().cache(),
+        )
+        .expect("an unreferenced block's absent selected field is not a missing field");
+
+        assert_eq!(
+            (
+                items.len(),
+                blocks.iter().map(|b| b.number).collect::<Vec<_>>()
+            ),
+            (1, vec![1, 2])
+        );
+    }
+
+    #[test]
+    fn keyless_transaction_is_dropped_unjudged() {
+        // The source returned a transaction with no (blockNumber, txIndex), so
+        // it joins to nothing; its absent `hash` must not fail a page whose
+        // routed item got the transaction it asked for.
+        let mut block = simple_types::Block::default();
+        block.number = Some(1);
+        block.hash = Some(Default::default());
+        block.timestamp = Some(Default::default());
+
+        let mut keyless = simple_types::Transaction::default();
+        keyless.hash = None;
+
+        let (items, _blocks) = process_response(
+            vec![vec![block]],
+            vec![vec![
+                simple_types::Transaction {
+                    block_number: Some(1u64.into()),
+                    transaction_index: Some(0u64.into()),
+                    hash: Some(Default::default()),
+                    ..Default::default()
+                },
+                keyless,
+            ]],
+            vec![vec![full_log(1)]],
+            &zero_event_decoder(),
+            false,
+            REQUIRED_BLOCK_FIELDS,
+            &[TransactionField::Hash],
+            &TransactionStore::new_evm(false),
+            &BlockStore::new_evm(false),
+            empty_set().cache(),
+        )
+        .expect("a keyless transaction's absent field is not a missing field");
+
+        assert_eq!(items.len(), 1);
     }
 
     #[test]

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -410,8 +410,7 @@ fn process_response(
         // only as long as routing takes.
         let address_store = decoder.lock_store();
         for log in logs.into_iter().flatten() {
-            let (log_index, src_address, block_number, transaction_index) =
-                flatten_log_for_js(&log, should_checksum).context("mapping log")?;
+            let flat = flatten_log_for_js(&log, should_checksum).context("mapping log")?;
             // The emitter's raw 20 bytes are already the store's key, so ownership
             // and the effectiveStartBlock gate cost one hash lookup each — no
             // round-trip through the address string.
@@ -419,7 +418,7 @@ fn process_response(
             let address = LogAddress {
                 key: address_key.as_slice(),
                 contract_name: set_cache.owner_of(address_key.as_slice()),
-                block_number,
+                block_number: flat.block_number,
             };
             // Only structurally malformed logs (missing topic0, bad topic bytes)
             // surface here; per-registration decode failures are dropped inside
@@ -430,14 +429,15 @@ fn process_response(
             if routed.is_empty() {
                 continue;
             }
-            referenced_blocks.insert(block_number as u64);
-            referenced_transactions.insert((block_number as u64, transaction_index as u32));
+            let (block_key, _) = flat.transaction_key;
+            referenced_blocks.insert(block_key);
+            referenced_transactions.insert(flat.transaction_key);
             for routed in routed {
                 items.push(EventItem {
-                    log_index,
-                    src_address: src_address.clone(),
-                    block_number,
-                    transaction_index,
+                    log_index: flat.log_index,
+                    src_address: flat.src_address.clone(),
+                    block_number: flat.block_number,
+                    transaction_index: flat.transaction_index,
                     on_event_registration_index: routed.index,
                     params: routed.params,
                 });
@@ -456,7 +456,7 @@ fn process_response(
         for tx in transactions.into_iter().flatten() {
             let key = match (tx.block_number, tx.transaction_index) {
                 (Some(block_number), Some(transaction_index)) => {
-                    Some((u64::from(block_number), u64::from(transaction_index) as u32))
+                    Some(transaction_key(block_number, transaction_index))
                 }
                 _ => None,
             };
@@ -551,10 +551,28 @@ fn process_response(
     Ok((items, out_blocks))
 }
 
+/// Key into the `TransactionStore`. The log side (which decides what a routed
+/// item references) and the transaction side (which fills the store) must
+/// produce identical keys or rows silently stop matching — a drift shows up as
+/// a phantom "transaction missing", not as a compile error — so both derive
+/// their keys here.
+fn transaction_key(block_number: impl Into<u64>, transaction_index: impl Into<u64>) -> (u64, u32) {
+    (block_number.into(), transaction_index.into() as u32)
+}
+
+/// A log's flattened JS fields, plus its transaction-store key.
+struct FlatLog {
+    log_index: i64,
+    src_address: String,
+    block_number: i64,
+    transaction_index: i64,
+    transaction_key: (u64, u32),
+}
+
 fn flatten_log_for_js(
     log: &hypersync_client::simple_types::Log,
     should_checksum: bool,
-) -> Result<(i64, String, i64, i64)> {
+) -> Result<FlatLog> {
     let log_index: i64 = u64::from(log.log_index.context("log.logIndex missing")?)
         .try_into()
         .context("log.logIndex overflow")?;
@@ -565,16 +583,23 @@ fn flatten_log_for_js(
     // block_number + transaction_index are force-selected in the query's log
     // field selection so they're always present, independent of the user's
     // field selection — they key the transaction store.
-    let block_number: i64 = u64::from(log.block_number.context("log.blockNumber missing")?)
+    let raw_block_number = log.block_number.context("log.blockNumber missing")?;
+    let raw_transaction_index = log
+        .transaction_index
+        .context("log.transactionIndex missing")?;
+    let block_number: i64 = u64::from(raw_block_number)
         .try_into()
         .context("log.blockNumber overflow")?;
-    let transaction_index: i64 = u64::from(
-        log.transaction_index
-            .context("log.transactionIndex missing")?,
-    )
-    .try_into()
-    .context("log.transactionIndex overflow")?;
-    Ok((log_index, src_address, block_number, transaction_index))
+    let transaction_index: i64 = u64::from(raw_transaction_index)
+        .try_into()
+        .context("log.transactionIndex overflow")?;
+    Ok(FlatLog {
+        log_index,
+        src_address,
+        block_number,
+        transaction_index,
+        transaction_key: transaction_key(raw_block_number, raw_transaction_index),
+    })
 }
 
 /// Failure modes specific to event-items conversion. `MissingFields` is the
@@ -719,6 +744,7 @@ pub(crate) fn map_err(e: anyhow::Error) -> napi::Error {
 mod tests {
     use super::*;
     use crate::address_store::test_support::{evm_store, set_of};
+    use crate::field_columns::test_support::str_column;
     use hypersync_client::simple_types;
 
     fn empty_decoder() -> SelectionDecoder {
@@ -1068,21 +1094,13 @@ mod tests {
             .await
             .expect("materialize blocks");
 
-        let column = |cols: &crate::field_columns::Columns, name: &str| match cols
-            .columns
-            .iter()
-            .find(|(n, _)| *n == name)
-        {
-            Some((_, crate::field_columns::Column::Str(values))) => values.clone(),
-            _ => panic!("expected a {name} string column"),
-        };
         let zero_hash = format!("0x{}", "00".repeat(32));
         assert_eq!(
             (
                 items.iter().map(|i| i.block_number).collect::<Vec<_>>(),
                 blocks.iter().map(|b| b.number).collect::<Vec<_>>(),
-                column(&stored_transaction_hashes, "hash"),
-                column(&stored_block_hashes, "hash"),
+                str_column(&stored_transaction_hashes, "hash"),
+                str_column(&stored_block_hashes, "hash"),
             ),
             (
                 vec![1],
@@ -1092,6 +1110,30 @@ mod tests {
                 vec![Some(zero_hash), None],
             )
         );
+    }
+
+    #[test]
+    fn unrouted_logs_do_not_demand_their_block_and_transaction() {
+        // The mirror of `missing_transaction_when_not_returned`: the source
+        // returned neither the block nor the transaction for this log, but it
+        // routes nowhere, so nothing will ever read them and the page stands.
+        // Without this, filtering the stores would silently diverge from what
+        // the coverage check still insists the source deliver.
+        let (items, blocks) = process_response(
+            vec![],
+            vec![],
+            vec![vec![unrouted_log(1)]],
+            &zero_event_decoder(),
+            false,
+            REQUIRED_BLOCK_FIELDS,
+            &[TransactionField::Hash],
+            &TransactionStore::new_evm(false),
+            &BlockStore::new_evm(false),
+            empty_set().cache(),
+        )
+        .expect("an unrouted log's absent block and transaction are not missing fields");
+
+        assert_eq!((items.len(), blocks.len()), (0, 0));
     }
 
     #[test]

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -328,9 +328,11 @@ pub struct BlockHeader {
 pub struct EventItemsResponse {
     pub archive_height: Option<i64>,
     pub next_block: i64,
-    /// The page's block headers, one per block number. Items reference them by
-    /// `block_number`; the full blocks live in the `BlockStore` returned
-    /// alongside this response.
+    /// The page's block headers, one per returned block number — including
+    /// blocks no item references, which reorg detection still reads. Items
+    /// reference theirs by `block_number`; the full blocks live in the
+    /// `BlockStore` returned alongside this response, which keeps only the
+    /// blocks items reference.
     pub blocks: Vec<BlockHeader>,
     pub items: Vec<EventItem>,
     pub rollback_guard: Option<RollbackGuard>,
@@ -375,9 +377,11 @@ fn push_unique(missing: &mut Vec<String>, name: String) {
     }
 }
 
-/// Builds the page's event items and its deduplicated blocks, accumulates the
-/// page's transactions into `transaction_store`, and checks that every requested
-/// block/transaction field came back. Returns `ConvertError::MissingFields`
+/// Builds the page's event items and its deduplicated block headers, fills the
+/// page's transaction and block stores, and checks that every requested
+/// block/transaction field came back. Only the blocks and transactions a routed
+/// item joins to reach the stores — a log that routes nowhere is dropped, and
+/// so is everything joined to it. Returns `ConvertError::MissingFields`
 /// (surfaced as `ImpossibleForTheQuery` on the JS side) when the source omitted
 /// a requested non-nullable field or a joined row, and propagates genuine decode
 /// errors otherwise.
@@ -394,36 +398,91 @@ fn process_response(
     block_store: &BlockStore,
     set_cache: &SetCache,
 ) -> std::result::Result<(Vec<EventItem>, Vec<BlockHeader>), ConvertError> {
-    // The server returns one block per number; items reference them by number,
-    // so keep them owned and track which numbers are present for coverage.
-    let response_blocks: Vec<simple_types::Block> = blocks.into_iter().flatten().collect();
-    let present_block_numbers: HashSet<u64> =
-        response_blocks.iter().filter_map(|b| b.number).collect();
-
     let mut missing: Vec<String> = Vec::new();
+
+    // Route before touching the joined tables: routing is what decides which
+    // blocks and transactions anything will ever read.
+    let mut items = Vec::with_capacity(logs.iter().map(Vec::len).sum());
+    let mut referenced_blocks: HashSet<u64> = HashSet::new();
+    let mut referenced_transactions: HashSet<(u64, u32)> = HashSet::new();
+    {
+        // One read lock for the whole page: registration from the JS thread waits
+        // only as long as routing takes.
+        let address_store = decoder.lock_store();
+        for log in logs.into_iter().flatten() {
+            let (log_index, src_address, block_number, transaction_index) =
+                flatten_log_for_js(&log, should_checksum).context("mapping log")?;
+            // The emitter's raw 20 bytes are already the store's key, so ownership
+            // and the effectiveStartBlock gate cost one hash lookup each — no
+            // round-trip through the address string.
+            let address_key = log.address.as_ref().context("log.address missing")?;
+            let address = LogAddress {
+                key: address_key.as_slice(),
+                contract_name: set_cache.owner_of(address_key.as_slice()),
+                block_number,
+            };
+            // Only structurally malformed logs (missing topic0, bad topic bytes)
+            // surface here; per-registration decode failures are dropped inside
+            // `route_and_decode`.
+            let routed = decoder
+                .route_and_decode_simple(&log, &address, &address_store)
+                .context("decode event params")?;
+            if routed.is_empty() {
+                continue;
+            }
+            referenced_blocks.insert(block_number as u64);
+            referenced_transactions.insert((block_number as u64, transaction_index as u32));
+            for routed in routed {
+                items.push(EventItem {
+                    log_index,
+                    src_address: src_address.clone(),
+                    block_number,
+                    transaction_index,
+                    on_event_registration_index: routed.index,
+                    params: routed.params,
+                });
+            }
+        }
+    }
 
     // Accumulate transactions into the store keyed by (blockNumber, txIndex).
     // Many logs share a transaction, and the server returns each one once, so
-    // the page's transactions go in as one chunk.
+    // the page's transactions go in as one chunk. A transaction no item
+    // references is dropped whole — nothing ever reads its fields, so they
+    // aren't validated either.
     let mut transaction_keys: HashSet<(u64, u32)> = HashSet::new();
     if !requested_transaction_fields.is_empty() {
         let mut kept: Vec<simple_types::Transaction> = Vec::new();
         for tx in transactions.into_iter().flatten() {
+            let key = match (tx.block_number, tx.transaction_index) {
+                (Some(block_number), Some(transaction_index)) => {
+                    Some((u64::from(block_number), u64::from(transaction_index) as u32))
+                }
+                _ => None,
+            };
+            if key.is_some_and(|key| !referenced_transactions.contains(&key)) {
+                continue;
+            }
             for &field in requested_transaction_fields {
                 if let Some(name) = transaction_field_missing(&tx, field) {
                     push_unique(&mut missing, format!("transaction.{}", name));
                 }
             }
-            if let (Some(block_number), Some(transaction_index)) =
-                (tx.block_number, tx.transaction_index)
-            {
-                transaction_keys
-                    .insert((u64::from(block_number), u64::from(transaction_index) as u32));
+            if let Some(key) = key {
+                transaction_keys.insert(key);
                 kept.push(tx);
             }
         }
         transaction_store.insert_evm_txs(kept);
     }
+
+    // The server returns one block per number. Every returned block still
+    // yields a header — reorg detection reads them all, items or not — so keep
+    // them owned, validate them all, and track which numbers are present for
+    // coverage.
+    let response_blocks: Vec<simple_types::Block> = blocks.into_iter().flatten().collect();
+    let present_block_numbers: HashSet<u64> =
+        response_blocks.iter().filter_map(|b| b.number).collect();
 
     // Validate every block field we requested — the user's selection plus the
     // always-required number/timestamp/hash — once per distinct block.
@@ -435,25 +494,19 @@ fn process_response(
         }
     }
 
-    // Coverage: every log must resolve to its block (when block fields were
-    // requested) and its transaction (when transaction fields were requested).
-    for log in logs.iter().flatten() {
-        if !validated_block_fields.is_empty() {
-            let present = log
-                .block_number
-                .is_some_and(|n| present_block_numbers.contains(&u64::from(n)));
-            if !present {
+    // Coverage: every routed item must resolve to its block (when block fields
+    // were requested) and its transaction (when transaction fields were
+    // requested).
+    if !validated_block_fields.is_empty() {
+        for block_number in &referenced_blocks {
+            if !present_block_numbers.contains(block_number) {
                 push_unique(&mut missing, "block".into());
             }
         }
-        if !requested_transaction_fields.is_empty() {
-            let present = match (log.block_number, log.transaction_index) {
-                (Some(bn), Some(ti)) => {
-                    transaction_keys.contains(&(u64::from(bn), u64::from(ti) as u32))
-                }
-                _ => false,
-            };
-            if !present {
+    }
+    if !requested_transaction_fields.is_empty() {
+        for key in &referenced_transactions {
+            if !transaction_keys.contains(key) {
                 push_unique(&mut missing, "transaction".into());
             }
         }
@@ -484,45 +537,16 @@ fn process_response(
         .collect::<Result<Vec<_>>>()
         .context("mapping block headers")?;
 
-    // Retained for every block, not just when an event selected a field beyond
-    // the trio: number/timestamp/hash decode from the store like any other
-    // field (see `decode_evm_block_field`), so the store needs an entry for
-    // every block the config's always-included trio selection touches.
-    block_store.insert_evm_blocks(response_blocks);
-
-    // One read lock for the whole page: registration from the JS thread waits
-    // only as long as routing takes.
-    let address_store = decoder.lock_store();
-    let mut items = Vec::with_capacity(logs.iter().map(Vec::len).sum());
-    for log in logs.into_iter().flatten() {
-        let (log_index, src_address, block_number, transaction_index) =
-            flatten_log_for_js(&log, should_checksum).context("mapping log")?;
-        // The emitter's raw 20 bytes are already the store's key, so ownership
-        // and the effectiveStartBlock gate cost one hash lookup each — no
-        // round-trip through the address string.
-        let address_key = log.address.as_ref().context("log.address missing")?;
-        let address = LogAddress {
-            key: address_key.as_slice(),
-            contract_name: set_cache.owner_of(address_key.as_slice()),
-            block_number,
-        };
-        // Only structurally malformed logs (missing topic0, bad topic bytes)
-        // surface here; per-registration decode failures are dropped inside
-        // `route_and_decode`.
-        let routed = decoder
-            .route_and_decode_simple(&log, &address, &address_store)
-            .context("decode event params")?;
-        for routed in routed {
-            items.push(EventItem {
-                log_index,
-                src_address: src_address.clone(),
-                block_number,
-                transaction_index,
-                on_event_registration_index: routed.index,
-                params: routed.params,
-            });
-        }
-    }
+    // Kept for every referenced block, not just when an event selected a field
+    // beyond the trio: number/timestamp/hash decode from the store like any
+    // other field (see `decode_evm_block_field`), so the store needs an entry
+    // for every block the config's always-included trio selection touches.
+    let mut kept_blocks = response_blocks;
+    kept_blocks.retain(|b| {
+        b.number
+            .is_some_and(|number| referenced_blocks.contains(&number))
+    });
+    block_store.insert_evm_blocks(kept_blocks);
 
     Ok((items, out_blocks))
 }
@@ -760,6 +784,18 @@ mod tests {
         }
     }
 
+    /// Same shape as `full_log`, but on a topic0 no fixture registration pins —
+    /// so it routes nowhere.
+    fn unrouted_log(block_number: u64) -> simple_types::Log {
+        let mut topic0 = [0u8; 32];
+        topic0[31] = 1;
+        let topic0 = hypersync_client::format::LogArgument::from(topic0);
+        simple_types::Log {
+            topics: std::iter::once(Some(topic0)).collect(),
+            ..full_log(block_number)
+        }
+    }
+
     #[test]
     fn missing_block_field_returns_typed_error() {
         // The server returned no block for the log but the user asked for
@@ -767,8 +803,8 @@ mod tests {
         let err = process_response(
             vec![],
             vec![],
-            vec![vec![simple_types::Log::default()]],
-            &empty_decoder(),
+            vec![vec![full_log(1)]],
+            &zero_event_decoder(),
             false,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[],
@@ -893,7 +929,7 @@ mod tests {
             vec![vec![block]],
             vec![vec![tx]],
             vec![vec![full_log(1)]],
-            &empty_decoder(),
+            &zero_event_decoder(),
             false,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[TransactionField::Hash],
@@ -924,7 +960,7 @@ mod tests {
             vec![vec![block]],
             vec![],
             vec![vec![full_log(1)]],
-            &empty_decoder(),
+            &zero_event_decoder(),
             false,
             &[BlockField::Number, BlockField::Hash, BlockField::Timestamp],
             &[TransactionField::Hash],
@@ -978,6 +1014,83 @@ mod tests {
                 blocks.iter().map(|b| b.number).collect::<Vec<_>>(),
             ),
             (vec![7], vec![7])
+        );
+    }
+
+    // `materialize` uses `block_in_place`, which needs a multi-thread runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unrouted_logs_keep_their_block_and_transaction_out_of_the_stores() {
+        // Block 1's log routes; block 2's doesn't. Both blocks and both
+        // transactions come back from the server, but only block 1's pair is
+        // ever read, so only it is stored.
+        let block = |number: u64| simple_types::Block {
+            number: Some(number),
+            hash: Some(Default::default()),
+            timestamp: Some(Default::default()),
+            ..Default::default()
+        };
+        let tx = |block_number: u64| simple_types::Transaction {
+            block_number: Some(block_number.into()),
+            transaction_index: Some(0u64.into()),
+            hash: Some(Default::default()),
+            ..Default::default()
+        };
+
+        let transaction_store = TransactionStore::new_evm(false);
+        let block_store = BlockStore::new_evm(false);
+        let (items, blocks) = process_response(
+            vec![vec![block(1), block(2)]],
+            vec![vec![tx(1), tx(2)]],
+            vec![vec![full_log(1), unrouted_log(2)]],
+            &zero_event_decoder(),
+            false,
+            REQUIRED_BLOCK_FIELDS,
+            &[TransactionField::Hash],
+            &transaction_store,
+            &block_store,
+            empty_set().cache(),
+        )
+        .expect("expected success");
+
+        let stored_transaction_hashes = transaction_store
+            .materialize(
+                vec![1, 2],
+                vec![0, 0],
+                vec![(1u64 << (crate::transaction_store::EvmTxField::Hash as u32)) as f64; 2],
+            )
+            .await
+            .expect("materialize transactions");
+        let stored_block_hashes = block_store
+            .materialize(
+                vec![1, 2],
+                vec![(1u64 << (crate::block_store::EvmBlockField::Hash as u32)) as f64; 2],
+            )
+            .await
+            .expect("materialize blocks");
+
+        let column = |cols: &crate::field_columns::Columns, name: &str| match cols
+            .columns
+            .iter()
+            .find(|(n, _)| *n == name)
+        {
+            Some((_, crate::field_columns::Column::Str(values))) => values.clone(),
+            _ => panic!("expected a {name} string column"),
+        };
+        let zero_hash = format!("0x{}", "00".repeat(32));
+        assert_eq!(
+            (
+                items.iter().map(|i| i.block_number).collect::<Vec<_>>(),
+                blocks.iter().map(|b| b.number).collect::<Vec<_>>(),
+                column(&stored_transaction_hashes, "hash"),
+                column(&stored_block_hashes, "hash"),
+            ),
+            (
+                vec![1],
+                // Every returned block still yields a header; only the store is filtered.
+                vec![1, 2],
+                vec![Some(zero_hash.clone()), None],
+                vec![Some(zero_hash), None],
+            )
         );
     }
 

--- a/packages/cli/src/field_columns.rs
+++ b/packages/cli/src/field_columns.rs
@@ -117,6 +117,28 @@ pub struct Columns {
     pub columns: Vec<(&'static str, Column)>,
 }
 
+/// Reading materialised columns back out, for the store tests across this crate.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::{Column, Columns};
+
+    pub(crate) fn column<'a>(cols: &'a Columns, name: &str) -> Option<&'a Column> {
+        cols.columns
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, c)| c)
+    }
+
+    /// The string column `name`, one entry per materialised row (`None` where
+    /// the store had no row, or the row no value).
+    pub(crate) fn str_column(cols: &Columns, name: &str) -> Vec<Option<String>> {
+        match column(cols, name) {
+            Some(Column::Str(values)) => values.clone(),
+            _ => panic!("expected a {name} string column"),
+        }
+    }
+}
+
 impl ToNapiValue for Columns {
     unsafe fn to_napi_value(env: sys::napi_env, val: Self) -> napi::Result<sys::napi_value> {
         let mut arr = std::ptr::null_mut();

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -52,10 +52,22 @@ use types::{opt_hex, to_hex, QueryResponse};
 /// instructions in one transaction collapse to a single stored row, and token
 /// balances land in the store's companion table joined back by key at
 /// materialisation.
+///
+/// `keys` restricts what is stored to the transactions routed items reference;
+/// `None` stores the whole response (the raw `get` query, which builds no
+/// items).
 fn build_svm_store(
-    transactions: Vec<simple::Transaction>,
-    token_balances: Vec<simple::TokenBalance>,
+    mut transactions: Vec<simple::Transaction>,
+    mut token_balances: Vec<simple::TokenBalance>,
+    keys: Option<&HashSet<(u64, u32)>>,
 ) -> TransactionStore {
+    if let Some(keys) = keys {
+        transactions.retain(|tx| keys.contains(&(tx.slot, tx.transaction_index)));
+        token_balances.retain(|b| {
+            b.transaction_index
+                .is_some_and(|i| keys.contains(&(b.slot, i)))
+        });
+    }
     let store = TransactionStore::new_svm();
     store.insert_svm_txs(transactions);
     store.insert_svm_token_balances(token_balances);
@@ -230,9 +242,10 @@ impl SvmHyperSyncClient {
         let store = build_svm_store(
             std::mem::take(&mut resp.transactions),
             std::mem::take(&mut resp.token_balances),
+            None,
         );
 
-        let (block_headers, block_store) = take_blocks(&mut resp).map_err(map_err)?;
+        let (block_headers, block_store) = take_blocks(&mut resp, None).map_err(map_err)?;
 
         let mut out = QueryResponse::try_from(resp)
             .context("convert solana response")
@@ -321,15 +334,11 @@ impl SvmHyperSyncClient {
             .context("solana get")
             .map_err(map_err)?;
 
-        let store = build_svm_store(
-            std::mem::take(&mut resp.transactions),
-            std::mem::take(&mut resp.token_balances),
-        );
-        let (block_headers, block_store) = take_blocks(&mut resp).map_err(map_err)?;
-
         let client_filtered = crate::client_filtered_contracts::ClientFilteredContracts::from_vec(
             params.client_filtered_contracts.unwrap_or_default(),
         );
+        // Route before filling the stores: an instruction that routes nowhere
+        // keeps neither its transaction nor its block.
         let items = {
             let store = self.address_store.read().unwrap();
             build_event_items(
@@ -343,6 +352,28 @@ impl SvmHyperSyncClient {
             )
             .map_err(map_err)?
         };
+
+        let referenced_transactions: HashSet<(u64, u32)> = items
+            .iter()
+            .filter_map(|item| {
+                Some((
+                    u64::try_from(item.slot).ok()?,
+                    u32::try_from(item.transaction_index).ok()?,
+                ))
+            })
+            .collect();
+        let referenced_slots: HashSet<u64> = referenced_transactions
+            .iter()
+            .map(|(slot, _)| *slot)
+            .collect();
+
+        let store = build_svm_store(
+            std::mem::take(&mut resp.transactions),
+            std::mem::take(&mut resp.token_balances),
+            Some(&referenced_transactions),
+        );
+        let (block_headers, block_store) =
+            take_blocks(&mut resp, Some(&referenced_slots)).map_err(map_err)?;
 
         let response = EventItemsResponse {
             next_slot: i64::try_from(resp.next_slot)
@@ -530,14 +561,25 @@ where
 /// Take the raw blocks out of the response, build the lean per-slot header
 /// from a borrow, then move the owned raw blocks into the store — avoiding a
 /// full raw-`Block` clone per block. slot/time/hash decode from the store like
-/// any other field, so every response block needs a store entry.
-fn take_blocks(resp: &mut simple::SolanaResponse) -> Result<(Vec<types::Block>, BlockStore)> {
-    let raw_blocks = std::mem::take(&mut resp.blocks);
+/// any other field, so every block an item reads needs a store entry.
+///
+/// `slots` restricts what is stored to the slots routed items reference;
+/// `None` stores every block (the raw `get` query, which builds no items).
+/// Headers are built for every returned block either way — reorg detection and
+/// the batch's latest timestamp read them whether an item landed there or not.
+fn take_blocks(
+    resp: &mut simple::SolanaResponse,
+    slots: Option<&HashSet<u64>>,
+) -> Result<(Vec<types::Block>, BlockStore)> {
+    let mut raw_blocks = std::mem::take(&mut resp.blocks);
     let block_headers: Vec<types::Block> = raw_blocks
         .iter()
         .map(types::Block::from_raw)
         .collect::<Result<Vec<_>>>()
         .context("mapping solana block headers")?;
+    if let Some(slots) = slots {
+        raw_blocks.retain(|b| slots.contains(&b.slot));
+    }
     let block_store = BlockStore::new_svm();
     block_store.insert_svm_blocks(raw_blocks);
     Ok((block_headers, block_store))
@@ -795,6 +837,117 @@ mod tests {
         assert_eq!(
             schemas.keys().collect::<Vec<_>>(),
             vec![TOKEN_METADATA_PROGRAM]
+        );
+    }
+
+    fn column<'a>(
+        cols: &'a crate::field_columns::Columns,
+        name: &str,
+    ) -> Option<&'a crate::field_columns::Column> {
+        cols.columns
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, c)| c)
+    }
+
+    fn str_column(cols: &crate::field_columns::Columns, name: &str) -> Vec<Option<String>> {
+        match column(cols, name) {
+            Some(crate::field_columns::Column::Str(values)) => values.clone(),
+            _ => panic!("expected a {name} string column"),
+        }
+    }
+
+    // `materialize` uses `block_in_place`, which needs a multi-thread runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn store_keeps_only_the_transactions_and_balances_items_reference() {
+        let tx = |slot, index| simple::Transaction {
+            slot,
+            transaction_index: index,
+            fee_payer: Some(format!("payer{slot}")),
+            ..Default::default()
+        };
+        let balance = |slot, index| simple::TokenBalance {
+            slot,
+            transaction_index: Some(index),
+            account: Some(format!("acct{slot}")),
+            mint: Some(format!("mint{slot}")),
+            ..Default::default()
+        };
+        // Only (42, 7) is routed; (43, 7) came back on the same page unreferenced.
+        let referenced: HashSet<(u64, u32)> = [(42u64, 7u32)].into_iter().collect();
+        let store = build_svm_store(
+            vec![tx(42, 7), tx(43, 7)],
+            vec![balance(42, 7), balance(43, 7)],
+            Some(&referenced),
+        );
+
+        let mask = ((1u64 << (crate::transaction_store::SvmTxField::FeePayer as u32))
+            | (1u64 << (crate::transaction_store::SvmTxField::TokenBalances as u32)))
+            as f64;
+        let cols = store
+            .materialize(vec![42, 43], vec![7, 7], vec![mask, mask])
+            .await
+            .expect("materialize");
+
+        let mints: Vec<Option<Vec<Option<String>>>> = match column(&cols, "tokenBalances") {
+            Some(crate::field_columns::Column::TokenBalances(rows)) => rows
+                .iter()
+                .map(|r| {
+                    r.as_ref()
+                        .map(|v| v.iter().map(|tb| tb.mint.clone()).collect())
+                })
+                .collect(),
+            _ => panic!("expected a tokenBalances column"),
+        };
+        assert_eq!(
+            (str_column(&cols, "feePayer"), mints),
+            (
+                vec![Some("payer42".to_string()), None],
+                // The unreferenced transaction keeps no balances either; a
+                // selected row with none materialises as `[]`.
+                vec![Some(vec![Some("mint42".to_string())]), Some(vec![])],
+            )
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn block_store_keeps_only_referenced_slots_while_headers_keep_all() {
+        let mut resp = simple::SolanaResponse {
+            blocks: vec![
+                simple::Block {
+                    slot: 42,
+                    blockhash: "hash42".to_string(),
+                    ..Default::default()
+                },
+                simple::Block {
+                    slot: 43,
+                    blockhash: "hash43".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let referenced: HashSet<u64> = [42u64].into_iter().collect();
+        let (headers, block_store) =
+            take_blocks(&mut resp, Some(&referenced)).expect("take blocks");
+
+        let mask = (1u64 << (crate::block_store::SvmBlockField::Hash as u32)) as f64;
+        let cols = block_store
+            .materialize(vec![42, 43], vec![mask, mask])
+            .await
+            .expect("materialize");
+
+        assert_eq!(
+            (
+                headers.iter().map(|b| b.slot).collect::<Vec<_>>(),
+                str_column(&cols, "hash"),
+            ),
+            (
+                // Reorg detection and the batch's latest timestamp read every
+                // returned slot, so headers aren't filtered.
+                vec![42, 43],
+                vec![Some("hash42".to_string()), None],
+            )
         );
     }
 }

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -840,22 +840,7 @@ mod tests {
         );
     }
 
-    fn column<'a>(
-        cols: &'a crate::field_columns::Columns,
-        name: &str,
-    ) -> Option<&'a crate::field_columns::Column> {
-        cols.columns
-            .iter()
-            .find(|(n, _)| *n == name)
-            .map(|(_, c)| c)
-    }
-
-    fn str_column(cols: &crate::field_columns::Columns, name: &str) -> Vec<Option<String>> {
-        match column(cols, name) {
-            Some(crate::field_columns::Column::Str(values)) => values.clone(),
-            _ => panic!("expected a {name} string column"),
-        }
-    }
+    use crate::field_columns::test_support::{column, str_column};
 
     // `materialize` uses `block_in_place`, which needs a multi-thread runtime.
     #[tokio::test(flavor = "multi_thread")]
@@ -906,6 +891,55 @@ mod tests {
                 // The unreferenced transaction keeps no balances either; a
                 // selected row with none materialises as `[]`.
                 vec![Some(vec![Some("mint42".to_string())]), Some(vec![])],
+            )
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_key_set_stores_the_whole_response() {
+        // The raw `get` query builds no items, so it has no reference set to
+        // filter by and must keep everything.
+        let mut resp = simple::SolanaResponse {
+            blocks: vec![simple::Block {
+                slot: 43,
+                blockhash: "hash43".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let store = build_svm_store(
+            vec![simple::Transaction {
+                slot: 43,
+                transaction_index: 7,
+                fee_payer: Some("payer43".to_string()),
+                ..Default::default()
+            }],
+            vec![],
+            None,
+        );
+        let (_, block_store) = take_blocks(&mut resp, None).expect("take blocks");
+
+        let txs = store
+            .materialize(
+                vec![43],
+                vec![7],
+                vec![(1u64 << (crate::transaction_store::SvmTxField::FeePayer as u32)) as f64],
+            )
+            .await
+            .expect("materialize transactions");
+        let blocks = block_store
+            .materialize(
+                vec![43],
+                vec![(1u64 << (crate::block_store::SvmBlockField::Hash as u32)) as f64],
+            )
+            .await
+            .expect("materialize blocks");
+
+        assert_eq!(
+            (str_column(&txs, "feePayer"), str_column(&blocks, "hash")),
+            (
+                vec![Some("payer43".to_string())],
+                vec![Some("hash43".to_string())],
             )
         );
     }

--- a/packages/cli/src/transaction_store.rs
+++ b/packages/cli/src/transaction_store.rs
@@ -658,12 +658,7 @@ mod tests {
         }
     }
 
-    fn column<'a>(cols: &'a Columns, name: &str) -> Option<&'a Column> {
-        cols.columns
-            .iter()
-            .find(|(n, _)| *n == name)
-            .map(|(_, c)| c)
-    }
+    use crate::field_columns::test_support::column;
 
     fn bit(field: EvmTxField) -> u64 {
         1u64 << (field as u32)

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -710,6 +710,9 @@ let groupBatchItems = (items: array<Internal.item>, ~includeBlocks: bool): (
           }
         }
       }
+    // onBlock items build their block from the handler's own block number, not
+    // from the stores — which is what lets the sources keep only the blocks and
+    // transactions an event item references.
     | Internal.Block(_) => ()
     }
   )

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -16,7 +16,7 @@ let reraisIfRateLimited = exn =>
 
 type logsQueryPage = {
   items: array<HyperSyncClient.EventItems.item>,
-  // Block headers referenced by `items`, deduplicated by block number.
+  // Headers for every returned block, deduplicated by block number.
   blocks: array<HyperSyncClient.EventItems.blockHeader>,
   nextBlock: int,
   archiveHeight: int,

--- a/packages/envio/src/sources/HyperSyncClient.res
+++ b/packages/envio/src/sources/HyperSyncClient.res
@@ -344,7 +344,9 @@ module EventItems = {
   type response = {
     archiveHeight: option<int>,
     nextBlock: int,
-    // One header per block number referenced by `items`.
+    // One header per returned block number, including blocks no item
+    // references — reorg detection reads them all. The block store keeps only
+    // the ones items reference.
     blocks: array<blockHeader>,
     items: array<item>,
     rollbackGuard: option<ResponseTypes.rollbackGuard>,
@@ -372,12 +374,7 @@ external classNew: (
 ) => t = "new"
 
 let makeWithAgent = (cfg, ~userAgent, ~eventRegistrations, ~addressStore) =>
-  Core.getAddon().evmHyperSyncClient->classNew(
-    cfg,
-    userAgent,
-    eventRegistrations,
-    addressStore,
-  )
+  Core.getAddon().evmHyperSyncClient->classNew(cfg, userAgent, eventRegistrations, addressStore)
 
 type logLevel = [#trace | #debug | #info | #warn | #error]
 let logLevelSchema: S.t<logLevel> = S.enum([#trace, #debug, #info, #warn, #error])

--- a/packages/envio/src/sources/SvmHyperSyncClient.res
+++ b/packages/envio/src/sources/SvmHyperSyncClient.res
@@ -224,8 +224,10 @@ module EventItems = {
 
   type response = {
     nextSlot: int,
-    // One lean header per slot referenced by `items`; the full blocks live in
-    // the block store returned alongside.
+    // One lean header per returned slot, including slots no item references —
+    // reorg detection and the batch's latest timestamp read them all. The full
+    // blocks live in the block store returned alongside, which keeps only the
+    // slots items reference.
     blocks: array<ResponseTypes.block>,
     items: array<item>,
   }


### PR DESCRIPTION
## Summary

Refactors block and transaction store population to only include data that routed items actually reference, rather than storing everything the server returns. This reduces memory usage and ensures validation only covers relevant data.

## Key Changes

**EVM HyperSync (`packages/cli/src/evm_hypersync_source/mod.rs`)**
- Moved routing logic before store population: items are now routed first to determine which blocks and transactions are actually needed
- Track `referenced_blocks` and `referenced_transactions` during routing
- Filter transaction store to only include transactions referenced by routed items
- Filter block store to only include blocks referenced by routed items
- Keep block headers for all returned blocks (needed for reorg detection), but only store full blocks for referenced ones
- Updated coverage validation to check only referenced blocks/transactions instead of all logs
- Added test `unrouted_logs_keep_their_block_and_transaction_out_of_the_stores` verifying unrouted logs don't pollute stores

**SVM HyperSync (`packages/cli/src/svm_hypersync_source/mod.rs`)**
- Added `keys` parameter to `build_svm_store` to filter transactions and token balances to only referenced ones
- Modified `take_blocks` to accept optional `slots` parameter for filtering stored blocks
- Route items before populating stores in the event query path
- Keep block headers for all returned slots but only store full blocks for referenced ones
- Added tests verifying stores only contain referenced transactions/balances and blocks

**Documentation (`packages/envio/src/sources/*.res`)**
- Updated comments in `HyperSyncClient.res` and `SvmHyperSyncClient.res` to clarify that block/slot headers are returned for all blocks but stores only keep referenced ones
- Clarified that reorg detection reads all headers regardless of item routing

## Implementation Details

- Routing happens in a single read lock to minimize contention with JS thread registration
- Unrouted logs (those that don't match any event registration) are dropped entirely—their blocks and transactions are not stored
- Block/slot headers are still generated for all returned blocks to support reorg detection and batch timestamp tracking
- Coverage checks now validate only the blocks and transactions that items actually reference

https://claude.ai/code/session_01MNYqQQUEH7HYFBWsv812XH