### PR TITLE
Refactor address store filtering and improve error handling

### DIFF
--- a/packages/cli/src/address_store.rs
+++ b/packages/cli/src/address_store.rs
@@ -20,9 +20,6 @@ use napi_derive::napi;
 
 use crate::field_columns::Ecosystem;
 
-/// A registration that hasn't been given an id yet — the store is empty of it.
-const NO_ID: u64 = u64::MAX;
-
 /// Binary form of an address, the identity the store keys on.
 ///
 /// EVM and Fuel addresses are hex-decoded (20 and 32 bytes), so a checksummed
@@ -167,6 +164,19 @@ impl StoreInner {
         ids.sort_unstable_by(|&a, &b| self.sort_key(a).cmp(&self.sort_key(b)));
         ids
     }
+
+    /// Live ids from `min_id` up that `keep` accepts, in set order. Every
+    /// selection the store makes runs through here, so "skips tombstones,
+    /// comes out sorted" is one rule rather than four copies of a scan.
+    fn sorted_live_ids(&self, min_id: u64, keep: impl Fn(&Entry) -> bool) -> Vec<u64> {
+        let ids = (min_id..self.entries.len() as u64)
+            .filter(|&id| {
+                let entry = self.entry(id);
+                !entry.dead && keep(entry)
+            })
+            .collect();
+        self.sorted_ids(ids)
+    }
 }
 
 /// Contract this chain has events for, with the earliest block any of its
@@ -303,21 +313,16 @@ impl AddressStore {
             None => Vec::new(),
             Some(contract_idx) => {
                 let min_id = options.min_id.unwrap_or(0).max(0) as u64;
-                let mut ids: Vec<u64> = (min_id..store.entries.len() as u64)
-                    .filter(|&id| {
-                        let entry = store.entry(id);
-                        !entry.dead
-                            && entry.contract_idx == contract_idx
-                            && options
-                                .from_start_block
-                                .is_none_or(|from| entry.effective_start_block >= from)
-                            && options
-                                .to_start_block
-                                .is_none_or(|to| entry.effective_start_block <= to)
-                    })
-                    .collect();
-                ids = store.sorted_ids(ids);
-                apply_window(ids, options.offset, options.limit)
+                let ids = store.sorted_live_ids(min_id, |entry| {
+                    entry.contract_idx == contract_idx
+                        && options
+                            .from_start_block
+                            .is_none_or(|from| entry.effective_start_block >= from)
+                        && options
+                            .to_start_block
+                            .is_none_or(|to| entry.effective_start_block <= to)
+                });
+                apply_window(&ids, options.offset, options.limit)
             }
         };
         drop(store);
@@ -357,13 +362,8 @@ impl AddressStore {
         let Some(contract_idx) = store.contract_idx(&contract_name) else {
             return Vec::new();
         };
-        let ids: Vec<u64> = (0..store.entries.len() as u64)
-            .filter(|&id| {
-                let entry = store.entry(id);
-                !entry.dead && entry.contract_idx == contract_idx
-            })
-            .collect();
-        group_start_blocks(&store, &store.sorted_ids(ids))
+        let ids = store.sorted_live_ids(0, |entry| entry.contract_idx == contract_idx);
+        group_start_blocks(&store, &ids)
     }
 
     #[napi]
@@ -461,30 +461,17 @@ impl AddressStore {
         let store = self.read();
         let mut out: Vec<String> = match store.contract_idx(&contract_name) {
             None => Vec::new(),
-            Some(contract_idx) => {
-                let ids: Vec<u64> = (0..store.entries.len() as u64)
-                    .filter(|&id| {
-                        let entry = store.entry(id);
-                        !entry.dead && entry.contract_idx == contract_idx
-                    })
-                    .collect();
-                store
-                    .sorted_ids(ids)
-                    .into_iter()
-                    .map(|id| address_string(store.ecosystem, &store.entry(id).key))
-                    .collect()
-            }
+            Some(contract_idx) => store
+                .sorted_live_ids(0, |entry| entry.contract_idx == contract_idx)
+                .into_iter()
+                .map(|id| address_string(store.ecosystem, &store.entry(id).key))
+                .collect(),
         };
-        // No-events entries have no id to order by, so they follow, ordered by
-        // their own key to keep the listing reproducible.
-        let mut no_events: Vec<String> = store
-            .no_events
-            .iter()
-            .filter(|(_, entry)| entry.contract_name == contract_name)
-            .map(|(key, _)| address_string(store.ecosystem, key))
-            .collect();
-        no_events.sort();
-        out.append(&mut no_events);
+        out.extend(
+            sorted_no_events_keys(&store, |entry| entry.contract_name == contract_name)
+                .into_iter()
+                .map(|key| address_string(store.ecosystem, key)),
+        );
         out
     }
 
@@ -493,11 +480,8 @@ impl AddressStore {
     #[napi]
     pub fn entries(&self) -> Vec<AddressEntry> {
         let store = self.read();
-        let live: Vec<u64> = (0..store.entries.len() as u64)
-            .filter(|&id| !store.entry(id).dead)
-            .collect();
         let mut out: Vec<AddressEntry> = store
-            .sorted_ids(live)
+            .sorted_live_ids(0, |_| true)
             .into_iter()
             .map(|id| {
                 let entry = store.entry(id);
@@ -509,18 +493,19 @@ impl AddressStore {
                 }
             })
             .collect();
-        let mut no_events: Vec<AddressEntry> = store
-            .no_events
-            .iter()
-            .map(|(key, entry)| AddressEntry {
-                address: address_string(store.ecosystem, key),
-                contract_name: entry.contract_name.clone(),
-                registration_block: entry.registration_block,
-                effective_start_block: entry.effective_start_block,
-            })
-            .collect();
-        no_events.sort_by(|a, b| a.address.cmp(&b.address));
-        out.append(&mut no_events);
+        out.extend(
+            sorted_no_events_keys(&store, |_| true)
+                .into_iter()
+                .map(|key| {
+                    let entry = &store.no_events[key];
+                    AddressEntry {
+                        address: address_string(store.ecosystem, key),
+                        contract_name: entry.contract_name.clone(),
+                        registration_block: entry.registration_block,
+                        effective_start_block: entry.effective_start_block,
+                    }
+                }),
+        );
         out
     }
 }
@@ -629,7 +614,6 @@ impl StoreInner {
             }
             Some(contract_idx) => {
                 let id = self.entries.len() as u64;
-                debug_assert!(id != NO_ID, "address id space exhausted");
                 self.id_by_key.insert(key.clone(), id);
                 self.entries.push(Entry {
                     key,
@@ -650,17 +634,31 @@ impl StoreInner {
     }
 }
 
-fn apply_window(ids: Vec<u64>, offset: Option<i64>, limit: Option<i64>) -> Vec<u64> {
+fn apply_window(ids: &[u64], offset: Option<i64>, limit: Option<i64>) -> Vec<u64> {
     let start = offset.unwrap_or(0).max(0) as usize;
     if start >= ids.len() {
         return Vec::new();
     }
     let end = match limit {
         Some(limit) if limit <= 0 => start,
-        Some(limit) => (start + limit as usize).min(ids.len()),
+        Some(limit) => start.saturating_add(limit as usize).min(ids.len()),
         None => ids.len(),
     };
     ids[start..end].to_vec()
+}
+
+/// No-events keys `keep` accepts, ordered by the same address bytes a live
+/// entry sorts on — they have no id to order by, and the rendered string would
+/// order checksummed EVM addresses differently from the rest of a listing.
+fn sorted_no_events_keys(store: &StoreInner, keep: impl Fn(&NoEventsEntry) -> bool) -> Vec<&Key> {
+    let mut keys: Vec<&Key> = store
+        .no_events
+        .iter()
+        .filter(|(_, entry)| keep(entry))
+        .map(|(key, _)| key)
+        .collect();
+    keys.sort_unstable();
+    keys
 }
 
 /// Ids must already be in set order, so equal start blocks are adjacent.
@@ -725,6 +723,15 @@ impl SetCache {
     }
 }
 
+/// A snapshot: the ids are fixed at construction, so a rollback that tombstones
+/// an entry leaves sets built before it still holding that id. Only
+/// `filter_by_registration_block` prunes those — everything else
+/// (`addresses`, `entries`, `slice`, `merge`, the cache) reports them, on
+/// purpose. A rollback rebuilds the fetch state's partitions from filtered sets
+/// straight after, and a stale set that outlives that still can't fetch a dead
+/// address: `is_indexed_at` answers `false` for it, so every router drops the
+/// items it would bring back. Pruning here instead would shift the offsets
+/// `start_block_groups` hands to `slice` mid-flight.
 #[napi]
 pub struct AddressSet {
     store: Arc<RwLock<StoreInner>>,
@@ -785,7 +792,7 @@ impl AddressSet {
 
     #[napi]
     pub fn slice(&self, offset: i64, limit: Option<i64>) -> AddressSet {
-        let ids = apply_window(self.ids.to_vec(), Some(offset), limit);
+        let ids = apply_window(&self.ids, Some(offset), limit);
         AddressSet::new(self.store.clone(), ids)
     }
 
@@ -793,7 +800,7 @@ impl AddressSet {
     #[napi]
     pub fn filter_by_contracts(&self, contract_names: Vec<String>) -> AddressSet {
         let store = self.store.read().unwrap();
-        let kept: Vec<u32> = contract_names
+        let kept: std::collections::HashSet<u32> = contract_names
             .iter()
             .filter_map(|name| store.contract_idx(name))
             .collect();
@@ -830,7 +837,10 @@ impl AddressSet {
     /// ids collapse, so merging overlapping partitions can't double-count.
     #[napi]
     pub fn merge(&self, other: &AddressSet) -> AddressSet {
-        debug_assert!(
+        // Not a debug assert: ids are store-scoped, so a foreign id silently
+        // indexes into the wrong entry — or out of bounds — and the query
+        // built from the result fetches addresses nobody registered.
+        assert!(
             Arc::ptr_eq(&self.store, &other.store),
             "merging address sets from different stores",
         );
@@ -1004,23 +1014,21 @@ pub(crate) mod test_support {
     /// handle alone, for routing tests that keep only the handle their client
     /// cloned.
     pub(crate) fn full_set(handle: &Arc<RwLock<StoreInner>>) -> AddressSet {
-        let ids = {
-            let store = handle.read().unwrap();
-            let live: Vec<u64> = (0..store.entries.len() as u64)
-                .filter(|&id| !store.entry(id).dead)
-                .collect();
-            store.sorted_ids(live)
-        };
-        AddressSet::new(handle.clone(), ids)
+        let ids = handle.read().unwrap().sorted_live_ids(0, |_| true);
+        let set = AddressSet::new(handle.clone(), ids);
+        let _ = set.cache();
+        set
     }
 
-    /// One set spanning every named contract's addresses.
+    /// One set spanning every named contract's addresses, with its cache
+    /// materialised — routing helpers read the cache while holding the store
+    /// guard, and initialising it there would take the same lock twice.
     pub(crate) fn set_of(store: &AddressStore, contract_names: &[&str]) -> AddressSet {
-        contract_names
-            .iter()
-            .fold(store.make_set(String::new(), None), |acc, name| {
-                acc.merge(&store.make_set(name.to_string(), None))
-            })
+        let set = contract_names.iter().fold(store.empty_set(), |acc, name| {
+            acc.merge(&store.make_set(name.to_string(), None))
+        });
+        let _ = set.cache();
+        set
     }
 }
 
@@ -1320,6 +1328,47 @@ mod tests {
                 vec![A.to_string(), B.to_string()],
             )
         );
+    }
+
+    #[test]
+    fn a_set_built_before_a_rollback_keeps_tombstones_but_cant_fetch_them() {
+        let store = store();
+        store.register_batch(vec![reg(A, "C", 100), reg(B, "C", 500)]);
+        // Cache the set before the rollback too, the way a partition that is
+        // mid-query would have.
+        let before = store.make_set("C".to_string(), None);
+        let _ = before.cache();
+        store.rollback(300);
+        assert_eq!(
+            (
+                // Still listed: only filter_by_registration_block prunes.
+                before.addresses(),
+                before.size(),
+                // But dead to every router, whichever gate it applies.
+                before.contains_at(B.to_string(), "C".to_string(), 600),
+                store.is_indexed_at(B.to_string(), "C".to_string(), 600),
+                before.filter_by_registration_block(300).addresses(),
+            ),
+            (
+                vec![A.to_string(), B.to_string()],
+                2,
+                false,
+                false,
+                vec![A.to_string()],
+            )
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "merging address sets from different stores")]
+    fn merging_sets_from_different_stores_panics() {
+        let left = store();
+        let right = store();
+        left.register_batch(vec![reg(A, "C", 100)]);
+        right.register_batch(vec![reg(B, "C", 100)]);
+        let _ = left
+            .make_set("C".to_string(), None)
+            .merge(&right.make_set("C".to_string(), None));
     }
 
     #[test]

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -158,6 +158,10 @@ let narrowSelectionToRange = (selection: selection, ~toBlock) =>
       }
     )
     switch inRange->Array.length {
+    // Every registration starts above the range. Narrowing to nothing would
+    // build a selection with no log filters, which each source reads as
+    // "select everything" — the opposite of the intent. The partition is
+    // queried unnarrowed instead and the routers drop what hasn't started.
     | 0 => selection
     | length if length === selection.onEventRegistrations->Array.length => selection
     | _ =>
@@ -1413,6 +1417,65 @@ let collapseClientFilteredContracts = (
   }
 }
 
+let warnAddressRegistration = (
+  ~chainId: ChainId.t,
+  ~contractAddress: Address.t,
+  ~params,
+  message,
+) =>
+  Logging.createChild(
+    ~params={
+      "chainId": chainId,
+      "contractAddress": contractAddress->Address.toString,
+      "details": params,
+    },
+  )->Logging.childWarn(message)
+
+// A rejected registration is simply absent from every partition, so without a
+// warning the user sees a contract that never indexes and nothing saying why.
+// Shared by config-time registration in `make` and by dynamic registration.
+let warnRejectedRegistration = (
+  verdict: AddressStore.verdict,
+  ~chainId: ChainId.t,
+  ~contractAddress: Address.t,
+  ~contractName: string,
+) =>
+  switch verdict {
+  | Conflict({existingContractName}) =>
+    warnAddressRegistration(
+      ~chainId,
+      ~contractAddress,
+      ~params={
+        "existingContractType": existingContractName,
+        "newContractType": contractName,
+      },
+      `Skipping contract registration: Contract address is already registered for one contract and cannot be registered for another contract.`,
+    )
+  | Duplicate({effectiveStartBlock, existingEffectiveStartBlock}) =>
+    // FIXME: Instead of filtering out duplicates, we should check the block
+    // number first. If a new registration has an earlier block number we
+    // should register it for the missing block range.
+    if existingEffectiveStartBlock > effectiveStartBlock {
+      warnAddressRegistration(
+        ~chainId,
+        ~contractAddress,
+        ~params={
+          "existingBlockNumber": existingEffectiveStartBlock,
+          "newBlockNumber": effectiveStartBlock,
+        },
+        `Skipping contract registration: Contract address is already registered at a later block number. Currently registration of the same contract address is not supported by Envio. Reach out to us if it's a problem for you.`,
+      )
+    }
+  | Invalid =>
+    warnAddressRegistration(
+      ~chainId,
+      ~contractAddress,
+      ~params={"contractName": contractName},
+      `Skipping contract registration: Not a valid address for this chain's ecosystem.`,
+    )
+  | Added(_) | NoEvents(_) => ()
+  }
+
 /**
 Creates partitions from indexing addresses with two phases:
 Phase 1: Create per-contract-name partitions (smart grouping by startBlock)
@@ -1659,21 +1722,12 @@ let registerDynamicContracts = (
   // single batch conflict the same way as across batches.
   let verdicts = addressStore->AddressStore.registerBatch(registrations)
 
-  let warn = (~contractAddress, ~params, message) =>
-    Logging.createChild(
-      ~params={
-        "chainId": fetchState.chainId,
-        "contractAddress": contractAddress,
-        "details": params,
-      },
-    )->Logging.childWarn(message)
-
   let registeringContractNames = []
   let hasNoEventsUpdatesRef = ref(false)
   for idx in 0 to verdicts->Array.length - 1 {
     let registration = registrations->Array.getUnsafe(idx)
-    let contractAddress = registration.address->Address.toString
-    let keep = switch verdicts->Array.getUnsafe(idx) {
+    let verdict = verdicts->Array.getUnsafe(idx)
+    let keep = switch verdict {
     | Added(_) =>
       if !(registeringContractNames->Array.includes(registration.contractName)) {
         registeringContractNames->Array.push(registration.contractName)->ignore
@@ -1684,42 +1738,18 @@ let registerDynamicContracts = (
       // Persist the address to the db so a future config change that adds
       // events for this contract can pick it up on restart, but skip partition
       // registration since there's nothing to fetch.
-      warn(
-        ~contractAddress,
+      warnAddressRegistration(
+        ~chainId=fetchState.chainId,
+        ~contractAddress=registration.address,
         ~params={"contractName": registration.contractName},
         `Persisting contract registration without fetching: Contract doesn't have any events to fetch. It'll be picked up on restart if you add events for the contract.`,
       )
       true
-    | Conflict({existingContractName}) =>
-      warn(
-        ~contractAddress,
-        ~params={
-          "existingContractType": existingContractName,
-          "newContractType": registration.contractName,
-        },
-        `Skipping contract registration: Contract address is already registered for one contract and cannot be registered for another contract.`,
-      )
-      false
-    | Duplicate({effectiveStartBlock, existingEffectiveStartBlock}) =>
-      // FIXME: Instead of filtering out duplicates, we should check the block
-      // number first. If a new registration has an earlier block number we
-      // should register it for the missing block range.
-      if existingEffectiveStartBlock > effectiveStartBlock {
-        warn(
-          ~contractAddress,
-          ~params={
-            "existingBlockNumber": existingEffectiveStartBlock,
-            "newBlockNumber": effectiveStartBlock,
-          },
-          `Skipping contract registration: Contract address is already registered at a later block number. Currently registration of the same contract address is not supported by Envio. Reach out to us if it's a problem for you.`,
-        )
-      }
-      false
-    | Invalid =>
-      warn(
-        ~contractAddress,
-        ~params={"contractName": registration.contractName},
-        `Skipping contract registration: Not a valid address for this chain's ecosystem.`,
+    | Conflict(_) | Duplicate(_) | Invalid =>
+      verdict->warnRejectedRegistration(
+        ~chainId=fetchState.chainId,
+        ~contractAddress=registration.address,
+        ~contractName=registration.contractName,
       )
       false
     }
@@ -2686,7 +2716,17 @@ let make = (
       registrationBlock: contract.registrationBlock,
     }),
   )
-  ->ignore
+  // Verdicts are in the batch's order, so they line up with `addresses`. A
+  // config address the store rejects is dropped exactly like a dynamic one, and
+  // needs the same warning — restored dynamic addresses come through here too.
+  ->Array.forEachWithIndex((verdict, idx) => {
+    let contract = addresses->Array.getUnsafe(idx)
+    verdict->warnRejectedRegistration(
+      ~chainId,
+      ~contractAddress=contract.address,
+      ~contractName=contract.contractName,
+    )
+  })
 
   let dynamicContracts = Utils.Set.make()
   let clientFilteredContracts = Utils.Set.make()

--- a/scenarios/test_codegen/test/lib_tests/AddressStore_test.res
+++ b/scenarios/test_codegen/test/lib_tests/AddressStore_test.res
@@ -195,6 +195,50 @@ describe("AddressStore", () => {
     ).toEqual([AddressStore.Conflict({existingContractName: "A"})])
   })
 
+  it("drops config addresses the store rejects, without failing startup", t => {
+    // Config addresses go through the same verdicts as dynamic ones, so a
+    // config listing one address under two contracts (or a malformed one) has
+    // to leave the chain indexing what it can rather than throwing.
+    let addresses = [
+      contract(~address=addr(0), ~contractName="A", ~registrationBlock=-1),
+      // Already held by A.
+      contract(~address=addr(0), ~contractName="B", ~registrationBlock=-1),
+      contract(~address="not-an-address"->Utils.magic, ~contractName="B", ~registrationBlock=-1),
+      contract(~address=addr(1), ~contractName="B", ~registrationBlock=-1),
+    ]
+    let store = AddressStore.make(
+      ~ecosystem=Evm,
+      ~shouldChecksum=true,
+      ~contracts=AddressStore.contractsOf(~onEventRegistrations),
+    )
+    let fetchState = FetchState.make(
+      ~onEventRegistrations,
+      ~addressStore=store,
+      ~addresses,
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=10,
+      ~maxOnBlockBufferSize=10,
+      ~chainId=1->ChainId.fromInt,
+      ~knownHeight=100,
+    )
+    t.expect({
+      "addressesOfA": store->AddressStore.contractAddresses("A"),
+      // Only the address B actually won; the conflicting and the malformed
+      // ones are gone.
+      "addressesOfB": store->AddressStore.contractAddresses("B"),
+      "size": store->AddressStore.size,
+      // Both survivors are config addresses starting at block 0, so they share
+      // one partition — the point is that startup got that far at all.
+      "partitions": fetchState.optimizedPartitions->FetchState.OptimizedPartitions.count,
+    }).toEqual({
+      "addressesOfA": [addr(0)],
+      "addressesOfB": [addr(1)],
+      "size": 2,
+      "partitions": 1,
+    })
+  })
+
   it("builds the same sets whatever order the addresses arrive in", t => {
     // A restored indexer registers everything in one batch and in a different
     // order than a live run did; the partitions it rebuilds must be identical.


### PR DESCRIPTION
## Summary

Consolidates repeated filtering patterns in the address store into reusable helpers, improves error handling for rejected registrations, and strengthens assertions around store invariants.

## Key Changes

**Rust CLI (`packages/cli/src/address_store.rs`)**
- Extract `sorted_live_ids()` helper to centralize the pattern of filtering live entries and sorting them — eliminates four separate filter-collect-sort sequences
- Extract `sorted_no_events_keys()` helper to consistently order no-events entries by their key bytes (matching how live entries sort) rather than by rendered string
- Change `apply_window()` to take `&[u64]` instead of `Vec<u64>` to avoid unnecessary allocations
- Replace `debug_assert!` with `assert!` when merging sets from different stores — ids are store-scoped, so a foreign id silently indexes into the wrong entry or out of bounds
- Remove unused `NO_ID` constant
- Add comprehensive comment explaining why sets built before a rollback retain tombstones but can't fetch them
- Add test case verifying a set built before rollback keeps tombstones but routers drop them

**ReScript (`packages/envio/src/FetchState.res`)**
- Extract `warnRejectedRegistration()` helper to handle all rejection verdicts (Conflict, Duplicate, Invalid) with appropriate warnings
- Apply the helper consistently to both dynamic registrations and config-time registrations
- Add comments explaining why narrowing a selection to nothing falls back to unnarrowed (routers drop what hasn't started)
- Add comments explaining why config addresses go through the same verdict path as dynamic ones

**Tests (`scenarios/test_codegen/test/lib_tests/AddressStore_test.res`)**
- Add test verifying config addresses that the store rejects are dropped without failing startup
- Covers conflict, malformed address, and successful registration in one batch

## Notable Details

- The refactoring preserves exact behavior: `sorted_live_ids()` and `sorted_no_events_keys()` implement the same logic that was previously inlined
- No-events entries now sort by key bytes consistently across all code paths, fixing a subtle inconsistency where they were sometimes sorted by rendered string
- The assertion change for set merging is intentional — a foreign id is a logic error that must fail loudly, not silently corrupt data
- Config address rejection warnings were previously missing; they now match dynamic registration warnings

https://claude.ai/code/session_01UDygR9KJe8UXSnS3ejuEGX