### PR TITLE
Implement catch-up partitions for dynamically registered addresses

### DIFF
--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -270,6 +270,47 @@ module OptimizedPartitions = {
   let ascSortFn = (a, b) =>
     Int.compare(a.latestFetchedBlock.blockNumber, b.latestFetchedBlock.blockNumber)
 
+  // Contracts a standing address-free partition already fetches client-side.
+  // Addresses registered for them after that partition passed get a normal
+  // address-bound partition which dies once it catches up (see make), instead
+  // of being folded into the address-free one.
+  let anchoredContracts = (partitions: array<partition>) => {
+    let set = Utils.Set.make()
+    partitions->Array.forEach(p =>
+      switch (p.mergeBlock, p.selection.clientFilteredContracts) {
+      | (None, Some(contractNames)) =>
+        contractNames->Array.forEach(name => set->Utils.Set.add(name)->ignore)
+      | _ => ()
+      }
+    )
+    set
+  }
+
+  // The furthest block an address-free partition's already-dispatched queries
+  // can deliver without the addresses registered from now on. A settled query
+  // claims only what it actually fetched — the rest of its range is re-queried
+  // later, by then against the updated address store — while an in-flight
+  // bounded query claims its whole toBlock. An in-flight unbounded query has no
+  // ceiling at all, so nothing is safe to stop a catch-up partition at yet.
+  let getAnchorSafeBlock = (p: partition) => {
+    let safeRef = ref(Some(p.latestFetchedBlock.blockNumber))
+    p.mutPendingQueries->Array.forEach(pq =>
+      switch (safeRef.contents, pq) {
+      | (None, _) => ()
+      | (Some(safe), {fetchedBlock: Some({blockNumber})}) =>
+        if blockNumber > safe {
+          safeRef := Some(blockNumber)
+        }
+      | (Some(safe), {toBlock: Some(toBlock)}) =>
+        if toBlock > safe {
+          safeRef := Some(toBlock)
+        }
+      | (Some(_), _) => safeRef := None
+      }
+    )
+    safeRef.contents
+  }
+
   /**
    * Optimizes partitions by finding opportunities to merge partitions that
    * are behind other partitions with same/superset of contract names.
@@ -288,19 +329,49 @@ module OptimizedPartitions = {
     let mergingPartitions = Dict.make()
     let nextPartitionIndexRef = ref(nextPartitionIndex)
 
+    // Where a catch-up partition for a client-filtered contract may stop, keyed
+    // by contract name. A contract absent from the dict while present in
+    // anchoredContractsSet has an unbounded query in flight on its address-free
+    // partition — its catch-up can't be bounded yet, and a later call will bound it.
+    let anchorSafeBlocks = Dict.make()
+    let anchoredContractsSet = Utils.Set.make()
+    if clientFilteredContracts->Utils.Set.size > 0 {
+      partitions->Array.forEach(p =>
+        switch (p.mergeBlock, p.selection.clientFilteredContracts) {
+        | (None, Some(contractNames)) =>
+          let safeBlock = p->getAnchorSafeBlock
+          contractNames->Array.forEach(name => {
+            anchoredContractsSet->Utils.Set.add(name)->ignore
+            switch safeBlock {
+            | Some(safeBlock) => anchorSafeBlocks->Dict.set(name, safeBlock)
+            | None => ()
+            }
+          })
+        | _ => ()
+        }
+      )
+    }
+
     for idx in 0 to partitions->Array.length - 1 {
       let p = partitions->Array.getUnsafe(idx)
       switch p {
+      // For now don't merge partitions with mergeBlock,
+      // assuming they are already merged,
+      // TODO: Although there might be cases with too far away mergeBlock,
+      // which is worth merging.
+      // A partition already at or past its merge block is done — normally
+      // handleQueryResponse removes it when the response lands, but a rollback
+      // can cap the merge block at the rolled-back frontier, leaving no
+      // response to ever remove it on.
+      | {mergeBlock: Some(mergeBlock)} =>
+        if p.latestFetchedBlock.blockNumber < mergeBlock {
+          newPartitions->Array.push(p)->ignore
+        }
       // Since it's not a dynamic contract partition,
       // there's no need for merge logic
       | {dynamicContract: None}
       | // Wildcard doesn't need merging
-      {selection: {dependsOnAddresses: false}}
-      | // For now don't merge partitions with mergeBlock,
-      // assuming they are already merged,
-      // TODO: Although there might be cases with too far away mergeBlock,
-      // which is worth merging
-      {mergeBlock: Some(_)} =>
+      {selection: {dependsOnAddresses: false}} =>
         newPartitions->Array.push(p)->ignore
       | {dynamicContract: Some(contractName)} =>
         let pAddressesCount = p.addresses->AddressSet.countFor(contractName)
@@ -398,14 +469,40 @@ module OptimizedPartitions = {
       newPartitions->Array.push(currentPRef.contents)->ignore
     }
 
-    // Sort partitions by latestFetchedBlock ascending
-    let _ = newPartitions->Array.sort(ascSortFn)
+    // A dynamic partition for a contract the address-free partition already
+    // fetches is a catch-up for addresses registered after that partition
+    // passed them. It merges by disappearing once it reaches the last block
+    // that partition's dispatched queries could have missed them on — its
+    // addresses are in the chain's store, so there is nothing to hand over.
+    let finalPartitions = if anchoredContractsSet->Utils.Set.size === 0 {
+      newPartitions
+    } else {
+      let anchored = []
+      newPartitions->Array.forEach(p =>
+        switch p {
+        | {dynamicContract: Some(contractName), mergeBlock: None}
+          if anchoredContractsSet->Utils.Set.has(contractName) =>
+          switch anchorSafeBlocks->Utils.Dict.dangerouslyGetNonOption(contractName) {
+          | None => anchored->Array.push(p)->ignore
+          | Some(anchorSafeBlock) =>
+            if p.latestFetchedBlock.blockNumber < anchorSafeBlock {
+              anchored->Array.push({...p, mergeBlock: Some(anchorSafeBlock)})->ignore
+            }
+          }
+        | _ => anchored->Array.push(p)->ignore
+        }
+      )
+      anchored
+    }
 
-    let partitionsCount = newPartitions->Array.length
+    // Sort partitions by latestFetchedBlock ascending
+    let _ = finalPartitions->Array.sort(ascSortFn)
+
+    let partitionsCount = finalPartitions->Array.length
     let idsInAscOrder = Utils.Array.jsArrayCreate(partitionsCount)
     let entities = Dict.make()
     for idx in 0 to partitionsCount - 1 {
-      let p = newPartitions->Array.getUnsafe(idx)
+      let p = finalPartitions->Array.getUnsafe(idx)
       idsInAscOrder->Array.setUnsafe(idx, p.id)
       entities->Dict.set(p.id, p)
     }
@@ -1004,6 +1101,10 @@ let claimedFetchedBlock = (p: partition, ~knownHeight) =>
 //   it on arrival. The overlap it re-delivers is deduped by mergeIntoBuffer, and
 //   the re-fetch doubles as history for freshly registered addresses: events
 //   dropped before the address was registered now pass the address gate.
+// - A dynamic partition for a contract the standing partition already covers is
+//   left alone: it is a catch-up for addresses registered after that partition
+//   passed them, and OptimizedPartitions.make bounds it against the standing
+//   partition's own claims instead.
 // - A partition mixing client-filtered and server-side contracts stays,
 //   stripped of the client-filtered contracts' addresses — the address-free
 //   partition covers those logs, so fetching them server-side too would only
@@ -1034,6 +1135,7 @@ let collapseClientFilteredContracts = (
     let backfills = []
     let absorbedPartitions = []
     let strippedFrontiers = []
+    let anchoredContracts = partitions->OptimizedPartitions.anchoredContracts
 
     partitions->Array.forEach(p =>
       switch p {
@@ -1048,6 +1150,17 @@ let collapseClientFilteredContracts = (
         let serverSideNames =
           contractNames->Array.filter(c => !(clientFilteredContracts->Utils.Set.has(c)))
         if serverSideNames->Array.length === contractNames->Array.length {
+          kept->Array.push(p)->ignore
+        } else if (
+          switch p.dynamicContract {
+          | Some(contractName) => anchoredContracts->Utils.Set.has(contractName)
+          | None => false
+          }
+        ) {
+          // A catch-up partition for addresses registered after the address-free
+          // partition already covered their contract. It is the correctness
+          // barrier for those addresses until it catches up — absorbing it would
+          // hand that job back to a guessed ceiling.
           kept->Array.push(p)->ignore
         } else if serverSideNames->Utils.Array.isEmpty {
           absorbedPartitions->Array.push(p)->ignore
@@ -1213,25 +1326,34 @@ OptimizedPartitions.t => {
   let nonDynamicPartitions = []
   let clientFilteredFrontiers = []
 
+  // Contracts an address-free partition already fetches. Their new addresses
+  // need a partition of their own: the address-free partition passed the blocks
+  // they were registered at without them in the store.
+  let anchoredContracts = existingPartitions->OptimizedPartitions.anchoredContracts
+
   let contractNames = registeringSetsByContract->Dict.keysToArray
   for cIdx in 0 to contractNames->Array.length - 1 {
     let contractName = contractNames->Array.getUnsafe(cIdx)
     let contractSet = registeringSetsByContract->Dict.getUnsafe(contractName)
 
-    let isDynamic = dynamicContracts->Utils.Set.has(contractName)
+    let isAnchored = anchoredContracts->Utils.Set.has(contractName)
+    // A catch-up partition must go through the dynamic merge logic — that's
+    // what bounds it against its anchor and removes it once it catches up.
+    let isDynamic = dynamicContracts->Utils.Set.has(contractName) || isAnchored
     let partitions = isDynamic ? dynamicPartitions : nonDynamicPartitions
 
     // A set is ordered by effectiveStartBlock, so its start-block groups are
     // ascending and each group's addresses are a contiguous slice.
     let groups = contractSet->AddressSet.startBlockGroups
 
-    if clientFilteredContracts->Utils.Set.has(contractName) {
-      // The address-free partition already fetches this contract, so chunking
-      // its addresses by maxAddrInPartition would only build partitions for the
-      // collapse below to absorb - hundreds of them for a contract big enough to
-      // be client-filtered in the first place. All the collapse needs is the
-      // earliest block the addresses aren't covered from, which is the first
-      // group's since groups are ascending.
+    if clientFilteredContracts->Utils.Set.has(contractName) && !isAnchored {
+      // The contract is switching to client-side filtering in this very call, so
+      // the collapse below folds everything it has into the address-free
+      // partition anyway. Chunking these addresses by maxAddrInPartition would
+      // only build partitions for it to absorb - hundreds of them for a contract
+      // big enough to be client-filtered in the first place. All the collapse
+      // needs is the earliest block the addresses aren't covered from, which is
+      // the first group's since groups are ascending.
       switch groups->Array.get(0) {
       | Some({startBlock}) =>
         clientFilteredFrontiers->Array.push({
@@ -2620,6 +2742,14 @@ let rollback = (fetchState: t, ~addressStore: AddressStore.t, ~targetBlockNumber
         latestFetchedBlock: p.latestFetchedBlock.blockNumber > targetBlockNumber
           ? {blockNumber: targetBlockNumber, blockTimestamp: 0}
           : p.latestFetchedBlock,
+        // Everything above the target is refetched by whichever partition this
+        // one was catching up to, so there is nothing left to catch up on past
+        // it. createPartitions drops the partition outright when the capped
+        // block is already reached.
+        mergeBlock: switch p.mergeBlock {
+        | Some(mergeBlock) if mergeBlock > targetBlockNumber => Some(targetBlockNumber)
+        | other => other
+        },
         mutPendingQueries: rollbackPendingQueries(p.mutPendingQueries, ~targetBlockNumber),
       })
       ->ignore

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -5292,6 +5292,83 @@ describe("FetchState client-side address filtering", () => {
     ).toEqual([(19, Some(120), ["Gravatar"]), (120, None, [])])
   })
 
+  // Both partitions probing open-ended at the same time: the standing partition
+  // can't bound the catch-up while its own query is unbounded, so the catch-up
+  // goes out unbounded too and the two responses may land in either order.
+  let makeTwoOpenEndedQueriesInFlight = () => {
+    let (advanced, addressStore, standingQuery) = makeCollapsedAt50WithQueryInFlight()
+    let afterReg =
+      advanced->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(~blockNumber=20, ~contractAddress=mockAddress3)->dcToItem,
+      ])
+    let catchUpQuery = switch afterReg->FetchState.getNextQuery(
+      ~chainTargetBlock=100,
+      ~chainTargetItems=10_000.,
+    ) {
+    | Ready([query]) => query
+    | _ => JsError.throwWithMessage("Expected a single catch-up query")
+    }
+    afterReg->FetchState.startFetchingQueries(~queries=[catchUpQuery])
+    (afterReg, standingQuery, catchUpQuery)
+  }
+
+  it("bounds and removes the catch-up when the standing response lands first", t => {
+    let (afterReg, standingQuery, catchUpQuery) = makeTwoOpenEndedQueriesInFlight()
+    // Dispatched after the catch-up's query (fromBlock 51 against 20) yet
+    // completing before it.
+    let afterStanding =
+      afterReg->FetchState.handleQueryResult(
+        ~query=standingQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=120),
+        ~newItems=[mockEvent(~blockNumber=60)],
+      )
+    // The catch-up had no bound when it went out, so it comes back past the
+    // merge block it has since been given — and is removed on arrival.
+    let afterCatchUp =
+      afterStanding->FetchState.handleQueryResult(
+        ~query=catchUpQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=150),
+        ~newItems=[mockEvent(~blockNumber=60)],
+      )
+    t.expect(
+      (
+        (standingQuery.toBlock, catchUpQuery.toBlock),
+        afterStanding->frontierShape,
+        afterCatchUp->frontierShape,
+        afterCatchUp->FetchState.bufferSize,
+      ),
+      ~message="both queries open-ended; the settled response bounds the catch-up, which then over-fetches past it and disappears, its overlap deduped",
+    ).toEqual(((None, None), [(19, Some(120), ["Gravatar"]), (120, None, [])], [(120, None, [])], 1))
+  })
+
+  it("keeps the catch-up unbounded when its own response lands first", t => {
+    let (afterReg, standingQuery, catchUpQuery) = makeTwoOpenEndedQueriesInFlight()
+    let afterCatchUp =
+      afterReg->FetchState.handleQueryResult(
+        ~query=catchUpQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=80),
+        ~newItems=[mockEvent(~blockNumber=60)],
+      )
+    let afterStanding =
+      afterCatchUp->FetchState.handleQueryResult(
+        ~query=standingQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=120),
+        ~newItems=[mockEvent(~blockNumber=60)],
+      )
+    t.expect(
+      (
+        afterCatchUp->frontierShape,
+        afterStanding->frontierShape,
+        afterStanding->FetchState.bufferSize,
+      ),
+      ~message="catch-up runs past the standing frontier unbounded, then is bounded by what the standing response actually covered",
+    ).toEqual((
+      [(50, None, []), (80, None, ["Gravatar"])],
+      [(80, Some(120), ["Gravatar"]), (120, None, [])],
+      1,
+    ))
+  })
+
   it("catches an address up over the in-flight range above the frontier", t => {
     let (advanced, addressStore, _inFlight) = makeCollapsedAt50WithQueryInFlight()
     // Registered at 60: above the standing frontier of 50, so nothing is behind

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -5203,10 +5203,12 @@ describe("FetchState client-side address filtering", () => {
     ).toEqual((["Gravatar"], [(false, Some(["Gravatar"]), [])]))
   })
 
+  // The address-free partition shows up with no addresses of its own; a
+  // catch-up partition for freshly registered addresses shows its contract.
   let frontierShape = (fetchState: FetchState.t) =>
     fetchState.optimizedPartitions.idsInAscOrder->Array.map(id => {
       let p = fetchState.optimizedPartitions.entities->Dict.getUnsafe(id)
-      (p.latestFetchedBlock.blockNumber, p.mergeBlock, p.selection.clientFilteredContracts)
+      (p.latestFetchedBlock.blockNumber, p.mergeBlock, p.addresses->AddressSet.contractNames)
     })
 
   // Standing address-free partition with its frontier advanced to block 50,
@@ -5254,7 +5256,7 @@ describe("FetchState client-side address filtering", () => {
     (advanced, addressStore, query)
   }
 
-  it("extends the backfill over an open-ended query in flight past the standing frontier", t => {
+  it("leaves the catch-up unbounded while an open-ended query is in flight", t => {
     let (advanced, addressStore, inFlight) = makeCollapsedAt50WithQueryInFlight()
     let afterReg =
       advanced->FetchState.registerDynamicContracts(~addressStore, [
@@ -5262,51 +5264,39 @@ describe("FetchState client-side address filtering", () => {
       ])
     t.expect(
       (inFlight.toBlock, afterReg->frontierShape),
-      // An open-ended probe carries no toBlock of its own, so the known height
-      // bounds what it can claim.
-      ~message="backfill reaches the known height, not the frontier at 50",
-    ).toEqual((None, [(19, Some(100), Some(["Gravatar"])), (50, None, Some(["Gravatar"]))]))
+      // An open-ended probe carries no toBlock of its own, so there's no block
+      // the standing partition is known to have covered the new address from.
+      // The catch-up stays unbounded and keeps fetching until a later
+      // optimization can bound it.
+      ~message="no merge block guessed from the known height",
+    ).toEqual((None, [(19, None, ["Gravatar"]), (50, None, [])]))
   })
 
-  it("extends the backfill to the arriving response's own frontier", t => {
-    let (advanced, addressStore, _inFlight) = makeCollapsedAt50WithQueryInFlight()
-    // The unbounded query came back at 120 — past the height known when it went
-    // out — and its registrations land before it is applied, so a catch-up
-    // stopping at the old height of 100 would leave [101, 120] fetched for
-    // every address but this one.
+  it("bounds the catch-up once the open-ended query settles", t => {
+    let (advanced, addressStore, inFlight) = makeCollapsedAt50WithQueryInFlight()
     let afterReg =
-      advanced->FetchState.registerDynamicContracts(
-        ~addressStore,
-        ~claimCeiling=120,
-        [makeDynContractRegistration(~blockNumber=20, ~contractAddress=mockAddress3)->dcToItem],
+      advanced->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(~blockNumber=20, ~contractAddress=mockAddress3)->dcToItem,
+      ])
+    // The query came back at 120 — past the height known when it went out. It
+    // carried nothing for the new address, so the catch-up must reach 120.
+    let settled =
+      afterReg->FetchState.handleQueryResult(
+        ~query=inFlight,
+        ~latestFetchedBlock=getBlockData(~blockNumber=120),
+        ~newItems=[],
       )
     t.expect(
-      afterReg->frontierShape,
-      ~message="catch-up reaches the response's frontier, not the stale known height",
-    ).toEqual([(19, Some(120), Some(["Gravatar"])), (50, None, Some(["Gravatar"]))])
+      settled->frontierShape,
+      ~message="catch-up bounded by what the response actually covered",
+    ).toEqual([(19, Some(120), ["Gravatar"]), (120, None, [])])
   })
 
-  it("backfills an address registered above the stale known height", t => {
-    let (advanced, addressStore, _inFlight) = makeCollapsedAt50WithQueryInFlight()
-    // Registered at 110: above both the frontier and the height known when the
-    // query went out, yet inside the range that query came back with.
-    let afterReg =
-      advanced->FetchState.registerDynamicContracts(
-        ~addressStore,
-        ~claimCeiling=120,
-        [makeDynContractRegistration(~blockNumber=110, ~contractAddress=mockAddress3)->dcToItem],
-      )
-    t.expect(
-      afterReg->frontierShape,
-      ~message="catch-up covers [109, 120] instead of being skipped entirely",
-    ).toEqual([(50, None, Some(["Gravatar"])), (109, Some(120), Some(["Gravatar"]))])
-  })
-
-  it("backfills an address registered above the frontier but inside a query in flight", t => {
+  it("catches an address up over the in-flight range above the frontier", t => {
     let (advanced, addressStore, _inFlight) = makeCollapsedAt50WithQueryInFlight()
     // Registered at 60: above the standing frontier of 50, so nothing is behind
-    // to backfill — but the query covering [51, 100] was routed before the
-    // address existed, so [59, 100] still needs a catch-up.
+    // to catch up on — but the query covering [51, ...] was routed before the
+    // address existed, so [59, ...] still needs its own partition.
     let afterReg =
       advanced->FetchState.registerDynamicContracts(~addressStore, [
         makeDynContractRegistration(~blockNumber=60, ~contractAddress=mockAddress3)->dcToItem,
@@ -5314,7 +5304,7 @@ describe("FetchState client-side address filtering", () => {
     t.expect(
       afterReg->frontierShape,
       ~message="catch-up covers the in-flight range above the frontier",
-    ).toEqual([(50, None, Some(["Gravatar"])), (59, Some(100), Some(["Gravatar"]))])
+    ).toEqual([(50, None, []), (59, None, ["Gravatar"])])
   })
 
   it("adds no catch-up above the frontier when nothing is in flight", t => {
@@ -5327,23 +5317,40 @@ describe("FetchState client-side address filtering", () => {
       ])
     t.expect(
       afterReg->frontierShape,
-      ~message="no backfill; the standing partition still covers everything ahead",
-    ).toEqual([(50, None, Some(["Gravatar"]))])
+      ~message="no catch-up; the standing partition still covers everything ahead",
+    ).toEqual([(50, None, [])])
   })
 
-  it("adds a bounded backfill instead of rebuilding when a client-filtered contract registers a new address", t => {
+  it("adds an address-bound catch-up partition when a client-filtered contract registers a new address", t => {
     let (advanced, addressStore) = makeCollapsedAt50()
     let afterReg =
       advanced->FetchState.registerDynamicContracts(~addressStore, [
         makeDynContractRegistration(~blockNumber=20, ~contractAddress=mockAddress3)->dcToItem,
       ])
+    let catchUp =
+      afterReg.optimizedPartitions.entities
+      ->Dict.valuesToArray
+      ->Array.find(p => p.id !== afterReg->standingId)
+      ->Option.getOrThrow
     t.expect(
-      (advanced->standingId === afterReg->standingId, afterReg->frontierShape),
-      ~message="standing partition untouched at 50; backfill covers [19, 50]",
-    ).toEqual((true, [(19, Some(50), Some(["Gravatar"])), (50, None, Some(["Gravatar"]))]))
+      (
+        advanced->standingId === afterReg->standingId,
+        afterReg->frontierShape,
+        (
+          catchUp.selection.dependsOnAddresses,
+          catchUp.dynamicContract,
+          catchUp.addresses->AddressSet.addresses,
+        ),
+      ),
+      ~message="standing partition untouched at 50; catch-up fetches only the new address over [19, 50]",
+    ).toEqual((
+      true,
+      [(19, Some(50), ["Gravatar"]), (50, None, [])],
+      (true, Some("Gravatar"), [mockAddress3]),
+    ))
   })
 
-  it("folds successive registrations into a single backfill partition", t => {
+  it("gives each successive registration its own catch-up partition", t => {
     let (advanced, addressStore) = makeCollapsedAt50()
     let afterSecond =
       advanced
@@ -5355,11 +5362,11 @@ describe("FetchState client-side address filtering", () => {
       ])
     t.expect(
       (advanced->standingId === afterSecond->standingId, afterSecond->frontierShape),
-      ~message="one backfill from the earliest uncovered block; standing partition untouched",
-    ).toEqual((true, [(19, Some(50), Some(["Gravatar"])), (50, None, Some(["Gravatar"]))]))
+      ~message="each catch-up starts at its own address's block; standing partition untouched",
+    ).toEqual((true, [(19, Some(50), ["Gravatar"]), (29, Some(50), ["Gravatar"]), (50, None, [])]))
   })
 
-  it("removes the backfill partition once it reaches its mergeBlock", t => {
+  it("removes the catch-up partition once it reaches its mergeBlock", t => {
     let (advanced, addressStore) = makeCollapsedAt50()
     let afterReg =
       advanced->FetchState.registerDynamicContracts(~addressStore, [
@@ -5373,18 +5380,70 @@ describe("FetchState client-side address filtering", () => {
     | _ => []
     }
     afterReg->FetchState.startFetchingQueries(~queries)
-    let backfillQuery =
+    let catchUpQuery =
       queries->Array.find(q => q.partitionId !== afterReg->standingId)->Option.getOrThrow
     let caughtUp =
       afterReg->FetchState.handleQueryResult(
-        ~query=backfillQuery,
+        ~query=catchUpQuery,
         ~latestFetchedBlock=getBlockData(~blockNumber=50),
         ~newItems=[],
       )
     t.expect(
-      (caughtUp->standingId === afterReg->standingId, caughtUp->frontierShape),
-      ~message="backfill deleted at its mergeBlock; standing partition untouched",
-    ).toEqual((true, [(50, None, Some(["Gravatar"]))]))
+      (
+        catchUpQuery.selection.dependsOnAddresses,
+        catchUpQuery.toBlock,
+        caughtUp->standingId === afterReg->standingId,
+        caughtUp->frontierShape,
+      ),
+      ~message="the catch-up queries server-side up to its mergeBlock, then is deleted; standing partition untouched",
+    ).toEqual((true, Some(50), true, [(50, None, [])]))
+  })
+
+  it("merges a surviving catch-up partition away on rollback", t => {
+    let (advanced, addressStore) = makeCollapsedAt50()
+    let afterReg =
+      advanced->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(~blockNumber=20, ~contractAddress=mockAddress3)->dcToItem,
+      ])
+    let queries = switch afterReg->FetchState.getNextQuery(
+      ~chainTargetBlock=100,
+      ~chainTargetItems=10_000.,
+    ) {
+    | Ready(queries) => queries
+    | _ => []
+    }
+    let catchUpQuery =
+      queries->Array.find(q => q.partitionId !== afterReg->standingId)->Option.getOrThrow
+    afterReg->FetchState.startFetchingQueries(~queries=[catchUpQuery])
+    let advancedCatchUp =
+      afterReg->FetchState.handleQueryResult(
+        ~query=catchUpQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=45),
+        ~newItems=[],
+      )
+    // Rolling back to 40 keeps the address (registered at 20) and puts every
+    // partition on the same frontier — nothing is left for a catch-up to cover,
+    // so the address-free partition stands alone again.
+    let rolledBack = advancedCatchUp->FetchState.rollback(~addressStore, ~targetBlockNumber=40)
+    t.expect(
+      (advancedCatchUp->frontierShape, rolledBack->frontierShape),
+      ~message="catch-up merges into the address-free partition instead of surviving the rollback",
+    ).toEqual(([(45, Some(50), ["Gravatar"]), (50, None, [])], [(40, None, [])]))
+  })
+
+  it("keeps a catch-up partition that rollback leaves behind the address-free partition", t => {
+    let (advanced, addressStore) = makeCollapsedAt50()
+    let afterReg =
+      advanced->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(~blockNumber=20, ~contractAddress=mockAddress3)->dcToItem,
+      ])
+    // The catch-up is still at 19 after the rollback to 30, so it keeps its
+    // range — now bounded by where the address-free partition was rolled back to.
+    let rolledBack = afterReg->FetchState.rollback(~addressStore, ~targetBlockNumber=30)
+    t.expect(
+      rolledBack->frontierShape,
+      ~message="catch-up survives with its merge block capped at the rollback target",
+    ).toEqual([(19, Some(30), ["Gravatar"]), (30, None, [])])
   })
 
   it("strips a client-filtered contract's addresses from a partition shared with a server-side contract", t => {


### PR DESCRIPTION
## Summary

Refactors how dynamically registered addresses are handled when they arrive after an address-free partition has already passed their registration block. Instead of merging them into the address-free partition with a guessed ceiling, they now get their own "catch-up" partitions that are bounded by what the standing partition's queries actually cover.

## Key Changes

- **Catch-up partition lifecycle**: When a contract is already client-filtered in an address-free partition, newly registered addresses for that contract get their own partition that:
  - Starts at the address's registration block
  - Merges away (disappears) once it reaches the block the standing partition's queries are known to have covered
  - Stays unbounded if the standing partition has an unbounded query in flight

- **Anchor-safe block calculation**: Added `getAnchorSafeBlock` to determine the furthest block an address-free partition's dispatched queries can safely claim without addresses registered after the query was sent. Settled queries claim only what they fetched; bounded in-flight queries claim their `toBlock`; unbounded queries provide no safe ceiling.

- **Partition optimization**: `OptimizedPartitions.make` now:
  - Identifies anchored contracts (those already client-filtered in address-free partitions)
  - Bounds catch-up partitions against their anchor's safe block
  - Removes catch-up partitions that have reached their merge block
  - Preserves catch-up partitions in `collapseClientFilteredContracts` instead of absorbing them

- **Rollback handling**: When rolling back, catch-up partitions have their merge block capped at the rollback target, and are removed if they've already reached it.

- **Test updates**: Comprehensive test suite updated to verify:
  - Catch-up partitions remain unbounded while standing partition's query is in flight
  - Catch-up partitions are bounded once the standing response settles
  - Multiple catch-up partitions can coexist for different addresses
  - Catch-up partitions are removed when they reach their merge block
  - Rollback correctly handles catch-up partition survival and merging

## Implementation Details

- Each dynamically registered address now gets its own partition (not folded into a single backfill) to preserve the correctness barrier until it catches up
- The `frontierShape` test helper changed from inspecting `selection.clientFilteredContracts` to `addresses->AddressSet.contractNames` to reflect the new partition structure
- Catch-up partitions are identified by having `dynamicContract: Some(contractName)` and `mergeBlock: Some(block)` set by the optimization pass

https://claude.ai/code/session_014wQagPRck9tBcbzAWemsWq