### PR TITLE
Scope address-param markers to partition's set, gate on store

### DIFF
--- a/packages/cli/src/address_store.rs
+++ b/packages/cli/src/address_store.rs
@@ -176,7 +176,8 @@ impl StoreInner {
 pub struct AddressStoreContract {
     pub name: String,
     /// The minimum `startBlock` across the contract's registrations; absent
-    /// means the chain's own start block governs.
+    /// means block 0, since partitions never query below the chain's own start
+    /// block anyway.
     pub start_block: Option<i64>,
 }
 
@@ -449,25 +450,40 @@ impl AddressStore {
         }
     }
 
-    /// Canonical strings for one contract's addresses, in set order. Used by
-    /// `chain.<Contract>.addresses` and by tests.
+    /// Canonical strings for every address registered under one contract, in set
+    /// order. Used by `chain.<Contract>.addresses` and by tests. Addresses of a
+    /// contract with no events are included: they're registered and persisted,
+    /// just never fetched, so the getter must still report them.
     #[napi]
     pub fn contract_addresses(&self, contract_name: String) -> Vec<String> {
         let store = self.read();
-        let Some(contract_idx) = store.contract_idx(&contract_name) else {
-            return Vec::new();
+        let mut out: Vec<String> = match store.contract_idx(&contract_name) {
+            None => Vec::new(),
+            Some(contract_idx) => {
+                let ids: Vec<u64> = (0..store.entries.len() as u64)
+                    .filter(|&id| {
+                        let entry = store.entry(id);
+                        !entry.dead && entry.contract_idx == contract_idx
+                    })
+                    .collect();
+                store
+                    .sorted_ids(ids)
+                    .into_iter()
+                    .map(|id| address_string(store.ecosystem, &store.entry(id).key))
+                    .collect()
+            }
         };
-        let ids: Vec<u64> = (0..store.entries.len() as u64)
-            .filter(|&id| {
-                let entry = store.entry(id);
-                !entry.dead && entry.contract_idx == contract_idx
-            })
+        // No-events entries have no id to order by, so they follow, ordered by
+        // their own key to keep the listing reproducible.
+        let mut no_events: Vec<String> = store
+            .no_events
+            .iter()
+            .filter(|(_, entry)| entry.contract_name == contract_name)
+            .map(|(key, _)| address_string(store.ecosystem, key))
             .collect();
-        store
-            .sorted_ids(ids)
-            .into_iter()
-            .map(|id| address_string(store.ecosystem, &store.entry(id).key))
-            .collect()
+        no_events.sort();
+        out.append(&mut no_events);
+        out
     }
 
     /// Every registered address in set order, no-events ones last (ordered by
@@ -720,17 +736,6 @@ impl AddressSet {
     #[napi]
     pub fn size(&self) -> i64 {
         self.ids.len() as i64
-    }
-
-    /// Live addresses per contract name. The fetch state carries this alongside
-    /// the set so partition sizing never walks the addresses.
-    #[napi]
-    pub fn count_by_contract(&self) -> HashMap<String, i64> {
-        self.cache()
-            .contracts
-            .iter()
-            .map(|slice| (slice.name.clone(), slice.addresses.len() as i64))
-            .collect()
     }
 
     /// The chain-wide gate, reachable through any set of the store. Not set
@@ -989,6 +994,20 @@ pub(crate) mod test_support {
         store_of(Ecosystem::Svm, entries)
     }
 
+    /// Every live address the store holds, as one set — reachable from a store
+    /// handle alone, for routing tests that keep only the handle their client
+    /// cloned.
+    pub(crate) fn full_set(handle: &Arc<RwLock<StoreInner>>) -> AddressSet {
+        let ids = {
+            let store = handle.read().unwrap();
+            let live: Vec<u64> = (0..store.entries.len() as u64)
+                .filter(|&id| !store.entry(id).dead)
+                .collect();
+            store.sorted_ids(live)
+        };
+        AddressSet::new(handle.clone(), ids)
+    }
+
     /// One set spanning every named contract's addresses.
     pub(crate) fn set_of(store: &AddressStore, contract_names: &[&str]) -> AddressSet {
         contract_names
@@ -1108,15 +1127,45 @@ mod tests {
             reg(A, "Unknown", 30),
         ]);
         assert_eq!(kinds(&verdicts), vec!["noEvents", "conflict", "duplicate"]);
-        // Never fetched: no contract owns it in a set, but it is still counted
-        // and listed so it gets persisted.
+        // Never fetched: no contract owns it in a set, but it is still counted,
+        // listed and reported by `chain.<Contract>.addresses` so it gets
+        // persisted and stays visible to the user.
         assert_eq!(
             (
                 store.make_set("Unknown".to_string(), None).size(),
                 store.size(),
-                store.entries().len()
+                store.entries().len(),
+                store.contract_addresses("Unknown".to_string()),
             ),
-            (0, 1, 1)
+            (0, 1, 1, vec![A.to_string()])
+        );
+    }
+
+    #[test]
+    fn contract_addresses_lists_live_and_no_events_entries() {
+        // A contract can hold both at once after a config change removes the
+        // events of some addresses but not others; the getter reports every
+        // address registered under the name, fetched or not.
+        let store = AddressStore::new_evm(false, contracts(&[("C", None)]));
+        let verdicts = store.register_batch(vec![
+            reg(B, "C", 20),
+            reg(A, "C", 10),
+            reg(C, "NoEvents", 30),
+        ]);
+        assert_eq!(
+            (
+                kinds(&verdicts),
+                store.contract_addresses("C".to_string()),
+                store.contract_addresses("NoEvents".to_string()),
+                store.contract_addresses("Missing".to_string()),
+            ),
+            (
+                vec!["added", "added", "noEvents"],
+                // Set order: A(10) before B(20).
+                vec![A.to_string(), B.to_string()],
+                vec![C.to_string()],
+                vec![],
+            )
         );
     }
 
@@ -1232,13 +1281,15 @@ mod tests {
             (
                 merged.addresses(),
                 merged.slice(1, Some(1)).addresses(),
-                merged.count_by_contract(),
+                merged.count_for("C".to_string()),
+                merged.count_for("D".to_string()),
             ),
             (
                 // Ordered by effectiveStartBlock: B(100), C(200), A(300).
                 vec![B.to_string(), C.to_string(), A.to_string()],
                 vec![C.to_string()],
-                HashMap::from([("C".to_string(), 2), ("D".to_string(), 1)]),
+                2,
+                1,
             )
         );
     }

--- a/packages/cli/src/client_filtered_contracts.rs
+++ b/packages/cli/src/client_filtered_contracts.rs
@@ -1,12 +1,12 @@
 //! Contracts a single query fetches address-free even though their
 //! registrations depend on addresses. When a contract's registered address
 //! count grows past the server-side threshold, the fetch state switches it to
-//! client-side filtering: its log/receipt selections are built
-//! without a server-side address filter and routing accepts any emitter, while
-//! the JS `clientAddressFilter` still drops items whose emitter isn't a
-//! registered address at/before the log's block. Shared by every source's
-//! selection builder and router so the "is this registration client-filtered"
-//! decision lives in one place.
+//! client-side filtering: its log/receipt selections are built without a
+//! server-side address filter, and routing — which can no longer ask the
+//! partition's set who owns an emitter, since the query carries none of the
+//! contract's addresses — gates the over-fetched items on the address store
+//! alone. Shared by every source's selection builder and router so the "is this
+//! registration client-filtered" decision lives in one place.
 
 use std::collections::HashSet;
 

--- a/packages/cli/src/evm_hypersync_source/decode.rs
+++ b/packages/cli/src/evm_hypersync_source/decode.rs
@@ -41,7 +41,7 @@ pub(crate) struct LogAddress<'a> {
 /// The 20 address bytes of a padded indexed topic, or `None` when the topic's
 /// upper bytes aren't zero — then it isn't an address at all.
 fn topic_address(topic: &LogArgument) -> Option<&[u8]> {
-    let bytes: &[u8; 32] = &***topic;
+    let bytes: &[u8; 32] = topic;
     bytes[..12].iter().all(|b| *b == 0).then(|| &bytes[12..])
 }
 

--- a/packages/cli/src/evm_hypersync_source/decode.rs
+++ b/packages/cli/src/evm_hypersync_source/decode.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use hypersync_client::format::{Data, Hex, LogArgument};
 use hypersync_client::simple_types;
 
-use crate::address_store::{AddressStore, StoreInner};
+use crate::address_store::{AddressStore, SetCache, StoreInner};
 use crate::evm_hypersync_source::selection::TopicSelectionInput;
 use crate::evm_hypersync_source::types::{
     sol_value_to_param, Log, OnEventRegistrationInput, ParamMeta, ParamValue,
@@ -20,10 +20,12 @@ enum TopicConstraint {
     /// Matches when the log's topic is one of these values.
     Values(Vec<[u8; 32]>),
     /// A `ContractAddresses` marker: the topic must be the padded form of an
-    /// address registered for the registration's own contract, at or before the
-    /// log's block. Both halves are answered by the chain's address store, so a
-    /// merged partition that over-fetches a param value registered later in the
-    /// chain drops it here instead of downstream.
+    /// address this partition holds for the registration's own contract, at or
+    /// before the log's block. Ownership is the partition set's answer — the
+    /// query materialised this position from that same set, so a sibling
+    /// selection's log carrying another partition's address must not fan out
+    /// here. The store answers only the temporal half, dropping a value
+    /// registered after the log's block that a merged partition over-fetched.
     ContractAddresses,
 }
 
@@ -88,13 +90,19 @@ impl TopicFilters {
     }
 
     /// Whether a log's topics satisfy any DNF alternative. `ContractAddresses`
-    /// markers resolve against the chain's address store under `contract_idx`,
-    /// gated on the log's block.
+    /// markers resolve against the partition's set under `contract_name`, then
+    /// against the store for the `effectiveStartBlock` gate. A client-filtered
+    /// contract (`force_wildcard`) has no addresses in the set, so there the
+    /// store answers ownership too.
+    #[allow(clippy::too_many_arguments)]
     fn matches(
         &self,
         topics: &[Option<LogArgument>],
+        contract_name: &str,
         contract_idx: u32,
         block_number: i64,
+        force_wildcard: bool,
+        cache: &SetCache,
         store: &StoreInner,
     ) -> bool {
         // No explicit empty-DNF guard: `any` over zero alternatives is already
@@ -115,7 +123,8 @@ impl TopicFilters {
                         TopicConstraint::Values(values) => values.iter().any(|v| v == &***topic),
                         TopicConstraint::ContractAddresses => {
                             topic_address(topic).is_some_and(|key| {
-                                store.is_indexed_at(key, contract_idx, block_number)
+                                (force_wildcard || cache.owner_of(key) == Some(contract_name))
+                                    && store.is_indexed_at(key, contract_idx, block_number)
                             })
                         }
                     }
@@ -177,13 +186,13 @@ impl OnEventRegistration {
     /// filters.
     ///
     /// Emitter rules. A wildcard registration accepts any address. A
-    /// contract-bound one accepts only an address the store holds for its own
-    /// contract, at or before the log's block — the temporal half matters even
-    /// when the partition fetched the address server-side, because a merged
-    /// partition's addresses don't all start at the same block. Which addresses
-    /// the *partition* may claim is the set's job (`contract_name`); a
-    /// client-filtered contract has none in the query, so the store answers
-    /// ownership on its own.
+    /// contract-bound one accepts only an address this partition's set holds for
+    /// its own contract (`address.contract_name`), registered at or before the
+    /// log's block — the temporal half matters even when the partition fetched
+    /// the address server-side, because a merged partition's addresses don't all
+    /// start at the same block. A client-filtered contract has none of its
+    /// addresses in the query, so there the store answers ownership on its own.
+    #[allow(clippy::too_many_arguments)]
     fn matches(
         &self,
         topic0: &[u8; 32],
@@ -191,6 +200,7 @@ impl OnEventRegistration {
         topics: &[Option<LogArgument>],
         address: &LogAddress,
         force_wildcard: bool,
+        cache: &SetCache,
         store: &StoreInner,
     ) -> bool {
         self.sighash == *topic0
@@ -198,9 +208,15 @@ impl OnEventRegistration {
             && (self.is_wildcard
                 || ((force_wildcard || address.contract_name == Some(self.contract_name.as_str()))
                     && store.is_indexed_at(address.key, self.contract_idx, address.block_number)))
-            && self
-                .topic_filters
-                .matches(topics, self.contract_idx, address.block_number, store)
+            && self.topic_filters.matches(
+                topics,
+                &self.contract_name,
+                self.contract_idx,
+                address.block_number,
+                force_wildcard,
+                cache,
+                store,
+            )
     }
 }
 
@@ -244,6 +260,11 @@ impl Decoder {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn store_handle(&self) -> &Arc<RwLock<StoreInner>> {
+        &self.store
+    }
+
     /// Resolves a query's registration selection into the decoder its response
     /// logs route through, so a log can only ever route to a registration
     /// belonging to the selection that fetched it.
@@ -251,6 +272,7 @@ impl Decoder {
         &self,
         registration_indexes: &[i64],
         client_filtered: &crate::client_filtered_contracts::ClientFilteredContracts,
+        cache: Arc<SetCache>,
     ) -> Result<SelectionDecoder> {
         let mut registrations = registration_indexes
             .iter()
@@ -275,6 +297,7 @@ impl Decoder {
             registrations,
             checksummed_addresses: self.checksummed_addresses,
             store: self.store.clone(),
+            cache,
         })
     }
 }
@@ -294,6 +317,10 @@ pub(crate) struct SelectionDecoder {
     registrations: Vec<SelectedRegistration>,
     checksummed_addresses: bool,
     store: Arc<RwLock<StoreInner>>,
+    /// The querying partition's set, materialised. Address-valued topic filters
+    /// resolve ownership against it, so a log only ever routes to the addresses
+    /// this partition asked for.
+    cache: Arc<SetCache>,
 }
 
 impl SelectionDecoder {
@@ -380,6 +407,7 @@ impl SelectionDecoder {
                 topics,
                 address,
                 sel.force_wildcard,
+                &self.cache,
                 store,
             ) {
                 continue;
@@ -572,6 +600,20 @@ mod tests {
         routed.iter().map(|r| r.index).collect()
     }
 
+    /// A query selection carrying the partition set a whole-store query would.
+    /// Tests that need a narrower partition build their own set and call
+    /// `Decoder::selection` directly.
+    fn selection_of(
+        core: &Decoder,
+        indexes: &[i64],
+        client_filtered: &crate::client_filtered_contracts::ClientFilteredContracts,
+    ) -> Result<SelectionDecoder> {
+        let cache = crate::address_store::test_support::full_set(core.store_handle())
+            .cache()
+            .clone();
+        core.selection(indexes, client_filtered, cache)
+    }
+
     /// Route one log, holding the store read lock the way a response does.
     fn route(decoder: &SelectionDecoder, log: &Log, address: &LogAddress) -> Vec<RoutedEvent> {
         let store = decoder.lock_store();
@@ -627,7 +669,9 @@ mod tests {
     #[test]
     fn unknown_registration_index_errors() {
         let core = Decoder::from_registrations(&[], false, &store(&[], None)).unwrap();
-        let err = core.selection(&[7], &Default::default()).err().unwrap();
+        let err = selection_of(&core, &[7], &Default::default())
+            .err()
+            .unwrap();
         assert!(format!("{err:#}").contains("Unknown registration index 7"));
     }
 
@@ -674,7 +718,7 @@ mod tests {
             ..Default::default()
         };
 
-        let decoder = core.selection(&[7], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[7], &Default::default()).unwrap();
         let mut routed = route(&decoder, &log, &owned("TestContract"));
         assert_eq!(routed.len(), 1);
         let routed = routed
@@ -708,7 +752,7 @@ mod tests {
             &store(&["Owned", "W1", "W2", "Other"], Some("Owned")),
         )
         .unwrap();
-        let decoder = core.selection(&[0, 1, 2, 3], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[0, 1, 2, 3], &Default::default()).unwrap();
         let log = value_log(VALID_SIGHASH);
 
         assert_eq!(
@@ -741,7 +785,7 @@ mod tests {
             crate::client_filtered_contracts::ClientFilteredContracts::from_vec(vec![
                 "Owned".to_string()
             ]);
-        let decoder = core.selection(&[0, 1], &client_filtered).unwrap();
+        let decoder = selection_of(&core, &[0, 1], &client_filtered).unwrap();
         let registered = LogAddress {
             key: &EMITTER_KEY,
             contract_name: None,
@@ -785,7 +829,7 @@ mod tests {
             &address_store,
         )
         .unwrap();
-        let decoder = core.selection(&[0], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[0], &Default::default()).unwrap();
         let log = value_log(VALID_SIGHASH);
         let at = |block_number| LogAddress {
             key: &EMITTER_KEY,
@@ -813,7 +857,7 @@ mod tests {
         )
         .unwrap();
         let log = value_log(VALID_SIGHASH);
-        let decoder = core.selection(&[0], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[0], &Default::default()).unwrap();
         assert_eq!(
             routed_indexes(&route(&decoder, &log, &owned("Owned"))),
             vec![0]
@@ -836,7 +880,7 @@ mod tests {
             &store(&["Disabled", "Live"], None),
         )
         .unwrap();
-        let decoder = core.selection(&[0, 1], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[0, 1], &Default::default()).unwrap();
         assert_eq!(
             routed_indexes(&route(&decoder, &value_log(VALID_SIGHASH), &unowned())),
             vec![1]
@@ -885,7 +929,7 @@ mod tests {
             data: value_log(VALID_SIGHASH).data,
             ..Default::default()
         };
-        let decoder = core.selection(&[0, 1], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[0, 1], &Default::default()).unwrap();
         assert_eq!(routed_indexes(&route(&decoder, &log, &unowned())), vec![0]);
     }
 
@@ -912,12 +956,211 @@ mod tests {
         }
     }
 
+    /// A second address the marker fixtures register alongside `EMITTER`.
+    const SECOND: &str = "0x00000000000000000000000000000000000000cc";
+
+    /// A registration filtering two indexed address params by
+    /// `chain.C.addresses`. `and_group` puts both markers in one DNF
+    /// alternative (both must hold); otherwise each gets its own alternative
+    /// (either may hold).
+    fn two_marker_reg(contract: &str, and_group: bool) -> OnEventRegistrationInput {
+        let mut reg = value_reg(0, contract, true, VALID_SIGHASH);
+        reg.topic_count = 3;
+        reg.params = vec![
+            pm("from", "address", true),
+            pm("to", "address", true),
+            pm("value", "uint256", false),
+        ];
+        let sighash = || vec![VALID_SIGHASH.to_string()];
+        reg.topic_selections = if and_group {
+            vec![TopicSelectionInput {
+                topic0: sighash(),
+                topic1: None,
+                topic2: None,
+                topic3: Some(vec![]),
+            }]
+        } else {
+            vec![
+                TopicSelectionInput {
+                    topic0: sighash(),
+                    topic1: None,
+                    topic2: Some(vec![]),
+                    topic3: Some(vec![]),
+                },
+                TopicSelectionInput {
+                    topic0: sighash(),
+                    topic1: Some(vec![]),
+                    topic2: None,
+                    topic3: Some(vec![]),
+                },
+            ]
+        };
+        reg
+    }
+
+    fn two_address_param_log(topic1: &str, topic2: &str) -> Log {
+        Log {
+            topics: vec![
+                Some(VALID_SIGHASH.to_string()),
+                Some(topic1.to_string()),
+                Some(topic2.to_string()),
+            ],
+            data: value_log(VALID_SIGHASH).data,
+            ..Default::default()
+        }
+    }
+
+    /// An emitter no contract owns, at `block_number` — for wildcard marker
+    /// registrations, where only the log's block feeds the gate.
+    fn at_block(block_number: i64) -> LogAddress<'static> {
+        LogAddress {
+            key: &FOREIGN_KEY,
+            contract_name: None,
+            block_number,
+        }
+    }
+
+    #[test]
+    fn marker_param_registered_after_the_log_block_is_dropped() {
+        // The temporal half of the param gate: a wildcard query over-fetches
+        // logs whose address param was only registered later, and the marker
+        // drops them at the log's own block rather than downstream.
+        let address_store = crate::address_store::AddressStore::new_evm(
+            false,
+            vec![crate::address_store::AddressStoreContract {
+                name: "C".to_string(),
+                start_block: None,
+            }],
+        );
+        address_store.register_batch(vec![crate::address_store::AddressRegistration {
+            address: EMITTER.to_string(),
+            contract_name: "C".to_string(),
+            registration_block: 100,
+        }]);
+        let core =
+            Decoder::from_registrations(&[marker_reg(0, "C")], false, &address_store).unwrap();
+        let decoder = selection_of(&core, &[0], &Default::default()).unwrap();
+        let log = address_param_log(&addr_topic("aa"));
+        assert_eq!(
+            (
+                routed_indexes(&route(&decoder, &log, &at_block(99))),
+                routed_indexes(&route(&decoder, &log, &at_block(100))),
+            ),
+            (vec![], vec![0])
+        );
+    }
+
+    #[test]
+    fn marker_scoped_to_the_partitions_addresses() {
+        // The querying partition holds only D's address, so it materialised the
+        // marker from that slice. A sibling selection's log carrying C's
+        // address — registered chain-wide, but not by this partition — must not
+        // route here, or the same log would be emitted from every partition.
+        let address_store = evm_store(&[("C", &[EMITTER]), ("D", &[SECOND])]);
+        let core =
+            Decoder::from_registrations(&[marker_reg(0, "C")], false, &address_store).unwrap();
+        let d_only = crate::address_store::test_support::set_of(&address_store, &["D"]);
+        let decoder = core
+            .selection(&[0], &Default::default(), d_only.cache().clone())
+            .unwrap();
+        assert_eq!(
+            routed_indexes(&route(
+                &decoder,
+                &address_param_log(&addr_topic("aa")),
+                &unowned()
+            )),
+            Vec::<i64>::new()
+        );
+    }
+
+    #[test]
+    fn client_filtered_marker_routes_on_the_store_alone() {
+        // A client-filtered contract is queried address-free, so its markers
+        // materialise to match-any and the partition set holds none of its
+        // addresses. The store has to answer ownership on its own — scoping to
+        // the (empty) set here would drop every one of the contract's events.
+        let address_store = evm_store(&[("C", &[EMITTER])]);
+        let core =
+            Decoder::from_registrations(&[marker_reg(0, "C")], false, &address_store).unwrap();
+        let client_filtered =
+            crate::client_filtered_contracts::ClientFilteredContracts::from_vec(vec![
+                "C".to_string()
+            ]);
+        let decoder = core
+            .selection(
+                &[0],
+                &client_filtered,
+                address_store.empty_set().cache().clone(),
+            )
+            .unwrap();
+        assert_eq!(
+            (
+                routed_indexes(&route(
+                    &decoder,
+                    &address_param_log(&addr_topic("aa")),
+                    &unowned()
+                )),
+                // Still gated: an address the store doesn't hold is dropped.
+                routed_indexes(&route(
+                    &decoder,
+                    &address_param_log(&addr_topic("bb")),
+                    &unowned()
+                )),
+            ),
+            (vec![0], vec![])
+        );
+    }
+
+    #[test]
+    fn marker_and_group_requires_every_param_registered() {
+        let core = Decoder::from_registrations(
+            &[two_marker_reg("C", true)],
+            false,
+            &evm_store(&[("C", &[EMITTER, SECOND])]),
+        )
+        .unwrap();
+        let decoder = selection_of(&core, &[0], &Default::default()).unwrap();
+        let routed = |t1: &str, t2: &str| {
+            routed_indexes(&route(
+                &decoder,
+                &two_address_param_log(&addr_topic(t1), &addr_topic(t2)),
+                &unowned(),
+            ))
+        };
+        assert_eq!(
+            (routed("aa", "cc"), routed("aa", "bb"), routed("bb", "cc")),
+            (vec![0], vec![], vec![])
+        );
+    }
+
+    #[test]
+    fn marker_or_of_groups_matches_either_alternative() {
+        let core = Decoder::from_registrations(
+            &[two_marker_reg("C", false)],
+            false,
+            &evm_store(&[("C", &[EMITTER, SECOND])]),
+        )
+        .unwrap();
+        let decoder = selection_of(&core, &[0], &Default::default()).unwrap();
+        let routed = |t1: &str, t2: &str| {
+            routed_indexes(&route(
+                &decoder,
+                &two_address_param_log(&addr_topic(t1), &addr_topic(t2)),
+                &unowned(),
+            ))
+        };
+        assert_eq!(
+            (routed("aa", "bb"), routed("bb", "cc"), routed("bb", "bb")),
+            (vec![0], vec![0], vec![])
+        );
+    }
+
     #[test]
     fn contract_addresses_marker_materialized_from_query_addresses() {
         let core =
             Decoder::from_registrations(&[marker_reg(0, "C")], false, &store(&["C"], Some("C")))
                 .unwrap();
-        let decoder = core.selection(&[0], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[0], &Default::default()).unwrap();
         assert_eq!(
             (
                 // topic1 is C's registered address → the marker matches.
@@ -954,7 +1197,7 @@ mod tests {
             &store(&["C", "S"], Some("C")),
         )
         .unwrap();
-        let decoder = core.selection(&[0, 1], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[0, 1], &Default::default()).unwrap();
         // Foreign address (0x..bb) in topic1: only the broad sibling matches.
         assert_eq!(
             routed_indexes(&route(
@@ -1006,7 +1249,7 @@ mod tests {
             data: Some(format!("0x{}", hex::encode(data))),
             ..Default::default()
         };
-        let decoder = core.selection(&[0, 1], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[0, 1], &Default::default()).unwrap();
         let routed = route(&decoder, &log, &unowned());
         // Both declarations decode this log (same word-sized types either
         // way), each reading the topic/body split its own registration
@@ -1075,14 +1318,14 @@ mod tests {
             data: Some(format!("0x{}", hex::encode(data))),
             ..Default::default()
         };
-        let decoder = core.selection(&[0, 1], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[0, 1], &Default::default()).unwrap();
         assert_eq!(routed_indexes(&route(&decoder, &log, &unowned())), vec![0]);
 
         // With only the failing declaration matched, the log drops rather than
         // erroring — a decode failure is a benign "not this declaration's log",
         // not malformed data (a wildcard registration routinely fetches foreign
         // same-signature logs it can't read under its own indexed split).
-        let decoder = core.selection(&[1], &Default::default()).unwrap();
+        let decoder = selection_of(&core, &[1], &Default::default()).unwrap();
         assert!(route(&decoder, &log, &unowned()).is_empty());
     }
 }

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -131,11 +131,15 @@ impl EvmHyperSyncClient {
             .selection_builder
             .build(&params.registration_indexes, address_set, &client_filtered)
             .map_err(map_err)?;
+        let set_cache = address_set.cache().clone();
         let selection_decoder = self
             .decoder
-            .selection(&params.registration_indexes, &client_filtered)
+            .selection(
+                &params.registration_indexes,
+                &client_filtered,
+                set_cache.clone(),
+            )
             .map_err(map_err)?;
-        let set_cache = address_set.cache().clone();
 
         let requested_transaction_fields = built.transaction_fields;
         let mut block_fields = built.block_fields;
@@ -700,7 +704,7 @@ mod tests {
     fn empty_decoder() -> SelectionDecoder {
         Decoder::from_registrations(&[], false, &evm_store(&[]))
             .unwrap()
-            .selection(&[], &Default::default())
+            .selection(&[], &Default::default(), empty_set().cache().clone())
             .unwrap()
     }
 
@@ -744,7 +748,7 @@ mod tests {
             &evm_store(&[("Zero", &[])]),
         )
         .unwrap()
-        .selection(&[0], &Default::default())
+        .selection(&[0], &Default::default(), empty_set().cache().clone())
         .unwrap()
     }
 

--- a/packages/cli/src/evm_hypersync_source/selection.rs
+++ b/packages/cli/src/evm_hypersync_source/selection.rs
@@ -236,8 +236,8 @@ impl SelectionBuilder {
             } else {
                 // Address-free: genuine wildcards, plus client-filtered contracts
                 // whose ContractAddresses markers materialize to match-any (empty
-                // address topics). The JS clientAddressFilter re-applies the
-                // address gate on the returned items.
+                // address topics). Routing re-applies the address gate on the
+                // returned items, against the store alone.
                 no_address.extend(reg.topic_selections.iter().map(|ts| ts.materialize(&[])));
             }
         }

--- a/packages/cli/src/evm_rpc_source/mod.rs
+++ b/packages/cli/src/evm_rpc_source/mod.rs
@@ -279,7 +279,11 @@ impl EvmRpcClient {
         let set_cache = address_set.cache().clone();
         let selection_decoder = std::sync::Arc::new(
             self.decoder
-                .selection(&params.registration_indexes, &client_filtered)
+                .selection(
+                    &params.registration_indexes,
+                    &client_filtered,
+                    set_cache.clone(),
+                )
                 .map_err(map_err)?,
         );
         let timeout = Duration::from_millis(self.sync_config.query_timeout_millis);

--- a/packages/cli/src/fuel_hypersync_source/mod.rs
+++ b/packages/cli/src/fuel_hypersync_source/mod.rs
@@ -89,13 +89,17 @@ impl FuelHyperSyncClient {
             .map_err(|e| request_err("Failed to get data from HyperFuel", e))?;
         let raw = convert_response(res).map_err(convert_error_to_napi)?;
 
+        // Materialise the set's cache before taking the store guard: `cache()`
+        // lazily initialises by reading the same lock, and a writer queued
+        // between the two reads would deadlock the pair.
+        let set_cache = address_set.cache().clone();
         let items = {
             let store = self.address_store.read().unwrap();
             route_receipts(
                 raw.receipts,
                 &raw.blocks,
                 &built,
-                address_set.cache(),
+                &set_cache,
                 &client_filtered,
                 &store,
             )
@@ -111,10 +115,11 @@ impl FuelHyperSyncClient {
     }
 }
 
-/// The whole per-query input for `get_event_items`: the block range, the
-/// partition's registration selection (by index), and its current addresses.
-/// Receipt selections, field selection, and routing are all derived internally
-/// from the registrations passed at construction.
+/// The whole per-query input for `get_event_items`: the block range and the
+/// partition's registration selection (by index). The partition's addresses
+/// arrive separately, as the `AddressSet` handle. Receipt selections, field
+/// selection, and routing are all derived internally from the registrations
+/// passed at construction.
 #[napi(object)]
 pub struct EventItemsQuery {
     pub from_block: i64,

--- a/packages/cli/src/fuel_hypersync_source/selection.rs
+++ b/packages/cli/src/fuel_hypersync_source/selection.rs
@@ -243,7 +243,13 @@ impl SelectionBuilder {
                 RegistrationKind::Transfer => needs_transfer = true,
                 RegistrationKind::Call => needs_call = true,
             }
-            match (reg.kind, reg.is_wildcard) {
+            // A client-filtered contract is fetched address-free — the query
+            // carries none of its addresses — so its receipt types pool with the
+            // wildcards. Routing gates the over-fetched receipts on the store
+            // alone (`force_wildcard`); dropping them from the query instead
+            // would mean never fetching the contract at all.
+            let address_free = reg.is_wildcard || client_filtered.applies(&reg.contract_name);
+            match (reg.kind, address_free) {
                 (RegistrationKind::LogData { rb }, true) => push_unique(&mut wildcard_rbs, rb),
                 (RegistrationKind::LogData { rb }, false) => push_unique(
                     rbs_by_contract
@@ -265,10 +271,7 @@ impl SelectionBuilder {
                     }
                 }
             }
-            if !reg.is_wildcard
-                && !client_filtered.applies(&reg.contract_name)
-                && !ordered_contracts.contains(&reg.contract_name.as_str())
-            {
+            if !address_free && !ordered_contracts.contains(&reg.contract_name.as_str()) {
                 ordered_contracts.push(reg.contract_name.as_str());
             }
         }
@@ -501,6 +504,84 @@ mod tests {
         .unwrap();
         let built = builder.build(&[0], &set, &Default::default()).unwrap();
         assert!(built.receipt_selections.is_empty());
+    }
+
+    #[test]
+    fn client_filtered_contract_is_fetched_address_free() {
+        // A contract switched to client-side filtering carries none of its
+        // addresses in the query, so its receipt types have to pool with the
+        // wildcards. Leaving them out of the selection would mean never
+        // fetching the contract at all, while routing — which accepts its
+        // receipts under `force_wildcard` — waited for receipts that were
+        // never requested.
+        let store = fuel_store(&[("C1", &[ADDR_1]), ("C2", &[ADDR_2])]);
+        let set = set_of(&store, &["C2"]);
+        let builder = SelectionBuilder::from_registrations(
+            &[
+                reg(0, "C1", FuelEventKind::Mint, false, None),
+                reg(1, "C1", FuelEventKind::LogData, false, Some("1")),
+                reg(2, "C2", FuelEventKind::Mint, false, None),
+            ],
+            &store.handle().read().unwrap(),
+        )
+        .unwrap();
+        let client_filtered =
+            crate::client_filtered_contracts::ClientFilteredContracts::from_vec(vec![
+                "C1".to_string()
+            ]);
+        let built = builder.build(&[0, 1, 2], &set, &client_filtered).unwrap();
+
+        let address_store = store.handle();
+        let address_store = address_store.read().unwrap();
+        let c1_reg = built.registrations.iter().find(|r| r.index == 0).unwrap();
+        let addr_1 = key_of(ADDR_1);
+        let addr_2 = key_of(ADDR_2);
+        // The partition's set can't claim a client-filtered address, so routing
+        // leans on the store alone.
+        let route_forced = |key: &Hash| {
+            c1_reg.matches(
+                RECEIPT_MINT,
+                None,
+                &ReceiptAddress {
+                    key: &key[..],
+                    contract_name: None,
+                    block_height: 0,
+                },
+                true,
+                &address_store,
+            )
+        };
+        assert_eq!(
+            (
+                built
+                    .receipt_selections
+                    .iter()
+                    .map(selection_view)
+                    .collect::<Vec<_>>(),
+                route_forced(&addr_1),
+                // Registered, but for C2 — still not C1's receipt.
+                route_forced(&addr_2),
+            ),
+            (
+                vec![
+                    (vec![], vec![RECEIPT_MINT], vec![], vec![TX_STATUS_SUCCESS]),
+                    (
+                        vec![],
+                        vec![RECEIPT_LOG_DATA],
+                        vec![1],
+                        vec![TX_STATUS_SUCCESS],
+                    ),
+                    (
+                        vec![ADDR_2.to_string()],
+                        vec![RECEIPT_MINT],
+                        vec![],
+                        vec![TX_STATUS_SUCCESS],
+                    ),
+                ],
+                true,
+                false,
+            )
+        );
     }
 
     #[test]

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -330,6 +330,10 @@ impl SvmHyperSyncClient {
         let client_filtered = crate::client_filtered_contracts::ClientFilteredContracts::from_vec(
             params.client_filtered_contracts.unwrap_or_default(),
         );
+        // Materialise the set's cache before taking the store guard: `cache()`
+        // lazily initialises by reading the same lock, and a writer queued
+        // between the two reads would deadlock the pair.
+        let set_cache = address_set.cache().clone();
         let items = {
             let store = self.address_store.read().unwrap();
             build_event_items(
@@ -337,7 +341,7 @@ impl SvmHyperSyncClient {
                 std::mem::take(&mut resp.logs),
                 &built,
                 &self.schemas,
-                address_set.cache(),
+                &set_cache,
                 &client_filtered,
                 &store,
             )
@@ -355,11 +359,11 @@ impl SvmHyperSyncClient {
     }
 }
 
-/// The whole per-query input for `get_event_items`: the slot range, the
-/// partition's registration selection (by index), and its current addresses
-/// (program ids per program name). Instruction selections, field selection,
-/// and routing are all derived internally from the registrations passed at
-/// construction.
+/// The whole per-query input for `get_event_items`: the slot range and the
+/// partition's registration selection (by index). The partition's addresses
+/// arrive separately, as the `AddressSet` handle. Instruction selections, field
+/// selection, and routing are all derived internally from the registrations
+/// passed at construction.
 #[napi(object)]
 pub struct EventItemsQuery {
     pub from_slot: i64,

--- a/packages/cli/src/svm_hypersync_source/selection.rs
+++ b/packages/cli/src/svm_hypersync_source/selection.rs
@@ -736,6 +736,37 @@ mod tests {
     }
 
     #[test]
+    fn program_registered_after_the_instruction_slot_is_dropped() {
+        // SVM gets the same temporal gate as EVM and Fuel: an instruction from
+        // before the program's registration slot never reaches its handler.
+        let mut owned = reg(0, PROG_A, Some("0x21"), 1, false);
+        owned.contract_name = "Owned".to_string();
+        let store = AddressStore::new_svm(vec![crate::address_store::AddressStoreContract {
+            name: "Owned".to_string(),
+            start_block: None,
+        }]);
+        store.register_batch(vec![crate::address_store::AddressRegistration {
+            address: PROG_A.to_string(),
+            contract_name: "Owned".to_string(),
+            registration_block: 70,
+        }]);
+        let set = set_of(&store, &["Owned"]);
+        let built = SelectionBuilder::from_registrations(
+            std::slice::from_ref(&owned),
+            &store.handle().read().unwrap(),
+        )
+        .unwrap()
+        .build(&[0])
+        .unwrap();
+        let at = |slot: u64| {
+            let mut instr = instruction(PROG_A, &[0x21]);
+            instr.slot = slot;
+            route_indexes(&store, &set, &built, &instr)
+        };
+        assert_eq!((at(69), at(70)), (Vec::<i64>::new(), vec![0]));
+    }
+
+    #[test]
     fn routing_scoped_to_program() {
         let (store, set, built) = build(
             &[

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -104,9 +104,6 @@ let isReady: t => bool
 let isFetchingAtHead: t => bool
 let isAtHeadWithoutEndBlock: t => bool
 
-// Drop over-fetched events an address-param filter rejects, before contract
-// registration runs on them. Uses the chain's current indexing addresses.
-
 // State transitions. The chain state is mutated only through these.
 let handleQueryResult: (
   t,

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -667,8 +667,7 @@ type t = {
   knownHeight: int,
   firstEventBlock: option<int>,
   // Per-contract registered-address count past which a dynamic contract is
-  // switched to client-side filtering. None disables the switch
-  // (sources that can't filter client-side, e.g. SVM/Fuel), leaving every
+  // switched to client-side filtering. None disables the switch, leaving every
   // contract filtered server-side.
   clientFilterAddressThreshold: option<int>,
 }
@@ -945,22 +944,6 @@ let updateInternal = (
   updatedFetchState
 }
 
-let warnDifferentContractType = (
-  fetchState,
-  ~existingContract: indexingAddress,
-  ~dc: indexingAddress,
-) => {
-  let logger = Logging.createChild(
-    ~params={
-      "chainId": fetchState.chainId,
-      "contractAddress": dc.address->Address.toString,
-      "existingContractType": existingContract.contractName,
-      "newContractType": dc.contractName,
-    },
-  )
-  logger->Logging.childWarn(`Skipping contract registration: Contract address is already registered for one contract and cannot be registered for another contract.`)
-}
-
 // Move a contract to client-side address filtering, recording why.
 let addClientFilteredContract = (
   clientFilteredContracts: Utils.Set.t<string>,
@@ -1231,7 +1214,8 @@ OptimizedPartitions.t => {
       let chunkOffsetRef = ref(offsetRef.contents)
       while remainingRef.contents > 0 {
         let take = Pervasives.min(remainingRef.contents, maxAddrInPartition)
-        let pAddresses = contractSet->AddressSet.slice(~offset=chunkOffsetRef.contents, ~limit=Some(take))
+        let pAddresses =
+          contractSet->AddressSet.slice(~offset=chunkOffsetRef.contents, ~limit=Some(take))
         partitions->Array.push({
           id: nextPartitionIndexRef.contents->Int.toString,
           latestFetchedBlock,
@@ -1346,7 +1330,7 @@ let registerDynamicContracts = (
   let sourceDcs: array<Internal.dcs> = []
   let sourceIndexes: array<int> = []
   for itemIdx in 0 to items->Array.length - 1 {
-    switch (items->Array.getUnsafe(itemIdx))->Internal.getItemDcs {
+    switch items->Array.getUnsafe(itemIdx)->Internal.getItemDcs {
     | None => ()
     | Some(dcs) =>
       for dcIdx in 0 to dcs->Array.length - 1 {
@@ -1439,18 +1423,14 @@ let registerDynamicContracts = (
     if !keep {
       // Mark for removal; the splice happens below, back to front, so earlier
       // indexes stay valid.
-      sourceIndexes->Array.setUnsafe(idx, -1 - (sourceIndexes->Array.getUnsafe(idx)))
+      sourceIndexes->Array.setUnsafe(idx, -1 - sourceIndexes->Array.getUnsafe(idx))
     }
   }
   for idx in verdicts->Array.length - 1 downto 0 {
     let marked = sourceIndexes->Array.getUnsafe(idx)
     if marked < 0 {
       let _ =
-        (sourceDcs->Array.getUnsafe(idx))->Array.splice(
-          ~start=-1 - marked,
-          ~remove=1,
-          ~insert=[],
-        )
+        sourceDcs->Array.getUnsafe(idx)->Array.splice(~start=-1 - marked, ~remove=1, ~insert=[])
     }
   }
 
@@ -1514,8 +1494,7 @@ let registerDynamicContracts = (
                         p->withAddresses(p.addresses->AddressSet.filterByContracts(restNames)),
                       )
 
-                      let splitAddresses =
-                        p.addresses->AddressSet.filterByContracts([contractName])
+                      let splitAddresses = p.addresses->AddressSet.filterByContracts([contractName])
                       newPartitions->Array.push({
                         id: newPartitionId,
                         latestFetchedBlock: p.latestFetchedBlock,

--- a/packages/envio/src/sources/AddressSet.res
+++ b/packages/envio/src/sources/AddressSet.res
@@ -11,10 +11,8 @@ type startBlockGroup = {startBlock: int, count: int}
 
 @send external size: t => int = "size"
 
-// Live addresses per contract name, derived once per set inside Rust — so the
+// Live addresses of one contract, derived once per set inside Rust — so the
 // fetch state can size and split partitions without ever walking the addresses.
-@send external countByContract: t => dict<int> = "countByContract"
-
 @send external countFor: (t, string) => int = "countFor"
 
 // The chain-wide address gate, reachable through any set of the store. Not set
@@ -48,14 +46,3 @@ type startBlockGroup = {startBlock: int, count: int}
 @send external entries: t => array<Internal.indexingContract> = "entries"
 
 let isEmpty = (set: t) => set->size === 0
-
-let mergeAll = (sets: array<t>) =>
-  switch sets {
-  | [] => None
-  | _ =>
-    let merged = ref(sets->Array.getUnsafe(0))
-    for idx in 1 to sets->Array.length - 1 {
-      merged := merged.contents->merge(sets->Array.getUnsafe(idx))
-    }
-    Some(merged.contents)
-  }

--- a/scenarios/fuel_test/test/FuelHyperSyncSourceHeight_test.res
+++ b/scenarios/fuel_test/test/FuelHyperSyncSourceHeight_test.res
@@ -43,6 +43,13 @@ describe("FuelHyperSyncSource - getHeightOrThrow", () => {
   // The native client validates that the token is a UUID before sending requests.
   let apiToken = "11111111-1111-1111-1111-111111111111"
 
+  // Height queries carry no selection, so an empty store is all the client needs.
+  let addressStore = AddressStore.make(
+    ~ecosystem=Ecosystem.Fuel,
+    ~shouldChecksum=false,
+    ~contracts=[],
+  )
+
   Async.it("Requests height via the client with auth and user agent headers", async t => {
     let capturedHeaders = ref(None)
     await withServer((req, res) => {
@@ -55,6 +62,7 @@ describe("FuelHyperSyncSource - getHeightOrThrow", () => {
         endpointUrl,
         apiToken: Some(apiToken),
         onEventRegistrations: [],
+        addressStore,
       })
       let {height} = await source.getHeightOrThrow()
 
@@ -81,6 +89,7 @@ describe("FuelHyperSyncSource - getHeightOrThrow", () => {
         endpointUrl,
         apiToken: Some(apiToken),
         onEventRegistrations: [],
+        addressStore,
       })
       let result = await Promise.race([
         source.getHeightOrThrow()->Promise.thenResolve(_ => "resolved"),

--- a/scenarios/test_codegen/test/helpers/TestAddresses.res
+++ b/scenarios/test_codegen/test/helpers/TestAddresses.res
@@ -79,13 +79,6 @@ function makeFakeSet(unordered) {
     countFor: function (name) {
       return entries.filter(function (e) { return e.contractName === name }).length;
     },
-    countByContract: function () {
-      var counts = {};
-      entries.forEach(function (e) {
-        counts[e.contractName] = (counts[e.contractName] || 0) + 1;
-      });
-      return counts;
-    },
     filterByContracts: function (names) {
       return makeFakeSet(entries.filter(function (e) { return names.includes(e.contractName) }));
     },

--- a/scenarios/test_codegen/test/lib_tests/AddressStore_test.res
+++ b/scenarios/test_codegen/test/lib_tests/AddressStore_test.res
@@ -94,7 +94,11 @@ describe("AddressStore", () => {
     t.expect({
       "verdicts": verdicts,
       "added": added->AddressSet.addresses,
-      "noEventsIsNotFetched": store->AddressStore.contractAddresses("NoEvents"),
+      // A no-events address is never fetched — it has no set — but it's still
+      // registered, so the chain reports and persists it.
+      "noEventsIsNotFetched": (store->AddressStore.makeSet(~contractName="NoEvents"))
+        ->AddressSet.size,
+      "noEventsIsStillReported": store->AddressStore.contractAddresses("NoEvents"),
       // No-events addresses still count towards what the chain tracks.
       "size": store->AddressStore.size,
     }).toEqual({
@@ -106,7 +110,8 @@ describe("AddressStore", () => {
       ],
       // Ordered by effectiveStartBlock, so addr(4) (10) precedes addr(3) (30).
       "added": [addr(4), addr(3)],
-      "noEventsIsNotFetched": [],
+      "noEventsIsNotFetched": 0,
+      "noEventsIsStillReported": [addr(5)],
       "size": 3,
     })
   })


### PR DESCRIPTION
## Summary

Refactors how `ContractAddresses` markers in topic filters resolve during log routing. Previously, markers resolved entirely against the chain-wide address store. Now they resolve in two stages: first against the querying partition's materialized set (to enforce ownership), then against the store's temporal gate (to enforce block-number constraints). This prevents logs carrying addresses from sibling partitions from incorrectly routing through this partition's registrations.

## Key Changes

- **EVM routing**: Updated `TopicFilters::matches` and `OnEventRegistration::matches` to accept the partition's `SetCache` and check address ownership before consulting the store. Client-filtered contracts (which have no addresses in the set) skip the ownership check and rely on the store alone.

- **Selection decoder**: Added `cache: Arc<SetCache>` field to `SelectionDecoder` and pass it through to matching functions. The cache is materialized before acquiring the store lock to avoid deadlock scenarios.

- **Address store API**: 
  - `contract_addresses()` now includes no-events entries (addresses registered but never fetched), ensuring they're visible to users and persisted correctly.
  - Removed `count_by_contract()` in favor of per-contract `count_for()` queries, reducing unnecessary work during partition sizing.
  - Added `full_set()` test helper to construct a set from a store handle alone.

- **Fuel and SVM sources**: Materialized `SetCache` before acquiring store locks to prevent deadlock when `cache()` lazily initializes.

- **Tests**: Added comprehensive test cases for marker scoping:
  - Markers drop logs with addresses registered after the log's block (temporal gate).
  - Markers reject logs carrying addresses from sibling partitions (ownership gate).
  - Client-filtered contracts route on store alone when the set is empty.
  - DNF alternatives with multiple markers (AND/OR grouping) work correctly.

## Notable Details

- The partition set's cache is now a required input to routing, making the ownership boundary explicit in the type system.
- Comments clarify the distinction between "which addresses the partition may claim" (set's job) vs. "which addresses are registered at/before the block" (store's job).
- No-events entries are now properly reported by `contract_addresses()` to maintain visibility and persistence, even though they're never fetched into a set.

https://claude.ai/code/session_011557Bibobxs1HAKSwG54fL