### PR TITLE
Fix sparse-chain target block overflow

### DIFF
--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -549,10 +549,12 @@ let targetBlock = (cs: t, ~chainTargetItems: float) => {
   let bufferBlockNumber = fetchState->FetchState.bufferBlockNumber
   switch cs->effectiveDensity {
   | Some(density) if density > 0. =>
-    Pervasives.min(
-      fetchCeiling,
-      bufferBlockNumber + Math.ceil(chainTargetItems /. density)->Float.toInt,
+    let remainingBlocks = fetchCeiling - bufferBlockNumber
+    let targetRange = Pervasives.min(
+      Math.ceil(chainTargetItems /. density),
+      remainingBlocks->Int.toFloat,
     )
+    bufferBlockNumber + targetRange->Float.toInt
   | _ => Pervasives.min(bufferBlockNumber + coldTargetRange, fetchCeiling)
   }
 }

--- a/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/CrossChainState_test.res
@@ -950,6 +950,18 @@ describe("ChainState cold start", () => {
 })
 
 describe("ChainState density from the ready buffer", () => {
+  it("clamps a sparse-chain target span before converting it to an int", t => {
+    // 100k items at this density implies ~2.86b blocks, beyond signed int32.
+    // Converting before clamping wraps the target negative and stalls fetching.
+    let cs = makeFetchingChainState(
+      ~chainId=1->ChainId.fromInt,
+      ~knownHeight=30_000_000,
+      ~latestFetchedBlock=29_000_000,
+      ~chainDensity=Some(0.000035),
+    )
+    t.expect(cs->ChainState.targetBlock(~chainTargetItems=100_000.)).toBe(30_000_000)
+  })
+
   it("a dense ready buffer overrides a stale-low processing EMA", t => {
     // 100 ready items over the 101-block span (-1 committed progress ->
     // frontier 100) prove ~1 item/block even though the EMA says 0.001.


### PR DESCRIPTION
## Summary

- clamp density-derived block spans to the remaining fetchable range before converting them to integers
- prevent sparse chains from producing negative target blocks and stalling query scheduling
- cover block-span estimates beyond the signed 32-bit range with a regression test

## Root cause

The scheduler converts its shared item budget into a target block using the chain's effective item density.

With the default 100,000-item target, a density below approximately `0.0000466` items per block produces an estimated span larger than the signed 32-bit maximum. For example, a density of `0.000035` implies a span of approximately 2.86 billion blocks.

`Float.toInt` performs a signed 32-bit conversion. Because the conversion happened before the result was clamped to the fetchable head, the estimated span wrapped to a negative integer. Adding it to the current frontier produced a negative target block.

The scheduler then stopped producing block-range queries even though source-height polling continued normally. This can leave progress permanently behind the head and makes the failure look like an RPC or realtime handoff problem.

The fix clamps the floating-point estimate to the remaining fetchable block range before converting the bounded value to an integer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block targeting for sparse chains and limited fetch ranges.
  * Prevented invalid negative target blocks when processing chains with known heights.

* **Tests**
  * Added regression coverage for sparse-chain targeting and overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->