### PR TITLE
Retire partitions until their last response lands

### DIFF
--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1244,6 +1244,13 @@ let collapseClientFilteredContracts = (
         standingRef := Some(p)
       | {selection: {dependsOnAddresses: false}, mergeBlock: Some(_)} =>
         backfills->Array.push(p)->ignore
+
+        // The backfill this call builds covers its remaining range from the
+        // same min frontier, so it is superseded — but not before the response
+        // it is waiting on lands.
+        if p->isFetching {
+          kept->Array.push(p->retire)->ignore
+        }
       | {selection: {dependsOnAddresses: false}} => p->absorb
       | _ =>
         let contractNames = p.addresses->AddressSet.contractNames

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -196,6 +196,14 @@ let getMinHistoryRange = (p: partition) => {
 // source-capacity history, including when an itemsTarget cap truncates a response.
 let getTrustedDensity = (p: partition) => p.eventDensity
 
+// A response is still owed for this partition, so it owns range nothing else
+// accounts for: removing it would let the frontier advance over blocks the
+// response can still deliver items from, and orphan the response itself.
+// Narrower than a non-empty queue on purpose — a settled query parked behind a
+// gap is data already in hand, and waiting on it would wedge a partition that
+// no longer queries.
+let isFetching = (p: partition) => p.mutPendingQueries->Array.some(pq => pq.fetchedBlock === None)
+
 let getMinQueryRange = (partitions: array<partition>) => {
   let min = ref(0)
   for i in 0 to partitions->Array.length - 1 {
@@ -431,9 +439,10 @@ module OptimizedPartitions = {
       // A partition already at or past its merge block is done — normally
       // handleQueryResponse removes it when the response lands, but a rollback
       // can cap the merge block at the rolled-back frontier, leaving no
-      // response to ever remove it on.
+      // response to ever remove it on. A retired partition still awaiting a
+      // response stays until it lands.
       | {mergeBlock: Some(mergeBlock)} =>
-        if p.latestFetchedBlock.blockNumber < mergeBlock {
+        if p.latestFetchedBlock.blockNumber < mergeBlock || p->isFetching {
           newPartitions->Array.push(p)->ignore
         }
       // Since it's not a dynamic contract partition,
@@ -556,6 +565,12 @@ module OptimizedPartitions = {
           | Some(anchorSafeBlock) =>
             if p.latestFetchedBlock.blockNumber < anchorSafeBlock {
               anchored->Array.push({...p, mergeBlock: Some(anchorSafeBlock)})->ignore
+            } else if p->isFetching {
+              // Caught up, but a response is still owed: keep it until that
+              // lands rather than dropping the range it owns.
+              anchored
+              ->Array.push({...p, mergeBlock: Some(p.latestFetchedBlock.blockNumber)})
+              ->ignore
             }
           }
         | _ => anchored->Array.push(p)->ignore
@@ -634,6 +649,10 @@ module OptimizedPartitions = {
     }
   }
 
+  // Every path that stops a partition from fetching keeps it until its last
+  // response lands, so a response always has a partition to advance. A rollback
+  // does delete partitions mid-run, but it bumps the indexer epoch and
+  // ChainFetching drops older responses before they reach here.
   let rec handleQueryResponse = (
     optimizedPartitions: t,
     ~query,
@@ -641,21 +660,13 @@ module OptimizedPartitions = {
     ~itemsCount,
     ~latestFetchedBlock: blockNumberAndTimestamp,
   ) =>
-    switch optimizedPartitions.entities->Utils.Dict.dangerouslyGetNonOption(query.partitionId) {
-    // The partition was absorbed into the address-free client-filtered partition
-    // while this query was in flight. Its items are still merged into the buffer
-    // by the caller (and deduped); there's no partition bookkeeping left to do,
-    // and its reservation is released by ChainState regardless.
-    | None => optimizedPartitions
-    | Some(p) =>
-      optimizedPartitions->handleQueryResponseForPartition(
-        ~p,
-        ~query,
-        ~knownHeight,
-        ~itemsCount,
-        ~latestFetchedBlock,
-      )
-    }
+    optimizedPartitions->handleQueryResponseForPartition(
+      ~p=optimizedPartitions->getOrThrow(~partitionId=query.partitionId),
+      ~query,
+      ~knownHeight,
+      ~itemsCount,
+      ~latestFetchedBlock,
+    )
 
   and handleQueryResponseForPartition = (
     optimizedPartitions: t,
@@ -728,11 +739,15 @@ module OptimizedPartitions = {
       ~initialLatestFetchedBlock=p.latestFetchedBlock,
     )
 
-    // Check if partition reached its mergeBlock and should be removed
-    let partitionReachedMergeBlock = switch p.mergeBlock {
-    | Some(mergeBlock) => updatedLatestFetchedBlock.blockNumber >= mergeBlock
-    | None => false
-    }
+    // Check if partition reached its mergeBlock and should be removed. A
+    // retired partition can hold several queries at once, so it goes only when
+    // the last of them has landed.
+    let partitionReachedMergeBlock =
+      switch p.mergeBlock {
+      | Some(mergeBlock) => updatedLatestFetchedBlock.blockNumber >= mergeBlock
+      | None => false
+      } &&
+      !(p->isFetching)
 
     if partitionReachedMergeBlock {
       mutEntities->Utils.Dict.deleteInPlace(p.id)
@@ -1159,9 +1174,10 @@ let claimedFetchedBlock = (p: partition, ~knownHeight) =>
 // fetching without tearing down established state:
 // - The standing address-free partition (no mergeBlock) keeps its id, frontier,
 //   in-flight queries and learned density. Only when a newly-switched contract
-//   must be added does its selection change — under a fresh id, so in-flight
-//   responses built from the old selection are orphaned instead of advancing
-//   the frontier past ranges the new contract wasn't fetched for.
+//   must be added does its selection change — under a fresh id, so responses
+//   built from the old selection can't advance the frontier past ranges the new
+//   contract wasn't fetched for. The old generation is retired beside it,
+//   keeping the queue those responses belong to.
 // - Partitions absorbed below the standing partition's claimed block
 //   (single-contract dynamic partitions and config partitions all of whose
 //   contracts are client-filtered, plus any prior backfill) become one bounded
@@ -1206,6 +1222,21 @@ let collapseClientFilteredContracts = (
     let strippedFrontiers = []
     let anchoredContracts = partitions->OptimizedPartitions.anchoredContracts
 
+    // Retire a partition in place of removing it: same id and selection, same
+    // pending queue, capped at its own frontier so it issues nothing more. It
+    // holds the frontier down and owns its in-flight response until that lands,
+    // then handleQueryResponse drops it.
+    let retire = (p: partition) => {
+      ...p,
+      mergeBlock: Some(p.latestFetchedBlock.blockNumber),
+    }
+    let absorb = p => {
+      absorbedPartitions->Array.push(p)->ignore
+      if p->isFetching {
+        kept->Array.push(p->retire)->ignore
+      }
+    }
+
     partitions->Array.forEach(p =>
       switch p {
       | {selection: {dependsOnAddresses: false}, mergeBlock: None}
@@ -1213,7 +1244,7 @@ let collapseClientFilteredContracts = (
         standingRef := Some(p)
       | {selection: {dependsOnAddresses: false}, mergeBlock: Some(_)} =>
         backfills->Array.push(p)->ignore
-      | {selection: {dependsOnAddresses: false}} => absorbedPartitions->Array.push(p)->ignore
+      | {selection: {dependsOnAddresses: false}} => p->absorb
       | _ =>
         let contractNames = p.addresses->AddressSet.contractNames
         let serverSideNames =
@@ -1232,7 +1263,7 @@ let collapseClientFilteredContracts = (
           // hand that job back to a guessed ceiling.
           kept->Array.push(p)->ignore
         } else if serverSideNames->Utils.Array.isEmpty {
-          absorbedPartitions->Array.push(p)->ignore
+          p->absorb
         } else {
           strippedFrontiers->Array.push(p.latestFetchedBlock)->ignore
           kept
@@ -1325,6 +1356,15 @@ let collapseClientFilteredContracts = (
         let standingOut = if selectionChanged {
           let id = nextPartitionIndexRef.contents->Int.toString
           nextPartitionIndexRef := nextPartitionIndexRef.contents + 1
+
+          // A response built from the old selection must not advance the new
+          // one's frontier over ranges the newly-switched contract wasn't
+          // fetched for, so the continuing partition takes a fresh id and an
+          // empty queue. The old generation is retired beside it rather than
+          // dropped: it keeps the queue those responses belong to.
+          if standing->isFetching {
+            kept->Array.push(standing->retire)->ignore
+          }
           {...standing, id, selection: newSelection, mutPendingQueries: []}
         } else {
           standing
@@ -1833,7 +1873,7 @@ let registerDynamicContracts = (
 
 /*
 Updates fetchState with a response for a given query.
-Returns Error if the partition with given query cannot be found (unexpected)
+Throws if the partition with given query cannot be found (unexpected)
 
 newItems are ordered earliest to latest (as they are returned from the worker)
 */

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -5150,7 +5150,7 @@ describe("FetchState client-side address filtering", () => {
     ).toEqual([(false, Some(["Gravatar"]))])
   })
 
-  it("tolerates a response for a partition absorbed while its query was in flight", t => {
+  it("rejects a response for a partition that no longer exists", t => {
     let (fetchState, addressStore) = makeGravatarFs(~clientFilterAddressThreshold=Some(1))
     let collapsed =
       fetchState->FetchState.registerDynamicContracts(~addressStore, [
@@ -5158,22 +5158,27 @@ describe("FetchState client-side address filtering", () => {
         makeDynContractRegistration(~blockNumber=4, ~contractAddress=mockAddress2)->dcToItem,
       ])
 
-    // A response tagged with a partition id that no longer exists (absorbed).
+    // Every path that stops a partition fetching now retires it until its last
+    // response lands, so an unknown partition id means the response outlived a
+    // rollback — which bumps the indexer epoch, so ChainFetching drops it long
+    // before here. Reaching this point at all is a broken invariant, and
+    // buffering the items would admit them below the frontier.
     let orphanQuery: FetchState.query = {
       ...defaultQuery,
       partitionId: "999",
       fromBlock: 0,
     }
-    let afterOrphan =
-      collapsed->FetchState.handleQueryResult(
-        ~query=orphanQuery,
-        ~latestFetchedBlock=getBlockData(~blockNumber=5),
-        ~newItems=[mockEvent(~blockNumber=1), mockEvent(~blockNumber=2)],
-      )
     t.expect(
-      (afterOrphan->FetchState.bufferSize, afterOrphan->partitionShape),
-      ~message="orphan response merges its items and leaves partitions untouched",
-    ).toEqual((2, [(false, Some(["Gravatar"]), [])]))
+      () =>
+        collapsed
+        ->FetchState.handleQueryResult(
+          ~query=orphanQuery,
+          ~latestFetchedBlock=getBlockData(~blockNumber=5),
+          ~newItems=[mockEvent(~blockNumber=1), mockEvent(~blockNumber=2)],
+        )
+        ->ignore,
+      ~message="a response with no partition to advance is rejected, not buffered",
+    ).toThrow()
   })
 
   it("holds the frontier below a query orphaned by a client-filter switch", t => {
@@ -5222,36 +5227,50 @@ describe("FetchState client-side address filtering", () => {
         )->dcToItem,
       ])
 
-    // The new generation fetches the same range and reports it fully fetched.
-    let newQuery = afterSwitch->takeQuery
-    afterSwitch->FetchState.startFetchingQueries(~queries=[newQuery])
-    let afterNewGeneration =
+    // The old generation is retired beside the new one rather than dropped, so
+    // it still holds the frontier and its query's budget reservation. Nothing
+    // fetches over that range again until the response lands.
+    let frontierAfterSwitch = afterSwitch->FetchState.bufferBlockNumber
+    let queryableAfterSwitch =
+      afterSwitch->FetchState.getNextQuery(~chainTargetBlock=1000, ~chainTargetItems=10_000.) !==
+        NothingToQuery
+
+    // The response lands against the partition that dispatched it.
+    let afterSettled =
       afterSwitch->FetchState.handleQueryResult(
-        ~query=newQuery,
+        ~query=inFlight,
         ~latestFetchedBlock=getBlockData(~blockNumber=500),
-        ~newItems=[],
+        ~newItems=[mockEvent(~blockNumber=200)],
       )
 
-    // The orphaned query only now returns, carrying an event from a block the
-    // frontier above already declared fully fetched.
-    let afterOrphan =
-      afterNewGeneration->FetchState.handleQueryResult(
-        ~query=inFlight,
+    // Retired and drained, so it's gone — but the frontier stays put: the new
+    // generation has not covered that range under the wider selection yet, so
+    // the item it delivered is buffered and not yet processable.
+    let frontierAfterSettled = afterSettled->FetchState.bufferBlockNumber
+    let readyAfterSettled = afterSettled->FetchState.bufferReadyCount
+
+    // Only now does the new generation fetch, re-delivering the same event.
+    let newQuery = afterSettled->takeQuery
+    afterSettled->FetchState.startFetchingQueries(~queries=[newQuery])
+    let afterNewGeneration =
+      afterSettled->FetchState.handleQueryResult(
+        ~query=newQuery,
         ~latestFetchedBlock=getBlockData(~blockNumber=500),
         ~newItems=[mockEvent(~blockNumber=200)],
       )
 
     t.expect(
       (
-        afterNewGeneration->FetchState.bufferBlockNumber,
-        afterOrphan.buffer->Array.map(Internal.getItemBlockNumber),
-        afterOrphan.buffer->Array.every(item =>
-          item->Internal.getItemBlockNumber >
-            afterNewGeneration->FetchState.bufferBlockNumber
+        (frontierAfterSwitch, queryableAfterSwitch),
+        (frontierAfterSettled, readyAfterSettled),
+        (
+          afterNewGeneration->FetchState.bufferBlockNumber,
+          afterNewGeneration.buffer->Array.map(Internal.getItemBlockNumber),
+          afterNewGeneration->FetchState.bufferReadyCount,
         ),
       ),
-      ~message="the orphaned query still owns pending work, so nothing above its frontier is processable until it settles",
-    ).toEqual((0, [200], true))
+      ~message="the retired generation holds the frontier until its response lands; no item is ever admitted below an already-processable frontier",
+    ).toEqual(((-1, false), (-1, 0), (500, [200], 1)))
   })
 
   // The standing address-free partition: client-filtered contracts' events are
@@ -5263,6 +5282,120 @@ describe("FetchState client-side address filtering", () => {
       ->Array.find(p => !p.selection.dependsOnAddresses && p.mergeBlock->Option.isNone)
       ->Option.getOrThrow
     ).id
+
+  it("keeps a retired generation until the last of its queries lands", t => {
+    let (fetchState, addressStore) = makeFs(
+      ~onEventRegistrations=[baseEventConfig, baseEventConfig2],
+      ~addresses=[makeConfigContract("Gravatar", mockAddress0)],
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=10,
+      ~chainId,
+      ~maxOnBlockBufferSize=targetBufferSize,
+      ~knownHeight=1000,
+      ~clientFilterAddressThreshold=Some(1),
+    )
+    let collapsed =
+      fetchState->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(~blockNumber=3, ~contractAddress=mockAddress1)->dcToItem,
+        makeDynContractRegistration(~blockNumber=4, ~contractAddress=mockAddress2)->dcToItem,
+      ])
+
+    // Two chunks in flight at once, so the first response drains only part of
+    // the queue: the merge block is reached but a response is still owed.
+    let standing = collapsed->standingId
+    let chunk = (fromBlock, toBlock): FetchState.query => {
+      ...defaultQuery,
+      partitionId: standing,
+      fromBlock,
+      toBlock: Some(toBlock),
+      isChunk: true,
+    }
+    let q1 = chunk(0, 100)
+    let q2 = chunk(101, 200)
+    collapsed->FetchState.startFetchingQueries(~queries=[q1, q2])
+
+    let afterSwitch =
+      collapsed->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(
+          ~blockNumber=5,
+          ~contractAddress=mockAddress3,
+          ~contractName="NftFactory",
+        )->dcToItem,
+        makeDynContractRegistration(
+          ~blockNumber=6,
+          ~contractAddress=mockAddress4,
+          ~contractName="NftFactory",
+        )->dcToItem,
+      ])
+    let holdsId = (fs: FetchState.t) => fs.optimizedPartitions.idsInAscOrder->Array.includes(standing)
+
+    let afterFirst =
+      afterSwitch->FetchState.handleQueryResult(
+        ~query=q1,
+        ~latestFetchedBlock=getBlockData(~blockNumber=100),
+        ~newItems=[],
+      )
+    let afterSecond =
+      afterFirst->FetchState.handleQueryResult(
+        ~query=q2,
+        ~latestFetchedBlock=getBlockData(~blockNumber=200),
+        ~newItems=[],
+      )
+
+    t.expect(
+      (afterSwitch->holdsId, afterFirst->holdsId, afterSecond->holdsId),
+      ~message="retired at a merge block it has already passed, it goes only once the second response lands",
+    ).toEqual((true, true, false))
+  })
+
+  it("retires every fetching partition the collapse would otherwise absorb", t => {
+    // Threshold 2: config address + one dynamic stays server-side, so real
+    // address-bound partitions exist and can be mid-query when the second
+    // registration pushes the count over and collapses them.
+    let (fetchState, addressStore) = makeFs(
+      ~onEventRegistrations=[baseEventConfig],
+      ~addresses=[makeConfigContract("Gravatar", mockAddress0)],
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=1,
+      ~chainId,
+      ~maxOnBlockBufferSize=targetBufferSize,
+      ~knownHeight=1000,
+      ~clientFilterAddressThreshold=Some(2),
+    )
+    let serverSide =
+      fetchState->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(~blockNumber=3, ~contractAddress=mockAddress1)->dcToItem,
+      ])
+
+    let fetchingIds = serverSide.optimizedPartitions.idsInAscOrder
+    serverSide->FetchState.startFetchingQueries(
+      ~queries=fetchingIds->Array.map((id): FetchState.query => {
+        ...defaultQuery,
+        partitionId: id,
+        fromBlock: 0,
+        toBlock: Some(100),
+        isChunk: true,
+      }),
+    )
+
+    let collapsed =
+      serverSide->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(~blockNumber=4, ~contractAddress=mockAddress2)->dcToItem,
+      ])
+
+    t.expect(
+      (
+        fetchingIds->Utils.Array.isEmpty,
+        fetchingIds->Array.filter(id =>
+          !(collapsed.optimizedPartitions.idsInAscOrder->Array.includes(id))
+        ),
+        collapsed.optimizedPartitions.clientFilteredContracts->Utils.Set.toArray,
+      ),
+      ~message="absorbed partitions with a response owed survive the collapse, so their items keep an owner",
+    ).toEqual((false, [], ["Gravatar"]))
+  })
 
   it("keeps the collapsed address-free partition across an unrelated registration batch", t => {
     let (fetchState, addressStore) = makeFs(
@@ -5520,6 +5653,51 @@ describe("FetchState client-side address filtering", () => {
       ),
       ~message="both queries open-ended; the settled response bounds the catch-up, which then over-fetches past it and disappears, its overlap deduped",
     ).toEqual(((None, None), [(19, Some(120), ["Gravatar"]), (120, None, [])], [(120, None, [])], 1))
+  })
+
+  it("retires an anchored catch-up that overshot its anchor while still fetching", t => {
+    let (afterReg, standingQuery, catchUpQuery) = makeTwoOpenEndedQueriesInFlight()
+    // The catch-up runs ahead of the standing partition, then dispatches again.
+    let afterCatchUp =
+      afterReg->FetchState.handleQueryResult(
+        ~query=catchUpQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=80),
+        ~newItems=[],
+      )
+    // Budget above the standing query's outstanding reservation, so the
+    // catch-up's second query isn't held back by it.
+    let secondCatchUpQuery = switch afterCatchUp->FetchState.getNextQuery(
+      ~chainTargetBlock=100,
+      ~chainTargetItems=100_000.,
+    ) {
+    | Ready([query]) => query
+    | _ => JsError.throwWithMessage("Expected a single catch-up query")
+    }
+    afterCatchUp->FetchState.startFetchingQueries(~queries=[secondCatchUpQuery])
+
+    // The standing query settles below the catch-up's frontier, so the block
+    // the catch-up was to stop at is one it has already passed — but its second
+    // query is still out, and dropping it would strand that response.
+    let afterStanding =
+      afterCatchUp->FetchState.handleQueryResult(
+        ~query=standingQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=70),
+        ~newItems=[],
+      )
+    let afterSecond =
+      afterStanding->FetchState.handleQueryResult(
+        ~query=secondCatchUpQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=90),
+        ~newItems=[mockEvent(~blockNumber=85)],
+      )
+    t.expect(
+      (afterStanding->frontierShape, afterSecond->frontierShape, afterSecond->FetchState.bufferSize),
+      ~message="the overshooting catch-up is retired rather than dropped, so its last response still has a partition to land on",
+    ).toEqual((
+      [(70, None, []), (80, Some(80), ["Gravatar"])],
+      [(70, None, [])],
+      1,
+    ))
   })
 
   it("keeps the catch-up unbounded when its own response lands first", t => {

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -5176,6 +5176,84 @@ describe("FetchState client-side address filtering", () => {
     ).toEqual((2, [(false, Some(["Gravatar"]), [])]))
   })
 
+  it("holds the frontier below a query orphaned by a client-filter switch", t => {
+    let (fetchState, addressStore) = makeFs(
+      ~onEventRegistrations=[baseEventConfig, baseEventConfig2],
+      ~addresses=[makeConfigContract("Gravatar", mockAddress0)],
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=10,
+      ~chainId,
+      ~maxOnBlockBufferSize=targetBufferSize,
+      ~knownHeight=1000,
+      ~clientFilterAddressThreshold=Some(1),
+    )
+
+    // Gravatar crosses the threshold → one standing address-free partition.
+    let collapsed =
+      fetchState->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(~blockNumber=3, ~contractAddress=mockAddress1)->dcToItem,
+        makeDynContractRegistration(~blockNumber=4, ~contractAddress=mockAddress2)->dcToItem,
+      ])
+
+    let takeQuery = fs =>
+      switch fs->FetchState.getNextQuery(~chainTargetBlock=1000, ~chainTargetItems=10_000.) {
+      | Ready([query]) => query
+      | _ => JsError.throwWithMessage("expected a single ready query")
+      }
+
+    // The standing partition dispatches a query over the whole known range.
+    let inFlight = collapsed->takeQuery
+    collapsed->FetchState.startFetchingQueries(~queries=[inFlight])
+
+    // NftFactory crosses the threshold while that query is still running, so the
+    // client-filtered set grows and the standing partition's selection changes.
+    let afterSwitch =
+      collapsed->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(
+          ~blockNumber=5,
+          ~contractAddress=mockAddress3,
+          ~contractName="NftFactory",
+        )->dcToItem,
+        makeDynContractRegistration(
+          ~blockNumber=6,
+          ~contractAddress=mockAddress4,
+          ~contractName="NftFactory",
+        )->dcToItem,
+      ])
+
+    // The new generation fetches the same range and reports it fully fetched.
+    let newQuery = afterSwitch->takeQuery
+    afterSwitch->FetchState.startFetchingQueries(~queries=[newQuery])
+    let afterNewGeneration =
+      afterSwitch->FetchState.handleQueryResult(
+        ~query=newQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=500),
+        ~newItems=[],
+      )
+
+    // The orphaned query only now returns, carrying an event from a block the
+    // frontier above already declared fully fetched.
+    let afterOrphan =
+      afterNewGeneration->FetchState.handleQueryResult(
+        ~query=inFlight,
+        ~latestFetchedBlock=getBlockData(~blockNumber=500),
+        ~newItems=[mockEvent(~blockNumber=200)],
+      )
+
+    t.expect(
+      (
+        afterNewGeneration->FetchState.bufferBlockNumber,
+        afterOrphan.buffer->Array.map(Internal.getItemBlockNumber),
+        afterOrphan.buffer->Array.every(item =>
+          item->Internal.getItemBlockNumber >
+            afterNewGeneration->FetchState.bufferBlockNumber
+        ),
+      ),
+      ~message="the orphaned query still owns pending work, so nothing above its frontier is processable until it settles",
+    ).toEqual((0, [200], true))
+  })
+
   // The standing address-free partition: client-filtered contracts' events are
   // fetched by it, while a bounded backfill (mergeBlock set) covers overlap.
   let standingId = (fetchState: FetchState.t) =>

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -5349,6 +5349,110 @@ describe("FetchState client-side address filtering", () => {
     ).toEqual((true, true, false))
   })
 
+  it("retires a fetching backfill when a later batch collapses again", t => {
+    let (fetchState, addressStore) = makeFs(
+      ~onEventRegistrations=[
+        baseEventConfig,
+        baseEventConfig2,
+        (MockIndexer.evmOnEventRegistration(
+          ~id="0",
+          ~contractName="SimpleNft",
+        ) :> Internal.onEventRegistration),
+      ],
+      ~addresses=[makeConfigContract("Gravatar", mockAddress0)],
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=10,
+      ~chainId,
+      ~maxOnBlockBufferSize=targetBufferSize,
+      ~knownHeight=1000,
+      ~clientFilterAddressThreshold=Some(1),
+    )
+    // Gravatar collapses, then its standing partition advances to 50.
+    let collapsed =
+      fetchState->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(~blockNumber=3, ~contractAddress=mockAddress1)->dcToItem,
+        makeDynContractRegistration(~blockNumber=4, ~contractAddress=mockAddress2)->dcToItem,
+      ])
+    let standingQuery: FetchState.query = {
+      ...defaultQuery,
+      partitionId: collapsed->standingId,
+      fromBlock: 0,
+      toBlock: Some(50),
+      isChunk: true,
+    }
+    collapsed->FetchState.startFetchingQueries(~queries=[standingQuery])
+    let advanced =
+      collapsed->FetchState.handleQueryResult(
+        ~query=standingQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=50),
+        ~newItems=[],
+      )
+
+    // NftFactory crosses the threshold too. Its partitions sit far below the
+    // standing frontier, so folding them in leaves a bounded backfill.
+    let withBackfill =
+      advanced->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(
+          ~blockNumber=5,
+          ~contractAddress=mockAddress3,
+          ~contractName="NftFactory",
+        )->dcToItem,
+        makeDynContractRegistration(
+          ~blockNumber=6,
+          ~contractAddress=mockAddress4,
+          ~contractName="NftFactory",
+        )->dcToItem,
+      ])
+    let backfillId =
+      (
+        withBackfill.optimizedPartitions.entities
+        ->Dict.valuesToArray
+        ->Array.find(p => !(p.selection.dependsOnAddresses) && p.mergeBlock->Option.isSome)
+        ->Option.getOrThrow
+      ).id
+    let backfillQuery: FetchState.query = {
+      ...defaultQuery,
+      partitionId: backfillId,
+      fromBlock: 5,
+      toBlock: Some(30),
+      isChunk: true,
+    }
+    withBackfill->FetchState.startFetchingQueries(~queries=[backfillQuery])
+
+    // A third contract crosses the threshold while that backfill is mid-query,
+    // so the collapse runs again. Its response must still find the partition it
+    // was sent for.
+    let recollapsed =
+      withBackfill->FetchState.registerDynamicContracts(~addressStore, [
+        makeDynContractRegistration(
+          ~blockNumber=40,
+          ~contractAddress=mockAddress5,
+          ~contractName="SimpleNft",
+        )->dcToItem,
+        makeDynContractRegistration(
+          ~blockNumber=41,
+          ~contractAddress=mockAddress6,
+          ~contractName="SimpleNft",
+        )->dcToItem,
+      ])
+    let afterBackfill =
+      recollapsed->FetchState.handleQueryResult(
+        ~query=backfillQuery,
+        ~latestFetchedBlock=getBlockData(~blockNumber=30),
+        ~newItems=[mockEvent(~blockNumber=12)],
+      )
+
+    t.expect(
+      (
+        recollapsed.optimizedPartitions.idsInAscOrder->Array.includes(backfillId),
+        afterBackfill.optimizedPartitions.idsInAscOrder->Array.includes(backfillId),
+        afterBackfill->FetchState.bufferSize,
+      ),
+      ~message="a backfill mid-query survives the recollapse and goes once its response lands",
+    ).toEqual((true, false, 1))
+  })
+
   it("retires every fetching partition the collapse would otherwise absorb", t => {
     // Threshold 2: config address + one dynamic stays server-side, so real
     // address-bound partitions exist and can be mid-query when the second


### PR DESCRIPTION
## Summary

Changes FetchState to retire partitions instead of dropping them when they can no longer fetch, ensuring responses always have a partition to advance. This prevents orphaned responses and maintains frontier integrity across partition lifecycle changes.

## Key Changes

- **New `isFetching` predicate**: Identifies partitions with outstanding responses by checking for pending queries without a fetched block.

- **Partition retirement on collapse**: When client-filtered contracts cause a partition collapse:
  - Partitions absorbed into the standing partition are retired (capped at their frontier) rather than dropped if they have in-flight queries
  - The standing partition itself is retired if it has in-flight queries when its selection changes, allowing responses built from the old selection to land safely

- **Retirement on catch-up overshoot**: When an anchored catch-up partition overshoots its anchor block while still fetching, it's retired with a merge block at its current frontier instead of being dropped.

- **Response handling**: `handleQueryResponse` now throws if a partition doesn't exist (treating it as a broken invariant) rather than silently accepting orphaned responses. This relies on the retirement mechanism ensuring every response has a partition.

- **Merge block semantics**: A partition only removes itself when reaching its merge block AND no longer fetching, allowing retired partitions with pending queries to persist until their last response lands.

## Implementation Details

- Retired partitions maintain their id, selection, and pending queue but are capped at their frontier to prevent new queries
- The frontier is held down by retired partitions until their responses land, preventing items from being admitted below an already-processable frontier
- Multiple responses can be in flight for a retired partition (e.g., chunked queries), so it only removes itself when the last response lands
- Rollbacks still delete partitions mid-run, but the indexer epoch bump ensures ChainFetching drops older responses before they reach the response handler

https://claude.ai/code/session_01KdED8f87CArBfetHKyq7gq