### PR TITLE
Make mock indexer entity queries generic

### DIFF
--- a/scenarios/test_codegen/test/ConcurrentWrite_test.res
+++ b/scenarios/test_codegen/test/ConcurrentWrite_test.res
@@ -136,7 +136,7 @@ describe("Concurrent batch write and processing", () => {
       await indexerMock.getBatchWritePromise()
 
       t.expect(
-        (writeBatchErrors, await indexerMock.queryHistory(SimpleEntity)),
+        (writeBatchErrors, await (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>)),
         ~message="The delete history row persisted by the in-flight write must not be written again by the next write",
       ).toEqual((
         [],

--- a/scenarios/test_codegen/test/E2E_test.res
+++ b/scenarios/test_codegen/test/E2E_test.res
@@ -245,7 +245,7 @@ describe("E2E tests", () => {
     ])
     await indexerMock.getBatchWritePromise()
 
-    t.expect(await indexerMock.query(SimpleEntity)).toEqual([
+    t.expect(await (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>)).toEqual([
       {Indexer.Entities.SimpleEntity.id: "1", value: "value-2"},
     ])
     t.expect(errors, ~message="should have an error thrown during set").toEqual([
@@ -1388,7 +1388,7 @@ describe("E2E tests", () => {
     // Item at 2000 should NOT be in DB yet — earlier chunks haven't completed,
     // so bufferBlockNumber=800 and 2000 > 800 means it's not ready.
     t.expect(
-      await indexerMock.query(SimpleEntity),
+      await (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
       ~message="Item at block 2000 should not be ready while earlier chunks are pending",
     ).toEqual([])
 
@@ -1415,7 +1415,7 @@ describe("E2E tests", () => {
     // Only item-850 should be in DB — chunk2 hasn't completed,
     // so chunk3's item at 2000 is still beyond the buffer.
     t.expect(
-      await indexerMock.query(SimpleEntity),
+      await (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
       ~message="Only item-850 should be in DB while chunk2 is pending",
     ).toEqual([{Indexer.Entities.SimpleEntity.id: "item-850", value: "from-chunk1"}])
 
@@ -1434,7 +1434,7 @@ describe("E2E tests", () => {
 
     // Both items should now be in DB
     t.expect(
-      await indexerMock.query(SimpleEntity),
+      await (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
       ~message="Both items should be in DB after chunk1 fully completes",
     ).toEqual([
       {Indexer.Entities.SimpleEntity.id: "item-850", value: "from-chunk1"},

--- a/scenarios/test_codegen/test/LoadLayer_test.res
+++ b/scenarios/test_codegen/test/LoadLayer_test.res
@@ -10,7 +10,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadById(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~entityId,
         ~item=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
@@ -38,7 +38,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadById(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~entityId,
         ~item=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
@@ -73,7 +73,7 @@ describe("LoadLayer", () => {
         LoadLayer.loadById(
           ~loadManager,
           ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-          ~entityConfig=MockIndexer.entityConfig(User),
+          ~entityConfig=MockIndexer.entityConfig("User"),
           ~indexerState,
           ~entityId,
           ~item=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
@@ -103,7 +103,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadById(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~entityId,
         ~item=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
@@ -148,7 +148,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadById(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~entityId,
         ~item=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
@@ -184,13 +184,13 @@ describe("LoadLayer", () => {
       )
 
       let indexerState = MockIndexer.InMemoryStore.make(
-        ~entities=[(MockIndexer.entityConfig(User), [user1])],
+        ~entities=[(MockIndexer.entityConfig("User"), [user1])],
       )
       let getUser = entityId =>
         LoadLayer.loadById(
           ~loadManager,
           ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-          ~entityConfig=MockIndexer.entityConfig(User),
+          ~entityConfig=MockIndexer.entityConfig("User"),
           ~indexerState,
           ~entityId,
           ~item=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
@@ -234,7 +234,7 @@ describe("LoadLayer", () => {
         LoadLayer.loadById(
           ~loadManager,
           ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-          ~entityConfig=MockIndexer.entityConfig(User),
+          ~entityConfig=MockIndexer.entityConfig("User"),
           ~indexerState,
           ~entityId,
           ~item=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
@@ -250,7 +250,7 @@ describe("LoadLayer", () => {
       await Promise.resolve()
 
       indexerState->MockIndexer.InMemoryStore.setEntity(
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         user1,
       )
 
@@ -284,14 +284,14 @@ describe("LoadLayer", () => {
       )
 
       let indexerState = MockIndexer.InMemoryStore.make(
-        ~entities=[(MockIndexer.entityConfig(User), [user1])],
+        ~entities=[(MockIndexer.entityConfig("User"), [user1])],
       )
 
       let getUser = entityId =>
         LoadLayer.loadById(
           ~loadManager,
           ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-          ~entityConfig=MockIndexer.entityConfig(User),
+          ~entityConfig=MockIndexer.entityConfig("User"),
           ~indexerState,
           ~entityId,
           ~item=MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem,
@@ -335,7 +335,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadByFilter(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~item,
         ~ecosystem=MockIndexer.config.ecosystem,
@@ -349,7 +349,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadByFilter(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~item,
         ~ecosystem=MockIndexer.config.ecosystem,
@@ -381,7 +381,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadByFilter(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~item,
         ~ecosystem=MockIndexer.config.ecosystem,
@@ -419,7 +419,7 @@ describe("LoadLayer", () => {
     }
 
     let indexerState = MockIndexer.InMemoryStore.make(
-      ~entities=[(MockIndexer.entityConfig(User), [user1])],
+      ~entities=[(MockIndexer.entityConfig("User"), [user1])],
     )
 
     let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem
@@ -427,7 +427,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadByFilter(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~item,
         ~ecosystem=MockIndexer.config.ecosystem,
@@ -469,7 +469,7 @@ describe("LoadLayer", () => {
 
       let storageMock = MockIndexer.Storage.make(
         [#loadOrThrow],
-        ~dbEntities=[(MockIndexer.entityConfig(User), [user1, user2, user("3", "0x3")])],
+        ~dbEntities=[(MockIndexer.entityConfig("User"), [user1, user2, user("3", "0x3")])],
       )
       let loadManager = LoadManager.make()
       let indexerState = MockIndexer.InMemoryStore.make()
@@ -479,7 +479,7 @@ describe("LoadLayer", () => {
         LoadLayer.loadByFilter(
           ~loadManager,
           ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-          ~entityConfig=MockIndexer.entityConfig(User),
+          ~entityConfig=MockIndexer.entityConfig("User"),
           ~indexerState,
           ~item,
           ~ecosystem=MockIndexer.config.ecosystem,
@@ -520,7 +520,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadByFilter(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~item,
         ~ecosystem=MockIndexer.config.ecosystem,
@@ -560,7 +560,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadByFilter(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~item,
         ~ecosystem=MockIndexer.config.ecosystem,
@@ -614,7 +614,7 @@ describe("LoadLayer", () => {
     }
 
     let indexerState = MockIndexer.InMemoryStore.make(
-      ~entities=[(MockIndexer.entityConfig(User), [user1, user2])],
+      ~entities=[(MockIndexer.entityConfig("User"), [user1, user2])],
     )
 
     let item = MockEvents.newGravatarLog1->MockEvents.newGravatarEventToBatchItem
@@ -622,7 +622,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadByFilter(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~item,
         ~ecosystem=MockIndexer.config.ecosystem,
@@ -637,7 +637,7 @@ describe("LoadLayer", () => {
       LoadLayer.loadByFilter(
         ~loadManager,
         ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         ~indexerState,
         ~item,
         ~ecosystem=MockIndexer.config.ecosystem,
@@ -678,7 +678,7 @@ describe("LoadLayer", () => {
     ).toEqual(2)
 
     indexerState->MockIndexer.InMemoryStore.setEntity(
-      ~entityConfig=MockIndexer.entityConfig(User),
+      ~entityConfig=MockIndexer.entityConfig("User"),
       {...user2, updatesCountOnUserForTesting: 0},
     )
 
@@ -714,7 +714,7 @@ describe("LoadLayer", () => {
         LoadLayer.loadByFilter(
           ~loadManager,
           ~persistence=storageMock->MockIndexer.Storage.toPersistence,
-          ~entityConfig=MockIndexer.entityConfig(User),
+          ~entityConfig=MockIndexer.entityConfig("User"),
           ~indexerState,
           ~item,
           ~ecosystem=MockIndexer.config.ecosystem,
@@ -737,7 +737,7 @@ describe("LoadLayer", () => {
       t.expect(storageMock.loadOrThrowCalls).toEqual(loadEntitiesByFieldSingleDbCall)
 
       indexerState->MockIndexer.InMemoryStore.setEntity(
-        ~entityConfig=MockIndexer.entityConfig(User),
+        ~entityConfig=MockIndexer.entityConfig("User"),
         user1,
       )
 

--- a/scenarios/test_codegen/test/WriteRead_test.res
+++ b/scenarios/test_codegen/test/WriteRead_test.res
@@ -96,18 +96,18 @@ describe("Write/read tests", () => {
     ])
     await indexerMock.getBatchWritePromise()
 
-    t.expect(await indexerMock.query(EntityWithAllTypes)).toEqual([entityWithAllTypes])
-    t.expect(await indexerMock.queryHistory(EntityWithAllTypes)).toEqual([
+    t.expect(await (indexerMock.query("EntityWithAllTypes"): promise<array<Indexer.Entities.EntityWithAllTypes.t>>)).toEqual([entityWithAllTypes])
+    t.expect(await (indexerMock.queryHistory("EntityWithAllTypes"): promise<array<Change.t<Indexer.Entities.EntityWithAllTypes.t>>>)).toEqual([
       Set({
         checkpointId: 1n,
         entityId: "1"->EntityId.unsafeOfString,
         entity: entityWithAllTypes,
       }),
     ])
-    t.expect(await indexerMock.query(EntityWithAllNonArrayTypes)).toEqual([
+    t.expect(await (indexerMock.query("EntityWithAllNonArrayTypes"): promise<array<Indexer.Entities.EntityWithAllNonArrayTypes.t>>)).toEqual([
       entityWithAllNonArrayTypes,
     ])
-    t.expect(await indexerMock.queryHistory(EntityWithAllNonArrayTypes)).toEqual([
+    t.expect(await (indexerMock.queryHistory("EntityWithAllNonArrayTypes"): promise<array<Change.t<Indexer.Entities.EntityWithAllNonArrayTypes.t>>>)).toEqual([
       Set({
         checkpointId: 1n,
         entityId: "1"->EntityId.unsafeOfString,
@@ -116,16 +116,14 @@ describe("Write/read tests", () => {
     ])
 
     t.expect(
-      await indexerMock.query(EntityWith63LenghtName______________________________________one),
+      await (indexerMock.query("EntityWith63LenghtName______________________________________one"): promise<array<Indexer.Entities.EntityWith63LenghtName______________________________________one.t>>),
     ).toEqual([
       {
         id: "1",
       },
     ])
     t.expect(
-      await indexerMock.queryHistory(
-        EntityWith63LenghtName______________________________________one,
-      ),
+      await (indexerMock.queryHistory("EntityWith63LenghtName______________________________________one"): promise<array<Change.t<Indexer.Entities.EntityWith63LenghtName______________________________________one.t>>>),
     ).toEqual([
       Set({
         checkpointId: 1n,
@@ -136,16 +134,14 @@ describe("Write/read tests", () => {
       }),
     ])
     t.expect(
-      await indexerMock.query(EntityWith63LenghtName______________________________________two),
+      await (indexerMock.query("EntityWith63LenghtName______________________________________two"): promise<array<Indexer.Entities.EntityWith63LenghtName______________________________________two.t>>),
     ).toEqual([
       {
         id: "2",
       },
     ])
     t.expect(
-      await indexerMock.queryHistory(
-        EntityWith63LenghtName______________________________________two,
-      ),
+      await (indexerMock.queryHistory("EntityWith63LenghtName______________________________________two"): promise<array<Change.t<Indexer.Entities.EntityWith63LenghtName______________________________________two.t>>>),
     ).toEqual([
       Set({
         checkpointId: 1n,
@@ -219,7 +215,7 @@ breaking precicion on big values. https://github.com/enviodev/hyperindex/issues/
       ])
       await indexerMock.getBatchWritePromise()
 
-      t.expect(await indexerMock.queryHistory(SimpleEntity)).toEqual([
+      t.expect(await (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>)).toEqual([
         Set({checkpointId: 1n, entityId: "untouched"->EntityId.unsafeOfString, entity: {id: "untouched", value: "batch1"}}),
         Set({checkpointId: 1n, entityId: "updated"->EntityId.unsafeOfString, entity: {id: "updated", value: "batch1"}}),
         Set({checkpointId: 3n, entityId: "updated"->EntityId.unsafeOfString, entity: {id: "updated", value: "batch2"}}),

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -6,8 +6,7 @@ let config = Config.load()
 let entityConfigByName = (config: Config.t, name): Internal.entityConfig =>
   config.userEntitiesByName->Dict.get(name)->Option.getOrThrow
 
-let entityConfig = (name: Indexer.Entities.name<_, _>): Internal.entityConfig =>
-  config->entityConfigByName(name->(Utils.magic: Indexer.Entities.name<_, _> => string))
+let entityConfig = (name: string): Internal.entityConfig => config->entityConfigByName(name)
 
 // The store requires a persistence/config even when the cycle never runs; reuse one.
 // Lazy so importing the helper doesn't open a pg client for tests that never use it.
@@ -384,8 +383,8 @@ module Indexer = {
   type rec t = {
     getBatchWritePromise: unit => promise<unit>,
     getRollbackReadyPromise: unit => promise<unit>,
-    query: 'entity 'id. Indexer.Entities.name<'entity, 'id> => promise<array<'entity>>,
-    queryHistory: 'entity 'id. Indexer.Entities.name<'entity, 'id> => promise<array<Change.t<'entity>>>,
+    query: 'entity. string => promise<array<'entity>>,
+    queryHistory: 'entity. string => promise<array<Change.t<'entity>>>,
     queryRaw: 'entity. Internal.entityConfig => promise<array<'entity>>,
     queryCheckpoints: unit => promise<array<InternalTable.Checkpoints.t>>,
     queryEffectCache: 'input 'output. (
@@ -590,9 +589,8 @@ module Indexer = {
           resolve()
         })
       },
-      query: (type entity id, name: Indexer.Entities.name<entity, id>) => {
-        let ec =
-          config->entityConfigByName(name->(Utils.magic: Indexer.Entities.name<entity, id> => string))
+      query: (type entity, name) => {
+        let ec = config->entityConfigByName(name)
         sql
         ->Postgres.unsafe(PgStorage.makeLoadAllQuery(~pgSchema, ~tableName=ec.table.tableName))
         ->Promise.thenResolve(items => {
@@ -600,9 +598,8 @@ module Indexer = {
         })
         ->(Utils.magic: promise<array<unknown>> => promise<array<entity>>)
       },
-      queryHistory: (type entity id, name: Indexer.Entities.name<entity, id>) => {
-        let ec =
-          config->entityConfigByName(name->(Utils.magic: Indexer.Entities.name<entity, id> => string))
+      queryHistory: (type entity, name) => {
+        let ec = config->entityConfigByName(name)
         sql
         ->Postgres.unsafe(
           PgStorage.makeLoadAllQuery(
@@ -618,7 +615,7 @@ module Indexer = {
             S.array(
               S.union([
                 PgStorage.getEntityHistory(~entityConfig=ec).setChangeSchema,
-                S.object((s): Change.t<'entity> => {
+                S.object((s): Change.t<Internal.entity> => {
                   s.tag(EntityHistory.changeFieldName, EntityHistory.RowAction.DELETE)
                   Delete({
                     entityId: s.field("id", ec.table->Table.getIdSchema),

--- a/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
@@ -2,7 +2,7 @@ open Vitest
 
 describe("Test makeClickHouseEntitySchema", () => {
   Async.it("Should serialize Date fields using getTime() instead of ISO string", async t => {
-    let entityConfig = MockIndexer.entityConfig(EntityWithAllTypes)
+    let entityConfig = MockIndexer.entityConfig("EntityWithAllTypes")
 
     // Create a schema using makeClickHouseEntitySchema
     let clickHouseSchema = ClickHouse.makeClickHouseEntitySchema(entityConfig.table)
@@ -162,7 +162,7 @@ ORDER BY (id)`
     Async.it(
       "Should create SQL for A entity history table",
       async t => {
-        let entityConfig = MockIndexer.entityConfig(EntityWithAllTypes)
+        let entityConfig = MockIndexer.entityConfig("EntityWithAllTypes")
         let query = ClickHouse.makeCreateHistoryTableQuery(~entityConfig, ~database="test_db")
 
         let expectedQuery = `CREATE TABLE IF NOT EXISTS test_db.\`envio_history_EntityWithAllTypes\` (
@@ -205,7 +205,7 @@ ORDER BY (id, envio_checkpoint_id)`
     Async.it(
       "Should add ON CLUSTER and ReplicatedMergeTree when replicated",
       async t => {
-        let entityConfig = MockIndexer.entityConfig(EntityWithAllTypes)
+        let entityConfig = MockIndexer.entityConfig("EntityWithAllTypes")
         let query = ClickHouse.makeCreateHistoryTableQuery(
           ~entityConfig,
           ~database="test_db",
@@ -418,7 +418,7 @@ TTL \`trade_time\` + INTERVAL 1 YEAR DELETE WHERE \`base_token_id\` != ''`)
     Async.it(
       "Should create SQL for A entity view",
       async t => {
-        let entity = MockIndexer.entityConfig(EntityWithAllTypes)
+        let entity = MockIndexer.entityConfig("EntityWithAllTypes")
         let query = ClickHouse.makeCreateViewQuery(~entityConfig=entity, ~database="test_db")
 
         let expectedQuery = `CREATE VIEW IF NOT EXISTS test_db.\`EntityWithAllTypes\` AS
@@ -439,7 +439,7 @@ WHERE \`envio_change\` = 'SET'`
     Async.it(
       "Should add ON CLUSTER when replicated",
       async t => {
-        let entity = MockIndexer.entityConfig(EntityWithAllTypes)
+        let entity = MockIndexer.entityConfig("EntityWithAllTypes")
         let query = ClickHouse.makeCreateViewQuery(
           ~entityConfig=entity,
           ~database="test_db",

--- a/scenarios/test_codegen/test/lib_tests/EntityIdType_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EntityIdType_test.res
@@ -361,7 +361,7 @@ describe("Test indexer reports deleted ids with the entity's id type", () => {
 
   it("keeps an Int id a number", t => {
     let deleted = deletedIdsOf(
-      ~entityConfig=MockIndexer.entityConfig(IntIdEntity),
+      ~entityConfig=MockIndexer.entityConfig("IntIdEntity"),
       ~entityId=137->EntityId.unsafeOfAny,
     )
     // Compared against the raw number, so a stringified "137" fails here.
@@ -370,7 +370,7 @@ describe("Test indexer reports deleted ids with the entity's id type", () => {
 
   it("keeps a BigInt id a bigint", t => {
     let deleted = deletedIdsOf(
-      ~entityConfig=MockIndexer.entityConfig(BigIntIdEntity),
+      ~entityConfig=MockIndexer.entityConfig("BigIntIdEntity"),
       ~entityId=999n->EntityId.unsafeOfAny,
     )
     t.expect(deleted).toEqual([999n->EntityId.unsafeOfAny])
@@ -378,7 +378,7 @@ describe("Test indexer reports deleted ids with the entity's id type", () => {
 
   it("keeps a string id a string", t => {
     let deleted = deletedIdsOf(
-      ~entityConfig=MockIndexer.entityConfig(User),
+      ~entityConfig=MockIndexer.entityConfig("User"),
       ~entityId="u1"->EntityId.unsafeOfString,
     )
     t.expect(deleted).toEqual(["u1"->EntityId.unsafeOfString])

--- a/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgStorage_test.res
@@ -136,7 +136,7 @@ describe("Test PgStorage SQL generation functions", () => {
       "Should create indices for A entity table",
       async t => {
         let query = PgStorage.makeCreateTableIndicesQuery(
-          MockIndexer.entityConfig(A).table,
+          MockIndexer.entityConfig("A").table,
           ~pgSchema="test_schema",
         )
 
@@ -149,7 +149,7 @@ describe("Test PgStorage SQL generation functions", () => {
       "Should handle table with no indices",
       async t => {
         let query = PgStorage.makeCreateTableIndicesQuery(
-          MockIndexer.entityConfig(B).table,
+          MockIndexer.entityConfig("B").table,
           ~pgSchema="test_schema",
         )
 
@@ -164,7 +164,7 @@ describe("Test PgStorage SQL generation functions", () => {
       "Should create SQL for A entity table",
       async t => {
         let query = PgStorage.makeCreateTableQuery(
-          MockIndexer.entityConfig(A).table,
+          MockIndexer.entityConfig("A").table,
           ~pgSchema="test_schema",
           ~isNumericArrayAsText=false,
         )
@@ -178,7 +178,7 @@ describe("Test PgStorage SQL generation functions", () => {
       "Should create SQL for B entity table with derived fields",
       async t => {
         let query = PgStorage.makeCreateTableQuery(
-          MockIndexer.entityConfig(B).table,
+          MockIndexer.entityConfig("B").table,
           ~pgSchema="test_schema",
           ~isNumericArrayAsText=false,
         )
@@ -192,7 +192,7 @@ describe("Test PgStorage SQL generation functions", () => {
       "Should handle default values",
       async t => {
         let query = PgStorage.makeCreateTableQuery(
-          MockIndexer.entityConfig(A).table,
+          MockIndexer.entityConfig("A").table,
           ~pgSchema="test_schema",
           ~isNumericArrayAsText=false,
         )
@@ -210,11 +210,11 @@ describe("Test PgStorage SQL generation functions", () => {
       "Should create complete initialization queries",
       async t => {
         let entities = [
-          MockIndexer.entityConfig(A),
-          MockIndexer.entityConfig(B),
-          MockIndexer.entityConfig(EntityWith63LenghtName______________________________________one),
-          MockIndexer.entityConfig(EntityWith63LenghtName______________________________________two),
-          MockIndexer.entityConfig(EntityWithAllTypes),
+          MockIndexer.entityConfig("A"),
+          MockIndexer.entityConfig("B"),
+          MockIndexer.entityConfig("EntityWith63LenghtName______________________________________one"),
+          MockIndexer.entityConfig("EntityWith63LenghtName______________________________________two"),
+          MockIndexer.entityConfig("EntityWithAllTypes"),
         ]
         let enums = MockIndexer.config.allEnums
 
@@ -381,7 +381,7 @@ FROM "test_schema"."envio_chains";`
       "Should create SQL for single entity with indices",
       async t => {
         // Test with just entity A which has an indexed field
-        let entities = [MockIndexer.entityConfig(A)]
+        let entities = [MockIndexer.entityConfig("A")]
 
         let queries = PgStorage.makeInitializeTransaction(
           ~pgSchema="public",
@@ -544,8 +544,8 @@ FROM "public"."envio_chains";`
       async t => {
         let query = PgStorage.makeInsertUnnestSetQuery(
           ~pgSchema="test_schema",
-          ~table=MockIndexer.entityConfig(EntityWithAllNonArrayTypes).table,
-          ~itemSchema=MockIndexer.entityConfig(EntityWithAllNonArrayTypes).schema,
+          ~table=MockIndexer.entityConfig("EntityWithAllNonArrayTypes").table,
+          ~itemSchema=MockIndexer.entityConfig("EntityWithAllNonArrayTypes").schema,
           ~isRawEvents=false,
         )
 
@@ -580,8 +580,8 @@ SELECT * FROM unnest($1::INTEGER[],$2::BIGINT[],$3::TEXT[],$4::TEXT[],$5::INTEGE
       async t => {
         let query = PgStorage.makeInsertValuesSetQuery(
           ~pgSchema="test_schema",
-          ~table=MockIndexer.entityConfig(A).table,
-          ~itemSchema=MockIndexer.entityConfig(A).schema,
+          ~table=MockIndexer.entityConfig("A").table,
+          ~itemSchema=MockIndexer.entityConfig("A").schema,
           ~itemsCount=2,
         )
 
@@ -601,8 +601,8 @@ VALUES($1,$3,$5),($2,$4,$6)ON CONFLICT("id") DO UPDATE SET "b_id" = EXCLUDED."b_
       async t => {
         let query = PgStorage.makeInsertValuesSetQuery(
           ~pgSchema="test_schema",
-          ~table=MockIndexer.entityConfig(B).table,
-          ~itemSchema=MockIndexer.entityConfig(B).schema,
+          ~table=MockIndexer.entityConfig("B").table,
+          ~itemSchema=MockIndexer.entityConfig("B").schema,
           ~itemsCount=1,
         )
 

--- a/scenarios/test_codegen/test/rollback/Rollback_test.res
+++ b/scenarios/test_codegen/test/rollback/Rollback_test.res
@@ -104,8 +104,8 @@ describe("E2E rollback tests", () => {
     t.expect(
       await Promise.all3((
         indexerMock.queryCheckpoints(),
-        indexerMock.query(SimpleEntity),
-        indexerMock.queryHistory(SimpleEntity),
+        (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
+        (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>),
       )),
       ~message="Should have two entities in the db",
     ).toEqual((
@@ -259,8 +259,8 @@ describe("E2E rollback tests", () => {
     t.expect(
       await Promise.all3((
         indexerMock.queryCheckpoints(),
-        indexerMock.query(SimpleEntity),
-        indexerMock.queryHistory(SimpleEntity),
+        (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
+        (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>),
       )),
       ~message="Should correctly rollback entities",
     ).toEqual((
@@ -509,7 +509,7 @@ describe("E2E rollback tests", () => {
     let rec waitForRecreatedEntityHistory = async () => {
       if shouldKeepWaitingForHistory.contents {
         let hasRecreatedEntityHistory =
-          (await indexerMock.queryHistory(SimpleEntity))->Array.length === 3
+          (await (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>))->Array.length === 3
         if shouldKeepWaitingForHistory.contents && !hasRecreatedEntityHistory {
           await Utils.delay(1)
           await waitForRecreatedEntityHistory()
@@ -535,8 +535,8 @@ describe("E2E rollback tests", () => {
 
     t.expect(
       await Promise.all2((
-        indexerMock.query(SimpleEntity),
-        indexerMock.queryHistory(SimpleEntity),
+        (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
+        (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>),
       )),
       ~message="Should establish SET -> DELETE -> SET history before the rollback",
     ).toEqual((
@@ -592,7 +592,7 @@ describe("E2E rollback tests", () => {
     await indexerMock.getBatchWritePromise()
 
     t.expect(
-      await indexerMock.query(SimpleEntity),
+      await (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
       ~message="The entity should remain deleted at the rollback target",
     ).toEqual([])
   })
@@ -1223,8 +1223,8 @@ This might be wrong after we start exposing a block hash for progress block.`,
     t.expect(
       await Promise.all3((
         indexerMock.queryCheckpoints(),
-        indexerMock.query(SimpleEntity),
-        indexerMock.queryHistory(SimpleEntity),
+        (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
+        (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>),
       )),
       ~message=`Should create history rows and checkpoints`,
     ).toEqual((
@@ -1485,8 +1485,8 @@ This might be wrong after we start exposing a block hash for progress block.`,
     t.expect(
       await Promise.all3((
         indexerMock.queryCheckpoints(),
-        indexerMock.query(SimpleEntity),
-        indexerMock.queryHistory(SimpleEntity),
+        (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
+        (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>),
       )),
     ).toEqual((
       [
@@ -1691,8 +1691,8 @@ This might be wrong after we start exposing a block hash for progress block.`,
       t.expect(
         await Promise.all3((
           indexerMock.queryCheckpoints(),
-          indexerMock.query(SimpleEntity),
-          indexerMock.queryHistory(SimpleEntity),
+          (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
+          (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>),
         )),
         ~message=`Should create history rows and checkpoints`,
       ).toEqual((
@@ -1793,8 +1793,8 @@ This might be wrong after we start exposing a block hash for progress block.`,
       ))
       t.expect(
         await Promise.all2((
-          indexerMock.query(EntityWithBigDecimal),
-          indexerMock.queryHistory(EntityWithBigDecimal),
+          (indexerMock.query("EntityWithBigDecimal"): promise<array<Indexer.Entities.EntityWithBigDecimal.t>>),
+          (indexerMock.queryHistory("EntityWithBigDecimal"): promise<array<Change.t<Indexer.Entities.EntityWithBigDecimal.t>>>),
         )),
         ~message="Should also add another entity for a non-reorg chain, which should also be rollbacked",
       ).toEqual((
@@ -1900,8 +1900,8 @@ This might be wrong after we start exposing a block hash for progress block.`,
       t.expect(
         await Promise.all3((
           indexerMock.queryCheckpoints(),
-          indexerMock.query(SimpleEntity),
-          indexerMock.queryHistory(SimpleEntity),
+          (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
+          (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>),
         )),
       ).toEqual((
         [
@@ -1972,8 +1972,8 @@ This might be wrong after we start exposing a block hash for progress block.`,
       ))
       t.expect(
         await Promise.all2((
-          indexerMock.query(EntityWithBigDecimal),
-          indexerMock.queryHistory(EntityWithBigDecimal),
+          (indexerMock.query("EntityWithBigDecimal"): promise<array<Indexer.Entities.EntityWithBigDecimal.t>>),
+          (indexerMock.queryHistory("EntityWithBigDecimal"): promise<array<Change.t<Indexer.Entities.EntityWithBigDecimal.t>>>),
         )),
         ~message="Should also add another entity for a non-reorg chain, which should also be rollbacked (theoretically)",
       ).toEqual((
@@ -2099,7 +2099,7 @@ This might be wrong after we start exposing a block hash for progress block.`,
     await indexerMock.getBatchWritePromise()
 
     t.expect(
-      await indexerMock.query(SimpleEntity),
+      await (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>),
       ~message="Should have all entities rolled back",
     ).toEqual([])
   })
@@ -3179,10 +3179,10 @@ This might be wrong after we start exposing a block hash for progress block.`,
 
       t.expect(
         (
-          (await indexerMock.query(SimpleEntity))->Array.toSorted((a, b) =>
+          (await (indexerMock.query("SimpleEntity"): promise<array<Indexer.Entities.SimpleEntity.t>>))->Array.toSorted((a, b) =>
             String.compare(a.id, b.id)
           ),
-          await indexerMock.queryHistory(SimpleEntity),
+          await (indexerMock.queryHistory("SimpleEntity"): promise<array<Change.t<Indexer.Entities.SimpleEntity.t>>>),
           await indexerMock.metric("envio_rollback_events"),
         ),
         ~message="Chain 100's in-flight entity change should be rolled back together with its progress and reapplied on refetch",

--- a/scenarios/test_codegen/test/schema_types/BigDecimal_test.res
+++ b/scenarios/test_codegen/test/schema_types/BigDecimal_test.res
@@ -40,7 +40,8 @@ describe("Load and save an entity with a BigDecimal from DB", () => {
     )
     await indexerMock.getBatchWritePromise()
 
-    let entities = await indexerMock.query(EntityWithBigDecimal)
+    let entities: array<Indexer.Entities.EntityWithBigDecimal.t> =
+      await indexerMock.query("EntityWithBigDecimal")
     switch entities->Array.find(e => e.id === "testEntity") {
     | Some(entity) => t.expect(entity.bigDecimal.toString()).toBe("123.456")
     | None => JsError.throwWithMessage("testEntity1 should exist")

--- a/scenarios/test_codegen/test/schema_types/Timestamp_test.res
+++ b/scenarios/test_codegen/test/schema_types/Timestamp_test.res
@@ -36,7 +36,8 @@ describe("Load and save an entity with a Timestamp from DB", () => {
     )
     await indexerMock.getBatchWritePromise()
 
-    let entities = await indexerMock.query(EntityWithTimestamp)
+    let entities: array<Indexer.Entities.EntityWithTimestamp.t> =
+      await indexerMock.query("EntityWithTimestamp")
     switch entities->Array.find(e => e.id === "testEntity") {
     | Some(entity) =>
       t.expect(entity.timestamp->Date.toISOString).toEqual("1970-01-01T00:02:03.456Z")


### PR DESCRIPTION
## Summary

- accept schema entity names as plain strings in the mock indexer API
- return polymorphic entity records directly from `query`, `queryHistory`, and `queryRaw`
- update scenario tests to pass their schema entity names directly and provide result annotations only where ReScript inference needs them

## Why

The mock indexer was coupled to generated `Indexer.Entities.name` values. That coupling blocks moving it into the internal test-indexer solution in the `envio` test package, where scenario-generated entity-name types are unavailable. Returning the caller-selected entity type directly keeps the API lightweight without introducing a separate opaque entity wrapper.

## Impact

Mock-indexer queries are intentionally less type-safe at the entity-name boundary: a string and its expected result type can disagree. Runtime entity lookup still validates the supplied name against the loaded project config.

## Validation

- `pnpm exec rescript`
- `pnpm exec tsc --noEmit`
- 153 focused Vitest tests across the affected mock-indexer, storage, rollback, and schema suites
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage for querying entities by name.
  * Improved type validation for entity and history query results.
  * Updated loading, storage, rollback, schema, and SQL-generation tests to use consistent entity configuration.
  * Removed an incorrect duplicate deletion test and retained the correct string-ID coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->