### PR TITLE
Enable viem transport batching in external-calls skill

### DIFF
--- a/packages/cli/templates/static/shared/.claude/skills/indexer-external-calls/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-external-calls/SKILL.md
@@ -61,7 +61,6 @@ Always pass `{ batch: true }` to the transport. The preload pass fires effects f
 
 ```ts
 const client = createPublicClient({
-  chain: mainnet,
   transport: http(process.env.ENVIO_RPC_URL, { batch: true }),
 });
 

--- a/packages/cli/templates/static/shared/.claude/skills/indexer-external-calls/SKILL.md
+++ b/packages/cli/templates/static/shared/.claude/skills/indexer-external-calls/SKILL.md
@@ -57,8 +57,13 @@ Full ref: https://raw.githubusercontent.com/DZakh/sury/refs/tags/v9.3.0/docs/js-
 
 ## RPC pattern (viem)
 
+Always pass `{ batch: true }` to the transport. The preload pass fires effects for the whole batch concurrently, and batching collapses them into a few JSON-RPC requests instead of one request per read.
+
 ```ts
-const client = createPublicClient({ transport: http(process.env.ENVIO_RPC_URL) });
+const client = createPublicClient({
+  chain: mainnet,
+  transport: http(process.env.ENVIO_RPC_URL, { batch: true }),
+});
 
 const getTokenMetadata = createEffect(
   {


### PR DESCRIPTION
## What

The viem RPC pattern in the `indexer-external-calls` skill created a public client with no `batch` transport option:

```ts
const client = createPublicClient({ transport: http(process.env.ENVIO_RPC_URL) });
```

Indexers generated off that snippet make one HTTP request per contract read. Since the preload pass fires a whole batch's effects concurrently, that multiplies into a lot of round trips where a handful of JSON-RPC batches would do.

Now:

```ts
const client = createPublicClient({
  transport: http(process.env.ENVIO_RPC_URL, { batch: true }),
});
```

Plus a one-line note above the block explaining *why* — the preload pass is the reason it matters.

## Notes

- `packages/cli/templates/static/external_calls_template/typescript/src/handlers/UniswapV3Factory.ts` already passed `{ batch: true }`; only the skill was out of step. The two are now consistent.
- Matches the [Viem transport batching](https://docs.envio.dev/docs/HyperIndex/effect-api#viem-transport-batching) docs, which recommend `batch: true` and nothing further (no custom batch size/wait, no `multicall`).
- Docs-only template change, so there is no test to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RPC integration guidance to highlight batching support.
  * Added an explanation of how batching can reduce concurrent JSON-RPC requests.
  * Improved the example configuration for clearer implementation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->