### PR TITLE
Fix height subscription stuck at head in multichain indexers

### DIFF
--- a/packages/envio-tests/test/lib_tests/Metrics_test.res
+++ b/packages/envio-tests/test/lib_tests/Metrics_test.res
@@ -45,7 +45,7 @@ newline`->Metrics.escapeLabelValue).toBe(`weird \\"name\\",a=b \\\\ with\\nnewli
       ~name="envio_source_request_seconds_total",
       ~help="Cumulative time spent on data source requests.",
       ~kind="counter",
-      ~entries=[(`{method="getLogs"}`, 1.5), (`{method="heightSubscription"}`, 0.)],
+      ~entries=[(`{method="getLogs"}`, 1.5), (`{method="heightPush"}`, 0.)],
       ~value=v => v !== 0. ? Some(v) : None,
     )
 
@@ -221,6 +221,20 @@ envio_info{version="${Utils.EnvioPackage.value.version}"} 1
           count: 42,
           seconds: 33.75,
         },
+        {
+          source: "HyperSync",
+          chainId: 1->ChainId.fromInt,
+          method: "heightPush",
+          count: 7,
+          seconds: 0.,
+        },
+        {
+          source: "HyperSync",
+          chainId: 1->ChainId.fromInt,
+          method: "heightPushIgnored",
+          count: 0,
+          seconds: 0.,
+        },
       ],
       sourceHeights: [
         {
@@ -351,9 +365,10 @@ envio_indexing_buffer_block{chainId="1"} 260
 # TYPE envio_indexing_end_block gauge
 envio_indexing_end_block{chainId="1"} 1000
 
-# HELP envio_source_request_total The number of requests made to data sources.
+# HELP envio_source_request_total The number of requests made to data sources. Heights pushed by a subscription stream are counted here too, under the heightPush and heightPushIgnored methods.
 # TYPE envio_source_request_total counter
 envio_source_request_total{source="HyperSync",chainId="1",method="getLogs"} 42
+envio_source_request_total{source="HyperSync",chainId="1",method="heightPush"} 7
 
 # HELP envio_source_request_seconds_total Cumulative time spent on data source requests.
 # TYPE envio_source_request_seconds_total counter

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -549,10 +549,13 @@ let targetBlock = (cs: t, ~chainTargetItems: float) => {
   let bufferBlockNumber = fetchState->FetchState.bufferBlockNumber
   switch cs->effectiveDensity {
   | Some(density) if density > 0. =>
+    // Clamped in float space: at low densities chainTargetItems /. density
+    // exceeds the int range, and truncating it first wraps negative — the
+    // target collapses below the frontier and the chain stops querying.
     Pervasives.min(
-      fetchCeiling,
-      bufferBlockNumber + Math.ceil(chainTargetItems /. density)->Float.toInt,
-    )
+      fetchCeiling->Int.toFloat,
+      bufferBlockNumber->Int.toFloat +. Math.ceil(chainTargetItems /. density),
+    )->Float.toInt
   | _ => Pervasives.min(bufferBlockNumber + coldTargetRange, fetchCeiling)
   }
 }

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -549,13 +549,16 @@ let targetBlock = (cs: t, ~chainTargetItems: float) => {
   let bufferBlockNumber = fetchState->FetchState.bufferBlockNumber
   switch cs->effectiveDensity {
   | Some(density) if density > 0. =>
-    // Clamped in float space: at low densities chainTargetItems /. density
-    // exceeds the int range, and truncating it first wraps negative — the
-    // target collapses below the frontier and the chain stops querying.
-    Pervasives.min(
-      fetchCeiling->Int.toFloat,
-      bufferBlockNumber->Int.toFloat +. Math.ceil(chainTargetItems /. density),
-    )->Float.toInt
+    // Decided by comparison so no unbounded value is ever converted to int:
+    // at low densities chainTargetItems /. density exceeds the int range, and
+    // truncating it wraps negative — the target collapses below the frontier
+    // and the chain stops querying. The division only runs when its result is
+    // provably below the ceiling-bounded range.
+    if density *. (fetchCeiling - bufferBlockNumber)->Int.toFloat <= chainTargetItems {
+      fetchCeiling
+    } else {
+      bufferBlockNumber + Math.ceil(chainTargetItems /. density)->Float.toInt
+    }
   | _ => Pervasives.min(bufferBlockNumber + coldTargetRange, fetchCeiling)
   }
 }

--- a/packages/envio/src/Metrics.res
+++ b/packages/envio/src/Metrics.res
@@ -445,15 +445,15 @@ let renderMetrics = (b: builder, metrics: t) => {
     ~entries=chains,
     ~value=m => m.endBlock->Option.map(Int.toFloat),
   )
-  b->series(
+  b->seriesOpt(
     ~name="envio_source_request_total",
-    ~help="The number of requests made to data sources.",
+    ~help="The number of requests made to data sources. Heights pushed by a subscription stream are counted here too, under the heightPush and heightPushIgnored methods.",
     ~kind="counter",
     ~entries=sourceRequests,
-    ~value=s => s.count->Int.toFloat,
+    ~value=s => s.count > 0 ? Some(s.count->Int.toFloat) : None,
   )
-  // Skips a method's seconds line when it has no timing (e.g. heightSubscription,
-  // which only ever records a count).
+  // Skips a method's seconds line when it has no timing (e.g. heightPush, which
+  // only ever records a count).
   b->seriesOpt(
     ~name="envio_source_request_seconds_total",
     ~help="Cumulative time spent on data source requests.",

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -468,16 +468,16 @@ let getSourceNewHeight = async (
               // head on every (re)connect; waking the wait loop on a height we already
               // know spins it and leaks fallback pollers (#1270).
               if newHeight > sourceState.knownHeight {
+                sourceState->recordRequestStats([{Source.method: "heightPush", seconds: 0.}])
                 sourceState.knownHeight = newHeight
                 let resolvers = sourceState.pendingHeightResolvers
                 sourceState.pendingHeightResolvers = []
                 resolvers->Array.forEach(resolve => resolve(newHeight))
+              } else {
+                sourceState->recordRequestStats([{Source.method: "heightPushIgnored", seconds: 0.}])
               }
             })
             sourceState.unsubscribe = Some(unsubscribe)
-            // Count a subscription (re)start rather than every pushed height —
-            // there's no request/response to time here.
-            sourceState->recordRequestStats([{Source.method: "heightSubscription", seconds: 0.}])
           | _ =>
             // Slowdown polling when the chain isn't progressing
             let pollingInterval = if reducedPolling {
@@ -724,9 +724,7 @@ let executeQuery = async (
     ) {
     | Some(s) =>
       if s.source !== sourceManager.activeSource {
-        let logger = Logging.createChild(
-          ~params={"chainId": sourceManager.activeSource.chainId},
-        )
+        let logger = Logging.createChild(~params={"chainId": sourceManager.activeSource.chainId})
         logger->Logging.childInfo({
           "msg": "Switching data-source",
           "source": s.source.name,
@@ -736,9 +734,7 @@ let executeQuery = async (
       }
       s
     | None =>
-      let logger = Logging.createChild(
-        ~params={"chainId": sourceManager.activeSource.chainId},
-      )
+      let logger = Logging.createChild(~params={"chainId": sourceManager.activeSource.chainId})
       %raw(`null`)->ErrorHandling.mkLogAndRaise(~logger, ~msg=noSourcesError)
     }
     sourceManager.activeSource = sourceState.source
@@ -895,9 +891,7 @@ let getBlockHashes = async (sourceManager: t, ~blockNumbers: array<int>, ~isReal
     let sourceState = switch sourceManager->getNextSource(~isRealtime) {
     | Some(s) => s
     | None =>
-      let logger = Logging.createChild(
-        ~params={"chainId": sourceManager.activeSource.chainId},
-      )
+      let logger = Logging.createChild(~params={"chainId": sourceManager.activeSource.chainId})
       %raw(`null`)->ErrorHandling.mkLogAndRaise(
         ~logger,
         ~msg="No data-sources available for fetching block hashes.",

--- a/scenarios/test_codegen/test/HeightPushMetric_test.res
+++ b/scenarios/test_codegen/test/HeightPushMetric_test.res
@@ -1,0 +1,91 @@
+open Vitest
+
+// The height stream pushes heights over SSE, so there's no request to count —
+// only the pushes themselves tell whether a subscribed chain is still being fed.
+// Accepted and ignored pushes are counted separately: a chain frozen at head
+// with `heightPush` flat means the stream went quiet, while `heightPushIgnored`
+// climbing means the stream is alive but re-emitting a head we already know.
+describe("Height subscription push metrics", () => {
+  Async.it("Counts accepted and ignored height pushes separately", async t => {
+    let sourceMock = MockIndexer.Source.make(
+      [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes, #createHeightSubscription],
+      ~chainId=#1337,
+      ~pollingInterval=1,
+    )
+
+    let indexerMock = await MockIndexer.Indexer.make(
+      ~chains=[
+        {
+          chain: #1337,
+          sourceConfig: Config.CustomSources([sourceMock.source]),
+          maxReorgDepth: 0,
+        },
+      ],
+      ~shouldRollbackOnReorg=false,
+      ~reducedPollingInterval=1,
+    )
+    await Utils.delay(0)
+
+    // Backfill to head so the indexer flips to realtime — the height
+    // subscription is only created there.
+    sourceMock.resolveGetHeightOrThrow(100)
+    await Utils.delay(0)
+    await Utils.delay(0)
+
+    await MockIndexer.Helper.waitItemsQuery(sourceMock)
+    sourceMock.resolveGetItemsOrThrow(
+      [{blockNumber: 50, logIndex: 0}],
+      ~latestFetchedBlockNumber=100,
+      ~knownHeight=100,
+    )
+    await indexerMock.getBatchWritePromise()
+
+    // The realtime wait polls once more; a same-height response is what makes
+    // it open the subscription.
+    let subscriptionOpened = () => sourceMock.heightSubscriptionCalls->Array.length > 0
+    let deadline = Date.now() +. 5_000.
+    while !subscriptionOpened() && Date.now() < deadline {
+      try sourceMock.resolveGetHeightOrThrow(100) catch {
+      | _ => ()
+      }
+      await Utils.delay(1)
+    }
+    t.expect(subscriptionOpened(), ~message="the height subscription should be open").toBe(true)
+
+    let heightPushSamples = async () => {
+      let samples = await indexerMock.metric("envio_source_request_total")
+      samples
+      ->Array.filterMap(({value, labels}: MockIndexer.Indexer.metric) =>
+        switch labels->Dict.get("method") {
+        | Some(method) if method->String.startsWith("height") => Some((method, value))
+        | _ => None
+        }
+      )
+      ->Array.toSorted(((a, _), (b, _)) => String.compare(a, b))
+    }
+
+    t.expect(
+      await heightPushSamples(),
+      ~message="opening a subscription is not a request and no push has arrived yet",
+    ).toEqual([])
+
+    // The stream finds a new block.
+    sourceMock.triggerHeightSubscription(101)
+    await MockIndexer.Helper.waitItemsQuery(sourceMock)
+
+    t.expect(
+      await heightPushSamples(),
+      ~message="the accepted push is counted, with no zero-count line for ignored pushes",
+    ).toEqual([("heightPush", "1")])
+
+    // The stream re-emits a head we already know, as it does on reconnect.
+    sourceMock.triggerHeightSubscription(101)
+    sourceMock.triggerHeightSubscription(100)
+    await Utils.delay(0)
+
+    t.expect(
+      await heightPushSamples(),
+      ~message="pushes dropped by the increasing-height guard are counted apart",
+    ).toEqual([("heightPush", "1"), ("heightPushIgnored", "2")])
+  })
+})

--- a/scenarios/test_codegen/test/MultichainStuckAtHead_test.res
+++ b/scenarios/test_codegen/test/MultichainStuckAtHead_test.res
@@ -9,10 +9,10 @@ open Vitest
 // v3.3.0 because sourceState.knownHeight (written only by the subscription
 // callback there) lagged fetchState.knownHeight (raised by getLogs
 // responses). After that, no getHeight request was ever made again
-// ("envio_source_request_total" for getHeight stayed flat,
-// "heightSubscription" stayed 1) and the chain waited for a new block
-// forever. Since v3.3.1 executeQuery syncs sourceState.knownHeight from
-// response heights, which keeps the gap from opening for a single source.
+// ("envio_source_request_total" for getHeight stayed flat) and the chain
+// waited for a new block forever. Since v3.3.1 executeQuery syncs
+// sourceState.knownHeight from response heights, which keeps the gap from
+// opening for a single source.
 describe("Multichain: chain with height subscription stuck at head", () => {
   Async.it(
     "polling fallback takes over when the subscription goes quiet after a partial height advance",

--- a/scenarios/test_codegen/test/MultichainStuckAtHead_test.res
+++ b/scenarios/test_codegen/test/MultichainStuckAtHead_test.res
@@ -1,0 +1,174 @@
+open Vitest
+
+// Regression for v3.3.0: a multichain indexer's chain with a HyperSync height
+// subscription stopped progressing at head while the other chains kept
+// indexing.
+//
+// The wait loop's REST polling fallback short-circuits forever once the
+// subscription advances the wait's height only partially — reachable on
+// v3.3.0 because sourceState.knownHeight (written only by the subscription
+// callback there) lagged fetchState.knownHeight (raised by getLogs
+// responses). After that, no getHeight request was ever made again
+// ("envio_source_request_total" for getHeight stayed flat,
+// "heightSubscription" stayed 1) and the chain waited for a new block
+// forever. Since v3.3.1 executeQuery syncs sourceState.knownHeight from
+// response heights, which keeps the gap from opening for a single source.
+describe("Multichain: chain with height subscription stuck at head", () => {
+  Async.it(
+    "polling fallback takes over when the subscription goes quiet after a partial height advance",
+    async t => {
+      let stuckChain = MockIndexer.Source.make(
+        [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes, #createHeightSubscription],
+        ~chainId=#100,
+        ~pollingInterval=1,
+      )
+      let healthyChain = MockIndexer.Source.make(
+        [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+        ~chainId=#1337,
+        ~pollingInterval=1,
+      )
+
+      let indexerMock = await MockIndexer.Indexer.make(
+        ~chains=[
+          {
+            chain: #100,
+            sourceConfig: Config.CustomSources([stuckChain.source]),
+            maxReorgDepth: 0,
+          },
+          {
+            chain: #1337,
+            sourceConfig: Config.CustomSources([healthyChain.source]),
+            maxReorgDepth: 0,
+          },
+        ],
+        ~shouldRollbackOnReorg=false,
+        ~reducedPollingInterval=1,
+      )
+      await Utils.delay(0)
+
+      // Backfill both chains to head 100 so the indexer flips to realtime —
+      // the height subscription is only created in realtime mode.
+      stuckChain.resolveGetHeightOrThrow(100)
+      healthyChain.resolveGetHeightOrThrow(100)
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      await MockIndexer.Helper.waitItemsQuery(stuckChain)
+      stuckChain.resolveGetItemsOrThrow(
+        [{blockNumber: 50, logIndex: 0}],
+        ~latestFetchedBlockNumber=100,
+        ~knownHeight=100,
+      )
+      await MockIndexer.Helper.waitItemsQuery(healthyChain)
+      healthyChain.resolveGetItemsOrThrow(
+        [{blockNumber: 60, logIndex: 0}],
+        ~latestFetchedBlockNumber=100,
+        ~knownHeight=100,
+      )
+      await indexerMock.getBatchWritePromise()
+
+      // The realtime wait polls height once more; a same-height response is
+      // what makes it open the subscription. Waits parked before the realtime
+      // flip keep REST-polling — feed them the same height until the
+      // subscription appears.
+      let subscriptionOpened = () => stuckChain.heightSubscriptionCalls->Array.length > 0
+      let deadline = Date.now() +. 5_000.
+      while !subscriptionOpened() && Date.now() < deadline {
+        try stuckChain.resolveGetHeightOrThrow(100) catch {
+        | _ => ()
+        }
+        await Utils.delay(1)
+      }
+      t.expect(
+        subscriptionOpened(),
+        ~message="realtime transition should open the height subscription",
+      ).toBe(true)
+      // Release any pre-realtime wait still REST-polling at the same height so
+      // it exits and gets discarded as stale.
+      try stuckChain.resolveGetHeightOrThrow(101) catch {
+      | _ => ()
+      }
+
+      // The stream finds block 101.
+      stuckChain.triggerHeightSubscription(101)
+      await MockIndexer.Helper.waitItemsQuery(stuckChain)
+      t.expect(
+        stuckChain.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+        ~message="the new block from the subscription should be queried",
+      ).toEqual([101])
+      // The getLogs response's archive height is already 102 — ahead of the
+      // stream. It raises fetchState.knownHeight, while on v3.3.0
+      // sourceState.knownHeight stays at the subscription's last height (101).
+      stuckChain.resolveGetItemsOrThrow(
+        [{blockNumber: 101, logIndex: 0}],
+        ~latestFetchedBlockNumber=101,
+        ~knownHeight=102,
+      )
+      await indexerMock.getBatchWritePromise()
+
+      await MockIndexer.Helper.waitItemsQuery(stuckChain)
+      t.expect(
+        stuckChain.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+        ~message="the newly known block 102 should be queried",
+      ).toEqual([102])
+      stuckChain.resolveGetItemsOrThrow(
+        [{blockNumber: 102, logIndex: 0}],
+        ~latestFetchedBlockNumber=102,
+        ~knownHeight=102,
+      )
+      await indexerMock.getBatchWritePromise()
+
+      // The chain is at head again: waiting for a block above 102 while the
+      // wait started from the subscription's last height 101. The stream
+      // re-emits the current head (as it does on reconnect) — a partial
+      // advance within the wait — and then goes quiet for good.
+      await Utils.delay(10)
+      stuckChain.triggerHeightSubscription(102)
+
+      // Meanwhile the other chain keeps progressing, so the cross-chain
+      // scheduler keeps ticking — ticks alone must not be needed to heal the
+      // stuck chain's wait.
+      try healthyChain.resolveGetHeightOrThrow(101) catch {
+      | _ => ()
+      }
+      await MockIndexer.Helper.waitItemsQuery(healthyChain)
+      healthyChain.resolveGetItemsOrThrow(
+        [{blockNumber: 101, logIndex: 0}],
+        ~latestFetchedBlockNumber=101,
+        ~knownHeight=101,
+      )
+      await indexerMock.getBatchWritePromise()
+
+      // The subscription is quiet, so the wait must fall back to REST height
+      // polling within the realtime stall window (10..20s). On v3.3.0 the
+      // fallback short-circuits without a single getHeight request and the
+      // chain stays stuck at head forever.
+      let heightCallsBefore = stuckChain.getHeightOrThrowCalls->Array.length
+      let pollDeadline = Date.now() +. 25_000.
+      while (
+        stuckChain.getHeightOrThrowCalls->Array.length === heightCallsBefore &&
+          Date.now() < pollDeadline
+      ) {
+        await Utils.delay(50)
+      }
+      t.expect(
+        stuckChain.getHeightOrThrowCalls->Array.length > heightCallsBefore,
+        ~message="the polling fallback should take over when the height subscription goes quiet",
+      ).toBe(true)
+
+      t.expect(
+        stuckChain.heightSubscriptionCalls->Array.length,
+        ~message="the subscription should not be recreated",
+      ).toEqual(1)
+
+      // The fallback poll finds block 103 and the chain resumes indexing.
+      stuckChain.resolveGetHeightOrThrow(103)
+      await MockIndexer.Helper.waitItemsQuery(stuckChain)
+      t.expect(
+        stuckChain.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+        ~message="the chain should resume fetching from the fallback-discovered height",
+      ).toEqual([103])
+    },
+    ~timeout=60_000,
+  )
+})

--- a/scenarios/test_codegen/test/SiblingRollbackStuckChain_test.res
+++ b/scenarios/test_codegen/test/SiblingRollbackStuckChain_test.res
@@ -1,0 +1,255 @@
+open Vitest
+
+// A chain at head with a partition query in flight while a reorg on a sibling
+// chain triggers a rollback: the epoch bump drops the in-flight response and
+// prepareReorg/rollback rebuild the chain's partitions. Afterwards the chain
+// must keep fetching — the incident on chain 42161 froze here: waits kept
+// resolving block after block while getNextQuery never produced a query again.
+let configYaml = `
+name: sibling-rollback
+contracts:
+  - name: Token
+    events:
+      - event: Transfer()
+chains:
+  - id: 1
+    start_block: 1
+    contracts:
+      - name: Token
+        address:
+          - "0x0000000000000000000000000000000000000001"
+          - "0x0000000000000000000000000000000000000002"
+  - id: 137
+    start_block: 1
+    contracts:
+      - name: Token
+        address: "0x0000000000000000000000000000000000000001"
+`
+
+let schema = `
+type Counter {
+  id: ID!
+  count: BigInt!
+}
+`
+
+type handlerCounter = {id: string, count: bigint}
+type counterOps = {set: {"id": string, "count": bigint} => unit}
+type handlerContext = {@as("Counter") counter: counterOps}
+
+let setCounter = (~block, ~count: bigint): MockIndexer.Source.itemMock => {
+  blockNumber: block,
+  logIndex: 0,
+  handler: async args => {
+    let context = args.context->(Utils.magic: MockIndexer.handlerContext => handlerContext)
+    context.counter.set({"id": "total", "count": count})
+  },
+}
+
+type tokenOps = {add: Address.t => unit}
+type registerContext = {chain: {"Token": tokenOps}}
+
+// Registers a dynamic Token address, like the factory events the incident
+// chain indexed. Re-runs when the block is re-fetched after a rollback.
+let registerToken = (~block): MockIndexer.Source.itemMock => {
+  blockNumber: block,
+  logIndex: 1,
+  handler: async _ => (),
+  contractRegister: async ({context}) => {
+    let context = context->(Utils.magic: Indexer.contractRegisterContext => registerContext)
+    (context.chain["Token"]).add(
+      "0x0000000000000000000000000000000000000003"->Address.Evm.fromStringOrThrow,
+    )
+  },
+}
+
+describe("Sibling-chain rollback with an in-flight query", () => {
+  Async.it(
+    "chain keeps fetching after its in-flight response is dropped by a sibling rollback",
+    async t => {
+      let {config} = InternalTestIndexer.fromUserApi(~schema, ~configYaml)
+
+      let victim = MockIndexer.Source.make(
+        [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+        ~chainId=#1,
+        ~pollingInterval=1,
+      )
+      let sibling = MockIndexer.Source.make(
+        [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+        ~chainId=#137,
+        ~pollingInterval=1,
+      )
+
+      let indexerMock = await MockIndexer.Indexer.make(
+        ~config,
+        ~chains=[
+          {chain: #1, sourceConfig: Config.CustomSources([victim.source]), maxReorgDepth: 200},
+          {chain: #137, sourceConfig: Config.CustomSources([sibling.source]), maxReorgDepth: 200},
+        ],
+        // Two addresses on chain 1 -> two partitions, so one partition's query
+        // can stay in flight while the other's response lands.
+        ~maxAddrInPartition=1,
+        ~reducedPollingInterval=1,
+      )
+      await Utils.delay(0)
+
+      victim.resolveGetHeightOrThrow(300)
+      sibling.resolveGetHeightOrThrow(300)
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      // Drive both chains to head 300 through the reorg-threshold transition,
+      // resolving every query as it appears.
+      let drainTo = async (source: MockIndexer.Source.t, ~latest, ~items=[]) => {
+        let attempts = ref(0)
+        while source.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
+          attempts := attempts.contents + 1
+          await Utils.delay(0)
+        }
+        source.resolveGetItemsOrThrow(items, ~latestFetchedBlockNumber=latest)
+        await Utils.delay(0)
+        await Utils.delay(0)
+      }
+
+      // Pre-threshold queries stop at 100 (head - maxReorgDepth).
+      await drainTo(victim, ~latest=100)
+      await drainTo(sibling, ~latest=100)
+      await indexerMock.getBatchWritePromise()
+
+      // Post-threshold queries reach the head. The victim's response also
+      // registers a dynamic Token address at block 250, spawning a catch-up
+      // partition mid-response like the incident chain's factory events.
+      await drainTo(
+        victim,
+        ~latest=300,
+        ~items=[setCounter(~block=200, ~count=1n), registerToken(~block=250)],
+      )
+      await drainTo(sibling, ~latest=300, ~items=[setCounter(~block=200, ~count=2n)])
+      // Serve the dynamic partition's catch-up queries until the chain is quiet.
+      let attempts = ref(0)
+      while attempts.contents < 200 {
+        attempts := attempts.contents + 1
+        if victim.getItemsOrThrowCalls->Array.length > 0 {
+          victim.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=300)
+        }
+        await Utils.delay(0)
+      }
+      await indexerMock.getBatchWritePromise()
+      await indexerMock.waitUntilReady()
+
+      // New block on the victim chain. The first partition queries it; its
+      // response lands, which schedules the tick that sends the second
+      // partition's query — that one stays in flight through the rollback,
+      // like partition 7 in the incident.
+      victim.resolveGetHeightOrThrow(301)
+      let attempts = ref(0)
+      while victim.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
+        attempts := attempts.contents + 1
+        try victim.resolveGetHeightOrThrow(301) catch {
+        | _ => ()
+        }
+        await Utils.delay(0)
+      }
+      victim.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=301)
+      let attempts = ref(0)
+      while victim.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
+        attempts := attempts.contents + 1
+        await Utils.delay(0)
+      }
+      t.expect(
+        victim.getItemsOrThrowCalls->Array.length,
+        ~message="the second victim partition should now be querying the new head block",
+      ).toEqual(1)
+
+      // Reorg on the sibling chain: block 300 comes back with a different hash.
+      try sibling.resolveGetHeightOrThrow(301) catch {
+      | _ => ()
+      }
+      let attempts = ref(0)
+      while sibling.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
+        attempts := attempts.contents + 1
+        try sibling.resolveGetHeightOrThrow(301) catch {
+        | _ => ()
+        }
+        await Utils.delay(0)
+      }
+      sibling.resolveGetItemsOrThrow(
+        [],
+        ~latestFetchedBlockNumber=301,
+        ~prevRangeLastBlock={blockNumber: 300, blockHash: "0x300-reorged"},
+      )
+      await Utils.delay(0)
+      // The victim's in-flight response lands inside the rollback window —
+      // after the reorg was detected but before the rollback applied.
+      switch victim.getItemsOrThrowCalls->Array.length {
+      | 0 => ()
+      | _ => victim.resolveGetItemsOrThrow([], ~resolveAt=#last, ~latestFetchedBlockNumber=301)
+      }
+      // The rollback target usually comes from the recorded safe checkpoints;
+      // serve getBlockHashes only if the depth search asks for it.
+      let attempts = ref(0)
+      while sibling.getBlockHashesCalls->Array.length === 0 && attempts.contents < 100 {
+        attempts := attempts.contents + 1
+        await Utils.delay(0)
+      }
+      if sibling.getBlockHashesCalls->Array.length > 0 {
+        sibling.resolveGetBlockHashes([
+          {blockNumber: 100, blockHash: "0x100", blockTimestamp: 100},
+          {blockNumber: 200, blockHash: "0x200", blockTimestamp: 200},
+        ])
+      }
+      await indexerMock.getRollbackReadyPromise()
+
+      // The rollback dropped the victim's pending query bookkeeping; its
+      // response arrives now, carrying the old epoch, and is discarded.
+      switch victim.getItemsOrThrowCalls->Array.length {
+      | 0 => ()
+      | _ => victim.resolveGetItemsOrThrow([], ~resolveAt=#last, ~latestFetchedBlockNumber=301)
+      }
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      // Both chains must resume fetching after the rollback and refetch their
+      // rolled-back ranges — including re-registering the pruned dynamic
+      // address when block 250 is re-delivered. The victim chain is wedged if
+      // it never catches back up to the head.
+      let victimMaxFromBlock = ref(0)
+      let attempts = ref(0)
+      while victimMaxFromBlock.contents < 302 && attempts.contents < 3000 {
+        attempts := attempts.contents + 1
+        victim.getItemsOrThrowCalls
+        ->Utils.Array.copy
+        ->Array.forEach(call => {
+          let fromBlock = call.payload["fromBlock"]
+          let toBlock = call.payload["toBlock"]->Option.getOr(302)
+          if fromBlock > victimMaxFromBlock.contents {
+            victimMaxFromBlock := fromBlock
+          }
+          let latest = Pervasives.min(toBlock, 302)
+          call.resolve(
+            fromBlock <= 250 && 250 <= latest ? [registerToken(~block=250)] : [],
+            ~latestFetchedBlockNumber=latest,
+          )
+        })
+        if sibling.getItemsOrThrowCalls->Array.length > 0 {
+          sibling.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=302)
+        }
+        try victim.resolveGetHeightOrThrow(302) catch {
+        | _ => ()
+        }
+        try sibling.resolveGetHeightOrThrow(302) catch {
+        | _ => ()
+        }
+        await Utils.delay(1)
+      }
+
+      t.expect(
+        victimMaxFromBlock.contents >= 302,
+        ~message="the victim chain should catch back up to the head after the sibling rollback",
+      ).toBe(true)
+
+      await indexerMock.stop()
+    },
+    ~timeout=30_000,
+  )
+})

--- a/scenarios/test_codegen/test/SparseDensityTargetOverflow_test.res
+++ b/scenarios/test_codegen/test/SparseDensityTargetOverflow_test.res
@@ -1,0 +1,69 @@
+open Vitest
+
+// A sparse chain freezes at head: with a low events-per-block density, the
+// target-block computation `bufferBlockNumber + ceil(chainTargetItems /
+// density)` exceeds 2^31 and the float-to-int truncation wraps negative, so
+// the target collapses below every partition's cursor and getNextQuery never
+// emits a query again. The wait loop keeps finding new blocks (knownHeight
+// advances) while the frontier and progress stay frozen — the chain-42161
+// incident on 3.5.1.
+//
+// One event across 30k blocks seeds chainDensity = 1/30000; with the 100k
+// buffer target the division is ~3e9, which truncates to a negative int.
+describe("Sparse-density target overflow", () => {
+  Async.it(
+    "keeps fetching new head blocks when the chain density is very low",
+    async t => {
+      let sourceMock = MockIndexer.Source.make(
+        [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
+        ~chainId=#1337,
+        ~pollingInterval=1,
+      )
+      let indexerMock = await MockIndexer.Indexer.make(
+        ~chains=[
+          {
+            chain: #1337,
+            sourceConfig: Config.CustomSources([sourceMock.source]),
+            maxReorgDepth: 0,
+          },
+        ],
+        ~shouldRollbackOnReorg=false,
+        ~targetBufferSize=100_000,
+        ~reducedPollingInterval=1,
+      )
+      await Utils.delay(0)
+
+      sourceMock.resolveGetHeightOrThrow(30_000)
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      // One event over the whole 30k-block range: the batch seeds the chain
+      // density at ~1/30000 events per block.
+      await MockIndexer.Helper.waitItemsQuery(sourceMock)
+      sourceMock.resolveGetItemsOrThrow(
+        [{blockNumber: 5, logIndex: 0}],
+        ~latestFetchedBlockNumber=30_000,
+      )
+      await indexerMock.getBatchWritePromise()
+
+      // A new block arrives. The chain is one block behind the head and must
+      // query it — on the broken version the wrapped target block leaves every
+      // partition out of range and the chain only ever waits.
+      let attempts = ref(0)
+      while sourceMock.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 2000 {
+        attempts := attempts.contents + 1
+        try sourceMock.resolveGetHeightOrThrow(30_001) catch {
+        | _ => ()
+        }
+        await Utils.delay(1)
+      }
+      t.expect(
+        sourceMock.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+        ~message="the chain should query the new head block despite its low event density",
+      ).toEqual([30_001])
+
+      await indexerMock.stop()
+    },
+    ~timeout=30_000,
+  )
+})

--- a/scenarios/test_codegen/test/lib_tests/FetchStateFuzz_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchStateFuzz_test.res
@@ -103,11 +103,11 @@ let fail = (run, ~seed, ~message) =>
 let tick = (run: run, ~waterfall=5000.) => {
   let buffer = run.fetchState->FetchState.bufferBlockNumber
   let ceiling = run.knownHeight
-  let target =
-    Pervasives.min(
-      ceiling->Int.toFloat,
-      buffer->Int.toFloat +. Math.ceil(waterfall /. run.density),
-    )->Float.toInt
+  let target = if run.density *. (ceiling - buffer)->Int.toFloat <= waterfall {
+    ceiling
+  } else {
+    buffer + Math.ceil(waterfall /. run.density)->Float.toInt
+  }
   let rangeCost = run.density *. (target - buffer)->Int.toFloat
   let budget = Pervasives.min(waterfall, Math.ceil(rangeCost) +. run.pendingBudget)
   switch run.fetchState->FetchState.getNextQuery(

--- a/scenarios/test_codegen/test/lib_tests/FetchStateFuzz_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchStateFuzz_test.res
@@ -169,7 +169,7 @@ let respond = (run: run, ~rng, ~index) => {
   run->log(`r p${q.partitionId}@${q.fromBlock->Int.toString}->${latest->Int.toString}`)
 }
 
-let checkInvariants = (run: run, ~seed) => {
+let checkInvariants = (run: run, ~seed, ~rng) => {
   run
   ->partitions
   ->Array.forEach(p => {
@@ -185,11 +185,14 @@ let checkInvariants = (run: run, ~seed) => {
     })
   })
   // With nothing in flight and a partition behind the head, a production tick
-  // must dispatch. Roll back the dispatch bookkeeping right after: the check
-  // must not perturb the run, so respond to what it started.
+  // must dispatch. Land whatever the probe started so the check leaves the run
+  // with an empty in-flight set and later ops keep their intended coverage.
   if run.inFlight->Utils.Array.isEmpty && run->minFrontier < run.knownHeight {
     if run->tick === 0 {
       run->fail(~seed, ~message="chain is frozen: behind the head with budget but no query")
+    }
+    while !(run.inFlight->Utils.Array.isEmpty) {
+      run->respond(~rng, ~index=0)
     }
   }
 }
@@ -261,7 +264,7 @@ let runSeed = (~seed, ~ops) => {
         )
       run->log(`rollback->${target->Int.toString}`)
     }
-    run->checkInvariants(~seed)
+    run->checkInvariants(~seed, ~rng)
   }
 
   // Drain: land every response, then keep ticking and responding until the

--- a/scenarios/test_codegen/test/lib_tests/FetchStateFuzz_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchStateFuzz_test.res
@@ -1,0 +1,317 @@
+open Vitest
+
+// State-machine fuzz over FetchState's public API, driven the way ChainState
+// drives it in production: ticks with the density-capped budget, responses
+// landing out of order and partially, dynamic registrations arriving from
+// responses, and occasional sibling-triggered rollbacks.
+//
+// Hunts the chain-42161 freeze on 3.5.1: a partition left with a pending query
+// that no response will ever clear (a "ghost") starves the whole chain —
+// its reservation eats the density-capped budget in acceptCandidates every
+// tick, and its unfetched entry pins isFetching so merge retirement never
+// runs, freezing bufferBlockNumber.
+//
+// Invariants checked after every op:
+// - no partition holds two pending queries with the same fromBlock (responses
+//   are matched by fromBlock, so a duplicate leaves an eternal ghost)
+// - with nothing in flight and a partition behind the head, a tick with the
+//   production budget formula must produce a query (no silent freeze)
+// - at quiescence every pending query has cleared
+
+let mulberry32: int => (unit => float) = %raw(`(seed) => {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}`)
+
+let contractNames = ["Gravatar", "NftFactory"]
+
+let makeAddress = (rng: unit => float) => {
+  let hex = "0123456789abcdef"
+  let chars = Array.fromInitializer(~length=40, _ =>
+    hex->String.charAt((rng() *. 16.)->Float.toInt)
+  )
+  ("0x" ++ chars->Array.join(""))->Address.Evm.fromStringOrThrow
+}
+
+type run = {
+  mutable fetchState: FetchState.t,
+  addressStore: AddressStore.t,
+  mutable knownHeight: int,
+  mutable pendingBudget: float,
+  inFlight: array<FetchState.query>,
+  density: float,
+  opLog: array<string>,
+}
+
+let log = (run, op) => {
+  run.opLog->Array.push(op)->ignore
+  if run.opLog->Array.length > 60 {
+    run.opLog->Array.shift->ignore
+  }
+}
+
+let partitions = (run: run) =>
+  run.fetchState.optimizedPartitions.entities->Dict.valuesToArray
+
+let minFrontier = (run: run) =>
+  run
+  ->partitions
+  ->Array.reduce(run.knownHeight, (min, p) =>
+    p.latestFetchedBlock.blockNumber < min ? p.latestFetchedBlock.blockNumber : min
+  )
+
+let describePartitions = (run: run) =>
+  run
+  ->partitions
+  ->Array.map(p =>
+    `{id:${p.id} lfb:${p.latestFetchedBlock.blockNumber->Int.toString} merge:${switch p.mergeBlock {
+      | Some(m) => m->Int.toString
+      | None => "-"
+      }} dyn:${p.dynamicContract->Option.getOr("-")} addrs:${p.addresses
+      ->AddressSet.size
+      ->Int.toString} depAddrs:${p.selection.dependsOnAddresses ? "y" : "n"} selStart:${switch p.selection.startBlock {
+      | Some(s) => s->Int.toString
+      | None => "-"
+      }} cap:${p.sourceRangeCapacity->Int.toString}/${p.prevSourceRangeCapacity->Int.toString} dens:${switch p.eventDensity {
+      | Some(d) => d->Float.toString
+      | None => "-"
+      }} pending:[${p.mutPendingQueries
+      ->Array.map(pq =>
+        `${pq.fromBlock->Int.toString}..${switch pq.toBlock {
+          | Some(t) => t->Int.toString
+          | None => "∞"
+          }}${pq.fetchedBlock === None ? "?" : "!"}`
+      )
+      ->Array.join(",")}]}`
+  )
+  ->Array.join(" ")
+
+let fail = (run, ~seed, ~message) =>
+  JsError.throwWithMessage(
+    `${message} (seed ${seed->Int.toString}, height ${run.knownHeight->Int.toString})\n` ++
+    `partitions: ${run->describePartitions}\n` ++
+    `ops: ${run.opLog->Array.join(" | ")}`,
+  )
+
+// Mirrors ChainState.getNextQuery's target and density-capped budget. Returns
+// the number of queries dispatched.
+let tick = (run: run, ~waterfall=5000.) => {
+  let buffer = run.fetchState->FetchState.bufferBlockNumber
+  let ceiling = run.knownHeight
+  let target =
+    Pervasives.min(
+      ceiling->Int.toFloat,
+      buffer->Int.toFloat +. Math.ceil(waterfall /. run.density),
+    )->Float.toInt
+  let rangeCost = run.density *. (target - buffer)->Int.toFloat
+  let budget = Pervasives.min(waterfall, Math.ceil(rangeCost) +. run.pendingBudget)
+  switch run.fetchState->FetchState.getNextQuery(
+    ~chainTargetBlock=target,
+    ~chainTargetItems=budget,
+  ) {
+  | Ready(queries) =>
+    run.fetchState->FetchState.startFetchingQueries(~queries)
+    queries->Array.forEach(q => {
+      run.pendingBudget = run.pendingBudget +. q.itemsEst->Int.toFloat
+      run.inFlight->Array.push(q)->ignore
+      run->log(`q p${q.partitionId}@${q.fromBlock->Int.toString}`)
+    })
+    queries->Array.length
+  | WaitingForNewBlock =>
+    run->log("wait")
+    0
+  | NothingToQuery =>
+    run->log("idle")
+    0
+  }
+}
+
+let respond = (run: run, ~rng, ~index) => {
+  let q = run.inFlight->Array.getUnsafe(index)
+  run.inFlight->Array.splice(~start=index, ~remove=1, ~insert=[])->ignore
+  let upper = Pervasives.min(q.toBlock->Option.getOr(run.knownHeight), run.knownHeight)
+  let upper = Pervasives.max(upper, q.fromBlock)
+  let latest = q.fromBlock + (rng() *. (upper - q.fromBlock + 1)->Int.toFloat)->Float.toInt
+  let latest = Pervasives.min(latest, upper)
+  // A response occasionally registers dynamic contracts, applied before the
+  // response the way ChainState.handleQueryResult does.
+  if rng() < 0.15 {
+    let contractName =
+      contractNames->Array.getUnsafe((rng() *. 2.)->Float.toInt)
+    let registrationBlock =
+      q.fromBlock + (rng() *. (latest - q.fromBlock + 1)->Int.toFloat)->Float.toInt
+    run.fetchState =
+      run.fetchState->FetchState.registerDynamicContracts(
+        ~addressStore=run.addressStore,
+        ~claimCeiling=Pervasives.max(run.knownHeight, latest),
+        [
+          {
+            address: makeAddress(rng),
+            contractName,
+            registrationBlock,
+          },
+        ],
+      )
+    run->log(`reg ${contractName}@${registrationBlock->Int.toString}`)
+  }
+  run.fetchState =
+    run.fetchState->FetchState.handleQueryResult(
+      ~query=q,
+      ~latestFetchedBlock={blockNumber: latest, blockTimestamp: 0},
+      ~newItems=[],
+    )
+  run.pendingBudget = Pervasives.max(0., run.pendingBudget -. q.itemsEst->Int.toFloat)
+  run->log(`r p${q.partitionId}@${q.fromBlock->Int.toString}->${latest->Int.toString}`)
+}
+
+let checkInvariants = (run: run, ~seed) => {
+  run
+  ->partitions
+  ->Array.forEach(p => {
+    let seen = Utils.Set.make()
+    p.mutPendingQueries->Array.forEach(pq => {
+      if seen->Utils.Set.has(pq.fromBlock) {
+        run->fail(
+          ~seed,
+          ~message=`partition ${p.id} holds two pending queries at fromBlock ${pq.fromBlock->Int.toString}`,
+        )
+      }
+      seen->Utils.Set.add(pq.fromBlock)->ignore
+    })
+  })
+  // With nothing in flight and a partition behind the head, a production tick
+  // must dispatch. Roll back the dispatch bookkeeping right after: the check
+  // must not perturb the run, so respond to what it started.
+  if run.inFlight->Utils.Array.isEmpty && run->minFrontier < run.knownHeight {
+    if run->tick === 0 {
+      run->fail(~seed, ~message="chain is frozen: behind the head with budget but no query")
+    }
+  }
+}
+
+let runSeed = (~seed, ~ops) => {
+  let rng = mulberry32(seed)
+  let onEventRegistrations = [
+    (MockIndexer.evmOnEventRegistration(~id="0", ~contractName="Gravatar") :> Internal.onEventRegistration),
+    (MockIndexer.evmOnEventRegistration(~id="1", ~contractName="NftFactory") :> Internal.onEventRegistration),
+  ]
+  let addresses = [
+    {
+      Internal.address: Envio.TestHelpers.Addresses.mockAddresses[0]->Option.getOrThrow,
+      contractName: "Gravatar",
+      registrationBlock: -1,
+    },
+  ]
+  let addressStore = TestAddresses.makeStore(~onEventRegistrations, ~addresses)
+  let run = {
+    fetchState: FetchState.make(
+      ~onEventRegistrations,
+      ~addressStore,
+      ~addresses,
+      ~startBlock=0,
+      ~endBlock=None,
+      ~maxAddrInPartition=2,
+      ~maxOnBlockBufferSize=5000,
+      ~chainId=1->ChainId.fromInt,
+      ~knownHeight=0,
+    ),
+    addressStore,
+    knownHeight: 100,
+    pendingBudget: 0.,
+    inFlight: [],
+    // Sparse chains decay the density EMA toward zero; sample the low range
+    // where the budget cap sits at ~1 item per tick.
+    density: Math.pow(10., ~exp=-1. -. rng() *. 5.),
+    opLog: [],
+  }
+  run.fetchState = run.fetchState->FetchState.updateKnownHeight(~knownHeight=run.knownHeight)
+
+  for _ in 1 to ops {
+    let roll = rng()
+    if roll < 0.3 {
+      // New blocks found.
+      run.knownHeight = run.knownHeight + 1 + (rng() *. 10.)->Float.toInt
+      run.fetchState = run.fetchState->FetchState.updateKnownHeight(~knownHeight=run.knownHeight)
+      run->log(`h${run.knownHeight->Int.toString}`)
+    } else if roll < 0.6 {
+      let _ = run->tick
+    } else if roll < 0.95 || run.inFlight->Utils.Array.isEmpty {
+      if !(run.inFlight->Utils.Array.isEmpty) {
+        run->respond(~rng, ~index=(rng() *. run.inFlight->Array.length->Int.toFloat)->Float.toInt)
+      } else {
+        let _ = run->tick
+      }
+    } else {
+      // A reorg on a sibling chain: in-flight responses get stale-dropped, the
+      // budget and pending queries reset, and the fetch state rolls back.
+      run.inFlight->Utils.Array.clearInPlace
+      run.pendingBudget = 0.
+      run.fetchState = run.fetchState->FetchState.resetPendingQueries
+      let upper = Pervasives.max(run->minFrontier, 1)
+      let target = (rng() *. upper->Int.toFloat)->Float.toInt
+      run.fetchState =
+        run.fetchState->FetchState.rollback(
+          ~addressStore=run.addressStore,
+          ~targetBlockNumber=target,
+        )
+      run->log(`rollback->${target->Int.toString}`)
+    }
+    run->checkInvariants(~seed)
+  }
+
+  // Drain: land every response, then keep ticking and responding until the
+  // chain goes quiet. A pending query that never clears, or a frontier that
+  // can't reach the head, is the freeze.
+  let attempts = ref(0)
+  while (
+    (!(run.inFlight->Utils.Array.isEmpty) || run->minFrontier < run.knownHeight) &&
+      attempts.contents < 500
+  ) {
+    attempts := attempts.contents + 1
+    while !(run.inFlight->Utils.Array.isEmpty) {
+      run->respond(~rng, ~index=0)
+    }
+    let _ = run->tick(~waterfall=100000.)
+  }
+  if run->minFrontier < run.knownHeight {
+    let probe = (~target, ~budget) =>
+      switch run.fetchState->FetchState.getNextQuery(
+        ~chainTargetBlock=target,
+        ~chainTargetItems=budget,
+      ) {
+      | Ready(queries) =>
+        `Ready(${queries
+          ->Array.map(q => `p${q.partitionId}@${q.fromBlock->Int.toString}`)
+          ->Array.join(",")})`
+      | WaitingForNewBlock => "Wait"
+      | NothingToQuery => "Nothing"
+      }
+    run->fail(
+      ~seed,
+      ~message=`drain could not bring the chain to the head; probes: ` ++
+      `head/100k=${probe(~target=run.knownHeight, ~budget=100000.)} ` ++
+      `head/1=${probe(~target=run.knownHeight, ~budget=1.)} ` ++
+      `buffer+1/100k=${probe(~target=run->minFrontier + 1, ~budget=100000.)}`,
+    )
+  }
+  run
+  ->partitions
+  ->Array.forEach(p => {
+    if p.mutPendingQueries->Array.some(pq => pq.fetchedBlock === None) {
+      run->fail(~seed, ~message=`partition ${p.id} still holds an unfetched pending query`)
+    }
+  })
+}
+
+describe("FetchState state-machine fuzz", () => {
+  it("keeps every partition fetchable through random ticks, responses, registrations and rollbacks", _t => {
+    for seed in 1 to 300 {
+      runSeed(~seed, ~ops=250)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Investigation and fixes for two production incidents where one chain of a multichain indexer silently stopped progressing at head while its wait loop kept finding new blocks.

### Incident 1 — v3.3.0, chain 130 (height-subscription fallback deadlock)

When the height subscription advanced a wait only partially (its last pushed height landed between the wait's starting height and `fetchState.knownHeight`) and then went quiet, the REST polling fallback short-circuited forever without a single `getHeight` request — the `!(newHeight.contents > initialHeight)` guard was permanently true. Reachable only on v3.3.0, where `sourceState.knownHeight` was written solely by the subscription callback while getLogs responses raised `fetchState.knownHeight` past it; #1441 (v3.3.1) incidentally closed the gap by syncing `sourceState.knownHeight` from response heights.

- `MultichainStuckAtHead_test.res` — regression test (fails on v3.3.0, passes since v3.3.1).

### Incident 2 — v3.5.1, chain 42161 (sparse-density target-block overflow)

`ChainState.targetBlock` computed `bufferBlockNumber + Math.ceil(chainTargetItems /. density)->Float.toInt`. `Float.toInt` is a signed 32-bit truncation, and on a sparse chain the density EMA decays toward zero through empty batches — once it drops below ~`chainTargetItems / 2^31` (≈4.7e-5 events/block with the default 100k buffer target) the division exceeds the int range and wraps negative. The target block collapses below every partition's cursor, `getNextQuery` stops emitting queries, and the chain waits at head forever while `knownHeight` keeps advancing. A restart heals it (the density EMA is in-memory) until the density decays again.

`targetBlock` now decides by comparison — when the density-implied cost of reaching the fetch ceiling fits the budget, the target is the ceiling outright; the division only runs when its result is provably inside the ceiling-bounded range, so the `[frontier, fetchCeiling]` invariant holds by construction and no unbounded value is ever converted to int.

- `SparseDensityTargetOverflow_test.res` — MockIndexer repro: one event over 30k blocks seeds a 1/30000 density; the chain must still query the next head block (failed before the fix).
- `FetchStateFuzz_test.res` — seeded state-machine fuzz over `FetchState`'s public API, driven the way `ChainState` drives it (density-capped budget ticks, out-of-order partial responses, mid-response dynamic registrations, sibling rollbacks), asserting no duplicate-fromBlock pending queries and that a chain behind the head with budget always keeps querying. Found the frozen state on seed 4 of 300; stays in CI as a liveness guard for the whole bug family.

Note: #1537 independently fixes the same root cause with a float-space clamp; this PR's comparison-structured version supersedes it and carries the repro + fuzz.

### Metrics

`envio_source_request_total{method="heightSubscription"}` (which only counted subscription starts and stayed at 1 while a stuck chain looked healthy) is replaced by `heightPush` (accepted stream heights) and `heightPushIgnored` (dropped by the increasing-height guard). A stuck chain with `heightPush` flat means the stream went quiet; `heightPushIgnored` climbing means the stream is alive but re-serving a known head. Zero-count entries render no sample. **Breaking for dashboards/alerts referencing `heightSubscription`** — worth a release-note line.

### Additional coverage

- `SiblingRollbackStuckChain_test.res` — sibling-chain reorg rolls the indexer back while the victim chain has a partition query in flight, with a dynamic address pruned by the rollback and re-registered on refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nUAHxdvLi5whfp7qGeTAL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Metrics**
  - Added Prometheus metrics for accepted height-subscription pushes and ignored stale or repeated pushes.
  - Metrics output now omits inactive source-request methods and documents height-push methods.

- **Bug Fixes**
  - Improved recovery when height subscriptions stop advancing, allowing REST polling to resume without recreating subscriptions.
  - Ensured affected chains continue fetching while others progress normally.
  - Improved recovery after sibling-chain rollbacks, preventing stale responses from blocking indexing.
  - Prevented overflow and incorrect block targets when indexing with very sparse event density.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->