### PR TITLE
Move column type from server to caller in ClickHouse sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
  "async-recursion",
  "bollard",
  "bs58",
+ "bytes",
  "clap",
  "clap-markdown",
  "colored",

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -15,6 +15,7 @@ clap-markdown = { version = "0.1.5" }
 alloy-primitives = "1.5"
 alloy-json-abi = "1.5"
 alloy-dyn-abi = "1.5"
+bytes = "1.10"
 graphql-parser = "0.4.1"
 include_dir = "0.7.4"
 inquire = "0.6.1"

--- a/packages/cli/src/clickhouse/ch_type.rs
+++ b/packages/cli/src/clickhouse/ch_type.rs
@@ -1,9 +1,11 @@
-//! ClickHouse column types, parsed from what the server reports in
-//! `system.columns`. Reading the type back from the server rather than deriving
-//! it from the schema is what makes the binary encoder safe against a table that
-//! already existed: `Enum8('SET','DELETE')` is stored as
-//! `Enum8('SET' = 1, 'DELETE' = 2)`, and RowBinary carries the numeric value, so
-//! guessing the mapping would silently write the wrong variant.
+//! ClickHouse column types, parsed from the type text the caller declared the
+//! column with — the same string its `CREATE TABLE` used.
+//!
+//! Only what the encoder has to know to lay out bytes is modelled. An `Enum` is
+//! the clearest case: RowBinary carries the variant's number rather than its
+//! name, so the numbering has to be in the type text. Envio writes it there
+//! explicitly for exactly that reason, rather than leaving it to the numbering
+//! ClickHouse would apply to an unnumbered list.
 
 use anyhow::{anyhow, bail, Result};
 

--- a/packages/cli/src/clickhouse/ch_type.rs
+++ b/packages/cli/src/clickhouse/ch_type.rs
@@ -32,9 +32,8 @@ pub enum ChType {
         precision: u32,
     },
     Decimal {
-        /// Width of the backing integer in bytes: 4, 8, 16 or 32.
-        bytes: usize,
-        /// Total digits the column accepts, which bounds the stored integer.
+        /// Total digits the column accepts, which bounds the stored integer and
+        /// fixes the width of the backing one.
         precision: u32,
         scale: u32,
     },
@@ -113,7 +112,7 @@ fn split_args(input: &str) -> Vec<&str> {
 }
 
 /// Number of bytes ClickHouse uses for a `Decimal` of the given precision.
-fn decimal_bytes(precision: u32) -> Result<usize> {
+pub fn decimal_bytes(precision: u32) -> Result<usize> {
     match precision {
         1..=9 => Ok(4),
         10..=18 => Ok(8),
@@ -174,23 +173,24 @@ pub fn parse(input: &str) -> Result<ChType> {
                     bail!("Decimal expects (precision, scale), got `{args}`");
                 }
                 let precision: u32 = parts[0].parse()?;
+                // Rejects a precision with no valid width here, so every parsed
+                // Decimal has one.
+                decimal_bytes(precision)?;
                 Ok(ChType::Decimal {
-                    bytes: decimal_bytes(precision)?,
                     precision,
                     scale: parts[1].parse()?,
                 })
             }
             "Decimal32" | "Decimal64" | "Decimal128" | "Decimal256" => {
-                // The shorthand fixes the width and takes the widest precision
-                // that width holds.
-                let (bytes, precision) = match name {
-                    "Decimal32" => (4, 9),
-                    "Decimal64" => (8, 18),
-                    "Decimal128" => (16, 38),
-                    _ => (32, 76),
+                // The shorthand fixes the width, so it stands for the widest
+                // precision that width holds.
+                let precision = match name {
+                    "Decimal32" => 9,
+                    "Decimal64" => 18,
+                    "Decimal128" => 38,
+                    _ => 76,
                 };
                 Ok(ChType::Decimal {
-                    bytes,
                     precision,
                     scale: args.trim().parse()?,
                 })
@@ -283,9 +283,8 @@ mod tests {
 
     #[test]
     fn parses_scalars() {
-        assert_eq!(parse("String").unwrap(), ChType::String);
-        assert_eq!(parse("UInt64").unwrap(), ChType::UInt64);
-        assert_eq!(parse("Bool").unwrap(), ChType::Bool);
+        let parsed = ["String", "UInt64", "Bool"].map(|input| parse(input).unwrap());
+        assert_eq!(parsed, [ChType::String, ChType::UInt64, ChType::Bool]);
     }
 
     #[test]
@@ -297,39 +296,45 @@ mod tests {
     }
 
     #[test]
-    fn parses_decimal_widths() {
+    fn parses_decimal_precision_and_scale() {
+        let parsed = [
+            "Decimal(9, 2)",
+            "Decimal(18, 0)",
+            "Decimal(50, 3)",
+            "Decimal64(4)",
+        ]
+        .map(|input| parse(input).unwrap());
         assert_eq!(
-            parse("Decimal(9, 2)").unwrap(),
-            ChType::Decimal {
-                bytes: 4,
-                precision: 9,
-                scale: 2
-            }
+            parsed,
+            [
+                ChType::Decimal {
+                    precision: 9,
+                    scale: 2
+                },
+                ChType::Decimal {
+                    precision: 18,
+                    scale: 0
+                },
+                ChType::Decimal {
+                    precision: 50,
+                    scale: 3
+                },
+                // The shorthand stands for the widest precision its width holds.
+                ChType::Decimal {
+                    precision: 18,
+                    scale: 4
+                },
+            ]
         );
-        assert_eq!(
-            parse("Decimal(18, 0)").unwrap(),
-            ChType::Decimal {
-                bytes: 8,
-                precision: 18,
-                scale: 0
-            }
-        );
-        assert_eq!(
-            parse("Decimal(38, 0)").unwrap(),
-            ChType::Decimal {
-                bytes: 16,
-                precision: 38,
-                scale: 0
-            }
-        );
-        assert_eq!(
-            parse("Decimal64(4)").unwrap(),
-            ChType::Decimal {
-                bytes: 8,
-                precision: 18,
-                scale: 4
-            }
-        );
+    }
+
+    /// The precision alone fixes the width, which is why the type does not carry
+    /// it: a pair that disagreed would shift every following column on the wire.
+    #[test]
+    fn precision_fixes_the_backing_width() {
+        let widths =
+            [9u32, 10, 18, 19, 38, 39, 76].map(|precision| decimal_bytes(precision).unwrap());
+        assert_eq!(widths, [4, 8, 8, 16, 16, 32, 32]);
     }
 
     #[test]
@@ -356,8 +361,10 @@ mod tests {
     #[test]
     fn enum_variant_may_contain_a_comma_or_paren() {
         let parsed = parse("Enum8('a,b' = 7, 'c(d)' = 9)").unwrap();
-        assert_eq!(parsed.enum_value("a,b"), Some(7));
-        assert_eq!(parsed.enum_value("c(d)"), Some(9));
+        assert_eq!(
+            (parsed.enum_value("a,b"), parsed.enum_value("c(d)")),
+            (Some(7), Some(9))
+        );
     }
 
     #[test]
@@ -367,19 +374,23 @@ mod tests {
 
     #[test]
     fn column_kind_follows_the_type() {
-        assert_eq!(parse("Int32").unwrap().column_kind(), ColumnKind::F64);
-        assert_eq!(parse("UInt64").unwrap().column_kind(), ColumnKind::U64);
+        let kinds = [
+            "Int32",
+            "UInt64",
+            "Nullable(String)",
+            "Array(String)",
+            "DateTime64(3, 'UTC')",
+        ]
+        .map(|input| parse(input).unwrap().column_kind());
         assert_eq!(
-            parse("Nullable(String)").unwrap().column_kind(),
-            ColumnKind::Text
-        );
-        assert_eq!(
-            parse("Array(String)").unwrap().column_kind(),
-            ColumnKind::Text
-        );
-        assert_eq!(
-            parse("DateTime64(3, 'UTC')").unwrap().column_kind(),
-            ColumnKind::F64
+            kinds,
+            [
+                ColumnKind::F64,
+                ColumnKind::U64,
+                ColumnKind::Text,
+                ColumnKind::Text,
+                ColumnKind::F64
+            ]
         );
     }
 

--- a/packages/cli/src/clickhouse/mock_server.rs
+++ b/packages/cli/src/clickhouse/mock_server.rs
@@ -1,7 +1,8 @@
 //! A stand-in ClickHouse over HTTP, for testing the parts of the sink that only
-//! show up when the server misbehaves. It answers the `system.columns` lookup
-//! from a fixed schema, records every insert body it accepts, and can be told to
-//! reject the first N inserts so the retry path runs for real.
+//! show up when the server misbehaves. It records every insert body it accepts,
+//! and can be told to reject the first N inserts so the retry path runs for
+//! real. Anything that is not an insert is counted and refused, because a sink
+//! that takes its column types from the caller has no reason to ask.
 
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
@@ -15,56 +16,44 @@ struct State {
     accepted: Vec<Vec<u8>>,
     /// Inserts still to be rejected before the server starts accepting.
     reject_next: usize,
-    /// Read queries still to be rejected — the `system.columns` lookup.
-    reject_next_queries: usize,
     /// Total inserts seen, accepted or not.
     seen: usize,
+    /// Total read queries seen.
+    queries: usize,
 }
 
 pub struct MockClickHouse {
     pub url: String,
     state: Arc<Mutex<State>>,
-    /// Column name and type text, as `system.columns` would report them.
-    columns: Vec<(String, String)>,
 }
 
 impl MockClickHouse {
     /// Serves until dropped. `reject_next` inserts fail with a 500 before the
     /// server starts accepting.
-    pub async fn start(columns: &[(&str, &str)], reject_next: usize) -> Self {
+    pub async fn start(reject_next: usize) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let url = format!("http://{}", listener.local_addr().unwrap());
         let state = Arc::new(Mutex::new(State {
             reject_next,
             ..Default::default()
         }));
-        let columns: Vec<(String, String)> = columns
-            .iter()
-            .map(|(name, ty)| (name.to_string(), ty.to_string()))
-            .collect();
 
         let accept_state = state.clone();
-        let accept_columns = columns.clone();
         tokio::spawn(async move {
             loop {
                 let Ok((stream, _)) = listener.accept().await else {
                     return;
                 };
                 let state = accept_state.clone();
-                let columns = accept_columns.clone();
                 tokio::spawn(async move {
                     // The sink pools connections, so one socket carries many
                     // requests; serve until the peer closes it.
-                    let _ = serve(stream, state, columns).await;
+                    let _ = serve(stream, state).await;
                 });
             }
         });
 
-        Self {
-            url,
-            state,
-            columns,
-        }
+        Self { url, state }
     }
 
     /// Accepts connections and reads whatever is sent, but never answers —
@@ -87,7 +76,6 @@ impl MockClickHouse {
         Self {
             url,
             state: Arc::new(Mutex::new(State::default())),
-            columns: Vec::new(),
         }
     }
 
@@ -95,13 +83,14 @@ impl MockClickHouse {
         self.state.lock().unwrap().accepted.clone()
     }
 
-    /// Fails the next `count` read queries before answering the schema lookup.
-    pub fn reject_next_queries(&self, count: usize) {
-        self.state.lock().unwrap().reject_next_queries = count;
-    }
-
     pub fn inserts_seen(&self) -> usize {
         self.state.lock().unwrap().seen
+    }
+
+    /// Read queries the server was asked, which for a sink that takes its types
+    /// from the caller should stay at zero.
+    pub fn queries_seen(&self) -> usize {
+        self.state.lock().unwrap().queries
     }
 
     /// Decodes every accepted body as rows of one `String` column, flattened in
@@ -118,10 +107,6 @@ impl MockClickHouse {
             }
         }
         out
-    }
-
-    pub fn column_types(&self) -> &[(String, String)] {
-        &self.columns
     }
 }
 
@@ -140,11 +125,7 @@ fn read_varint(bytes: &[u8]) -> (usize, usize) {
     }
 }
 
-async fn serve(
-    mut stream: TcpStream,
-    state: Arc<Mutex<State>>,
-    columns: Vec<(String, String)>,
-) -> std::io::Result<()> {
+async fn serve(mut stream: TcpStream, state: Arc<Mutex<State>>) -> std::io::Result<()> {
     let mut buffered: VecDeque<u8> = VecDeque::new();
     loop {
         let head = match read_until_headers(&mut stream, &mut buffered).await? {
@@ -200,22 +181,8 @@ async fn serve(
                 http_response(200, "")
             }
         } else {
-            let reject = {
-                let mut state = state.lock().unwrap();
-                let reject = state.reject_next_queries > 0;
-                state.reject_next_queries = state.reject_next_queries.saturating_sub(1);
-                reject
-            };
-            if reject {
-                http_response(500, "Code: 999. DB::Exception: mock query rejection")
-            } else {
-                let tsv = columns
-                    .iter()
-                    .map(|(name, ty)| format!("{name}\t{ty}"))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                http_response(200, &format!("{tsv}\n"))
-            }
+            state.lock().unwrap().queries += 1;
+            http_response(400, "the sink should not be querying the server")
         };
         stream.write_all(&response).await?;
         stream.flush().await?;

--- a/packages/cli/src/clickhouse/mock_server.rs
+++ b/packages/cli/src/clickhouse/mock_server.rs
@@ -15,6 +15,8 @@ struct State {
     accepted: Vec<Vec<u8>>,
     /// Inserts still to be rejected before the server starts accepting.
     reject_next: usize,
+    /// Read queries still to be rejected — the `system.columns` lookup.
+    reject_next_queries: usize,
     /// Total inserts seen, accepted or not.
     seen: usize,
 }
@@ -65,8 +67,37 @@ impl MockClickHouse {
         }
     }
 
+    /// Accepts connections and reads whatever is sent, but never answers —
+    /// a server or load balancer that black-holes an established connection.
+    /// Nothing short of a client-side timeout ends a request against this.
+    pub async fn start_unresponsive() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    return;
+                };
+                // Holding the stream keeps the connection open rather than
+                // closing it, which the client would see as a failure.
+                held.push(stream);
+            }
+        });
+        Self {
+            url,
+            state: Arc::new(Mutex::new(State::default())),
+            columns: Vec::new(),
+        }
+    }
+
     pub fn accepted(&self) -> Vec<Vec<u8>> {
         self.state.lock().unwrap().accepted.clone()
+    }
+
+    /// Fails the next `count` read queries before answering the schema lookup.
+    pub fn reject_next_queries(&self, count: usize) {
+        self.state.lock().unwrap().reject_next_queries = count;
     }
 
     pub fn inserts_seen(&self) -> usize {
@@ -169,12 +200,22 @@ async fn serve(
                 http_response(200, "")
             }
         } else {
-            let tsv = columns
-                .iter()
-                .map(|(name, ty)| format!("{name}\t{ty}"))
-                .collect::<Vec<_>>()
-                .join("\n");
-            http_response(200, &format!("{tsv}\n"))
+            let reject = {
+                let mut state = state.lock().unwrap();
+                let reject = state.reject_next_queries > 0;
+                state.reject_next_queries = state.reject_next_queries.saturating_sub(1);
+                reject
+            };
+            if reject {
+                http_response(500, "Code: 999. DB::Exception: mock query rejection")
+            } else {
+                let tsv = columns
+                    .iter()
+                    .map(|(name, ty)| format!("{name}\t{ty}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                http_response(200, &format!("{tsv}\n"))
+            }
         };
         stream.write_all(&response).await?;
         stream.flush().await?;

--- a/packages/cli/src/clickhouse/mod.rs
+++ b/packages/cli/src/clickhouse/mod.rs
@@ -11,29 +11,33 @@
 //! a JS value can only be read while holding the isolate, so `stage` copies the
 //! batch into owned Rust memory on the JS thread and `flush` does the encoding
 //! and the HTTP round trip on the tokio pool.
+//!
+//! Column types come with the values. The caller creates these tables, so it
+//! knows their shape, and asking the server to describe them back would only add
+//! a round trip and a second answer to keep in step. The insert names every
+//! column it sends, which is what keeps that safe: the table's own column order
+//! stops mattering, and anything envio does not write — a column a user added, a
+//! DEFAULT or MATERIALIZED expression, a type this encoder has never heard of —
+//! is left for the server to fill.
 
 pub mod ch_type;
 #[cfg(test)]
 mod mock_server;
 pub mod row_binary;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use bytes::Bytes;
 use napi::bindgen_prelude::{BigInt64Array, BigUint64Array, Float64Array, Uint32Array, Uint8Array};
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi::{Env, Status};
 use napi_derive::napi;
 
-use ch_type::ChType;
-
-/// A table's columns in position order, as ClickHouse reports them.
-type TableSchema = Arc<Vec<(String, ChType)>>;
-use row_binary::{Column, ColumnValues, EncodedRows, StagedValues};
+use row_binary::{Column, EncodedRows, StagedValues};
 
 /// Retries an insert this many times before giving up, matching the JS client's
 /// policy: halve the batch while more than one row remains, otherwise wait.
@@ -101,6 +105,11 @@ impl RetryPolicy {
 #[napi(object)]
 pub struct ColumnInput {
     pub name: String,
+    /// The column's ClickHouse type, the same string the DDL declared it with.
+    /// The caller creates these tables, so it already knows the shape; reading
+    /// it back from `system.columns` would only add a round trip and a second
+    /// place for the answer to come from.
+    pub ch_type: String,
     /// Int8/16/32, UInt8/16/32, Float32/64, Bool (0/1), Date, DateTime,
     /// DateTime64 (ticks).
     pub numbers: Option<Float64Array>,
@@ -121,8 +130,37 @@ pub struct ColumnInput {
 /// A staged column, owned by Rust so it can leave the JS thread.
 struct StagedColumn {
     name: String,
+    /// The column's ClickHouse type, exactly as the DDL declared it.
+    ch_type: String,
     values: StagedValues,
     nulls: Vec<u8>,
+}
+
+impl StagedColumn {
+    /// Parses the declared type and resolves the text spans — the work that
+    /// needs neither the isolate nor the network, so it runs off the JS thread.
+    fn resolve(self) -> Result<Column> {
+        let ch_type = ch_type::parse(&self.ch_type)
+            .with_context(|| format!("Column `{}` has type `{}`", self.name, self.ch_type))?;
+        let values = self
+            .values
+            .resolve()
+            .with_context(|| format!("Column `{}`", self.name))?;
+        let kind = ch_type.column_kind();
+        if values.kind() != kind {
+            bail!(
+                "Column `{}` is {ch_type:?} and must be sent as {kind:?}, got {:?}",
+                self.name,
+                values.kind()
+            );
+        }
+        Ok(Column {
+            name: self.name,
+            ch_type,
+            values,
+            nulls: self.nulls,
+        })
+    }
 }
 
 struct Staged {
@@ -138,12 +176,6 @@ pub struct ClickHouseSink {
     username: String,
     password: String,
     database: String,
-    /// Column name and type per table, read from `system.columns` on first use.
-    schemas: Mutex<HashMap<String, TableSchema>>,
-    /// Tables whose column mismatch has already been reported. A mismatch is a
-    /// property of the table, so repeating it once per batch would be noise for
-    /// the rest of the run.
-    reported: Mutex<HashSet<String>>,
     staged: Mutex<HashMap<u32, Staged>>,
     next_handle: AtomicU32,
     tuning: Tuning,
@@ -218,8 +250,6 @@ impl ClickHouseSink {
             username: options.username,
             password: options.password,
             database: options.database,
-            schemas: Mutex::new(HashMap::new()),
-            reported: Mutex::new(HashSet::new()),
             staged: Mutex::new(HashMap::new()),
             next_handle: AtomicU32::new(1),
             tuning,
@@ -236,6 +266,7 @@ impl ClickHouseSink {
         for column in columns {
             let ColumnInput {
                 name,
+                ch_type,
                 numbers,
                 unsigned64,
                 signed64,
@@ -266,6 +297,7 @@ impl ClickHouseSink {
             };
             staged_columns.push(StagedColumn {
                 name,
+                ch_type,
                 values,
                 nulls: nulls.map(|n| n.to_vec()).unwrap_or_default(),
             });
@@ -294,134 +326,43 @@ impl ClickHouseSink {
             })?;
         self.insert_staged(staged).await.map_err(to_napi)
     }
-
-    /// Forgets the cached column types for `table`, so the next insert re-reads
-    /// them. Called after DDL recreates a table.
-    #[napi]
-    pub fn invalidate_schema(&self, table: String) {
-        self.schemas.lock().unwrap().remove(&table);
-        self.reported.lock().unwrap().remove(&table);
-    }
 }
 
 impl ClickHouseSink {
     async fn insert_staged(&self, staged: Staged) -> Result<()> {
-        let schema = self.table_schema(&staged.table).await?;
-        let (encoded, warnings) = tokio::task::block_in_place(|| {
-            let (columns, warnings) = align_to_schema(&schema, staged.columns, staged.rows)?;
-            row_binary::encode(&columns, staged.rows).map(|encoded| (encoded, warnings))
+        let table = staged.table;
+        let encoded = tokio::task::block_in_place(|| {
+            let columns = staged
+                .columns
+                .into_iter()
+                .map(StagedColumn::resolve)
+                .collect::<Result<Vec<_>>>()?;
+            row_binary::encode(&columns, staged.rows).map(|encoded| (encoded, columns))
         })
-        .with_context(|| {
-            format!(
-                "Failed encoding rows for ClickHouse table `{}`",
-                staged.table
-            )
-        })?;
-        // A column mismatch is a property of the table, so repeating it once per
-        // batch would be noise for the rest of the run.
-        if !warnings.is_empty() && self.reported.lock().unwrap().insert(staged.table.clone()) {
-            for warning in &warnings {
-                (self.warn)(warning);
-            }
-        }
+        .with_context(|| format!("Failed encoding rows for ClickHouse table `{table}`"))?;
+        let (encoded, columns) = encoded;
         if encoded.rows() == 0 {
             return Ok(());
         }
-        self.insert_with_retry(&staged.table, &encoded).await
-    }
-
-    /// Reads a table's column types from the server. Doing this instead of
-    /// deriving them from envio's schema keeps the encoder honest about a table
-    /// that already existed — an `Enum8` reports the numeric value RowBinary
-    /// needs, which nothing on the JS side knows.
-    async fn table_schema(&self, table: &str) -> Result<TableSchema> {
-        if let Some(cached) = self.schemas.lock().unwrap().get(table) {
-            return Ok(cached.clone());
-        }
-        let query = format!(
-            // MATERIALIZED and ALIAS columns are computed, not stored, so a
-            // `FORMAT RowBinary` row must not carry a value for them.
-            "SELECT name, type FROM system.columns \
-             WHERE database = {} AND table = {} \
-               AND default_kind NOT IN ('MATERIALIZED', 'ALIAS') \
-             ORDER BY position FORMAT TSVRaw",
-            quote_literal(&self.database),
-            quote_literal(table)
-        );
-        let text = self.run_query_with_retry(&query).await?;
-        let mut columns = Vec::new();
-        for line in text.lines().filter(|l| !l.is_empty()) {
-            let (name, ty) = line
-                .split_once('\t')
-                .ok_or_else(|| anyhow!("Malformed system.columns row `{line}`"))?;
-            let parsed = ch_type::parse(ty)
-                .with_context(|| format!("Column `{table}`.`{name}` has type `{ty}`"))?;
-            columns.push((name.to_string(), parsed));
-        }
-        if columns.is_empty() {
-            bail!(
-                "ClickHouse table `{}`.`{table}` has no columns — was it created?",
-                self.database
-            );
-        }
-        let schema = Arc::new(columns);
-        self.schemas
-            .lock()
-            .unwrap()
-            .insert(table.to_string(), schema.clone());
-        Ok(schema)
-    }
-
-    /// The schema lookup is a read, so a failure is retried whole rather than
-    /// halved. It sits in front of every insert to a table the sink has not seen
-    /// yet, so leaving it uncovered would let one blip fail a batch that the
-    /// insert path itself would have ridden out.
-    async fn run_query_with_retry(&self, query: &str) -> Result<String> {
-        let mut retries = self.tuning.retry.attempts;
-        loop {
-            let err = match self.run_query(query).await {
-                Ok(text) => return Ok(text),
-                Err(err) if retries == 0 => return Err(err),
-                Err(err) => err,
-            };
-            (self.warn)(&format!(
-                "ClickHouse query failed, {} retries left: {err:#}",
-                retries - 1
-            ));
-            tokio::time::sleep(self.tuning.retry.delay(retries)).await;
-            retries -= 1;
-        }
-    }
-
-    async fn run_query(&self, query: &str) -> Result<String> {
-        let response = self
-            .client
-            .post(&self.url)
-            .header("X-ClickHouse-User", &self.username)
-            .header("X-ClickHouse-Key", &self.password)
-            .header("X-ClickHouse-Database", &self.database)
-            .body(query.to_string())
-            .send()
-            .await
-            .context("ClickHouse request failed")?;
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        if !status.is_success() {
-            bail!("ClickHouse returned {status}: {text}");
-        }
-        Ok(text)
+        self.insert_with_retry(&table, &columns, &encoded).await
     }
 
     /// Mirrors the JS client's policy: on a transient failure halve the range and
     /// retry each half; with a single row left, wait and retry it. The delay
     /// grows from 100ms to 1s as retries run down.
-    async fn insert_with_retry(&self, table: &str, encoded: &EncodedRows) -> Result<()> {
+    async fn insert_with_retry(
+        &self,
+        table: &str,
+        columns: &[Column],
+        encoded: &EncodedRows,
+    ) -> Result<()> {
+        let query = insert_query(&self.database, table, columns);
         let mut attempted: Vec<String> = Vec::new();
         // Ranges still to send, most recent first; a failed range is replaced by
         // its two halves so the retry never re-sends rows that already landed.
         let mut pending = vec![(0usize, encoded.rows(), self.tuning.retry.attempts)];
         while let Some((start, end, retries)) = pending.pop() {
-            match self.post_rows(table, encoded.slice(start, end)).await {
+            match self.post_rows(&query, encoded.slice(start, end)).await {
                 Ok(()) => continue,
                 Err(err) if retries == 0 => {
                     // The attempts leading here are the diagnosis; returning the
@@ -454,16 +395,11 @@ impl ClickHouseSink {
         Ok(())
     }
 
-    async fn post_rows(&self, table: &str, body: Bytes) -> Result<()> {
-        let query = format!(
-            "INSERT INTO {}.{} FORMAT RowBinary",
-            quote_identifier(&self.database),
-            quote_identifier(table)
-        );
+    async fn post_rows(&self, query: &str, body: Bytes) -> Result<()> {
         let response = self
             .client
             .post(&self.url)
-            .query(&[("query", query.as_str())])
+            .query(&[("query", query)])
             .header("X-ClickHouse-User", &self.username)
             .header("X-ClickHouse-Key", &self.password)
             .header("X-ClickHouse-Database", &self.database)
@@ -492,98 +428,24 @@ pub fn clickhouse_column_kind(ch_type: String) -> napi::Result<u8> {
         .map_err(to_napi)
 }
 
+/// Names every column the body carries, so the table's own column order stops
+/// mattering and anything envio does not write — an extra column a user added, a
+/// MATERIALIZED or DEFAULT expression — is left for the server to fill.
+fn insert_query(database: &str, table: &str, columns: &[Column]) -> String {
+    let names = columns
+        .iter()
+        .map(|column| quote_identifier(&column.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "INSERT INTO {}.{} ({names}) FORMAT RowBinary",
+        quote_identifier(database),
+        quote_identifier(table)
+    )
+}
+
 fn quote_identifier(name: &str) -> String {
     format!("`{}`", name.replace('`', "``"))
-}
-
-fn quote_literal(value: &str) -> String {
-    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "\\'"))
-}
-
-/// Puts the staged columns in the target table's column order and pairs each
-/// with its type.
-///
-/// A table column the caller has no values for takes the type's default for
-/// every row, which is what omitting it from a JSONEachRow row used to do — a
-/// table carrying a column envio no longer writes must keep working. It is still
-/// reported, since for an envio-created table the columns cannot legitimately
-/// diverge from the DDL. The reverse is an error: a value with no column to go in
-/// would shift every following column on the wire.
-fn align_to_schema(
-    schema: &[(String, ChType)],
-    columns: Vec<StagedColumn>,
-    rows: usize,
-) -> Result<(Vec<Column>, Vec<String>)> {
-    let mut by_name: HashMap<String, StagedColumn> = columns
-        .into_iter()
-        .map(|column| (column.name.clone(), column))
-        .collect();
-    let mut aligned = Vec::with_capacity(schema.len());
-    let mut defaulted = Vec::new();
-    for (name, ch_type) in schema {
-        let staged = match by_name.remove(name) {
-            Some(staged) => staged,
-            None => {
-                defaulted.push(name.clone());
-                aligned.push(Column {
-                    name: name.clone(),
-                    ch_type: ch_type.clone(),
-                    values: default_values(ch_type, rows),
-                    nulls: vec![1; rows],
-                });
-                continue;
-            }
-        };
-        if staged.values.len() != rows {
-            bail!(
-                "Column `{name}` has {} values but the batch has {rows} rows",
-                staged.values.len()
-            );
-        }
-        let values = staged
-            .values
-            .resolve()
-            .with_context(|| format!("Column `{name}`"))?;
-        let expected = ch_type.column_kind();
-        if values.kind() != expected {
-            bail!(
-                "Column `{name}` is {ch_type:?} and must be sent as {expected:?}, got {:?}",
-                values.kind()
-            );
-        }
-        aligned.push(Column {
-            name: name.clone(),
-            ch_type: ch_type.clone(),
-            values,
-            nulls: staged.nulls,
-        });
-    }
-    if let Some(extra) = by_name.keys().next() {
-        bail!("Column `{extra}` is not part of the target table");
-    }
-    let warnings = if defaulted.is_empty() {
-        Vec::new()
-    } else {
-        vec![format!(
-            "No values supplied for ClickHouse column(s) {}; every row took the column's default",
-            defaulted.join(", ")
-        )]
-    };
-    Ok((aligned, warnings))
-}
-
-/// Placeholder values for a column with nothing to write. Every row is masked as
-/// null, so the encoder never reads them — only the kind has to match the type.
-fn default_values(ch_type: &ChType, rows: usize) -> ColumnValues {
-    match ch_type.column_kind() {
-        ch_type::ColumnKind::F64 => ColumnValues::F64(vec![0.0; rows]),
-        ch_type::ColumnKind::U64 => ColumnValues::U64(vec![0; rows]),
-        ch_type::ColumnKind::I64 => ColumnValues::I64(vec![0; rows]),
-        ch_type::ColumnKind::Text => ColumnValues::Text {
-            data: String::new(),
-            bounds: vec![(0, 0); rows],
-        },
-    }
 }
 
 #[cfg(test)]
@@ -591,80 +453,55 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
-    fn schema() -> Vec<(String, ChType)> {
-        vec![
-            ("id".to_string(), ch_type::parse("String").unwrap()),
-            ("n".to_string(), ch_type::parse("Int32").unwrap()),
-        ]
-    }
-
-    fn text(name: &str, values: &[&str]) -> StagedColumn {
+    /// A staged column of text values, declared as `ty`.
+    fn column(name: &str, ty: &str, values: &[&str]) -> Column {
         StagedColumn {
             name: name.to_string(),
+            ch_type: ty.to_string(),
             values: StagedValues::Text {
                 data: values.concat(),
                 bounds: values.iter().map(|v| v.len() as u32).collect(),
             },
             nulls: Vec::new(),
         }
+        .resolve()
+        .unwrap()
     }
 
+    // The caller declares each column's type, so a value that cannot travel as
+    // that type is caught before anything is encoded.
     #[test]
-    fn aligns_columns_into_table_order() {
-        let columns = vec![
-            StagedColumn {
-                name: "n".to_string(),
-                values: StagedValues::F64(vec![1.0]),
-                nulls: Vec::new(),
-            },
-            text("id", &["a"]),
-        ];
-        let (aligned, warnings) = align_to_schema(&schema(), columns, 1).unwrap();
-        assert_eq!(
-            (
-                aligned.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
-                warnings
-            ),
-            (vec!["id", "n"], Vec::<String>::new())
-        );
-    }
-
-    // A table carrying a column envio does not write — an older version's field,
-    // or one a user added — kept working under JSONEachRow because an omitted
-    // column takes its default. RowBinary has no way to omit one, so the encoder
-    // has to fill it, and say so.
-    #[test]
-    fn defaults_a_table_column_with_no_values_and_reports_it() {
-        let (aligned, warnings) = align_to_schema(&schema(), vec![text("id", &["a"])], 1).unwrap();
-        let encoded = row_binary::encode(&aligned, 1).unwrap();
-        assert_eq!(
-            (encoded.body.to_vec(), warnings),
-            (
-                vec![1, b'a', 0, 0, 0, 0],
-                vec![
-                    "No values supplied for ClickHouse column(s) n; every row took the column's \
-                     default"
-                        .to_string()
-                ]
-            )
-        );
-    }
-
-    #[test]
-    fn rejects_a_column_the_table_does_not_have() {
-        let columns = vec![
-            text("id", &["a"]),
-            StagedColumn {
-                name: "n".to_string(),
-                values: StagedValues::F64(vec![1.0]),
-                nulls: Vec::new(),
-            },
-            text("surprise", &["x"]),
-        ];
-        let err = align_to_schema(&schema(), columns, 1).unwrap_err();
+    fn rejects_values_that_do_not_match_the_declared_type() {
+        let err = StagedColumn {
+            name: "n".to_string(),
+            ch_type: "String".to_string(),
+            values: StagedValues::F64(vec![1.0]),
+            nulls: Vec::new(),
+        }
+        .resolve()
+        .unwrap_err();
         assert_eq!(
             format!("{err:#}"),
-            "Column `surprise` is not part of the target table"
+            "Column `n` is String and must be sent as Text, got F64"
+        );
+    }
+
+    #[test]
+    fn rejects_a_type_it_cannot_encode() {
+        let err = StagedColumn {
+            name: "t".to_string(),
+            ch_type: "Tuple(String, UInt8)".to_string(),
+            values: StagedValues::Text {
+                data: String::new(),
+                bounds: vec![0],
+            },
+            nulls: Vec::new(),
+        }
+        .resolve()
+        .unwrap_err();
+        assert_eq!(
+            format!("{err:#}"),
+            "Column `t` has type `Tuple(String, UInt8)`: unsupported ClickHouse type `Tuple`"
         );
     }
 
@@ -727,6 +564,7 @@ mod tests {
             values.len() as u32,
             vec![ColumnInput {
                 name: "id".to_string(),
+                ch_type: "String".to_string(),
                 numbers: None,
                 unsigned64: None,
                 signed64: None,
@@ -748,7 +586,7 @@ mod tests {
     // that already landed must not be sent again.
     #[tokio::test(flavor = "multi_thread")]
     async fn a_rejected_insert_is_retried_as_halves_and_every_row_lands_once() {
-        let server = mock_server::MockClickHouse::start(&[("id", "String")], 1).await;
+        let server = mock_server::MockClickHouse::start(1).await;
         let sink = sink_for(&server, 4);
         let handle = stage_ids(&sink, &["a", "b", "c", "d"]);
 
@@ -777,7 +615,7 @@ mod tests {
     // Halving bottoms out at a single row, which is then retried whole.
     #[tokio::test(flavor = "multi_thread")]
     async fn a_single_row_is_retried_in_place_until_it_lands() {
-        let server = mock_server::MockClickHouse::start(&[("id", "String")], 2).await;
+        let server = mock_server::MockClickHouse::start(2).await;
         let sink = sink_for(&server, 4);
         let handle = stage_ids(&sink, &["only"]);
 
@@ -791,7 +629,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn an_insert_that_never_succeeds_surfaces_the_error() {
-        let server = mock_server::MockClickHouse::start(&[("id", "String")], usize::MAX).await;
+        let server = mock_server::MockClickHouse::start(usize::MAX).await;
         let sink = sink_for(&server, 2);
         let handle = stage_ids(&sink, &["a", "b"]);
 
@@ -836,51 +674,22 @@ mod tests {
         );
     }
 
-    // The schema lookup runs in front of every insert to a table the sink has not
-    // seen. The old JS path had no separate lookup, so nothing about a batch was
-    // outside the retry; leaving this uncovered would make one blip fatal.
+    // Types come from the caller, so an insert is the only request the sink ever
+    // makes — no `system.columns` round trip in front of a table it has not seen.
     #[tokio::test(flavor = "multi_thread")]
-    async fn a_failed_schema_lookup_is_retried() {
-        let server = mock_server::MockClickHouse::start(&[("id", "String")], 0).await;
-        server.reject_next_queries(2);
-        let sink = sink_for(&server, 4);
-        let handle = stage_ids(&sink, &["a"]);
-
-        sink.flush(handle).await.unwrap();
-
-        assert_eq!(
-            (server.accepted_strings(), sink.warnings().len()),
-            (vec!["a".to_string()], 2)
-        );
-    }
-
-    // The column types come from the server, so a table the sink has never seen
-    // costs one lookup and no more.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn the_column_types_are_read_once_per_table() {
-        let server = mock_server::MockClickHouse::start(&[("id", "String")], 0).await;
+    async fn the_sink_asks_the_server_for_nothing_but_the_insert() {
+        let server = mock_server::MockClickHouse::start(0).await;
         let sink = sink_for(&server, 4);
         for _ in 0..3 {
             let handle = stage_ids(&sink, &["x"]);
             sink.flush(handle).await.unwrap();
         }
-        let cached = sink.schemas.lock().unwrap();
-        assert_eq!(
-            (
-                cached.len(),
-                cached["t"]
-                    .iter()
-                    .map(|(name, _)| name.as_str())
-                    .collect::<Vec<_>>(),
-                server.column_types().len()
-            ),
-            (1, vec!["id"], 1)
-        );
+        assert_eq!((server.inserts_seen(), server.queries_seen()), (3, 0));
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn a_value_the_column_cannot_hold_fails_before_anything_is_sent() {
-        let server = mock_server::MockClickHouse::start(&[("e", "Enum8('SET' = 1)")], 0).await;
+        let server = mock_server::MockClickHouse::start(0).await;
         let sink = sink_for(&server, 4);
         let handle = sink
             .stage(
@@ -888,6 +697,7 @@ mod tests {
                 1,
                 vec![ColumnInput {
                     name: "e".to_string(),
+                    ch_type: "Enum8('SET' = 1)".to_string(),
                     numbers: None,
                     unsigned64: None,
                     signed64: None,
@@ -909,11 +719,14 @@ mod tests {
     }
 
     #[test]
-    fn quotes_identifiers_and_literals() {
+    fn the_insert_names_every_column_it_sends() {
+        let columns = vec![
+            column("id", "String", &["a"]),
+            column("n`quoted", "String", &["1"]),
+        ];
         assert_eq!(
-            quote_identifier("envio_history_A`B"),
-            "`envio_history_A``B`"
+            insert_query("db", "envio_history_A`B", &columns),
+            "INSERT INTO `db`.`envio_history_A``B` (`id`, `n``quoted`) FORMAT RowBinary"
         );
-        assert_eq!(quote_literal("it's"), "'it\\'s'");
     }
 }

--- a/packages/cli/src/clickhouse/mod.rs
+++ b/packages/cli/src/clickhouse/mod.rs
@@ -23,18 +23,31 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
+use bytes::Bytes;
 use napi::bindgen_prelude::{BigInt64Array, BigUint64Array, Float64Array, Uint32Array, Uint8Array};
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use napi::{Env, Status};
 use napi_derive::napi;
 
 use ch_type::ChType;
 
 /// A table's columns in position order, as ClickHouse reports them.
 type TableSchema = Arc<Vec<(String, ChType)>>;
-use row_binary::{Column, ColumnValues, EncodedRows};
+use row_binary::{Column, ColumnValues, EncodedRows, StagedValues};
 
 /// Retries an insert this many times before giving up, matching the JS client's
 /// policy: halve the batch while more than one row remains, otherwise wait.
 const MAX_RETRIES: u32 = 8;
+
+/// `@clickhouse/client`'s `request_timeout` default, which the JS insert path
+/// ran under. Without it a peer that accepts a connection and then goes silent
+/// — a black-holed socket through a load balancer sends neither RST nor FIN —
+/// leaves the request hanging forever, and with it the whole write batch.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Probes an idle pooled socket so a connection dropped by a NAT or proxy is
+/// discovered before a batch is handed to it.
+const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
 
 /// How hard to retry a failed insert. Only the tests vary it, to skip the waits.
 #[derive(Debug, Clone, Copy)]
@@ -48,6 +61,23 @@ impl Default for RetryPolicy {
         Self {
             attempts: MAX_RETRIES,
             wait: true,
+        }
+    }
+}
+
+/// Knobs the tests turn down so a run takes milliseconds: the retry waits and
+/// the request timeout a hanging server has to trip.
+#[derive(Debug, Clone, Copy)]
+struct Tuning {
+    retry: RetryPolicy,
+    request_timeout: Duration,
+}
+
+impl Default for Tuning {
+    fn default() -> Self {
+        Self {
+            retry: RetryPolicy::default(),
+            request_timeout: REQUEST_TIMEOUT,
         }
     }
 }
@@ -89,13 +119,6 @@ pub struct ColumnInput {
 }
 
 /// A staged column, owned by Rust so it can leave the JS thread.
-enum StagedValues {
-    F64(Vec<f64>),
-    U64(Vec<u64>),
-    I64(Vec<i64>),
-    Text { data: String, lengths: Vec<u32> },
-}
-
 struct StagedColumn {
     name: String,
     values: StagedValues,
@@ -123,8 +146,14 @@ pub struct ClickHouseSink {
     reported: Mutex<HashSet<String>>,
     staged: Mutex<HashMap<u32, Staged>>,
     next_handle: AtomicU32,
-    retry: RetryPolicy,
+    tuning: Tuning,
+    warn: WarningSink,
 }
+
+/// Where a degradation notice goes. Retries happen while a `flush` is still in
+/// flight, so handing them back at the end would leave an operator staring at
+/// silence for the whole episode — they have to leave Rust as they occur.
+type WarningSink = Arc<dyn Fn(&str) + Send + Sync>;
 
 #[napi(object)]
 pub struct ClickHouseSinkOptions {
@@ -141,16 +170,41 @@ fn to_napi(err: anyhow::Error) -> napi::Error {
 #[napi]
 impl ClickHouseSink {
     #[napi(factory)]
-    pub fn new(options: ClickHouseSinkOptions) -> napi::Result<Self> {
-        Self::build(options, RetryPolicy::default())
+    pub fn new(
+        env: &Env,
+        options: ClickHouseSinkOptions,
+        mut on_warning: ThreadsafeFunction<String, (), String, Status, false>,
+    ) -> napi::Result<Self> {
+        // A referenced threadsafe function holds the event loop open, so a sink
+        // that outlives the run keeps the whole process from exiting. The
+        // deprecation points at the `Weak` type parameter instead, but a weak
+        // callback can be collected once JS drops its own reference — which it
+        // does immediately, the closure being passed inline — and warnings would
+        // then stop arriving with nothing to show for it.
+        #[allow(deprecated)]
+        on_warning.unref(env)?;
+        Self::build(
+            options,
+            Tuning::default(),
+            Arc::new(move |message: &str| {
+                on_warning.call(message.to_string(), ThreadsafeFunctionCallMode::NonBlocking);
+            }),
+        )
     }
 
-    fn build(options: ClickHouseSinkOptions, retry: RetryPolicy) -> napi::Result<Self> {
+    fn build(
+        options: ClickHouseSinkOptions,
+        tuning: Tuning,
+        warn: WarningSink,
+    ) -> napi::Result<Self> {
         let client = reqwest::Client::builder()
             // The sink writes continuously; keeping sockets warm avoids a TLS
             // handshake per batch against a remote cluster.
             .pool_idle_timeout(Duration::from_secs(90))
             .pool_max_idle_per_host(8)
+            .timeout(tuning.request_timeout)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .tcp_keepalive(TCP_KEEPALIVE)
             // reqwest picks up HTTP_PROXY/HTTPS_PROXY by default; Node's http
             // client never did, so honouring them here would silently start
             // routing a deployment's inserts through a proxy that nothing asked
@@ -168,7 +222,8 @@ impl ClickHouseSink {
             reported: Mutex::new(HashSet::new()),
             staged: Mutex::new(HashMap::new()),
             next_handle: AtomicU32::new(1),
-            retry,
+            tuning,
+            warn,
         })
     }
 
@@ -200,7 +255,7 @@ impl ClickHouseSink {
                     })?;
                     StagedValues::Text {
                         data,
-                        lengths: lengths.to_vec(),
+                        bounds: lengths.to_vec(),
                     }
                 }
                 _ => {
@@ -229,10 +284,10 @@ impl ClickHouseSink {
 
     /// Encodes the staged batch as RowBinary and inserts it, retrying by halving
     /// the batch. The handle is consumed either way, so a failed flush never
-    /// leaves the batch behind. Returns one message per retry, for the caller to
-    /// put through the indexer's own logger.
+    /// leaves the batch behind. Degradation notices go to the warning callback as
+    /// they happen rather than coming back at the end.
     #[napi]
-    pub async fn flush(&self, handle: u32) -> napi::Result<Vec<String>> {
+    pub async fn flush(&self, handle: u32) -> napi::Result<()> {
         let staged =
             self.staged.lock().unwrap().remove(&handle).ok_or_else(|| {
                 napi::Error::from_reason(format!("Unknown staged batch {handle}"))
@@ -250,9 +305,9 @@ impl ClickHouseSink {
 }
 
 impl ClickHouseSink {
-    async fn insert_staged(&self, staged: Staged) -> Result<Vec<String>> {
+    async fn insert_staged(&self, staged: Staged) -> Result<()> {
         let schema = self.table_schema(&staged.table).await?;
-        let (encoded, mut warnings) = tokio::task::block_in_place(|| {
+        let (encoded, warnings) = tokio::task::block_in_place(|| {
             let (columns, warnings) = align_to_schema(&schema, staged.columns, staged.rows)?;
             row_binary::encode(&columns, staged.rows).map(|encoded| (encoded, warnings))
         })
@@ -262,14 +317,17 @@ impl ClickHouseSink {
                 staged.table
             )
         })?;
-        if !warnings.is_empty() && !self.reported.lock().unwrap().insert(staged.table.clone()) {
-            warnings.clear();
+        // A column mismatch is a property of the table, so repeating it once per
+        // batch would be noise for the rest of the run.
+        if !warnings.is_empty() && self.reported.lock().unwrap().insert(staged.table.clone()) {
+            for warning in &warnings {
+                (self.warn)(warning);
+            }
         }
         if encoded.rows() == 0 {
-            return Ok(warnings);
+            return Ok(());
         }
-        warnings.extend(self.insert_with_retry(&staged.table, &encoded).await?);
-        Ok(warnings)
+        self.insert_with_retry(&staged.table, &encoded).await
     }
 
     /// Reads a table's column types from the server. Doing this instead of
@@ -290,7 +348,7 @@ impl ClickHouseSink {
             quote_literal(&self.database),
             quote_literal(table)
         );
-        let text = self.run_query(&query).await?;
+        let text = self.run_query_with_retry(&query).await?;
         let mut columns = Vec::new();
         for line in text.lines().filter(|l| !l.is_empty()) {
             let (name, ty) = line
@@ -312,6 +370,27 @@ impl ClickHouseSink {
             .unwrap()
             .insert(table.to_string(), schema.clone());
         Ok(schema)
+    }
+
+    /// The schema lookup is a read, so a failure is retried whole rather than
+    /// halved. It sits in front of every insert to a table the sink has not seen
+    /// yet, so leaving it uncovered would let one blip fail a batch that the
+    /// insert path itself would have ridden out.
+    async fn run_query_with_retry(&self, query: &str) -> Result<String> {
+        let mut retries = self.tuning.retry.attempts;
+        loop {
+            let err = match self.run_query(query).await {
+                Ok(text) => return Ok(text),
+                Err(err) if retries == 0 => return Err(err),
+                Err(err) => err,
+            };
+            (self.warn)(&format!(
+                "ClickHouse query failed, {} retries left: {err:#}",
+                retries - 1
+            ));
+            tokio::time::sleep(self.tuning.retry.delay(retries)).await;
+            retries -= 1;
+        }
     }
 
     async fn run_query(&self, query: &str) -> Result<String> {
@@ -336,31 +415,32 @@ impl ClickHouseSink {
     /// Mirrors the JS client's policy: on a transient failure halve the range and
     /// retry each half; with a single row left, wait and retry it. The delay
     /// grows from 100ms to 1s as retries run down.
-    async fn insert_with_retry(&self, table: &str, encoded: &EncodedRows) -> Result<Vec<String>> {
-        let mut warnings: Vec<String> = Vec::new();
+    async fn insert_with_retry(&self, table: &str, encoded: &EncodedRows) -> Result<()> {
+        let mut attempted: Vec<String> = Vec::new();
         // Ranges still to send, most recent first; a failed range is replaced by
         // its two halves so the retry never re-sends rows that already landed.
-        let mut pending = vec![(0usize, encoded.rows(), self.retry.attempts)];
+        let mut pending = vec![(0usize, encoded.rows(), self.tuning.retry.attempts)];
         while let Some((start, end, retries)) = pending.pop() {
-            let body = encoded.slice(start, end).to_vec();
-            match self.post_rows(table, body).await {
+            match self.post_rows(table, encoded.slice(start, end)).await {
                 Ok(()) => continue,
                 Err(err) if retries == 0 => {
                     // The attempts leading here are the diagnosis; returning the
                     // last error alone would drop them.
-                    return Err(match warnings.is_empty() {
+                    return Err(match attempted.is_empty() {
                         true => err,
-                        false => err.context(format!("after {}", warnings.join("; "))),
+                        false => err.context(format!("after {}", attempted.join("; "))),
                     });
                 }
                 Err(err) => {
                     let rows = end - start;
-                    warnings.push(format!(
+                    let warning = format!(
                         "ClickHouse insert of {rows} row(s) into `{table}` failed, \
                          {} retries left: {err:#}",
                         retries - 1
-                    ));
-                    tokio::time::sleep(self.retry.delay(retries)).await;
+                    );
+                    (self.warn)(&warning);
+                    attempted.push(warning);
+                    tokio::time::sleep(self.tuning.retry.delay(retries)).await;
                     if rows > 1 {
                         let mid = start + rows / 2;
                         pending.push((mid, end, retries - 1));
@@ -371,10 +451,10 @@ impl ClickHouseSink {
                 }
             }
         }
-        Ok(warnings)
+        Ok(())
     }
 
-    async fn post_rows(&self, table: &str, body: Vec<u8>) -> Result<()> {
+    async fn post_rows(&self, table: &str, body: Bytes) -> Result<()> {
         let query = format!(
             "INSERT INTO {}.{} FORMAT RowBinary",
             quote_identifier(&self.database),
@@ -401,10 +481,10 @@ impl ClickHouseSink {
     }
 }
 
-/// The wire kind a column of this ClickHouse type must be sent as. Exposed so a
-/// test can pin ReScript's `ClickHouseSink.kindOfField` to it: the two derive the
-/// kind from different inputs (a `Table.fieldType` there, the type text here) and
-/// a mismatch would only surface as a wrongly encoded column.
+/// The wire kind a column of this ClickHouse type must be sent as. Exposed so
+/// the JS side can pick a column's typed array from the same derivation the
+/// encoder uses, instead of mapping envio's own field types to a kind a second
+/// time — a mismatch there would only surface as a wrongly encoded column.
 #[napi]
 pub fn clickhouse_column_kind(ch_type: String) -> napi::Result<u8> {
     ch_type::parse(&ch_type)
@@ -454,22 +534,16 @@ fn align_to_schema(
                 continue;
             }
         };
-        let values = match staged.values {
-            StagedValues::F64(v) => ColumnValues::F64(v),
-            StagedValues::U64(v) => ColumnValues::U64(v),
-            StagedValues::I64(v) => ColumnValues::I64(v),
-            StagedValues::Text { data, lengths } => {
-                if lengths.len() != rows {
-                    bail!(
-                        "Column `{name}` has {} lengths but the batch has {rows} rows",
-                        lengths.len()
-                    );
-                }
-                let spans = row_binary::spans_from_utf16_lengths(&data, &lengths)
-                    .with_context(|| format!("Column `{name}`"))?;
-                ColumnValues::Text { data, spans }
-            }
-        };
+        if staged.values.len() != rows {
+            bail!(
+                "Column `{name}` has {} values but the batch has {rows} rows",
+                staged.values.len()
+            );
+        }
+        let values = staged
+            .values
+            .resolve()
+            .with_context(|| format!("Column `{name}`"))?;
         let expected = ch_type.column_kind();
         if values.kind() != expected {
             bail!(
@@ -507,7 +581,7 @@ fn default_values(ch_type: &ChType, rows: usize) -> ColumnValues {
         ch_type::ColumnKind::I64 => ColumnValues::I64(vec![0; rows]),
         ch_type::ColumnKind::Text => ColumnValues::Text {
             data: String::new(),
-            spans: vec![(0, 0); rows],
+            bounds: vec![(0, 0); rows],
         },
     }
 }
@@ -529,7 +603,7 @@ mod tests {
             name: name.to_string(),
             values: StagedValues::Text {
                 data: values.concat(),
-                lengths: values.iter().map(|v| v.len() as u32).collect(),
+                bounds: values.iter().map(|v| v.len() as u32).collect(),
             },
             nulls: Vec::new(),
         }
@@ -564,7 +638,7 @@ mod tests {
         let (aligned, warnings) = align_to_schema(&schema(), vec![text("id", &["a"])], 1).unwrap();
         let encoded = row_binary::encode(&aligned, 1).unwrap();
         assert_eq!(
-            (encoded.body, warnings),
+            (encoded.body.to_vec(), warnings),
             (
                 vec![1, b'a', 0, 0, 0, 0],
                 vec![
@@ -594,22 +668,56 @@ mod tests {
         );
     }
 
-    fn sink_for(server: &mock_server::MockClickHouse, attempts: u32) -> ClickHouseSink {
-        ClickHouseSink::build(
+    /// A sink pointed at `server`, holding on to the warnings it emitted so a
+    /// test can assert on what an operator would have seen.
+    struct TestSink {
+        sink: ClickHouseSink,
+        warnings: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl TestSink {
+        fn warnings(&self) -> Vec<String> {
+            self.warnings.lock().unwrap().clone()
+        }
+    }
+
+    impl std::ops::Deref for TestSink {
+        type Target = ClickHouseSink;
+        fn deref(&self) -> &ClickHouseSink {
+            &self.sink
+        }
+    }
+
+    fn sink_with(server: &mock_server::MockClickHouse, tuning: Tuning) -> TestSink {
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let collected = warnings.clone();
+        let sink = ClickHouseSink::build(
             ClickHouseSinkOptions {
                 url: server.url.clone(),
                 username: "default".to_string(),
                 password: String::new(),
                 database: "mock".to_string(),
             },
-            RetryPolicy {
-                attempts,
-                // The waits are the policy's, not the encoder's; skipping them
-                // keeps the test at milliseconds.
-                wait: false,
+            tuning,
+            Arc::new(move |message: &str| collected.lock().unwrap().push(message.to_string())),
+        )
+        .unwrap();
+        TestSink { sink, warnings }
+    }
+
+    fn sink_for(server: &mock_server::MockClickHouse, attempts: u32) -> TestSink {
+        sink_with(
+            server,
+            Tuning {
+                retry: RetryPolicy {
+                    attempts,
+                    // The waits are the policy's, not the encoder's; skipping
+                    // them keeps the test at milliseconds.
+                    wait: false,
+                },
+                ..Tuning::default()
             },
         )
-        .unwrap()
     }
 
     /// Stages `values` as a single `String` column named `id`.
@@ -644,13 +752,13 @@ mod tests {
         let sink = sink_for(&server, 4);
         let handle = stage_ids(&sink, &["a", "b", "c", "d"]);
 
-        let warnings = sink.flush(handle).await.unwrap();
+        sink.flush(handle).await.unwrap();
 
         assert_eq!(
             (
                 server.accepted_strings(),
                 server.inserts_seen(),
-                warnings.len()
+                sink.warnings().len()
             ),
             // One rejection, then the two halves; four rows, each exactly once.
             (
@@ -689,12 +797,61 @@ mod tests {
 
         let err = sink.flush(handle).await.unwrap_err();
 
-        assert!(
-            err.reason.contains("mock rejection"),
+        assert_eq!(
+            (
+                err.reason.contains("mock rejection"),
+                server.accepted_strings()
+            ),
+            (true, Vec::<String>::new()),
             "expected the server's message, got: {}",
             err.reason
         );
-        assert_eq!(server.accepted_strings(), Vec::<String>::new());
+    }
+
+    // A peer that accepts the connection and then goes silent sends nothing to
+    // react to, so only a client-side deadline ends the request. Without one the
+    // flush — and the write batch behind it — never resolves at all.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_server_that_never_answers_times_out_rather_than_hanging() {
+        let server = mock_server::MockClickHouse::start_unresponsive().await;
+        let sink = sink_with(
+            &server,
+            Tuning {
+                retry: RetryPolicy {
+                    attempts: 1,
+                    wait: false,
+                },
+                request_timeout: Duration::from_millis(150),
+            },
+        );
+        let handle = stage_ids(&sink, &["a"]);
+
+        let err = sink.flush(handle).await.unwrap_err();
+
+        assert_eq!(
+            err.reason.contains("operation timed out"),
+            true,
+            "expected a timeout, got: {}",
+            err.reason
+        );
+    }
+
+    // The schema lookup runs in front of every insert to a table the sink has not
+    // seen. The old JS path had no separate lookup, so nothing about a batch was
+    // outside the retry; leaving this uncovered would make one blip fatal.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_failed_schema_lookup_is_retried() {
+        let server = mock_server::MockClickHouse::start(&[("id", "String")], 0).await;
+        server.reject_next_queries(2);
+        let sink = sink_for(&server, 4);
+        let handle = stage_ids(&sink, &["a"]);
+
+        sink.flush(handle).await.unwrap();
+
+        assert_eq!(
+            (server.accepted_strings(), sink.warnings().len()),
+            (vec!["a".to_string()], 2)
+        );
     }
 
     // The column types come from the server, so a table the sink has never seen
@@ -743,12 +900,12 @@ mod tests {
 
         let err = sink.flush(handle).await.unwrap_err();
 
-        assert!(
-            err.reason.contains("not a variant"),
+        assert_eq!(
+            (err.reason.contains("not a variant"), server.inserts_seen()),
+            (true, 0),
             "expected the encoder's message, got: {}",
             err.reason
         );
-        assert_eq!(server.inserts_seen(), 0);
     }
 
     #[test]

--- a/packages/cli/src/clickhouse/row_binary.rs
+++ b/packages/cli/src/clickhouse/row_binary.rs
@@ -568,7 +568,7 @@ mod tests {
         let spans = spans_from_utf16_lengths(&data, &[1, 1, 2, 1]).unwrap();
         let values: Vec<&str> = spans
             .iter()
-            .map(|(s, e)| &data[*s as usize..*e as usize])
+            .map(|(s, e)| &data[*s..*e])
             .collect();
         assert_eq!(values, vec!["a", "é", "😀", "b"]);
     }

--- a/packages/cli/src/clickhouse/row_binary.rs
+++ b/packages/cli/src/clickhouse/row_binary.rs
@@ -6,23 +6,49 @@
 //! row.
 
 use anyhow::{anyhow, bail, Context, Result};
+use bytes::Bytes;
 
 use super::ch_type::ChType;
 
-/// One column's values for a batch, already owned by Rust.
+/// How a text column's concatenated values are delimited. JS measures UTF-16
+/// code units for free, so that is what crosses the boundary; resolving them to
+/// byte ranges is a scan over the whole column and belongs off the JS thread.
+pub trait TextBounds {
+    fn count(&self) -> usize;
+}
+
+/// UTF-16 code-unit length per value, as `String.prototype.length` reports it.
+pub type Utf16Lengths = Vec<u32>;
+/// Byte range per value into the concatenated data.
+pub type ByteSpans = Vec<(usize, usize)>;
+
+impl TextBounds for Utf16Lengths {
+    fn count(&self) -> usize {
+        self.len()
+    }
+}
+
+impl TextBounds for ByteSpans {
+    fn count(&self) -> usize {
+        self.len()
+    }
+}
+
+/// One column's values for a batch, already owned by Rust. The text delimiting
+/// is a parameter so staging and encoding share one enum: a new wire kind is one
+/// variant and one `kind` arm, not a second enum to keep in step.
 #[derive(Debug)]
-pub enum ColumnValues {
+pub enum ColumnValues<B = ByteSpans> {
     F64(Vec<f64>),
     U64(Vec<u64>),
     I64(Vec<i64>),
-    /// Concatenated values plus each value's byte range in it.
-    Text {
-        data: String,
-        spans: Vec<(u32, u32)>,
-    },
+    Text { data: String, bounds: B },
 }
 
-impl ColumnValues {
+/// A column as it arrives from JS, before the span scan.
+pub type StagedValues = ColumnValues<Utf16Lengths>;
+
+impl<B: TextBounds> ColumnValues<B> {
     /// The wire kind these values arrived as, for checking against the column's
     /// ClickHouse type.
     pub fn kind(&self) -> super::ch_type::ColumnKind {
@@ -40,15 +66,36 @@ impl ColumnValues {
             ColumnValues::F64(v) => v.len(),
             ColumnValues::U64(v) => v.len(),
             ColumnValues::I64(v) => v.len(),
-            ColumnValues::Text { spans, .. } => spans.len(),
+            ColumnValues::Text { bounds, .. } => bounds.count(),
         }
     }
+}
 
+impl StagedValues {
+    /// Resolves the UTF-16 lengths into byte spans. The only step between the two
+    /// representations, so it is also where a text column's shape is checked.
+    pub fn resolve(self) -> Result<ColumnValues> {
+        Ok(match self {
+            ColumnValues::F64(v) => ColumnValues::F64(v),
+            ColumnValues::U64(v) => ColumnValues::U64(v),
+            ColumnValues::I64(v) => ColumnValues::I64(v),
+            ColumnValues::Text { data, bounds } => {
+                let spans = spans_from_utf16_lengths(&data, &bounds)?;
+                ColumnValues::Text {
+                    data,
+                    bounds: spans,
+                }
+            }
+        })
+    }
+}
+
+impl ColumnValues {
     fn text_at(&self, row: usize) -> Result<&str> {
         match self {
-            ColumnValues::Text { data, spans } => {
-                let (start, end) = spans[row];
-                Ok(&data[start as usize..end as usize])
+            ColumnValues::Text { data, bounds } => {
+                let (start, end) = bounds[row];
+                Ok(&data[start..end])
             }
             other => bail!("expected a text column, got {other:?}"),
         }
@@ -75,7 +122,7 @@ impl Column {
 ///
 /// The scan is over UTF-8 bytes, so it cannot index by code unit directly:
 /// a character outside the BMP is two UTF-16 units and up to four UTF-8 bytes.
-pub fn spans_from_utf16_lengths(data: &str, lengths: &[u32]) -> Result<Vec<(u32, u32)>> {
+pub fn spans_from_utf16_lengths(data: &str, lengths: &[u32]) -> Result<ByteSpans> {
     let mut spans = Vec::with_capacity(lengths.len());
     let bytes = data.as_bytes();
     let mut offset = 0usize;
@@ -108,7 +155,7 @@ pub fn spans_from_utf16_lengths(data: &str, lengths: &[u32]) -> Result<Vec<(u32,
             offset += width;
             remaining -= units;
         }
-        spans.push((start as u32, offset as u32));
+        spans.push((start, offset));
     }
     if offset != bytes.len() {
         bail!(
@@ -169,20 +216,33 @@ fn decimal_to_i128(text: &str, scale: u32) -> Result<i128> {
         bail!("`{text}` is not a decimal");
     }
     // Exponent shifts the point; `scale` then fixes how many fractional digits
-    // the stored integer keeps.
-    let shift = scale as i32 + exponent - frac_part.len() as i32;
+    // the stored integer keeps. Widened to i64 because `exponent` is an
+    // unconstrained i32 and the subtraction would otherwise be able to overflow.
+    let shift = i64::from(scale) + i64::from(exponent) - frac_part.len() as i64;
     // An all-zero mantissa trims to the empty string, which `parse` rejects.
     let trimmed = digits.trim_start_matches('0');
-    let mut value = if trimmed.is_empty() {
-        0i128
+    // Parsed unsigned: i128::MIN's magnitude is one past i128::MAX, so parsing
+    // the digits as i128 and negating afterwards would reject a legal value.
+    let magnitude = if trimmed.is_empty() {
+        0u128
     } else {
         trimmed
-            .parse::<i128>()
+            .parse::<u128>()
             .map_err(|_| anyhow!("decimal `{text}` overflows Int128"))?
     };
+    let mut value = match negative {
+        true if magnitude <= (i128::MAX as u128) + 1 => (magnitude as i128).wrapping_neg(),
+        false if magnitude <= i128::MAX as u128 => magnitude as i128,
+        _ => bail!("decimal `{text}` overflows Int128"),
+    };
+    // Each step past zero is a no-op, so the guard also bounds the loops: an
+    // exponent may be any i32, but 39 iterations settle every reachable value.
     match shift.cmp(&0) {
         std::cmp::Ordering::Greater => {
             for _ in 0..shift {
+                if value == 0 {
+                    break;
+                }
                 value = value
                     .checked_mul(10)
                     .context("decimal overflows the column's precision")?;
@@ -191,12 +251,15 @@ fn decimal_to_i128(text: &str, scale: u32) -> Result<i128> {
         std::cmp::Ordering::Less => {
             // Truncates toward zero, matching ClickHouse's own cast.
             for _ in 0..-shift {
+                if value == 0 {
+                    break;
+                }
                 value /= 10;
             }
         }
         std::cmp::Ordering::Equal => {}
     }
-    Ok(if negative { -value } else { value })
+    Ok(value)
 }
 
 fn put_int_raw(out: &mut Vec<u8>, value: i128, bytes: usize) {
@@ -229,14 +292,13 @@ fn int_bounds(ch_type: &ChType) -> Result<(i128, i128)> {
         ChType::UInt128 => (0, i128::MAX),
         ChType::Date32 => (i32::MIN as i128, i32::MAX as i128),
         ChType::DateTime64 { .. } => (i64::MIN as i128, i64::MAX as i128),
-        // A Decimal's precision, not its byte width, is what it accepts.
-        ChType::Decimal { precision, .. } => {
-            let limit = 10i128
-                .checked_pow(*precision)
-                .context("decimal precision is too wide to represent")?
-                - 1;
-            (-limit, limit)
-        }
+        // A Decimal's precision, not its byte width, is what it accepts — until
+        // the precision outgrows the 128-bit value we carry, as it does for a
+        // Decimal256, and the wire width becomes the tighter bound.
+        ChType::Decimal { precision, .. } => match 10i128.checked_pow(*precision) {
+            Some(limit) => (1 - limit, limit - 1),
+            None => (i128::MIN, i128::MAX),
+        },
         ChType::Enum { bytes, .. } => {
             if *bytes == 1 {
                 (i8::MIN as i128, i8::MAX as i128)
@@ -254,6 +316,38 @@ fn put_int(out: &mut Vec<u8>, value: i128, ch_type: &ChType) -> Result<()> {
         bail!("{value} is out of range for a {ch_type:?} column");
     }
     put_int_raw(out, value, fixed_width(ch_type)?);
+    Ok(())
+}
+
+fn put_fixed_string(out: &mut Vec<u8>, text: &str, width: usize) -> Result<()> {
+    let bytes = text.as_bytes();
+    if bytes.len() > width {
+        bail!(
+            "`{text}` is {} bytes, which a FixedString({width}) column cannot hold",
+            bytes.len()
+        );
+    }
+    out.extend_from_slice(bytes);
+    out.extend(std::iter::repeat_n(0u8, width - bytes.len()));
+    Ok(())
+}
+
+/// Encodes a scalar whose value arrives as text. Every value from JS is text
+/// unless its column has a typed array, and a JSON array's elements stringify to
+/// the same thing, so both paths land here and cannot drift apart.
+fn encode_text_scalar(out: &mut Vec<u8>, ch_type: &ChType, text: &str) -> Result<()> {
+    match ch_type {
+        ChType::String => put_string(out, text),
+        ChType::FixedString(width) => put_fixed_string(out, text, *width)?,
+        ChType::Decimal { scale, .. } => put_int(out, decimal_to_i128(text, *scale)?, ch_type)?,
+        ChType::Enum { .. } => {
+            let numeric = ch_type
+                .enum_value(text)
+                .with_context(|| format!("`{text}` is not a variant of the enum column"))?;
+            put_int(out, numeric as i128, ch_type)?;
+        }
+        other => put_int(out, decimal_to_i128(text, 0)?, other)?,
+    }
     Ok(())
 }
 
@@ -277,51 +371,17 @@ fn encode_json_value(out: &mut Vec<u8>, ch_type: &ChType, value: &serde_json::Va
                 encode_json_value(out, inner, item)?;
             }
         }
-        ChType::String => match value {
-            Value::String(s) => put_string(out, s),
-            other => put_string(out, &other.to_string()),
-        },
-        ChType::FixedString(width) => {
-            let s = value.as_str().unwrap_or_default();
-            let mut bytes = s.as_bytes().to_vec();
-            bytes.resize(*width, 0);
-            out.extend_from_slice(&bytes);
-        }
+        // The three types JSON represents natively; everything else is the same
+        // text the column path encodes.
         ChType::Bool => out.push(u8::from(value.as_bool().unwrap_or(false))),
-        ChType::Decimal { scale, .. } => {
-            let text = match value {
-                Value::String(s) => s.clone(),
-                other => other.to_string(),
-            };
-            put_int(out, decimal_to_i128(&text, *scale)?, ch_type)?;
-        }
-        ChType::Enum { .. } => {
-            let name = value
-                .as_str()
-                .context("expected a string for an Enum column")?;
-            let numeric = ch_type
-                .enum_value(name)
-                .with_context(|| format!("`{name}` is not a variant of the enum column"))?;
-            put_int(out, numeric as i128, ch_type)?;
-        }
         ChType::Float32 => {
             out.extend_from_slice(&(value.as_f64().unwrap_or(0.0) as f32).to_le_bytes())
         }
         ChType::Float64 => out.extend_from_slice(&value.as_f64().unwrap_or(0.0).to_le_bytes()),
-        ChType::Int128 | ChType::UInt128 => {
-            let text = match value {
-                Value::String(s) => s.clone(),
-                other => other.to_string(),
-            };
-            put_int(out, decimal_to_i128(&text, 0)?, ch_type)?;
-        }
-        _ => {
-            let numeric = match value {
-                Value::String(s) => decimal_to_i128(s, 0)?,
-                other => other.as_f64().unwrap_or(0.0) as i128,
-            };
-            put_int(out, numeric, ch_type)?;
-        }
+        other => match value {
+            Value::String(s) => encode_text_scalar(out, other, s)?,
+            value => encode_text_scalar(out, other, &value.to_string())?,
+        },
     }
     Ok(())
 }
@@ -334,7 +394,8 @@ fn fixed_width(ch_type: &ChType) -> Result<usize> {
         ChType::Int32 | ChType::UInt32 | ChType::DateTime | ChType::Date32 => 4,
         ChType::Int64 | ChType::UInt64 | ChType::DateTime64 { .. } => 8,
         ChType::Int128 | ChType::UInt128 => 16,
-        ChType::Decimal { bytes, .. } | ChType::Enum { bytes, .. } => *bytes,
+        ChType::Decimal { precision, .. } => super::ch_type::decimal_bytes(*precision)?,
+        ChType::Enum { bytes, .. } => *bytes,
         ChType::Float32 => 4,
         ChType::Float64 => 8,
         other => bail!("{other:?} has no fixed width"),
@@ -403,34 +464,12 @@ fn encode_cell(out: &mut Vec<u8>, column: &Column, row: usize) -> Result<()> {
             let text = column.values.text_at(row)?;
             let parsed: serde_json::Value = serde_json::from_str(text)
                 .with_context(|| format!("column `{}` row {row} is not JSON", column.name))?;
-            encode_json_value(out, ch_type, &parsed)?;
-        }
-        (ColumnValues::Text { .. }, ChType::String) => put_string(out, column.values.text_at(row)?),
-        (ColumnValues::Text { .. }, ChType::FixedString(width)) => {
-            let mut bytes = column.values.text_at(row)?.as_bytes().to_vec();
-            bytes.resize(*width, 0);
-            out.extend_from_slice(&bytes);
-        }
-        (ColumnValues::Text { .. }, ChType::Decimal { scale, .. }) => {
-            let text = column.values.text_at(row)?;
-            put_int(
-                out,
-                decimal_to_i128(text, *scale).with_context(|| {
-                    format!("column `{}` row {row} is not a decimal", column.name)
-                })?,
-                ch_type,
-            )?;
-        }
-        (ColumnValues::Text { .. }, ChType::Enum { .. }) => {
-            let name = column.values.text_at(row)?;
-            let numeric = ch_type.enum_value(name).with_context(|| {
-                format!("`{name}` is not a variant of enum column `{}`", column.name)
-            })?;
-            put_int(out, numeric as i128, ch_type)?;
+            encode_json_value(out, ch_type, &parsed)
+                .with_context(|| format!("column `{}` row {row}", column.name))?;
         }
         (ColumnValues::Text { .. }, other) => {
-            let text = column.values.text_at(row)?;
-            put_int(out, decimal_to_i128(text, 0)?, other)?;
+            encode_text_scalar(out, other, column.values.text_at(row)?)
+                .with_context(|| format!("column `{}` row {row}", column.name))?
         }
     }
     Ok(())
@@ -440,8 +479,10 @@ fn encode_cell(out: &mut Vec<u8>, column: &Column, row: usize) -> Result<()> {
 /// so a failed insert can be split at a row boundary and retried in halves.
 #[derive(Debug)]
 pub struct EncodedRows {
-    pub body: Vec<u8>,
-    pub row_offsets: Vec<u32>,
+    /// Reference-counted so a retry can take a range without copying the batch,
+    /// which for the usual single successful send is the whole body.
+    pub body: Bytes,
+    pub row_offsets: Vec<usize>,
 }
 
 impl EncodedRows {
@@ -450,13 +491,13 @@ impl EncodedRows {
     }
 
     /// The bytes of rows `start..end`.
-    pub fn slice(&self, start: usize, end: usize) -> &[u8] {
-        let from = self.row_offsets[start] as usize;
+    pub fn slice(&self, start: usize, end: usize) -> Bytes {
+        let from = self.row_offsets[start];
         let to = match self.row_offsets.get(end) {
-            Some(offset) => *offset as usize,
+            Some(offset) => *offset,
             None => self.body.len(),
         };
-        &self.body[from..to]
+        self.body.slice(from..to)
     }
 }
 
@@ -476,13 +517,16 @@ pub fn encode(columns: &[Column], rows: usize) -> Result<EncodedRows> {
     let mut body = Vec::with_capacity(rows * columns.len() * 12);
     let mut row_offsets = Vec::with_capacity(rows);
     for row in 0..rows {
-        row_offsets.push(body.len() as u32);
+        row_offsets.push(body.len());
         for column in columns {
             encode_cell(&mut body, column, row)
                 .with_context(|| format!("encoding column `{}` row {row}", column.name))?;
         }
     }
-    Ok(EncodedRows { body, row_offsets })
+    Ok(EncodedRows {
+        body: body.into(),
+        row_offsets,
+    })
 }
 
 #[cfg(test)]
@@ -501,7 +545,7 @@ mod tests {
             name: name.to_string(),
             ch_type: ch_type::parse(ty).unwrap(),
             values: ColumnValues::Text {
-                spans: spans_from_utf16_lengths(&data, &lengths).unwrap(),
+                bounds: spans_from_utf16_lengths(&data, &lengths).unwrap(),
                 data,
             },
             nulls: Vec::new(),
@@ -689,9 +733,14 @@ mod tests {
     #[test]
     fn row_offsets_allow_splitting_at_a_row_boundary() {
         let encoded = encode(&[text_column("id", "String", &["a", "bb", "ccc"])], 3).unwrap();
-        assert_eq!(encoded.rows(), 3);
-        assert_eq!(encoded.slice(0, 1), &[1, b'a']);
-        assert_eq!(encoded.slice(1, 3), &[2, b'b', b'b', 3, b'c', b'c', b'c']);
+        assert_eq!(
+            (
+                encoded.rows(),
+                encoded.slice(0, 1).to_vec(),
+                encoded.slice(1, 3).to_vec()
+            ),
+            (3, vec![1, b'a'], vec![2, b'b', b'b', 3, b'c', b'c', b'c'])
+        );
     }
 
     // RowBinary is the raw integer, so nothing downstream notices a value that

--- a/packages/e2e-tests/src/config.ts
+++ b/packages/e2e-tests/src/config.ts
@@ -119,6 +119,13 @@ export const config = {
     return `http://localhost:${this.clickhousePort}`;
   },
 
+  /** Postgres settings, matching what docker_env provisions for tests */
+  pgHost: "localhost",
+  pgPort: 5433,
+  pgUser: "postgres",
+  pgPassword: "testing",
+  pgDatabase: "envio-dev",
+
   /** Timeouts (ms) */
   timeouts: {
     healthCheck: 5000,

--- a/packages/e2e-tests/src/e2e/clickhouse-parity.test.ts
+++ b/packages/e2e-tests/src/e2e/clickhouse-parity.test.ts
@@ -17,7 +17,10 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import path from "path";
 import { config } from "../config.js";
 import { runCommand } from "../utils/process.js";
-import { queryClickHouse } from "../utils/clickhouse.js";
+import {
+  queryClickHouse,
+  isClickHouseReachable,
+} from "../utils/clickhouse.js";
 import { pgRows, closePg, isPgReachable } from "../utils/pg-direct.js";
 
 const PROJECT_DIR = path.join(config.scenariosDir, "e2e_test");
@@ -39,19 +42,7 @@ const indexerEnv = {
   E2E_EXPECTED_END_BLOCK: END_BLOCK,
 };
 
-const servicesReachable = async () => {
-  if (!(await isPgReachable())) return false;
-  try {
-    const res = await fetch(`${config.clickhouseUrl}/ping`, {
-      signal: AbortSignal.timeout(2000),
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
-};
-
-const reachable = await servicesReachable();
+const reachable = (await isPgReachable()) && (await isClickHouseReachable());
 
 // In CI both services are provisioned, so an unreachable one is a broken
 // pipeline rather than a machine without them.
@@ -110,8 +101,10 @@ describe.skipIf(!reachable)("E2E: ClickHouse mirrors Postgres", () => {
          FROM ${CH_DATABASE}.\`Transfer\` ORDER BY id`
       ),
     ]);
-    expect(pg.length).toBeGreaterThan(0);
-    expect(ch).toEqual(asText(pg));
+    expect({ hasRows: pg.length > 0, rows: ch }).toEqual({
+      hasRows: true,
+      rows: asText(pg),
+    });
   });
 
   // A per-chain entity carries the chain id in its primary key, spelled
@@ -127,8 +120,10 @@ describe.skipIf(!reachable)("E2E: ClickHouse mirrors Postgres", () => {
          FROM ${CH_DATABASE}.\`ChainTransfer\` ORDER BY chainId, id`
       ),
     ]);
-    expect(pg.length).toBeGreaterThan(0);
-    expect(ch).toEqual(asText(pg));
+    expect({ hasRows: pg.length > 0, rows: ch }).toEqual({
+      hasRows: true,
+      rows: asText(pg),
+    });
   });
 
   // The one entity written repeatedly under the same id, and deleted on some
@@ -146,8 +141,10 @@ describe.skipIf(!reachable)("E2E: ClickHouse mirrors Postgres", () => {
          FROM ${CH_DATABASE}.\`Holder\` ORDER BY id`
       ),
     ]);
-    expect(pg.length).toBeGreaterThan(0);
-    expect(ch).toEqual(asText(pg));
+    expect({ hasRows: pg.length > 0, rows: ch }).toEqual({
+      hasRows: true,
+      rows: asText(pg),
+    });
   });
 
   it("Holder deletes leave no row in either backend", async () => {

--- a/packages/e2e-tests/src/utils/clickhouse.ts
+++ b/packages/e2e-tests/src/utils/clickhouse.ts
@@ -39,7 +39,7 @@ export async function queryClickHouse<T = unknown>(sql: string): Promise<T> {
 /**
  * Check if ClickHouse is reachable by hitting its ping endpoint.
  */
-async function isClickHouseReachable(): Promise<boolean> {
+export async function isClickHouseReachable(): Promise<boolean> {
   try {
     const response = await fetch(`${config.clickhouseUrl}/ping`, {
       signal: AbortSignal.timeout(2000),

--- a/packages/e2e-tests/src/utils/pg-direct.ts
+++ b/packages/e2e-tests/src/utils/pg-direct.ts
@@ -8,18 +8,21 @@
 
 import postgres from "postgres";
 
-const env = (name: string, fallback: string) => process.env[name] ?? fallback;
+import { config } from "../config.js";
+
+const env = (name: string, fallback: string | number) =>
+  process.env[name] ?? String(fallback);
 
 let sql: ReturnType<typeof postgres> | null = null;
 
 export function pg() {
   if (!sql) {
     sql = postgres({
-      host: env("ENVIO_PG_HOST", "localhost"),
-      port: Number(env("ENVIO_PG_PORT", "5433")),
-      username: env("ENVIO_PG_USER", "postgres"),
-      password: env("ENVIO_PG_PASSWORD", "testing"),
-      database: env("ENVIO_PG_DATABASE", "envio-dev"),
+      host: env("ENVIO_PG_HOST", config.pgHost),
+      port: Number(env("ENVIO_PG_PORT", config.pgPort)),
+      username: env("ENVIO_PG_USER", config.pgUser),
+      password: env("ENVIO_PG_PASSWORD", config.pgPassword),
+      database: env("ENVIO_PG_DATABASE", config.pgDatabase),
       // Values are compared against ClickHouse's text output, so keep whatever
       // the driver gives and stringify at the comparison site.
       max: 2,

--- a/packages/envio-tests/test/lib_tests/ColumnNameFormat_test.res
+++ b/packages/envio-tests/test/lib_tests/ColumnNameFormat_test.res
@@ -147,7 +147,7 @@ VALUES($1,$2,$3,$4,$5)ON CONFLICT("id","envio_checkpoint_id") DO UPDATE SET "env
   \`transactionIndex\` Int32,
   \`tokenOwner_id\` String,
   \`envio_checkpoint_id\` UInt64,
-  \`envio_change\` Enum8('SET', 'DELETE')
+  \`envio_change\` Enum8('SET' = 1, 'DELETE' = 2)
 )
 ENGINE = MergeTree()
 ORDER BY (id, envio_checkpoint_id)`)
@@ -195,7 +195,7 @@ ORDER BY (id, envio_checkpoint_id)`)
   \`id\` String,
   \`token_id\` Int32,
   \`envio_checkpoint_id\` UInt64,
-  \`envio_change\` Enum8('SET', 'DELETE')
+  \`envio_change\` Enum8('SET' = 1, 'DELETE' = 2)
 )
 ENGINE = MergeTree()
 ORDER BY (id, envio_checkpoint_id)`,

--- a/packages/envio/src/Core.res
+++ b/packages/envio/src/Core.res
@@ -46,8 +46,8 @@ type addon = {
   addressStore: addressStoreCtor,
   @as("ClickHouseSink")
   clickHouseSink: clickHouseSinkCtor,
-  // The wire kind Rust expects for a ClickHouse column type, so a test can pin
-  // `ClickHouseSink.kindOfField` to it.
+  // The wire kind Rust expects for a ClickHouse column type. The JS side picks
+  // its typed array from this rather than deriving the kind a second time.
   clickhouseColumnKind: string => int,
   // Ordered transaction-field names exposed for the field-code contract test
   // (the ReScript `transactionFields` arrays must match the Rust ordinals).

--- a/packages/envio/src/Sink.res
+++ b/packages/envio/src/Sink.res
@@ -40,7 +40,7 @@ let makeClickHouse = (
   {
     name: "clickhouse",
     initialize: (~chainConfigs as _=[], ~entities=[], ~enums=[]) => {
-      ClickHouse.initialize(client, ~sink, ~database, ~entities, ~enums, ~chainIdMode)
+      ClickHouse.initialize(client, ~database, ~entities, ~enums, ~chainIdMode)
     },
     resume: (~checkpointId) => {
       ClickHouse.resume(client, ~database, ~checkpointId)

--- a/packages/envio/src/Sink.res
+++ b/packages/envio/src/Sink.res
@@ -12,7 +12,13 @@ type t = {
   ) => promise<unit>,
 }
 
-let makeClickHouse = (~host, ~database, ~username, ~password, ~chainIdMode: ChainId.mode=Int32): t => {
+let makeClickHouse = (
+  ~host,
+  ~database,
+  ~username,
+  ~password,
+  ~chainIdMode: ChainId.mode=Int32,
+): t => {
   let client = ClickHouse.createClient({
     url: host,
     username,
@@ -25,7 +31,9 @@ let makeClickHouse = (~host, ~database, ~username, ~password, ~chainIdMode: Chai
   // Inserts go through the Rust sink: values cross the napi boundary columnar,
   // get encoded as RowBinary and are sent off the Node main thread. DDL, the
   // current-state views and the reorg cleanup stay on the JS client.
-  let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database)
+  let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database, ~onWarning=msg =>
+    ClickHouse.logger->Logging.childWarn({"msg": msg})
+  )
 
   let cache = Dict.make()
 
@@ -40,14 +48,7 @@ let makeClickHouse = (~host, ~database, ~username, ~password, ~chainIdMode: Chai
     writeBatch: async (~batch, ~updatedEntities) => {
       await Promise.all(
         updatedEntities->Array.map(({entityConfig, scope, changes}) => {
-          ClickHouse.setUpdatesOrThrow(
-            sink,
-            ~cache,
-            ~changes,
-            ~entityConfig,
-            ~scope,
-            ~chainIdMode,
-          )
+          ClickHouse.setUpdatesOrThrow(sink, ~cache, ~changes, ~entityConfig, ~scope, ~chainIdMode)
         }),
       )->Utils.Promise.ignoreValue
       // Checkpoints land after the rows they cover: the current-state view reads

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -79,13 +79,16 @@ let getClickHouseFieldType = (
       // Theoretically we can store 256 variants in Enum8,
       // but it'd require to explicitly start with a negative index (probably)
       let enumType = variantsLength <= 127 ? "Enum8" : "Enum16"
+      // Numbered explicitly, because RowBinary carries the number rather than
+      // the name: leaving it to ClickHouse's own numbering would make the
+      // encoder depend on a server rule instead of on this string.
       let enumValues =
         config.variants
-        ->Array.map(variant => {
+        ->Array.mapWithIndex((variant, index) => {
           let variantStr = variant->(Utils.magic: 'a => string)
-          `'${variantStr}'`
+          `'${variantStr}' = ${(index + 1)->Int.toString}`
         })
-        ->Array.joinUnsafe(", ")
+        ->Array.join(", ")
       `${enumType}(${enumValues})`
     }
   }
@@ -152,6 +155,20 @@ let makeClickHouseEntitySchema = (table: Table.table): S.t<Internal.entity> => {
 
 let logger = Logging.createChild(~params={"context": "ClickHouse"})
 
+// The two columns every history table carries beyond the entity's own. Shared
+// with the DDL so the type the encoder is handed is the one the column was
+// created with.
+let checkpointIdClickHouseType = getClickHouseFieldType(
+  ~fieldType=UInt64,
+  ~isNullable=false,
+  ~isArray=false,
+)
+let changeClickHouseType = getClickHouseFieldType(
+  ~fieldType=Enum({config: EntityHistory.RowAction.config->Table.fromGenericEnumConfig}),
+  ~isNullable=false,
+  ~isArray=false,
+)
+
 // The checkpoints table as ClickHouse holds it, in column order: the DDL and the
 // insert both read it, so neither can describe a column the other doesn't.
 // `events_processed` is widened here rather than taken from
@@ -169,7 +186,7 @@ let checkpointColumns: array<(string, Table.fieldType, bool)> = [
 // allocates its own builders, so two writes can never share storage.
 type entityColumns = {
   tableName: string,
-  columns: array<(string, ClickHouseSink.kind)>,
+  columns: array<(string, string)>,
   convertSetOrThrow: Change.t<Internal.entity> => dict<unknown>,
   convertDeleteOrThrow: Change.t<Internal.entity> => dict<unknown>,
 }
@@ -198,13 +215,13 @@ let makeEntityColumns = (
           ~isNullable=f.isNullable,
           ~isArray=f.isArray,
           ~chainIdMode,
-        )->ClickHouseSink.kindOfClickHouseType,
+        ),
       ))
     | DerivedFrom(_) => None
     }
   )
-  columns->Array.push((EntityHistory.checkpointIdFieldName, ClickHouseSink.U64))
-  columns->Array.push((EntityHistory.changeFieldName, Text))
+  columns->Array.push((EntityHistory.checkpointIdFieldName, checkpointIdClickHouseType))
+  columns->Array.push((EntityHistory.changeFieldName, changeClickHouseType))
 
   {
     tableName: EntityHistory.historyTableName(
@@ -261,12 +278,7 @@ let setCheckpointsOrThrow = async (sink, ~batch: Batch.t, ~chainIdMode: ChainId.
       checkpointColumns->Array.map(((name, fieldType, isNullable)) =>
         ClickHouseSink.makeBuilder(
           ~name,
-          ~kind=getClickHouseFieldType(
-            ~fieldType,
-            ~isNullable,
-            ~isArray=false,
-            ~chainIdMode,
-          )->ClickHouseSink.kindOfClickHouseType,
+          ~chType=getClickHouseFieldType(~fieldType, ~isNullable, ~isArray=false, ~chainIdMode),
           ~rows,
         )
       )
@@ -337,7 +349,7 @@ let setUpdatesOrThrow = async (
 
     let handle = try {
       let builders =
-        columns->Array.map(((name, kind)) => ClickHouseSink.makeBuilder(~name, ~kind, ~rows))
+        columns->Array.map(((name, chType)) => ClickHouseSink.makeBuilder(~name, ~chType, ~rows))
       for row in 0 to rows - 1 {
         let change = changes->Array.getUnsafe(row)
         // The entity history table is the source of truth for ClickHouse, so
@@ -503,16 +515,8 @@ let makeCreateHistoryTableQuery = (
       ~entityIndex=entityConfig.index,
     )}\`${onClusterClause(~onCluster)} (
   ${fieldDefinitions->Array.joinUnsafe(",\n  ")},
-  \`${EntityHistory.checkpointIdFieldName}\` ${getClickHouseFieldType(
-      ~fieldType=UInt64,
-      ~isNullable=false,
-      ~isArray=false,
-    )},
-  \`${EntityHistory.changeFieldName}\` ${getClickHouseFieldType(
-      ~fieldType=Enum({config: EntityHistory.RowAction.config->Table.fromGenericEnumConfig}),
-      ~isNullable=false,
-      ~isArray=false,
-    )}
+  \`${EntityHistory.checkpointIdFieldName}\` ${checkpointIdClickHouseType},
+  \`${EntityHistory.changeFieldName}\` ${changeClickHouseType}
 )
 ENGINE = ${tableEngine}${partitionByClause}
 ORDER BY (${orderByColumns})${ttlClause}`
@@ -600,24 +604,11 @@ WHERE \`${EntityHistory.changeFieldName}\` = '${(EntityHistory.RowAction.SET :> 
 // Initialize ClickHouse tables for entities
 let initialize = async (
   client,
-  ~sink: ClickHouseSink.t,
   ~database: string,
   ~entities: array<Internal.entityConfig>,
   ~enums as _: array<Table.enumConfig<Table.enum>>,
   ~chainIdMode: ChainId.mode=Int32,
 ) => {
-  // A reset drops and recreates the tables, so any column types the sink read
-  // earlier in this process no longer describe them.
-  entities->Array.forEach(entityConfig =>
-    sink->ClickHouseSink.invalidateSchema(
-      EntityHistory.historyTableName(
-        ~entityName=entityConfig.name,
-        ~entityIndex=entityConfig.index,
-      ),
-    )
-  )
-  sink->ClickHouseSink.invalidateSchema(InternalTable.Checkpoints.table.tableName)
-
   try {
     let databaseEngine = Env.ClickHouse.databaseEngine()
     let databaseEngineClause = switch databaseEngine {

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -152,6 +152,18 @@ let makeClickHouseEntitySchema = (table: Table.table): S.t<Internal.entity> => {
 
 let logger = Logging.createChild(~params={"context": "ClickHouse"})
 
+// The checkpoints table as ClickHouse holds it, in column order: the DDL and the
+// insert both read it, so neither can describe a column the other doesn't.
+// `events_processed` is widened here rather than taken from
+// `InternalTable.Checkpoints.table`, whose Int32 is what Postgres stores.
+let checkpointColumns: array<(string, Table.fieldType, bool)> = [
+  ((#id: InternalTable.Checkpoints.field :> string), UInt64, false),
+  ((#chain_id: InternalTable.Checkpoints.field :> string), ChainId, false),
+  ((#block_number: InternalTable.Checkpoints.field :> string), Int32, false),
+  ((#block_hash: InternalTable.Checkpoints.field :> string), String, true),
+  ((#events_processed: InternalTable.Checkpoints.field :> string), UInt64, false),
+]
+
 // Column set of an entity history table, resolved once per entity and scope.
 // Only the column list and the compiled serializers are cached; each write
 // allocates its own builders, so two writes can never share storage.
@@ -163,13 +175,7 @@ type entityColumns = {
 }
 
 let compileToColumnValues = schema =>
-  S.compile(
-    schema,
-    ~input=Value,
-    ~output=Json,
-    ~typeValidation=false,
-    ~mode=Sync,
-  )->(
+  S.compile(schema, ~input=Value, ~output=Json, ~typeValidation=false, ~mode=Sync)->(
     Utils.magic: (Change.t<Internal.entity> => JSON.t) => Change.t<Internal.entity> => dict<unknown>
   )
 
@@ -187,7 +193,12 @@ let makeEntityColumns = (
     | Table.Field(f) =>
       Some((
         f->Table.getClickHouseDbFieldName,
-        ClickHouseSink.kindOfField(~fieldType=f.fieldType, ~isArray=f.isArray, ~chainIdMode),
+        getClickHouseFieldType(
+          ~fieldType=f.fieldType,
+          ~isNullable=f.isNullable,
+          ~isArray=f.isArray,
+          ~chainIdMode,
+        )->ClickHouseSink.kindOfClickHouseType,
       ))
     | DerivedFrom(_) => None
     }
@@ -226,21 +237,17 @@ let makeEntityColumns = (
   }
 }
 
-let insertBuilders = async (sink, ~tableName, ~builders: array<ClickHouseSink.builder>, ~rows) => {
-  let handle =
-    sink->ClickHouseSink.stage(
-      ~table=tableName,
-      ~rows,
-      ~columns=builders->Array.map(ClickHouseSink.builderPayload),
-    )
-  let warnings = await sink->ClickHouseSink.flush(handle)
-  warnings->Array.forEach(msg =>
-    logger->Logging.childWarn({
-      "msg": msg,
-      "table": tableName,
-    })
+// Copies the batch into the sink and returns the handle to flush. Splitting the
+// two lets a caller attribute a staging failure differently from an insert one.
+let stageBuilders = (sink, ~tableName, ~builders: array<ClickHouseSink.builder>, ~rows) =>
+  sink->ClickHouseSink.stage(
+    ~table=tableName,
+    ~rows,
+    ~columns=builders->Array.map(ClickHouseSink.builderPayload),
   )
-}
+
+let insertBuilders = async (sink, ~tableName, ~builders, ~rows) =>
+  await sink->ClickHouseSink.flush(sink->stageBuilders(~tableName, ~builders, ~rows))
 
 let setCheckpointsOrThrow = async (sink, ~batch: Batch.t, ~chainIdMode: ChainId.mode) => {
   let rows = batch.checkpointIds->Array.length
@@ -248,39 +255,35 @@ let setCheckpointsOrThrow = async (sink, ~batch: Batch.t, ~chainIdMode: ChainId.
     ()
   } else {
     let tableName = InternalTable.Checkpoints.table.tableName
-    // Kinds mirror `makeCreateCheckpointsTableQuery`, where events_processed is
-    // widened to UInt64 rather than the Int32 the Postgres table uses.
-    let id = ClickHouseSink.makeBuilder(~name="id", ~kind=U64, ~rows)
-    let chainId = ClickHouseSink.makeBuilder(
-      ~name="chain_id",
-      ~kind=ClickHouseSink.kindOfField(~fieldType=ChainId, ~isArray=false, ~chainIdMode),
-      ~rows,
-    )
-    let blockNumber = ClickHouseSink.makeBuilder(~name="block_number", ~kind=F64, ~rows)
-    let blockHash = ClickHouseSink.makeBuilder(~name="block_hash", ~kind=Text, ~rows)
-    let eventsProcessed = ClickHouseSink.makeBuilder(~name="events_processed", ~kind=U64, ~rows)
-    let builders = [id, chainId, blockNumber, blockHash, eventsProcessed]
+    // Same column list the DDL is built from, so a column added there arrives
+    // here with a builder rather than silently taking the type's default.
+    let builders =
+      checkpointColumns->Array.map(((name, fieldType, isNullable)) =>
+        ClickHouseSink.makeBuilder(
+          ~name,
+          ~kind=getClickHouseFieldType(
+            ~fieldType,
+            ~isNullable,
+            ~isArray=false,
+            ~chainIdMode,
+          )->ClickHouseSink.kindOfClickHouseType,
+          ~rows,
+        )
+      )
+    let values: array<array<unknown>> = [
+      batch.checkpointIds->(Utils.magic: array<bigint> => array<unknown>),
+      batch.checkpointChainIds->(Utils.magic: array<ChainId.t> => array<unknown>),
+      batch.checkpointBlockNumbers->(Utils.magic: array<int> => array<unknown>),
+      batch.checkpointBlockHashes->(Utils.magic: array<Null.t<string>> => array<unknown>),
+      batch.checkpointEventsProcessed->(Utils.magic: array<int> => array<unknown>),
+    ]
 
     for row in 0 to rows - 1 {
-      id->ClickHouseSink.writeValue(
-        ~row,
-        batch.checkpointIds->Array.getUnsafe(row)->(Utils.magic: bigint => unknown),
-      )
-      chainId->ClickHouseSink.writeValue(
-        ~row,
-        batch.checkpointChainIds->Array.getUnsafe(row)->(Utils.magic: ChainId.t => unknown),
-      )
-      blockNumber->ClickHouseSink.writeValue(
-        ~row,
-        batch.checkpointBlockNumbers->Array.getUnsafe(row)->(Utils.magic: int => unknown),
-      )
-      blockHash->ClickHouseSink.writeValue(
-        ~row,
-        batch.checkpointBlockHashes->Array.getUnsafe(row)->(Utils.magic: Null.t<string> => unknown),
-      )
-      eventsProcessed->ClickHouseSink.writeValue(
-        ~row,
-        batch.checkpointEventsProcessed->Array.getUnsafe(row)->(Utils.magic: int => unknown),
+      builders->Array.forEachWithIndex((builder, column) =>
+        builder->ClickHouseSink.writeValue(
+          ~row,
+          values->Array.getUnsafe(column)->Array.getUnsafe(row),
+        )
       )
     }
 
@@ -311,8 +314,12 @@ let setUpdatesOrThrow = async (
     ()
   } else {
     let cacheKey = `${entityConfig.name}|${scope->Internal.chainScopeToString}`
-    let {tableName, columns, convertSetOrThrow, convertDeleteOrThrow} = switch cache
-    ->Utils.Dict.dangerouslyGetNonOption(cacheKey) {
+    let {
+      tableName,
+      columns,
+      convertSetOrThrow,
+      convertDeleteOrThrow,
+    } = switch cache->Utils.Dict.dangerouslyGetNonOption(cacheKey) {
     | Some(cached) => cached
     | None =>
       let cached = makeEntityColumns(~entityConfig, ~scope, ~chainIdMode)
@@ -352,11 +359,7 @@ let setUpdatesOrThrow = async (
           builder->ClickHouseSink.writeValue(~row, values->Dict.getUnsafe(builder.name))
         )
       }
-      sink->ClickHouseSink.stage(
-        ~table=tableName,
-        ~rows,
-        ~columns=builders->Array.map(ClickHouseSink.builderPayload),
-      )
+      sink->stageBuilders(~tableName, ~builders, ~rows)
     } catch {
     | exn =>
       throw(
@@ -368,13 +371,7 @@ let setUpdatesOrThrow = async (
     }
 
     try {
-      let warnings = await sink->ClickHouseSink.flush(handle)
-      warnings->Array.forEach(msg =>
-        logger->Logging.childWarn({
-          "msg": msg,
-          "table": tableName,
-        })
-      )
+      await sink->ClickHouseSink.flush(handle)
     } catch {
     | exn =>
       throw(
@@ -530,36 +527,22 @@ let makeCreateCheckpointsTableQuery = (
 ) => {
   let tableEngine = replicated ? "ReplicatedMergeTree" : "MergeTree()"
   let idField = (#id: InternalTable.Checkpoints.field :> string)
-  let chainIdField = (#chain_id: InternalTable.Checkpoints.field :> string)
-  let blockNumberField = (#block_number: InternalTable.Checkpoints.field :> string)
-  let blockHashField = (#block_hash: InternalTable.Checkpoints.field :> string)
-  let eventsProcessedField = (#events_processed: InternalTable.Checkpoints.field :> string)
+  let columns =
+    checkpointColumns
+    ->Array.map(((name, fieldType, isNullable)) =>
+      `  \`${name}\` ${getClickHouseFieldType(
+          ~fieldType,
+          ~isNullable,
+          ~isArray=false,
+          ~chainIdMode,
+        )}`
+    )
+    ->Array.join(",\n")
 
   `CREATE TABLE IF NOT EXISTS ${database}.\`${InternalTable.Checkpoints.table.tableName}\`${onClusterClause(
       ~onCluster,
     )} (
-  \`${idField}\` ${getClickHouseFieldType(~fieldType=UInt64, ~isNullable=false, ~isArray=false)},
-  \`${chainIdField}\` ${getClickHouseFieldType(
-      ~fieldType=ChainId,
-      ~isNullable=false,
-      ~isArray=false,
-      ~chainIdMode,
-    )},
-  \`${blockNumberField}\` ${getClickHouseFieldType(
-      ~fieldType=Int32,
-      ~isNullable=false,
-      ~isArray=false,
-    )},
-  \`${blockHashField}\` ${getClickHouseFieldType(
-      ~fieldType=String,
-      ~isNullable=true,
-      ~isArray=false,
-    )},
-  \`${eventsProcessedField}\` ${getClickHouseFieldType(
-      ~fieldType=UInt64,
-      ~isNullable=false,
-      ~isArray=false,
-    )}
+${columns}
 )
 ENGINE = ${tableEngine}
 ORDER BY (${idField})`

--- a/packages/envio/src/bindings/ClickHouseSink.res
+++ b/packages/envio/src/bindings/ClickHouseSink.res
@@ -16,7 +16,10 @@ type options = {
   database: string,
 }
 
-@send external classNew: (Core.clickHouseSinkCtor, options) => t = "new"
+// The warning callback is how a degradation reaches the indexer's logger while
+// it is still happening: retries run inside a single `flush`, so anything handed
+// back at the end would only be read once the episode is over.
+@send external classNew: (Core.clickHouseSinkCtor, options, string => unit) => t = "new"
 
 // Column payload as the Rust `ColumnInput` object expects it: exactly one of the
 // value fields is set.
@@ -32,48 +35,27 @@ type columnInput = {
 
 @send
 external stage: (t, ~table: string, ~rows: int, ~columns: array<columnInput>) => int = "stage"
-@send external flush: (t, int) => promise<array<string>> = "flush"
+@send external flush: (t, int) => promise<unit> = "flush"
 @send external invalidateSchema: (t, string) => unit = "invalidateSchema"
 
-let make = (~url, ~username, ~password, ~database) =>
-  Core.getAddon().clickHouseSink->classNew({url, username, password, database})
+let make = (~url, ~username, ~password, ~database, ~onWarning) =>
+  Core.getAddon().clickHouseSink->classNew({url, username, password, database}, onWarning)
 
-// How a column's values travel. Derived from the same `Table.fieldType` the DDL
-// is generated from, and pinned against the type ClickHouse reports for the
-// column by `ClickHouseColumnKind_test`.
+// How a column's values travel. Read back from the column's ClickHouse type
+// rather than mapped from `Table.fieldType` a second time: Rust already derives
+// the kind from that type to decide how to encode, so a JS copy of the mapping
+// could only ever be found wrong at runtime, as a rejected insert against a live
+// table.
 type kind =
   | @as(0) F64
   | @as(1) U64
   | @as(2) I64
   | @as(3) Text
 
-let kindOfField = (~fieldType: Table.fieldType, ~isArray, ~chainIdMode: ChainId.mode) =>
-  if isArray {
-    // An array is sent as the JSON of its elements.
-    Text
-  } else {
-    switch fieldType {
-    | Int32
-    | Uint32
-    | Serial
-    | Boolean
-    | Number
-    | Date => F64
-    | ChainId =>
-      switch chainIdMode {
-      | Int32 => F64
-      | Int64 => U64
-      }
-    | UInt52
-    | UInt64 => U64
-    | BigSerial => I64
-    | BigInt(_)
-    | BigDecimal(_)
-    | String
-    | Json
-    | Enum(_) => Text
-    }
-  }
+external kindOfOrdinal: int => kind = "%identity"
+
+let kindOfClickHouseType = clickHouseType =>
+  Core.getAddon().clickhouseColumnKind(clickHouseType)->kindOfOrdinal
 
 %%private(let isString: unknown => bool = %raw(`(v) => typeof v === "string"`))
 external asString: unknown => string = "%identity"

--- a/packages/envio/src/bindings/ClickHouseSink.res
+++ b/packages/envio/src/bindings/ClickHouseSink.res
@@ -25,6 +25,8 @@ type options = {
 // value fields is set.
 type columnInput = {
   name: string,
+  @as("chType")
+  chType: string,
   numbers?: Float64Array.t,
   unsigned64?: BigUint64Array.t,
   signed64?: BigInt64Array.t,
@@ -36,7 +38,6 @@ type columnInput = {
 @send
 external stage: (t, ~table: string, ~rows: int, ~columns: array<columnInput>) => int = "stage"
 @send external flush: (t, int) => promise<unit> = "flush"
-@send external invalidateSchema: (t, string) => unit = "invalidateSchema"
 
 let make = (~url, ~username, ~password, ~database, ~onWarning) =>
   Core.getAddon().clickHouseSink->classNew({url, username, password, database}, onWarning)
@@ -77,6 +78,10 @@ let toText = (value: unknown) =>
 // `stage` copies it into Rust memory, and nothing reads it afterwards.
 type builder = {
   name: string,
+  // The column's ClickHouse type, as the DDL declared it. Sent with the values
+  // so Rust encodes against the shape envio created rather than one it has to
+  // go and ask the server for.
+  chType: string,
   kind: kind,
   floats: Float64Array.t,
   unsigned: BigUint64Array.t,
@@ -89,10 +94,12 @@ type builder = {
 }
 
 // Only the storage the column's kind uses is allocated; the rest stay empty.
-let makeBuilder = (~name, ~kind, ~rows) => {
+let makeBuilder = (~name, ~chType, ~rows) => {
   let empty = 0
+  let kind = chType->kindOfClickHouseType
   {
     name,
+    chType,
     kind,
     floats: Float64Array.fromLength(kind === F64 ? rows : empty),
     unsigned: BigUint64Array.fromLength(kind === U64 ? rows : empty),
@@ -134,7 +141,7 @@ let writeValue = (builder, ~row, value: unknown) =>
   }
 
 let builderPayload = (builder): columnInput => {
-  let base = {name: builder.name, nulls: ?builder.nulls}
+  let base = {name: builder.name, chType: builder.chType, nulls: ?builder.nulls}
   switch builder.kind {
   | F64 => {...base, numbers: builder.floats}
   | U64 => {...base, unsigned64: builder.unsigned}

--- a/scenarios/test_codegen/test/lib_tests/ClickHouseColumnKind_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouseColumnKind_test.res
@@ -1,10 +1,10 @@
 open Vitest
 
-// `ClickHouseSink.kindOfField` decides how a column's values cross the napi
-// boundary from a `Table.fieldType`; Rust decides how to decode them from the
-// type text ClickHouse reports. The two derivations are independent, and a
-// mismatch shows up only as a wrongly encoded column, so pin them together over
-// every field type the DDL can emit.
+// `ClickHouseSink.kindOfClickHouseType` casts Rust's `ColumnKind` ordinal
+// straight into a ReScript variant, and the column types it is asked about are
+// whatever the DDL emits. So two things have to hold: every type envio can
+// generate is one Rust knows, and the ordinals still line up. Neither fails
+// loudly on its own — a reordered enum silently picks the wrong typed array.
 
 let fieldTypes: array<Table.fieldType> = [
   String,
@@ -35,8 +35,8 @@ let fieldTypes: array<Table.fieldType> = [
 ]
 
 describe("ClickHouse column kind contract", () => {
-  it("ReScript picks the wire kind Rust decodes for every field type", t => {
-    let mismatches = []
+  it("Rust resolves a wire kind for every type the DDL emits", t => {
+    let unresolved = []
     fieldTypes->Array.forEach(fieldType => {
       ([ChainId.Int32, Int64]: array<ChainId.mode>)->Array.forEach(chainIdMode => {
         [false, true]->Array.forEach(isArray => {
@@ -47,24 +47,44 @@ describe("ClickHouse column kind contract", () => {
               ~isArray,
               ~chainIdMode,
             )
-            let fromRescript =
-              ClickHouseSink.kindOfField(~fieldType, ~isArray, ~chainIdMode)->(
-                Utils.magic: ClickHouseSink.kind => int
-              )
-            let fromRust = Core.getAddon().clickhouseColumnKind(chType)
-            if fromRescript !== fromRust {
-              mismatches
-              ->Array.push({
-                "chType": chType,
-                "rescriptKind": fromRescript,
-                "rustKind": fromRust,
-              })
+            try {
+              ClickHouseSink.kindOfClickHouseType(chType)->ignore
+            } catch {
+            | exn =>
+              unresolved
+              ->Array.push({"chType": chType, "error": exn->Utils.prettifyExn})
               ->ignore
             }
           })
         })
       })
     })
-    t.expect(mismatches).toEqual([])
+    t.expect(unresolved).toEqual([])
+  })
+
+  it("the ordinals ReScript casts match the kinds Rust assigns", t => {
+    let kinds =
+      [
+        "Int32",
+        "Float64",
+        "UInt64",
+        "Int64",
+        "String",
+        "Decimal(20,0)",
+        "Array(String)",
+        "Nullable(String)",
+        "DateTime64(3, 'UTC')",
+      ]->Array.map(ClickHouseSink.kindOfClickHouseType)
+    t.expect(kinds).toEqual([
+      ClickHouseSink.F64,
+      F64,
+      U64,
+      I64,
+      Text,
+      Text,
+      Text,
+      Text,
+      F64,
+    ])
   })
 })

--- a/scenarios/test_codegen/test/lib_tests/ClickHouseRoundtrip_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouseRoundtrip_test.res
@@ -63,7 +63,7 @@ describe("ClickHouse RowBinary roundtrip", () => {
         query: ClickHouse.makeCreateHistoryTableQuery(~entityConfig, ~database),
       })
 
-      let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database)
+      let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database, ~onWarning=ignore)
       await ClickHouse.setUpdatesOrThrow(
         sink,
         ~cache=Dict.make(),
@@ -92,10 +92,7 @@ describe("ClickHouse RowBinary roundtrip", () => {
         %raw(`[
           {
             id: "roundtrip-1",
-            // Not ASCII on purpose: the sink hands Rust one concatenated string per column
-  // plus each value's UTF-16 length, and Rust has to re-split it over UTF-8
-  // bytes. "é" is one UTF-16 unit over two bytes, "😀" is two units over four.
-  string: "héllo 😀",
+            string: "héllo 😀",
             optString: null,
             arrayOfStrings: ["a", "日本"],
             int_: -7,
@@ -173,7 +170,7 @@ describe("ClickHouse RowBinary roundtrip", () => {
         query: ClickHouse.makeCreateCheckpointsTableQuery(~database, ~chainIdMode=Int64),
       })
 
-      let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database)
+      let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database, ~onWarning=ignore)
       await ClickHouse.setCheckpointsOrThrow(
         sink,
         ~batch={
@@ -231,7 +228,7 @@ describe("ClickHouse RowBinary roundtrip", () => {
       await client->ClickHouse.exec({
         query: ClickHouse.makeCreateHistoryTableQuery(~entityConfig, ~database),
       })
-      let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database)
+      let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database, ~onWarning=ignore)
 
       let attempt = async rogue => {
         switch await ClickHouse.setUpdatesOrThrow(

--- a/scenarios/test_codegen/test/lib_tests/ClickHouseRoundtrip_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouseRoundtrip_test.res
@@ -283,4 +283,62 @@ describe("ClickHouse RowBinary roundtrip", () => {
       ))
     },
   )
+  // Naming every column in the INSERT is what lets a table carry columns envio
+  // does not write. The server fills them, so a DEFAULT expression is evaluated
+  // rather than replaced by the type's zero value, and a column whose type the
+  // encoder has never heard of is simply not its business.
+  Async.it_skipIf(chHost->Option.isNone)(
+    "Leaves columns it does not write to the server",
+    async t => {
+      let host = chHost->Option.getUnsafe
+      let database = "test_codegen_roundtrip_extra"
+      let entityConfig = MockIndexer.entityConfig("EntityWithAllTypes")
+      let tableName = EntityHistory.historyTableName(
+        ~entityName=entityConfig.name,
+        ~entityIndex=entityConfig.index,
+      )
+
+      let client = ClickHouse.createClient({url: host, username, password})
+      await client->ClickHouse.exec({query: `DROP DATABASE IF EXISTS ${database}`})
+      await client->ClickHouse.exec({query: `CREATE DATABASE ${database}`})
+      await client->ClickHouse.exec({
+        query: ClickHouse.makeCreateHistoryTableQuery(~entityConfig, ~database),
+      })
+      // A column with a default expression, and one of a type the RowBinary
+      // encoder cannot represent at all.
+      await client->ClickHouse.exec({
+        query: `ALTER TABLE ${database}.\`${tableName}\` ADD COLUMN ingested_by String DEFAULT 'envio'`,
+      })
+      await client->ClickHouse.exec({
+        query: `ALTER TABLE ${database}.\`${tableName}\` ADD COLUMN trace UUID DEFAULT generateUUIDv4()`,
+      })
+
+      let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database, ~onWarning=ignore)
+      await ClickHouse.setUpdatesOrThrow(
+        sink,
+        ~cache=Dict.make(),
+        ~changes=[
+          Set({
+            entityId: entity.id->EntityId.unsafeOfString,
+            checkpointId: 1n,
+            entity: entity->(Utils.magic: Indexer.Entities.EntityWithAllTypes.t => Internal.entity),
+          }),
+        ],
+        ~entityConfig,
+        ~scope=CrossChain,
+        ~chainIdMode=Int32,
+      )
+
+      let result = await client->ClickHouse.query({
+        query: `SELECT id, ingested_by, trace != toUUID('00000000-0000-0000-0000-000000000000') AS has_trace FROM ${database}.\`${tableName}\``,
+      })
+      let rows = (await result->ClickHouse.json)["data"]
+      await client->ClickHouse.exec({query: `DROP DATABASE ${database}`})
+      await client->ClickHouse.close
+
+      t.expect(rows).toEqual(
+        %raw(`[{ id: "roundtrip-1", ingested_by: "envio", has_trace: 1 }]`),
+      )
+    },
+  )
 })

--- a/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouse_test.res
@@ -188,10 +188,10 @@ ORDER BY (id)`
   \`timestamp\` DateTime64(3, 'UTC'),
   \`optTimestamp\` Nullable(DateTime64(3, 'UTC')),
   \`json\` String,
-  \`enumField\` Enum8('ADMIN', 'USER'),
-  \`optEnumField\` Nullable(Enum8('ADMIN', 'USER')),
+  \`enumField\` Enum8('ADMIN' = 1, 'USER' = 2),
+  \`optEnumField\` Nullable(Enum8('ADMIN' = 1, 'USER' = 2)),
   \`envio_checkpoint_id\` UInt64,
-  \`envio_change\` Enum8('SET', 'DELETE')
+  \`envio_change\` Enum8('SET' = 1, 'DELETE' = 2)
 )
 ENGINE = MergeTree()
 ORDER BY (id, envio_checkpoint_id)`
@@ -236,10 +236,10 @@ ORDER BY (id, envio_checkpoint_id)`
   \`timestamp\` DateTime64(3, 'UTC'),
   \`optTimestamp\` Nullable(DateTime64(3, 'UTC')),
   \`json\` String,
-  \`enumField\` Enum8('ADMIN', 'USER'),
-  \`optEnumField\` Nullable(Enum8('ADMIN', 'USER')),
+  \`enumField\` Enum8('ADMIN' = 1, 'USER' = 2),
+  \`optEnumField\` Nullable(Enum8('ADMIN' = 1, 'USER' = 2)),
   \`envio_checkpoint_id\` UInt64,
-  \`envio_change\` Enum8('SET', 'DELETE')
+  \`envio_change\` Enum8('SET' = 1, 'DELETE' = 2)
 )
 ENGINE = ReplicatedMergeTree
 ORDER BY (id, envio_checkpoint_id)`
@@ -306,7 +306,7 @@ chains:
   \`timestamp\` DateTime64(3, 'UTC'),
   \`amount\` String,
   \`envio_checkpoint_id\` UInt64,
-  \`envio_change\` Enum8('SET', 'DELETE')
+  \`envio_change\` Enum8('SET' = 1, 'DELETE' = 2)
 )
 ENGINE = MergeTree()
 PARTITION BY toYYYYMM(\`timestamp\`)
@@ -355,7 +355,7 @@ chains:
   \`base_token_id\` String,
   \`trade_time\` DateTime64(3, 'UTC'),
   \`envio_checkpoint_id\` UInt64,
-  \`envio_change\` Enum8('SET', 'DELETE')
+  \`envio_change\` Enum8('SET' = 1, 'DELETE' = 2)
 )
 ENGINE = MergeTree()
 ORDER BY (\`base_token_id\`, \`trade_time\`, envio_checkpoint_id)`)
@@ -404,7 +404,7 @@ chains:
   \`base_token_id\` String,
   \`trade_time\` DateTime64(3, 'UTC'),
   \`envio_checkpoint_id\` UInt64,
-  \`envio_change\` Enum8('SET', 'DELETE')
+  \`envio_change\` Enum8('SET' = 1, 'DELETE' = 2)
 )
 ENGINE = MergeTree()
 PARTITION BY toYYYYMM(\`trade_time\`)


### PR DESCRIPTION
The ClickHouse sink previously queried `system.columns` to learn each table's schema on first use, then aligned staged columns to that schema before encoding. This change shifts responsibility: callers now declare column types when staging, and the sink uses those types directly.

## Key changes

- **Column type declaration**: `ColumnInput` now includes a `ch_type` field with the ClickHouse type string (e.g., `"Enum8('SET' = 1, 'DELETE' = 2)"`). Callers already know their table shapes from DDL, so reading them back adds only latency and a second source of truth.

- **Removed schema caching**: Deleted `table_schema()`, `run_query()`, `invalidate_schema()`, and the `schemas`/`reported` caches. The sink no longer queries the server for column metadata.

- **Type resolution moved off JS thread**: `StagedColumn::resolve()` now parses the type string and resolves UTF-16 text spans — work that needs neither the isolate nor the network, so it runs in `block_in_place` during `flush`.

- **Enum numbering explicit**: Envio's DDL now writes enum variants with explicit numbers (`Enum8('SET' = 1, 'DELETE' = 2)`) instead of relying on ClickHouse's implicit numbering. RowBinary carries the number, not the name, so the mapping must be in the type text.

- **Warning callback**: Retries now call a `WarningSink` callback as they happen rather than returning messages at the end. A `flush` can retry for seconds while the caller waits, so degradation notices must leave Rust immediately to reach the indexer's logger.

- **Timeout and keepalive tuning**: Added `REQUEST_TIMEOUT`, `CONNECT_TIMEOUT`, and `TCP_KEEPALIVE` constants to the HTTP client. Tests can override these via a `Tuning` struct to avoid waits.

- **Text span resolution**: `StagedValues` carries UTF-16 lengths from JS; `StagedColumn::resolve()` converts them to byte spans in a single pass, catching shape mismatches early.

## Implementation details

- The `ColumnValues` enum is now generic over text delimiters (`TextBounds` trait), allowing staging to use UTF-16 lengths and encoding to use byte spans without duplicating the enum.
- Decimal parsing now handles overflow correctly by parsing as unsigned, then applying the sign, and bounds-checking against `i128::MAX` rather than computing `10^precision`.
- The insert query is built once per batch (in `insert_with_retry`) and reused across retries, avoiding repeated formatting.
- `StagedColumn::resolve()` validates that the column's declared type matches the wire kind of its values, catching mismatches before encoding.

https://claude.ai/code/session_01AKrbMVCcCCzFBbFRnLu1E4