### PR TITLE
Rename has_events to depends_on_addresses

### DIFF
--- a/packages/cli/src/address_store.rs
+++ b/packages/cli/src/address_store.rs
@@ -101,7 +101,7 @@ pub struct StoreInner {
     ecosystem: Ecosystem,
     contract_names: Vec<String>,
     contract_start_blocks: Vec<i64>,
-    contract_has_events: Vec<bool>,
+    contract_depends_on_addresses: Vec<bool>,
     contract_idx_by_name: HashMap<String, u32>,
     entries: Vec<Entry>,
     id_by_key: HashMap<Key, u64>,
@@ -183,11 +183,11 @@ pub struct AddressStoreContract {
     /// chain; absent means block 0, since partitions never query below the
     /// chain's own start block anyway.
     pub start_block: Option<i64>,
-    /// Whether this chain has address-dependent events for the contract. False
-    /// for a config contract this chain never fetches for: its addresses are
-    /// still registered and persisted, so a config that later adds events picks
-    /// them up, but no partition is ever built from them.
-    pub has_events: bool,
+    /// Whether any of this chain's events for the contract are fetched by
+    /// address. False both for a config contract this chain has no events for
+    /// and for one whose events are all wildcard — either way its addresses are
+    /// registered and persisted, but no partition is ever built from them.
+    pub depends_on_addresses: bool,
 }
 
 /// One address a batch asks the store to register.
@@ -582,7 +582,7 @@ impl AddressStore {
         let mut contract_names = Vec::with_capacity(contracts.len());
         let mut contract_start_blocks = Vec::with_capacity(contracts.len());
         let mut contract_idx_by_name = HashMap::with_capacity(contracts.len());
-        let mut contract_has_events = Vec::with_capacity(contracts.len());
+        let mut contract_depends_on_addresses = Vec::with_capacity(contracts.len());
         for contract in contracts {
             if contract_idx_by_name.contains_key(&contract.name) {
                 continue;
@@ -590,7 +590,7 @@ impl AddressStore {
             contract_idx_by_name.insert(contract.name.clone(), contract_names.len() as u32);
             contract_names.push(contract.name);
             contract_start_blocks.push(contract.start_block.unwrap_or(0).max(0));
-            contract_has_events.push(contract.has_events);
+            contract_depends_on_addresses.push(contract.depends_on_addresses);
         }
         let live_count_by_contract = vec![0u32; contract_names.len()];
         Self {
@@ -598,7 +598,7 @@ impl AddressStore {
                 ecosystem,
                 contract_names,
                 contract_start_blocks,
-                contract_has_events,
+                contract_depends_on_addresses,
                 contract_idx_by_name,
                 entries: Vec::new(),
                 id_by_key: HashMap::new(),
@@ -699,7 +699,7 @@ impl StoreInner {
         }
         RegistrationVerdict {
             kind: VERDICT_ADDED.to_string(),
-            fetchable: self.contract_has_events[contract_idx as usize],
+            fetchable: self.contract_depends_on_addresses[contract_idx as usize],
             effective_start_block,
             existing_contract_name: None,
             existing_effective_start_block: None,
@@ -1040,7 +1040,7 @@ pub(crate) mod test_support {
                 .map(|(name, _)| AddressStoreContract {
                     name: name.to_string(),
                     start_block: None,
-                    has_events: true,
+                    depends_on_addresses: true,
                 })
                 .collect(),
         );
@@ -1117,18 +1117,19 @@ mod tests {
             .map(|(name, start_block)| AddressStoreContract {
                 name: name.to_string(),
                 start_block: *start_block,
-                has_events: true,
+                depends_on_addresses: true,
             })
             .collect()
     }
 
-    /// A contract the chain indexes no events for — registered and persisted
-    /// like any other, never fetched.
-    fn no_events_contract(name: &str) -> AddressStoreContract {
+    /// A contract nothing on this chain fetches by address — either it has no
+    /// events here, or they're all wildcard. Registered and persisted like any
+    /// other, never fetched.
+    fn address_independent_contract(name: &str) -> AddressStoreContract {
         AddressStoreContract {
             name: name.to_string(),
             start_block: None,
-            has_events: false,
+            depends_on_addresses: false,
         }
     }
 
@@ -1215,10 +1216,10 @@ mod tests {
     }
 
     #[test]
-    fn an_address_belongs_to_one_contract_whether_or_not_it_has_events() {
-        // "D" stands in for a contract the chain indexes no events for: the
-        // store treats it like any other, and the fetch state decides nothing
-        // is queried for it.
+    fn an_address_belongs_to_one_contract_whether_or_not_it_is_fetched() {
+        // "D" stands in for a contract nothing on this chain fetches by
+        // address: the store treats it like any other, and the fetch state
+        // decides nothing is queried for it.
         let store = store();
         let verdicts = store.register_seed(vec![reg(A, "D", 10), reg(A, "C", 20), reg(A, "D", 30)]);
         assert_eq!(
@@ -1255,10 +1256,13 @@ mod tests {
     }
 
     #[test]
-    fn only_a_contract_with_events_is_fetchable() {
+    fn only_an_address_dependent_contract_is_fetchable() {
         let store = AddressStore::new_evm(
             false,
-            vec![contracts(&[("C", None)]).remove(0), no_events_contract("D")],
+            vec![
+                contracts(&[("C", None)]).remove(0),
+                address_independent_contract("D"),
+            ],
         );
         let verdicts = store.register_seed(vec![reg(A, "C", 10), reg(B, "D", 20)]);
         assert_eq!(

--- a/packages/cli/src/address_store.rs
+++ b/packages/cli/src/address_store.rs
@@ -556,25 +556,6 @@ impl AddressStore {
                 .collect(),
         }
     }
-
-    /// Every registered address in set order. For assertions.
-    #[napi]
-    pub fn entries(&self) -> Vec<AddressEntry> {
-        let store = self.read();
-        store
-            .sorted_live_ids(0, |_| true)
-            .into_iter()
-            .map(|id| {
-                let entry = store.entry(id);
-                AddressEntry {
-                    address: address_string(store.ecosystem, &entry.key),
-                    contract_name: store.contract_name(entry.contract_idx).to_string(),
-                    registration_block: entry.registration_block,
-                    effective_start_block: entry.effective_start_block,
-                }
-            })
-            .collect()
-    }
 }
 
 impl AddressStore {

--- a/packages/cli/src/evm_hypersync_source/decode.rs
+++ b/packages/cli/src/evm_hypersync_source/decode.rs
@@ -852,7 +852,7 @@ mod tests {
             vec![crate::address_store::AddressStoreContract {
                 name: "Owned".to_string(),
                 start_block: None,
-                has_events: true,
+                depends_on_addresses: true,
             }],
         );
         address_store.register_seed(vec![crate::address_store::AddressRegistration {
@@ -1067,7 +1067,7 @@ mod tests {
             vec![crate::address_store::AddressStoreContract {
                 name: "C".to_string(),
                 start_block: None,
-                has_events: true,
+                depends_on_addresses: true,
             }],
         );
         address_store.register_seed(vec![crate::address_store::AddressRegistration {

--- a/packages/cli/src/fuel_hypersync_source/selection.rs
+++ b/packages/cli/src/fuel_hypersync_source/selection.rs
@@ -684,7 +684,7 @@ mod tests {
         let store = AddressStore::new_fuel(vec![crate::address_store::AddressStoreContract {
             name: "Owned".to_string(),
             start_block: None,
-            has_events: true,
+            depends_on_addresses: true,
         }]);
         store.register_seed(vec![crate::address_store::AddressRegistration {
             address: ADDR_1.to_string(),

--- a/packages/cli/src/svm_hypersync_source/selection.rs
+++ b/packages/cli/src/svm_hypersync_source/selection.rs
@@ -753,7 +753,7 @@ mod tests {
         let store = AddressStore::new_svm(vec![crate::address_store::AddressStoreContract {
             name: "Owned".to_string(),
             start_block: None,
-            has_events: true,
+            depends_on_addresses: true,
         }]);
         store.register_seed(vec![crate::address_store::AddressRegistration {
             address: PROG_A.to_string(),

--- a/packages/envio-tests/test/HyperSyncClient_test.res
+++ b/packages/envio-tests/test/HyperSyncClient_test.res
@@ -45,7 +45,7 @@ let transferEventRegistration: HyperSyncClient.Registration.input = {
 let addressStore = AddressStore.make(
   ~ecosystem=Ecosystem.Evm,
   ~shouldChecksum=false,
-  ~contracts=[{name: "ERC20", startBlock: None, hasEvents: true}, {name: "Unrelated", startBlock: None, hasEvents: true}],
+  ~contracts=[{name: "ERC20", startBlock: None, dependsOnAddresses: true}, {name: "Unrelated", startBlock: None, dependsOnAddresses: true}],
 )
 let _ = addressStore->AddressStore.seedBatch([
   {address: usdcAddress, contractName: "ERC20", registrationBlock: -1},

--- a/packages/envio-tests/test/HyperSync_test.res
+++ b/packages/envio-tests/test/HyperSync_test.res
@@ -10,7 +10,7 @@ let testApiToken =
 let addressStore = AddressStore.make(
   ~ecosystem=Ecosystem.Evm,
   ~shouldChecksum=true,
-  ~contracts=[{name: "ERC20", startBlock: None, hasEvents: true}],
+  ~contracts=[{name: "ERC20", startBlock: None, dependsOnAddresses: true}],
 )
 
 describe_skip("Test Hyperliquid broken transaction response", () => {

--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -99,7 +99,7 @@ let capturedRegistrationInputs: array<array<SvmHyperSyncClient.Registration.inpu
 let addressStore = AddressStore.make(
   ~ecosystem=Ecosystem.Svm,
   ~shouldChecksum=false,
-  ~contracts=[{name: "TokenMetadata", startBlock: None, hasEvents: true}],
+  ~contracts=[{name: "TokenMetadata", startBlock: None, dependsOnAddresses: true}],
 )
 
 let makeMockClient = (~response=mockResponse): SvmHyperSyncClient.t => {

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -1707,15 +1707,10 @@ let registerDynamicContracts = (
       if !(registeringContractNames->Array.includes(registration.contractName)) {
         registeringContractNames->Array.push(registration.contractName)->ignore
       }
-    | Added({fetchable: false}) =>
-      // The address is still stored and persisted, so a future config change
-      // that adds events for this contract picks it up on restart.
-      warnAddressRegistration(
-        ~chainId=fetchState.chainId,
-        ~contractAddress=registration.address,
-        ~params={"contractName": registration.contractName},
-        `Persisting contract registration without fetching: Contract doesn't have any events to fetch. It'll be picked up on restart if you add events for the contract.`,
-      )
+    // Nothing on this chain is fetched by address for the contract, so there's
+    // no partition to build. The address is still stored and persisted, so a
+    // config that later adds address-dependent events picks it up on restart.
+    | Added({fetchable: false}) => ()
     | Conflict(_) | Duplicate(_) | Invalid =>
       verdict->warnRejectedRegistration(
         ~chainId=fetchState.chainId,

--- a/packages/envio/src/sources/AddressStore.res
+++ b/packages/envio/src/sources/AddressStore.res
@@ -161,8 +161,6 @@ external drainForWrite: (t, int, array<int>) => array<drainedAddress> = "drainFo
 // The registrations still awaiting persistence. For assertions.
 @send external pendingEntries: t => array<Internal.indexingContract> = "pendingEntries"
 @send external makeSetRaw: (t, string, makeSetOptions) => AddressSet.t = "makeSet"
-@send
-external startBlockGroups: (t, string) => array<AddressSet.startBlockGroup> = "startBlockGroups"
 @send external contractCount: (t, string) => int = "contractCount"
 @send external size: t => int = "size"
 
@@ -178,8 +176,6 @@ external startBlockGroups: (t, string) => array<AddressSet.startBlockGroup> = "s
 @send external getRaw: (t, Address.t) => Null.t<Internal.indexingContract> = "get"
 
 @send external contractAddresses: (t, string) => array<Address.t> = "contractAddresses"
-
-@send external entries: t => array<Internal.indexingContract> = "entries"
 
 let toVerdict = (raw: rawVerdict): verdict =>
   switch raw.kind {

--- a/packages/envio/src/sources/AddressStore.res
+++ b/packages/envio/src/sources/AddressStore.res
@@ -9,10 +9,10 @@ type t
 
 // A contract an address may be registered for. Every config contract of every
 // chain, since `context.chain.<Contract>.add` validates against that whole set
-// — a name outside it makes the store throw. `hasEvents` is whether this chain
-// fetches for the contract at all, which is what makes the store able to answer
-// `fetchable` on a verdict.
-type contract = {name: string, startBlock: option<int>, hasEvents: bool}
+// — a name outside it makes the store throw. `dependsOnAddresses` is whether
+// this chain fetches for the contract by address, which is what makes the store
+// able to answer `fetchable` on a verdict.
+type contract = {name: string, startBlock: option<int>, dependsOnAddresses: bool}
 
 type registration = {
   address: Address.t,
@@ -22,7 +22,7 @@ type registration = {
 }
 
 type verdict =
-  // `fetchable` is false when the chain has no address-dependent events for the
+  // `fetchable` is false when nothing on the chain is fetched by address for the
   // contract: the address is still stored and persisted, so a config that later
   // adds events picks it up on restart, but no partition is built from it.
   | Added({effectiveStartBlock: int, fetchable: bool})
@@ -86,11 +86,11 @@ let make = (~ecosystem: Ecosystem.name, ~shouldChecksum: bool, ~contracts: array
 // contract's address gate open from the chain's start, and the per-registration
 // start block still holds back the registrations that declared one.
 //
-// `hasEvents` follows `dependsOnAddresses` rather than the mere presence of a
-// registration: a contract whose events are all wildcard is fetched without
-// consulting addresses, so registering one changes nothing about what's queried.
-// Contracts named only by `configContractNames` carry `false` — their addresses
-// are stored and persisted, never fetched.
+// A contract whose events are all wildcard is fetched without consulting
+// addresses, so registering one changes nothing about what's queried — it
+// carries `dependsOnAddresses: false` just like a contract named only by
+// `configContractNames`. Either way the addresses are stored and persisted,
+// never fetched.
 let contractsOf = (
   ~onEventRegistrations: array<Internal.onEventRegistration>,
   ~configContractNames: array<string>,
@@ -99,7 +99,7 @@ let contractsOf = (
   // storing `None` in a dict would be indistinguishable from "not seen yet".
   let startBlocks: dict<int> = Dict.make()
   let unrestricted = Utils.Set.make()
-  let withEvents = Utils.Set.make()
+  let addressDependent = Utils.Set.make()
   let names = []
   let addName = name =>
     if !(names->Array.includes(name)) {
@@ -109,7 +109,7 @@ let contractsOf = (
     let name = reg.eventConfig.contractName
     addName(name)
     if reg.dependsOnAddresses {
-      withEvents->Utils.Set.add(name)->ignore
+      addressDependent->Utils.Set.add(name)->ignore
     }
     switch reg.startBlock {
     | None => unrestricted->Utils.Set.add(name)->ignore
@@ -129,7 +129,7 @@ let contractsOf = (
     startBlock: unrestricted->Utils.Set.has(name)
       ? None
       : startBlocks->Utils.Dict.dangerouslyGetNonOption(name),
-    hasEvents: withEvents->Utils.Set.has(name),
+    dependsOnAddresses: addressDependent->Utils.Set.has(name),
   })
 }
 

--- a/scenarios/test_codegen/test/DynamicContractPersistence_test.res
+++ b/scenarios/test_codegen/test/DynamicContractPersistence_test.res
@@ -20,42 +20,56 @@ let queryAddresses = (indexerMock: MockIndexer.Indexer.t) =>
 let dcAddress = "0x1111111111111111111111111111111111111111"->Address.Evm.fromStringOrThrow
 let lateDcAddress = "0x2222222222222222222222222222222222222222"->Address.Evm.fromStringOrThrow
 
+let row = (address, contractName, registrationBlock) => (
+  `1337-${address->Address.toString}`,
+  contractName,
+  registrationBlock,
+)
+
 let handler: Internal.genericHandlerArgs<
   MockIndexer.eventLog<unknown>,
   MockIndexer.handlerContext,
 > => promise<unit> = async _ => ()
 
+let startIndexer = async () => {
+  let sourceMock = MockIndexer.Source.make(
+    [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+    ~chainId=#1337,
+  )
+  let indexerMock = await MockIndexer.Indexer.make(
+    ~chains=[{chain: #1337, sourceConfig: Config.CustomSources([sourceMock.source])}],
+  )
+  await Utils.delay(0)
+
+  sourceMock.resolveGetHeightOrThrow(1000)
+  await Utils.delay(0)
+  await Utils.delay(0)
+
+  (sourceMock, indexerMock)
+}
+
+// An event whose only job is to register `address` for `contractName`.
+let registeringItem = (~blockNumber, ~register): MockIndexer.Source.itemMock => {
+  blockNumber,
+  logIndex: 0,
+  handler,
+  contractRegister: async ({context}) => register(context),
+}
+
 describe("Dynamic contract persistence", () => {
   Async.it("writes one row for an address registered by several events", async t => {
-    let sourceMock = MockIndexer.Source.make(
-      [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
-      ~chainId=#1337,
-    )
-    let indexerMock = await MockIndexer.Indexer.make(
-      ~chains=[{chain: #1337, sourceConfig: Config.CustomSources([sourceMock.source])}],
-    )
-    await Utils.delay(0)
-
-    sourceMock.resolveGetHeightOrThrow(1000)
-    await Utils.delay(0)
-    await Utils.delay(0)
+    let (sourceMock, indexerMock) = await startIndexer()
 
     // Two events in different blocks register the same address. The second is a
     // duplicate the store rejects, so only the first is ever written.
     sourceMock.resolveGetItemsOrThrow(
       [
-        {
-          blockNumber: 10,
-          logIndex: 0,
-          handler,
-          contractRegister: async ({context}) => context.chain.\"Gravatar".add(dcAddress),
-        },
-        {
-          blockNumber: 11,
-          logIndex: 0,
-          handler,
-          contractRegister: async ({context}) => context.chain.\"Gravatar".add(dcAddress),
-        },
+        registeringItem(~blockNumber=10, ~register=context =>
+          context.chain.\"Gravatar".add(dcAddress)
+        ),
+        registeringItem(~blockNumber=11, ~register=context =>
+          context.chain.\"Gravatar".add(dcAddress)
+        ),
       ],
       ~resolveAt=#all,
       ~latestFetchedBlockNumber=200,
@@ -69,39 +83,22 @@ describe("Dynamic contract persistence", () => {
     t.expect(
       await queryAddresses(indexerMock),
       ~message="the duplicate registration doesn't produce a second row",
-    ).toEqual([(`1337-${dcAddress->Address.toString}`, "Gravatar", 10)])
+    ).toEqual([row(dcAddress, "Gravatar", 10)])
   })
 
   Async.it("writes no row for an address rejected as a conflict", async t => {
-    let sourceMock = MockIndexer.Source.make(
-      [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
-      ~chainId=#1337,
-    )
-    let indexerMock = await MockIndexer.Indexer.make(
-      ~chains=[{chain: #1337, sourceConfig: Config.CustomSources([sourceMock.source])}],
-    )
-    await Utils.delay(0)
-
-    sourceMock.resolveGetHeightOrThrow(1000)
-    await Utils.delay(0)
-    await Utils.delay(0)
+    let (sourceMock, indexerMock) = await startIndexer()
 
     // One address claimed by two contracts: the first wins, the second is
     // rejected and must not reach the database under either name.
     sourceMock.resolveGetItemsOrThrow(
       [
-        {
-          blockNumber: 10,
-          logIndex: 0,
-          handler,
-          contractRegister: async ({context}) => context.chain.\"Gravatar".add(dcAddress),
-        },
-        {
-          blockNumber: 11,
-          logIndex: 0,
-          handler,
-          contractRegister: async ({context}) => context.chain.\"NftFactory".add(dcAddress),
-        },
+        registeringItem(~blockNumber=10, ~register=context =>
+          context.chain.\"Gravatar".add(dcAddress)
+        ),
+        registeringItem(~blockNumber=11, ~register=context =>
+          context.chain.\"NftFactory".add(dcAddress)
+        ),
       ],
       ~resolveAt=#all,
       ~latestFetchedBlockNumber=200,
@@ -115,22 +112,11 @@ describe("Dynamic contract persistence", () => {
     t.expect(
       await queryAddresses(indexerMock),
       ~message="the conflicting registration is dropped, the first one stands",
-    ).toEqual([(`1337-${dcAddress->Address.toString}`, "Gravatar", 10)])
+    ).toEqual([row(dcAddress, "Gravatar", 10)])
   })
 
   Async.it("writes a registration the first batch didn't progress past", async t => {
-    let sourceMock = MockIndexer.Source.make(
-      [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
-      ~chainId=#1337,
-    )
-    let indexerMock = await MockIndexer.Indexer.make(
-      ~chains=[{chain: #1337, sourceConfig: Config.CustomSources([sourceMock.source])}],
-    )
-    await Utils.delay(0)
-
-    sourceMock.resolveGetHeightOrThrow(1000)
-    await Utils.delay(0)
-    await Utils.delay(0)
+    let (sourceMock, indexerMock) = await startIndexer()
 
     // Both registrations happen at fetch time, but registering the block 10
     // address spawns a partition that hasn't fetched yet — so the first batch
@@ -138,18 +124,12 @@ describe("Dynamic contract persistence", () => {
     // pending until a later batch covers it.
     sourceMock.resolveGetItemsOrThrow(
       [
-        {
-          blockNumber: 10,
-          logIndex: 0,
-          handler,
-          contractRegister: async ({context}) => context.chain.\"Gravatar".add(dcAddress),
-        },
-        {
-          blockNumber: 150,
-          logIndex: 0,
-          handler,
-          contractRegister: async ({context}) => context.chain.\"Gravatar".add(lateDcAddress),
-        },
+        registeringItem(~blockNumber=10, ~register=context =>
+          context.chain.\"Gravatar".add(dcAddress)
+        ),
+        registeringItem(~blockNumber=150, ~register=context =>
+          context.chain.\"Gravatar".add(lateDcAddress)
+        ),
       ],
       ~resolveAt=#all,
       ~latestFetchedBlockNumber=200,
@@ -174,11 +154,8 @@ describe("Dynamic contract persistence", () => {
       ~message="each registration lands in the batch that progressed past its block",
     ).toEqual((
       [],
-      [(`1337-${dcAddress->Address.toString}`, "Gravatar", 10)],
-      [
-        (`1337-${dcAddress->Address.toString}`, "Gravatar", 10),
-        (`1337-${lateDcAddress->Address.toString}`, "Gravatar", 150),
-      ],
+      [row(dcAddress, "Gravatar", 10)],
+      [row(dcAddress, "Gravatar", 10), row(lateDcAddress, "Gravatar", 150)],
     ))
   })
 })

--- a/scenarios/test_codegen/test/helpers/NativeDecoder.res
+++ b/scenarios/test_codegen/test/helpers/NativeDecoder.res
@@ -46,7 +46,7 @@ let decodeLogs = async (
         ~contracts=eventRegistrations->Array.map((reg): AddressStore.contract => {
           name: reg.contractName,
           startBlock: None,
-          hasEvents: true,
+          dependsOnAddresses: true,
         }),
       )
       let addressSet = switch ownedBy {

--- a/scenarios/test_codegen/test/lib_tests/AddressStore_test.res
+++ b/scenarios/test_codegen/test/lib_tests/AddressStore_test.res
@@ -105,11 +105,12 @@ describe("AddressStore", () => {
   })
 
   it("keeps a contract unrestricted when any registration has no start block", t => {
-    let reg = (~contractName, ~startBlock=?) =>
+    let reg = (~contractName, ~startBlock=?, ~isWildcard=false) =>
       (MockIndexer.evmOnEventRegistration(
         ~id=contractName,
         ~contractName,
         ~startBlock?,
+        ~isWildcard,
       ) :> Internal.onEventRegistration)
 
     t.expect({
@@ -144,18 +145,25 @@ describe("AddressStore", () => {
         ~onEventRegistrations=[reg(~contractName="A")],
         ~configContractNames=["A", "NoEvents"],
       ),
+      // A wildcard event is fetched without consulting addresses, so
+      // registering one changes nothing about what's queried.
+      "wildcardOnly": AddressStore.contractsOf(
+        ~onEventRegistrations=[reg(~contractName="A", ~isWildcard=true)],
+        ~configContractNames=["A"],
+      ),
     }).toEqual({
-      "noneThenSome": [({name: "A", startBlock: None, hasEvents: true}: AddressStore.contract)],
-      "someThenNone": [({name: "A", startBlock: None, hasEvents: true}: AddressStore.contract)],
-      "allRestricted": [({name: "A", startBlock: Some(50), hasEvents: true}: AddressStore.contract)],
+      "noneThenSome": [({name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract)],
+      "someThenNone": [({name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract)],
+      "allRestricted": [({name: "A", startBlock: Some(50), dependsOnAddresses: true}: AddressStore.contract)],
       "perContract": [
-        ({name: "B", startBlock: Some(50), hasEvents: true}: AddressStore.contract),
-        ({name: "A", startBlock: None, hasEvents: true}: AddressStore.contract),
+        ({name: "B", startBlock: Some(50), dependsOnAddresses: true}: AddressStore.contract),
+        ({name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract),
       ],
       "configOnly": [
-        ({name: "A", startBlock: None, hasEvents: true}: AddressStore.contract),
-        ({name: "NoEvents", startBlock: None, hasEvents: false}: AddressStore.contract),
+        ({name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract),
+        ({name: "NoEvents", startBlock: None, dependsOnAddresses: false}: AddressStore.contract),
       ],
+      "wildcardOnly": [({name: "A", startBlock: None, dependsOnAddresses: false}: AddressStore.contract)],
     })
   })
 

--- a/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
+++ b/scenarios/test_codegen/test/lib_tests/EvmRpcClient_test.res
@@ -236,7 +236,7 @@ describe("EvmRpcClient - getNextPage via napi", () => {
     let store = AddressStore.make(
       ~ecosystem=Ecosystem.Evm,
       ~shouldChecksum=false,
-      ~contracts=[{name: "ERC20", startBlock: None, hasEvents: true}],
+      ~contracts=[{name: "ERC20", startBlock: None, dependsOnAddresses: true}],
     )
     let _ = store->AddressStore.seedBatch([
       {


### PR DESCRIPTION
Clarify the semantics of the address store's contract configuration by renaming `has_events` / `hasEvents` to `depends_on_addresses` / `dependsOnAddresses`.

The field indicates whether a contract's events on a given chain are fetched *by address* — not merely whether events exist. A contract with only wildcard events (no address filtering) should have this flag set to `false`, since registering addresses for it changes nothing about what gets queried. Similarly, a contract with no events on a chain carries `false`.

In both cases, addresses are still stored and persisted, allowing a config change that later adds address-dependent events to pick them up on restart. But no partition is built from the addresses until then.

**Key changes:**
- Rust: `contract_has_events` → `contract_depends_on_addresses`, `AddressStoreContract.has_events` → `AddressStoreContract.depends_on_addresses`
- ReScript: `hasEvents` → `dependsOnAddresses` across `AddressStore.res`, test files, and generated code
- Updated docstrings and comments to reflect the new semantics
- Removed warning log when an address is registered for a non-address-dependent contract (it's expected behavior)
- Added test case for wildcard-only events to verify they carry `dependsOnAddresses: false`
- Refactored test helpers in `DynamicContractPersistence_test.res` to reduce duplication

https://claude.ai/code/session_01WsjZVbzNzGMFhVw3CmmLuR