### PR TITLE
Document testing strategy and development workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,15 +19,29 @@
 
 - Rust CLI: `packages/cli`, entry at `lib.rs`, commands at `commands.rs`.
 - Config parsing pipeline: `human_config.rs` → `system_config.rs` → internal JSON → `hbs_templating/codegen_templates.rs` → `Config.res`.
-- Shared runtime library: `packages/envio`.
+- Shared runtime library: `packages/envio`. Its tests: `packages/envio-tests`.
+- Scenario projects: `scenarios/` — `test_codegen`, `e2e_test`, `fuel_test`, `svm_test`.
 - To edit runtime code, edit templates under `packages/cli/templates/` or `packages/envio/`, not the codegen output under `<project>/.envio/`.
 - Prefer reading `.res` modules directly; ignore compiled `.js` artifacts.
 
-## Testing
+## Testing and Development
 
-Prefer Public module API for testing.
+Every change starts with a failing reproduction — bug fix, review finding, or new feature. Write it before touching the source, watch it fail, then fix. No change without one.
 
-Verify your change by compiling with `pnpm rescript` and running only the tests relevant to it — pass the test file or a name filter to vitest (e.g. `pnpm vitest run path/to/File_test.res` or `pnpm vitest run -t "name"`). Don't run the full `pnpm vitest run` suite locally; CI runs it on push, so rely on the CI result for full coverage.
+Reproduce from the outside in — real `config.yaml`, real `schema.graphql`, real handler source. Never reach into an internal module to trigger a bug. If it can't be reached from the outside, that's the finding: say so before writing a fix.
+
+Pick the highest rung that reproduces:
+
+1. **User API** — `packages/envio-tests`, via `InternalTestIndexer.fromUserApi(~configYaml, ~schema, ~handlers, ~test)`. User YAML, schema and handler source, type-checked and executed, with `createTestIndexer()` in the test. No codegen, no database. See `TokenIndexer_test.res`. Default — start here.
+   `cd packages/envio-tests && pnpm rescript && pnpm vitest run -t "name"`
+2. **Mock indexer** — `scenarios/test_codegen`, via `test/helpers/MockIndexer.res`. Real indexer loop over the generated config with `Source` and `Storage` mocked, Postgres included. Use when the bug is in the loop itself: fetching, reorgs, batching, writes. The config can still come from `fromUserApi` — see `YamlConfigIndexer_test.res`.
+   `cd scenarios/test_codegen && pnpm exec envio codegen && pnpm rescript && pnpm vitest run test/X_test.res`
+3. **End to end** — `scenarios/e2e_test`. For what the rungs above can't mock: ClickHouse, Hasura, and the CLI itself. CI runs it against real services, so anything beyond the local smoke test lands here.
+   `cd scenarios/e2e_test && pnpm exec envio codegen && pnpm test`
+
+Link the issue above the case when there is one: `// https://github.com/enviodev/hyperindex/issues/N`
+
+Run only the tests relevant to your change — never the full suite locally. CI runs it on push.
 
 ## ReScript
 


### PR DESCRIPTION
Updated CLAUDE.md to establish a clear testing and development workflow that emphasizes reproduction-driven development and provides guidance on choosing the appropriate testing level for different scenarios.

**Key changes:**

- Renamed "Testing" section to "Testing and Development" and restructured guidance around a three-rung testing hierarchy
- Added requirement that every change starts with a failing reproduction case (bug fix, review finding, or new feature)
- Documented the principle of reproducing bugs from the outside in using real config, schema, and handlers rather than reaching into internal modules
- Defined three testing rungs with specific tools and use cases:
  1. **User API** via `packages/envio-tests` — default starting point for most changes
  2. **Mock indexer** via `scenarios/test_codegen` — for bugs in the indexer loop (fetching, reorgs, batching)
  3. **End to end** via `scenarios/e2e_test` — for integration with ClickHouse, Hasura, and CLI
- Added guidance to link GitHub issues in test cases
- Clarified that only relevant tests should run locally; CI handles full suite verification
- Updated navigation section to reference `packages/envio-tests` alongside the runtime library

This establishes a disciplined approach to testing that prevents internal-only bugs and ensures changes are validated at the appropriate level of integration.

https://claude.ai/code/session_01W9mMdSpCqMMxG7U1EtCbQH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified navigation guidance for shared runtime libraries, templates, generated files, and source modules.
  * Replaced testing instructions with a structured development and validation workflow.
  * Added guidance for reproducing issues from realistic configurations and selecting the appropriate test level.
  * Clarified expectations for linking issues and running targeted tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->