### PR TITLE
Support ClickHouse data skipping indexes in @storage(clickhouse: {skippingIndexes})

### DIFF
--- a/packages/cli/src/config_parsing/entity_parsing.rs
+++ b/packages/cli/src/config_parsing/entity_parsing.rs
@@ -416,10 +416,25 @@ impl GraphQLEnum {
     }
 }
 
+/// A data skipping index on the entity's ClickHouse history table, emitted
+/// into the DDL as `INDEX <name> <expr> TYPE <type> GRANULARITY <granularity>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClickHouseSkipIndex {
+    pub name: String,
+    /// Raw ClickHouse expression the index is built over.
+    pub expr: String,
+    /// Raw ClickHouse index type passed through verbatim — e.g.
+    /// `bloom_filter(0.01)`, `set(100)`, `minmax` — so no type is ruled out.
+    pub index_type: String,
+    /// `GRANULARITY` clause; omitted leaves ClickHouse's default of 1.
+    pub granularity: Option<u32>,
+}
+
 /// Per-entity tuning of the ClickHouse history table layout, written as an
 /// object argument of the `@storage` directive:
 /// `@storage(clickhouse: {partitionBy: "toYYYYMM(timestamp)", orderBy:
-/// ["timestamp"], ttl: "timestamp + INTERVAL 2 YEAR"})`.
+/// ["timestamp"], ttl: "timestamp + INTERVAL 2 YEAR", indices: [{name:
+/// "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)"}]})`.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ClickHouseTableOptions {
     /// Raw ClickHouse expression emitted as `PARTITION BY <expr>`.
@@ -430,6 +445,8 @@ pub struct ClickHouseTableOptions {
     pub order_by: Option<Vec<String>>,
     /// Raw ClickHouse expression emitted as `TTL <expr>`.
     pub ttl: Option<String>,
+    /// Data skipping indices emitted into the table's column list.
+    pub indices: Option<Vec<ClickHouseSkipIndex>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -973,11 +990,46 @@ fn parse_clickhouse_table_options(
                 };
                 options.order_by = Some(field_names);
             }
+            "indices" => {
+                let items = match value {
+                    Value::List(items) if !items.is_empty() => items,
+                    _ => {
+                        return Err(anyhow!(
+                            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` \
+                             must be a non-empty list of index objects, \
+                             {CLICKHOUSE_SKIP_INDEX_HINT}."
+                        ));
+                    }
+                };
+                let indices = items
+                    .iter()
+                    .map(|item| match item {
+                        Value::Object(index_fields) => {
+                            parse_clickhouse_skip_index(entity_name, index_fields)
+                        }
+                        _ => Err(anyhow!(
+                            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` \
+                             must be a list of index objects, {CLICKHOUSE_SKIP_INDEX_HINT}."
+                        )),
+                    })
+                    .collect::<anyhow::Result<Vec<ClickHouseSkipIndex>>>()?;
+                let mut seen = HashSet::new();
+                for index in &indices {
+                    if !seen.insert(&index.name) {
+                        return Err(anyhow!(
+                            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` \
+                             lists index name `{}` more than once.",
+                            index.name
+                        ));
+                    }
+                }
+                options.indices = Some(indices);
+            }
             other => {
                 return Err(anyhow!(
                     "Invalid @storage directive on `{entity_name}`. Unknown `clickhouse` option \
-                     `{other}`. Expected options from {{partitionBy, orderBy, ttl}}, e.g. \
-                     clickhouse: {{partitionBy: \"toYYYYMM(timestamp)\", orderBy: \
+                     `{other}`. Expected options from {{partitionBy, orderBy, ttl, indices}}, \
+                     e.g. clickhouse: {{partitionBy: \"toYYYYMM(timestamp)\", orderBy: \
                      [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}}."
                 ));
             }
@@ -985,6 +1037,87 @@ fn parse_clickhouse_table_options(
     }
 
     Ok(options)
+}
+
+const CLICKHOUSE_SKIP_INDEX_HINT: &str = "e.g. clickhouse: {indices: [{name: \"idx_from\", expr: \
+                                          \"fromAddress\", type: \"bloom_filter(0.01)\", \
+                                          granularity: 4}]}";
+
+fn parse_clickhouse_skip_index(
+    entity_name: &str,
+    fields: &std::collections::BTreeMap<String, Value<'_, String>>,
+) -> anyhow::Result<ClickHouseSkipIndex> {
+    let string_value = |key: &str, value: &Value<'_, String>| match value {
+        Value::String(s) if !s.trim().is_empty() => Ok(s.trim().to_string()),
+        _ => Err(anyhow!(
+            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` entry field \
+             `{key}` must be a non-empty string, {CLICKHOUSE_SKIP_INDEX_HINT}."
+        )),
+    };
+
+    let mut name = None;
+    let mut expr = None;
+    let mut index_type = None;
+    let mut granularity = None;
+    for (key, value) in fields {
+        match key.as_str() {
+            "name" => name = Some(string_value(key, value)?),
+            "expr" => expr = Some(string_value(key, value)?),
+            "type" => index_type = Some(string_value(key, value)?),
+            "granularity" => {
+                let parsed = match value {
+                    Value::Int(i) => i.as_i64().filter(|v| (1..=i64::from(u32::MAX)).contains(v)),
+                    _ => None,
+                };
+                match parsed {
+                    Some(v) => granularity = Some(v as u32),
+                    None => {
+                        return Err(anyhow!(
+                            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` \
+                             entry field `granularity` must be a positive integer, \
+                             {CLICKHOUSE_SKIP_INDEX_HINT}."
+                        ));
+                    }
+                }
+            }
+            other => {
+                return Err(anyhow!(
+                    "Invalid @storage directive on `{entity_name}`. Unknown `clickhouse.indices` \
+                     entry field `{other}`. Expected fields from {{name, expr, type, \
+                     granularity}}, {CLICKHOUSE_SKIP_INDEX_HINT}."
+                ));
+            }
+        }
+    }
+
+    let require = |value: Option<String>, key: &str| {
+        value.ok_or_else(|| {
+            anyhow!(
+                "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` entry is \
+                 missing required field `{key}`, {CLICKHOUSE_SKIP_INDEX_HINT}."
+            )
+        })
+    };
+    let name = require(name, "name")?;
+    // The name is backtick-quoted in the emitted DDL, so restrict it to
+    // identifier characters to keep the statement well-formed.
+    let valid_name = name
+        .chars()
+        .enumerate()
+        .all(|(i, c)| c == '_' || c.is_ascii_alphabetic() || (i > 0 && c.is_ascii_digit()));
+    if !valid_name {
+        return Err(anyhow!(
+            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` name `{name}` \
+             must contain only alphanumeric characters and underscores, and must not start with \
+             a digit."
+        ));
+    }
+    Ok(ClickHouseSkipIndex {
+        name,
+        expr: require(expr, "expr")?,
+        index_type: require(index_type, "type")?,
+        granularity,
+    })
 }
 
 /// ClickHouse rejects Nullable and Array columns in the sorting key
@@ -2049,8 +2182,9 @@ impl GqlScalar {
 #[cfg(test)]
 mod tests {
     use super::{
-        anyhow, ClickHouseEntityStorage, ClickHouseTableOptions, Entity, Field, FieldType,
-        GqlScalar, GraphQLEnum, IndexFieldDirection, Schema, UserDefinedFieldType,
+        anyhow, ClickHouseEntityStorage, ClickHouseSkipIndex, ClickHouseTableOptions, Entity,
+        Field, FieldType, GqlScalar, GraphQLEnum, IndexFieldDirection, Schema,
+        UserDefinedFieldType,
     };
     use crate::config_parsing::field_types::Primitive as PGPrimitive;
     use graphql_parser::schema::{parse_schema, Definition, Document, ObjectType, TypeDefinition};
@@ -3188,6 +3322,7 @@ type TestEntity @storage(clickhouse: {partitionBy: "toYYYYMM(timestamp)"}) {
                 partition_by: Some("toYYYYMM(timestamp)".to_string()),
                 order_by: None,
                 ttl: None,
+                indices: None,
             }))
         );
     }
@@ -3224,7 +3359,92 @@ type Token { id: ID! }
                 partition_by: None,
                 order_by: Some(vec!["token".to_string(), "timestamp".to_string()]),
                 ttl: None,
+                indices: None,
             }))
+        );
+    }
+
+    #[test]
+    fn storage_directive_clickhouse_skip_indices() {
+        let schema_str = r#"
+type TestEntity @storage(clickhouse: {indices: [
+  {name: "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)", granularity: 4},
+  {name: "idx_amount", expr: "amount", type: "minmax"}
+]}) {
+  id: ID!
+  fromAddress: String!
+  amount: BigInt!
+}
+        "#;
+        let entity = Entity::from_object(&get_first_entity_from_string(schema_str)).unwrap();
+        assert_eq!(
+            entity.clickhouse,
+            Some(ClickHouseEntityStorage::Options(ClickHouseTableOptions {
+                indices: Some(vec![
+                    ClickHouseSkipIndex {
+                        name: "idx_from".to_string(),
+                        expr: "fromAddress".to_string(),
+                        index_type: "bloom_filter(0.01)".to_string(),
+                        granularity: Some(4),
+                    },
+                    ClickHouseSkipIndex {
+                        name: "idx_amount".to_string(),
+                        expr: "amount".to_string(),
+                        index_type: "minmax".to_string(),
+                        granularity: None,
+                    },
+                ]),
+                ..ClickHouseTableOptions::default()
+            }))
+        );
+    }
+
+    #[test]
+    fn storage_directive_clickhouse_skip_indices_errors() {
+        let assert_error_contains = |schema_str: &str, expected: &str| {
+            let err = Entity::from_object(&get_first_entity_from_string(schema_str))
+                .expect_err(&format!("expected error containing '{expected}'"));
+            let message = format!("{err:#}");
+            assert!(
+                message.contains(expected),
+                "expected error containing '{expected}', got: {message}"
+            );
+        };
+
+        assert_error_contains(
+            r#"type TestEntity @storage(clickhouse: {indices: []}) { id: ID! }"#,
+            "`clickhouse.indices` must be a non-empty list",
+        );
+        assert_error_contains(
+            r#"type TestEntity @storage(clickhouse: {indices: ["idx"]}) { id: ID! }"#,
+            "`clickhouse.indices` must be a list of index objects",
+        );
+        assert_error_contains(
+            r#"type TestEntity @storage(clickhouse: {indices: [{name: "idx", type: "minmax"}]}) { id: ID! }"#,
+            "missing required field `expr`",
+        );
+        assert_error_contains(
+            r#"type TestEntity @storage(clickhouse: {indices: [{name: "idx", expr: "", type: "minmax"}]}) { id: ID! }"#,
+            "`expr` must be a non-empty string",
+        );
+        assert_error_contains(
+            r#"type TestEntity @storage(clickhouse: {indices: [{name: "idx", expr: "id", type: "minmax", size: 1}]}) { id: ID! }"#,
+            "Unknown `clickhouse.indices` entry field `size`",
+        );
+        assert_error_contains(
+            r#"type TestEntity @storage(clickhouse: {indices: [{name: "idx", expr: "id", type: "minmax", granularity: 0}]}) { id: ID! }"#,
+            "`granularity` must be a positive integer",
+        );
+        assert_error_contains(
+            r#"type TestEntity @storage(clickhouse: {indices: [{name: "bad name", expr: "id", type: "minmax"}]}) { id: ID! }"#,
+            "must contain only alphanumeric characters and underscores",
+        );
+        assert_error_contains(
+            r#"type TestEntity @storage(clickhouse: {indices: [
+  {name: "idx", expr: "id", type: "minmax"},
+  {name: "idx", expr: "id", type: "set(100)"}
+]}) { id: ID! }"#,
+            "lists index name `idx` more than once",
         );
     }
 

--- a/packages/cli/src/config_parsing/entity_parsing.rs
+++ b/packages/cli/src/config_parsing/entity_parsing.rs
@@ -419,7 +419,7 @@ impl GraphQLEnum {
 /// A data skipping index on the entity's ClickHouse history table, emitted
 /// into the DDL as `INDEX <name> <expr> TYPE <type> GRANULARITY <granularity>`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ClickHouseSkipIndex {
+pub struct ClickHouseSkippingIndex {
     pub name: String,
     /// Raw ClickHouse expression the index is built over.
     pub expr: String,
@@ -433,7 +433,7 @@ pub struct ClickHouseSkipIndex {
 /// Per-entity tuning of the ClickHouse history table layout, written as an
 /// object argument of the `@storage` directive:
 /// `@storage(clickhouse: {partitionBy: "toYYYYMM(timestamp)", orderBy:
-/// ["timestamp"], ttl: "timestamp + INTERVAL 2 YEAR", indices: [{name:
+/// ["timestamp"], ttl: "timestamp + INTERVAL 2 YEAR", skippingIndexes: [{name:
 /// "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)"}]})`.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ClickHouseTableOptions {
@@ -445,8 +445,8 @@ pub struct ClickHouseTableOptions {
     pub order_by: Option<Vec<String>>,
     /// Raw ClickHouse expression emitted as `TTL <expr>`.
     pub ttl: Option<String>,
-    /// Data skipping indices emitted into the table's column list.
-    pub indices: Option<Vec<ClickHouseSkipIndex>>,
+    /// Data skipping indexes emitted into the table's column list.
+    pub skipping_indexes: Option<Vec<ClickHouseSkippingIndex>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -990,14 +990,14 @@ fn parse_clickhouse_table_options(
                 };
                 options.order_by = Some(field_names);
             }
-            "indices" => {
+            "skippingIndexes" => {
                 let items = match value {
                     Value::List(items) if !items.is_empty() => items,
                     _ => {
                         return Err(anyhow!(
-                            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` \
+                            "Invalid @storage directive on `{entity_name}`. `clickhouse.skippingIndexes` \
                              must be a non-empty list of index objects, \
-                             {CLICKHOUSE_SKIP_INDEX_HINT}."
+                             {CLICKHOUSE_SKIPPING_INDEX_HINT}."
                         ));
                     }
                 };
@@ -1005,30 +1005,30 @@ fn parse_clickhouse_table_options(
                     .iter()
                     .map(|item| match item {
                         Value::Object(index_fields) => {
-                            parse_clickhouse_skip_index(entity_name, index_fields)
+                            parse_clickhouse_skipping_index(entity_name, index_fields)
                         }
                         _ => Err(anyhow!(
-                            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` \
-                             must be a list of index objects, {CLICKHOUSE_SKIP_INDEX_HINT}."
+                            "Invalid @storage directive on `{entity_name}`. `clickhouse.skippingIndexes` \
+                             must be a list of index objects, {CLICKHOUSE_SKIPPING_INDEX_HINT}."
                         )),
                     })
-                    .collect::<anyhow::Result<Vec<ClickHouseSkipIndex>>>()?;
+                    .collect::<anyhow::Result<Vec<ClickHouseSkippingIndex>>>()?;
                 let mut seen = HashSet::new();
                 for index in &indices {
                     if !seen.insert(&index.name) {
                         return Err(anyhow!(
-                            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` \
+                            "Invalid @storage directive on `{entity_name}`. `clickhouse.skippingIndexes` \
                              lists index name `{}` more than once.",
                             index.name
                         ));
                     }
                 }
-                options.indices = Some(indices);
+                options.skipping_indexes = Some(indices);
             }
             other => {
                 return Err(anyhow!(
                     "Invalid @storage directive on `{entity_name}`. Unknown `clickhouse` option \
-                     `{other}`. Expected options from {{partitionBy, orderBy, ttl, indices}}, \
+                     `{other}`. Expected options from {{partitionBy, orderBy, ttl, skippingIndexes}}, \
                      e.g. clickhouse: {{partitionBy: \"toYYYYMM(timestamp)\", orderBy: \
                      [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}}."
                 ));
@@ -1039,20 +1039,23 @@ fn parse_clickhouse_table_options(
     Ok(options)
 }
 
-const CLICKHOUSE_SKIP_INDEX_HINT: &str = "e.g. clickhouse: {indices: [{name: \"idx_from\", expr: \
+const CLICKHOUSE_SKIPPING_INDEX_HINT: &str =
+    "e.g. clickhouse: {skippingIndexes: [{name: \"idx_from\", expr: \
                                           \"fromAddress\", type: \"bloom_filter(0.01)\", \
                                           granularity: 4}]}";
 
-fn parse_clickhouse_skip_index(
+fn parse_clickhouse_skipping_index(
     entity_name: &str,
     fields: &std::collections::BTreeMap<String, Value<'_, String>>,
-) -> anyhow::Result<ClickHouseSkipIndex> {
-    let string_value = |key: &str, value: &Value<'_, String>| match value {
+) -> anyhow::Result<ClickHouseSkippingIndex> {
+    let string_value = |key: &str, value: &Value<'_, String>| {
+        match value {
         Value::String(s) if !s.trim().is_empty() => Ok(s.trim().to_string()),
         _ => Err(anyhow!(
-            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` entry field \
-             `{key}` must be a non-empty string, {CLICKHOUSE_SKIP_INDEX_HINT}."
+            "Invalid @storage directive on `{entity_name}`. `clickhouse.skippingIndexes` entry field \
+             `{key}` must be a non-empty string, {CLICKHOUSE_SKIPPING_INDEX_HINT}."
         )),
+    }
     };
 
     let mut name = None;
@@ -1073,18 +1076,18 @@ fn parse_clickhouse_skip_index(
                     Some(v) => granularity = Some(v as u32),
                     None => {
                         return Err(anyhow!(
-                            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` \
+                            "Invalid @storage directive on `{entity_name}`. `clickhouse.skippingIndexes` \
                              entry field `granularity` must be a positive integer, \
-                             {CLICKHOUSE_SKIP_INDEX_HINT}."
+                             {CLICKHOUSE_SKIPPING_INDEX_HINT}."
                         ));
                     }
                 }
             }
             other => {
                 return Err(anyhow!(
-                    "Invalid @storage directive on `{entity_name}`. Unknown `clickhouse.indices` \
+                    "Invalid @storage directive on `{entity_name}`. Unknown `clickhouse.skippingIndexes` \
                      entry field `{other}`. Expected fields from {{name, expr, type, \
-                     granularity}}, {CLICKHOUSE_SKIP_INDEX_HINT}."
+                     granularity}}, {CLICKHOUSE_SKIPPING_INDEX_HINT}."
                 ));
             }
         }
@@ -1093,8 +1096,8 @@ fn parse_clickhouse_skip_index(
     let require = |value: Option<String>, key: &str| {
         value.ok_or_else(|| {
             anyhow!(
-                "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` entry is \
-                 missing required field `{key}`, {CLICKHOUSE_SKIP_INDEX_HINT}."
+                "Invalid @storage directive on `{entity_name}`. `clickhouse.skippingIndexes` entry is \
+                 missing required field `{key}`, {CLICKHOUSE_SKIPPING_INDEX_HINT}."
             )
         })
     };
@@ -1107,12 +1110,12 @@ fn parse_clickhouse_skip_index(
         .all(|(i, c)| c == '_' || c.is_ascii_alphabetic() || (i > 0 && c.is_ascii_digit()));
     if !valid_name {
         return Err(anyhow!(
-            "Invalid @storage directive on `{entity_name}`. `clickhouse.indices` name `{name}` \
+            "Invalid @storage directive on `{entity_name}`. `clickhouse.skippingIndexes` name `{name}` \
              must contain only alphanumeric characters and underscores, and must not start with \
              a digit."
         ));
     }
-    Ok(ClickHouseSkipIndex {
+    Ok(ClickHouseSkippingIndex {
         name,
         expr: require(expr, "expr")?,
         index_type: require(index_type, "type")?,
@@ -2182,7 +2185,7 @@ impl GqlScalar {
 #[cfg(test)]
 mod tests {
     use super::{
-        anyhow, ClickHouseEntityStorage, ClickHouseSkipIndex, ClickHouseTableOptions, Entity,
+        anyhow, ClickHouseEntityStorage, ClickHouseSkippingIndex, ClickHouseTableOptions, Entity,
         Field, FieldType, GqlScalar, GraphQLEnum, IndexFieldDirection, Schema,
         UserDefinedFieldType,
     };
@@ -3322,7 +3325,7 @@ type TestEntity @storage(clickhouse: {partitionBy: "toYYYYMM(timestamp)"}) {
                 partition_by: Some("toYYYYMM(timestamp)".to_string()),
                 order_by: None,
                 ttl: None,
-                indices: None,
+                skipping_indexes: None,
             }))
         );
     }
@@ -3359,15 +3362,15 @@ type Token { id: ID! }
                 partition_by: None,
                 order_by: Some(vec!["token".to_string(), "timestamp".to_string()]),
                 ttl: None,
-                indices: None,
+                skipping_indexes: None,
             }))
         );
     }
 
     #[test]
-    fn storage_directive_clickhouse_skip_indices() {
+    fn storage_directive_clickhouse_skipping_indexes() {
         let schema_str = r#"
-type TestEntity @storage(clickhouse: {indices: [
+type TestEntity @storage(clickhouse: {skippingIndexes: [
   {name: "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)", granularity: 4},
   {name: "idx_amount", expr: "amount", type: "minmax"}
 ]}) {
@@ -3380,14 +3383,14 @@ type TestEntity @storage(clickhouse: {indices: [
         assert_eq!(
             entity.clickhouse,
             Some(ClickHouseEntityStorage::Options(ClickHouseTableOptions {
-                indices: Some(vec![
-                    ClickHouseSkipIndex {
+                skipping_indexes: Some(vec![
+                    ClickHouseSkippingIndex {
                         name: "idx_from".to_string(),
                         expr: "fromAddress".to_string(),
                         index_type: "bloom_filter(0.01)".to_string(),
                         granularity: Some(4),
                     },
-                    ClickHouseSkipIndex {
+                    ClickHouseSkippingIndex {
                         name: "idx_amount".to_string(),
                         expr: "amount".to_string(),
                         index_type: "minmax".to_string(),
@@ -3400,7 +3403,7 @@ type TestEntity @storage(clickhouse: {indices: [
     }
 
     #[test]
-    fn storage_directive_clickhouse_skip_indices_errors() {
+    fn storage_directive_clickhouse_skipping_indexes_errors() {
         let assert_error_contains = |schema_str: &str, expected: &str| {
             let err = Entity::from_object(&get_first_entity_from_string(schema_str))
                 .expect_err(&format!("expected error containing '{expected}'"));
@@ -3412,35 +3415,35 @@ type TestEntity @storage(clickhouse: {indices: [
         };
 
         assert_error_contains(
-            r#"type TestEntity @storage(clickhouse: {indices: []}) { id: ID! }"#,
-            "`clickhouse.indices` must be a non-empty list",
+            r#"type TestEntity @storage(clickhouse: {skippingIndexes: []}) { id: ID! }"#,
+            "`clickhouse.skippingIndexes` must be a non-empty list",
         );
         assert_error_contains(
-            r#"type TestEntity @storage(clickhouse: {indices: ["idx"]}) { id: ID! }"#,
-            "`clickhouse.indices` must be a list of index objects",
+            r#"type TestEntity @storage(clickhouse: {skippingIndexes: ["idx"]}) { id: ID! }"#,
+            "`clickhouse.skippingIndexes` must be a list of index objects",
         );
         assert_error_contains(
-            r#"type TestEntity @storage(clickhouse: {indices: [{name: "idx", type: "minmax"}]}) { id: ID! }"#,
+            r#"type TestEntity @storage(clickhouse: {skippingIndexes: [{name: "idx", type: "minmax"}]}) { id: ID! }"#,
             "missing required field `expr`",
         );
         assert_error_contains(
-            r#"type TestEntity @storage(clickhouse: {indices: [{name: "idx", expr: "", type: "minmax"}]}) { id: ID! }"#,
+            r#"type TestEntity @storage(clickhouse: {skippingIndexes: [{name: "idx", expr: "", type: "minmax"}]}) { id: ID! }"#,
             "`expr` must be a non-empty string",
         );
         assert_error_contains(
-            r#"type TestEntity @storage(clickhouse: {indices: [{name: "idx", expr: "id", type: "minmax", size: 1}]}) { id: ID! }"#,
-            "Unknown `clickhouse.indices` entry field `size`",
+            r#"type TestEntity @storage(clickhouse: {skippingIndexes: [{name: "idx", expr: "id", type: "minmax", size: 1}]}) { id: ID! }"#,
+            "Unknown `clickhouse.skippingIndexes` entry field `size`",
         );
         assert_error_contains(
-            r#"type TestEntity @storage(clickhouse: {indices: [{name: "idx", expr: "id", type: "minmax", granularity: 0}]}) { id: ID! }"#,
+            r#"type TestEntity @storage(clickhouse: {skippingIndexes: [{name: "idx", expr: "id", type: "minmax", granularity: 0}]}) { id: ID! }"#,
             "`granularity` must be a positive integer",
         );
         assert_error_contains(
-            r#"type TestEntity @storage(clickhouse: {indices: [{name: "bad name", expr: "id", type: "minmax"}]}) { id: ID! }"#,
+            r#"type TestEntity @storage(clickhouse: {skippingIndexes: [{name: "bad name", expr: "id", type: "minmax"}]}) { id: ID! }"#,
             "must contain only alphanumeric characters and underscores",
         );
         assert_error_contains(
-            r#"type TestEntity @storage(clickhouse: {indices: [
+            r#"type TestEntity @storage(clickhouse: {skippingIndexes: [
   {name: "idx", expr: "id", type: "minmax"},
   {name: "idx", expr: "id", type: "set(100)"}
 ]}) { id: ID! }"#,

--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -153,11 +153,11 @@ struct EntityClickHouseOptionsJson {
     #[serde(skip_serializing_if = "Option::is_none")]
     ttl: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    indices: Option<Vec<EntityClickHouseIndexJson>>,
+    skipping_indexes: Option<Vec<EntityClickHouseSkippingIndexJson>>,
 }
 
 #[derive(Serialize, Debug)]
-struct EntityClickHouseIndexJson {
+struct EntityClickHouseSkippingIndexJson {
     name: String,
     expr: String,
     #[serde(rename = "type")]
@@ -175,10 +175,10 @@ impl From<&entity_parsing::ClickHouseEntityStorage> for EntityClickHouseStorageJ
                     partition_by: options.partition_by.clone(),
                     order_by: options.order_by.clone(),
                     ttl: options.ttl.clone(),
-                    indices: options.indices.as_ref().map(|indices| {
+                    skipping_indexes: options.skipping_indexes.as_ref().map(|indices| {
                         indices
                             .iter()
-                            .map(|index| EntityClickHouseIndexJson {
+                            .map(|index| EntityClickHouseSkippingIndexJson {
                                 name: index.name.clone(),
                                 expr: index.expr.clone(),
                                 index_type: index.index_type.clone(),

--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -152,6 +152,18 @@ struct EntityClickHouseOptionsJson {
     order_by: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     ttl: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    indices: Option<Vec<EntityClickHouseIndexJson>>,
+}
+
+#[derive(Serialize, Debug)]
+struct EntityClickHouseIndexJson {
+    name: String,
+    expr: String,
+    #[serde(rename = "type")]
+    index_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    granularity: Option<u32>,
 }
 
 impl From<&entity_parsing::ClickHouseEntityStorage> for EntityClickHouseStorageJson {
@@ -163,6 +175,17 @@ impl From<&entity_parsing::ClickHouseEntityStorage> for EntityClickHouseStorageJ
                     partition_by: options.partition_by.clone(),
                     order_by: options.order_by.clone(),
                     ttl: options.ttl.clone(),
+                    indices: options.indices.as_ref().map(|indices| {
+                        indices
+                            .iter()
+                            .map(|index| EntityClickHouseIndexJson {
+                                name: index.name.clone(),
+                                expr: index.expr.clone(),
+                                index_type: index.index_type.clone(),
+                                granularity: index.granularity,
+                            })
+                            .collect()
+                    }),
                 })
             }
         }

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -3420,7 +3420,7 @@ mod test {
                             "partitionBy": "toYYYYMM(timestamp)",
                             "orderBy": ["timestamp"],
                             "ttl": "timestamp + INTERVAL 2 YEAR",
-                            "indices": [
+                            "skippingIndexes": [
                                 {
                                     "name": "idx_from",
                                     "expr": "fromAddress",

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -3419,7 +3419,16 @@ mod test {
                         "clickhouse": {
                             "partitionBy": "toYYYYMM(timestamp)",
                             "orderBy": ["timestamp"],
-                            "ttl": "timestamp + INTERVAL 2 YEAR"
+                            "ttl": "timestamp + INTERVAL 2 YEAR",
+                            "indices": [
+                                {
+                                    "name": "idx_from",
+                                    "expr": "fromAddress",
+                                    "type": "bloom_filter(0.01)",
+                                    "granularity": 4
+                                },
+                                {"name": "idx_amount", "expr": "amount", "type": "minmax"}
+                            ]
                         }
                     }))
                 ),

--- a/packages/cli/test/schemas/schema-with-clickhouse-options.graphql
+++ b/packages/cli/test/schemas/schema-with-clickhouse-options.graphql
@@ -3,9 +3,14 @@
 type Transfer @storage(clickhouse: {
   partitionBy: "toYYYYMM(timestamp)",
   orderBy: ["timestamp"],
-  ttl: "timestamp + INTERVAL 2 YEAR"
+  ttl: "timestamp + INTERVAL 2 YEAR",
+  indices: [
+    { name: "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)", granularity: 4 },
+    { name: "idx_amount", expr: "amount", type: "minmax" }
+  ]
 }) {
   id: ID!
+  fromAddress: String!
   timestamp: Timestamp!
   amount: BigInt!
 }

--- a/packages/cli/test/schemas/schema-with-clickhouse-options.graphql
+++ b/packages/cli/test/schemas/schema-with-clickhouse-options.graphql
@@ -4,7 +4,7 @@ type Transfer @storage(clickhouse: {
   partitionBy: "toYYYYMM(timestamp)",
   orderBy: ["timestamp"],
   ttl: "timestamp + INTERVAL 2 YEAR",
-  indices: [
+  skippingIndexes: [
     { name: "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)", granularity: 4 },
     { name: "idx_amount", expr: "amount", type: "minmax" }
   ]

--- a/packages/e2e-tests/src/e2e/e2e.test.ts
+++ b/packages/e2e-tests/src/e2e/e2e.test.ts
@@ -520,9 +520,9 @@ describe.skipIf(!dockerAvailable)("E2E: Indexer with GraphQL and ClickHouse sink
     });
   });
 
-  it("ClickHouse history table has the schema-declared skip indices", async () => {
-    // Transfer declares two bloom-filter indices via
-    // @storage(clickhouse: {indices: [...]}). An omitted granularity falls
+  it("ClickHouse history table has the schema-declared skipping indexes", async () => {
+    // Transfer declares two bloom-filter skipping indexes via
+    // @storage(clickhouse: {skippingIndexes: [...]}). An omitted granularity falls
     // back to ClickHouse's default of 1.
     const result = await queryClickHouse<
       ClickHouseResult<{ name: string; type_full: string; granularity: number }>

--- a/packages/e2e-tests/src/e2e/e2e.test.ts
+++ b/packages/e2e-tests/src/e2e/e2e.test.ts
@@ -520,6 +520,26 @@ describe.skipIf(!dockerAvailable)("E2E: Indexer with GraphQL and ClickHouse sink
     });
   });
 
+  it("ClickHouse history table has the schema-declared skip indices", async () => {
+    // Transfer declares two bloom-filter indices via
+    // @storage(clickhouse: {indices: [...]}). An omitted granularity falls
+    // back to ClickHouse's default of 1.
+    const result = await queryClickHouse<
+      ClickHouseResult<{ name: string; type_full: string; granularity: number }>
+    >(
+      `SELECT name, type_full, toUInt32(granularity) as granularity
+       FROM system.data_skipping_indices
+       WHERE database = '${CH_DATABASE}' AND table = 'envio_history_Transfer'
+       ORDER BY name
+       FORMAT JSON`
+    );
+
+    expect(result.data).toEqual([
+      { name: "idx_from", type_full: "bloom_filter(0.01)", granularity: 4 },
+      { name: "idx_to", type_full: "bloom_filter(0.01)", granularity: 1 },
+    ]);
+  });
+
   // --- Per-entity @storage routing ---
   //
   // The e2e_test schema declares:

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -11,7 +11,8 @@ let expectParseError = (t, ~schema=?, ~env=?, ~files=?, yaml, message) => {
 }
 
 let parseAddressConfig = (~addressFormat="checksum", ~contractName="ERC20", address): Config.t =>
-  InternalTestIndexer.fromUserApi(~configYaml=`
+  InternalTestIndexer.fromUserApi(
+    ~configYaml=`
 name: address-config
 address_format: ${addressFormat}
 contracts:
@@ -24,7 +25,8 @@ chains:
     contracts:
       - name: ${contractName}
         address: "${address}"
-`).config
+`,
+  ).config
 
 let firstContract = (config: Config.t): Config.contract => {
   let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
@@ -33,10 +35,7 @@ let firstContract = (config: Config.t): Config.contract => {
 
 describe("InternalTestIndexer.fromUserApi validation", () => {
   it("parses user YAML with explicit env and no project schema", t => {
-    let env = Dict.fromArray([
-      ("RPC_URL", "https://rpc.example.test"),
-      ("START_BLOCK", "42"),
-    ])
+    let env = Dict.fromArray([("RPC_URL", "https://rpc.example.test"), ("START_BLOCK", "42")])
 
     let {config} = InternalTestIndexer.fromUserApi(
       ~env,
@@ -67,10 +66,7 @@ chains:
 
   it("resolves ABI paths from caller-provided virtual files", t => {
     let files = Dict.fromArray([
-      (
-        "abis/token.json",
-        `[{"type":"event","name":"Transfer","inputs":[],"anonymous":false}]`,
-      ),
+      ("abis/token.json", `[{"type":"event","name":"Transfer","inputs":[],"anonymous":false}]`),
     ])
 
     let {config} = InternalTestIndexer.fromUserApi(
@@ -98,18 +94,19 @@ chains:
 })
 
 describe("EVM config YAML", () => {
-  [("greeter", "Greeter"), ("Greeter", "Greeter")]->Array.forEach(
-    ((inputName, expectedName)) => {
-      it(`normalizes contract name ${inputName}`, t => {
+  [("greeter", "Greeter"), ("Greeter", "Greeter")]->Array.forEach(((inputName, expectedName)) => {
+    it(
+      `normalizes contract name ${inputName}`,
+      t => {
         let contract =
           parseAddressConfig(
             ~contractName=inputName,
             "0x0000000000000000000000000000000000000001",
           )->firstContract
         t.expect(contract.name).toBe(expectedName)
-      })
-    },
-  )
+      },
+    )
+  })
 
   it("preserves a full 20-byte address through the complete YAML pipeline", t => {
     let address = "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
@@ -124,24 +121,31 @@ describe("EVM config YAML", () => {
     ("lowercase", "0xa2f6e6029638ccb484a2ccb6414499ad3e825cac"),
     ("lowercase", "0xA2F6E6029638CCB484A2CCB6414499AD3E825CAC"),
   ]->Array.forEach(((addressFormat, address)) => {
-    it(`normalizes ${address} with address_format: ${addressFormat}`, t => {
-      let contract = parseAddressConfig(~addressFormat, address)->firstContract
-      let parsed = contract.addresses->Array.getUnsafe(0)
-      t.expect(parsed->Address.toString).toBe(
-        switch addressFormat {
-        | "lowercase" => "0xa2f6e6029638ccb484a2ccb6414499ad3e825cac"
-        | _ => "0xa2F6E6029638cCb484A2ccb6414499aD3e825CaC"
-        },
-      )
-    })
+    it(
+      `normalizes ${address} with address_format: ${addressFormat}`,
+      t => {
+        let contract = parseAddressConfig(~addressFormat, address)->firstContract
+        let parsed = contract.addresses->Array.getUnsafe(0)
+        t.expect(parsed->Address.toString).toBe(
+          switch addressFormat {
+          | "lowercase" => "0xa2f6e6029638ccb484a2ccb6414499ad3e825cac"
+          | _ => "0xa2F6E6029638cCb484A2ccb6414499aD3e825CaC"
+          },
+        )
+      },
+    )
   })
 
   ["checksum", "lowercase"]->Array.forEach(addressFormat => {
-    it(`rejects invalid addresses with address_format: ${addressFormat}`, t => {
-      t->toThrowErrorEqual(() => parseAddressConfig(~addressFormat, "0xfoo")->ignore, 
-        `Config parse error: Contract "ERC20" on chain 1 has invalid address "0xfoo". Expected a 20-byte hex string starting with 0x.`,
-      )
-    })
+    it(
+      `rejects invalid addresses with address_format: ${addressFormat}`,
+      t => {
+        t->toThrowErrorEqual(
+          () => parseAddressConfig(~addressFormat, "0xfoo")->ignore,
+          `Config parse error: Contract "ERC20" on chain 1 has invalid address "0xfoo". Expected a 20-byte hex string starting with 0x.`,
+        )
+      },
+    )
   })
 
   it("rejects one address assigned to two contracts on the same chain", t => {
@@ -192,7 +196,8 @@ chains:
   })
 
   it("allows the same address on different chains", t => {
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: multichain-address
 contracts:
   - name: AaveToken
@@ -209,7 +214,8 @@ chains:
     contracts:
       - name: AaveToken
         address: "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
-`)
+`,
+    )
     t.expect(config.chainMap->ChainMap.values->Array.length).toBe(2)
   })
 
@@ -318,7 +324,7 @@ type Transfer @storage(clickhouse: {
   partitionBy: "toYYYYMM(timestamp)",
   orderBy: ["timestamp"],
   ttl: "timestamp + INTERVAL 2 YEAR",
-  indices: [{ name: "idx_amount", expr: "amount", type: "minmax", granularity: 4 }]
+  skippingIndexes: [{ name: "idx_amount", expr: "amount", type: "minmax", granularity: 4 }]
 }) {
   id: ID!
   timestamp: Timestamp!
@@ -345,7 +351,7 @@ chains:
         partitionBy: "toYYYYMM(timestamp)",
         orderBy: ["timestamp"],
         ttl: "timestamp + INTERVAL 2 YEAR",
-        indices: [{name: "idx_amount", expr: "amount", type_: "minmax", granularity: 4}],
+        skippingIndexes: [{name: "idx_amount", expr: "amount", type_: "minmax", granularity: 4}],
       },
     })
   })
@@ -549,10 +555,12 @@ chains:
     )
   })
 
-  it("rejects two events with the same name but different signatures, suggesting the name alias", t => {
-    expectParseError(
-      t,
-      `
+  it(
+    "rejects two events with the same name but different signatures, suggesting the name alias",
+    t => {
+      expectParseError(
+        t,
+        `
 name: overloaded-event
 contracts:
   - name: Token
@@ -563,9 +571,10 @@ chains:
   - id: 1
     start_block: 0
 `,
-      `Config parse error: Failed parsing globally defined contract: Contract Token has two events named "Transfer". Give one of them a unique name with the "name" field so the generated code and the indexer's routing can tell them apart.`,
-    )
-  })
+        `Config parse error: Failed parsing globally defined contract: Contract Token has two events named "Transfer". Give one of them a unique name with the "name" field so the generated code and the indexer's routing can tell them apart.`,
+      )
+    },
+  )
 
   it("preserves the root cause from nested Rust error contexts", t => {
     expectParseError(
@@ -885,7 +894,8 @@ describe("config YAML success cases", () => {
   it("allows distinct events on one contract and the same event across contracts", t => {
     // Distinct signatures on one contract are fine, and the same event on two
     // different contracts is allowed — routing scopes matches by contract.
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: distinct-and-cross-contract-events
 contracts:
   - name: ERC20
@@ -903,7 +913,8 @@ chains:
         address: "0x1111111111111111111111111111111111111111"
       - name: ERC721
         address: "0x2222222222222222222222222222222222222222"
-`)
+`,
+    )
     let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
     t.expect(chain.contracts->Array.length).toBe(2)
   })
@@ -912,7 +923,8 @@ chains:
     // Two events resolving to the name "Transfer" would clash, but the alias on
     // one gives them distinct names (and their signatures differ, so no dispatch
     // collision either).
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: aliased-overload
 contracts:
   - name: Token
@@ -926,40 +938,46 @@ chains:
     contracts:
       - name: Token
         address: "0x1111111111111111111111111111111111111111"
-`)
+`,
+    )
     let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
     let contract = chain.contracts->Array.getUnsafe(0)
     t.expect(contract.events->Array.map(e => e.name)).toEqual(["TransferSimple", "Transfer"])
   })
 
   it("parses a minimal Fuel config through the public boundary", t => {
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: fuel-config
 ecosystem: fuel
 chains:
   - id: 0
     start_block: 7
-`)
+`,
+    )
     let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
     t.expect(config.ecosystem.name).toEqual(Ecosystem.Fuel)
     t.expect((chain.id->ChainId.toString, chain.startBlock)).toEqual(("0", 7))
   })
 
   it("parses a minimal SVM config through the public boundary", t => {
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: svm-config
 ecosystem: svm
 chains:
   - rpc: https://solana.example.test
     start_block: 8
-`)
+`,
+    )
     let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
     t.expect(config.ecosystem.name).toEqual(Ecosystem.Svm)
     t.expect((chain.id->ChainId.toString, chain.startBlock)).toEqual(("0", 8))
   })
 
   it("validates event field selections against only the chain that uses them", t => {
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: mixed-sync-sources
 chains:
   - id: 1
@@ -979,12 +997,14 @@ chains:
       - name: RpcOnly
         events:
           - event: Ping()
-`)
+`,
+    )
     t.expect(config.chainMap->ChainMap.values->Array.length).toBe(2)
   })
 
   it("allows a global contract with HyperSync-only fields when unrelated chains use RPC", t => {
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: mixed-global-contract
 contracts:
   - name: HyperOnly
@@ -1002,12 +1022,14 @@ chains:
       url: https://rpc.example.test
       for: sync
     start_block: 0
-`)
+`,
+    )
     t.expect(config.chainMap->ChainMap.values->Array.length).toBe(2)
   })
 
   it("removes skipped chains from runtime config", t => {
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: chain-options
 chains:
   - id: 1
@@ -1015,7 +1037,8 @@ chains:
     start_block: 1000
   - id: 137
     start_block: 2000
-`)
+`,
+    )
     let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
     t.expect(config.chainMap->ChainMap.values->Array.length).toBe(1)
     t.expect(chain.id->ChainId.toString).toBe("137")
@@ -1023,14 +1046,16 @@ chains:
   })
 
   it("normalizes trailing slashes in HyperSync URLs", t => {
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: hypersync-url
 chains:
   - id: 1
     hypersync_config:
       url: https://eth.hypersync.xyz//
     start_block: 0
-`)
+`,
+    )
     let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
     switch chain.sourceConfig {
     | Config.EvmSourceConfig({hypersync: Some(url)}) =>
@@ -1067,7 +1092,8 @@ chains:
   })
 
   it("accepts user event signatures with prefixes, tuple spacing, and trailing semicolons", t => {
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: event-signature-formatting
 contracts:
   - name: Shop
@@ -1078,7 +1104,8 @@ chains:
     start_block: 0
     contracts:
       - name: Shop
-`)
+`,
+    )
     let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
     let contract = chain.contracts->Array.getUnsafe(0)
     let event = contract.events->Array.getUnsafe(0)
@@ -1100,7 +1127,8 @@ chains:
   })
 
   it("resolves per-contract start blocks and leaves unset ones to the chain default", t => {
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: per-contract-start-block
 contracts:
   - name: Early
@@ -1124,7 +1152,8 @@ chains:
         start_block: 1500
       - name: Default
         address: "0x3333333333333333333333333333333333333333"
-`)
+`,
+    )
     let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
     let byName = chain.contracts->Array.toSorted((a, b) => String.compare(a.name, b.name))
     t.expect(byName->Array.map(c => (c.name, c.startBlock))).toEqual([
@@ -1135,7 +1164,8 @@ chains:
   })
 
   it("keeps a contract with no address for dynamic registration", t => {
-    let {config} = InternalTestIndexer.fromUserApi(~configYaml=`
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
 name: factory-and-dynamic
 contracts:
   - name: Factory
@@ -1151,7 +1181,8 @@ chains:
       - name: Factory
         address: "0x1F98431c8aD98523631AE4a59f267346ea31F984"
       - name: Pool
-`)
+`,
+    )
     let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
     let byName = chain.contracts->Array.toSorted((a, b) => String.compare(a.name, b.name))
     t.expect(byName->Array.map(c => (c.name, c.addresses->Array.length))).toEqual([
@@ -1568,7 +1599,7 @@ type Token @storage(clickhouse: {indexGranularity: 1024}) {
   id: ID!
 }
 `,
-      "Config parse error: Failed converting schema doc to schema struct: Failed constructing entities in schema from document: Invalid @storage directive on \`Token\`. Unknown \`clickhouse\` option \`indexGranularity\`. Expected options from {partitionBy, orderBy, ttl, indices}, e.g. clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}.",
+      "Config parse error: Failed converting schema doc to schema struct: Failed constructing entities in schema from document: Invalid @storage directive on \`Token\`. Unknown \`clickhouse\` option \`indexGranularity\`. Expected options from {partitionBy, orderBy, ttl, skippingIndexes}, e.g. clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}.",
     ),
     (
       "rejects clickhouse orderBy referencing missing fields",
@@ -1844,7 +1875,11 @@ chains:
 `
 
   it("reports an ABI path omitted from virtual files", t => {
-    expectParseError(t, evmYaml, "Config parse error: Failed parsing abi types for events in contract Token on network 1: Failed to get ABI relative to the config: Virtual config file \"abis/Token.json\" was not provided")
+    expectParseError(
+      t,
+      evmYaml,
+      "Config parse error: Failed parsing abi types for events in contract Token on network 1: Failed to get ABI relative to the config: Virtual config file \"abis/Token.json\" was not provided",
+    )
   })
 
   it("reports malformed ABI JSON", t => {
@@ -1860,10 +1895,7 @@ chains:
     expectParseError(
       t,
       ~files=Dict.fromArray([
-        (
-          "abis/Token.json",
-          `[{"type":"event","name":"Approval","inputs":[],"anonymous":false}]`,
-        ),
+        ("abis/Token.json", `[{"type":"event","name":"Approval","inputs":[],"anonymous":false}]`),
       ]),
       evmYaml,
       "Config parse error: Failed parsing abi types for events in contract Token on network 1: Event Transfer not found in ABI file",

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -317,7 +317,8 @@ chains:
 type Transfer @storage(clickhouse: {
   partitionBy: "toYYYYMM(timestamp)",
   orderBy: ["timestamp"],
-  ttl: "timestamp + INTERVAL 2 YEAR"
+  ttl: "timestamp + INTERVAL 2 YEAR",
+  indices: [{ name: "idx_amount", expr: "amount", type: "minmax", granularity: 4 }]
 }) {
   id: ID!
   timestamp: Timestamp!
@@ -344,6 +345,7 @@ chains:
         partitionBy: "toYYYYMM(timestamp)",
         orderBy: ["timestamp"],
         ttl: "timestamp + INTERVAL 2 YEAR",
+        indices: [{name: "idx_amount", expr: "amount", type_: "minmax", granularity: 4}],
       },
     })
   })
@@ -1566,7 +1568,7 @@ type Token @storage(clickhouse: {indexGranularity: 1024}) {
   id: ID!
 }
 `,
-      "Config parse error: Failed converting schema doc to schema struct: Failed constructing entities in schema from document: Invalid @storage directive on \`Token\`. Unknown \`clickhouse\` option \`indexGranularity\`. Expected options from {partitionBy, orderBy, ttl}, e.g. clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}.",
+      "Config parse error: Failed converting schema doc to schema struct: Failed constructing entities in schema from document: Invalid @storage directive on \`Token\`. Unknown \`clickhouse\` option \`indexGranularity\`. Expected options from {partitionBy, orderBy, ttl, indices}, e.g. clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}.",
     ),
     (
       "rejects clickhouse orderBy referencing missing fields",

--- a/packages/envio-tests/test/lib_tests/ClickHouse_test.res
+++ b/packages/envio-tests/test/lib_tests/ClickHouse_test.res
@@ -205,17 +205,19 @@ ORDER BY (id)`
 ENGINE = ReplicatedMergeTree
 ORDER BY (id)`
 
-        t.expect(
-          query,
-          ~message="Replicated checkpoints table SQL should match exactly",
-        ).toBe(expectedQuery)
+        t.expect(query, ~message="Replicated checkpoints table SQL should match exactly").toBe(
+          expectedQuery,
+        )
       },
     )
 
     Async.it(
       "Should use ReplicatedMergeTree without ON CLUSTER for Replicated database engine",
       async t => {
-        let query = ClickHouse.makeCreateCheckpointsTableQuery(~database="test_db", ~replicated=true)
+        let query = ClickHouse.makeCreateCheckpointsTableQuery(
+          ~database="test_db",
+          ~replicated=true,
+        )
 
         let expectedQuery = `CREATE TABLE IF NOT EXISTS test_db.\`envio_checkpoints\` (
   \`id\` UInt64,
@@ -321,10 +323,9 @@ ORDER BY (id, envio_checkpoint_id)`
 ENGINE = ReplicatedMergeTree
 ORDER BY (id, envio_checkpoint_id)`
 
-        t.expect(
-          query,
-          ~message="Replicated entity history table SQL should match exactly",
-        ).toBe(expectedQuery)
+        t.expect(query, ~message="Replicated entity history table SQL should match exactly").toBe(
+          expectedQuery,
+        )
       },
     )
   })
@@ -491,14 +492,14 @@ TTL \`trade_time\` + INTERVAL 1 YEAR DELETE WHERE \`base_token_id\` != ''`)
     )
 
     Async.it(
-      "Should emit data skipping indices with expressions resolved to columns",
+      "Should emit data skipping indexes with expressions resolved to columns",
       async t => {
         // https://github.com/enviodev/hyperindex/issues/1524
         let config = InternalTestIndexer.fromUserApi(
           ~schema=`
 type Transfer @storage(clickhouse: {
   orderBy: ["timestamp"],
-  indices: [
+  skippingIndexes: [
     { name: "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)", granularity: 4 },
     { name: "idx_amount", expr: "amount", type: "minmax" }
   ]
@@ -510,7 +511,7 @@ type Transfer @storage(clickhouse: {
 }
 `,
           ~configYaml=`
-name: clickhouse-skip-indices
+name: clickhouse-skipping-indexes
 storage:
   postgres:
     default: true
@@ -530,7 +531,7 @@ chains:
             "storage": entityConfig.storage,
             "query": query,
           },
-          ~message="Skip indices should reach the entity storage and the history table SQL",
+          ~message="Skipping indexes should reach the entity storage and the history table SQL",
         ).toEqual({
           "storage": (
             {
@@ -538,7 +539,7 @@ chains:
               clickhouse: true,
               clickhouseOptions: {
                 orderBy: ["timestamp"],
-                indices: [
+                skippingIndexes: [
                   {
                     name: "idx_from",
                     expr: "fromAddress",
@@ -567,12 +568,12 @@ ORDER BY (\`timestamp\`, envio_checkpoint_id)`,
     )
 
     Async.it(
-      "Should create the declared skip indices on a live ClickHouse",
+      "Should create the declared skipping indexes on a live ClickHouse",
       async t => {
         let config = InternalTestIndexer.fromUserApi(
           ~schema=`
 type Transfer @storage(clickhouse: {
-  indices: [
+  skippingIndexes: [
     { name: "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)", granularity: 4 },
     { name: "idx_amount", expr: "amount", type: "minmax" }
   ]
@@ -583,7 +584,7 @@ type Transfer @storage(clickhouse: {
 }
 `,
           ~configYaml=`
-name: clickhouse-skip-indices-live
+name: clickhouse-skipping-indexes-live
 storage:
   postgres:
     default: true

--- a/packages/envio-tests/test/lib_tests/ClickHouse_test.res
+++ b/packages/envio-tests/test/lib_tests/ClickHouse_test.res
@@ -489,6 +489,141 @@ ORDER BY (id, envio_checkpoint_id)
 TTL \`trade_time\` + INTERVAL 1 YEAR DELETE WHERE \`base_token_id\` != ''`)
       },
     )
+
+    Async.it(
+      "Should emit data skipping indices with expressions resolved to columns",
+      async t => {
+        // https://github.com/enviodev/hyperindex/issues/1524
+        let config = InternalTestIndexer.fromUserApi(
+          ~schema=`
+type Transfer @storage(clickhouse: {
+  orderBy: ["timestamp"],
+  indices: [
+    { name: "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)", granularity: 4 },
+    { name: "idx_amount", expr: "amount", type: "minmax" }
+  ]
+}) {
+  id: ID!
+  fromAddress: String!
+  timestamp: Timestamp!
+  amount: BigInt!
+}
+`,
+          ~configYaml=`
+name: clickhouse-skip-indices
+storage:
+  postgres:
+    default: true
+  clickhouse:
+    column_name_format: snake_case
+chains:
+  - id: 1
+    start_block: 0
+`,
+        ).config
+        let entityConfig = config.userEntitiesByName->Dict.getUnsafe("Transfer")
+
+        let query = ClickHouse.makeCreateHistoryTableQuery(~entityConfig, ~database="test_db")
+
+        t.expect(
+          {
+            "storage": entityConfig.storage,
+            "query": query,
+          },
+          ~message="Skip indices should reach the entity storage and the history table SQL",
+        ).toEqual({
+          "storage": (
+            {
+              postgres: false,
+              clickhouse: true,
+              clickhouseOptions: {
+                orderBy: ["timestamp"],
+                indices: [
+                  {
+                    name: "idx_from",
+                    expr: "fromAddress",
+                    type_: "bloom_filter(0.01)",
+                    granularity: 4,
+                  },
+                  {name: "idx_amount", expr: "amount", type_: "minmax"},
+                ],
+              },
+            }: Internal.entityStorage
+          ),
+          "query": `CREATE TABLE IF NOT EXISTS test_db.\`envio_history_Transfer\` (
+  \`id\` String,
+  \`from_address\` String,
+  \`timestamp\` DateTime64(3, 'UTC'),
+  \`amount\` String,
+  \`envio_checkpoint_id\` UInt64,
+  \`envio_change\` Enum8('SET', 'DELETE'),
+  INDEX \`idx_from\` \`from_address\` TYPE bloom_filter(0.01) GRANULARITY 4,
+  INDEX \`idx_amount\` \`amount\` TYPE minmax
+)
+ENGINE = MergeTree()
+ORDER BY (\`timestamp\`, envio_checkpoint_id)`,
+        })
+      },
+    )
+
+    Async.it(
+      "Should create the declared skip indices on a live ClickHouse",
+      async t => {
+        let config = InternalTestIndexer.fromUserApi(
+          ~schema=`
+type Transfer @storage(clickhouse: {
+  indices: [
+    { name: "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)", granularity: 4 },
+    { name: "idx_amount", expr: "amount", type: "minmax" }
+  ]
+}) {
+  id: ID!
+  fromAddress: String!
+  amount: BigInt!
+}
+`,
+          ~configYaml=`
+name: clickhouse-skip-indices-live
+storage:
+  postgres:
+    default: true
+  clickhouse: true
+chains:
+  - id: 1
+    start_block: 0
+`,
+        ).config
+        let entityConfig = config.userEntitiesByName->Dict.getUnsafe("Transfer")
+
+        let database = TestClickHouse.make()
+        let client = ClickHouse.createClient({
+          url: TestClickHouse.host(),
+          username: TestClickHouse.username(),
+          password: TestClickHouse.password(),
+        })
+        let indices = try {
+          await ClickHouse.initialize(client, ~database, ~entities=[entityConfig], ~enums=[])
+          await TestClickHouse.query(
+            `SELECT name, type_full, toUInt32(granularity) AS granularity
+FROM system.data_skipping_indices
+WHERE database = '${database}' AND table = 'envio_history_Transfer'
+ORDER BY name
+FORMAT JSONCompactEachRow`,
+          )
+        } catch {
+        | exn =>
+          await TestClickHouse.drop(~database)
+          await ClickHouse.close(client)
+          throw(exn)
+        }
+        await TestClickHouse.drop(~database)
+        await ClickHouse.close(client)
+
+        t.expect(indices).toBe(`["idx_amount", "minmax", 1]
+["idx_from", "bloom_filter(0.01)", 4]
+`)
+      },
+    )
   })
 
   describe("makeCreateViewQuery", () => {

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -348,7 +348,7 @@ let propertySchema = S.schema(s =>
   }
 )
 
-let clickhouseIndexSchema: S.t<Internal.clickhouseIndex> = S.object(s => {
+let clickhouseSkippingIndexSchema: S.t<Internal.clickhouseSkippingIndex> = S.object(s => {
   Internal.name: s.field("name", S.string),
   expr: s.field("expr", S.string),
   type_: s.field("type", S.string),
@@ -359,7 +359,7 @@ let clickhouseTableOptionsSchema: S.t<Internal.clickhouseTableOptions> = S.objec
   Internal.partitionBy: ?s.field("partitionBy", S.option(S.string)),
   orderBy: ?s.field("orderBy", S.option(S.array(S.string))),
   ttl: ?s.field("ttl", S.option(S.string)),
-  indices: ?s.field("indices", S.option(S.array(clickhouseIndexSchema))),
+  skippingIndexes: ?s.field("skippingIndexes", S.option(S.array(clickhouseSkippingIndexSchema))),
 })
 
 // The entity's `clickhouse` storage arg mirrors the @storage directive:

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -348,10 +348,18 @@ let propertySchema = S.schema(s =>
   }
 )
 
+let clickhouseIndexSchema: S.t<Internal.clickhouseIndex> = S.object(s => {
+  Internal.name: s.field("name", S.string),
+  expr: s.field("expr", S.string),
+  type_: s.field("type", S.string),
+  granularity: ?s.field("granularity", S.option(S.int)),
+})
+
 let clickhouseTableOptionsSchema: S.t<Internal.clickhouseTableOptions> = S.object(s => {
   Internal.partitionBy: ?s.field("partitionBy", S.option(S.string)),
   orderBy: ?s.field("orderBy", S.option(S.array(S.string))),
   ttl: ?s.field("ttl", S.option(S.string)),
+  indices: ?s.field("indices", S.option(S.array(clickhouseIndexSchema))),
 })
 
 // The entity's `clickhouse` storage arg mirrors the @storage directive:

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -782,12 +782,23 @@ let fuelTransferParamsSchema = S.schema(s => {
 
 type entity = private {id: string}
 
+// A data skipping index emitted into the history table DDL as
+// `INDEX <name> <expr> TYPE <type> GRANULARITY <granularity>`.
+type clickhouseIndex = {
+  name: string,
+  expr: string,
+  @as("type")
+  type_: string,
+  granularity?: int,
+}
+
 // Raw ClickHouse expressions/field names from the entity's
 // @storage(clickhouse: {...}) directive, applied to the history table DDL.
 type clickhouseTableOptions = {
   partitionBy?: string,
   orderBy?: array<string>,
   ttl?: string,
+  indices?: array<clickhouseIndex>,
 }
 
 // Per-entity storage resolved at parse time against the global storage

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -784,7 +784,7 @@ type entity = private {id: string}
 
 // A data skipping index emitted into the history table DDL as
 // `INDEX <name> <expr> TYPE <type> GRANULARITY <granularity>`.
-type clickhouseIndex = {
+type clickhouseSkippingIndex = {
   name: string,
   expr: string,
   @as("type")
@@ -798,7 +798,7 @@ type clickhouseTableOptions = {
   partitionBy?: string,
   orderBy?: array<string>,
   ttl?: string,
-  indices?: array<clickhouseIndex>,
+  skippingIndexes?: array<clickhouseSkippingIndex>,
 }
 
 // Per-entity storage resolved at parse time against the global storage

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -395,8 +395,8 @@ let makeCreateHistoryTableQuery = (
     }
   })
 
-  let (partitionBy, orderBy, ttl, indices) = switch entityConfig.storage.clickhouseOptions {
-  | Some(options) => (options.partitionBy, options.orderBy, options.ttl, options.indices)
+  let (partitionBy, orderBy, ttl, skippingIndexes) = switch entityConfig.storage.clickhouseOptions {
+  | Some(options) => (options.partitionBy, options.orderBy, options.ttl, options.skippingIndexes)
   | None => (None, None, None, None)
   }
 
@@ -461,11 +461,11 @@ let makeCreateHistoryTableQuery = (
   | None => ""
   }
 
-  // Data skipping indices live inside the column list, after the last column.
+  // Data skipping indexes live inside the column list, after the last column.
   // GRANULARITY is omitted when unset, leaving ClickHouse's default of 1.
-  let skipIndexDefinitions = switch indices {
-  | Some(indices) =>
-    indices
+  let skippingIndexDefinitions = switch skippingIndexes {
+  | Some(skippingIndexes) =>
+    skippingIndexes
     ->Array.map(index => {
       let granularityClause = switch index.granularity {
       | Some(granularity) => ` GRANULARITY ${granularity->Int.toString}`
@@ -491,7 +491,7 @@ let makeCreateHistoryTableQuery = (
       ~fieldType=Enum({config: EntityHistory.RowAction.config->Table.fromGenericEnumConfig}),
       ~isNullable=false,
       ~isArray=false,
-    )}${skipIndexDefinitions}
+    )}${skippingIndexDefinitions}
 )
 ENGINE = ${tableEngine}${partitionByClause}
 ORDER BY (${orderByColumns})${ttlClause}`

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -395,9 +395,9 @@ let makeCreateHistoryTableQuery = (
     }
   })
 
-  let (partitionBy, orderBy, ttl) = switch entityConfig.storage.clickhouseOptions {
-  | Some(options) => (options.partitionBy, options.orderBy, options.ttl)
-  | None => (None, None, None)
+  let (partitionBy, orderBy, ttl, indices) = switch entityConfig.storage.clickhouseOptions {
+  | Some(options) => (options.partitionBy, options.orderBy, options.ttl, options.indices)
+  | None => (None, None, None, None)
   }
 
   // Schema field name -> ClickHouse column name, so @storage(clickhouse: {...})
@@ -461,6 +461,22 @@ let makeCreateHistoryTableQuery = (
   | None => ""
   }
 
+  // Data skipping indices live inside the column list, after the last column.
+  // GRANULARITY is omitted when unset, leaving ClickHouse's default of 1.
+  let skipIndexDefinitions = switch indices {
+  | Some(indices) =>
+    indices
+    ->Array.map(index => {
+      let granularityClause = switch index.granularity {
+      | Some(granularity) => ` GRANULARITY ${granularity->Int.toString}`
+      | None => ""
+      }
+      `,\n  INDEX \`${index.name}\` ${index.expr->resolveExpressionColumns} TYPE ${index.type_}${granularityClause}`
+    })
+    ->Array.joinUnsafe("")
+  | None => ""
+  }
+
   `CREATE TABLE IF NOT EXISTS ${database}.\`${EntityHistory.historyTableName(
       ~entityName=entityConfig.name,
       ~entityIndex=entityConfig.index,
@@ -475,7 +491,7 @@ let makeCreateHistoryTableQuery = (
       ~fieldType=Enum({config: EntityHistory.RowAction.config->Table.fromGenericEnumConfig}),
       ~isNullable=false,
       ~isArray=false,
-    )}
+    )}${skipIndexDefinitions}
 )
 ENGINE = ${tableEngine}${partitionByClause}
 ORDER BY (${orderByColumns})${ttlClause}`

--- a/scenarios/e2e_test/schema.graphql
+++ b/scenarios/e2e_test/schema.graphql
@@ -2,7 +2,12 @@
 # in introspection. Only string descriptions ("""...""" or "...") are exposed.
 
 "An ERC-20 transfer event"
-type Transfer @crossChain @storage(postgres: true, clickhouse: true) {
+type Transfer @crossChain @storage(postgres: true, clickhouse: {
+  indices: [
+    { name: "idx_from", expr: "from", type: "bloom_filter(0.01)", granularity: 4 }
+    { name: "idx_to", expr: "to", type: "bloom_filter(0.01)" }
+  ]
+}) {
   "Composite ID built from chainId-block-logIndex"
   id: ID!
   "Sender address"

--- a/scenarios/e2e_test/schema.graphql
+++ b/scenarios/e2e_test/schema.graphql
@@ -3,7 +3,7 @@
 
 "An ERC-20 transfer event"
 type Transfer @crossChain @storage(postgres: true, clickhouse: {
-  indices: [
+  skippingIndexes: [
     { name: "idx_from", expr: "from", type: "bloom_filter(0.01)", granularity: 4 }
     { name: "idx_to", expr: "to", type: "bloom_filter(0.01)" }
   ]


### PR DESCRIPTION
Implements proposal 1 (data skipping indices) from #1524.

## What

Adds a `skippingIndexes` option to the per-entity ClickHouse table options, next to `partitionBy`/`orderBy`/`ttl`:

```graphql
type Transfer @storage(
  clickhouse: {
    partitionBy: "toYYYYMM(timestamp)"
    orderBy: ["chainId", "timestamp"]
    skippingIndexes: [
      { name: "idx_from", expr: "fromAddress", type: "bloom_filter(0.01)", granularity: 4 },
      { name: "idx_to",   expr: "toAddress",   type: "bloom_filter(0.01)" }
    ]
  }
) { ... }
```

emitted into the history table DDL inside the column list:

```sql
CREATE TABLE IF NOT EXISTS db.`envio_history_Transfer` (
  ...,
  `envio_change` Enum8('SET', 'DELETE'),
  INDEX `idx_from` `from_address` TYPE bloom_filter(0.01) GRANULARITY 4,
  INDEX `idx_to` `to_address` TYPE bloom_filter(0.01)
)
ENGINE = ...
```

Design points requested in the issue, all baked in:

- **`expr` goes through `resolveExpressionColumns`** — the same rewriting `partitionBy`/`ttl` use, so schema field names work and get column renames (`column_name_format: snake_case`) and linked-entity `_id` suffixes resolved.
- **`type` is a verbatim passthrough string** — `bloom_filter(0.01)`, `set(100)`, `minmax`, `ngrambf_v1(...)` all work; nothing is hardcoded so the type can't be wrong for a given column.
- **`granularity` is optional** — omitted leaves ClickHouse's default of 1.

Validation at codegen: `name`/`expr`/`type` required non-empty strings, `name` restricted to identifier characters (it's backtick-quoted in the DDL), `granularity` a positive integer, unknown entry fields and duplicate index names rejected.

Changing `skippingIndexes` on a deployed indexer is flagged by the existing persisted-config diff (same behavior as `partitionBy`), since the DDL only applies on table creation.

## Flow

`entity_parsing.rs` (directive parse + validation) → `public_config.rs` (internal config JSON) → `Config.res` (runtime parse) → `ClickHouse.res` `makeCreateHistoryTableQuery` (DDL).

## Tests

- **User API** (`ClickHouse_test.res`): DDL generation with renamed columns and mixed granularity, plus a live round-trip — `ClickHouse.initialize` against the test ClickHouse server, asserting `system.data_skipping_indices` reports the declared indexes.
- **`UserApiValidation_test.res`**: options resolution across the public config boundary.
- **Rust** (`entity_parsing.rs`): parse shapes and all error cases; `codegen_templates.rs`: internal config JSON mirroring.
- **e2e** (`scenarios/e2e_test` + `packages/e2e-tests`): `Transfer` now declares `from`/`to` bloom-filter skipping indexes (the exact workload from #1524), asserted against the CI ClickHouse service.

Also validated the emitted DDL manually against ClickHouse 25.8 (`clickhouse local`), including the combined `PARTITION BY` + `TTL` + `INDEX` form.

## Not in scope

Proposals 2–4 from #1524 (projections, lifecycle-managed MVs, append-only view hint) — the issue's `OR`-across-columns caveat makes projections a separate design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBaviAXfeRVnk7ML24ctxa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring ClickHouse data-skipping indexes in storage options.
  * Indexes can specify a name, expression, type, and optional granularity.
  * Configured indexes are created on generated ClickHouse history tables, with schema fields resolved to database column names.

* **Bug Fixes**
  * Added validation for missing or invalid index settings, non-positive granularity, unsafe names, and duplicate index names.

* **Tests**
  * Added coverage for configuration parsing, SQL generation, serialization, and live ClickHouse index creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->