### PR TITLE
Track which contracts have address-dependent events

### DIFF
--- a/packages/cli/src/address_store.rs
+++ b/packages/cli/src/address_store.rs
@@ -101,13 +101,14 @@ pub struct StoreInner {
     ecosystem: Ecosystem,
     contract_names: Vec<String>,
     contract_start_blocks: Vec<i64>,
+    contract_has_events: Vec<bool>,
     contract_idx_by_name: HashMap<String, u32>,
     entries: Vec<Entry>,
     id_by_key: HashMap<Key, u64>,
     live_count_by_contract: Vec<u32>,
     /// Ids of dynamic registrations not yet persisted to `envio_addresses`,
-    /// in registration order. Drained by `take_unwritten_entries` when the
-    /// batch covering their registration block is written.
+    /// in registration order. Drained by `drain_for_write` when the batch
+    /// covering their registration block is written.
     unwritten: Vec<u64>,
 }
 
@@ -182,6 +183,11 @@ pub struct AddressStoreContract {
     /// chain; absent means block 0, since partitions never query below the
     /// chain's own start block anyway.
     pub start_block: Option<i64>,
+    /// Whether this chain has address-dependent events for the contract. False
+    /// for a config contract this chain never fetches for: its addresses are
+    /// still registered and persisted, so a config that later adds events picks
+    /// them up, but no partition is ever built from them.
+    pub has_events: bool,
 }
 
 /// One address a batch asks the store to register.
@@ -199,6 +205,10 @@ pub struct AddressRegistration {
 pub struct RegistrationVerdict {
     /// `added` | `duplicate` | `conflict` | `invalid`
     pub kind: String,
+    /// Whether an `added` address is one this chain fetches for — the store
+    /// answers it because the store is what holds the contract list. False for
+    /// every rejected verdict.
+    pub fetchable: bool,
     /// Derived for the incoming registration; 0 when the address was rejected.
     pub effective_start_block: i64,
     /// The contract already holding this address — set for `duplicate` (same
@@ -230,6 +240,18 @@ pub struct AddressEntry {
     pub contract_name: String,
     pub registration_block: i64,
     pub effective_start_block: i64,
+}
+
+/// A drained registration paired with the checkpoint that must own its row.
+#[napi(object)]
+pub struct DrainedAddress {
+    pub address: String,
+    pub contract_name: String,
+    pub registration_block: i64,
+    /// Index into the `checkpoint_block_numbers` passed to `drain_for_write`.
+    /// The ids themselves are bigints the caller already holds, so only the
+    /// pairing crosses the boundary.
+    pub checkpoint_idx: u32,
 }
 
 /// Which of a contract's addresses `makeSet` should take.
@@ -280,52 +302,100 @@ impl AddressStore {
         self.read().entries.len() as i64
     }
 
-    /// Registers a batch, resolving each address against both the store and the
-    /// batch's own earlier entries, so two contracts claiming one address inside
-    /// a single batch conflict just as they would across batches.
-    ///
-    /// `track_unwritten` marks what this batch adds as pending persistence.
-    /// Registrations restored from the database (config addresses and resumed
-    /// dynamic ones) are already stored, so they pass `false`.
+    /// Registers a batch of dynamic registrations, resolving each address
+    /// against both the store and the batch's own earlier entries, so two
+    /// contracts claiming one address inside a single batch conflict just as
+    /// they would across batches. What it adds is marked pending persistence.
     #[napi]
     pub fn register_batch(
         &self,
         registrations: Vec<AddressRegistration>,
-        track_unwritten: bool,
     ) -> napi::Result<Vec<RegistrationVerdict>> {
-        let mut store = self.inner.write().unwrap();
-        registrations
-            .iter()
-            .map(|reg| store.register_one(reg, track_unwritten))
-            .collect()
+        self.register_all(registrations, true)
+    }
+
+    /// `register_batch` for addresses the database already holds — config
+    /// addresses and the dynamic ones a resume restores. Nothing is marked
+    /// pending, so nothing is ever written back.
+    #[napi]
+    pub fn seed_batch(
+        &self,
+        registrations: Vec<AddressRegistration>,
+    ) -> napi::Result<Vec<RegistrationVerdict>> {
+        self.register_all(registrations, false)
     }
 
     /// Drains the registrations awaiting persistence whose registration block is
     /// at or below `to_block_inclusive` — everything the batch being written
-    /// covers. What sits above that block stays pending for a later batch.
+    /// covers — pairing each with the checkpoint at its registration block.
+    /// What sits above that block stays pending for a later batch.
     ///
-    /// Draining is destructive: a batch write that fails takes the indexer down,
-    /// and the restart re-seeds every stored address from the database.
+    /// A drained registration with no checkpoint at its block means it came from
+    /// an event this batch never processed, which would write a row no rollback
+    /// could reach. That errors with the queue untouched, so the caller can fail
+    /// without the store having lied about what is still pending.
     #[napi]
-    pub fn take_unwritten_entries(&self, to_block_inclusive: i64) -> Vec<AddressEntry> {
+    pub fn drain_for_write(
+        &self,
+        to_block_inclusive: i64,
+        checkpoint_block_numbers: Vec<i64>,
+    ) -> napi::Result<Vec<DrainedAddress>> {
         let mut store = self.inner.write().unwrap();
-        let mut taken = Vec::new();
+        let mut drained = Vec::new();
         let mut pending = Vec::new();
-        for id in std::mem::take(&mut store.unwritten) {
+        for &id in store.unwritten.iter() {
             let entry = store.entry(id);
-            if entry.registration_block <= to_block_inclusive {
-                taken.push(AddressEntry {
+            if entry.registration_block > to_block_inclusive {
+                pending.push(id);
+                continue;
+            }
+            let Some(checkpoint_idx) = checkpoint_block_numbers
+                .iter()
+                .position(|&block| block == entry.registration_block)
+            else {
+                return Err(napi::Error::from_reason(format!(
+                    "Registered address {} at block {} has no checkpoint in the batch that writes it.",
+                    address_string(store.ecosystem, &entry.key),
+                    entry.registration_block
+                )));
+            };
+            drained.push(DrainedAddress {
+                address: address_string(store.ecosystem, &entry.key),
+                contract_name: store.contract_name(entry.contract_idx).to_string(),
+                registration_block: entry.registration_block,
+                checkpoint_idx: checkpoint_idx as u32,
+            });
+        }
+        store.unwritten = pending;
+        Ok(drained)
+    }
+
+    /// How many registrations await persistence. Lets the write path skip
+    /// assembling a batch's checkpoints for the common chain that registered
+    /// nothing.
+    #[napi]
+    pub fn pending_count(&self) -> i64 {
+        self.read().unwritten.len() as i64
+    }
+
+    /// The registrations still awaiting persistence, in registration order. For
+    /// assertions — draining is what the write path uses.
+    #[napi]
+    pub fn pending_entries(&self) -> Vec<AddressEntry> {
+        let store = self.read();
+        store
+            .unwritten
+            .iter()
+            .map(|&id| {
+                let entry = store.entry(id);
+                AddressEntry {
                     address: address_string(store.ecosystem, &entry.key),
                     contract_name: store.contract_name(entry.contract_idx).to_string(),
                     registration_block: entry.registration_block,
                     effective_start_block: entry.effective_start_block,
-                });
-            } else {
-                pending.push(id);
-            }
-        }
-        store.unwritten = pending;
-        taken
+                }
+            })
+            .collect()
     }
 
     /// An ordered snapshot of one contract's addresses. Empty selections are
@@ -512,6 +582,7 @@ impl AddressStore {
         let mut contract_names = Vec::with_capacity(contracts.len());
         let mut contract_start_blocks = Vec::with_capacity(contracts.len());
         let mut contract_idx_by_name = HashMap::with_capacity(contracts.len());
+        let mut contract_has_events = Vec::with_capacity(contracts.len());
         for contract in contracts {
             if contract_idx_by_name.contains_key(&contract.name) {
                 continue;
@@ -519,6 +590,7 @@ impl AddressStore {
             contract_idx_by_name.insert(contract.name.clone(), contract_names.len() as u32);
             contract_names.push(contract.name);
             contract_start_blocks.push(contract.start_block.unwrap_or(0).max(0));
+            contract_has_events.push(contract.has_events);
         }
         let live_count_by_contract = vec![0u32; contract_names.len()];
         Self {
@@ -526,6 +598,7 @@ impl AddressStore {
                 ecosystem,
                 contract_names,
                 contract_start_blocks,
+                contract_has_events,
                 contract_idx_by_name,
                 entries: Vec::new(),
                 id_by_key: HashMap::new(),
@@ -544,32 +617,52 @@ impl AddressStore {
     pub fn handle(&self) -> Arc<RwLock<StoreInner>> {
         self.inner.clone()
     }
+
+    /// Rejects the whole batch before applying any of it: an unknown contract
+    /// name is a bug upstream, and a caller that survives the error must not
+    /// find the earlier registrations already applied.
+    fn register_all(
+        &self,
+        registrations: Vec<AddressRegistration>,
+        track_unwritten: bool,
+    ) -> napi::Result<Vec<RegistrationVerdict>> {
+        let mut store = self.inner.write().unwrap();
+        for reg in registrations.iter() {
+            if store.contract_idx(&reg.contract_name).is_none() {
+                return Err(napi::Error::from_reason(format!(
+                    "Address {} registered for contract \"{}\", which the chain doesn't index.",
+                    reg.address, reg.contract_name
+                )));
+            }
+        }
+        Ok(registrations
+            .iter()
+            .map(|reg| store.register_one(reg, track_unwritten))
+            .collect())
+    }
 }
 
 impl StoreInner {
+    /// Infallible: `register_all` has already rejected every unknown contract
+    /// name, so nothing here can fail partway through a batch.
     fn register_one(
         &mut self,
         reg: &AddressRegistration,
         track_unwritten: bool,
-    ) -> napi::Result<RegistrationVerdict> {
+    ) -> RegistrationVerdict {
         let Some(key) = address_key(self.ecosystem, &reg.address) else {
-            return Ok(RegistrationVerdict {
+            return RegistrationVerdict {
                 kind: VERDICT_INVALID.to_string(),
+                fetchable: false,
                 effective_start_block: 0,
                 existing_contract_name: None,
                 existing_effective_start_block: None,
-            });
+            };
         };
 
-        // Every name the user can register is a config contract, and a config
-        // contract that disappears fails the resume compat check before any
-        // address is restored — so an unknown name here is a bug upstream.
-        let Some(contract_idx) = self.contract_idx(&reg.contract_name) else {
-            return Err(napi::Error::from_reason(format!(
-                "Address {} registered for contract \"{}\", which the chain doesn't index.",
-                reg.address, reg.contract_name
-            )));
-        };
+        let contract_idx = self
+            .contract_idx(&reg.contract_name)
+            .expect("register_all validates every contract name before applying the batch");
         let contract_start_block = self.contract_start_blocks[contract_idx as usize];
         let effective_start_block =
             derive_effective_start_block(reg.registration_block, contract_start_block);
@@ -582,12 +675,13 @@ impl StoreInner {
             } else {
                 VERDICT_CONFLICT
             };
-            return Ok(RegistrationVerdict {
+            return RegistrationVerdict {
                 kind: kind.to_string(),
+                fetchable: false,
                 effective_start_block,
                 existing_effective_start_block: Some(entry.effective_start_block),
                 existing_contract_name: Some(existing_contract_name),
-            });
+            };
         }
 
         let id = self.entries.len() as u64;
@@ -603,12 +697,13 @@ impl StoreInner {
         if track_unwritten {
             self.unwritten.push(id);
         }
-        Ok(RegistrationVerdict {
+        RegistrationVerdict {
             kind: VERDICT_ADDED.to_string(),
+            fetchable: self.contract_has_events[contract_idx as usize],
             effective_start_block,
             existing_contract_name: None,
             existing_effective_start_block: None,
-        })
+        }
     }
 }
 
@@ -922,12 +1017,12 @@ impl AddressSet {
 
 #[cfg(test)]
 impl AddressStore {
-    /// `register_batch` for tests that aren't exercising pending-write tracking.
+    /// `seed_batch` for tests, which never register an unknown contract name.
     pub(crate) fn register_seed(
         &self,
         registrations: Vec<AddressRegistration>,
     ) -> Vec<RegistrationVerdict> {
-        self.register_batch(registrations, false).unwrap()
+        self.seed_batch(registrations).unwrap()
     }
 }
 
@@ -945,6 +1040,7 @@ pub(crate) mod test_support {
                 .map(|(name, _)| AddressStoreContract {
                     name: name.to_string(),
                     start_block: None,
+                    has_events: true,
                 })
                 .collect(),
         );
@@ -1021,8 +1117,19 @@ mod tests {
             .map(|(name, start_block)| AddressStoreContract {
                 name: name.to_string(),
                 start_block: *start_block,
+                has_events: true,
             })
             .collect()
+    }
+
+    /// A contract the chain indexes no events for — registered and persisted
+    /// like any other, never fetched.
+    fn no_events_contract(name: &str) -> AddressStoreContract {
+        AddressStoreContract {
+            name: name.to_string(),
+            start_block: None,
+            has_events: false,
+        }
     }
 
     fn reg(address: &str, contract_name: &str, registration_block: i64) -> AddressRegistration {
@@ -1131,9 +1238,33 @@ mod tests {
     #[test]
     fn registering_for_a_contract_the_chain_doesnt_index_is_an_error() {
         let store = store();
+        assert!(store.register_batch(vec![reg(A, "Unknown", 10)]).is_err());
+        assert!(store.seed_batch(vec![reg(A, "Unknown", 10)]).is_err());
+    }
+
+    #[test]
+    fn a_batch_with_an_unknown_name_applies_none_of_itself() {
+        let store = store();
         assert!(store
-            .register_batch(vec![reg(A, "Unknown", 10)], false)
+            .register_batch(vec![reg(A, "C", 10), reg(B, "Unknown", 20)])
             .is_err());
+        // The valid registration ahead of the bad one must not have landed —
+        // a caller that survives the error would otherwise see a store holding
+        // an address it was never told about.
+        assert_eq!((store.size(), store.pending_entries().len()), (0, 0));
+    }
+
+    #[test]
+    fn only_a_contract_with_events_is_fetchable() {
+        let store = AddressStore::new_evm(
+            false,
+            vec![contracts(&[("C", None)]).remove(0), no_events_contract("D")],
+        );
+        let verdicts = store.register_seed(vec![reg(A, "C", 10), reg(B, "D", 20)]);
+        assert_eq!(
+            verdicts.iter().map(|v| v.fetchable).collect::<Vec<_>>(),
+            vec![true, false]
+        );
     }
 
     #[test]
@@ -1157,30 +1288,57 @@ mod tests {
         );
     }
 
+    fn drained(
+        store: &AddressStore,
+        to_block: i64,
+        checkpoints: &[i64],
+    ) -> Vec<(String, i64, u32)> {
+        store
+            .drain_for_write(to_block, checkpoints.to_vec())
+            .unwrap()
+            .into_iter()
+            .map(|e| (e.address, e.registration_block, e.checkpoint_idx))
+            .collect()
+    }
+
     #[test]
     fn unwritten_entries_drain_up_to_the_written_block() {
         let store = store();
         store.register_seed(vec![reg(A, "C", 100)]);
         store
-            .register_batch(vec![reg(B, "C", 200), reg(C, "C", 400)], true)
+            .register_batch(vec![reg(B, "C", 200), reg(C, "C", 400)])
             .unwrap();
 
-        let taken = store.take_unwritten_entries(300);
         assert_eq!(
             (
                 // The seeded address is already stored, so it never drains.
-                taken
-                    .iter()
-                    .map(|e| (e.address.as_str(), e.registration_block))
-                    .collect::<Vec<_>>(),
-                store.take_unwritten_entries(300).len(),
-                store
-                    .take_unwritten_entries(400)
-                    .iter()
-                    .map(|e| e.address.clone())
-                    .collect::<Vec<_>>(),
+                drained(&store, 300, &[100, 200]),
+                drained(&store, 300, &[100, 200]),
+                drained(&store, 400, &[400]),
             ),
-            (vec![(B, 200)], 0, vec![C.to_string()])
+            (
+                vec![(B.to_string(), 200, 1)],
+                vec![],
+                vec![(C.to_string(), 400, 0)]
+            )
+        );
+    }
+
+    #[test]
+    fn draining_without_a_checkpoint_errors_and_keeps_the_queue() {
+        let store = store();
+        store
+            .register_batch(vec![reg(A, "C", 100), reg(B, "C", 200)])
+            .unwrap();
+
+        // Block 200 has no checkpoint: the batch never processed the event that
+        // registered B, so the row would be unreachable by a rollback.
+        assert!(store.drain_for_write(300, vec![100]).is_err());
+        // Nothing was consumed, so a retry with the right checkpoints still
+        // sees both — the failed drain didn't silently swallow A.
+        assert_eq!(
+            drained(&store, 300, &[100, 200]),
+            vec![(A.to_string(), 100, 0), (B.to_string(), 200, 1)]
         );
     }
 
@@ -1188,19 +1346,15 @@ mod tests {
     fn rollback_drops_pending_writes_of_the_addresses_it_kills() {
         let store = store();
         store
-            .register_batch(vec![reg(A, "C", 100), reg(B, "C", 400)], true)
+            .register_batch(vec![reg(A, "C", 100), reg(B, "C", 400)])
             .unwrap();
         store.rollback(200);
         // Re-registering after the rollback makes the address pending again.
-        store.register_batch(vec![reg(B, "C", 500)], true).unwrap();
+        store.register_batch(vec![reg(B, "C", 500)]).unwrap();
 
         assert_eq!(
-            store
-                .take_unwritten_entries(1000)
-                .iter()
-                .map(|e| (e.address.as_str(), e.registration_block))
-                .collect::<Vec<_>>(),
-            vec![(A, 100), (B, 500)]
+            drained(&store, 1000, &[100, 500]),
+            vec![(A.to_string(), 100, 0), (B.to_string(), 500, 1)]
         );
     }
 

--- a/packages/cli/src/evm_hypersync_source/decode.rs
+++ b/packages/cli/src/evm_hypersync_source/decode.rs
@@ -852,6 +852,7 @@ mod tests {
             vec![crate::address_store::AddressStoreContract {
                 name: "Owned".to_string(),
                 start_block: None,
+                has_events: true,
             }],
         );
         address_store.register_seed(vec![crate::address_store::AddressRegistration {
@@ -1066,6 +1067,7 @@ mod tests {
             vec![crate::address_store::AddressStoreContract {
                 name: "C".to_string(),
                 start_block: None,
+                has_events: true,
             }],
         );
         address_store.register_seed(vec![crate::address_store::AddressRegistration {

--- a/packages/cli/src/fuel_hypersync_source/selection.rs
+++ b/packages/cli/src/fuel_hypersync_source/selection.rs
@@ -684,6 +684,7 @@ mod tests {
         let store = AddressStore::new_fuel(vec![crate::address_store::AddressStoreContract {
             name: "Owned".to_string(),
             start_block: None,
+            has_events: true,
         }]);
         store.register_seed(vec![crate::address_store::AddressRegistration {
             address: ADDR_1.to_string(),

--- a/packages/cli/src/svm_hypersync_source/selection.rs
+++ b/packages/cli/src/svm_hypersync_source/selection.rs
@@ -753,6 +753,7 @@ mod tests {
         let store = AddressStore::new_svm(vec![crate::address_store::AddressStoreContract {
             name: "Owned".to_string(),
             start_block: None,
+            has_events: true,
         }]);
         store.register_seed(vec![crate::address_store::AddressRegistration {
             address: PROG_A.to_string(),

--- a/packages/envio-tests/test/HyperSyncClient_test.res
+++ b/packages/envio-tests/test/HyperSyncClient_test.res
@@ -45,11 +45,11 @@ let transferEventRegistration: HyperSyncClient.Registration.input = {
 let addressStore = AddressStore.make(
   ~ecosystem=Ecosystem.Evm,
   ~shouldChecksum=false,
-  ~contracts=[{name: "ERC20", startBlock: None}, {name: "Unrelated", startBlock: None}],
+  ~contracts=[{name: "ERC20", startBlock: None, hasEvents: true}, {name: "Unrelated", startBlock: None, hasEvents: true}],
 )
-let _ = addressStore->AddressStore.registerBatch([
+let _ = addressStore->AddressStore.seedBatch([
   {address: usdcAddress, contractName: "ERC20", registrationBlock: -1},
-], ~trackUnwritten=false)
+])
 let usdcSet = addressStore->AddressStore.makeSet(~contractName="ERC20")
 
 let makeClient = (~eventRegistrations) =>

--- a/packages/envio-tests/test/HyperSync_test.res
+++ b/packages/envio-tests/test/HyperSync_test.res
@@ -10,7 +10,7 @@ let testApiToken =
 let addressStore = AddressStore.make(
   ~ecosystem=Ecosystem.Evm,
   ~shouldChecksum=true,
-  ~contracts=[{name: "ERC20", startBlock: None}],
+  ~contracts=[{name: "ERC20", startBlock: None, hasEvents: true}],
 )
 
 describe_skip("Test Hyperliquid broken transaction response", () => {

--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -99,7 +99,7 @@ let capturedRegistrationInputs: array<array<SvmHyperSyncClient.Registration.inpu
 let addressStore = AddressStore.make(
   ~ecosystem=Ecosystem.Svm,
   ~shouldChecksum=false,
-  ~contracts=[{name: "TokenMetadata", startBlock: None}],
+  ~contracts=[{name: "TokenMetadata", startBlock: None, hasEvents: true}],
 )
 
 let makeMockClient = (~response=mockResponse): SvmHyperSyncClient.t => {
@@ -161,13 +161,13 @@ let makeSource = (~onEventRegistrations=[makeReg()], ~client=mockClient) => {
 // The chain's address index, with the Metaplex program registered for the
 // TokenMetadata program name.
 let programSet = {
-  let _ = addressStore->AddressStore.registerBatch([
+  let _ = addressStore->AddressStore.seedBatch([
     {
       address: metaplexProgramId->Address.unsafeFromString,
       contractName: "TokenMetadata",
       registrationBlock: -1,
     },
-  ], ~trackUnwritten=false)
+  ])
   addressStore->AddressStore.makeSet(~contractName="TokenMetadata")
 }
 

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -130,6 +130,19 @@ let make = (
   }
 }
 
+// Every chain's contracts, not just one chain's: `context.chain.X.add` accepts
+// any config contract, whichever chain declared it, so every chain's address
+// store has to hold the whole set.
+let configContractNames = (config: Config.t) => {
+  let names = Utils.Set.make()
+  config.chainMap
+  ->ChainMap.values
+  ->Array.forEach(chain =>
+    chain.contracts->Array.forEach(contract => names->Utils.Set.add(contract.name)->ignore)
+  )
+  names->Utils.Set.toArray
+}
+
 let makeInternal = (
   ~chainConfig: Config.chain,
   ~indexingAddresses: array<Internal.indexingAddress>,
@@ -176,11 +189,7 @@ let makeInternal = (
     ~shouldChecksum=!lowercaseAddresses,
     ~contracts=AddressStore.contractsOf(
       ~onEventRegistrations,
-      // Every chain's contracts, not just this one's: `context.chain.X.add`
-      // accepts any config contract, whichever chain declared it.
-      ~configContractNames=config.chainMap
-      ->ChainMap.values
-      ->Array.flatMap(chain => chain.contracts->Array.map(contract => contract.name)),
+      ~configContractNames=config->configContractNames,
     ),
   )
 
@@ -439,10 +448,13 @@ let contractAddresses = (cs: t, ~contractName) =>
   cs.addressStore->AddressStore.contractAddresses(contractName)
 
 // Hands over the dynamically registered addresses the database hasn't seen yet,
-// up to the block the caller is about to commit. Destructive: the caller must
-// persist them or take the indexer down.
-let takeUnwrittenAddresses = (cs: t, ~toBlockInclusive) =>
-  cs.addressStore->AddressStore.takeUnwrittenEntries(toBlockInclusive)
+// up to the block the caller is about to commit, each paired with the checkpoint
+// that owns its row. Destructive: the caller must persist them or take the
+// indexer down. Throws with nothing consumed when a registration's block has no
+// checkpoint in the batch.
+let drainAddressesForWrite = (cs: t, ~toBlockInclusive, ~checkpointBlockNumbers) =>
+  cs.addressStore->AddressStore.drainForWrite(toBlockInclusive, checkpointBlockNumbers)
+let hasAddressesToWrite = (cs: t) => cs.addressStore->AddressStore.pendingCount > 0
 let bufferSize = (cs: t) => cs.fetchState->FetchState.bufferSize
 let bufferReadyCount = (cs: t) => cs.fetchState->FetchState.bufferReadyCount
 let getProgressPercentage = (cs: t) => cs.fetchState->FetchState.getProgressPercentage

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -69,7 +69,12 @@ let setRollbackTargetBlock: (t, ~blockNumber: int) => unit
 // Fetch-frontier reads.
 let knownHeight: t => int
 let contractAddresses: (t, ~contractName: string) => array<Address.t>
-let takeUnwrittenAddresses: (t, ~toBlockInclusive: int) => array<Internal.indexingContract>
+let drainAddressesForWrite: (
+  t,
+  ~toBlockInclusive: int,
+  ~checkpointBlockNumbers: array<int>,
+) => array<AddressStore.drainedAddress>
+let hasAddressesToWrite: t => bool
 let bufferSize: t => int
 let bufferReadyCount: t => int
 let getProgressPercentage: t => float

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -114,7 +114,8 @@ module EnvioAddresses = {
     id: string,
     @as("chain_id") chainId: ChainId.t,
     @as("registration_block") registrationBlock: int,
-    // -1 when the address was registered from a block handler (no log index)
+    // Vestigial: always written as -1 and never read back. The column stays so
+    // an existing schema doesn't need a migration.
     @as("registration_log_index") registrationLogIndex: int,
     @as("contract_name") contractName: string,
   }

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1689,42 +1689,33 @@ let registerDynamicContracts = (
     )
   }
 
-  // Registering an address only causes fetching when the chain has
-  // address-dependent events for its contract — the same gate `make` applies to
-  // the addresses it restores.
-  let contractNamesWithNormalEvents = Utils.Set.make()
-  fetchState.normalSelection.onEventRegistrations->Array.forEach(reg =>
-    contractNamesWithNormalEvents->Utils.Set.add(reg.eventConfig.contractName)->ignore
-  )
-
   // Ids are handed out in registration order, so a cursor taken now selects
   // exactly what this batch adds.
   let idCursor = addressStore->AddressStore.nextId
   // The store resolves each address against both what it already holds and the
   // batch's own earlier entries, so two contracts claiming one address inside a
-  // single batch conflict the same way as across batches.
-  let verdicts = addressStore->AddressStore.registerBatch(registrations, ~trackUnwritten=true)
+  // single batch conflict the same way as across batches. It also decides which
+  // additions this chain fetches for, since it's what holds the contract list.
+  let verdicts = addressStore->AddressStore.registerBatch(registrations)
 
   let registeringContractNames = []
   for idx in 0 to verdicts->Array.length - 1 {
     let registration = registrations->Array.getUnsafe(idx)
     let verdict = verdicts->Array.getUnsafe(idx)
     switch verdict {
-    | Added(_) =>
-      if contractNamesWithNormalEvents->Utils.Set.has(registration.contractName) {
-        if !(registeringContractNames->Array.includes(registration.contractName)) {
-          registeringContractNames->Array.push(registration.contractName)->ignore
-        }
-      } else {
-        // The address is still stored and persisted, so a future config change
-        // that adds events for this contract picks it up on restart.
-        warnAddressRegistration(
-          ~chainId=fetchState.chainId,
-          ~contractAddress=registration.address,
-          ~params={"contractName": registration.contractName},
-          `Persisting contract registration without fetching: Contract doesn't have any events to fetch. It'll be picked up on restart if you add events for the contract.`,
-        )
+    | Added({fetchable: true}) =>
+      if !(registeringContractNames->Array.includes(registration.contractName)) {
+        registeringContractNames->Array.push(registration.contractName)->ignore
       }
+    | Added({fetchable: false}) =>
+      // The address is still stored and persisted, so a future config change
+      // that adds events for this contract picks it up on restart.
+      warnAddressRegistration(
+        ~chainId=fetchState.chainId,
+        ~contractAddress=registration.address,
+        ~params={"contractName": registration.contractName},
+        `Persisting contract registration without fetching: Contract doesn't have any events to fetch. It'll be picked up on restart if you add events for the contract.`,
+      )
     | Conflict(_) | Duplicate(_) | Invalid =>
       verdict->warnRejectedRegistration(
         ~chainId=fetchState.chainId,
@@ -2674,14 +2665,14 @@ let make = (
   // contract has no address-dependent events, so a later registration of the
   // same address still conflicts and the address is still persisted.
   addressStore
-  ->AddressStore.registerBatch(
+  // These come from the config or from a resume, so they're already stored and
+  // must never be drained back into a write.
+  ->AddressStore.seedBatch(
     addresses->Array.map((contract): AddressStore.registration => {
       address: contract.address,
       contractName: contract.contractName,
       registrationBlock: contract.registrationBlock,
     }),
-    // These come from the config or from a resume, so they're already stored.
-    ~trackUnwritten=false,
   )
   // Verdicts are in the batch's order, so they line up with `addresses`. A
   // config address the store rejects is dropped exactly like a dynamic one, and

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -165,66 +165,50 @@ let setBatchDcs = (state: IndexerState.t, ~batch: Batch.t) => {
   let inMemTable = state->getInMemTable(~entityConfig=InternalTable.EnvioAddresses.entityConfig)
   let committedCheckpointId = state->IndexerState.committedCheckpointId
 
-  let checkpointKey = (~chainId, ~blockNumber) =>
-    chainId->ChainId.toString ++ "-" ++ blockNumber->Int.toString
-
-  // Built on first use: most batches register nothing.
-  let checkpointIdByKeyRef = ref(None)
-  let getCheckpointId = (~chainId, ~blockNumber) => {
-    let checkpointIdByKey = switch checkpointIdByKeyRef.contents {
-    | Some(dict) => dict
-    | None => {
-        let dict = Dict.make()
-        for idx in 0 to batch.checkpointIds->Array.length - 1 {
-          dict->Dict.set(
-            checkpointKey(
-              ~chainId=batch.checkpointChainIds->Array.getUnsafe(idx),
-              ~blockNumber=batch.checkpointBlockNumbers->Array.getUnsafe(idx),
-            ),
-            batch.checkpointIds->Array.getUnsafe(idx),
-          )
-        }
-        checkpointIdByKeyRef := Some(dict)
-        dict
-      }
-    }
-    switch checkpointIdByKey->Utils.Dict.dangerouslyGetNonOption(
-      checkpointKey(~chainId, ~blockNumber),
-    ) {
-    | Some(checkpointId) => checkpointId
-    | None =>
-      // A registration can only come from an event the batch itself processes,
-      // and every block with a processed event gets a checkpoint.
-      JsError.throwWithMessage(
-        `Registered address at block ${blockNumber->Int.toString} of chain ${chainId->ChainId.toString} has no checkpoint in the batch that writes it.`,
-      )
-    }
-  }
-
   batch.progressedChainsById->Utils.Dict.forEach(progressedChain => {
     let chainId = progressedChain.fetchState.chainId
-    state
-    ->IndexerState.getChainState(~chainId)
-    ->ChainState.takeUnwrittenAddresses(~toBlockInclusive=progressedChain.progressBlockNumber)
-    ->Array.forEach(dc => {
-      let entity: InternalTable.EnvioAddresses.t = {
-        id: InternalTable.EnvioAddresses.makeId(~chainId, ~address=dc.address),
-        chainId,
-        contractName: dc.contractName,
-        registrationBlock: dc.registrationBlock,
-        // Only ever written, never read back. Kept on the table so the column
-        // doesn't need a migration.
-        registrationLogIndex: -1,
+    let chainState = state->IndexerState.getChainState(~chainId)
+
+    // Most batches register nothing, so the checkpoints are only collected for a
+    // chain that has something waiting.
+    if chainState->ChainState.hasAddressesToWrite {
+      // The store pairs each drained registration with a checkpoint of its own
+      // chain, so only this chain's checkpoints go in — and the index it returns
+      // points back into these two parallel arrays.
+      let checkpointIds = []
+      let checkpointBlockNumbers = []
+      for idx in 0 to batch.checkpointIds->Array.length - 1 {
+        if batch.checkpointChainIds->Array.getUnsafe(idx) === chainId {
+          checkpointIds->Array.push(batch.checkpointIds->Array.getUnsafe(idx))
+          checkpointBlockNumbers->Array.push(batch.checkpointBlockNumbers->Array.getUnsafe(idx))
+        }
       }
 
-      inMemTable->InMemoryTable.Entity.set(
-        ~committedCheckpointId,
-        Set({
-          entityId: entity.id->EntityId.unsafeOfString,
-          checkpointId: getCheckpointId(~chainId, ~blockNumber=dc.registrationBlock),
-          entity: entity->InternalTable.EnvioAddresses.castToInternal,
-        }),
+      chainState
+      ->ChainState.drainAddressesForWrite(
+        ~toBlockInclusive=progressedChain.progressBlockNumber,
+        ~checkpointBlockNumbers,
       )
-    })
+      ->Array.forEach(dc => {
+        let entity: InternalTable.EnvioAddresses.t = {
+          id: InternalTable.EnvioAddresses.makeId(~chainId, ~address=dc.address),
+          chainId,
+          contractName: dc.contractName,
+          registrationBlock: dc.registrationBlock,
+          // Only ever written, never read back. Kept on the table so the column
+          // doesn't need a migration.
+          registrationLogIndex: -1,
+        }
+
+        inMemTable->InMemoryTable.Entity.set(
+          ~committedCheckpointId,
+          Set({
+            entityId: entity.id->EntityId.unsafeOfString,
+            checkpointId: checkpointIds->Array.getUnsafe(dc.checkpointIdx),
+            entity: entity->InternalTable.EnvioAddresses.castToInternal,
+          }),
+        )
+      })
+    }
   })
 }

--- a/packages/envio/src/sources/AddressStore.res
+++ b/packages/envio/src/sources/AddressStore.res
@@ -9,8 +9,10 @@ type t
 
 // A contract an address may be registered for. Every config contract of every
 // chain, since `context.chain.<Contract>.add` validates against that whole set
-// — a name outside it makes the store throw.
-type contract = {name: string, startBlock: option<int>}
+// — a name outside it makes the store throw. `hasEvents` is whether this chain
+// fetches for the contract at all, which is what makes the store able to answer
+// `fetchable` on a verdict.
+type contract = {name: string, startBlock: option<int>, hasEvents: bool}
 
 type registration = {
   address: Address.t,
@@ -20,7 +22,10 @@ type registration = {
 }
 
 type verdict =
-  | Added({effectiveStartBlock: int})
+  // `fetchable` is false when the chain has no address-dependent events for the
+  // contract: the address is still stored and persisted, so a config that later
+  // adds events picks it up on restart, but no partition is built from it.
+  | Added({effectiveStartBlock: int, fetchable: bool})
   // Already registered for the same contract.
   | Duplicate({effectiveStartBlock: int, existingEffectiveStartBlock: int})
   // Already registered for a different contract.
@@ -30,9 +35,20 @@ type verdict =
 
 type rawVerdict = {
   kind: string,
+  fetchable: bool,
   effectiveStartBlock: int,
   existingContractName: Null.t<string>,
   existingEffectiveStartBlock: Null.t<int>,
+}
+
+// A registration the store handed over for persistence, paired with the
+// checkpoint that owns its row. `checkpointIdx` indexes the block numbers
+// passed to `drainForWrite` — the ids stay on the JS side.
+type drainedAddress = {
+  address: Address.t,
+  contractName: string,
+  registrationBlock: int,
+  checkpointIdx: int,
 }
 
 type makeSetOptions = {
@@ -68,9 +84,13 @@ let make = (~ecosystem: Ecosystem.name, ~shouldChecksum: bool, ~contracts: array
 // of this chain's events for it may fire at. `None` means unrestricted, so it
 // wins over any `Some`: one registration without a start block makes the whole
 // contract's address gate open from the chain's start, and the per-registration
-// start block still holds back the registrations that declared one. Contracts
-// this chain has no events for carry `None` — nothing is fetched for them, so
-// their effective start block only shapes what gets persisted.
+// start block still holds back the registrations that declared one.
+//
+// `hasEvents` follows `dependsOnAddresses` rather than the mere presence of a
+// registration: a contract whose events are all wildcard is fetched without
+// consulting addresses, so registering one changes nothing about what's queried.
+// Contracts named only by `configContractNames` carry `false` — their addresses
+// are stored and persisted, never fetched.
 let contractsOf = (
   ~onEventRegistrations: array<Internal.onEventRegistration>,
   ~configContractNames: array<string>,
@@ -79,11 +99,17 @@ let contractsOf = (
   // storing `None` in a dict would be indistinguishable from "not seen yet".
   let startBlocks: dict<int> = Dict.make()
   let unrestricted = Utils.Set.make()
+  let withEvents = Utils.Set.make()
   let names = []
-  onEventRegistrations->Array.forEach(reg => {
-    let name = reg.eventConfig.contractName
+  let addName = name =>
     if !(names->Array.includes(name)) {
       names->Array.push(name)->ignore
+    }
+  onEventRegistrations->Array.forEach(reg => {
+    let name = reg.eventConfig.contractName
+    addName(name)
+    if reg.dependsOnAddresses {
+      withEvents->Utils.Set.add(name)->ignore
     }
     switch reg.startBlock {
     | None => unrestricted->Utils.Set.add(name)->ignore
@@ -97,16 +123,13 @@ let contractsOf = (
       )
     }
   })
-  configContractNames->Array.forEach(name => {
-    if !(names->Array.includes(name)) {
-      names->Array.push(name)->ignore
-    }
-  })
+  configContractNames->Array.forEach(addName)
   names->Array.map(name => {
     name,
     startBlock: unrestricted->Utils.Set.has(name)
       ? None
       : startBlocks->Utils.Dict.dangerouslyGetNonOption(name),
+    hasEvents: withEvents->Utils.Set.has(name),
   })
 }
 
@@ -121,12 +144,22 @@ let contractsOf = (
 // different stores can't be merged.
 @send external makeSetOf: (t, array<Address.t>) => AddressSet.t = "makeSetOf"
 @send
-external registerBatchRaw: (t, array<registration>, bool) => array<rawVerdict> = "registerBatch"
+external registerBatchRaw: (t, array<registration>) => array<rawVerdict> = "registerBatch"
+@send external seedBatchRaw: (t, array<registration>) => array<rawVerdict> = "seedBatch"
 
 // Drains the registrations awaiting persistence at or below the given block —
-// what the batch being written covers. Later registrations stay pending.
+// what the batch being written covers — pairing each with the checkpoint at its
+// registration block. Later registrations stay pending. Throws, with the queue
+// untouched, when a drained registration's block has no checkpoint in the batch.
 @send
-external takeUnwrittenEntries: (t, int) => array<Internal.indexingContract> = "takeUnwrittenEntries"
+external drainForWrite: (t, int, array<int>) => array<drainedAddress> = "drainForWrite"
+
+// How many registrations await persistence — lets a caller skip the work of
+// assembling what `drainForWrite` needs.
+@send external pendingCount: t => int = "pendingCount"
+
+// The registrations still awaiting persistence. For assertions.
+@send external pendingEntries: t => array<Internal.indexingContract> = "pendingEntries"
 @send external makeSetRaw: (t, string, makeSetOptions) => AddressSet.t = "makeSet"
 @send
 external startBlockGroups: (t, string) => array<AddressSet.startBlockGroup> = "startBlockGroups"
@@ -150,7 +183,7 @@ external startBlockGroups: (t, string) => array<AddressSet.startBlockGroup> = "s
 
 let toVerdict = (raw: rawVerdict): verdict =>
   switch raw.kind {
-  | "added" => Added({effectiveStartBlock: raw.effectiveStartBlock})
+  | "added" => Added({effectiveStartBlock: raw.effectiveStartBlock, fetchable: raw.fetchable})
   | "duplicate" =>
     Duplicate({
       effectiveStartBlock: raw.effectiveStartBlock,
@@ -161,16 +194,21 @@ let toVerdict = (raw: rawVerdict): verdict =>
   | kind => JsError.throwWithMessage(`Unexpected address registration verdict "${kind}"`)
   }
 
-// Registers a batch, resolving each address against both the store and the
-// batch's own earlier entries — so two contracts claiming one address inside a
-// single batch conflict just as they would across batches. Verdicts come back
-// in the batch's order.
+// Registers dynamic registrations, resolving each address against both the
+// store and the batch's own earlier entries — so two contracts claiming one
+// address inside a single batch conflict just as they would across batches.
+// Verdicts come back in the batch's order. What it adds is pending persistence
+// until a batch write drains it.
 //
-// `trackUnwritten` marks what the batch adds as pending persistence. Addresses
-// restored from the database are already stored, so they pass `false`.
-let registerBatch = (store: t, registrations: array<registration>, ~trackUnwritten): array<
-  verdict,
-> => store->registerBatchRaw(registrations, trackUnwritten)->Array.map(toVerdict)
+// An unknown contract name throws with none of the batch applied.
+let registerBatch = (store: t, registrations: array<registration>): array<verdict> =>
+  store->registerBatchRaw(registrations)->Array.map(toVerdict)
+
+// `registerBatch` for addresses the database already holds — config addresses
+// and the dynamic ones a resume restores. Nothing is marked pending, so nothing
+// is ever written back.
+let seedBatch = (store: t, registrations: array<registration>): array<verdict> =>
+  store->seedBatchRaw(registrations)->Array.map(toVerdict)
 
 let makeSet = (store: t, ~contractName, ~options={}: makeSetOptions) =>
   store->makeSetRaw(contractName, options)

--- a/scenarios/test_codegen/test/DynamicContractPersistence_test.res
+++ b/scenarios/test_codegen/test/DynamicContractPersistence_test.res
@@ -18,8 +18,12 @@ let queryAddresses = (indexerMock: MockIndexer.Indexer.t) =>
   )
 
 let dcAddress = "0x1111111111111111111111111111111111111111"->Address.Evm.fromStringOrThrow
+let lateDcAddress = "0x2222222222222222222222222222222222222222"->Address.Evm.fromStringOrThrow
 
-let handler = (async _ => ())->Obj.magic
+let handler: Internal.genericHandlerArgs<
+  MockIndexer.eventLog<unknown>,
+  MockIndexer.handlerContext,
+> => promise<unit> = async _ => ()
 
 describe("Dynamic contract persistence", () => {
   Async.it("writes one row for an address registered by several events", async t => {
@@ -112,5 +116,69 @@ describe("Dynamic contract persistence", () => {
       await queryAddresses(indexerMock),
       ~message="the conflicting registration is dropped, the first one stands",
     ).toEqual([(`1337-${dcAddress->Address.toString}`, "Gravatar", 10)])
+  })
+
+  Async.it("writes a registration the first batch didn't progress past", async t => {
+    let sourceMock = MockIndexer.Source.make(
+      [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+      ~chainId=#1337,
+    )
+    let indexerMock = await MockIndexer.Indexer.make(
+      ~chains=[{chain: #1337, sourceConfig: Config.CustomSources([sourceMock.source])}],
+    )
+    await Utils.delay(0)
+
+    sourceMock.resolveGetHeightOrThrow(1000)
+    await Utils.delay(0)
+    await Utils.delay(0)
+
+    // Both registrations happen at fetch time, but registering the block 10
+    // address spawns a partition that hasn't fetched yet — so the first batch
+    // can't progress past block 10, and the block 150 registration has to stay
+    // pending until a later batch covers it.
+    sourceMock.resolveGetItemsOrThrow(
+      [
+        {
+          blockNumber: 10,
+          logIndex: 0,
+          handler,
+          contractRegister: async ({context}) => context.chain.\"Gravatar".add(dcAddress),
+        },
+        {
+          blockNumber: 150,
+          logIndex: 0,
+          handler,
+          contractRegister: async ({context}) => context.chain.\"Gravatar".add(lateDcAddress),
+        },
+      ],
+      ~resolveAt=#all,
+      ~latestFetchedBlockNumber=200,
+    )
+    await indexerMock.getBatchWritePromise()
+    // Nothing is written yet: the chain hasn't progressed to block 10, so both
+    // registrations sit pending across this write.
+    let afterFirstWrite = await queryAddresses(indexerMock)
+
+    // Let the new partition fetch only to block 50. Progress lands between the
+    // two registration blocks, so the drain has to split the queue: block 10 is
+    // covered, block 150 stays pending.
+    sourceMock.resolveGetItemsOrThrow([], ~resolveAt=#all, ~latestFetchedBlockNumber=50)
+    await indexerMock.getBatchWritePromise()
+    let afterPartialDrain = await queryAddresses(indexerMock)
+
+    sourceMock.resolveGetItemsOrThrow([], ~resolveAt=#all, ~latestFetchedBlockNumber=200)
+    await indexerMock.getBatchWritePromise()
+
+    t.expect(
+      (afterFirstWrite, afterPartialDrain, await queryAddresses(indexerMock)),
+      ~message="each registration lands in the batch that progressed past its block",
+    ).toEqual((
+      [],
+      [(`1337-${dcAddress->Address.toString}`, "Gravatar", 10)],
+      [
+        (`1337-${dcAddress->Address.toString}`, "Gravatar", 10),
+        (`1337-${lateDcAddress->Address.toString}`, "Gravatar", 150),
+      ],
+    ))
   })
 })

--- a/scenarios/test_codegen/test/helpers/NativeDecoder.res
+++ b/scenarios/test_codegen/test/helpers/NativeDecoder.res
@@ -46,18 +46,19 @@ let decodeLogs = async (
         ~contracts=eventRegistrations->Array.map((reg): AddressStore.contract => {
           name: reg.contractName,
           startBlock: None,
+          hasEvents: true,
         }),
       )
       let addressSet = switch ownedBy {
       | None => addressStore->AddressStore.emptySet
       | Some(contractName) =>
-        let _ = addressStore->AddressStore.registerBatch([
+        let _ = addressStore->AddressStore.seedBatch([
           {
             address: mockAddress->Address.unsafeFromString,
             contractName,
             registrationBlock: -1,
           },
-        ], ~trackUnwritten=false)
+        ])
         addressStore->AddressStore.makeSet(~contractName)
       }
       let client = EvmRpcClient.make(

--- a/scenarios/test_codegen/test/helpers/TestAddresses.res
+++ b/scenarios/test_codegen/test/helpers/TestAddresses.res
@@ -19,13 +19,14 @@ let makeStore = (
     ~shouldChecksum,
     ~contracts=AddressStore.contractsOf(~onEventRegistrations, ~configContractNames),
   )
-  let _ = store->AddressStore.registerBatch(
+  // Config addresses, like `FetchState.make` seeds them: already stored, so
+  // they never drain back into a write.
+  let _ = store->AddressStore.seedBatch(
     addresses->Array.map((contract): AddressStore.registration => {
       address: contract.address,
       contractName: contract.contractName,
       registrationBlock: contract.registrationBlock,
     }),
-    ~trackUnwritten=false,
   )
   store
 }

--- a/scenarios/test_codegen/test/lib_tests/AddressStore_test.res
+++ b/scenarios/test_codegen/test/lib_tests/AddressStore_test.res
@@ -139,13 +139,22 @@ describe("AddressStore", () => {
         ],
         ~configContractNames=[],
       ),
+      // A contract only the config names is registrable but never fetched.
+      "configOnly": AddressStore.contractsOf(
+        ~onEventRegistrations=[reg(~contractName="A")],
+        ~configContractNames=["A", "NoEvents"],
+      ),
     }).toEqual({
-      "noneThenSome": [({name: "A", startBlock: None}: AddressStore.contract)],
-      "someThenNone": [({name: "A", startBlock: None}: AddressStore.contract)],
-      "allRestricted": [({name: "A", startBlock: Some(50)}: AddressStore.contract)],
+      "noneThenSome": [({name: "A", startBlock: None, hasEvents: true}: AddressStore.contract)],
+      "someThenNone": [({name: "A", startBlock: None, hasEvents: true}: AddressStore.contract)],
+      "allRestricted": [({name: "A", startBlock: Some(50), hasEvents: true}: AddressStore.contract)],
       "perContract": [
-        ({name: "B", startBlock: Some(50)}: AddressStore.contract),
-        ({name: "A", startBlock: None}: AddressStore.contract),
+        ({name: "B", startBlock: Some(50), hasEvents: true}: AddressStore.contract),
+        ({name: "A", startBlock: None, hasEvents: true}: AddressStore.contract),
+      ],
+      "configOnly": [
+        ({name: "A", startBlock: None, hasEvents: true}: AddressStore.contract),
+        ({name: "NoEvents", startBlock: None, hasEvents: false}: AddressStore.contract),
       ],
     })
   })
@@ -167,7 +176,6 @@ describe("AddressStore", () => {
           // state is what decides nothing is queried for it.
           {address: addr(5), contractName: "NoEvents", registrationBlock: 40},
         ],
-        ~trackUnwritten=false,
       )
     let added = store->AddressStore.makeSet(~contractName="B", ~options={minId: cursor})
     t.expect({
@@ -177,10 +185,11 @@ describe("AddressStore", () => {
       "size": store->AddressStore.size,
     }).toEqual({
       "verdicts": [
-        AddressStore.Added({effectiveStartBlock: 30}),
-        Added({effectiveStartBlock: 10}),
+        AddressStore.Added({effectiveStartBlock: 30, fetchable: true}),
+        Added({effectiveStartBlock: 10, fetchable: true}),
         Duplicate({effectiveStartBlock: 30, existingEffectiveStartBlock: 30}),
-        Added({effectiveStartBlock: 40}),
+        // Registered and persisted, but nothing on this chain fetches for it.
+        Added({effectiveStartBlock: 40, fetchable: false}),
       ],
       // Ordered by effectiveStartBlock, so addr(4) (10) precedes addr(3) (30).
       "added": [addr(4), addr(3)],
@@ -195,7 +204,6 @@ describe("AddressStore", () => {
       () =>
         store->AddressStore.registerBatch(
           [{address: addr(3), contractName: "Missing", registrationBlock: 7}],
-          ~trackUnwritten=true,
         ),
     ).toThrow()
   })
@@ -206,24 +214,45 @@ describe("AddressStore", () => {
       ~addresses=[contract(~address=addr(0), ~contractName="A", ~registrationBlock=-1)],
     )
     let _ =
-      store->AddressStore.registerBatch(
-        [
-          {address: addr(1), contractName: "A", registrationBlock: 10},
-          {address: addr(2), contractName: "A", registrationBlock: 30},
-        ],
-        ~trackUnwritten=true,
-      )
+      store->AddressStore.registerBatch([
+        {address: addr(1), contractName: "A", registrationBlock: 10},
+        {address: addr(2), contractName: "A", registrationBlock: 30},
+      ])
+
+    let drain = (~toBlockInclusive, ~checkpointBlockNumbers) =>
+      store
+      ->AddressStore.drainForWrite(toBlockInclusive, checkpointBlockNumbers)
+      ->Array.map(dc => (dc.address, dc.checkpointIdx))
 
     t.expect({
       // The config address was never pending, and addr(2) is above the bound.
-      "upToBlock20": store->AddressStore.takeUnwrittenEntries(20)->Array.map(ia => ia.address),
-      "drainedOnce": store->AddressStore.takeUnwrittenEntries(20)->Array.map(ia => ia.address),
-      "rest": store->AddressStore.takeUnwrittenEntries(30)->Array.map(ia => ia.address),
+      "upToBlock20": drain(~toBlockInclusive=20, ~checkpointBlockNumbers=[5, 10]),
+      "drainedOnce": drain(~toBlockInclusive=20, ~checkpointBlockNumbers=[5, 10]),
+      "rest": drain(~toBlockInclusive=30, ~checkpointBlockNumbers=[30]),
+      "nothingLeftPending": store->AddressStore.pendingEntries,
     }).toEqual({
-      "upToBlock20": [addr(1)],
+      // The checkpoint index points back at the block numbers passed in.
+      "upToBlock20": [(addr(1), 1)],
       "drainedOnce": [],
-      "rest": [addr(2)],
+      "rest": [(addr(2), 0)],
+      "nothingLeftPending": [],
     })
+  })
+
+  it("refuses to drain a registration the batch has no checkpoint for", t => {
+    let store = TestAddresses.makeStore(~onEventRegistrations)
+    let _ =
+      store->AddressStore.registerBatch([
+        {address: addr(1), contractName: "A", registrationBlock: 10},
+      ])
+
+    t.expect(() => store->AddressStore.drainForWrite(20, [9])).toThrow()
+    t.expect(
+      // The failed drain consumed nothing, so the registration is still there
+      // to be written by a batch that does cover it.
+      store->AddressStore.pendingEntries->Array.map(ia => ia.address),
+      ~message="a failed drain leaves the queue intact",
+    ).toEqual([addr(1)])
   })
 
   it("rejects an address already held by another contract", t => {
@@ -234,7 +263,6 @@ describe("AddressStore", () => {
     t.expect(
       store->AddressStore.registerBatch(
         [{address: addr(0), contractName: "B", registrationBlock: 7}],
-        ~trackUnwritten=true,
       ),
     ).toEqual([AddressStore.Conflict({existingContractName: "A"})])
   })

--- a/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
@@ -236,15 +236,15 @@ describe("EvmRpcClient - getNextPage via napi", () => {
     let store = AddressStore.make(
       ~ecosystem=Ecosystem.Evm,
       ~shouldChecksum=false,
-      ~contracts=[{name: "ERC20", startBlock: None}],
+      ~contracts=[{name: "ERC20", startBlock: None, hasEvents: true}],
     )
-    let _ = store->AddressStore.registerBatch([
+    let _ = store->AddressStore.seedBatch([
       {
         address: contractAddress->Address.unsafeFromString,
         contractName: "ERC20",
         registrationBlock: -1,
       },
-    ], ~trackUnwritten=false)
+    ])
     store
   }
 

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -892,7 +892,7 @@ describe("FetchState.registerDynamicContracts", () => {
           // still written to the db, so a config that later adds events for
           // the contract picks the address up on restart
           addressStore
-          ->AddressStore.takeUnwrittenEntries(10)
+          ->AddressStore.pendingEntries
           ->Array.map(ia => ia.address),
           // partitions unchanged - no fetching for contracts without events
           updatedFetchState.optimizedPartitions === fetchState.optimizedPartitions,
@@ -950,7 +950,7 @@ describe("FetchState.registerDynamicContracts", () => {
         (
           // Only the first registration is ever written.
           addressStore
-          ->AddressStore.takeUnwrittenEntries(12)
+          ->AddressStore.pendingEntries
           ->Array.map(ia => (ia.address, ia.contractName, ia.registrationBlock)),
           // First registration is the tracked one (first wins).
           addressStore->AddressStore.get(mockAddress1)
@@ -1042,7 +1042,7 @@ describe("FetchState.registerDynamicContracts", () => {
         (
           // rejected, so it never reaches the db and can't overwrite the
           // existing Gravatar entry
-          addressStore->AddressStore.takeUnwrittenEntries(10),
+          addressStore->AddressStore.pendingEntries,
           // addressStore still has the original contract name
           addressStore->AddressStore.get(mockAddress0)
           ->Option.map(ia => ia.contractName),
@@ -1081,7 +1081,7 @@ describe("FetchState.registerDynamicContracts", () => {
         ->Option.map(ia => ia.contractName),
         // the rejected dc is never persisted to envio_addresses
         addressStore
-        ->AddressStore.takeUnwrittenEntries(10)
+        ->AddressStore.pendingEntries
         ->Array.map(ia => (ia.address, ia.contractName)),
         updatedFetchState.optimizedPartitions.entities
         ->Dict.valuesToArray
@@ -1128,7 +1128,7 @@ describe("FetchState.registerDynamicContracts", () => {
           ->Option.map(ia => ia.contractName),
           // one row for the address, under the contract that claimed it first
           addressStore
-          ->AddressStore.takeUnwrittenEntries(10)
+          ->AddressStore.pendingEntries
           ->Array.map(ia => (ia.address, ia.contractName)),
         ),
         ~message=`the events registration is preserved on addressStore
@@ -1163,7 +1163,7 @@ describe("FetchState.registerDynamicContracts", () => {
           addressStore->AddressStore.get(mockAddress1)
           ->Option.map(ia => ia.contractName),
           addressStore
-          ->AddressStore.takeUnwrittenEntries(10)
+          ->AddressStore.pendingEntries
           ->Array.map(ia => (ia.address, ia.contractName)),
           updatedFetchState.optimizedPartitions.entities
           ->Dict.valuesToArray
@@ -1489,7 +1489,7 @@ describe("FetchState.registerDynamicContracts", () => {
 
     t.expect(
       addressStore
-      ->AddressStore.takeUnwrittenEntries(20)
+      ->AddressStore.pendingEntries
       ->Array.map(ia => (ia.address, ia.registrationBlock)),
       ~message=`Should choose the earliest dc from the batch
   And drop the later one, so they are not duplicated in the db`,


### PR DESCRIPTION
## Summary

Refactors the address store and write path to distinguish between contracts that have address-dependent events (which trigger fetching when addresses are registered) and those that don't (which are registered and persisted but never fetched). This enables config contracts to be registered without triggering unnecessary fetches, and allows future config changes to pick them up on restart.

## Key Changes

- **AddressStore contract metadata**: Added `has_events` field to `AddressStoreContract` to track whether a chain fetches address-dependent events for each contract. Contracts named only in `configContractNames` carry `false`; those with `dependsOnAddresses` events carry `true`.

- **Registration verdicts**: Extended `RegistrationVerdict` with a `fetchable` field that indicates whether an `Added` address is one this chain actually fetches for. Rejected verdicts always have `fetchable: false`.

- **Drain operation refactored**: Replaced `take_unwritten_entries` with `drain_for_write`, which pairs each drained registration with the checkpoint at its registration block. This ensures every persisted address has a reachable checkpoint row. The operation errors (with queue untouched) if a registration's block has no checkpoint in the batch.

- **Batch registration validation**: Moved unknown contract name validation into `register_all`, which rejects the entire batch before applying any registrations. This prevents partial application when a caller survives the error.

- **Split registration paths**: `register_batch` marks registrations as pending persistence (for dynamic registrations); `seed_batch` does not (for config addresses and resumed dynamic ones from the database).

- **Helper methods**: Added `pending_count` and `pending_entries` to let callers check what's awaiting persistence without draining.

- **Write path simplification**: The batch write path now collects only the checkpoints for chains with pending addresses, and uses the checkpoint index returned by `drain_for_write` to pair each address with its row's checkpoint.

## Notable Implementation Details

- The `has_events` field is computed from `dependsOnAddresses` on event registrations and the presence in `configContractNames`, not from the mere existence of a registration. A contract whose events are all wildcard is fetched without consulting addresses.

- Draining is destructive and must succeed or the indexer goes down; a restart re-seeds every stored address from the database. The new checkpoint pairing ensures no address row can be orphaned by a rollback.

- Tests verify that registrations for contracts without events are still stored and persisted (so a config change that adds events picks them up), but no partition is built from them.

https://claude.ai/code/session_01EHej2UFwYMhPB8YzmWCMJW