### PR TITLE
Refactor field selection into a shared type across ecosystems

### DIFF
--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -2860,6 +2860,11 @@ impl FieldSelection {
         // Every block field is derivable from `eth_getBlockByNumber`, so only
         // transactions have an RPC-unavailable set: the two whose complex array
         // shape has no parser in `RpcSource`'s field registry.
+        //
+        // The runtime re-checks this over every registration in
+        // `HandlerRegister.validateRpcFieldSelection`, which is the only check
+        // an inline `fields` selection reaches. This one runs at codegen, so a
+        // `config.yaml` selection fails before a project is even built.
         if has_rpc_src {
             let invalid_rpc_tx_fields: Vec<_> = transaction_fields
                 .iter()

--- a/packages/envio-tests/test/ClientAddressFilter_test.res
+++ b/packages/envio-tests/test/ClientAddressFilter_test.res
@@ -91,7 +91,6 @@ describe("the registration carries its address-param groups", () => {
       ~contractRegister=None,
       ~where=Some(eventFilters),
       ~chainId=1->ChainId.fromInt,
-      ~enableRawEvents=false,
       ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
     )
 

--- a/packages/envio-tests/test/EvmHandlersApi_test.res
+++ b/packages/envio-tests/test/EvmHandlersApi_test.res
@@ -41,6 +41,20 @@ chains:
 
 let check = handlers => InternalTestIndexer.fromUserApi(~schema=ApiTypesFixtures.schema, ~handlers, ~configYaml)->ignore
 
+// For the cases that must NOT type-check: returns the type errors instead of
+// throwing them.
+let checkResult = handlers =>
+  try {
+    check(handlers)
+    "no type error"
+  } catch {
+  | JsExn(e) => e->JsExn.message->Option.getOr("no message")
+  }
+
+let aliasPreamble = `import { indexer, type EvmOnEventOptions } from "envio";
+type Transfer = { contractName: "Token"; eventName: "Transfer" };
+`
+
 describe("EVM API types", () => {
   it("resolves config-bound chain/contract name and id unions", _ =>
     check(`
@@ -153,7 +167,10 @@ expectType<
       readonly event: "Synced";
       readonly wildcard?: boolean;
       readonly where?: EvmOnEventWhere<{}, "Token">;
-      readonly fields?: EvmFieldsSelection;
+      // The alias can't infer the selection the way a call site does, so it
+      // defaults to naming no fields rather than to the widened selection —
+      // which \`onEvent\` would only reject.
+      readonly fields?: undefined;
     }
   >
 >(true);
@@ -767,6 +784,82 @@ expectType<SingleOrMultiple<Address>>(_multi);
 expectType<
   TypeEqual<Logger["info"], (message: string, params?: Record<string, unknown> | Error) => void>
 >(true);
+`)
+  )
+
+  // An options value declared through the alias has to stay assignable to what
+  // `onEvent` accepts. The selection is the part the alias can't infer, so its
+  // default decides whether the other options survive the round trip.
+  it("accepts alias-declared options that name no selection", _ =>
+    check(
+      aliasPreamble ++ `
+const plain: EvmOnEventOptions<Transfer> = { contract: "Token", event: "Transfer" };
+indexer.onEvent(plain, async () => {});
+
+const filtered: EvmOnEventOptions<Transfer> = {
+  contract: "Token",
+  event: "Transfer",
+  where: ({ chain }) => chain.id === 1,
+};
+indexer.onEvent(filtered, async () => {});
+`,
+    )
+  )
+
+  it("accepts an alias-declared selection passed as the Fields generic", _ =>
+    check(
+      aliasPreamble ++ `
+const fields = { transaction: ["to"] } as const;
+const opts: EvmOnEventOptions<Transfer, {}, typeof fields> = {
+  contract: "Token",
+  event: "Transfer",
+  fields,
+};
+indexer.onEvent(opts, async () => {});
+`,
+    )
+  )
+
+  // Rejected at the declaration rather than at the `onEvent` call: the alias
+  // widens the selection to its element types, which no longer name the fields
+  // the registration listed.
+  it("rejects an alias-declared selection without the Fields generic", t =>
+    t.expect(
+      checkResult(
+        aliasPreamble ++ `
+const opts: EvmOnEventOptions<Transfer> = {
+  contract: "Token",
+  event: "Transfer",
+  fields: { transaction: ["to"] },
+};
+indexer.onEvent(opts, async () => {});
+`,
+      )->String.includes("is not assignable to type 'undefined'"),
+    ).toBe(true)
+  )
+
+  it("accepts alias-declared contractRegister options", _ =>
+    check(`
+import { indexer, type EvmContractRegisterOptions } from "envio";
+type Transfer = { contractName: "Token"; eventName: "Transfer" };
+const opts: EvmContractRegisterOptions<Transfer> = { contract: "Token", event: "Transfer" };
+indexer.contractRegister(opts, async () => {});
+`)
+  )
+
+  // `EvmFieldsSelection`'s own keys are optional, so a selection annotated with
+  // any type derived from it lists its fields under optional keys. Those name
+  // the same selection the runtime resolves, and have to type as selected.
+  it("narrows fields listed under optional keys", _ =>
+    check(`
+import { indexer } from "envio";
+import { expectType, type TypeEqual } from "ts-expect";
+
+const pinned: { block?: readonly ["parentHash"] } = { block: ["parentHash"] };
+indexer.onEvent({ contract: "Token", event: "Transfer", fields: pinned }, async ({ event }) => {
+  expectType<TypeEqual<typeof event.block.parentHash, string>>(true);
+  expectType<TypeEqual<typeof event.block.number, number>>(true);
+});
 `)
   )
 })

--- a/packages/envio-tests/test/EvmInlineFieldSelection_test.res
+++ b/packages/envio-tests/test/EvmInlineFieldSelection_test.res
@@ -152,6 +152,27 @@ chains:
 `,
 ).config
 
+let multichainConfig = InternalTestIndexer.fromUserApi(
+  ~configYaml=`
+name: inline-field-selection-multichain
+contracts:
+  - name: Token
+    events:
+      - event: Transfer(address indexed from, address indexed to, uint256 value)
+chains:
+  - id: 1
+    start_block: 0
+    contracts:
+      - name: Token
+        address: "0x1111111111111111111111111111111111111111"
+  - id: 137
+    start_block: 0
+    contracts:
+      - name: Token
+        address: "0x2222222222222222222222222222222222222222"
+`,
+).config
+
 let rpcConfig = InternalTestIndexer.fromUserApi(
   ~configYaml=`
 name: inline-field-selection-rpc
@@ -171,9 +192,9 @@ chains:
 `,
 ).config
 
-let selections = (registrations: HandlerRegister.registrationsByChainId) => {
+let selections = (registrations: HandlerRegister.registrationsByChainId, ~chain="1") => {
   let chainRegistrations: HandlerRegister.chainRegistrations =
-    registrations->Utils.Dict.dangerouslyGetNonOption("1")->Option.getOrThrow
+    registrations->Utils.Dict.dangerouslyGetNonOption(chain)->Option.getOrThrow
   chainRegistrations.onEventRegistrations->Array.map(reg => (
     reg.fieldSelection.blockFields->Utils.Set.toArray->Array.toSorted(String.compare),
     reg.fieldSelection.transactionFields->Utils.Set.toArray->Array.toSorted(String.compare),
@@ -191,6 +212,14 @@ let register = (~config, fn) => {
 
 let setHandler = (~fields=?, ~where=?, ()) =>
   HandlerRegister.setHandler(
+    ~contractName="Token",
+    ~eventName="Transfer",
+    %raw(`() => Promise.resolve()`),
+    ~eventOptions=Some({?fields, ?where}),
+  )
+
+let setContractRegister = (~fields=?, ~where=?, ()) =>
+  HandlerRegister.setContractRegister(
     ~contractName="Token",
     ~eventName="Transfer",
     %raw(`() => Promise.resolve()`),
@@ -254,6 +283,47 @@ describe("EVM inline field selection", () => {
     t.expect(
       message,
     ).toBe(`The "accessList" transaction field selected for the "Transfer" event on contract "Token" is unavailable for indexing via RPC. Remove it from the field selection, or index chain 1 via HyperSync.`)
+  })
+
+  // A registration resolves for every chain that configures the event, so one
+  // chain's set of registrations is rarely the next one's — a `where` can opt a
+  // registration out of a chain the others still cover.
+  it("gives every chain the selections of the registrations that chain kept", t => {
+    let registrations = register(
+      ~config=multichainConfig,
+      () => {
+        setHandler(~fields={transaction: ["to"]}, ~where=%raw(`({chain}) => chain.id === 1`), ())
+        setHandler(~fields={block: ["miner"]}, ())
+      },
+    )
+    t.expect((
+      registrations->selections,
+      registrations->selections(~chain="137"),
+    )).toEqual(([(["number"], ["to"]), (["miner", "number"], [])], [(["miner", "number"], [])]))
+  })
+
+  // The inline selection resolves once per `onEvent` call and every chain's
+  // registration shares it, so a merge (which unions two selections) has to
+  // build a new one rather than widen the shared value in place.
+  it("keeps a merge on one chain out of the same registration on another", t => {
+    let registrations = register(
+      ~config=multichainConfig,
+      () => {
+        setHandler(~fields={block: ["parentHash"]}, ())
+        setContractRegister(
+          ~fields={transaction: ["gasUsed"]},
+          ~where=%raw(`({chain}) => chain.id === 1`),
+          (),
+        )
+      },
+    )
+    t.expect((
+      registrations->selections,
+      registrations->selections(~chain="137"),
+    )).toEqual((
+      [(["number", "parentHash"], ["gasUsed"])],
+      [(["number", "parentHash"], [])],
+    ))
   })
 
   // The registration is dropped for this chain before it reaches the source, so

--- a/packages/envio-tests/test/EvmInlineFieldSelection_test.res
+++ b/packages/envio-tests/test/EvmInlineFieldSelection_test.res
@@ -171,13 +171,12 @@ chains:
 `,
 ).config
 
-// Per-registration selection on chain 1, as sorted field-name arrays.
 let selections = (registrations: HandlerRegister.registrationsByChainId) => {
   let chainRegistrations: HandlerRegister.chainRegistrations =
     registrations->Utils.Dict.dangerouslyGetNonOption("1")->Option.getOrThrow
   chainRegistrations.onEventRegistrations->Array.map(reg => (
-    reg.selectedBlockFields->Utils.Set.toArray->Array.toSorted(String.compare),
-    reg.selectedTransactionFields->Utils.Set.toArray->Array.toSorted(String.compare),
+    reg.fieldSelection.blockFields->Utils.Set.toArray->Array.toSorted(String.compare),
+    reg.fieldSelection.transactionFields->Utils.Set.toArray->Array.toSorted(String.compare),
   ))
 }
 

--- a/packages/envio-tests/test/SvmHandlersApi_test.res
+++ b/packages/envio-tests/test/SvmHandlersApi_test.res
@@ -26,6 +26,32 @@ chains:
 
 let check = handlers => InternalTestIndexer.fromUserApi(~schema=ApiTypesFixtures.schema, ~handlers, ~configYaml)->ignore
 
+// `onInstruction` shares its registration path with EVM's `onEvent`, so the
+// EVM-only fields option reaches it whenever the project doesn't type-check.
+// SVM takes its selection from the config, so a dropped option would leave the
+// handler reading fields it never selected — it has to be rejected instead.
+InternalTestIndexer.fromUserApi(
+  ~schema=ApiTypesFixtures.schema,
+  ~configYaml,
+  ~test=`
+import { describe, it } from "vitest";
+import { indexer } from "envio";
+
+describe("the EVM-only fields option on an SVM instruction", () => {
+  it("is rejected at the registration call site", (t) => {
+    t.expect(() =>
+      indexer.onInstruction(
+        { program: "Swapper", instruction: "swap", fields: { block: ["slot"] } } as never,
+        async () => {},
+      ),
+    ).toThrowError(
+      \`The fields option of the "swap" event registration on contract "Swapper" is only supported on EVM. Select the fields in your config instead.\`,
+    );
+  });
+});
+`,
+)->ignore
+
 describe("SVM API types", () => {
   it("resolves config-bound SVM chain name and id unions", _ =>
     check(`

--- a/packages/envio-tests/test/lib_tests/ChainState_materialize_test.res
+++ b/packages/envio-tests/test/lib_tests/ChainState_materialize_test.res
@@ -3,7 +3,7 @@ open Vitest
 // Build an `Internal.item` Event. `inlineTransaction`/`inlineBlock` (when
 // given) put the payload in the "already inline" shape RPC/simulate/Fuel use;
 // omitted, the payload is store-backed for that dimension.
-// `transactionMask`/`blockMask` mirror the per-event `onEventRegistration.eventConfig`
+// `transactionMask`/`blockMask` mirror the `onEventRegistration.fieldSelection`
 // masks that `ChainState.groupBatchItems` reads for each dimension.
 let materializeChainId = 987->ChainId.fromInt
 let makeItem = (
@@ -31,8 +31,10 @@ let makeItem = (
     "chain": materializeChainId,
     "onEventRegistration":
       {
-        "transactionFieldMask": transactionMask,
-        "blockFieldMask": blockMask,
+        "fieldSelection": {
+          "transactionMask": transactionMask,
+          "blockMask": blockMask,
+        },
       }->(Utils.magic: {..} => Internal.onEventRegistration),
     "payload": payload,
   }->(Utils.magic: {..} => Internal.item)

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -822,13 +822,17 @@ type EvmSelectedFields<All, Selected extends string, Knob extends string> = {
         string}' is not selected for this handler. Add it to fields.${Knob} in the registration options.`>;
 };
 
-/** Field names listed under `Knob`, or `never` when the key is absent. */
-type EvmListedFields<Fields, Knob extends keyof EvmFieldsSelection> = Fields extends Record<
-  Knob,
-  readonly (infer Name extends string)[]
->
-  ? Name
-  : never;
+/** Field names listed under `Knob`, or `never` when the key is absent or lists
+ * nothing. Reads the value through `EvmListedArray` for the same reason that
+ * type exists: an optional property doesn't satisfy a `Record<Knob, _>`
+ * conditional, which would type every listed field as unselected for a
+ * selection whose keys are optional. Element access rather than `infer`, which
+ * falls back to its `string` constraint on an absent key — naming every field
+ * as selected. */
+type EvmListedFields<Fields, Knob extends keyof EvmFieldsSelection> = NonNullable<
+  EvmListedArray<Fields, Knob>
+>[number] &
+  string;
 
 /** The value listed under `Knob`, keeping optional keys (which a `Record<Knob, _>`
  * conditional would miss, since an optional property doesn't satisfy a required
@@ -890,7 +894,7 @@ export type EvmEventWithFields<Event, Fields> = Fields extends EvmFieldsSelectio
 export type EvmOnEventOptions<
   Event extends EventLike = _ProjectEvmEvent,
   Params = {},
-  Fields extends EvmFieldsSelection | undefined = EvmFieldsSelection,
+  Fields extends EvmFieldsSelection | undefined = undefined,
 > = Event extends EventLike
   ? {
       readonly contract: Event["contractName"];
@@ -898,8 +902,11 @@ export type EvmOnEventOptions<
       readonly wildcard?: boolean;
       readonly where?: EvmOnEventWhere<Params, Event["contractName"] & string>;
       /** Pass the selection's literal type as the `Fields` generic to get the
-       * same narrowing `indexer.onEvent` infers from the call site. */
-      readonly fields?: Fields;
+       * same narrowing `indexer.onEvent` infers from the call site. Defaults to
+       * no selection, mirroring the call-site default: `EvmFieldsSelection`
+       * names no fields in particular, so an options value declared with it
+       * would carry a selection `onEvent` can only reject. */
+      readonly fields?: Fields & EvmFieldsLiteralCheck<Fields>;
     }
   : never;
 
@@ -913,7 +920,7 @@ export type EvmOnEventHandler<
 export type EvmContractRegisterOptions<
   Event extends EventLike = _ProjectEvmEvent,
   Params = {},
-  Fields extends EvmFieldsSelection | undefined = EvmFieldsSelection,
+  Fields extends EvmFieldsSelection | undefined = undefined,
 > = EvmOnEventOptions<Event, Params, Fields>;
 
 /** Handler function for an EVM contractRegister registration. */

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -739,7 +739,7 @@ let groupBatchItems = (items: array<Internal.item>, ~includeBlocks: bool): (
       | Some(_) => () // RPC/simulate/Fuel carry the transaction inline.
       | None =>
         let {transactionIndex} = eventItem
-        let mask = eventItem.onEventRegistration.transactionFieldMask
+        let mask = eventItem.onEventRegistration.fieldSelection.transactionMask
         if mask != 0. {
           anyTransactionFieldSelected := true
         }
@@ -766,7 +766,7 @@ let groupBatchItems = (items: array<Internal.item>, ~includeBlocks: bool): (
         switch eventItem.payload->Internal.getPayloadBlock->Nullable.toOption {
         | Some(_) => () // RPC/simulate/Fuel carry the block inline.
         | None =>
-          let mask = eventItem.onEventRegistration.blockFieldMask
+          let mask = eventItem.onEventRegistration.fieldSelection.blockMask
           let last = blockItemGroups->Array.length - 1
           if last >= 0 && blockBlockNumbers->Array.getUnsafe(last) == blockNumber {
             blockItemGroups->Array.getUnsafe(last)->Array.push(eventItem)

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -314,12 +314,7 @@ let selectionKinds = ["block", "transaction"]
 // typo, and an unrecognised key would read as an empty selection — silently
 // dropping every field `config.yaml` selected. Rejected here so the option is
 // held to the same shape whether or not the project type-checks it.
-let validateFieldsShapeOrThrow = (
-  fields: Internal.evmFieldsSelection,
-  ~contractName: string,
-  ~eventName: string,
-) => {
-  let registration = `the "${eventName}" event registration on contract "${contractName}"`
+let validateFieldsShapeOrThrow = (fields: Internal.evmFieldsSelection, ~registration: string) => {
   let raw = fields->(Utils.magic: Internal.evmFieldsSelection => unknown)
   if typeof(raw) !== #object || raw === %raw(`null`) || Array.isArray(raw) {
     JsError.throwWithMessage(
@@ -344,29 +339,28 @@ let parseFieldsOrThrow = (
   fields: option<array<string>>,
   ~valid: array<string>,
   ~kind: string,
-  ~contractName: string,
-  ~eventName: string,
+  ~registration: string,
 ) => {
   let seen = Utils.Set.make()
   let fields = switch fields {
   | None => []
   | Some(fields) if !Array.isArray(fields) =>
     JsError.throwWithMessage(
-      `The fields.${kind} option of the "${eventName}" event registration on contract "${contractName}" must be an array of field names.`,
+      `The fields.${kind} option of ${registration} must be an array of field names.`,
     )
   | Some(fields) => fields
   }
   fields->Array.forEach(name => {
     if !(valid->Array.includes(name)) {
       JsError.throwWithMessage(
-        `Invalid "${name}" field in the fields.${kind} option of the "${eventName}" event registration on contract "${contractName}". Valid ${kind} fields: ${valid->Array.joinUnsafe(
+        `Invalid "${name}" field in the fields.${kind} option of ${registration}. Valid ${kind} fields: ${valid->Array.joinUnsafe(
             ", ",
           )}.`,
       )
     }
     if seen->Utils.Set.has(name) {
       JsError.throwWithMessage(
-        `Duplicate "${name}" field in the fields.${kind} option of the "${eventName}" event registration on contract "${contractName}".`,
+        `Duplicate "${name}" field in the fields.${kind} option of ${registration}.`,
       )
     }
     seen->Utils.Set.add(name)->ignore
@@ -374,53 +368,53 @@ let parseFieldsOrThrow = (
   seen
 }
 
-// Resolve the registration's selection: the event config's selection by
-// default, or the inline `fields` option when the registration supplies one.
-let resolveRegistrationFieldSelection = (
-  ~fields: option<Internal.evmFieldsSelection>,
-  ~eventConfig: Internal.evmEventConfig,
+// The selection every registration of this event gets unless it names fields
+// inline. The sets come from the event config by reference, which is what lets
+// a merge of two un-customized registrations stay allocation-free and keeps the
+// per-source parser caches (keyed on set identity) effective.
+let eventConfigFieldSelection = (eventConfig: Internal.evmEventConfig): Internal.fieldSelection => {
+  blockFields: eventConfig.selectedBlockFields->(
+    Utils.magic: Utils.Set.t<Internal.evmBlockField> => Utils.Set.t<string>
+  ),
+  transactionFields: eventConfig.selectedTransactionFields,
+  blockMask: eventConfig.blockFieldMask,
+  transactionMask: eventConfig.transactionFieldMask,
+}
+
+// Resolve an inline `fields` option into a selection. Depends only on the
+// option itself (the names are for error messages), never on the chain, so one
+// `onEvent` call resolves once and shares the result across every chain.
+let resolveInlineFieldSelection = (
+  fields: Internal.evmFieldsSelection,
+  ~contractName: string,
+  ~eventName: string,
   ~enableRawEvents: bool,
-) =>
-  switch fields {
-  | None => (
-      eventConfig.selectedBlockFields->(
-        Utils.magic: Utils.Set.t<Internal.evmBlockField> => Utils.Set.t<string>
-      ),
-      eventConfig.selectedTransactionFields,
-      eventConfig.blockFieldMask,
-      eventConfig.transactionFieldMask,
-    )
-  | Some(fields) =>
-    validateFieldsShapeOrThrow(
-      fields,
-      ~contractName=eventConfig.contractName,
-      ~eventName=eventConfig.name,
-    )
-    let selectedBlockFields = parseFieldsOrThrow(
-      fields.block,
-      ~valid=Evm.blockFields,
-      ~kind="block",
-      ~contractName=eventConfig.contractName,
-      ~eventName=eventConfig.name,
-    )
-    let selectedTransactionFields = parseFieldsOrThrow(
-      fields.transaction,
-      ~valid=Evm.transactionFields,
-      ~kind="transaction",
-      ~contractName=eventConfig.contractName,
-      ~eventName=eventConfig.name,
-    )
-    internalBlockFields->Array.forEach(name => selectedBlockFields->Utils.Set.add(name)->ignore)
-    if enableRawEvents {
-      rawEventBlockFields->Array.forEach(name => selectedBlockFields->Utils.Set.add(name)->ignore)
-    }
-    (
-      selectedBlockFields,
-      selectedTransactionFields,
-      Evm.eventBlockFieldMask(selectedBlockFields),
-      Evm.eventTransactionFieldMask(selectedTransactionFields),
-    )
+): Internal.fieldSelection => {
+  let registration = `the "${eventName}" event registration on contract "${contractName}"`
+  validateFieldsShapeOrThrow(fields, ~registration)
+  let blockFields = parseFieldsOrThrow(
+    fields.block,
+    ~valid=Evm.blockFields,
+    ~kind="block",
+    ~registration,
+  )
+  let transactionFields = parseFieldsOrThrow(
+    fields.transaction,
+    ~valid=Evm.transactionFields,
+    ~kind="transaction",
+    ~registration,
+  )
+  blockFields->Utils.Set.addMany(internalBlockFields)
+  if enableRawEvents {
+    blockFields->Utils.Set.addMany(rawEventBlockFields)
   }
+  {
+    blockFields,
+    transactionFields,
+    blockMask: Evm.eventBlockFieldMask(blockFields),
+    transactionMask: Evm.eventTransactionFieldMask(transactionFields),
+  }
+}
 
 // ============== Build complete EVM event config ==============
 
@@ -474,18 +468,12 @@ let buildEvmOnEventRegistration = (
   ~where: option<JSON.t>,
   ~chainId: ChainId.t,
   ~onEventBlockFilterSchema: S.t<option<unknown>>,
-  ~fields: option<Internal.evmFieldsSelection>=?,
-  ~enableRawEvents: bool,
+  // The registration's inline selection, already resolved; absent when it named
+  // no fields and takes the event config's.
+  ~fieldSelection: option<Internal.fieldSelection>=?,
   ~startBlock: option<int>=?,
 ): Internal.evmOnEventRegistration => {
   let indexedParams = eventConfig.paramsMetadata->Array.filter(p => p.indexed)
-
-  let (
-    selectedBlockFields,
-    selectedTransactionFields,
-    blockFieldMask,
-    transactionFieldMask,
-  ) = resolveRegistrationFieldSelection(~fields, ~eventConfig, ~enableRawEvents)
 
   let {resolvedWhere, filterByAddresses, addressFilterParamGroups} = LogSelection.parseWhereOrThrow(
     ~where,
@@ -518,10 +506,10 @@ let buildEvmOnEventRegistration = (
     addressFilterParamGroups,
     dependsOnAddresses: Internal.dependsOnAddresses(~isWildcard, ~filterByAddresses),
     startBlock: resolvedStartBlock,
-    selectedBlockFields,
-    selectedTransactionFields,
-    blockFieldMask,
-    transactionFieldMask,
+    fieldSelection: switch fieldSelection {
+    | Some(fieldSelection) => fieldSelection
+    | None => eventConfigFieldSelection(eventConfig)
+    },
   }
 }
 
@@ -605,12 +593,14 @@ let buildSvmOnEventRegistration = (
   filterByAddresses: false,
   dependsOnAddresses: Internal.dependsOnAddresses(~isWildcard, ~filterByAddresses=false),
   startBlock,
-  selectedBlockFields: eventConfig.selectedBlockFields->(
-    Utils.magic: Utils.Set.t<Internal.svmBlockField> => Utils.Set.t<string>
-  ),
-  selectedTransactionFields: eventConfig.selectedTransactionFields,
-  blockFieldMask: eventConfig.blockFieldMask,
-  transactionFieldMask: eventConfig.transactionFieldMask,
+  fieldSelection: {
+    blockFields: eventConfig.selectedBlockFields->(
+      Utils.magic: Utils.Set.t<Internal.svmBlockField> => Utils.Set.t<string>
+    ),
+    transactionFields: eventConfig.selectedTransactionFields,
+    blockMask: eventConfig.blockFieldMask,
+    transactionMask: eventConfig.transactionFieldMask,
+  },
 }
 
 // ============== Build Fuel event config ==============
@@ -688,8 +678,11 @@ let buildFuelOnEventRegistration = (
   filterByAddresses: false,
   dependsOnAddresses: Internal.dependsOnAddresses(~isWildcard, ~filterByAddresses=false),
   startBlock,
-  selectedBlockFields: Utils.Set.make(),
-  selectedTransactionFields: eventConfig.selectedTransactionFields,
-  blockFieldMask: eventConfig.blockFieldMask,
-  transactionFieldMask: eventConfig.transactionFieldMask,
+  fieldSelection: {
+    // Fuel carries the block on the payload, so nothing is fetched for it.
+    blockFields: Utils.Set.make(),
+    transactionFields: eventConfig.selectedTransactionFields,
+    blockMask: eventConfig.blockFieldMask,
+    transactionMask: eventConfig.transactionFieldMask,
+  },
 }

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -104,16 +104,9 @@ let buildOnEventRegistrationWith = (
   ~handler: option<Internal.handler>,
   ~contractRegister: option<Internal.contractRegister>,
   ~where: option<JSON.t>,
-  ~fields: option<Internal.evmFieldsSelection>,
+  ~fieldSelection: option<Internal.fieldSelection>,
   ~startBlock=?,
 ): Internal.onEventRegistration => {
-  // Only EVM resolves a registration selection of its own; Fuel and SVM take
-  // theirs from the event config, so an inline one would be silently dropped.
-  if fields->Option.isSome && config.ecosystem.name !== Evm {
-    JsError.throwWithMessage(
-      `The fields option of the "${eventConfig.name}" event registration on contract "${eventConfig.contractName}" is only supported on EVM. Select the fields in your config instead.`,
-    )
-  }
   switch config.ecosystem.name {
   | Fuel =>
     (EventConfigBuilder.buildFuelOnEventRegistration(
@@ -142,8 +135,7 @@ let buildOnEventRegistrationWith = (
       ~where,
       ~chainId,
       ~onEventBlockFilterSchema=config.ecosystem.onEventBlockFilterSchema,
-      ~fields?,
-      ~enableRawEvents=config.enableRawEvents,
+      ~fieldSelection?,
       ~startBlock?,
     ) :> Internal.onEventRegistration)
   }
@@ -185,16 +177,32 @@ let unionFields = (a: Utils.Set.t<string>, b: Utils.Set.t<string>) =>
     a
   } else {
     let union = Utils.Set.fromArray(a->Utils.Set.toArray)
-    b->Utils.Set.forEach(name => union->Utils.Set.add(name)->ignore)
+    union->Utils.Set.addMany(b->Utils.Set.toArray)
     union
   }
 
-let unionSelection = (a: Internal.onEventRegistration, b: Internal.onEventRegistration) => (
-  unionFields(a.selectedBlockFields, b.selectedBlockFields),
-  unionFields(a.selectedTransactionFields, b.selectedTransactionFields),
-  FieldMask.orMask(a.blockFieldMask, b.blockFieldMask),
-  FieldMask.orMask(a.transactionFieldMask, b.transactionFieldMask),
-)
+let unionSelection = (
+  a: Internal.fieldSelection,
+  b: Internal.fieldSelection,
+): Internal.fieldSelection => {
+  blockFields: unionFields(a.blockFields, b.blockFields),
+  transactionFields: unionFields(a.transactionFields, b.transactionFields),
+  blockMask: FieldMask.orMask(a.blockMask, b.blockMask),
+  transactionMask: FieldMask.orMask(a.transactionMask, b.transactionMask),
+}
+
+// The merged registration keeps `base`'s handler and slot, picks up the
+// contractRegister from `other`, and carries the union of what both callbacks
+// read. Relies on `onEventRegistration` having an optional field so the spread
+// stays a runtime spread and keeps `other`'s ecosystem-only fields.
+let mergeInto = (
+  base: Internal.onEventRegistration,
+  ~other: Internal.onEventRegistration,
+): Internal.onEventRegistration => {
+  ...base,
+  contractRegister: other.contractRegister,
+  fieldSelection: unionSelection(base.fieldSelection, other.fieldSelection),
+}
 
 // Merge each contractRegister into a matching handler registration (either
 // registration order; the merged registration takes the handler's slot so
@@ -218,25 +226,10 @@ let mergeRegistrations = (resolved: array<Internal.onEventRegistration>, ~config
       | -1 => merged := merged.contents->Array.concat([reg])
       | i =>
         let target = merged.contents->Array.getUnsafe(i)
-        let (
-          selectedBlockFields,
-          selectedTransactionFields,
-          blockFieldMask,
-          transactionFieldMask,
-        ) = unionSelection(reg, target)
         merged :=
           merged.contents
           ->Array.filterWithIndex((_, j) => j !== i)
-          ->Array.concat([
-            {
-              ...reg,
-              contractRegister: target.contractRegister,
-              selectedBlockFields,
-              selectedTransactionFields,
-              blockFieldMask,
-              transactionFieldMask,
-            },
-          ])
+          ->Array.concat([reg->mergeInto(~other=target)])
       }
     } else {
       // A contractRegister merges into a matching handler registration,
@@ -249,24 +242,8 @@ let mergeRegistrations = (resolved: array<Internal.onEventRegistration>, ~config
       | -1 => merged := merged.contents->Array.concat([reg])
       | i =>
         let target = merged.contents->Array.getUnsafe(i)
-        let (
-          selectedBlockFields,
-          selectedTransactionFields,
-          blockFieldMask,
-          transactionFieldMask,
-        ) = unionSelection(target, reg)
         let next = merged.contents->Array.copy
-        next->Array.setUnsafe(
-          i,
-          {
-            ...target,
-            contractRegister: reg.contractRegister,
-            selectedBlockFields,
-            selectedTransactionFields,
-            blockFieldMask,
-            transactionFieldMask,
-          },
-        )
+        next->Array.setUnsafe(i, target->mergeInto(~other=reg))
         merged := next
       }
     }
@@ -313,7 +290,27 @@ let addOnEventRegistration = (
 ) => {
   let isWildcard = eventOptions->Option.flatMap(v => v.wildcard)->Option.getOr(false)
   let where = eventOptions->Option.flatMap(v => v.where)
-  let fields = eventOptions->Option.flatMap(v => v.fields)
+  // The inline selection doesn't vary by chain: resolve it once here and share
+  // the one value (and its sets) across every chain's registration.
+  let fieldSelection = switch eventOptions->Option.flatMap(v => v.fields) {
+  | None => None
+  | Some(fields) =>
+    // Only EVM resolves a registration selection of its own; Fuel and SVM take
+    // theirs from the event config, so an inline one would be silently dropped.
+    if registration.config.ecosystem.name !== Evm {
+      JsError.throwWithMessage(
+        `The fields option of the "${eventName}" event registration on contract "${contractName}" is only supported on EVM. Select the fields in your config instead.`,
+      )
+    }
+    Some(
+      EventConfigBuilder.resolveInlineFieldSelection(
+        fields,
+        ~contractName,
+        ~eventName,
+        ~enableRawEvents=registration.config.enableRawEvents,
+      ),
+    )
+  }
   let matched = ref(false)
   registration.config.chainMap
   ->ChainMap.values
@@ -333,7 +330,7 @@ let addOnEventRegistration = (
           ~handler,
           ~contractRegister,
           ~where,
-          ~fields,
+          ~fieldSelection,
           ~startBlock=?contract.startBlock,
         )
         (registration->getChainRegistrations(~chainId=chainConfig.id)).onEventRegistrations
@@ -463,7 +460,7 @@ let getSimulateOnEventRegistrations = (
         ~handler=None,
         ~contractRegister=None,
         ~where=None,
-        ~fields=None,
+        ~fieldSelection=None,
       ),
     ]
   }
@@ -477,6 +474,12 @@ let getSimulateOnEventRegistrations = (
 // option, so the message names neither. Runs on the registrations a chain
 // actually keeps, so a handler whose `where` opts out of this chain isn't held
 // to its limits.
+//
+// The `config.yaml` half of this is also rejected at codegen, by the
+// `RpcTransactionField` subenum in `system_config.rs`. That one reports every
+// offending field at once and before the project builds; this one is the only
+// check an inline selection reaches. `RpcFieldSelection_test.res` pins the two
+// to the same field set.
 let validateRpcFieldSelection = (
   chainConfig: Config.chain,
   registrations: array<Internal.onEventRegistration>,
@@ -487,9 +490,7 @@ let validateRpcFieldSelection = (
   }
   if hasRpc {
     registrations->Array.forEach(reg =>
-      reg.selectedTransactionFields
-      ->Utils.Set.toArray
-      ->Array.forEach(name =>
+      reg.fieldSelection.transactionFields->Utils.Set.forEach(name =>
         if !RpcSource.isRpcTransactionField(name) {
           JsError.throwWithMessage(
             `The "${name}" transaction field selected for the "${reg.eventConfig.name}" event on contract "${reg.eventConfig.contractName}" is unavailable for indexing via RPC. Remove it from the field selection, or index chain ${chainConfig.id->ChainId.toString} via HyperSync.`,
@@ -550,7 +551,7 @@ let finishRegistration = (~config: Config.t): registrationsByChainId => {
                       ~handler=None,
                       ~contractRegister=None,
                       ~where=None,
-                      ~fields=None,
+                      ~fieldSelection=None,
                       ~startBlock=?contract.startBlock,
                     ),
                   )

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -557,6 +557,18 @@ type svmInstructionEventConfig = {
   definedTypes: JSON.t,
 }
 
+// What a single registration fetches and materialises. Field names are strings
+// so every ecosystem shares one type — the typed field variants are strings at
+// runtime. Each set carries its precompiled mask, and the two always describe
+// the same fields: build them together, never one without the other.
+type fieldSelection = {
+  blockFields: Utils.Set.t<string>,
+  transactionFields: Utils.Set.t<string>,
+  // The sets precompiled to the store selections `ChainState` materialises with.
+  blockMask: float,
+  transactionMask: float,
+}
+
 // Per-(event, chain) registration produced when user handler code registers an
 // event (`onEvent`) or a dynamic contract registers. References its definition
 // by value as `.eventConfig` and adds the handler binding plus the
@@ -591,15 +603,12 @@ type onEventRegistration = {
   // Final start block: the contract/chain config value, overridden by a
   // `where.block.number._gte` when the registered `where` supplies one.
   startBlock: option<int>,
-  // Field selection for this registration: the `eventConfig` values unless the
-  // registration passed an inline `fields` option, which replaces them. Two
+  // Field selection for this registration: the `eventConfig` selection unless
+  // the registration passed an inline `fields` option, which replaces it. Two
   // registrations of one event can select different fields, so every consumer
-  // (query building, store materialisation) reads them from here rather than
-  // from the shared `eventConfig`.
-  selectedBlockFields: Utils.Set.t<string>,
-  selectedTransactionFields: Utils.Set.t<string>,
-  transactionFieldMask: float,
-  blockFieldMask: float,
+  // (query building, store materialisation) reads it from here rather than from
+  // the shared `eventConfig`.
+  fieldSelection: fieldSelection,
 }
 
 type evmOnEventRegistration = {

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -291,7 +291,12 @@ let getGlobalIndexer = (): 'indexer => {
   let parseSvmIdentityConfig = (identityConfig: 'a) => {
     let raw =
       identityConfig->(
-        Utils.magic: 'a => {"program": unknown, "instruction": unknown, "where": option<JSON.t>}
+        Utils.magic: 'a => {
+          "program": unknown,
+          "instruction": unknown,
+          "where": option<JSON.t>,
+          "fields": option<Internal.evmFieldsSelection>,
+        }
       )
     let (programName, instructionName) = if typeof(raw["program"]) === #string {
       (
@@ -303,11 +308,16 @@ let getGlobalIndexer = (): 'indexer => {
       (inst["contract"], inst["_0"])
     }
     let where = raw["where"]
-    let eventOptions: option<Internal.eventOptions<_>> = switch where {
-    | None => None
-    | Some(_) =>
+    // SVM takes its selection from the config, so `fields` is carried through
+    // only to be rejected by the registration — dropping it here would leave a
+    // plain-JS caller with a silently ignored option.
+    let fields = raw["fields"]
+    let eventOptions: option<Internal.eventOptions<_>> = switch (where, fields) {
+    | (None, None) => None
+    | (where, fields) =>
       Some({
         where: ?(where->(Utils.magic: option<JSON.t> => option<_>)),
+        ?fields,
       })
     }
     (programName, instructionName, eventOptions)

--- a/packages/envio/src/sources/HyperSyncClient.res
+++ b/packages/envio/src/sources/HyperSyncClient.res
@@ -295,10 +295,10 @@ module Registration = {
         }),
         // Capitalized to match the Rust BlockField/TransactionField string
         // enums.
-        blockFields: reg.selectedBlockFields
+        blockFields: reg.fieldSelection.blockFields
         ->Utils.Set.toArray
         ->Array.map(Utils.String.capitalize),
-        transactionFields: reg.selectedTransactionFields
+        transactionFields: reg.fieldSelection.transactionFields
         ->Utils.Set.toArray
         ->Array.map(Utils.String.capitalize),
       }

--- a/packages/envio/src/sources/RpcSource.res
+++ b/packages/envio/src/sources/RpcSource.res
@@ -901,12 +901,12 @@ let make = (
         async () => {
           let (block, transaction) = try await Promise.all2((
             log->getEventBlockOrThrow(
-              ~selectedBlockFields=onEventRegistration.selectedBlockFields->(
+              ~selectedBlockFields=onEventRegistration.fieldSelection.blockFields->(
                 Utils.magic: Utils.Set.t<string> => Utils.Set.t<Internal.evmBlockField>
               ),
             ),
             log->getEventTransactionOrThrow(
-              ~selectedTransactionFields=onEventRegistration.selectedTransactionFields->(
+              ~selectedTransactionFields=onEventRegistration.fieldSelection.transactionFields->(
                 Utils.magic: Utils.Set.t<string> => Utils.Set.t<Internal.evmTransactionField>
               ),
             ),

--- a/packages/envio/src/sources/SvmHyperSyncClient.res
+++ b/packages/envio/src/sources/SvmHyperSyncClient.res
@@ -67,8 +67,8 @@ module Registration = {
             },
           )
         ),
-        transactionFields: reg.selectedTransactionFields->Utils.Set.toArray,
-        blockFields: reg.selectedBlockFields->Utils.Set.toArray,
+        transactionFields: reg.fieldSelection.transactionFields->Utils.Set.toArray,
+        blockFields: reg.fieldSelection.blockFields->Utils.Set.toArray,
         accounts: eventConfig.accounts,
         argsJson: ?switch eventConfig.args {
         | JSON.Null => None

--- a/scenarios/test_codegen/test/EventBlockFilter_test.res
+++ b/scenarios/test_codegen/test/EventBlockFilter_test.res
@@ -254,7 +254,6 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
       ~contractRegister=None,
       ~where=eventFilters,
       ~chainId=1->ChainId.fromInt,
-      ~enableRawEvents=false,
       ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
       ~startBlock?,
     )
@@ -305,7 +304,6 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
       ~contractRegister=None,
       ~where=Some(whereFn),
       ~chainId=137->ChainId.fromInt,
-      ~enableRawEvents=false,
       ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
       ~startBlock=1,
     )
@@ -321,7 +319,6 @@ describe("EventConfigBuilder — where.block.number._gte overrides contract star
       ~contractRegister=None,
       ~where=Some(whereFn),
       ~chainId=1->ChainId.fromInt,
-      ~enableRawEvents=false,
       ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
       ~startBlock=1,
     )
@@ -356,7 +353,6 @@ describe("FetchState — where.block._gte drives the first query's fromBlock", (
       ~contractRegister=None,
       ~where=Some(%raw(`{block: {number: {_gte: 5000}}}`)),
       ~chainId=1->ChainId.fromInt,
-      ~enableRawEvents=false,
       ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
       ~startBlock?,
     )

--- a/scenarios/test_codegen/test/EventFilters_test.res
+++ b/scenarios/test_codegen/test/EventFilters_test.res
@@ -524,7 +524,6 @@ describe("Test eventFilters", () => {
           %raw(`{params: {from: "0x0000000000000000000000000000000000000000", to: "0x0000000000000000000000000000000000000000"}}`),
         ),
         ~chainId=137->ChainId.fromInt,
-        ~enableRawEvents=false,
         ~onEventBlockFilterSchema=config.ecosystem.onEventBlockFilterSchema,
       )
     , `Invalid where configuration. The event doesn't have an indexed parameter "to" and can't use it for filtering`)

--- a/scenarios/test_codegen/test/SourceBlockHashes_test.res
+++ b/scenarios/test_codegen/test/SourceBlockHashes_test.res
@@ -70,12 +70,7 @@ let pairCreatedRegistration: Internal.evmOnEventRegistration = {
   startBlock: None,
   handler: None,
   contractRegister: None,
-  selectedBlockFields: pairCreatedEventConfig.selectedBlockFields->(
-    Utils.magic: Utils.Set.t<Internal.evmBlockField> => Utils.Set.t<string>
-  ),
-  selectedTransactionFields: pairCreatedEventConfig.selectedTransactionFields,
-  blockFieldMask: pairCreatedEventConfig.blockFieldMask,
-  transactionFieldMask: pairCreatedEventConfig.transactionFieldMask,
+  fieldSelection: EventConfigBuilder.eventConfigFieldSelection(pairCreatedEventConfig),
   resolvedWhere: {
     topicSelections: [
       {

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -392,10 +392,12 @@ let makeMockSourceRegistration = (~index, ~contractName): Internal.onEventRegist
     startBlock: None,
     handler: Some(handler),
     contractRegister: Some(contractRegister),
-    selectedBlockFields: Utils.Set.make(),
-    selectedTransactionFields: Utils.Set.make(),
-    transactionFieldMask: 0.,
-    blockFieldMask: 0.,
+    fieldSelection: {
+      blockFields: Utils.Set.make(),
+      transactionFields: Utils.Set.make(),
+      blockMask: 0.,
+      transactionMask: 0.,
+    },
     resolvedWhere: {topicSelections: [], startBlock: None},
   }: Internal.evmOnEventRegistration :> Internal.onEventRegistration)
 }
@@ -1318,12 +1320,7 @@ let evmOnEventRegistration = (
     startBlock,
     handler: None,
     contractRegister: None,
-    selectedBlockFields: eventConfig.selectedBlockFields->(
-      Utils.magic: Utils.Set.t<Internal.evmBlockField> => Utils.Set.t<string>
-    ),
-    selectedTransactionFields,
-    blockFieldMask: eventConfig.blockFieldMask,
-    transactionFieldMask: eventConfig.transactionFieldMask,
+    fieldSelection: EventConfigBuilder.eventConfigFieldSelection(eventConfig),
     resolvedWhere: {
       topicSelections: switch eventFilters {
       | Some(topicSelections) => topicSelections

--- a/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SameSignatureEventDecode_test.res
@@ -26,7 +26,6 @@ let makeReg = (~name, ~params): Internal.evmOnEventRegistration =>
     ~contractRegister=None,
     ~where=None,
     ~chainId=1->ChainId.fromInt,
-    ~enableRawEvents=false,
     ~onEventBlockFilterSchema=Evm.make(~logger=Logging.getLogger()).onEventBlockFilterSchema,
   )
 


### PR DESCRIPTION
## Summary

Consolidates field selection representation across EVM, SVM, and Fuel ecosystems by introducing a unified `fieldSelection` type. Previously, each registration carried four separate fields (`selectedBlockFields`, `selectedTransactionFields`, `blockFieldMask`, `transactionFieldMask`); now they're grouped into a single `fieldSelection` record that's shared across all ecosystems.

## Key Changes

- **New `Internal.fieldSelection` type**: Groups block/transaction field sets and their precompiled masks into a single record, replacing four separate fields on `onEventRegistration`.

- **Inline field selection resolution**: Extracted `resolveInlineFieldSelection` function that resolves a registration's `fields` option once per `onEvent` call (not per-chain), enabling the resolved selection to be shared across all chains and improving cache effectiveness.

- **Separated concerns**: 
  - `eventConfigFieldSelection`: Returns the default selection from event config
  - `resolveInlineFieldSelection`: Resolves an inline `fields` option to a selection
  - `buildEvmOnEventRegistration`: Now accepts pre-resolved `fieldSelection` instead of raw `fields` option

- **Validation moved earlier**: The check that `fields` is only supported on EVM now runs in `HandlerRegister.addOnEventRegistration` before per-chain registration, preventing silent drops on SVM/Fuel.

- **Merge operation simplified**: `mergeInto` helper encapsulates the logic for merging two registrations, unioning their field selections via the new `unionSelection` function.

- **Type system improvements**: Updated `EvmOnEventOptions` to default `Fields` generic to `undefined` (matching call-site behavior), with clearer documentation about when to pass the `Fields` generic.

## Notable Implementation Details

- Field selection is resolved once and shared by reference across chains, keeping per-source parser caches (keyed on set identity) effective and avoiding allocation overhead for un-customized registrations.

- The `fieldSelection` record always keeps block and transaction fields in sync with their precompiled masks — they're built together and never separated.

- SVM and Fuel now carry their selections in the same `fieldSelection` structure as EVM, eliminating ecosystem-specific field handling in consumers like `ChainState`, `HyperSyncClient`, and `RpcSource`.

- Test coverage expanded to verify multichain behavior: registrations with `where` filters that opt out of a chain don't affect that chain's field selection.

https://claude.ai/code/session_01XeZSDDk79Wk77Jd398dgsh