### PR TITLE
Simplify ClickHouse encoder for supported types only

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -12,8 +12,7 @@ shape identical on both backends.
 ## Setup
 
 ```sh
-ln -s ../../packages/envio node_modules/envio
-ln -s ../envio/bin.mjs node_modules/.bin/envio
+pnpm install           # from the repo root; bench is a workspace package
 cp .env.example .env   # then point it at your Postgres and ClickHouse
 export ENVIO_API_TOKEN=...
 ```

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -14,9 +14,15 @@ OUT_DIR="$BENCH_DIR/results"
 mkdir -p "$OUT_DIR"
 
 CONFIG="config.$VARIANT.generated.yaml"
-sed -e "s/^    start_block: .*/    start_block: $START/" \
-    -e "s/^    end_block: .*/    end_block: $END/" \
+# Indentation is captured rather than matched, and the result is checked: a
+# rewrite that quietly matched nothing would benchmark the committed block range
+# under the requested label, so pg and ch could be compared over different data.
+sed -e "s/^\( *\)start_block:.*/\1start_block: $START/" \
+    -e "s/^\( *\)end_block:.*/\1end_block: $END/" \
     "config.$VARIANT.yaml" > "$CONFIG"
+for field in "start_block: $START" "end_block: $END"; do
+  grep -q "$field" "$CONFIG" || { echo "run.sh: failed to set '$field' in $CONFIG" >&2; exit 1; }
+done
 
 export ENVIO_CONFIG="$CONFIG"
 export ENVIO_PG_SCHEMA="bench_$VARIANT"
@@ -75,7 +81,11 @@ def labelled(name, key):
         if lm:
             out[lm.group(1)] = float(m.group(2))
     return out
-events = sum(labelled("envio_progress_events", "chainId").values()) or None
+# A run that processed nothing is a result, not a missing scrape: `or None`
+# would report both as null and hide a stalled run from anyone comparing the
+# pg and ch outputs.
+progress = labelled("envio_progress_events", "chainId")
+events = sum(progress.values()) if progress else None
 writes = labelled("envio_storage_write_total", "storage")
 secs = labelled("envio_storage_write_seconds", "storage")
 res = {
@@ -83,7 +93,7 @@ res = {
     "wall_seconds": wall,
     "exit_code": exit_code,
     "events_processed": events,
-    "events_per_second": round(events / wall, 1) if events else None,
+    "events_per_second": round(events / wall, 1) if events is not None and wall > 0 else None,
     "progress_block": labelled("envio_progress_block", "chainId"),
     "write_seconds": secs,
     "write_total": writes,

--- a/packages/cli/src/clickhouse/ch_type.rs
+++ b/packages/cli/src/clickhouse/ch_type.rs
@@ -1,34 +1,25 @@
 //! ClickHouse column types, parsed from the type text the caller declared the
 //! column with — the same string its `CREATE TABLE` used.
 //!
-//! Only what the encoder has to know to lay out bytes is modelled. An `Enum` is
-//! the clearest case: RowBinary carries the variant's number rather than its
-//! name, so the numbering has to be in the type text. Envio writes it there
-//! explicitly for exactly that reason, rather than leaving it to the numbering
-//! ClickHouse would apply to an unnumbered list.
+//! Only the types envio's DDL generates are modelled, so what the encoder has to
+//! keep correct is exactly what it can be handed. An `Enum` shows why the
+//! numbering has to be in the type text: RowBinary carries the variant's number
+//! rather than its name. Envio writes those numbers explicitly, and an unnumbered
+//! list is rejected here rather than auto-numbered — inferring them would put a
+//! second copy of ClickHouse's numbering rule on the encoding side, free to drift
+//! from the one the DDL wrote.
 
 use anyhow::{anyhow, bail, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChType {
-    Int8,
-    Int16,
     Int32,
     Int64,
-    Int128,
-    UInt8,
-    UInt16,
     UInt32,
     UInt64,
-    UInt128,
-    Float32,
     Float64,
     Bool,
     String,
-    FixedString(usize),
-    Date,
-    Date32,
-    DateTime,
     /// Ticks of 10^-precision seconds, stored as Int64.
     DateTime64 {
         precision: u32,
@@ -113,26 +104,27 @@ fn split_args(input: &str) -> Vec<&str> {
     parts
 }
 
-/// Number of bytes ClickHouse uses for a `Decimal` of the given precision.
+/// Number of bytes ClickHouse uses for a `Decimal` of the given precision. Envio
+/// falls back to `String` past 38 digits, so the 256-bit width never comes up and
+/// every Decimal that reaches the encoder fits the 128-bit value it carries.
 pub fn decimal_bytes(precision: u32) -> Result<usize> {
     match precision {
         1..=9 => Ok(4),
         10..=18 => Ok(8),
         19..=38 => Ok(16),
-        39..=76 => Ok(32),
         other => bail!("unsupported Decimal precision {other}"),
     }
 }
 
 fn parse_enum_variants(args: &str) -> Result<Vec<(String, i16)>> {
     let mut variants = Vec::new();
-    // ClickHouse always reports explicit values, but an unnumbered list is
-    // still valid input syntax and auto-numbers from 1.
-    let mut next_implicit = 1i16;
     for arg in split_args(args) {
         let (name_part, value_part) = match find_unquoted(arg, b'=') {
-            Some(i) => (arg[..i].trim(), Some(arg[i + 1..].trim())),
-            None => (arg, None),
+            Some(i) => (arg[..i].trim(), arg[i + 1..].trim()),
+            None => bail!(
+                "enum variant `{arg}` has no explicit value; RowBinary carries the \
+                 number, so the type text has to state it"
+            ),
         };
         let name = name_part
             .strip_prefix('\'')
@@ -140,12 +132,7 @@ fn parse_enum_variants(args: &str) -> Result<Vec<(String, i16)>> {
             .ok_or_else(|| anyhow!("malformed enum variant `{arg}`"))?
             .replace("\\'", "'")
             .replace("\\\\", "\\");
-        let value = match value_part {
-            Some(v) => v.parse::<i16>()?,
-            None => next_implicit,
-        };
-        next_implicit = value + 1;
-        variants.push((name, value));
+        variants.push((name, value_part.parse::<i16>()?));
     }
     if variants.is_empty() {
         bail!("enum with no variants");
@@ -157,12 +144,8 @@ pub fn parse(input: &str) -> Result<ChType> {
     let input = input.trim();
     if let Some((name, args)) = split_parameterized(input) {
         return match name {
-            // Only the inner type matters on the wire.
-            "LowCardinality" | "SimpleAggregateFunction" => parse(split_args(args).last().unwrap()),
             "Nullable" => Ok(ChType::Nullable(Box::new(parse(args)?))),
             "Array" => Ok(ChType::Array(Box::new(parse(args)?))),
-            "FixedString" => Ok(ChType::FixedString(args.trim().parse()?)),
-            "DateTime" => Ok(ChType::DateTime),
             "DateTime64" => {
                 let parts = split_args(args);
                 Ok(ChType::DateTime64 {
@@ -183,21 +166,7 @@ pub fn parse(input: &str) -> Result<ChType> {
                     scale: parts[1].parse()?,
                 })
             }
-            "Decimal32" | "Decimal64" | "Decimal128" | "Decimal256" => {
-                // The shorthand fixes the width, so it stands for the widest
-                // precision that width holds.
-                let precision = match name {
-                    "Decimal32" => 9,
-                    "Decimal64" => 18,
-                    "Decimal128" => 38,
-                    _ => 76,
-                };
-                Ok(ChType::Decimal {
-                    precision,
-                    scale: args.trim().parse()?,
-                })
-            }
-            "Enum" | "Enum8" => Ok(ChType::Enum {
+            "Enum8" => Ok(ChType::Enum {
                 bytes: 1,
                 variants: parse_enum_variants(args)?,
             }),
@@ -210,23 +179,13 @@ pub fn parse(input: &str) -> Result<ChType> {
     }
 
     match input {
-        "Int8" => Ok(ChType::Int8),
-        "Int16" => Ok(ChType::Int16),
         "Int32" => Ok(ChType::Int32),
         "Int64" => Ok(ChType::Int64),
-        "Int128" => Ok(ChType::Int128),
-        "UInt8" => Ok(ChType::UInt8),
-        "UInt16" => Ok(ChType::UInt16),
         "UInt32" => Ok(ChType::UInt32),
         "UInt64" => Ok(ChType::UInt64),
-        "UInt128" => Ok(ChType::UInt128),
-        "Float32" => Ok(ChType::Float32),
         "Float64" => Ok(ChType::Float64),
-        "Bool" | "Boolean" => Ok(ChType::Bool),
+        "Bool" => Ok(ChType::Bool),
         "String" => Ok(ChType::String),
-        "Date" => Ok(ChType::Date),
-        "Date32" => Ok(ChType::Date32),
-        "DateTime" => Ok(ChType::DateTime),
         other => bail!("unsupported ClickHouse type `{other}`"),
     }
 }
@@ -251,29 +210,17 @@ impl ChType {
     pub fn column_kind(&self) -> ColumnKind {
         match self {
             ChType::Nullable(inner) => inner.column_kind(),
-            ChType::Int8
-            | ChType::Int16
-            | ChType::Int32
-            | ChType::UInt8
-            | ChType::UInt16
+            ChType::Int32
             | ChType::UInt32
-            | ChType::Float32
             | ChType::Float64
             | ChType::Bool
-            | ChType::Date
-            | ChType::Date32
-            | ChType::DateTime
             | ChType::DateTime64 { .. } => ColumnKind::F64,
             ChType::UInt64 => ColumnKind::U64,
             ChType::Int64 => ColumnKind::I64,
-            ChType::String
-            | ChType::FixedString(_)
-            | ChType::Int128
-            | ChType::UInt128
-            | ChType::Decimal { .. }
-            | ChType::Enum { .. } => ColumnKind::Text,
             // An array arrives as the JSON of its elements.
-            ChType::Array(_) => ColumnKind::Text,
+            ChType::String | ChType::Decimal { .. } | ChType::Enum { .. } | ChType::Array(_) => {
+                ColumnKind::Text
+            }
         }
     }
 }
@@ -299,13 +246,8 @@ mod tests {
 
     #[test]
     fn parses_decimal_precision_and_scale() {
-        let parsed = [
-            "Decimal(9, 2)",
-            "Decimal(18, 0)",
-            "Decimal(50, 3)",
-            "Decimal64(4)",
-        ]
-        .map(|input| parse(input).unwrap());
+        let parsed = ["Decimal(9, 2)", "Decimal(18, 0)", "Decimal(38, 3)"]
+            .map(|input| parse(input).unwrap());
         assert_eq!(
             parsed,
             [
@@ -318,13 +260,8 @@ mod tests {
                     scale: 0
                 },
                 ChType::Decimal {
-                    precision: 50,
+                    precision: 38,
                     scale: 3
-                },
-                // The shorthand stands for the widest precision its width holds.
-                ChType::Decimal {
-                    precision: 18,
-                    scale: 4
                 },
             ]
         );
@@ -334,13 +271,22 @@ mod tests {
     /// it: a pair that disagreed would shift every following column on the wire.
     #[test]
     fn precision_fixes_the_backing_width() {
-        let widths =
-            [9u32, 10, 18, 19, 38, 39, 76].map(|precision| decimal_bytes(precision).unwrap());
-        assert_eq!(widths, [4, 8, 8, 16, 16, 32, 32]);
+        let widths = [9u32, 10, 18, 19, 38].map(|precision| decimal_bytes(precision).unwrap());
+        assert_eq!(widths, [4, 8, 8, 16, 16]);
+    }
+
+    /// Envio falls back to `String` past 38 digits, so a wider Decimal is a
+    /// declaration the encoder should refuse rather than silently truncate.
+    #[test]
+    fn rejects_a_decimal_wider_than_the_value_it_carries() {
+        assert_eq!(
+            parse("Decimal(50, 3)").unwrap_err().to_string(),
+            "unsupported Decimal precision 50"
+        );
     }
 
     #[test]
-    fn parses_enum_with_server_reported_values() {
+    fn parses_enum_with_explicit_values() {
         assert_eq!(
             parse("Enum8('SET' = 1, 'DELETE' = 2)").unwrap(),
             ChType::Enum {
@@ -350,13 +296,14 @@ mod tests {
         );
     }
 
+    /// Auto-numbering an unnumbered list would be a second copy of ClickHouse's
+    /// own rule, which is exactly what writing the numbers into the DDL avoids.
     #[test]
-    fn auto_numbers_an_unnumbered_enum_from_one() {
+    fn rejects_an_unnumbered_enum_rather_than_inferring_the_numbering() {
         assert_eq!(
-            parse("Enum8('SET', 'DELETE')")
-                .unwrap()
-                .enum_value("DELETE"),
-            Some(2)
+            parse("Enum8('SET', 'DELETE')").unwrap_err().to_string(),
+            "enum variant `'SET'` has no explicit value; RowBinary carries the number, \
+             so the type text has to state it"
         );
     }
 
@@ -367,11 +314,6 @@ mod tests {
             (parsed.enum_value("a,b"), parsed.enum_value("c(d)")),
             (Some(7), Some(9))
         );
-    }
-
-    #[test]
-    fn unwraps_low_cardinality() {
-        assert_eq!(parse("LowCardinality(String)").unwrap(), ChType::String);
     }
 
     #[test]
@@ -396,8 +338,36 @@ mod tests {
         );
     }
 
+    /// The DDL generator emits a closed set of types; anything outside it is a
+    /// column envio did not declare, and guessing at its layout would put bytes
+    /// on the wire that shift every column after it.
     #[test]
-    fn rejects_an_unknown_type() {
-        assert!(parse("Tuple(String, UInt8)").is_err());
+    fn rejects_types_the_ddl_never_emits() {
+        let errors = [
+            "Tuple(String, UInt8)",
+            "Int8",
+            "UInt128",
+            "Float32",
+            "FixedString(4)",
+            "Date",
+            "DateTime",
+            "Decimal64(4)",
+            "LowCardinality(String)",
+        ]
+        .map(|input| parse(input).unwrap_err().to_string());
+        assert_eq!(
+            errors,
+            [
+                "unsupported ClickHouse type `Tuple`",
+                "unsupported ClickHouse type `Int8`",
+                "unsupported ClickHouse type `UInt128`",
+                "unsupported ClickHouse type `Float32`",
+                "unsupported ClickHouse type `FixedString`",
+                "unsupported ClickHouse type `Date`",
+                "unsupported ClickHouse type `DateTime`",
+                "unsupported ClickHouse type `Decimal64`",
+                "unsupported ClickHouse type `LowCardinality`",
+            ]
+        );
     }
 }

--- a/packages/cli/src/clickhouse/mock_server.rs
+++ b/packages/cli/src/clickhouse/mock_server.rs
@@ -20,6 +20,8 @@ struct State {
     seen: usize,
     /// Total read queries seen.
     queries: usize,
+    /// Request line and headers of every request, in arrival order.
+    heads: Vec<String>,
 }
 
 pub struct MockClickHouse {
@@ -93,35 +95,33 @@ impl MockClickHouse {
         self.state.lock().unwrap().queries
     }
 
+    /// Request line and headers of every request the server handled.
+    pub fn heads(&self) -> Vec<String> {
+        self.state.lock().unwrap().heads.clone()
+    }
+
     /// Decodes every accepted body as rows of one `String` column, flattened in
-    /// arrival order — enough to tell which rows landed and how often.
+    /// arrival order — enough to tell which rows landed and how often. A body
+    /// that is not that shape is a bug in the encoder under test, so it fails
+    /// here rather than being reported as missing rows.
     pub fn accepted_strings(&self) -> Vec<String> {
         let mut out = Vec::new();
         for body in self.accepted() {
             let mut i = 0usize;
             while i < body.len() {
-                let (len, read) = read_varint(&body[i..]);
+                let (len, read) = super::row_binary::read_varint(&body[i..])
+                    .expect("accepted body is not a String column");
                 i += read;
-                out.push(String::from_utf8(body[i..i + len].to_vec()).unwrap());
-                i += len;
+                let end = i + len as usize;
+                let bytes = body
+                    .get(i..end)
+                    .expect("accepted body ends mid-string")
+                    .to_vec();
+                out.push(String::from_utf8(bytes).unwrap());
+                i = end;
             }
         }
         out
-    }
-}
-
-fn read_varint(bytes: &[u8]) -> (usize, usize) {
-    let mut value = 0usize;
-    let mut shift = 0u32;
-    let mut read = 0usize;
-    loop {
-        let byte = bytes[read];
-        value |= ((byte & 0x7F) as usize) << shift;
-        read += 1;
-        if byte & 0x80 == 0 {
-            return (value, read);
-        }
-        shift += 7;
     }
 }
 
@@ -143,25 +143,19 @@ async fn serve(mut stream: TcpStream, state: Arc<Mutex<State>>) -> std::io::Resu
             })
             .unwrap_or(0);
 
-        let mut body = vec![0u8; content_length];
-        for (i, slot) in body.iter_mut().enumerate() {
-            *slot = match buffered.pop_front() {
-                Some(byte) => byte,
-                None => {
-                    let mut chunk = vec![0u8; content_length - i];
-                    stream.read_exact(&mut chunk).await?;
-                    let mut iter = chunk.into_iter();
-                    let first = iter.next().unwrap();
-                    buffered.extend(iter);
-                    first
-                }
-            };
-        }
+        // Whatever of the body already arrived with the headers, then the rest
+        // straight off the socket.
+        let buffered_bytes = buffered.len().min(content_length);
+        let mut body: Vec<u8> = buffered.drain(..buffered_bytes).collect();
+        body.resize(content_length, 0);
+        stream.read_exact(&mut body[buffered_bytes..]).await?;
+
+        state.lock().unwrap().heads.push(head.clone());
 
         // The request line carries the query for an insert; a read query arrives
         // in the body instead.
         let request_line = head.lines().next().unwrap_or_default().to_string();
-        let is_insert = request_line.contains("INSERT") || request_line.contains("INSERT+INTO");
+        let is_insert = request_line.contains("INSERT");
 
         let response = if is_insert {
             let reject = {

--- a/packages/cli/src/clickhouse/mod.rs
+++ b/packages/cli/src/clickhouse/mod.rs
@@ -52,49 +52,50 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Probes an idle pooled socket so a connection dropped by a NAT or proxy is
 /// discovered before a batch is handed to it.
 const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
-
-/// How hard to retry a failed insert. Only the tests vary it, to skip the waits.
-#[derive(Debug, Clone, Copy)]
-struct RetryPolicy {
-    attempts: u32,
-    wait: bool,
-}
-
-impl Default for RetryPolicy {
-    fn default() -> Self {
-        Self {
-            attempts: MAX_RETRIES,
-            wait: true,
-        }
-    }
-}
+/// How long a pooled socket may sit idle before the client drops it. Deliberately
+/// under ClickHouse's own `keep_alive_timeout` (3s on older servers, 10s by
+/// default), which is the deadline that matters: past it the server closes the
+/// socket, and a batch dispatched onto one already carrying a FIN fails with
+/// `connection closed before message completed`. `@clickhouse/client` set its
+/// `idle_socket_ttl` to 2.5s for the same reason.
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_millis(2_500);
+/// The longest a retry waits, which the delay ramps up to.
+const MAX_RETRY_DELAY: Duration = Duration::from_millis(1_000);
 
 /// Knobs the tests turn down so a run takes milliseconds: the retry waits and
 /// the request timeout a hanging server has to trip.
 #[derive(Debug, Clone, Copy)]
 struct Tuning {
-    retry: RetryPolicy,
+    attempts: u32,
+    /// Ceiling on the retry backoff. Tests pass `ZERO` to skip the waits, which
+    /// are the policy's concern rather than the encoder's.
+    max_retry_delay: Duration,
     request_timeout: Duration,
 }
 
 impl Default for Tuning {
     fn default() -> Self {
         Self {
-            retry: RetryPolicy::default(),
+            attempts: MAX_RETRIES,
+            max_retry_delay: MAX_RETRY_DELAY,
             request_timeout: REQUEST_TIMEOUT,
         }
     }
 }
 
-impl RetryPolicy {
-    /// Grows from 100ms to 1s as the remaining retries run down.
+impl Tuning {
+    /// Grows from a tenth of the ceiling up to it as the remaining retries run
+    /// down.
     fn delay(&self, retries_left: u32) -> Duration {
-        if !self.wait || self.attempts < 2 {
+        if self.attempts < 2 {
             return Duration::ZERO;
         }
+        let span = self.max_retry_delay.as_millis() as u64;
         Duration::from_millis(
-            (100 + 900 * u64::from(self.attempts - retries_left) / u64::from(self.attempts - 1))
-                .min(1000),
+            (span / 10
+                + (span - span / 10) * u64::from(self.attempts - retries_left)
+                    / u64::from(self.attempts - 1))
+            .min(span),
         )
     }
 }
@@ -110,15 +111,14 @@ pub struct ColumnInput {
     /// it back from `system.columns` would only add a round trip and a second
     /// place for the answer to come from.
     pub ch_type: String,
-    /// Int8/16/32, UInt8/16/32, Float32/64, Bool (0/1), Date, DateTime,
-    /// DateTime64 (ticks).
+    /// Int32, UInt32, Float64, Bool (0/1), DateTime64 (ticks).
     pub numbers: Option<Float64Array>,
     /// UInt64, which loses precision as an f64.
     pub unsigned64: Option<BigUint64Array>,
     /// Int64.
     pub signed64: Option<BigInt64Array>,
-    /// String, Decimal, Enum, Int128/UInt128 and JSON for Array columns: every
-    /// value concatenated, split by `lengths`.
+    /// String, Decimal, Enum, and the JSON of an Array column: every value
+    /// concatenated, split by `lengths`.
     pub text: Option<String>,
     /// UTF-16 code-unit length of each value in `text` — a JS string's own
     /// `.length`, so the caller never has to measure UTF-8.
@@ -142,18 +142,20 @@ impl StagedColumn {
     fn resolve(self) -> Result<Column> {
         let ch_type = ch_type::parse(&self.ch_type)
             .with_context(|| format!("Column `{}` has type `{}`", self.name, self.ch_type))?;
+        // Checked before resolving, so a column sent as the wrong kind is caught
+        // without first scanning its text for span boundaries.
+        let kind = ch_type.column_kind();
+        let staged_kind = self.values.kind();
+        if staged_kind != kind {
+            bail!(
+                "Column `{}` is {ch_type:?} and must be sent as {kind:?}, got {staged_kind:?}",
+                self.name,
+            );
+        }
         let values = self
             .values
             .resolve()
             .with_context(|| format!("Column `{}`", self.name))?;
-        let kind = ch_type.column_kind();
-        if values.kind() != kind {
-            bail!(
-                "Column `{}` is {ch_type:?} and must be sent as {kind:?}, got {:?}",
-                self.name,
-                values.kind()
-            );
-        }
         Ok(Column {
             name: self.name,
             ch_type,
@@ -232,7 +234,7 @@ impl ClickHouseSink {
         let client = reqwest::Client::builder()
             // The sink writes continuously; keeping sockets warm avoids a TLS
             // handshake per batch against a remote cluster.
-            .pool_idle_timeout(Duration::from_secs(90))
+            .pool_idle_timeout(POOL_IDLE_TIMEOUT)
             .pool_max_idle_per_host(8)
             .timeout(tuning.request_timeout)
             .connect_timeout(CONNECT_TIMEOUT)
@@ -286,7 +288,7 @@ impl ClickHouseSink {
                     })?;
                     StagedValues::Text {
                         data,
-                        bounds: lengths.to_vec(),
+                        utf16_lengths: lengths.to_vec(),
                     }
                 }
                 _ => {
@@ -360,7 +362,7 @@ impl ClickHouseSink {
         let mut attempted: Vec<String> = Vec::new();
         // Ranges still to send, most recent first; a failed range is replaced by
         // its two halves so the retry never re-sends rows that already landed.
-        let mut pending = vec![(0usize, encoded.rows(), self.tuning.retry.attempts)];
+        let mut pending = vec![(0usize, encoded.rows(), self.tuning.attempts)];
         while let Some((start, end, retries)) = pending.pop() {
             match self.post_rows(&query, encoded.slice(start, end)).await {
                 Ok(()) => continue,
@@ -381,7 +383,7 @@ impl ClickHouseSink {
                     );
                     (self.warn)(&warning);
                     attempted.push(warning);
-                    tokio::time::sleep(self.tuning.retry.delay(retries)).await;
+                    tokio::time::sleep(self.tuning.delay(retries)).await;
                     if rows > 1 {
                         let mid = start + rows / 2;
                         pending.push((mid, end, retries - 1));
@@ -399,10 +401,12 @@ impl ClickHouseSink {
         let response = self
             .client
             .post(&self.url)
-            .query(&[("query", query)])
-            .header("X-ClickHouse-User", &self.username)
-            .header("X-ClickHouse-Key", &self.password)
-            .header("X-ClickHouse-Database", &self.database)
+            .query(&[("query", query), ("database", &self.database)])
+            // Base64 of the credentials rather than the X-ClickHouse-User/Key
+            // headers: a header value may only carry visible ASCII, so a password
+            // with a non-ASCII character in it fails every request before it is
+            // sent. `@clickhouse/client` authenticated this way too.
+            .basic_auth(&self.username, Some(&self.password))
             .header("Content-Type", "application/octet-stream")
             .body(body)
             .send()
@@ -460,7 +464,7 @@ mod tests {
             ch_type: ty.to_string(),
             values: StagedValues::Text {
                 data: values.concat(),
-                bounds: values.iter().map(|v| v.len() as u32).collect(),
+                utf16_lengths: values.iter().map(|v| v.len() as u32).collect(),
             },
             nulls: Vec::new(),
         }
@@ -493,7 +497,7 @@ mod tests {
             ch_type: "Tuple(String, UInt8)".to_string(),
             values: StagedValues::Text {
                 data: String::new(),
-                bounds: vec![0],
+                utf16_lengths: vec![0],
             },
             nulls: Vec::new(),
         }
@@ -546,12 +550,10 @@ mod tests {
         sink_with(
             server,
             Tuning {
-                retry: RetryPolicy {
-                    attempts,
-                    // The waits are the policy's, not the encoder's; skipping
-                    // them keeps the test at milliseconds.
-                    wait: false,
-                },
+                attempts,
+                // The waits are the policy's, not the encoder's; skipping them
+                // keeps the test at milliseconds.
+                max_retry_delay: Duration::ZERO,
                 ..Tuning::default()
             },
         )
@@ -655,10 +657,8 @@ mod tests {
         let sink = sink_with(
             &server,
             Tuning {
-                retry: RetryPolicy {
-                    attempts: 1,
-                    wait: false,
-                },
+                attempts: 1,
+                max_retry_delay: Duration::ZERO,
                 request_timeout: Duration::from_millis(150),
             },
         );
@@ -715,6 +715,44 @@ mod tests {
             (true, 0),
             "expected the encoder's message, got: {}",
             err.reason
+        );
+    }
+
+    // A header value may only carry visible ASCII, so credentials sent as
+    // X-ClickHouse-User/Key fail to build the request at all for a password no
+    // stricter than a deployment is free to choose.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_non_ascii_password_still_authenticates() {
+        let server = mock_server::MockClickHouse::start(0).await;
+        let sink = ClickHouseSink::build(
+            ClickHouseSinkOptions {
+                url: server.url.clone(),
+                username: "défaut".to_string(),
+                password: "pässwörd".to_string(),
+                database: "mock".to_string(),
+            },
+            Tuning::default(),
+            Arc::new(|_: &str| ()),
+        )
+        .unwrap();
+        let handle = stage_ids(&sink, &["a"]);
+
+        sink.flush(handle).await.unwrap();
+
+        let head = server.heads().first().cloned().unwrap_or_default();
+        // base64("défaut:pässwörd"), which is what a Basic credential carries.
+        assert_eq!(
+            (
+                head.to_lowercase().contains(
+                    "authorization: basic ZMOpZmF1dDpww6Rzc3fDtnJk"
+                        .to_lowercase()
+                        .as_str()
+                ),
+                head.contains("database=mock"),
+                server.accepted_strings()
+            ),
+            (true, true, vec!["a".to_string()]),
+            "expected a Basic credential, got head: {head}"
         );
     }
 

--- a/packages/cli/src/clickhouse/row_binary.rs
+++ b/packages/cli/src/clickhouse/row_binary.rs
@@ -9,92 +9,79 @@ use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
 
 use super::ch_type::ChType;
+use super::ch_type::ColumnKind;
 
-/// How a text column's concatenated values are delimited. JS measures UTF-16
-/// code units for free, so that is what crosses the boundary; resolving them to
-/// byte ranges is a scan over the whole column and belongs off the JS thread.
-pub trait TextBounds {
-    fn count(&self) -> usize;
-}
-
-/// UTF-16 code-unit length per value, as `String.prototype.length` reports it.
-pub type Utf16Lengths = Vec<u32>;
-/// Byte range per value into the concatenated data.
-pub type ByteSpans = Vec<(usize, usize)>;
-
-impl TextBounds for Utf16Lengths {
-    fn count(&self) -> usize {
-        self.len()
-    }
-}
-
-impl TextBounds for ByteSpans {
-    fn count(&self) -> usize {
-        self.len()
-    }
-}
-
-/// One column's values for a batch, already owned by Rust. The text delimiting
-/// is a parameter so staging and encoding share one enum: a new wire kind is one
-/// variant and one `kind` arm, not a second enum to keep in step.
+/// One column's values as they arrive from JS. A text column crosses as every
+/// value concatenated plus each value's UTF-16 code-unit length, which JS
+/// measures for free; resolving those to byte ranges is a scan over the whole
+/// column and belongs off the JS thread.
 #[derive(Debug)]
-pub enum ColumnValues<B = ByteSpans> {
+pub enum StagedValues {
     F64(Vec<f64>),
     U64(Vec<u64>),
     I64(Vec<i64>),
-    Text { data: String, bounds: B },
+    Text {
+        data: String,
+        utf16_lengths: Vec<u32>,
+    },
 }
 
-/// A column as it arrives from JS, before the span scan.
-pub type StagedValues = ColumnValues<Utf16Lengths>;
-
-impl<B: TextBounds> ColumnValues<B> {
-    /// The wire kind these values arrived as, for checking against the column's
-    /// ClickHouse type.
-    pub fn kind(&self) -> super::ch_type::ColumnKind {
-        use super::ch_type::ColumnKind;
-        match self {
-            ColumnValues::F64(_) => ColumnKind::F64,
-            ColumnValues::U64(_) => ColumnKind::U64,
-            ColumnValues::I64(_) => ColumnKind::I64,
-            ColumnValues::Text { .. } => ColumnKind::Text,
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        match self {
-            ColumnValues::F64(v) => v.len(),
-            ColumnValues::U64(v) => v.len(),
-            ColumnValues::I64(v) => v.len(),
-            ColumnValues::Text { bounds, .. } => bounds.count(),
-        }
-    }
+/// The same values with each text value resolved to its byte range.
+#[derive(Debug)]
+pub enum ColumnValues {
+    F64(Vec<f64>),
+    U64(Vec<u64>),
+    I64(Vec<i64>),
+    Text {
+        data: String,
+        spans: Vec<(usize, usize)>,
+    },
 }
 
 impl StagedValues {
+    /// The wire kind these values arrived as, for checking against the column's
+    /// ClickHouse type.
+    pub fn kind(&self) -> ColumnKind {
+        match self {
+            StagedValues::F64(_) => ColumnKind::F64,
+            StagedValues::U64(_) => ColumnKind::U64,
+            StagedValues::I64(_) => ColumnKind::I64,
+            StagedValues::Text { .. } => ColumnKind::Text,
+        }
+    }
+
     /// Resolves the UTF-16 lengths into byte spans. The only step between the two
     /// representations, so it is also where a text column's shape is checked.
     pub fn resolve(self) -> Result<ColumnValues> {
         Ok(match self {
-            ColumnValues::F64(v) => ColumnValues::F64(v),
-            ColumnValues::U64(v) => ColumnValues::U64(v),
-            ColumnValues::I64(v) => ColumnValues::I64(v),
-            ColumnValues::Text { data, bounds } => {
-                let spans = spans_from_utf16_lengths(&data, &bounds)?;
-                ColumnValues::Text {
-                    data,
-                    bounds: spans,
-                }
+            StagedValues::F64(v) => ColumnValues::F64(v),
+            StagedValues::U64(v) => ColumnValues::U64(v),
+            StagedValues::I64(v) => ColumnValues::I64(v),
+            StagedValues::Text {
+                data,
+                utf16_lengths,
+            } => {
+                let spans = spans_from_utf16_lengths(&data, &utf16_lengths)?;
+                ColumnValues::Text { data, spans }
             }
         })
     }
 }
 
 impl ColumnValues {
+    pub fn len(&self) -> usize {
+        match self {
+            ColumnValues::F64(v) => v.len(),
+            ColumnValues::U64(v) => v.len(),
+            ColumnValues::I64(v) => v.len(),
+            ColumnValues::Text { spans, .. } => spans.len(),
+        }
+    }
+
     fn text_at(&self, row: usize) -> Result<&str> {
         match self {
-            ColumnValues::Text { data, bounds } => {
-                let (start, end) = bounds[row];
+            ColumnValues::Text { data, spans } => {
+                let (start, end) = spans[row];
                 Ok(&data[start..end])
             }
             other => bail!("expected a text column, got {other:?}"),
@@ -122,7 +109,7 @@ impl Column {
 ///
 /// The scan is over UTF-8 bytes, so it cannot index by code unit directly:
 /// a character outside the BMP is two UTF-16 units and up to four UTF-8 bytes.
-pub fn spans_from_utf16_lengths(data: &str, lengths: &[u32]) -> Result<ByteSpans> {
+pub fn spans_from_utf16_lengths(data: &str, lengths: &[u32]) -> Result<Vec<(usize, usize)>> {
     let mut spans = Vec::with_capacity(lengths.len());
     let bytes = data.as_bytes();
     let mut offset = 0usize;
@@ -181,13 +168,31 @@ fn put_varint(out: &mut Vec<u8>, mut value: u64) {
     }
 }
 
+/// Reads a varint back, returning its value and the bytes consumed. Only the
+/// tests decode one, but it lives beside `put_varint` so the pair cannot drift.
+#[cfg(test)]
+pub fn read_varint(bytes: &[u8]) -> Result<(u64, usize)> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    for (read, &byte) in bytes.iter().enumerate() {
+        value |= u64::from(byte & 0x7F)
+            .checked_shl(shift)
+            .context("varint is wider than 64 bits")?;
+        if byte & 0x80 == 0 {
+            return Ok((value, read + 1));
+        }
+        shift += 7;
+    }
+    bail!("varint runs past the end of the buffer")
+}
+
 fn put_string(out: &mut Vec<u8>, value: &str) {
     put_varint(out, value.len() as u64);
     out.extend_from_slice(value.as_bytes());
 }
 
-/// Parses a decimal literal (`-12.34`, `1e3`, `0x…` excluded) into the scaled
-/// integer ClickHouse stores for `Decimal(P, S)`.
+/// Parses a decimal literal (`-12.34`, `1e3`) into the scaled integer ClickHouse
+/// stores for `Decimal(P, S)`.
 fn decimal_to_i128(text: &str, scale: u32) -> Result<i128> {
     let text = text.trim();
     if text.is_empty() {
@@ -206,30 +211,32 @@ fn decimal_to_i128(text: &str, scale: u32) -> Result<i128> {
         Some((i, f)) => (i, f),
         None => (mantissa, ""),
     };
-    if int_part.is_empty() && frac_part.is_empty() {
-        bail!("`{text}` is not a decimal");
+    // Folded straight into the accumulator: the digits are the whole value, so
+    // joining them into a string first would allocate once per cell in the hot
+    // encode loop only to parse the same bytes back out.
+    let mut magnitude = 0u128;
+    let mut digits = 0usize;
+    for part in [int_part, frac_part] {
+        for byte in part.bytes() {
+            if !byte.is_ascii_digit() {
+                bail!("`{text}` is not a decimal");
+            }
+            digits += 1;
+            magnitude = magnitude
+                .checked_mul(10)
+                .and_then(|shifted| shifted.checked_add(u128::from(byte - b'0')))
+                .ok_or_else(|| anyhow!("decimal `{text}` overflows Int128"))?;
+        }
     }
-    let mut digits = String::with_capacity(int_part.len() + frac_part.len());
-    digits.push_str(int_part);
-    digits.push_str(frac_part);
-    if !digits.bytes().all(|b| b.is_ascii_digit()) {
+    if digits == 0 {
         bail!("`{text}` is not a decimal");
     }
     // Exponent shifts the point; `scale` then fixes how many fractional digits
     // the stored integer keeps. Widened to i64 because `exponent` is an
     // unconstrained i32 and the subtraction would otherwise be able to overflow.
     let shift = i64::from(scale) + i64::from(exponent) - frac_part.len() as i64;
-    // An all-zero mantissa trims to the empty string, which `parse` rejects.
-    let trimmed = digits.trim_start_matches('0');
     // Parsed unsigned: i128::MIN's magnitude is one past i128::MAX, so parsing
     // the digits as i128 and negating afterwards would reject a legal value.
-    let magnitude = if trimmed.is_empty() {
-        0u128
-    } else {
-        trimmed
-            .parse::<u128>()
-            .map_err(|_| anyhow!("decimal `{text}` overflows Int128"))?
-    };
     let mut value = match negative {
         true if magnitude <= (i128::MAX as u128) + 1 => (magnitude as i128).wrapping_neg(),
         false if magnitude <= i128::MAX as u128 => magnitude as i128,
@@ -263,13 +270,7 @@ fn decimal_to_i128(text: &str, scale: u32) -> Result<i128> {
 }
 
 fn put_int_raw(out: &mut Vec<u8>, value: i128, bytes: usize) {
-    let le = value.to_le_bytes();
-    out.extend_from_slice(&le[..bytes.min(16)]);
-    if bytes > 16 {
-        // Int256/Decimal256: sign-extend past the 128-bit value we carry.
-        let fill = if value < 0 { 0xFF } else { 0x00 };
-        out.extend(std::iter::repeat_n(fill, bytes - 16));
-    }
+    out.extend_from_slice(&value.to_le_bytes()[..bytes]);
 }
 
 /// What the column accepts. RowBinary is just the raw integer, so nothing on the
@@ -279,26 +280,19 @@ fn put_int_raw(out: &mut Vec<u8>, value: i128, bytes: usize) {
 /// negative number.
 fn int_bounds(ch_type: &ChType) -> Result<(i128, i128)> {
     Ok(match ch_type {
-        ChType::Int8 => (i8::MIN as i128, i8::MAX as i128),
-        ChType::Int16 => (i16::MIN as i128, i16::MAX as i128),
         ChType::Int32 => (i32::MIN as i128, i32::MAX as i128),
         ChType::Int64 => (i64::MIN as i128, i64::MAX as i128),
-        ChType::Int128 => (i128::MIN, i128::MAX),
-        ChType::UInt8 | ChType::Bool => (0, u8::MAX as i128),
-        ChType::UInt16 | ChType::Date => (0, u16::MAX as i128),
-        ChType::UInt32 | ChType::DateTime => (0, u32::MAX as i128),
+        ChType::Bool => (0, u8::MAX as i128),
+        ChType::UInt32 => (0, u32::MAX as i128),
         ChType::UInt64 => (0, u64::MAX as i128),
-        // The wire value is 128 bits, so that is the widest we can carry.
-        ChType::UInt128 => (0, i128::MAX),
-        ChType::Date32 => (i32::MIN as i128, i32::MAX as i128),
         ChType::DateTime64 { .. } => (i64::MIN as i128, i64::MAX as i128),
-        // A Decimal's precision, not its byte width, is what it accepts — until
-        // the precision outgrows the 128-bit value we carry, as it does for a
-        // Decimal256, and the wire width becomes the tighter bound.
-        ChType::Decimal { precision, .. } => match 10i128.checked_pow(*precision) {
-            Some(limit) => (1 - limit, limit - 1),
-            None => (i128::MIN, i128::MAX),
-        },
+        // A Decimal's precision, not its byte width, is what it accepts.
+        ChType::Decimal { precision, .. } => {
+            let limit = 10i128
+                .checked_pow(*precision)
+                .context("Decimal precision is wider than the value the encoder carries")?;
+            (1 - limit, limit - 1)
+        }
         ChType::Enum { bytes, .. } => {
             if *bytes == 1 {
                 (i8::MIN as i128, i8::MAX as i128)
@@ -319,26 +313,12 @@ fn put_int(out: &mut Vec<u8>, value: i128, ch_type: &ChType) -> Result<()> {
     Ok(())
 }
 
-fn put_fixed_string(out: &mut Vec<u8>, text: &str, width: usize) -> Result<()> {
-    let bytes = text.as_bytes();
-    if bytes.len() > width {
-        bail!(
-            "`{text}` is {} bytes, which a FixedString({width}) column cannot hold",
-            bytes.len()
-        );
-    }
-    out.extend_from_slice(bytes);
-    out.extend(std::iter::repeat_n(0u8, width - bytes.len()));
-    Ok(())
-}
-
 /// Encodes a scalar whose value arrives as text. Every value from JS is text
-/// unless its column has a typed array, and a JSON array's elements stringify to
-/// the same thing, so both paths land here and cannot drift apart.
+/// unless its column has a typed array, so the column path and an array's
+/// stringly elements land here together and cannot drift apart.
 fn encode_text_scalar(out: &mut Vec<u8>, ch_type: &ChType, text: &str) -> Result<()> {
     match ch_type {
         ChType::String => put_string(out, text),
-        ChType::FixedString(width) => put_fixed_string(out, text, *width)?,
         ChType::Decimal { scale, .. } => put_int(out, decimal_to_i128(text, *scale)?, ch_type)?,
         ChType::Enum { .. } => {
             let numeric = ch_type
@@ -351,10 +331,31 @@ fn encode_text_scalar(out: &mut Vec<u8>, ch_type: &ChType, text: &str) -> Result
     Ok(())
 }
 
+/// A JSON number as the integer its column stores. A fractional value is
+/// rejected rather than truncated: the column has no fractional part to put it
+/// in, and ClickHouse itself rejected it on the JSONEachRow path this replaced.
+fn json_integer(number: &serde_json::Number, ch_type: &ChType) -> Result<i128> {
+    if let Some(value) = number.as_i64() {
+        return Ok(i128::from(value));
+    }
+    if let Some(value) = number.as_u64() {
+        return Ok(i128::from(value));
+    }
+    let float = number
+        .as_f64()
+        .with_context(|| format!("`{number}` is not a number a {ch_type:?} column can hold"))?;
+    if !float.is_finite() || float.fract() != 0.0 {
+        bail!("{float} is not an integer, which a {ch_type:?} column requires");
+    }
+    Ok(float as i128)
+}
+
+/// Encodes one element of an `Array` column, whose values arrive as JSON rather
+/// than in a typed array.
 fn encode_json_value(out: &mut Vec<u8>, ch_type: &ChType, value: &serde_json::Value) -> Result<()> {
     use serde_json::Value;
-    match ch_type {
-        ChType::Nullable(inner) => {
+    match (ch_type, value) {
+        (ChType::Nullable(inner), _) => {
             if value.is_null() {
                 out.push(1);
             } else {
@@ -362,7 +363,11 @@ fn encode_json_value(out: &mut Vec<u8>, ch_type: &ChType, value: &serde_json::Va
                 encode_json_value(out, inner, value)?;
             }
         }
-        ChType::Array(inner) => {
+        // Outside a Nullable column RowBinary has nowhere to put a null, and
+        // writing the type's default would store a value the handler never set —
+        // the JSONEachRow path this replaced had the server reject it instead.
+        (_, Value::Null) => bail!("null is not a value a {ch_type:?} element can hold"),
+        (ChType::Array(inner), _) => {
             let items = value
                 .as_array()
                 .context("expected a JSON array for an Array column")?;
@@ -371,17 +376,24 @@ fn encode_json_value(out: &mut Vec<u8>, ch_type: &ChType, value: &serde_json::Va
                 encode_json_value(out, inner, item)?;
             }
         }
-        // The three types JSON represents natively; everything else is the same
-        // text the column path encodes.
-        ChType::Bool => out.push(u8::from(value.as_bool().unwrap_or(false))),
-        ChType::Float32 => {
-            out.extend_from_slice(&(value.as_f64().unwrap_or(0.0) as f32).to_le_bytes())
+        (ChType::Bool, Value::Bool(bit)) => out.push(u8::from(*bit)),
+        (ChType::Float64, Value::Number(number)) => {
+            let float = number
+                .as_f64()
+                .context("a Float64 element must be a finite JSON number")?;
+            out.extend_from_slice(&float.to_le_bytes())
         }
-        ChType::Float64 => out.extend_from_slice(&value.as_f64().unwrap_or(0.0).to_le_bytes()),
-        other => match value {
-            Value::String(s) => encode_text_scalar(out, other, s)?,
-            value => encode_text_scalar(out, other, &value.to_string())?,
-        },
+        (ChType::String, Value::String(text)) => put_string(out, text),
+        (ChType::Enum { .. }, Value::String(text)) => encode_text_scalar(out, ch_type, text)?,
+        (ChType::Decimal { .. }, Value::String(text)) => encode_text_scalar(out, ch_type, text)?,
+        (ChType::Decimal { scale, .. }, Value::Number(number)) => {
+            put_int(out, decimal_to_i128(&number.to_string(), *scale)?, ch_type)?
+        }
+        // The integer columns, whose elements JSON carries natively. Feeding the
+        // number straight in keeps the encode loop off a render-to-text and
+        // parse-back round trip per element.
+        (_, Value::Number(number)) => put_int(out, json_integer(number, ch_type)?, ch_type)?,
+        _ => bail!("`{value}` is not a value a {ch_type:?} element can hold"),
     }
     Ok(())
 }
@@ -389,15 +401,12 @@ fn encode_json_value(out: &mut Vec<u8>, ch_type: &ChType, value: &serde_json::Va
 /// Byte width of a fixed-size integer-ish type.
 fn fixed_width(ch_type: &ChType) -> Result<usize> {
     Ok(match ch_type {
-        ChType::Int8 | ChType::UInt8 | ChType::Bool => 1,
-        ChType::Int16 | ChType::UInt16 | ChType::Date => 2,
-        ChType::Int32 | ChType::UInt32 | ChType::DateTime | ChType::Date32 => 4,
+        ChType::Bool => 1,
+        ChType::Int32 | ChType::UInt32 => 4,
         ChType::Int64 | ChType::UInt64 | ChType::DateTime64 { .. } => 8,
-        ChType::Int128 | ChType::UInt128 => 16,
+        ChType::Float64 => 8,
         ChType::Decimal { precision, .. } => super::ch_type::decimal_bytes(*precision)?,
         ChType::Enum { bytes, .. } => *bytes,
-        ChType::Float32 => 4,
-        ChType::Float64 => 8,
         other => bail!("{other:?} has no fixed width"),
     })
 }
@@ -410,8 +419,6 @@ fn put_default(out: &mut Vec<u8>, ch_type: &ChType) -> Result<()> {
         ChType::Nullable(_) => out.push(1),
         ChType::Array(_) => put_varint(out, 0),
         ChType::String => put_varint(out, 0),
-        ChType::FixedString(width) => out.extend(std::iter::repeat_n(0u8, *width)),
-        ChType::Float32 => out.extend_from_slice(&0f32.to_le_bytes()),
         ChType::Float64 => out.extend_from_slice(&0f64.to_le_bytes()),
         // An Enum's default is its first variant, which is how ClickHouse fills
         // an omitted enum column.
@@ -442,9 +449,6 @@ fn encode_cell(out: &mut Vec<u8>, column: &Column, row: usize) -> Result<()> {
 
     match (&column.values, ch_type) {
         (ColumnValues::F64(v), ChType::Bool) => out.push(u8::from(v[row] != 0.0)),
-        (ColumnValues::F64(v), ChType::Float32) => {
-            out.extend_from_slice(&(v[row] as f32).to_le_bytes())
-        }
         (ColumnValues::F64(v), ChType::Float64) => out.extend_from_slice(&v[row].to_le_bytes()),
         (ColumnValues::F64(v), other) => {
             let value = v[row];
@@ -545,7 +549,7 @@ mod tests {
             name: name.to_string(),
             ch_type: ch_type::parse(ty).unwrap(),
             values: ColumnValues::Text {
-                bounds: spans_from_utf16_lengths(&data, &lengths).unwrap(),
+                spans: spans_from_utf16_lengths(&data, &lengths).unwrap(),
                 data,
             },
             nulls: Vec::new(),
@@ -566,10 +570,7 @@ mod tests {
         // "é" is 1 UTF-16 unit / 2 UTF-8 bytes, "😀" is 2 units / 4 bytes.
         let data = "aé😀b".to_string();
         let spans = spans_from_utf16_lengths(&data, &[1, 1, 2, 1]).unwrap();
-        let values: Vec<&str> = spans
-            .iter()
-            .map(|(s, e)| &data[*s..*e])
-            .collect();
+        let values: Vec<&str> = spans.iter().map(|(s, e)| &data[*s..*e]).collect();
         assert_eq!(values, vec!["a", "é", "😀", "b"]);
     }
 
@@ -593,8 +594,36 @@ mod tests {
     fn encodes_a_long_string_length_as_multi_byte_varint() {
         let long = "x".repeat(300);
         let encoded = encode(&[text_column("id", "String", &[&long])], 1).unwrap();
-        assert_eq!(&encoded.body[..2], &[0xAC, 0x02]);
-        assert_eq!(encoded.body.len(), 302);
+        assert_eq!(
+            (&encoded.body[..2], encoded.body.len()),
+            (&[0xAC, 0x02][..], 302)
+        );
+    }
+
+    #[test]
+    fn reads_back_the_varints_it_writes() {
+        let mut out = Vec::new();
+        for value in [0u64, 1, 127, 128, 300, u64::MAX] {
+            put_varint(&mut out, value);
+        }
+        let mut decoded = Vec::new();
+        let mut offset = 0;
+        while offset < out.len() {
+            let (value, read) = read_varint(&out[offset..]).unwrap();
+            decoded.push(value);
+            offset += read;
+        }
+        assert_eq!(decoded, vec![0, 1, 127, 128, 300, u64::MAX]);
+    }
+
+    /// A truncated body is a bug in whatever produced it, so the reader has to
+    /// say so rather than walk off the end of the buffer.
+    #[test]
+    fn a_truncated_varint_is_an_error_not_a_panic() {
+        assert_eq!(
+            read_varint(&[0x80]).unwrap_err().to_string(),
+            "varint runs past the end of the buffer"
+        );
     }
 
     #[test]
@@ -602,12 +631,12 @@ mod tests {
         let encoded = encode(
             &[
                 f64_column("a", "Int32", &[-2.0]),
-                f64_column("b", "UInt8", &[7.0]),
+                f64_column("b", "Bool", &[1.0]),
             ],
             1,
         )
         .unwrap();
-        assert_eq!(encoded.body, vec![0xFE, 0xFF, 0xFF, 0xFF, 7]);
+        assert_eq!(encoded.body, vec![0xFE, 0xFF, 0xFF, 0xFF, 1]);
     }
 
     #[test]
@@ -650,7 +679,7 @@ mod tests {
     }
 
     #[test]
-    fn encodes_an_enum_as_its_server_reported_value() {
+    fn encodes_an_enum_as_its_declared_value() {
         let encoded = encode(
             &[text_column(
                 "envio_change",
@@ -702,6 +731,77 @@ mod tests {
         expected.extend_from_slice(&10i128.to_le_bytes());
         expected.extend_from_slice(&20i128.to_le_bytes());
         assert_eq!(encoded.body, expected);
+    }
+
+    #[test]
+    fn encodes_a_uint64_array_element_past_float_precision() {
+        let encoded = encode(
+            &[text_column(
+                "xs",
+                "Array(UInt64)",
+                &["[18446744073709551615]"],
+            )],
+            1,
+        )
+        .unwrap();
+        let mut expected = vec![1];
+        expected.extend_from_slice(&u64::MAX.to_le_bytes());
+        assert_eq!(encoded.body, expected);
+    }
+
+    // The scalar path rejects a fractional value for an integer column, and an
+    // array's elements have to agree: truncating one silently stores a number
+    // the handler never wrote.
+    #[test]
+    fn rejects_a_fractional_array_element_for_an_integer_column() {
+        let err = encode(&[text_column("xs", "Array(Int32)", &["[1.5]"])], 1).unwrap_err();
+        assert_eq!(
+            format!("{err:#}").contains("is not an integer"),
+            true,
+            "expected an integrality error, got: {err:#}"
+        );
+    }
+
+    // A null element for a non-nullable inner type used to be rendered as the
+    // text "null" — stored verbatim in an Array(String), and an unrelated parse
+    // error anywhere else.
+    #[test]
+    fn rejects_a_null_element_for_a_non_nullable_inner_type() {
+        let strings =
+            encode(&[text_column("xs", "Array(String)", &["[\"a\",null]"])], 1).unwrap_err();
+        let ints = encode(&[text_column("xs", "Array(Int32)", &["[null]"])], 1).unwrap_err();
+        assert_eq!(
+            (
+                format!("{strings:#}").contains("null is not a value"),
+                format!("{ints:#}").contains("null is not a value")
+            ),
+            (true, true),
+            "expected null-element errors, got: {strings:#} / {ints:#}"
+        );
+    }
+
+    #[test]
+    fn encodes_a_null_element_where_the_inner_type_is_nullable() {
+        let encoded = encode(
+            &[text_column("xs", "Array(Nullable(UInt32))", &["[null,7]"])],
+            1,
+        )
+        .unwrap();
+        let mut expected = vec![2, 1, 0];
+        expected.extend_from_slice(&7u32.to_le_bytes());
+        assert_eq!(encoded.body, expected);
+    }
+
+    // A JSON element of the wrong shape used to be coerced — a bool became 0.0
+    // for a Float64, an object became its own JSON text for a String.
+    #[test]
+    fn rejects_an_element_of_the_wrong_json_shape() {
+        let err = encode(&[text_column("xs", "Array(Float64)", &["[true]"])], 1).unwrap_err();
+        assert_eq!(
+            format!("{err:#}").contains("is not a value a Float64 element can hold"),
+            true,
+            "expected a shape error, got: {err:#}"
+        );
     }
 
     #[test]
@@ -759,6 +859,18 @@ mod tests {
         );
     }
 
+    // The same bound applies to an array's elements, which reach `put_int` by a
+    // different route.
+    #[test]
+    fn rejects_an_array_element_wider_than_its_column() {
+        let err = encode(&[text_column("xs", "Array(Int32)", &["[3000000000]"])], 1).unwrap_err();
+        assert_eq!(
+            format!("{err:#}").contains("out of range"),
+            true,
+            "expected a range error, got: {err:#}"
+        );
+    }
+
     #[test]
     fn accepts_the_exact_bounds_of_a_column() {
         let encoded = encode(
@@ -800,6 +912,15 @@ mod tests {
             format!("{err:#}").contains("overflows"),
             "expected an overflow error, got: {err:#}"
         );
+    }
+
+    // Leading zeros carry no magnitude, so a literal padded past 39 digits is
+    // still the value it spells rather than an overflow.
+    #[test]
+    fn a_decimal_padded_with_leading_zeros_keeps_its_value() {
+        let padded = format!("{}42", "0".repeat(60));
+        let encoded = encode(&[text_column("d", "Decimal(38, 0)", &[&padded])], 1).unwrap();
+        assert_eq!(encoded.body, 42i128.to_le_bytes().to_vec());
     }
 
     #[test]

--- a/packages/e2e-tests/src/e2e/clickhouse-parity.test.ts
+++ b/packages/e2e-tests/src/e2e/clickhouse-parity.test.ts
@@ -90,11 +90,17 @@ describe.skipIf(!reachable)("E2E: ClickHouse mirrors Postgres", () => {
   // Postgres renames columns to snake_case for this project while ClickHouse
   // keeps the schema's spelling, so each side is listed explicitly: the
   // assertion covers the naming as well as the values.
+  //
+  // Both sides order by id under `COLLATE "C"`, which is byte order — what
+  // ClickHouse sorts a String by. Postgres would otherwise use the database's
+  // own collation, where en_US largely ignores `-` at the primary level and ids
+  // like `1-…` and `137-…` interleave differently than ClickHouse puts them,
+  // failing the row-for-row comparison on data that actually matches.
   it("Transfer matches column for column", async () => {
     const [pg, ch] = await Promise.all([
       pgRows(
         `SELECT "id", "from", "to", "value", "block_number", "transaction_hash"
-         FROM "${PG_SCHEMA}"."Transfer" ORDER BY "id"`
+         FROM "${PG_SCHEMA}"."Transfer" ORDER BY "id" COLLATE "C"`
       ),
       chRows(
         `SELECT id, \`from\`, \`to\`, value, blockNumber, transactionHash
@@ -113,7 +119,7 @@ describe.skipIf(!reachable)("E2E: ClickHouse mirrors Postgres", () => {
     const [pg, ch] = await Promise.all([
       pgRows(
         `SELECT "id", "from", "value", "chain_id"
-         FROM "${PG_SCHEMA}"."ChainTransfer" ORDER BY "chain_id", "id"`
+         FROM "${PG_SCHEMA}"."ChainTransfer" ORDER BY "chain_id", "id" COLLATE "C"`
       ),
       chRows(
         `SELECT id, \`from\`, value, chainId
@@ -134,7 +140,7 @@ describe.skipIf(!reachable)("E2E: ClickHouse mirrors Postgres", () => {
     const [pg, ch] = await Promise.all([
       pgRows(
         `SELECT "id", "last_block", "last_value"
-         FROM "${PG_SCHEMA}"."Holder" ORDER BY "id"`
+         FROM "${PG_SCHEMA}"."Holder" ORDER BY "id" COLLATE "C"`
       ),
       chRows(
         `SELECT id, lastBlock, lastValue

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -169,24 +169,119 @@ let changeClickHouseType = getClickHouseFieldType(
   ~isArray=false,
 )
 
-// The checkpoints table as ClickHouse holds it, in column order: the DDL and the
-// insert both read it, so neither can describe a column the other doesn't.
+// The checkpoints table as ClickHouse holds it, in column order. The DDL, the
+// insert's column list and the values it sends all come from this one list, so a
+// column cannot be declared in one and forgotten in another — nor, worse, end up
+// paired with a different column's values, which nothing downstream could catch:
+// every array reaches the builders as `unknown`.
 // `events_processed` is widened here rather than taken from
 // `InternalTable.Checkpoints.table`, whose Int32 is what Postgres stores.
-let checkpointColumns: array<(string, Table.fieldType, bool)> = [
-  ((#id: InternalTable.Checkpoints.field :> string), UInt64, false),
-  ((#chain_id: InternalTable.Checkpoints.field :> string), ChainId, false),
-  ((#block_number: InternalTable.Checkpoints.field :> string), Int32, false),
-  ((#block_hash: InternalTable.Checkpoints.field :> string), String, true),
-  ((#events_processed: InternalTable.Checkpoints.field :> string), UInt64, false),
+type checkpointColumn = {
+  name: string,
+  fieldType: Table.fieldType,
+  isNullable: bool,
+  valuesOf: Batch.t => array<unknown>,
+}
+
+let checkpointColumns: array<checkpointColumn> = [
+  {
+    name: (#id: InternalTable.Checkpoints.field :> string),
+    fieldType: UInt64,
+    isNullable: false,
+    valuesOf: batch => batch.checkpointIds->(Utils.magic: array<bigint> => array<unknown>),
+  },
+  {
+    name: (#chain_id: InternalTable.Checkpoints.field :> string),
+    fieldType: ChainId,
+    isNullable: false,
+    valuesOf: batch => batch.checkpointChainIds->(Utils.magic: array<ChainId.t> => array<unknown>),
+  },
+  {
+    name: (#block_number: InternalTable.Checkpoints.field :> string),
+    fieldType: Int32,
+    isNullable: false,
+    valuesOf: batch => batch.checkpointBlockNumbers->(Utils.magic: array<int> => array<unknown>),
+  },
+  {
+    name: (#block_hash: InternalTable.Checkpoints.field :> string),
+    fieldType: String,
+    isNullable: true,
+    valuesOf: batch =>
+      batch.checkpointBlockHashes->(Utils.magic: array<Null.t<string>> => array<unknown>),
+  },
+  {
+    name: (#events_processed: InternalTable.Checkpoints.field :> string),
+    fieldType: UInt64,
+    isNullable: false,
+    valuesOf: batch => batch.checkpointEventsProcessed->(Utils.magic: array<int> => array<unknown>),
+  },
 ]
+
+// Resolved per chain-id mode, which is the only thing the column types vary
+// with. Resolving a wire kind crosses into Rust, so it does not belong on the
+// path a batch takes.
+let checkpointSinkColumns = {
+  let cache = Dict.make()
+  (~chainIdMode: ChainId.mode) => {
+    let key = switch chainIdMode {
+    | Int32 => "Int32"
+    | Int64 => "Int64"
+    }
+    switch cache->Utils.Dict.dangerouslyGetNonOption(key) {
+    | Some(columns) => columns
+    | None =>
+      let columns =
+        checkpointColumns->Array.map(({name, fieldType, isNullable}) =>
+          ClickHouseSink.makeColumn(
+            ~name,
+            ~chType=getClickHouseFieldType(~fieldType, ~isNullable, ~isArray=false, ~chainIdMode),
+          )
+        )
+      cache->Dict.set(key, columns)
+      columns
+    }
+  }
+}
+
+// Every column envio declares on an entity's history table, in DDL order. The
+// CREATE TABLE, the insert and the startup type check all read this, so a column
+// is encoded against the type it was created with.
+let entityColumnTypes = (~entityConfig: Internal.entityConfig, ~chainIdMode: ChainId.mode): array<(
+  string,
+  string,
+)> => {
+  let columns = entityConfig.table.fields->Array.filterMap(field =>
+    switch field {
+    | Table.Field(f) =>
+      Some((
+        f->Table.getClickHouseDbFieldName,
+        getClickHouseFieldType(
+          ~fieldType=f.fieldType,
+          ~isNullable=f.isNullable,
+          ~isArray=f.isArray,
+          ~chainIdMode,
+        ),
+      ))
+    | DerivedFrom(_) => None
+    }
+  )
+  columns->Array.push((EntityHistory.checkpointIdFieldName, checkpointIdClickHouseType))
+  columns->Array.push((EntityHistory.changeFieldName, changeClickHouseType))
+  columns
+}
+
+let checkpointColumnTypes = (~chainIdMode: ChainId.mode): array<(string, string)> =>
+  checkpointColumns->Array.map(({name, fieldType, isNullable}) => (
+    name,
+    getClickHouseFieldType(~fieldType, ~isNullable, ~isArray=false, ~chainIdMode),
+  ))
 
 // Column set of an entity history table, resolved once per entity and scope.
 // Only the column list and the compiled serializers are cached; each write
 // allocates its own builders, so two writes can never share storage.
 type entityColumns = {
   tableName: string,
-  columns: array<(string, string)>,
+  columns: array<ClickHouseSink.column>,
   convertSetOrThrow: Change.t<Internal.entity> => dict<unknown>,
   convertDeleteOrThrow: Change.t<Internal.entity> => dict<unknown>,
 }
@@ -205,23 +300,10 @@ let makeEntityColumns = (
   let scopeChainId = scope->Internal.chainScopeChainId
   let idSchema = entityConfig.table->Table.getIdSchema
 
-  let columns = entityConfig.table.fields->Array.filterMap(field =>
-    switch field {
-    | Table.Field(f) =>
-      Some((
-        f->Table.getClickHouseDbFieldName,
-        getClickHouseFieldType(
-          ~fieldType=f.fieldType,
-          ~isNullable=f.isNullable,
-          ~isArray=f.isArray,
-          ~chainIdMode,
-        ),
-      ))
-    | DerivedFrom(_) => None
-    }
-  )
-  columns->Array.push((EntityHistory.checkpointIdFieldName, checkpointIdClickHouseType))
-  columns->Array.push((EntityHistory.changeFieldName, changeClickHouseType))
+  let columns =
+    entityColumnTypes(~entityConfig, ~chainIdMode)->Array.map(((name, chType)) =>
+      ClickHouseSink.makeColumn(~name, ~chType)
+    )
 
   {
     tableName: EntityHistory.historyTableName(
@@ -263,9 +345,6 @@ let stageBuilders = (sink, ~tableName, ~builders: array<ClickHouseSink.builder>,
     ~columns=builders->Array.map(ClickHouseSink.builderPayload),
   )
 
-let insertBuilders = async (sink, ~tableName, ~builders, ~rows) =>
-  await sink->ClickHouseSink.flush(sink->stageBuilders(~tableName, ~builders, ~rows))
-
 let setCheckpointsOrThrow = async (sink, ~batch: Batch.t, ~chainIdMode: ChainId.mode) => {
   let rows = batch.checkpointIds->Array.length
   if rows === 0 {
@@ -273,34 +352,25 @@ let setCheckpointsOrThrow = async (sink, ~batch: Batch.t, ~chainIdMode: ChainId.
   } else {
     let tableName = InternalTable.Checkpoints.table.tableName
     // Same column list the DDL is built from, so a column added there arrives
-    // here with a builder rather than silently taking the type's default.
+    // here with a builder rather than silently taking the type's default, and
+    // with the values that belong to it rather than a neighbour's.
     let builders =
-      checkpointColumns->Array.map(((name, fieldType, isNullable)) =>
-        ClickHouseSink.makeBuilder(
-          ~name,
-          ~chType=getClickHouseFieldType(~fieldType, ~isNullable, ~isArray=false, ~chainIdMode),
-          ~rows,
-        )
-      )
-    let values: array<array<unknown>> = [
-      batch.checkpointIds->(Utils.magic: array<bigint> => array<unknown>),
-      batch.checkpointChainIds->(Utils.magic: array<ChainId.t> => array<unknown>),
-      batch.checkpointBlockNumbers->(Utils.magic: array<int> => array<unknown>),
-      batch.checkpointBlockHashes->(Utils.magic: array<Null.t<string>> => array<unknown>),
-      batch.checkpointEventsProcessed->(Utils.magic: array<int> => array<unknown>),
-    ]
-
-    for row in 0 to rows - 1 {
-      builders->Array.forEachWithIndex((builder, column) =>
-        builder->ClickHouseSink.writeValue(
-          ~row,
-          values->Array.getUnsafe(column)->Array.getUnsafe(row),
-        )
-      )
-    }
+      checkpointSinkColumns(~chainIdMode)->Array.map(ClickHouseSink.makeBuilder(_, ~rows))
+    let values = checkpointColumns->Array.map(({valuesOf}) => valuesOf(batch))
 
     try {
-      await sink->insertBuilders(~tableName, ~builders, ~rows)
+      // Inside the wrapper because writing a value can fail: a checkpoint id
+      // past what UInt64 holds is refused here rather than being reduced to a
+      // different id by the typed array it would land in.
+      for row in 0 to rows - 1 {
+        builders->Array.forEachWithIndex((builder, column) =>
+          builder->ClickHouseSink.writeValue(
+            ~row,
+            values->Array.getUnsafe(column)->Array.getUnsafe(row),
+          )
+        )
+      }
+      await sink->ClickHouseSink.flush(sink->stageBuilders(~tableName, ~builders, ~rows))
     } catch {
     | exn =>
       throw(
@@ -348,8 +418,7 @@ let setUpdatesOrThrow = async (
     }
 
     let handle = try {
-      let builders =
-        columns->Array.map(((name, chType)) => ClickHouseSink.makeBuilder(~name, ~chType, ~rows))
+      let builders = columns->Array.map(ClickHouseSink.makeBuilder(_, ~rows))
       for row in 0 to rows - 1 {
         let change = changes->Array.getUnsafe(row)
         // The entity history table is the source of truth for ClickHouse, so
@@ -427,22 +496,10 @@ let makeCreateHistoryTableQuery = (
   ~chainIdMode: ChainId.mode=Int32,
 ) => {
   let tableEngine = replicated ? "ReplicatedMergeTree" : "MergeTree()"
-  let fieldDefinitions = entityConfig.table.fields->Array.filterMap(field => {
-    switch field {
-    | Field(field) =>
-      Some({
-        let fieldName = field->Table.getClickHouseDbFieldName
-        let clickHouseType = getClickHouseFieldType(
-          ~fieldType=field.fieldType,
-          ~isNullable=field.isNullable,
-          ~isArray=field.isArray,
-          ~chainIdMode,
-        )
-        `\`${fieldName}\` ${clickHouseType}`
-      })
-    | DerivedFrom(_) => None
-    }
-  })
+  let fieldDefinitions =
+    entityColumnTypes(~entityConfig, ~chainIdMode)->Array.map(((name, chType)) =>
+      `\`${name}\` ${chType}`
+    )
 
   let (partitionBy, orderBy, ttl) = switch entityConfig.storage.clickhouseOptions {
   | Some(options) => (options.partitionBy, options.orderBy, options.ttl)
@@ -514,9 +571,7 @@ let makeCreateHistoryTableQuery = (
       ~entityName=entityConfig.name,
       ~entityIndex=entityConfig.index,
     )}\`${onClusterClause(~onCluster)} (
-  ${fieldDefinitions->Array.joinUnsafe(",\n  ")},
-  \`${EntityHistory.checkpointIdFieldName}\` ${checkpointIdClickHouseType},
-  \`${EntityHistory.changeFieldName}\` ${changeClickHouseType}
+  ${fieldDefinitions->Array.joinUnsafe(",\n  ")}
 )
 ENGINE = ${tableEngine}${partitionByClause}
 ORDER BY (${orderByColumns})${ttlClause}`
@@ -533,7 +588,7 @@ let makeCreateCheckpointsTableQuery = (
   let idField = (#id: InternalTable.Checkpoints.field :> string)
   let columns =
     checkpointColumns
-    ->Array.map(((name, fieldType, isNullable)) =>
+    ->Array.map(({name, fieldType, isNullable}) =>
       `  \`${name}\` ${getClickHouseFieldType(
           ~fieldType,
           ~isNullable,

--- a/packages/envio/src/bindings/ClickHouseSink.res
+++ b/packages/envio/src/bindings/ClickHouseSink.res
@@ -58,6 +58,13 @@ external kindOfOrdinal: int => kind = "%identity"
 let kindOfClickHouseType = clickHouseType =>
   Core.getAddon().clickhouseColumnKind(clickHouseType)->kindOfOrdinal
 
+// A column of the target table, with its wire kind resolved. Resolving crosses
+// into Rust to parse the type text, so it belongs to the column set — which is
+// built once per entity and scope — rather than to each batch written through it.
+type column = {name: string, chType: string, kind: kind}
+
+let makeColumn = (~name, ~chType) => {name, chType, kind: chType->kindOfClickHouseType}
+
 %%private(let isString: unknown => bool = %raw(`(v) => typeof v === "string"`))
 external asString: unknown => string = "%identity"
 @val external toNumber: unknown => float = "Number"
@@ -94,9 +101,8 @@ type builder = {
 }
 
 // Only the storage the column's kind uses is allocated; the rest stay empty.
-let makeBuilder = (~name, ~chType, ~rows) => {
+let makeBuilder = ({name, chType, kind}: column, ~rows) => {
   let empty = 0
-  let kind = chType->kindOfClickHouseType
   {
     name,
     chType,
@@ -122,6 +128,52 @@ let markNull = (builder, ~row) => {
   nulls->TypedArray.set(row, 1)
 }
 
+%%private(let isHighSurrogate = unit => unit >= 0xD800 && unit <= 0xDBFF)
+%%private(let isLowSurrogate = unit => unit >= 0xDC00 && unit <= 0xDFFF)
+let replacementCharacter = "\u{FFFD}"
+
+// A lone surrogate is not a character, and napi already substitutes U+FFFD for
+// one on the way to UTF-8 — which costs the value nothing, since both are a
+// single UTF-16 unit. What no value survives on its own is the concatenation:
+// a value ending in a high surrogate followed by one starting with a low
+// surrogate spells a real pair across the seam, which napi then encodes as one
+// 4-byte character where the two lengths each claim a unit, and the span scan
+// rejects the whole column. Only a first or last unit can have its other half in
+// a neighbouring value, so substituting at the two ends is the whole fix.
+let withoutBoundarySurrogates = text => {
+  let last = text->String.length - 1
+  if last < 0 {
+    text
+  } else {
+    let leading = text->String.charCodeAtUnsafe(0)->isLowSurrogate
+    let trailing = text->String.charCodeAtUnsafe(last)->isHighSurrogate
+    switch (leading, trailing) {
+    | (false, false) => text
+    | _ if last === 0 => replacementCharacter
+    | _ =>
+      (leading ? replacementCharacter : text->String.charAt(0)) ++
+      text->String.slice(~start=1, ~end=last) ++ (
+        trailing ? replacementCharacter : text->String.charAt(last)
+      )
+    }
+  }
+}
+
+// RowBinary carries the raw integer, so a value the column cannot hold is not
+// rejected anywhere downstream — and a typed array reduces it modulo 2^64 on
+// the way in rather than refusing it, which would leave no trace at all.
+%%private(
+  let checkedBigInt = (value: unknown, ~builder, ~min, ~max) => {
+    let value = value->toBigInt
+    if value < min || value > max {
+      JsError.throwWithMessage(
+        `${value->BigInt.toString} is out of range for a ${builder.chType} column`,
+      )
+    }
+    value
+  }
+)
+
 // Writes one value into the column. `undefined`/`null` marks the row's null bit;
 // the slot keeps its zero value, which is what a column omitted from a
 // JSONEachRow row used to resolve to.
@@ -131,10 +183,18 @@ let writeValue = (builder, ~row, value: unknown) =>
   } else {
     switch builder.kind {
     | F64 => builder.floats->TypedArray.set(row, value->toNumber)
-    | U64 => builder.unsigned->TypedArray.set(row, value->toBigInt)
-    | I64 => builder.signed->TypedArray.set(row, value->toBigInt)
+    | U64 =>
+      builder.unsigned->TypedArray.set(
+        row,
+        value->checkedBigInt(~builder, ~min=0n, ~max=18446744073709551615n),
+      )
+    | I64 =>
+      builder.signed->TypedArray.set(
+        row,
+        value->checkedBigInt(~builder, ~min=-9223372036854775808n, ~max=9223372036854775807n),
+      )
     | Text =>
-      let text = value->toText
+      let text = value->toText->withoutBoundarySurrogates
       builder.texts->Array.setUnsafe(row, text)
       builder.lengths->TypedArray.set(row, text->String.length)
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,12 @@ importers:
 
   .: {}
 
+  bench:
+    dependencies:
+      envio:
+        specifier: file:../packages/envio
+        version: link:../packages/envio
+
   packages/build-envio:
     devDependencies:
       '@types/node':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "packages/*"
   - "scenarios/*"
+  - "bench"
 onlyBuiltDependencies:
   - rescript
   - esbuild

--- a/scenarios/test_codegen/test/lib_tests/ClickHouseRoundtrip_test.res
+++ b/scenarios/test_codegen/test/lib_tests/ClickHouseRoundtrip_test.res
@@ -15,6 +15,11 @@ let database = "test_codegen_roundtrip"
 
 let timestamp = Date.fromTime(1234567890123.0)
 
+// Half of a surrogate pair each. ReScript rejects a lone surrogate as a string
+// literal escape, so they are built from their code units.
+let highSurrogate = String.fromCharCode(0xD800)
+let lowSurrogate = String.fromCharCode(0xDC00)
+
 let entity: Indexer.Entities.EntityWithAllTypes.t = {
   id: "roundtrip-1",
   // Not ASCII on purpose: the sink hands Rust one concatenated string per column
@@ -283,6 +288,181 @@ describe("ClickHouse RowBinary roundtrip", () => {
       ))
     },
   )
+  // Values reach Rust as one concatenated string per column plus each value's
+  // UTF-16 length. A lone surrogate is not a character and napi substitutes
+  // U+FFFD for one, which costs a value nothing on its own — but a value ending
+  // in a high surrogate next to one starting with a low surrogate spells a real
+  // pair across the seam, which encodes as a single character where the lengths
+  // claim two. The whole column then fails to split, and no retry can help
+  // because the batch is unchanged.
+  Async.it_skipIf(chHost->Option.isNone)(
+    "Stores values whose lone surrogates would pair across the concatenation",
+    async t => {
+      let host = chHost->Option.getUnsafe
+      let database = "test_codegen_roundtrip_surrogate"
+      let entityConfig = MockIndexer.entityConfig("EntityWithAllTypes")
+      let tableName = EntityHistory.historyTableName(
+        ~entityName=entityConfig.name,
+        ~entityIndex=entityConfig.index,
+      )
+
+      let client = ClickHouse.createClient({url: host, username, password})
+      await client->ClickHouse.exec({query: `DROP DATABASE IF EXISTS ${database}`})
+      await client->ClickHouse.exec({query: `CREATE DATABASE ${database}`})
+      await client->ClickHouse.exec({
+        query: ClickHouse.makeCreateHistoryTableQuery(~entityConfig, ~database),
+      })
+
+      let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database, ~onWarning=ignore)
+      await ClickHouse.setUpdatesOrThrow(
+        sink,
+        ~cache=Dict.make(),
+        ~changes=[
+          Set({
+            entityId: "surrogate-1"->EntityId.unsafeOfString,
+            checkpointId: 1n,
+            entity: {...entity, id: "surrogate-1", string: "ends" ++ highSurrogate}->(
+              Utils.magic: Indexer.Entities.EntityWithAllTypes.t => Internal.entity
+            ),
+          }),
+          Set({
+            entityId: "surrogate-2"->EntityId.unsafeOfString,
+            checkpointId: 2n,
+            entity: {...entity, id: "surrogate-2", string: lowSurrogate ++ "starts"}->(
+              Utils.magic: Indexer.Entities.EntityWithAllTypes.t => Internal.entity
+            ),
+          }),
+        ],
+        ~entityConfig,
+        ~scope=CrossChain,
+        ~chainIdMode=Int32,
+      )
+
+      let result = await client->ClickHouse.query({
+        query: `SELECT id, string FROM ${database}.\`${tableName}\` ORDER BY envio_checkpoint_id`,
+      })
+      let rows = (await result->ClickHouse.json)["data"]
+      await client->ClickHouse.exec({query: `DROP DATABASE ${database}`})
+      await client->ClickHouse.close
+
+      // Each lone surrogate becomes U+FFFD, which is what napi would have stored
+      // for either value on its own.
+      t.expect(rows).toEqual(
+        %raw(`[
+          { id: "surrogate-1", string: "ends�" },
+          { id: "surrogate-2", string: "�starts" }
+        ]`),
+      )
+    },
+  )
+
+  // An array's elements travel as JSON rather than in a typed array, so they
+  // reach the encoder by a different route than a scalar of the same type — and
+  // used to be coerced where a scalar would have been rejected.
+  Async.it_skipIf(chHost->Option.isNone)(
+    "Rejects array elements a scalar of the same type would be rejected for",
+    async t => {
+      let host = chHost->Option.getUnsafe
+      let database = "test_codegen_roundtrip_elements"
+      let entityConfig = MockIndexer.entityConfig("EntityWithAllTypes")
+
+      let client = ClickHouse.createClient({url: host, username, password})
+      await client->ClickHouse.exec({query: `DROP DATABASE IF EXISTS ${database}`})
+      await client->ClickHouse.exec({query: `CREATE DATABASE ${database}`})
+      await client->ClickHouse.exec({
+        query: ClickHouse.makeCreateHistoryTableQuery(~entityConfig, ~database),
+      })
+      let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database, ~onWarning=ignore)
+
+      let attempt = async rogue =>
+        switch await ClickHouse.setUpdatesOrThrow(
+          sink,
+          ~cache=Dict.make(),
+          ~changes=[
+            Set({
+              entityId: entity.id->EntityId.unsafeOfString,
+              checkpointId: 1n,
+              entity: rogue->(Utils.magic: Indexer.Entities.EntityWithAllTypes.t => Internal.entity),
+            }),
+          ],
+          ~entityConfig,
+          ~scope=CrossChain,
+          ~chainIdMode=Int32,
+        ) {
+        | () => "stored without complaint"
+        | exception Persistence.StorageError({reason}) =>
+          reason->(Utils.magic: exn => {"message": string})->(r => r["message"])
+        | exception _ => "not a StorageError"
+        }
+
+      // Truncated to 1 before; the scalar `int_` path has always refused this.
+      let fractional = await attempt({
+        ...entity,
+        arrayOfInts: [1.5]->(Utils.magic: array<float> => array<int>),
+      })
+      // Stored as the four-character string "null" before.
+      let nullElement = await attempt({
+        ...entity,
+        arrayOfStrings: [Null.null]->(Utils.magic: array<Null.t<string>> => array<string>),
+      })
+
+      await client->ClickHouse.exec({query: `DROP DATABASE ${database}`})
+      await client->ClickHouse.close
+
+      t.expect((
+        fractional->String.includes("is not an integer"),
+        nullElement->String.includes("null is not a value"),
+      )).toEqual((true, true))
+    },
+  )
+
+  // A UInt64 column's values reach Rust in a BigUint64Array, which reduces an
+  // out-of-range bigint modulo 2^64 on the way in rather than refusing it —
+  // the one wire kind whose values Rust never gets the chance to bounds-check.
+  Async.it_skipIf(chHost->Option.isNone)(
+    "Rejects a checkpoint id the UInt64 column cannot hold",
+    async t => {
+      let host = chHost->Option.getUnsafe
+      let database = "test_codegen_roundtrip_uint64"
+
+      let client = ClickHouse.createClient({url: host, username, password})
+      await client->ClickHouse.exec({query: `DROP DATABASE IF EXISTS ${database}`})
+      await client->ClickHouse.exec({query: `CREATE DATABASE ${database}`})
+      await client->ClickHouse.exec({
+        query: ClickHouse.makeCreateCheckpointsTableQuery(~database),
+      })
+      let sink = ClickHouseSink.make(~url=host, ~username, ~password, ~database, ~onWarning=ignore)
+
+      let message = switch await ClickHouse.setCheckpointsOrThrow(
+        sink,
+        ~batch={
+          totalBatchSize: 1,
+          items: [],
+          progressedChainsById: Dict.make(),
+          isInReorgThreshold: false,
+          // Wrapped to 18446744073709551615 before, landing a checkpoint far
+          // past the head that the current-state view would then read up to.
+          checkpointIds: [-1n],
+          checkpointChainIds: [1->ChainId.fromInt],
+          checkpointBlockNumbers: [1],
+          checkpointBlockHashes: [Null.null],
+          checkpointEventsProcessed: [1],
+        },
+        ~chainIdMode=Int32,
+      ) {
+      | () => "stored without complaint"
+      | exception Persistence.StorageError({reason}) =>
+        reason->(Utils.magic: exn => {"message": string})->(r => r["message"])
+      | exception _ => "not a StorageError"
+      }
+
+      await client->ClickHouse.exec({query: `DROP DATABASE ${database}`})
+      await client->ClickHouse.close
+
+      t.expect(message->String.includes("out of range for a UInt64 column")).toEqual(true)
+    },
+  )
+
   // Naming every column in the INSERT is what lets a table carry columns envio
   // does not write. The server fills them, so a DEFAULT expression is evaluated
   // rather than replaced by the type's zero value, and a column whose type the


### PR DESCRIPTION
Narrows the ClickHouse type system to only what envio's DDL generates, eliminating dead code paths and simplifying the encoder. This reduces the surface area for bugs and makes the type system's constraints explicit.

## Key changes

**Type system simplification:**
- Remove unsupported integer types (Int8, Int16, Int128, UInt8, UInt16, UInt128)
- Remove unsupported float type (Float32)
- Remove unsupported date types (Date, Date32, DateTime)
- Remove FixedString support
- Reject unnumbered Enum variants (require explicit numbering in type text)
- Reject Decimal256 (precision > 38) since envio falls back to String

**Column value representation:**
- Split `ColumnValues<B>` generic into two concrete types: `StagedValues` (with UTF-16 lengths) and `ColumnValues` (with byte spans)
- Move `len()` and `kind()` methods to their respective types
- Rename `bounds` field to `spans` for clarity

**Decimal parsing optimization:**
- Accumulate digit magnitude directly instead of building an intermediate string
- Eliminates allocation per cell in the hot encode loop

**JSON array element encoding:**
- Add `json_integer()` helper to parse JSON numbers as integers with proper bounds checking
- Reject fractional values and nulls in array elements (matching scalar behavior)
- Improve error messages to distinguish between type mismatches and value errors

**Surrogate pair handling:**
- Add `withoutBoundarySurrogates()` in ReScript to substitute U+FFFD at concatenation boundaries
- Prevents lone surrogates from pairing across value boundaries during UTF-16 to UTF-8 conversion
- Includes test coverage for surrogate pair edge cases

**Retry and connection tuning:**
- Make retry delay configurable via `Tuning` struct
- Set pool idle timeout to 2.5s (under ClickHouse's keep-alive timeout)
- Improve delay calculation to scale from 10% to 100% of max delay

**Test improvements:**
- Add tests for surrogate pair handling across concatenation boundaries
- Add tests for array element validation (rejecting fractional integers and nulls)
- Add test for UInt64 bounds checking on checkpoint IDs
- Improve mock server to track request headers for debugging

**Workspace configuration:**
- Add `bench` directory as a workspace package for pnpm

## Notable implementation details

The column value refactoring makes the two-stage process explicit: `StagedValues` arrives from JS with UTF-16 lengths, then `resolve()` scans the text once to produce `ColumnValues` with byte spans. This prevents the span scan from being skipped or applied twice.

The surrogate pair fix operates at the JS boundary where the concatenated string is built, substituting replacement characters only at the two ends where a lone surrogate could pair with a neighboring value's boundary character.

Decimal parsing now accumulates magnitude directly with overflow checking, eliminating the intermediate string allocation that would occur once per cell during encoding.

https://claude.ai/code/session_01HmCrh1V1bVBpnhphL2x6Qb