### PR TITLE
Centralize field selection construction and fix Fuel transaction fields

### DIFF
--- a/packages/envio-tests/test/EvmHandlersApi_test.res
+++ b/packages/envio-tests/test/EvmHandlersApi_test.res
@@ -439,18 +439,12 @@ indexer.onEvent(${source}, async () => {});
 `)
     t.expect((
       at(`{ contract: "Token", event: "Transfer", fields: { /*HERE*/ } }`),
-      at(`{ contract: "Token", event: "Transfer", fields: { block: ["/*HERE*/"] } }`)->Array.slice(
-        ~start=0,
-        ~end=4,
-      ),
-      at(`{ contract: "Token", event: "Transfer", fields: { transaction: ["/*HERE*/"] } }`)->Array.slice(
-        ~start=0,
-        ~end=4,
-      ),
+      at(`{ contract: "Token", event: "Transfer", fields: { block: ["/*HERE*/"] } }`),
+      at(`{ contract: "Token", event: "Transfer", fields: { transaction: ["/*HERE*/"] } }`),
     )).toEqual((
       ["block", "transaction"],
-      ["baseFeePerGas", "blobGasUsed", "difficulty", "excessBlobGas"],
-      ["accessList", "authorizationList", "blobVersionedHashes", "contractAddress"],
+      Evm.blockFields->Array.toSorted(String.compare),
+      Evm.transactionFields->Array.toSorted(String.compare),
     ))
   })
 

--- a/packages/envio-tests/test/TransactionStore_test.res
+++ b/packages/envio-tests/test/TransactionStore_test.res
@@ -8,11 +8,9 @@ open Vitest
 describe("field-code mask ceiling", () => {
   it("no ecosystem exceeds the 32 field codes a mask can hold", t => {
     t.expect({
+      // Pinned because it sits exactly on the ceiling — the next EVM
+      // transaction field is the one that breaks `orMask`.
       "evmTransaction": Evm.transactionFields->Array.length,
-      "evmBlock": Evm.blockFields->Array.length,
-      "svmTransaction": Svm.transactionFields->Array.length,
-      "svmBlock": Svm.blockFields->Array.length,
-      "fuelBlock": Fuel.blockFields->Array.length,
       "overCeiling": [
         Evm.transactionFields,
         Evm.blockFields,
@@ -22,10 +20,6 @@ describe("field-code mask ceiling", () => {
       ]->Array.filter(fields => fields->Array.length > 32),
     }).toEqual({
       "evmTransaction": 32,
-      "evmBlock": 27,
-      "svmTransaction": 11,
-      "svmBlock": 6,
-      "fuelBlock": 3,
       // Widen `orMask` (BigInt, or a pair of floats) before adding the 33rd.
       "overCeiling": [],
     })

--- a/packages/envio-tests/test/helpers/InternalTestIndexer.res
+++ b/packages/envio-tests/test/helpers/InternalTestIndexer.res
@@ -60,8 +60,6 @@ let writeModule = (~kind, ~site, ~source) => {
 // per test file; parse-only calls are unrestricted.
 let ranTestAt: ref<option<string>> = ref(None)
 
-// What an editor offers at the `/*HERE*/` marker in `handlers`, checked
-// against the same generated types a project would have.
 let completionsAt = (~schema=?, ~env=?, ~files=?, ~handlers, ~configYaml): array<string> => {
   let {indexerTypes} = Core.fromUserApi(~schema?, ~env?, ~files?, ~withIndexerTypes=true, configYaml)
   switch indexerTypes->Null.toOption {

--- a/packages/envio-tests/test/helpers/TypeChecker.ts
+++ b/packages/envio-tests/test/helpers/TypeChecker.ts
@@ -141,6 +141,29 @@ export function checkSources(
   return diagnostics.map((d) => ts.formatDiagnostic(d, formatHost).trim());
 }
 
+const serviceHost: ts.LanguageServiceHost = {
+  getScriptFileNames: () => [typesPath, handlersPath],
+  // The content itself is the version, so the service re-reads exactly the
+  // fixture files that changed and keeps the rest of the graph parsed.
+  getScriptVersion: (fileName) => virtualFiles.get(fileName) ?? "",
+  getScriptSnapshot: (fileName) => {
+    const contents = host.readFile(fileName);
+    return contents === undefined ? undefined : ts.ScriptSnapshot.fromString(contents);
+  },
+  getCurrentDirectory: () => helpersDir,
+  getCompilationSettings: () => compilerOptions,
+  getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+  fileExists: host.fileExists,
+  readFile: host.readFile,
+  readDirectory: ts.sys.readDirectory,
+  directoryExists: ts.sys.directoryExists,
+  getDirectories: ts.sys.getDirectories,
+};
+
+// Built once for the same reason `sourceFileCache` exists: a per-call service
+// (and registry) re-parses the whole lib/`envio` declaration graph every time.
+const service = ts.createLanguageService(serviceHost, ts.createDocumentRegistry());
+
 /**
  * The member names an editor offers at the `/*HERE*\/` marker in `handlers`,
  * sorted. Drives the language service rather than the checker, because a
@@ -157,25 +180,6 @@ export function completionsAt(typesDts: string, handlers: string): string[] {
     [handlersPath, text],
   ]);
 
-  const serviceHost: ts.LanguageServiceHost = {
-    getScriptFileNames: () => [typesPath, handlersPath],
-    // Keyed on content so the service re-reads whenever a fixture changes.
-    getScriptVersion: (fileName) => String(virtualFiles.get(fileName)?.length ?? 0),
-    getScriptSnapshot: (fileName) => {
-      const contents = virtualFiles.get(fileName) ?? baseReadFile(fileName);
-      return contents === undefined ? undefined : ts.ScriptSnapshot.fromString(contents);
-    },
-    getCurrentDirectory: () => helpersDir,
-    getCompilationSettings: () => compilerOptions,
-    getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
-    fileExists: host.fileExists,
-    readFile: host.readFile,
-    readDirectory: ts.sys.readDirectory,
-    directoryExists: ts.sys.directoryExists,
-    getDirectories: ts.sys.getDirectories,
-  };
-
-  const service = ts.createLanguageService(serviceHost, ts.createDocumentRegistry());
   const completions = service.getCompletionsAtPosition(handlersPath, position, {});
   return (completions?.entries ?? []).map((entry) => entry.name).sort();
 }

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -903,9 +903,9 @@ export type EvmOnEventOptions<
       readonly where?: EvmOnEventWhere<Params, Event["contractName"] & string>;
       /** Pass the selection's literal type as the `Fields` generic to get the
        * same narrowing `indexer.onEvent` infers from the call site. Defaults to
-       * no selection, mirroring the call-site default: `EvmFieldsSelection`
-       * names no fields in particular, so an options value declared with it
-       * would carry a selection `onEvent` can only reject. */
+       * no selection: `EvmFieldsSelection` names no fields in particular, so an
+       * options value declared without the generic would carry a selection
+       * `onEvent` can only reject. */
       readonly fields?: Fields & EvmFieldsLiteralCheck<Fields>;
     }
   : never;

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -283,8 +283,6 @@ let resolveFieldSelection = (
   | Some(fields) => Utils.Set.fromArray(fields)
   | None => globalTransactionFieldsSet
   }
-  // Stored as string sets — the typed field variants are strings at runtime,
-  // and sources recover the typed view where they need it.
   Internal.makeFieldSelection(
     ~blockFields=selectedBlockFields->(
       Utils.magic: Utils.Set.t<Internal.evmBlockField> => Utils.Set.t<string>
@@ -402,12 +400,12 @@ let resolveInlineFieldSelection = (
   if enableRawEvents {
     blockFields->Utils.Set.addMany(rawEventBlockFields)
   }
-  {
-    blockFields,
-    transactionFields,
-    blockMask: Evm.eventBlockFieldMask(blockFields),
-    transactionMask: Evm.eventTransactionFieldMask(transactionFields),
-  }
+  Internal.makeFieldSelection(
+    ~blockFields,
+    ~transactionFields,
+    ~blockMaskFn=Evm.eventBlockFieldMask,
+    ~transactionMaskFn=Evm.eventTransactionFieldMask,
+  )
 }
 
 // ============== Build complete EVM event config ==============
@@ -524,8 +522,6 @@ let buildSvmInstructionEventConfig = (
     ->Utils.Schema.coerceToJsonPgType
     ->(Utils.magic: S.t<JSON.t> => S.t<Internal.eventParams>)
 
-  // The base eventConfig stores these as a string set (field names match the
-  // typed variants at runtime).
   let fieldSelection = Internal.makeFieldSelection(
     ~blockFields=Utils.Set.fromArray(Array.concat(alwaysIncludedSvmBlockFields, blockFields))->(
       Utils.magic: Utils.Set.t<Internal.svmBlockField> => Utils.Set.t<string>
@@ -632,9 +628,9 @@ let buildFuelEventConfig = (
     // always-queried trio.
     fieldSelection: Internal.makeFieldSelection(
       ~blockFields=Utils.Set.fromArray(Fuel.blockFields),
-      ~transactionFields=Utils.Set.make(),
+      ~transactionFields=Utils.Set.fromArray(Fuel.transactionFields),
       ~blockMaskFn=Fuel.eventBlockFieldMask,
-      ~transactionMaskFn=_ => 0.,
+      ~transactionMaskFn=Fuel.eventTransactionFieldMask,
     ),
     kind: fuelKind,
   }

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -418,8 +418,10 @@ type indexingContract = {
 
 // What a single registration fetches and materialises. Field names are strings
 // so every ecosystem shares one type — the typed field variants are strings at
-// runtime. Each set carries its precompiled mask, and the two always describe
-// the same fields: build them together, never one without the other.
+// runtime. Always built through `makeFieldSelection`/`unionFieldSelection`
+// below, so a set and its mask are never derived from different inputs. Unlike
+// `eventConfig`, not `private` — that would block those two constructors too,
+// since a private record can only be coerced from a distinct record type.
 type fieldSelection = {
   blockFields: Utils.Set.t<string>,
   transactionFields: Utils.Set.t<string>,
@@ -428,10 +430,9 @@ type fieldSelection = {
   transactionMask: float,
 }
 
-// The only way to build a `fieldSelection`, so a set and its mask can never be
-// derived from different inputs. `~blockMaskFn`/`~transactionMaskFn` are the
-// ecosystem's `Evm`/`Svm`/`Fuel` mask functions, which the ecosystem modules
-// pass in (they depend on this module, so it can't reach them).
+// `~blockMaskFn`/`~transactionMaskFn` are the ecosystem's `Evm`/`Svm`/`Fuel`
+// mask functions, which the ecosystem modules pass in (they depend on this
+// module, so it can't reach them).
 let makeFieldSelection = (
   ~blockFields: Utils.Set.t<string>,
   ~transactionFields: Utils.Set.t<string>,
@@ -451,14 +452,13 @@ let makeFieldSelection = (
 // The overwhelmingly common case is two registrations that never named fields
 // inline and so share their event config's sets by reference — returning those
 // unchanged keeps the merge allocation-free.
+let unionFields = (a, b) => a === b ? a : a->Utils.Set.union(b)
+
 let unionFieldSelection = (a: fieldSelection, b: fieldSelection): fieldSelection => {
-  let unionFields = (a, b) => a === b ? a : a->Utils.Set.union(b)
-  {
-    blockFields: unionFields(a.blockFields, b.blockFields),
-    transactionFields: unionFields(a.transactionFields, b.transactionFields),
-    blockMask: FieldMask.orMask(a.blockMask, b.blockMask),
-    transactionMask: FieldMask.orMask(a.transactionMask, b.transactionMask),
-  }
+  blockFields: unionFields(a.blockFields, b.blockFields),
+  transactionFields: unionFields(a.transactionFields, b.transactionFields),
+  blockMask: FieldMask.orMask(a.blockMask, b.blockMask),
+  transactionMask: FieldMask.orMask(a.transactionMask, b.transactionMask),
 }
 
 // Definition of an event/instruction we know how to decode: identity + decode

--- a/packages/envio/src/sources/Fuel.res
+++ b/packages/envio/src/sources/Fuel.res
@@ -20,10 +20,13 @@ external toPayload: Internal.eventPayload => payload = "%identity"
 let blockFields = ["height", "id", "time"]
 
 // Fuel has no per-event block field selection: every event materialises the
-// full (height, time, id) trio, matching what the source always queries. Kept
-// as a mask function like the other ecosystems so `Internal.makeFieldSelection`
-// derives the mask from the same set it stores.
+// full (height, time, id) trio, matching what the source always queries.
 let eventBlockFieldMask = BlockStore.makeMaskFn(blockFields)
+
+// Fuel keeps the transaction inline on the event payload rather than in the
+// per-chain store, so there is nothing to select and no field code to hold.
+let transactionFields = []
+let eventTransactionFieldMask = TransactionStore.makeMaskFn(transactionFields)
 
 let cleanUpRawEventFieldsInPlace: JSON.t => unit = %raw(`fields => {
     delete fields.id

--- a/scenarios/test_codegen/test/helpers/MockIndexer.res
+++ b/scenarios/test_codegen/test/helpers/MockIndexer.res
@@ -404,12 +404,12 @@ let makeMockSourceRegistration = (~index, ~contractName): Internal.onEventRegist
     startBlock: None,
     handler: Some(handler),
     contractRegister: Some(contractRegister),
-    fieldSelection: {
-      blockFields: Utils.Set.make(),
-      transactionFields: Utils.Set.make(),
-      blockMask: 0.,
-      transactionMask: 0.,
-    },
+    fieldSelection: Internal.makeFieldSelection(
+      ~blockFields=Utils.Set.make(),
+      ~transactionFields=Utils.Set.make(),
+      ~blockMaskFn=Evm.eventBlockFieldMask,
+      ~transactionMaskFn=Evm.eventTransactionFieldMask,
+    ),
     resolvedWhere: {topicSelections: [], startBlock: None},
   }: Internal.evmOnEventRegistration :> Internal.onEventRegistration)
 }


### PR DESCRIPTION
## Summary

Refactors field selection construction to always use `makeFieldSelection` and `unionFieldSelection` functions, ensuring field sets and their masks are never derived from different inputs. Fixes Fuel ecosystem to properly declare and use transaction fields.

## Key Changes

- **TypeChecker.ts**: Moved `serviceHost` and `service` creation outside `completionsAt` function to reuse across calls, improving performance by avoiding re-parsing the entire lib/envio declaration graph on each invocation.

- **Internal.res**: 
  - Extracted `unionFields` helper outside `unionFieldSelection` for reusability
  - Updated comments to clarify that `fieldSelection` is always built through `makeFieldSelection`/`unionFieldSelection`, removing outdated constraints about privacy
  - Simplified `unionFieldSelection` record syntax

- **EventConfigBuilder.res**:
  - Changed `resolveInlineFieldSelection` to use `Internal.makeFieldSelection` instead of constructing the record directly
  - Fixed Fuel event config to use `Fuel.transactionFields` and `Fuel.eventTransactionFieldMask` instead of hardcoded empty set and zero mask

- **Fuel.res**:
  - Added `transactionFields = []` declaration
  - Added `eventTransactionFieldMask` function using `TransactionStore.makeMaskFn`
  - Updated comments to clarify Fuel's transaction handling

- **Test updates**:
  - `EvmHandlersApi_test.res`: Simplified completion assertions to use actual field arrays instead of hardcoded slices
  - `TransactionStore_test.res`: Pinned only the EVM transaction field count (32, at ceiling) with explanatory comment; removed other ecosystem counts
  - `MockIndexer.res`: Changed mock registration to use `Internal.makeFieldSelection` instead of direct record construction
  - `InternalTestIndexer.res`: Removed redundant comment about `completionsAt`

- **index.d.ts**: Clarified TypeScript documentation for `EvmOnEventOptions` fields parameter default behavior

## Implementation Details

The refactoring ensures consistency across all field selection construction sites. By centralizing through `makeFieldSelection`, the mask functions are always applied to the same field sets that are stored, preventing subtle bugs where masks could be computed from different inputs. This is particularly important for the Fuel ecosystem, which previously had a hardcoded zero mask for transactions despite having an empty transaction field set.

https://claude.ai/code/session_019kgLJg46yuzwSg3kh31KFk