### PR TITLE
Fix index manager to prevent Exact requests resolving on LeadingColumns builds

### DIFF
--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -98,8 +98,11 @@ type storage = {
   // `finalizeBackfill`: an index dropped or invalidated while it was down would
   // otherwise never be rebuilt. Best-effort, and safe to run with indexing live.
   ensureSchemaIndexes: (~entities: array<Internal.entityConfig>) => promise<unit>,
-  // Creates every schema-defined index still missing and stamps `ready_at` on
-  // the given chains, atomically. Called once, when backfill completes.
+  // Creates every schema-defined index still missing, then stamps `ready_at` on
+  // the given chains. Called once, when backfill completes. The indexes are
+  // committed one at a time so a failure part way through doesn't undo the ones
+  // already built; `ready_at` is only written once they all verify, and all
+  // chains are stamped together.
   finalizeBackfill: (
     ~entities: array<Internal.entityConfig>,
     ~chainIds: array<ChainId.t>,

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1886,16 +1886,22 @@ SELECT id, chain_id, -1, -1, contract_name FROM unnest($1::text[],$2::${addrChai
     // Reached only once every definition is verified against pg_catalog, so a
     // crash either leaves `ready_at` null and the retry finds the indexes
     // already built, or commits readiness the schema backs.
+    //
+    // One transaction for the whole set: readiness is an indexer-wide fact, and
+    // a crash part way through would otherwise leave some chains stamped and
+    // some not, reporting the indexer as half ready.
     let setReadyAtQuery = InternalTable.Chains.makeSetReadyAtQuery(~pgSchema)
-    for idx in 0 to chainIds->Array.length - 1 {
-      let _ = await sql->Postgres.preparedUnsafe(
-        setReadyAtQuery,
-        [
-          readyAt->(Utils.magic: Date.t => unknown),
-          chainIds->Array.getUnsafe(idx)->(Utils.magic: ChainId.t => unknown),
-        ]->(Utils.magic: array<unknown> => unknown),
-      )
-    }
+    let _ = await sql->Postgres.beginSql(async sql => {
+      for idx in 0 to chainIds->Array.length - 1 {
+        let _ = await sql->Postgres.preparedUnsafe(
+          setReadyAtQuery,
+          [
+            readyAt->(Utils.magic: Date.t => unknown),
+            chainIds->Array.getUnsafe(idx)->(Utils.magic: ChainId.t => unknown),
+          ]->(Utils.magic: array<unknown> => unknown),
+        )
+      }
+    })
 
     Logging.info({
       "storage": storageName,

--- a/packages/envio/src/db/IndexCatalog.res
+++ b/packages/envio/src/db/IndexCatalog.res
@@ -132,6 +132,12 @@ let leadsWith = (entry, definition: IndexDefinition.t) =>
 // amplification.
 type coverage = Exact | LeadingColumns
 
+let coverageKey = coverage =>
+  switch coverage {
+  | Exact => "="
+  | LeadingColumns => "^"
+  }
+
 // Why an index can't serve a request, in the order the checks are worth
 // reporting. `None` means it can.
 let rejectReason = (entry, definition: IndexDefinition.t, ~coverage) =>
@@ -218,10 +224,7 @@ let size = catalog => catalog.byName->Dict.keysToArray->Array.length
 let nothingCovers = ""
 
 let find = (catalog, definition, ~coverage) => {
-  let cacheKey = `${switch coverage {
-    | Exact => "="
-    | LeadingColumns => "^"
-    }}${definition->IndexDefinition.key}`
+  let cacheKey = `${coverage->coverageKey}${definition->IndexDefinition.key}`
   switch catalog.covering->Utils.Dict.dangerouslyGetNonOption(cacheKey) {
   | Some(name) if name === nothingCovers => None
   | Some(name) => catalog.byName->Utils.Dict.dangerouslyGetNonOption(name)

--- a/packages/envio/src/db/IndexManager.res
+++ b/packages/envio/src/db/IndexManager.res
@@ -14,7 +14,8 @@ type prepared = {
 
 type t = {
   mutable catalog: IndexCatalog.t,
-  // Keyed by index identity so concurrent identical requests await one build.
+  // Keyed by index identity and coverage so concurrent identical requests
+  // await one build.
   inflight: dict<promise<unit>>,
   // Tail of the build chain per table, so two different indexes on the same
   // table are built one after the other rather than at once.
@@ -117,7 +118,11 @@ let ensure = (manager, ~definition: IndexDefinition.t, ~coverage, ~build) =>
   if manager->isSatisfied(definition, ~coverage) {
     Promise.resolve()
   } else {
-    let key = definition->IndexDefinition.key
+    // Keyed by coverage as well as identity: an `Exact` request joining an
+    // in-flight `LeadingColumns` one would resolve as soon as that build
+    // decided a leading composite already served it, and the declared index
+    // would never be created.
+    let key = `${coverage->IndexCatalog.coverageKey}${definition->IndexDefinition.key}`
     switch manager.inflight->Utils.Dict.dangerouslyGetNonOption(key) {
     | Some(promise) => promise
     | None =>

--- a/scenarios/test_codegen/test/lib_tests/IndexManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/IndexManager_test.res
@@ -361,6 +361,49 @@ describe("Serialising builds", () => {
     t.expect((beforeBuild, afterBuild, afterDrop)).toEqual((false, true, false))
   })
 
+  // A getWhere build settles for any index leading with its column, a schema
+  // index doesn't. Sharing one in-flight slot between them would let the
+  // declared index resolve on the getWhere's answer and never get built.
+  Async.it("Doesn't let an Exact request resolve on an in-flight LeadingColumns build", async t => {
+    let manager = IndexManager.make()
+    let composite = makeRow(
+      ~tableName="Token",
+      ~indexName="Token_owner_id_minted_at",
+      ~columns=["owner_id", "minted_at"],
+    )
+    let exactRuns = ref(0)
+    let releaseLeading = ref(() => ())
+
+    let leading =
+      manager->IndexManager.ensure(~definition=ownerId, ~coverage=LeadingColumns, ~build=async () => {
+        await Promise.make((resolve, _) => releaseLeading := (() => resolve()))
+        // The composite already serves the query, so nothing under the
+        // generated name is created.
+        manager->IndexManager.record(composite->IndexCatalog.fromRow)
+      })
+    let exact =
+      manager->IndexManager.ensure(~definition=ownerId, ~coverage=Exact, ~build=async () => {
+        exactRuns := exactRuns.contents + 1
+        manager->IndexManager.record(
+          makeRow(
+            ~tableName="Token",
+            ~indexName=ownerId->IndexDefinition.name,
+            ~columns=["owner_id"],
+          )->IndexCatalog.fromRow,
+        )
+      })
+
+    await tick()
+    releaseLeading.contents()
+    await leading
+    await exact
+
+    t.expect((exactRuns.contents, manager->names)).toEqual((
+      1,
+      ["Token_owner_id_minted_at", ownerId->IndexDefinition.name]->Array.toSorted(String.compare),
+    ))
+  })
+
   Async.it("Replaces the whole catalog on reload, so a restart is authoritative", async t => {
     let manager = IndexManager.make()
     await manager->build(~definition=ownerId, ~run=() => Promise.resolve())


### PR DESCRIPTION
## Summary

Fixes a race condition in the index manager where an `Exact` coverage request could incorrectly resolve when an in-flight `LeadingColumns` build decided a composite index already satisfied the query. This prevented the declared exact index from ever being built.

## Key Changes

- **IndexManager**: Updated in-flight request deduplication to key by both index identity and coverage type, preventing different coverage requests from sharing the same build promise
- **IndexCatalog**: Extracted `coverageKey` helper function to consistently map coverage types to string prefixes (`"="` for Exact, `"^"` for LeadingColumns)
- **PgStorage**: Wrapped multiple `setReadyAtQuery` updates in a single transaction to ensure atomicity — a crash mid-way would otherwise leave some chains marked ready while others aren't
- **Persistence**: Updated documentation to clarify that schema index creation and `ready_at` stamping are separate concerns with different atomicity guarantees
- **Tests**: Added regression test verifying that an Exact request doesn't resolve on an in-flight LeadingColumns build

## Implementation Details

The core issue was that `IndexManager.ensure` keyed in-flight builds only by index identity, not coverage. When a `LeadingColumns` build found a composite index that satisfied the query and recorded it, any concurrent `Exact` request for the same columns would see the recorded index and resolve without building the declared exact index.

The fix includes both the manager change and a test case that reproduces the scenario: a `LeadingColumns` build that records a composite index, followed by an `Exact` request that must still build its own index despite the composite being available.

https://claude.ai/code/session_01L6m8PctfexybKDs2BnX83u