### PR TITLE
Upgrade TypeScript target to ES2023

### DIFF
--- a/packages/build-envio/tsconfig.json
+++ b/packages/build-envio/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "Node16",
     "moduleResolution": "Node16",
     "strict": true,

--- a/packages/cli/templates/static/blank_template/typescript/tsconfig.json
+++ b/packages/cli/templates/static/blank_template/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -22,7 +22,7 @@
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/packages/cli/templates/static/erc20_template/typescript/tsconfig.json
+++ b/packages/cli/templates/static/erc20_template/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -22,7 +22,7 @@
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/packages/cli/templates/static/external_calls_template/typescript/tsconfig.json
+++ b/packages/cli/templates/static/external_calls_template/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -22,7 +22,7 @@
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/packages/cli/templates/static/factory_template/typescript/tsconfig.json
+++ b/packages/cli/templates/static/factory_template/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -22,7 +22,7 @@
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/packages/cli/templates/static/greeter_template/typescript/tsconfig.json
+++ b/packages/cli/templates/static/greeter_template/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -22,7 +22,7 @@
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/packages/cli/templates/static/greeteronfuel_template/typescript/tsconfig.json
+++ b/packages/cli/templates/static/greeteronfuel_template/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -22,7 +22,7 @@
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/tsconfig.json
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -22,7 +22,7 @@
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/packages/cli/templates/static/svmblock_template/typescript/tsconfig.json
+++ b/packages/cli/templates/static/svmblock_template/typescript/tsconfig.json
@@ -4,7 +4,7 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -22,7 +22,7 @@
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/packages/e2e-tests/tsconfig.json
+++ b/packages/e2e-tests/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -14,7 +14,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   },
   "include": ["src"]

--- a/packages/envio-tests/test/helpers/TypeChecker.ts
+++ b/packages/envio-tests/test/helpers/TypeChecker.ts
@@ -22,7 +22,7 @@ if (ts.version !== EXPECTED_TS_VERSION) {
 const TSCONFIG_COMPILER_OPTIONS = {
   esModuleInterop: true,
   skipLibCheck: true,
-  target: "es2022",
+  target: "es2023",
   allowJs: true,
   resolveJsonModule: true,
   moduleDetection: "force",
@@ -34,7 +34,7 @@ const TSCONFIG_COMPILER_OPTIONS = {
   module: "ESNext",
   moduleResolution: "bundler",
   noEmit: true,
-  lib: ["es2022"],
+  lib: ["es2023"],
   types: ["node"],
 };
 

--- a/scenarios/e2e_test/tsconfig.json
+++ b/scenarios/e2e_test/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -14,7 +14,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   },
   "include": ["src", "envio-env.d.ts"]

--- a/scenarios/fuel_test/contracts/ts-interaction-tools/tsconfig.json
+++ b/scenarios/fuel_test/contracts/ts-interaction-tools/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2023",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */

--- a/scenarios/fuel_test/tsconfig.json
+++ b/scenarios/fuel_test/tsconfig.json
@@ -4,7 +4,7 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -22,7 +22,7 @@
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   },
   "exclude": ["contracts/ts-interaction-tools"]

--- a/scenarios/svm_flow_xray/tsconfig.json
+++ b/scenarios/svm_flow_xray/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -14,7 +14,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/scenarios/svm_metaplex_demo/tsconfig.json
+++ b/scenarios/svm_metaplex_demo/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -14,7 +14,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/scenarios/svm_test/tsconfig.json
+++ b/scenarios/svm_test/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -14,7 +14,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/scenarios/test_codegen/tsconfig.json
+++ b/scenarios/test_codegen/tsconfig.json
@@ -4,7 +4,7 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "es2022",
+    "target": "es2023",
     "allowJs": true,
     "resolveJsonModule": true,
     "moduleDetection": "force",
@@ -22,7 +22,7 @@
     "noEmit": true,
 
     /* Code doesn't run in the DOM: */
-    "lib": ["es2022"],
+    "lib": ["es2023"],
     "types": ["node"]
   },
   "include": ["src", "test", "envio-env.d.ts"]


### PR DESCRIPTION
Updates TypeScript compiler target and library configuration from ES2022 to ES2023 across all project templates and test configurations.

## Changes

- Updated `target` compiler option from `"es2022"` to `"es2023"` in all TypeScript configuration files
- Updated `lib` compiler option from `["es2022"]` to `["es2023"]` in all TypeScript configuration files
- Affected files include:
  - CLI templates: blank, ERC20, external calls, factory, greeter, greeteronfuel, SVM metaplex, and SVM block templates
  - Test configurations: e2e-tests, envio-tests, and scenario tests
  - Build configuration: build-envio
  - One legacy configuration updated from ES2016 to ES2023: fuel_test/contracts/ts-interaction-tools

This upgrade enables support for newer JavaScript features available in ES2023 while maintaining compatibility across the codebase.

https://claude.ai/code/session_01S3KDp1aVXkXBCrgysCwEBR