### PR TITLE
Finalize indexes sequentially and deduplicate finalization runs

### DIFF
--- a/packages/envio/src/FinalizeBackfill.res
+++ b/packages/envio/src/FinalizeBackfill.res
@@ -1,13 +1,12 @@
-// The FinalizingIndexes phase. Runs once, from the processing loop, when every
+// The FinalizingIndexes phase. Reached from the processing loop when every
 // chain has caught up: processing is already paused (the loop awaits this),
-// pending writes are flushed, then storage creates every missing schema-defined
-// index and stamps `ready_at` in one transaction. A failure rolls back both and
-// reaches the processing loop's error boundary, which stops the indexer — the
-// rollback leaves nothing half-done, so a restart picks the work up cleanly.
-// Either way the indexer never reports ready with an index the schema promised
-// still missing.
+// pending writes are flushed, then storage builds every missing schema-defined
+// index and, once they all verify, commits `ready_at`. A failure part-way
+// leaves the indexes built so far in place and reaches the processing loop's
+// error boundary; the retry only owes what's left. Either way the indexer never
+// reports ready with an index the schema promised still missing.
 
-let run = async (state: IndexerState.t) => {
+let runOnce = async (state: IndexerState.t) => {
   Logging.info(
     "All chains are caught up. Finalizing the indexer before switching to realtime: flushing pending writes, then creating the indexes the schema promises.",
   )
@@ -30,7 +29,22 @@ let run = async (state: IndexerState.t) => {
       ~readyAt,
     )
 
+    // Only after the commit: in-memory readiness must never run ahead of the
+    // `ready_at` a restart would read back.
     state->IndexerState.markReady(~readyAt)
     Logging.info("The indexer is ready. Switching to realtime indexing.")
   }
 }
+
+// Several paths reach the phase — a processed batch, a tick that progressed
+// nothing — and a height update can bring another one round while the first is
+// still building. They all join the in-flight run rather than starting a second
+// pass over the same indexes.
+let run = (state: IndexerState.t) =>
+  switch state->IndexerState.finalizeFiber {
+  | Some(fiber) => fiber
+  | None =>
+    let fiber = runOnce(state)->Promise.finally(() => state->IndexerState.endFinalizeFiber)
+    state->IndexerState.beginFinalizeFiber(fiber)
+    fiber
+  }

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -90,6 +90,10 @@ type t = {
   mutable processedBatchesCount: int,
   // The single in-flight write loop, None when idle.
   mutable writeFiber: option<promise<unit>>,
+  // The single in-flight finalization, None when none is running. Every path
+  // that reaches the FinalizingIndexes phase awaits this one instead of
+  // starting a second pass over the same indexes.
+  mutable finalizeFiber: option<promise<unit>>,
   // Set once a write throws, to stop the loop. The error itself goes to onError.
   mutable hasFailedWrite: bool,
   // Resolved after every commit so capacity/flush waiters can re-evaluate.
@@ -191,6 +195,7 @@ let make = (
     processedBatches: [],
     processedBatchesCount: 0,
     writeFiber: None,
+    finalizeFiber: None,
     hasFailedWrite: false,
     commitWaiters: [],
     chainMeta: Dict.make(),
@@ -461,6 +466,7 @@ let processedCheckpointId = (state: t) => state.processedCheckpointId
 let processedBatches = (state: t) => state.processedBatches
 let processedBatchesCount = (state: t) => state.processedBatchesCount
 let writeFiber = (state: t) => state.writeFiber
+let finalizeFiber = (state: t) => state.finalizeFiber
 let hasFailedWrite = (state: t) => state.hasFailedWrite
 let chainMetaDirty = (state: t) => state.chainMetaDirty
 let chainMetaThrottler = (state: t) => state.chainMetaThrottler
@@ -806,6 +812,9 @@ let recordWriteFailure = (state: t, exn) => {
 
 let beginWriteFiber = (state: t, fiber) => state.writeFiber = Some(fiber)
 let endWriteFiber = (state: t) => state.writeFiber = None
+
+let beginFinalizeFiber = (state: t, fiber) => state.finalizeFiber = Some(fiber)
+let endFinalizeFiber = (state: t) => state.finalizeFiber = None
 
 // Resolve and clear everyone waiting on a commit so they can re-evaluate.
 let wakeCommitWaiters = (state: t) => {

--- a/packages/envio/src/IndexerState.resi
+++ b/packages/envio/src/IndexerState.resi
@@ -87,6 +87,7 @@ let processedCheckpointId: t => Internal.checkpointId
 let processedBatches: t => array<Batch.t>
 let processedBatchesCount: t => int
 let writeFiber: t => option<promise<unit>>
+let finalizeFiber: t => option<promise<unit>>
 let hasFailedWrite: t => bool
 let chainMetaDirty: t => bool
 let chainMetaThrottler: t => Throttler.t
@@ -145,6 +146,8 @@ let beginRollbackDiff: (
 let recordWriteFailure: (t, exn) => unit
 let beginWriteFiber: (t, promise<unit>) => unit
 let endWriteFiber: t => unit
+let beginFinalizeFiber: (t, promise<unit>) => unit
+let endFinalizeFiber: t => unit
 let wakeCommitWaiters: t => unit
 let addCommitWaiter: (t, unit => unit) => unit
 let stageChainMeta: (t, dict<InternalTable.Chains.metaFields>) => unit

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1788,7 +1788,7 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
     // Reached only once every definition is verified against pg_catalog. A
     // single statement, so a crash either leaves `ready_at` null and the retry
     // finds the indexes already built, or commits readiness the schema backs.
-    let _ = await sql->Postgres.preparedUnsafe(
+    let _ = await sql->Postgres.unpreparedUnsafe(
       InternalTable.Chains.makeSetReadyAtQuery(~pgSchema),
       [readyAt->(Utils.magic: Date.t => unknown), chainIds->(Utils.magic: array<int> => unknown)]->(
         Utils.magic: array<unknown> => unknown

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1709,15 +1709,14 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
     ->Promise.all
   }
 
-  // Unlike `ensureQueryIndexes`, this doesn't go through `IndexManager.ensure`:
-  // its builds have to share one transaction with `ready_at`, and waiting on
-  // the per-table queues while holding that transaction open is a good way to
-  // deadlock. It's safe because the caller guarantees exclusivity —
-  // `FinalizeBackfill.run` is reached from the processing loop with processing
-  // already paused, so no handler can be running a getWhere. Were that to
-  // change, an automatic build landing the same identity mid-transaction would
-  // take the create to "already exists" and roll `ready_at` back with it; the
-  // catalog refresh below means the retry recovers rather than looping.
+  // Unlike `ensureQueryIndexes`, this doesn't go through `IndexManager.ensure`.
+  // It's safe because the caller guarantees exclusivity — `FinalizeBackfill.run`
+  // is reached from the processing loop with processing already paused, so no
+  // handler can be running a getWhere.
+  //
+  // Each index is built on its own rather than in one transaction with
+  // `ready_at`: a build that dies half way through a large schema would
+  // otherwise roll back every index before it and make the retry start over.
   let finalizeBackfill = async (
     ~entities: array<Internal.entityConfig>,
     ~chainIds: array<int>,
@@ -1727,8 +1726,8 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
       ~entities=entities->Array.filter((e: Internal.entityConfig) => e.storage.postgres),
     )
 
-    // Resolved up front so a name held by an unrelated index fails before the
-    // transaction opens, rather than rolling one back.
+    // Resolved up front so a name held by an unrelated index fails before any
+    // DDL runs, rather than part way through the set.
     //
     // `Exact`, so the set built here is decided by the schema alone: matching a
     // declared index against a composite that happens to lead with the same
@@ -1770,47 +1769,31 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::int[],$3::
     }
     let timeRef = Performance.now()
 
-    let run = () =>
-      sql->Postgres.beginSql(async sql => {
-        let verified = []
-        for idx in 0 to missing->Array.length - 1 {
-          let entry = await sql->runAndVerify(missing->Array.getUnsafe(idx))
-          verified->Array.push(entry)->ignore
-        }
-        let _ = await sql->Postgres.preparedUnsafe(
-          InternalTable.Chains.makeSetReadyAtQuery(~pgSchema),
-          [
-            readyAt->(Utils.magic: Date.t => unknown),
-            chainIds->(Utils.magic: array<int> => unknown),
-          ]->(Utils.magic: array<unknown> => unknown),
-        )
-        verified
-      })
-
-    let verified = switch await run() {
-    | verified => verified
-    | exception exn =>
-      // A rollback takes the indexes with it, but a connection lost while
-      // acknowledging the COMMIT leaves them in place and unrecorded. Re-reading
-      // the schema means the retry plans against the database rather than
-      // replaying creates that can only raise "already exists" and never reach
-      // ready.
-      try {
-        let _ = await refreshIndexCatalog()
-      } catch {
-      | refreshExn =>
-        Logging.debug({
-          "storage": storageName,
-          "msg": "Could not re-read the index catalog after a failed finalize. The next attempt reads it again.",
-          "err": refreshExn->Utils.prettifyExn,
-        })
+    // Sequential, one committed index at a time: whatever is built before a
+    // failure stays built and recorded, so the retry owes only the rest.
+    for idx in 0 to missing->Array.length - 1 {
+      let prepared = missing->Array.getUnsafe(idx)
+      switch await sql->runAndVerify(prepared) {
+      | entry => indexManager->IndexManager.record(entry)
+      | exception exn =>
+        // The DDL is outside a transaction, so a create that commits and then
+        // fails its read-back leaves the index in place and unrecorded.
+        // Re-reading it means the retry plans against the database rather than
+        // replaying a create that can only raise "already exists".
+        await resyncIndex(prepared.name)
+        throw(exn)
       }
-      throw(exn)
     }
 
-    // Only after the commit: a rollback takes both the indexes and ready_at
-    // with it, and the catalog must not claim what the schema doesn't have.
-    verified->Array.forEach(entry => indexManager->IndexManager.record(entry))
+    // Reached only once every definition is verified against pg_catalog. A
+    // single statement, so a crash either leaves `ready_at` null and the retry
+    // finds the indexes already built, or commits readiness the schema backs.
+    let _ = await sql->Postgres.preparedUnsafe(
+      InternalTable.Chains.makeSetReadyAtQuery(~pgSchema),
+      [readyAt->(Utils.magic: Date.t => unknown), chainIds->(Utils.magic: array<int> => unknown)]->(
+        Utils.magic: array<unknown> => unknown
+      ),
+    )
 
     Logging.info({
       "storage": storageName,

--- a/scenarios/test_codegen/test/SchemaIndexes_test.res
+++ b/scenarios/test_codegen/test/SchemaIndexes_test.res
@@ -44,13 +44,23 @@ let method = (entry: IndexCatalog.entry) => entry.method
 let aBIdIndex = IndexDefinition.single(~tableName="A", ~column="b_id")
 let aBIdIndexName = aBIdIndex->IndexDefinition.name
 
-let readyAtByChainId = async () => {
+let readyAtRows = async () => {
   let rows: array<{"id": int, "ready_at": Null.t<Date.t>}> =
     await sql->Postgres.unsafe(
       `SELECT "id", "ready_at" FROM "${Env.Db.publicSchema}"."envio_chains" ORDER BY "id";`,
     )
-  rows->Array.map(row => (row["id"], row["ready_at"]->Null.toOption->Option.isSome))
+  rows
 }
+
+let readyAtByChainId = async () =>
+  (await readyAtRows())->Array.map(row => (row["id"], row["ready_at"]->Null.toOption->Option.isSome))
+
+// Timestamps rather than flags, for the chains that have to share one.
+let readyAtTimesByChainId = async () =>
+  (await readyAtRows())->Array.map(row => (
+    row["id"],
+    row["ready_at"]->Null.toOption->Option.map(Date.toISOString),
+  ))
 
 describe("Deferred schema indexes", () => {
   Async.it(
@@ -104,6 +114,8 @@ describe("Deferred schema indexes", () => {
         (await indexNames(), await readyAtByChainId()),
         ~message="A resume rediscovers the indexes from the catalog — none are dropped or recreated",
       ).toEqual((indexesBeforeRestart, [(1337, true)]))
+
+      await restarted.stop()
     },
   )
 
@@ -149,6 +161,135 @@ describe("Deferred schema indexes", () => {
         await readyAtByChainId(),
       ),
     ).toEqual(([aBIdIndexName], [(1337, true)]))
+
+    await indexerMock.stop()
+  })
+
+  // Every scheduling path that reaches the FinalizingIndexes phase joins the
+  // in-flight run. Without that, a fetch response landing while the indexes are
+  // being built starts a second pass over the same schema.
+  Async.it("Finalize once however many ticks reach the phase", async t => {
+    let gate = MockIndexer.Gate.make()
+    let finalizeCalls = ref(0)
+    let sourceMock = MockIndexer.Source.make(~chain=#1337, [#getHeightOrThrow, #getItemsOrThrow])
+    let indexerMock = await MockIndexer.Indexer.make(
+      ~chains=[{chain: #1337, sourceConfig: Config.CustomSources([sourceMock.source])}],
+      ~shouldRollbackOnReorg=false,
+      ~mapStorage=storage => {
+        ...storage,
+        finalizeBackfill: (~entities, ~chainIds, ~readyAt) => {
+          finalizeCalls := finalizeCalls.contents + 1
+          gate.wait()->Promise.then(() =>
+            storage.finalizeBackfill(~entities, ~chainIds, ~readyAt)
+          )
+        },
+      },
+    )
+    await Utils.delay(0)
+
+    sourceMock.resolveGetHeightOrThrow(100)
+    await Utils.delay(0)
+    await Utils.delay(0)
+    sourceMock.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=100)
+    while gate.entered.contents === 0 {
+      await Utils.delay(0)
+    }
+
+    t.expect(
+      (finalizeCalls.contents, await indexerMock.metric("envio_progress_ready")),
+      ~message="Finalization is under way and nothing is ready while it is held",
+    ).toEqual((1, [{value: "0", labels: dict{"chainId": "1337"}}]))
+
+    // A height update while the build is held: the chain fetches the new range
+    // and its response schedules processing again.
+    sourceMock.resolveGetHeightOrThrow(200)
+    await MockIndexer.Helper.waitItemsQuery(sourceMock)
+    sourceMock.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=200)
+    let ticks = ref(0)
+    while ticks.contents < 20 {
+      ticks := ticks.contents + 1
+      await Utils.delay(0)
+    }
+
+    t.expect(
+      (finalizeCalls.contents, await indexerMock.metric("envio_progress_ready")),
+      ~message="The new tick joins the in-flight finalization instead of starting another",
+    ).toEqual((1, [{value: "0", labels: dict{"chainId": "1337"}}]))
+
+    gate.release()
+    await indexerMock.waitUntilReady()
+
+    t.expect(
+      (finalizeCalls.contents, await indexerMock.metric("envio_progress_ready")),
+      ~message="Releasing the build is what makes the indexer ready",
+    ).toEqual((1, [{value: "1", labels: dict{"chainId": "1337"}}]))
+
+    await indexerMock.stop()
+  })
+
+  // Readiness is a whole-indexer transition: one chain reaching its head means
+  // nothing while another is still backfilling.
+  Async.it("Wait for every chain before finalizing, and stamp them together", async t => {
+    let finalizeCalls = ref(0)
+    let chainA = MockIndexer.Source.make(~chain=#100, [#getHeightOrThrow, #getItemsOrThrow])
+    let chainB = MockIndexer.Source.make(~chain=#1337, [#getHeightOrThrow, #getItemsOrThrow])
+    let indexerMock = await MockIndexer.Indexer.make(
+      ~chains=[
+        {chain: #100, sourceConfig: Config.CustomSources([chainA.source])},
+        {chain: #1337, sourceConfig: Config.CustomSources([chainB.source])},
+      ],
+      ~shouldRollbackOnReorg=false,
+      ~mapStorage=storage => {
+        ...storage,
+        finalizeBackfill: (~entities, ~chainIds, ~readyAt) => {
+          finalizeCalls := finalizeCalls.contents + 1
+          storage.finalizeBackfill(~entities, ~chainIds, ~readyAt)
+        },
+      },
+    )
+    await Utils.delay(0)
+
+    chainA.resolveGetHeightOrThrow(100)
+    chainB.resolveGetHeightOrThrow(100)
+    await Utils.delay(0)
+    await Utils.delay(0)
+
+    await MockIndexer.Helper.waitItemsQuery(chainA)
+    chainA.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=100)
+    await indexerMock.getBatchWritePromise()
+
+    t.expect(
+      (finalizeCalls.contents, await readyAtByChainId()),
+      ~message="Chain A is at its head, but chain B is still backfilling",
+    ).toEqual((0, [(100, false), (1337, false)]))
+
+    await MockIndexer.Helper.waitItemsQuery(chainB)
+    chainB.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=100)
+    await indexerMock.waitUntilReady()
+
+    let readyAtTimes = await readyAtTimesByChainId()
+    let times = readyAtTimes->Array.map(((_, readyAt)) => readyAt)
+    t.expect(
+      (
+        finalizeCalls.contents,
+        readyAtTimes->Array.map(((id, _)) => id),
+        times->Array.every(Option.isSome),
+        times->Array.get(0) == times->Array.get(1),
+        await indexerMock.metric("envio_progress_ready"),
+      ),
+      ~message="Both chains are stamped with the same timestamp by a single finalization",
+    ).toEqual((
+      1,
+      [100, 1337],
+      true,
+      true,
+      [
+        {value: "1", labels: dict{"chainId": "100"}},
+        {value: "1", labels: dict{"chainId": "1337"}},
+      ],
+    ))
+
+    await indexerMock.stop()
   })
 
   // The false-ready bug: `A_b_id` was the name the indexer picked for
@@ -195,6 +336,8 @@ describe("Deferred schema indexes", () => {
       aIndexes->Array.map(entry => entry.name),
       ~message="The generated name can't be the one an unrelated index took",
     ).toEqual([aBIdIndexName])
+
+    await indexerMock.stop()
   })
 })
 

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -458,6 +458,9 @@ module Indexer = {
       ~scope: Internal.chainScope,
     ) => promise<array<{"id": string, "output": JSON.t}>>,
     metric: string => promise<array<metric>>,
+    // Quiesce the run: its loops keep driving the shared database otherwise, and
+    // a later test resetting the schema would take their writes into it.
+    stop: unit => promise<unit>,
     restart: unit => promise<t>,
     graphql: 'data. string => promise<graphqlResponse<'data>>,
   }
@@ -602,6 +605,17 @@ module Indexer = {
       ~onError,
     )
     state->IndexerLoop.start
+
+    // Persist before stopping, else a resumed indexer loses uncommitted state,
+    // then let any in-flight batch or write settle so nothing from this run
+    // lands on the shared database afterwards.
+    let stop = async () => {
+      await state->Writing.flush
+      state->IndexerState.stop
+      while state->IndexerState.isProcessing || state->IndexerState.writeFiber->Option.isSome {
+        await Utils.delay(1)
+      }
+    }
 
     {
       getBatchWritePromise: () => {
@@ -836,18 +850,11 @@ module Indexer = {
           }
         )
       },
+      stop,
       restart: async () => {
-        // Persist before restarting, else the resumed indexer loses uncommitted state.
-        await state->Writing.flush
-        // Stop the previous run's loops so they don't keep driving the shared db
-        // once the resumed indexer takes over.
-        state->IndexerState.stop
-        // Let any in-flight batch or write from the stopped run settle before the
-        // resumed indexer takes over the shared persistence, else the two runs
-        // race against the same db.
-        while state->IndexerState.isProcessing || state->IndexerState.writeFiber->Option.isSome {
-          await Utils.delay(1)
-        }
+        // The previous run has to be quiet before the resumed one takes over the
+        // shared persistence, else the two race against the same db.
+        await stop()
         await make(
           ~chains,
           ~config=?customConfig,

--- a/scenarios/test_codegen/test/lib_tests/FinalizeBackfill_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FinalizeBackfill_test.res
@@ -1,0 +1,63 @@
+open Vitest
+
+// The phase is reached from more than one place in the processing loop, and a
+// build can take minutes. Anything arriving while one is in flight has to join
+// it: a second pass would replay creates against a schema the first one is
+// still changing.
+describe("Finalizing the backfill", () => {
+  Async.it("Runs once when two paths reach the phase together", async t => {
+    let gate = MockIndexer.Gate.make()
+    let calls = ref(0)
+    let base = MockIndexer.Storage.make([])
+    let storage = {
+      ...base.storage,
+      finalizeBackfill: (~entities as _, ~chainIds as _, ~readyAt as _) => {
+        calls := calls.contents + 1
+        gate.wait()
+      },
+    }
+    let persistence = {
+      ...PgStorage.makePersistenceFromConfig(~config=MockIndexer.config, ~storage),
+      storageStatus: Persistence.Ready({
+        cleanRun: false,
+        cache: Dict.make(),
+        chains: [],
+        reorgCheckpoints: [],
+        checkpointId: 0n,
+        envioInfo: None,
+      }),
+    }
+    let state = IndexerState.make(
+      ~config=MockIndexer.config,
+      ~persistence,
+      ~chainStates=Dict.make(),
+      ~isInReorgThreshold=false,
+      ~isRealtime=false,
+      ~onError=errHandler => errHandler->ErrorHandling.raiseExn,
+    )
+
+    let first = FinalizeBackfill.run(state)
+    let second = FinalizeBackfill.run(state)
+    while gate.entered.contents === 0 {
+      await Utils.delay(0)
+    }
+
+    t.expect(
+      (calls.contents, state->IndexerState.isRealtime),
+      ~message="The second caller joined the in-flight run instead of starting another",
+    ).toEqual((1, false))
+
+    gate.release()
+    await first
+    await second
+
+    t.expect(
+      (
+        calls.contents,
+        state->IndexerState.isRealtime,
+        state->IndexerState.finalizeFiber->Option.isSome,
+      ),
+      ~message="Both callers see the same finalization through, and it stops being in flight",
+    ).toEqual((1, true, false))
+  })
+})

--- a/scenarios/test_codegen/test/lib_tests/PgIndexes_test.res
+++ b/scenarios/test_codegen/test/lib_tests/PgIndexes_test.res
@@ -118,6 +118,14 @@ let aBIdName = aBId->IndexDefinition.name
 
 let readyAt = Date.fromString("2024-01-01T00:00:00Z")
 
+let readyAtByChainId = async pgSchema => {
+  let rows: array<{"id": int, "ready_at": Null.t<Date.t>}> =
+    await sql->Postgres.unsafe(
+      `SELECT "id", "ready_at" FROM "${pgSchema}"."${InternalTable.Chains.table.tableName}" ORDER BY "id";`,
+    )
+  rows->Array.map(row => (row["id"], row["ready_at"]->Null.toOption->Option.isSome))
+}
+
 let catchMessage = promise =>
   promise
   ->Promise.thenResolve(_ => None)
@@ -323,6 +331,88 @@ describe("Indexes built against a real schema", () => {
       ),
       ~message="Later requests are served from the catalog instead of retrying a doomed create",
     ).toEqual(([], [aBIdName]))
+  })
+
+  // A finalize that dies part way through must not undo the indexes it already
+  // built, and must not claim readiness the schema doesn't back yet.
+  Async.it("Keeps the indexes it built when a later one fails, and retries the rest", async t => {
+    let pgSchema = "test_pg_indexes_partial_failure"
+    let tableName = "Triple"
+    let entity: Internal.entityConfig = {
+      ...entityA,
+      name: tableName,
+      table: Table.mkTable(
+        tableName,
+        ~fields=[
+          Table.mkField("id", String, ~isPrimaryKey=true, ~fieldSchema=S.string),
+          Table.mkField("first_id", String, ~isIndex=true, ~fieldSchema=S.string),
+          Table.mkField("second_id", String, ~isIndex=true, ~fieldSchema=S.string),
+          Table.mkField("third_id", String, ~isIndex=true, ~fieldSchema=S.string),
+        ],
+      ),
+    }
+    let indexNames =
+      ["first_id", "second_id", "third_id"]->Array.map(column =>
+        IndexDefinition.single(~tableName, ~column)->IndexDefinition.name
+      )
+    let secondName = indexNames->Array.getUnsafe(1)
+
+    let queries = []
+    let failSecondBuild = ref(true)
+    let flakySql = makeFlakySql(sql, queries, query =>
+      failSecondBuild.contents &&
+        query->String.includes("CREATE INDEX") &&
+        query->String.includes(secondName)
+    )
+    let storage = await setup(
+      ~pgSchema,
+      ~sql=flakySql,
+      ~entities=[entity, InternalTable.EnvioAddresses.entityConfig],
+    )
+    let chainIds = config.chainMap->ChainMap.values->Array.map(chain => chain.id)
+    let createdIndexNames = async () =>
+      (await loadCatalog(pgSchema))
+      ->IndexCatalog.entries
+      ->Array.filterMap((entry: IndexCatalog.entry) =>
+        indexNames->Array.includes(entry.name) ? Some(entry.name) : None
+      )
+      ->Array.toSorted(String.compare)
+    let attemptedBuilds = () =>
+      indexNames->Array.filter(name =>
+        queries->Array.some(query =>
+          query->String.includes("CREATE INDEX") && query->String.includes(name)
+        )
+      )
+
+    let failure = await storage.finalizeBackfill(~entities=[entity], ~chainIds, ~readyAt)->catchMessage
+
+    t.expect(
+      (
+        failure->Option.isSome,
+        await createdIndexNames(),
+        attemptedBuilds(),
+        await readyAtByChainId(pgSchema),
+      ),
+      ~message="The first index survives the failure, the third is never attempted, and nothing is ready",
+    ).toEqual((
+      true,
+      [indexNames->Array.getUnsafe(0)],
+      indexNames->Array.slice(~start=0, ~end=2),
+      chainIds->Array.map(id => (id, false)),
+    ))
+
+    failSecondBuild := false
+    queries->Utils.Array.clearInPlace
+    await storage.finalizeBackfill(~entities=[entity], ~chainIds, ~readyAt)
+
+    t.expect(
+      (await createdIndexNames(), attemptedBuilds(), await readyAtByChainId(pgSchema)),
+      ~message="The retry owes only what's left, and readiness is committed once it's all there",
+    ).toEqual((
+      indexNames->Array.toSorted(String.compare),
+      indexNames->Array.slice(~start=1, ~end=3),
+      chainIds->Array.map(id => (id, true)),
+    ))
   })
 
   Async.it("Skips the schema index an automatic build already created", async t => {


### PR DESCRIPTION
## Summary

Refactors the backfill finalization process to build schema indexes sequentially rather than in a single transaction, and ensures only one finalization runs at a time even when multiple code paths reach the phase concurrently.

## Key Changes

- **Sequential index builds**: Each index is now built and verified independently rather than all within one transaction. This allows partial progress to persist if a build fails mid-way, so retries only need to build the remaining indexes instead of starting over.

- **Deduplicated finalization**: Introduced `finalizeFiber` to `IndexerState` to track the in-flight finalization. When multiple paths reach the `FinalizingIndexes` phase (e.g., a processed batch and a height update tick), they now join the existing run instead of starting a second pass over the same indexes.

- **Improved error recovery**: When an index build fails, the storage layer now re-syncs the catalog to account for any DDL that committed before the failure, ensuring the retry plans against the actual database state rather than replaying creates that would fail with "already exists".

- **Readiness commitment**: The `ready_at` timestamp is now committed in a separate statement after all indexes verify, ensuring it only records readiness when the schema actually has all promised indexes.

## Implementation Details

- `FinalizeBackfill.run` now wraps `runOnce` to check for and join any in-flight finalization fiber
- `PgStorage.finalizeBackfill` builds indexes sequentially with individual verification, committing `ready_at` only after all succeed
- Added `resyncIndex` helper to refresh the catalog when a build partially succeeds
- Updated test helpers to properly stop indexer instances and clean up shared database state between tests
- New test coverage for concurrent finalization paths and partial failure scenarios

https://claude.ai/code/session_01XiAsUYyXuBuhdBVJ3ZoMoP