### PR TITLE
Simplify ClickHouse text column encoding and retry logic

### DIFF
--- a/packages/cli/src/clickhouse/ch_type.rs
+++ b/packages/cli/src/clickhouse/ch_type.rs
@@ -200,8 +200,7 @@ pub enum ColumnKind {
     U64 = 1,
     /// BigInt64Array.
     I64 = 2,
-    /// Concatenated text plus per-row UTF-16 lengths. Also carries the JSON of
-    /// an `Array` column.
+    /// One string per row. Also carries the JSON of an `Array` column.
     Text = 3,
 }
 

--- a/packages/cli/src/clickhouse/mock_server.rs
+++ b/packages/cli/src/clickhouse/mock_server.rs
@@ -16,6 +16,9 @@ struct State {
     accepted: Vec<Vec<u8>>,
     /// Inserts still to be rejected before the server starts accepting.
     reject_next: usize,
+    /// The body a rejection carries, which is what tells the sink whether the
+    /// rows are worth sending again.
+    rejection: String,
     /// Total inserts seen, accepted or not.
     seen: usize,
     /// Total read queries seen.
@@ -31,12 +34,20 @@ pub struct MockClickHouse {
 
 impl MockClickHouse {
     /// Serves until dropped. `reject_next` inserts fail with a 500 before the
-    /// server starts accepting.
+    /// server starts accepting, carrying a keeper exception — an error the rows
+    /// themselves are not to blame for, so the sink retries it.
     pub async fn start(reject_next: usize) -> Self {
+        Self::rejecting_with(reject_next, "Code: 999. DB::Exception: mock rejection").await
+    }
+
+    /// Rejects with `rejection` as the body, for a test that turns on how the
+    /// sink reads the server's verdict.
+    pub async fn rejecting_with(reject_next: usize, rejection: &str) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let url = format!("http://{}", listener.local_addr().unwrap());
         let state = Arc::new(Mutex::new(State {
             reject_next,
+            rejection: rejection.to_string(),
             ..Default::default()
         }));
 
@@ -158,21 +169,20 @@ async fn serve(mut stream: TcpStream, state: Arc<Mutex<State>>) -> std::io::Resu
         let is_insert = request_line.contains("INSERT");
 
         let response = if is_insert {
-            let reject = {
+            let rejection = {
                 let mut state = state.lock().unwrap();
                 state.seen += 1;
                 if state.reject_next > 0 {
                     state.reject_next -= 1;
-                    true
+                    Some(state.rejection.clone())
                 } else {
                     state.accepted.push(body.clone());
-                    false
+                    None
                 }
             };
-            if reject {
-                http_response(500, "Code: 999. DB::Exception: mock rejection")
-            } else {
-                http_response(200, "")
+            match rejection {
+                Some(rejection) => http_response(500, &rejection),
+                None => http_response(200, ""),
             }
         } else {
             state.lock().unwrap().queries += 1;

--- a/packages/cli/src/clickhouse/mod.rs
+++ b/packages/cli/src/clickhouse/mod.rs
@@ -381,11 +381,7 @@ impl ClickHouseSink {
         entities: Vec<u32>,
         checkpoints: Option<u32>,
     ) -> napi::Result<()> {
-        let mut handles = entities;
-        handles.extend(checkpoints);
-        let mut staged = self.take_staged(&handles).map_err(to_napi)?;
-        // Taken last above, so it comes off the end.
-        let checkpoints = checkpoints.and_then(|_| staged.pop());
+        let (staged, checkpoints) = self.take_staged(&entities, checkpoints).map_err(to_napi)?;
 
         futures_util::future::try_join_all(
             staged.into_iter().map(|staged| self.insert_staged(staged)),
@@ -438,19 +434,33 @@ impl ClickHouseSink {
     }
 
     /// Removes every handle from the staging map before any of them is sent, so
-    /// an unknown handle cannot leave the batches beside it stranded there.
-    fn take_staged(&self, handles: &[u32]) -> Result<Vec<Staged>> {
-        let taken: Vec<Option<Staged>> = {
+    /// an unknown handle cannot leave the batches beside it stranded there. The
+    /// checkpoints come back separately because they are sent separately —
+    /// after the rows they cover.
+    fn take_staged(
+        &self,
+        entities: &[u32],
+        checkpoints: Option<u32>,
+    ) -> Result<(Vec<Staged>, Option<Staged>)> {
+        let (entities, checkpoints) = {
             let mut staged = self.staged.lock().unwrap();
-            handles.iter().map(|handle| staged.remove(handle)).collect()
+            let entities: Vec<(u32, Option<Staged>)> = entities
+                .iter()
+                .map(|&handle| (handle, staged.remove(&handle)))
+                .collect();
+            let checkpoints = checkpoints.map(|handle| (handle, staged.remove(&handle)));
+            (entities, checkpoints)
         };
-        taken
-            .into_iter()
-            .zip(handles)
-            .map(|(staged, handle)| {
-                staged.with_context(|| format!("Unknown staged ClickHouse batch {handle}"))
-            })
-            .collect()
+        let found = |(handle, staged): (u32, Option<Staged>)| {
+            staged.with_context(|| format!("Unknown staged ClickHouse batch {handle}"))
+        };
+        Ok((
+            entities
+                .into_iter()
+                .map(found)
+                .collect::<Result<Vec<_>>>()?,
+            checkpoints.map(found).transpose()?,
+        ))
     }
 
     /// Statements go in the body rather than the query string: DDL runs long and

--- a/packages/cli/src/clickhouse/mod.rs
+++ b/packages/cli/src/clickhouse/mod.rs
@@ -27,20 +27,21 @@ pub mod ch_type;
 mod mock_server;
 pub mod row_binary;
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
-use napi::bindgen_prelude::{BigInt64Array, BigUint64Array, Float64Array, Uint32Array, Uint8Array};
+use napi::bindgen_prelude::{BigInt64Array, BigUint64Array, Float64Array, Uint8Array};
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi::{Env, Status};
 use napi_derive::napi;
 
 use ch_type::{ChType, ColumnKind};
-use row_binary::{Column, EncodedRows, StagedValues};
+use row_binary::{Column, ColumnValues, EncodedRows};
 
 /// Retries an insert this many times before giving up, matching the JS client's
 /// policy: halve the batch while more than one row remains, otherwise wait.
@@ -133,12 +134,8 @@ pub struct ColumnValuesInput {
     pub unsigned64: Option<BigUint64Array>,
     /// Int64.
     pub signed64: Option<BigInt64Array>,
-    /// String, Decimal, Enum, and the JSON of an Array column: every value
-    /// concatenated, split by `lengths`.
-    pub text: Option<String>,
-    /// UTF-16 code-unit length of each value in `text` — a JS string's own
-    /// `.length`, so the caller never has to measure UTF-8.
-    pub lengths: Option<Uint32Array>,
+    /// String, Decimal, Enum, and the JSON of an Array column.
+    pub texts: Option<Vec<String>>,
     /// `1` marks a NULL. Omitted when the column has none.
     pub nulls: Option<Uint8Array>,
 }
@@ -162,7 +159,7 @@ struct TableSchema {
 /// One column's staged values, owned by Rust so they can leave the JS thread.
 /// The name and type live in the table's schema rather than being re-sent.
 struct StagedColumnValues {
-    values: StagedValues,
+    values: ColumnValues,
     nulls: Vec<u8>,
 }
 
@@ -330,34 +327,21 @@ impl ClickHouseSink {
                 numbers,
                 unsigned64,
                 signed64,
-                text,
-                lengths,
+                texts,
                 nulls,
             } = column;
             let name = &spec.name;
-            let values = match (numbers, unsigned64, signed64, text) {
-                (Some(v), None, None, None) => StagedValues::F64(v.to_vec()),
-                (None, Some(v), None, None) => StagedValues::U64(v.to_vec()),
-                (None, None, Some(v), None) => StagedValues::I64(v.to_vec()),
-                (None, None, None, Some(data)) => {
-                    let lengths = lengths.ok_or_else(|| {
-                        napi::Error::from_reason(format!(
-                            "Column `{name}` carries text without per-row lengths"
-                        ))
-                    })?;
-                    StagedValues::Text {
-                        data,
-                        utf16_lengths: lengths.to_vec(),
-                    }
-                }
+            let values = match (numbers, unsigned64, signed64, texts) {
+                (Some(v), None, None, None) => ColumnValues::F64(v.to_vec()),
+                (None, Some(v), None, None) => ColumnValues::U64(v.to_vec()),
+                (None, None, Some(v), None) => ColumnValues::I64(v.to_vec()),
+                (None, None, None, Some(v)) => ColumnValues::Text(v),
                 _ => {
                     return Err(napi::Error::from_reason(format!(
-                        "Column `{name}` must carry exactly one of numbers/unsigned64/signed64/text"
-                    )))
+                    "Column `{name}` must carry exactly one of numbers/unsigned64/signed64/texts"
+                )))
                 }
             };
-            // Checked against the registered type, so a column sent as the wrong
-            // kind is caught before its text is scanned for span boundaries.
             let staged_kind = values.kind();
             if staged_kind != spec.kind {
                 return Err(napi::Error::from_reason(format!(
@@ -429,7 +413,10 @@ impl ClickHouseSink {
     /// Runs a statement that returns nothing — the DDL and the reorg cleanup.
     #[napi]
     pub async fn exec(&self, query: String) -> napi::Result<()> {
-        self.post_statement(query).await.map(|_| ()).map_err(to_napi)
+        self.post_statement(query)
+            .await
+            .map(|_| ())
+            .map_err(to_napi)
     }
 
     /// Runs a statement and hands back the server's response body verbatim, so
@@ -488,68 +475,84 @@ impl ClickHouseSink {
     }
 
     async fn insert_staged(&self, staged: Staged) -> Result<()> {
-        let schema = staged.schema;
-        let table = &schema.table;
-        let encoded = tokio::task::block_in_place(|| {
-            let columns = schema
+        let Staged {
+            schema,
+            rows,
+            columns,
+        } = staged;
+        // On the blocking pool rather than in place: `write_batch` drives every
+        // table's insert from one task, and blocking that task would serialize
+        // the encodes and stall the round trips already in flight beside them.
+        let encode_schema = schema.clone();
+        let encoded = tokio::task::spawn_blocking(move || {
+            let columns: Vec<Column> = encode_schema
                 .columns
                 .iter()
-                .zip(staged.columns)
-                .map(|(spec, values)| {
-                    Ok(Column {
-                        name: spec.name.clone(),
-                        ch_type: spec.ch_type.clone(),
-                        values: values
-                            .values
-                            .resolve()
-                            .with_context(|| format!("Column `{}`", spec.name))?,
-                        nulls: values.nulls,
-                    })
+                .zip(columns)
+                .map(|(spec, values)| Column {
+                    name: Cow::Borrowed(&spec.name),
+                    ch_type: Cow::Borrowed(&spec.ch_type),
+                    values: values.values,
+                    nulls: values.nulls,
                 })
-                .collect::<Result<Vec<_>>>()?;
-            row_binary::encode(&columns, staged.rows)
+                .collect();
+            row_binary::encode(&columns, rows)
         })
-        .with_context(|| format!("Failed encoding rows for ClickHouse table `{table}`"))?;
+        .await
+        .context("ClickHouse encode task failed")?
+        .with_context(|| {
+            format!(
+                "Failed encoding rows for ClickHouse table `{}`",
+                schema.table
+            )
+        })?;
         if encoded.rows() == 0 {
             return Ok(());
         }
-        self.insert_with_retry(table, &schema.insert_query, &encoded)
+        self.insert_with_retry(&schema.table, &schema.insert_query, &encoded)
             .await
     }
 
-    /// Mirrors the JS client's policy: on a transient failure halve the range and
-    /// retry each half; with a single row left, wait and retry it. The delay
-    /// grows from 100ms to 1s as retries run down.
+    /// Halves a failed range and retries each half; with a single row left, waits
+    /// and retries it. The delay grows from 100ms to 1s as retries run down.
+    ///
+    /// Only a failure another attempt could answer differently is retried. A
+    /// server that read the rows and rejected them gives the same verdict however
+    /// few of them come back, so retrying one costs a batch's worth of doomed
+    /// requests and every backoff between them before the error surfaces.
     async fn insert_with_retry(
         &self,
         table: &str,
         query: &str,
         encoded: &EncodedRows,
     ) -> Result<()> {
-        let mut attempted: Vec<String> = Vec::new();
+        let mut failures = 0usize;
         // Ranges still to send, most recent first; a failed range is replaced by
         // its two halves so the retry never re-sends rows that already landed.
         let mut pending = vec![(0usize, encoded.rows(), self.tuning.attempts)];
         while let Some((start, end, retries)) = pending.pop() {
             match self.post_rows(query, encoded.slice(start, end)).await {
                 Ok(()) => continue,
-                Err(err) if retries == 0 => {
-                    // The attempts leading here are the diagnosis; returning the
-                    // last error alone would drop them.
-                    return Err(match attempted.is_empty() {
-                        true => err,
-                        false => err.context(format!("after {}", attempted.join("; "))),
+                Err(failure) if retries == 0 || !failure.retriable => {
+                    // Every attempt behind this one already left through `warn`
+                    // as it happened; what the terminal error still owes the
+                    // reader is how many there were.
+                    return Err(match failures {
+                        0 => failure.error,
+                        n => failure
+                            .error
+                            .context(format!("after {n} failed attempt(s)")),
                     });
                 }
-                Err(err) => {
+                Err(failure) => {
+                    failures += 1;
                     let rows = end - start;
-                    let warning = format!(
+                    (self.warn)(&format!(
                         "ClickHouse insert of {rows} row(s) into `{table}` failed, \
-                         {} retries left: {err:#}",
-                        retries - 1
-                    );
-                    (self.warn)(&warning);
-                    attempted.push(warning);
+                         {} retries left: {:#}",
+                        retries - 1,
+                        failure.error
+                    ));
                     tokio::time::sleep(self.tuning.delay(retries)).await;
                     if rows > 1 {
                         let mid = start + rows / 2;
@@ -564,8 +567,8 @@ impl ClickHouseSink {
         Ok(())
     }
 
-    async fn post_rows(&self, query: &str, body: Bytes) -> Result<()> {
-        let response = self
+    async fn post_rows(&self, query: &str, body: Bytes) -> std::result::Result<(), InsertFailure> {
+        let request = self
             .client
             .post(&self.url)
             .query(&[("query", query), ("database", &self.database)])
@@ -575,17 +578,76 @@ impl ClickHouseSink {
             // sent. `@clickhouse/client` authenticated this way too.
             .basic_auth(&self.username, Some(&self.password))
             .header("Content-Type", "application/octet-stream")
-            .body(body)
-            .send()
-            .await
-            .context("ClickHouse insert request failed")?;
+            .body(body);
+        let response = match request.send().await {
+            Ok(response) => response,
+            // The request never reached a verdict, so nothing about the rows has
+            // been decided and another attempt is worth making.
+            Err(err) => {
+                return Err(InsertFailure {
+                    error: anyhow::Error::new(err).context("ClickHouse insert request failed"),
+                    retriable: true,
+                })
+            }
+        };
         let status = response.status();
-        if !status.is_success() {
-            let text = response.text().await.unwrap_or_default();
-            bail!("ClickHouse returned {status}: {text}");
+        if status.is_success() {
+            return Ok(());
         }
-        Ok(())
+        let text = response.text().await.unwrap_or_default();
+        Err(InsertFailure {
+            retriable: is_retriable(status, &text),
+            error: anyhow!("ClickHouse returned {status}: {text}"),
+        })
     }
+}
+
+/// A failed insert, and whether another attempt could answer differently.
+struct InsertFailure {
+    error: anyhow::Error,
+    retriable: bool,
+}
+
+/// ClickHouse error codes worth another attempt: the server was busy, lost a
+/// peer, or could not say what happened — none of which is a verdict on the rows.
+/// Whitelisted rather than blacklisted so a code nobody has thought about ends a
+/// write with the server's own message instead of a batch's worth of doomed
+/// requests.
+const RETRIABLE_ERROR_CODES: &[u32] = &[
+    159,  // TIMEOUT_EXCEEDED
+    202,  // TOO_MANY_SIMULTANEOUS_QUERIES
+    203,  // NO_FREE_CONNECTION
+    209,  // SOCKET_TIMEOUT
+    210,  // NETWORK_ERROR
+    241,  // MEMORY_LIMIT_EXCEEDED — the one the halving is actually for
+    252,  // TOO_MANY_PARTS
+    285,  // TOO_FEW_LIVE_REPLICAS
+    319,  // UNKNOWN_STATUS_OF_INSERT
+    425,  // SYSTEM_ERROR
+    999,  // KEEPER_EXCEPTION
+    1002, // UNKNOWN_EXCEPTION
+];
+
+fn is_retriable(status: reqwest::StatusCode, body: &str) -> bool {
+    match clickhouse_error_code(body) {
+        Some(code) => RETRIABLE_ERROR_CODES.contains(&code),
+        // No ClickHouse verdict in the body, so something in front of it
+        // answered — a proxy or load balancer — and only its status says
+        // whether the rows ever got as far as being judged.
+        None => status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS,
+    }
+}
+
+/// The `N` of the `Code: N. DB::Exception: ...` a ClickHouse error body opens
+/// with.
+fn clickhouse_error_code(body: &str) -> Option<u32> {
+    let digits: String = body
+        .split_once("Code: ")?
+        .1
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
 }
 
 /// Names every column the body carries, so the table's own column order stops
@@ -623,21 +685,12 @@ mod tests {
         }
     }
 
-    /// Text values packed the way the JS side sends them: one concatenated
-    /// string plus each value's UTF-16 length.
     fn text_values(values: &[&str]) -> ColumnValuesInput {
         ColumnValuesInput {
             numbers: None,
             unsigned64: None,
             signed64: None,
-            text: Some(values.concat()),
-            lengths: Some(
-                values
-                    .iter()
-                    .map(|v| v.chars().map(char::len_utf16).sum::<usize>() as u32)
-                    .collect::<Vec<u32>>()
-                    .into(),
-            ),
+            texts: Some(values.iter().map(|v| v.to_string()).collect()),
             nulls: None,
         }
     }
@@ -825,6 +878,33 @@ mod tests {
             ),
             (true, Vec::<String>::new()),
             "expected the server's message, got: {}",
+            err.reason
+        );
+    }
+
+    // Halving a batch is for a server that could not take the rows, not for one
+    // that read them and said no: a verdict on the rows themselves is the same
+    // verdict however few of them are sent again.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_rejection_the_rows_are_to_blame_for_is_not_retried() {
+        let server = mock_server::MockClickHouse::rejecting_with(
+            usize::MAX,
+            "Code: 60. DB::Exception: Table mock.t does not exist",
+        )
+        .await;
+        let sink = sink_for(&server, 8);
+        let handle = stage_ids(&sink, &["a", "b", "c", "d"]);
+
+        let err = write(&sink, handle).await.unwrap_err();
+
+        assert_eq!(
+            (
+                err.reason.contains("does not exist"),
+                server.inserts_seen(),
+                sink.warnings()
+            ),
+            (true, 1, Vec::<String>::new()),
+            "expected one attempt and the server's message, got: {}",
             err.reason
         );
     }

--- a/packages/cli/src/clickhouse/row_binary.rs
+++ b/packages/cli/src/clickhouse/row_binary.rs
@@ -200,6 +200,19 @@ fn put_int_raw(out: &mut Vec<u8>, value: i128, bytes: usize) {
     out.extend_from_slice(&value.to_le_bytes()[..bytes]);
 }
 
+/// `10^i` for every precision a `Decimal` column can declare — 38 digits being
+/// where envio falls back to `String`. Tabulated because the bound is worked out
+/// again for every value the column carries.
+const POW10: [i128; 39] = {
+    let mut table = [1i128; 39];
+    let mut i = 1;
+    while i < table.len() {
+        table[i] = table[i - 1] * 10;
+        i += 1;
+    }
+    table
+};
+
 /// What the column accepts. RowBinary is just the raw integer, so nothing on the
 /// server side rejects an out-of-range value: it wraps into whatever the bytes
 /// happen to mean. The JSONEachRow path this replaced had ClickHouse do the
@@ -215,8 +228,8 @@ fn int_bounds(ch_type: &ChType) -> Result<(i128, i128)> {
         ChType::DateTime64 { .. } => (i64::MIN as i128, i64::MAX as i128),
         // A Decimal's precision, not its byte width, is what it accepts.
         ChType::Decimal { precision, .. } => {
-            let limit = 10i128
-                .checked_pow(*precision)
+            let limit = POW10
+                .get(*precision as usize)
                 .context("Decimal precision is wider than the value the encoder carries")?;
             (1 - limit, limit - 1)
         }
@@ -394,6 +407,11 @@ fn encode_cell(out: &mut Vec<u8>, column: &Column, row: usize) -> Result<()> {
         (ColumnValues::U64(v), ChType::Float64) => {
             out.extend_from_slice(&(v[row] as f64).to_le_bytes())
         }
+        // Straight through: the column's range is the wire type's own, so the
+        // bounds check below could only ever pass. Every history row carries a
+        // UInt64 checkpoint id, which makes this the most travelled arm here.
+        (ColumnValues::U64(v), ChType::UInt64) => out.extend_from_slice(&v[row].to_le_bytes()),
+        (ColumnValues::I64(v), ChType::Int64) => out.extend_from_slice(&v[row].to_le_bytes()),
         (ColumnValues::U64(v), other) => put_int(out, v[row] as i128, other)?,
         (ColumnValues::I64(v), other) => put_int(out, v[row] as i128, other)?,
         (ColumnValues::Text { .. }, ChType::Array(_)) => {
@@ -744,9 +762,9 @@ mod tests {
         );
     }
 
-    // A null element for a non-nullable inner type used to be rendered as the
-    // text "null" — stored verbatim in an Array(String), and an unrelated parse
-    // error anywhere else.
+    // A null has no representation in a non-nullable element, so it has to be
+    // refused rather than rendered: the text "null" would store verbatim in an
+    // Array(String) and mean nothing anywhere else.
     #[test]
     fn rejects_a_null_element_for_a_non_nullable_inner_type() {
         let strings =
@@ -774,8 +792,8 @@ mod tests {
         assert_eq!(encoded.body, expected);
     }
 
-    // A JSON element of the wrong shape used to be coerced — a bool became 0.0
-    // for a Float64, an object became its own JSON text for a String.
+    // An element the column's type has no room for is refused rather than
+    // coerced: a bool is not a Float64, and an object is not a String.
     #[test]
     fn rejects_an_element_of_the_wrong_json_shape() {
         let err = encode(&[text_column("xs", "Array(Float64)", &["[true]"])], 1).unwrap_err();

--- a/packages/cli/src/clickhouse/row_binary.rs
+++ b/packages/cli/src/clickhouse/row_binary.rs
@@ -2,8 +2,9 @@
 //!
 //! RowBinary is row-major, so the encoder walks the columns once per row. Values
 //! arrive columnar because that is what crosses the napi boundary cheaply: one
-//! typed array or one concatenated string per column, instead of a JS object per
-//! row.
+//! typed array or one string array per column, instead of a JS object per row.
+
+use std::borrow::Cow;
 
 use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
@@ -11,147 +12,64 @@ use bytes::Bytes;
 use super::ch_type::ChType;
 use super::ch_type::ColumnKind;
 
-/// One column's values as they arrive from JS. A text column crosses as every
-/// value concatenated plus each value's UTF-16 code-unit length, which JS
-/// measures for free; resolving those to byte ranges is a scan over the whole
-/// column and belongs off the JS thread.
-#[derive(Debug)]
-pub enum StagedValues {
-    F64(Vec<f64>),
-    U64(Vec<u64>),
-    I64(Vec<i64>),
-    Text {
-        data: String,
-        utf16_lengths: Vec<u32>,
-    },
-}
-
-/// The same values with each text value resolved to its byte range.
+/// One column's values as they arrive from JS. Text crosses as one JS string per
+/// value: napi converts each to UTF-8 as it reads it, which is the same work a
+/// single concatenated string would pay for, minus the concatenation itself and
+/// the ceiling V8 puts on how long one string may be.
 #[derive(Debug)]
 pub enum ColumnValues {
     F64(Vec<f64>),
     U64(Vec<u64>),
     I64(Vec<i64>),
-    Text {
-        data: String,
-        spans: Vec<(usize, usize)>,
-    },
+    Text(Vec<String>),
 }
 
-impl StagedValues {
+impl ColumnValues {
     /// The wire kind these values arrived as, for checking against the column's
     /// ClickHouse type.
     pub fn kind(&self) -> ColumnKind {
         match self {
-            StagedValues::F64(_) => ColumnKind::F64,
-            StagedValues::U64(_) => ColumnKind::U64,
-            StagedValues::I64(_) => ColumnKind::I64,
-            StagedValues::Text { .. } => ColumnKind::Text,
+            ColumnValues::F64(_) => ColumnKind::F64,
+            ColumnValues::U64(_) => ColumnKind::U64,
+            ColumnValues::I64(_) => ColumnKind::I64,
+            ColumnValues::Text(_) => ColumnKind::Text,
         }
     }
 
-    /// Resolves the UTF-16 lengths into byte spans. The only step between the two
-    /// representations, so it is also where a text column's shape is checked.
-    pub fn resolve(self) -> Result<ColumnValues> {
-        Ok(match self {
-            StagedValues::F64(v) => ColumnValues::F64(v),
-            StagedValues::U64(v) => ColumnValues::U64(v),
-            StagedValues::I64(v) => ColumnValues::I64(v),
-            StagedValues::Text {
-                data,
-                utf16_lengths,
-            } => {
-                let spans = spans_from_utf16_lengths(&data, &utf16_lengths)?;
-                ColumnValues::Text { data, spans }
-            }
-        })
-    }
-}
-
-impl ColumnValues {
     pub fn len(&self) -> usize {
         match self {
             ColumnValues::F64(v) => v.len(),
             ColumnValues::U64(v) => v.len(),
             ColumnValues::I64(v) => v.len(),
-            ColumnValues::Text { spans, .. } => spans.len(),
+            ColumnValues::Text(v) => v.len(),
         }
     }
 
     fn text_at(&self, row: usize) -> Result<&str> {
         match self {
-            ColumnValues::Text { data, spans } => {
-                let (start, end) = spans[row];
-                Ok(&data[start..end])
-            }
+            ColumnValues::Text(values) => Ok(&values[row]),
             other => bail!("expected a text column, got {other:?}"),
         }
     }
 }
 
+/// Borrowed from the registered table's schema, which outlives the encode: a
+/// column's name and type are fixed at registration, so a batch has no reason to
+/// copy them — and an `Enum`'s variant list is the whole table's worth of
+/// strings.
 #[derive(Debug)]
-pub struct Column {
-    pub name: String,
-    pub ch_type: ChType,
+pub struct Column<'a> {
+    pub name: Cow<'a, str>,
+    pub ch_type: Cow<'a, ChType>,
     pub values: ColumnValues,
     /// `1` marks a NULL. Empty when the column has none.
     pub nulls: Vec<u8>,
 }
 
-impl Column {
+impl Column<'_> {
     fn is_null(&self, row: usize) -> bool {
         self.nulls.get(row).copied().unwrap_or(0) != 0
     }
-}
-
-/// Splits a concatenated column into per-value byte spans using each value's
-/// UTF-16 code-unit length, which is what a JS string reports as `.length`.
-///
-/// The scan is over UTF-8 bytes, so it cannot index by code unit directly:
-/// a character outside the BMP is two UTF-16 units and up to four UTF-8 bytes.
-pub fn spans_from_utf16_lengths(data: &str, lengths: &[u32]) -> Result<Vec<(usize, usize)>> {
-    let mut spans = Vec::with_capacity(lengths.len());
-    let bytes = data.as_bytes();
-    let mut offset = 0usize;
-    for (row, &len) in lengths.iter().enumerate() {
-        let start = offset;
-        let mut remaining = len as usize;
-        while remaining > 0 {
-            if offset >= bytes.len() {
-                bail!(
-                    "column text ran out at row {row}: expected {len} more UTF-16 units, \
-                     buffer is {} bytes",
-                    bytes.len()
-                );
-            }
-            let b = bytes[offset];
-            // Leading-byte pattern gives the character's UTF-8 width; only a
-            // 4-byte sequence is a surrogate pair, i.e. two UTF-16 units.
-            let (width, units) = if b < 0x80 {
-                (1, 1)
-            } else if b < 0xE0 {
-                (2, 1)
-            } else if b < 0xF0 {
-                (3, 1)
-            } else {
-                (4, 2)
-            };
-            if units > remaining {
-                bail!("column text row {row} splits a surrogate pair");
-            }
-            offset += width;
-            remaining -= units;
-        }
-        spans.push((start, offset));
-    }
-    if offset != bytes.len() {
-        bail!(
-            "column text has {} trailing bytes after {} rows",
-            bytes.len() - offset,
-            lengths.len()
-        );
-    }
-    Ok(spans)
 }
 
 fn put_varint(out: &mut Vec<u8>, mut value: u64) {
@@ -444,7 +362,7 @@ fn put_default(out: &mut Vec<u8>, ch_type: &ChType) -> Result<()> {
 }
 
 fn encode_cell(out: &mut Vec<u8>, column: &Column, row: usize) -> Result<()> {
-    let (ch_type, is_nullable) = match &column.ch_type {
+    let (ch_type, is_nullable) = match column.ch_type.as_ref() {
         ChType::Nullable(inner) => {
             if column.is_null(row) {
                 out.push(1);
@@ -463,13 +381,6 @@ fn encode_cell(out: &mut Vec<u8>, column: &Column, row: usize) -> Result<()> {
     }
 
     match (&column.values, ch_type) {
-        (ColumnValues::F64(v), ChType::Bool) => {
-            let value = v[row];
-            if !value.is_finite() {
-                bail!("{value} is not a value a Bool column can hold");
-            }
-            out.push(u8::from(value != 0.0))
-        }
         (ColumnValues::F64(v), ChType::Float64) => out.extend_from_slice(&v[row].to_le_bytes()),
         (ColumnValues::F64(v), other) => {
             let value = v[row];
@@ -558,49 +469,33 @@ mod tests {
     use crate::clickhouse::ch_type;
     use pretty_assertions::assert_eq;
 
-    fn text_column(name: &str, ty: &str, values: &[&str]) -> Column {
-        let data: String = values.concat();
-        let lengths: Vec<u32> = values
-            .iter()
-            .map(|v| v.chars().map(char::len_utf16).sum::<usize>() as u32)
-            .collect();
+    fn owned_column(name: &str, ty: &str, values: ColumnValues) -> Column<'static> {
         Column {
-            name: name.to_string(),
-            ch_type: ch_type::parse(ty).unwrap(),
-            values: ColumnValues::Text {
-                spans: spans_from_utf16_lengths(&data, &lengths).unwrap(),
-                data,
-            },
+            name: Cow::Owned(name.to_string()),
+            ch_type: Cow::Owned(ch_type::parse(ty).unwrap()),
+            values,
             nulls: Vec::new(),
         }
     }
 
-    fn f64_column(name: &str, ty: &str, values: &[f64]) -> Column {
-        Column {
-            name: name.to_string(),
-            ch_type: ch_type::parse(ty).unwrap(),
-            values: ColumnValues::F64(values.to_vec()),
-            nulls: Vec::new(),
-        }
+    fn text_column(name: &str, ty: &str, values: &[&str]) -> Column<'static> {
+        owned_column(
+            name,
+            ty,
+            ColumnValues::Text(values.iter().map(|v| v.to_string()).collect()),
+        )
     }
 
-    #[test]
-    fn spans_handle_multi_byte_and_surrogate_pairs() {
-        // "é" is 1 UTF-16 unit / 2 UTF-8 bytes, "😀" is 2 units / 4 bytes.
-        let data = "aé😀b".to_string();
-        let spans = spans_from_utf16_lengths(&data, &[1, 1, 2, 1]).unwrap();
-        let values: Vec<&str> = spans.iter().map(|(s, e)| &data[*s..*e]).collect();
-        assert_eq!(values, vec!["a", "é", "😀", "b"]);
+    fn f64_column(name: &str, ty: &str, values: &[f64]) -> Column<'static> {
+        owned_column(name, ty, ColumnValues::F64(values.to_vec()))
     }
 
+    // The varint length prefix counts UTF-8 bytes, which is not the length JS
+    // reports for anything outside Latin-1.
     #[test]
-    fn spans_reject_a_length_that_overruns_the_buffer() {
-        assert!(spans_from_utf16_lengths("ab", &[3]).is_err());
-    }
-
-    #[test]
-    fn spans_reject_trailing_bytes() {
-        assert!(spans_from_utf16_lengths("abc", &[1]).is_err());
+    fn encodes_multi_byte_characters_by_their_utf8_length() {
+        let encoded = encode(&[text_column("id", "String", &["é😀"])], 1).unwrap();
+        assert_eq!(encoded.body, "\u{6}é😀".as_bytes());
     }
 
     #[test]
@@ -660,12 +555,11 @@ mod tests {
 
     #[test]
     fn encodes_uint64_beyond_float_precision_exactly() {
-        let column = Column {
-            name: "checkpoint".to_string(),
-            ch_type: ch_type::parse("UInt64").unwrap(),
-            values: ColumnValues::U64(vec![u64::MAX - 1]),
-            nulls: Vec::new(),
-        };
+        let column = owned_column(
+            "checkpoint",
+            "UInt64",
+            ColumnValues::U64(vec![u64::MAX - 1]),
+        );
         let encoded = encode(&[column], 1).unwrap();
         assert_eq!(encoded.body, (u64::MAX - 1).to_le_bytes().to_vec());
     }
@@ -747,6 +641,17 @@ mod tests {
         );
     }
 
+    // The same policy as the array element above: a scalar Bool has no more room
+    // for a 7 than one inside an `Array(Bool)` does.
+    #[test]
+    fn rejects_a_scalar_number_a_bool_column_cannot_hold() {
+        let err = encode(&[f64_column("flag", "Bool", &[7.0])], 1).unwrap_err();
+        assert_eq!(
+            format!("{err:#}"),
+            "encoding column `flag` row 0: 7 is out of range for a Bool column"
+        );
+    }
+
     // Every other non-numeric text is refused, so an empty one must be too —
     // storing 0 for it would silently invent a value the handler never wrote.
     #[test]
@@ -766,7 +671,7 @@ mod tests {
         let err = encode(&[f64_column("flag", "Bool", &[f64::NAN])], 1).unwrap_err();
         assert_eq!(
             format!("{err:#}"),
-            "encoding column `flag` row 0: NaN is not a value a Bool column can hold"
+            "encoding column `flag` row 0: NaN is not an integer, which a Bool column requires"
         );
     }
 

--- a/packages/cli/src/mock_hypersync_server.rs
+++ b/packages/cli/src/mock_hypersync_server.rs
@@ -144,7 +144,11 @@ impl Drop for MockHyperSyncServer {
     }
 }
 
-async fn serve(listener: StdTcpListener, state: Arc<Mutex<State>>, shutdown: watch::Receiver<bool>) {
+async fn serve(
+    listener: StdTcpListener,
+    state: Arc<Mutex<State>>,
+    shutdown: watch::Receiver<bool>,
+) {
     let listener = match tokio::net::TcpListener::from_std(listener) {
         Ok(listener) => listener,
         Err(e) => {
@@ -248,8 +252,13 @@ async fn handle_connection(
                     // instead of with a page: rate limiting and
                     // payload-too-large are statuses the client acts on.
                     Some(raw) => {
-                        write_response_with(&mut stream, raw.status, &raw.headers, raw.body.as_bytes())
-                            .await?
+                        write_response_with(
+                            &mut stream,
+                            raw.status,
+                            &raw.headers,
+                            raw.body.as_bytes(),
+                        )
+                        .await?
                     }
                     None => {
                         let page = serde_json::from_str(&request.body)
@@ -297,7 +306,10 @@ fn raw_reply(spec: &Value) -> Option<RawReply> {
                 .map(|(name, value)| {
                     (
                         name.clone(),
-                        value.as_str().map(str::to_string).unwrap_or_else(|| value.to_string()),
+                        value
+                            .as_str()
+                            .map(str::to_string)
+                            .unwrap_or_else(|| value.to_string()),
                     )
                 })
                 .collect()
@@ -426,7 +438,8 @@ fn build_page(spec: Option<&Value>, query: &Value, height: u64) -> Result<Vec<u8
 
     let mut message = capnp::message::Builder::new_default();
     {
-        let mut response = message.init_root::<hypersync_net_types_capnp::query_response::Builder>();
+        let mut response =
+            message.init_root::<hypersync_net_types_capnp::query_response::Builder>();
         response.set_archive_height(archive_height);
         response.set_next_block(next_block);
         response.set_total_execution_time(0);
@@ -579,8 +592,8 @@ fn encode_table(rows: Option<&Value>, kind_of: fn(&str) -> Result<Kind>) -> Resu
     for name in &names {
         let kind = kind_of(name).with_context(|| format!("column '{name}'"))?;
         let values = rows.iter().map(|row| row.get(name));
-        let (data_type, array) = build_column(kind, values)
-            .with_context(|| format!("column '{name}'"))?;
+        let (data_type, array) =
+            build_column(kind, values).with_context(|| format!("column '{name}'"))?;
         fields.push(Field::new(name, data_type, true));
         columns.push(array);
     }
@@ -789,7 +802,10 @@ mod tests {
                 decoded.blocks[0].timestamp.as_ref().map(Hex::encode_hex),
                 decoded.logs[0].log_index.map(u64::from),
                 decoded.logs[0].address.as_ref().map(Hex::encode_hex),
-                decoded.transactions[0].gas_used.as_ref().map(Hex::encode_hex),
+                decoded.transactions[0]
+                    .gas_used
+                    .as_ref()
+                    .map(Hex::encode_hex),
             ),
             (
                 Some(10),

--- a/packages/envio-tests/test/lib_tests/ClickHouseColumnKind_test.res
+++ b/packages/envio-tests/test/lib_tests/ClickHouseColumnKind_test.res
@@ -67,12 +67,16 @@ let fieldTypes =
   ->Array.map(samples)
   ->Array.flat
 
-// Every shape the DDL can wrap a base type in.
-let everyEmittedType = fieldTypes->Array.flatMap(fieldType =>
-  [(false, false), (true, false), (false, true)]->Array.map(((isNullable, isArray)) =>
-    ClickHouse.getClickHouseFieldType(~fieldType, ~isNullable, ~isArray)
+// Every shape the DDL can wrap a base type in, nullable array included: a
+// nullable list field emits `Nullable(Array(T))`, which nests the two wrappers
+// the parser handles separately.
+let everyEmittedType =
+  fieldTypes->Array.flatMap(fieldType =>
+    [(false, false), (true, false), (false, true), (true, true)]->Array.map(((
+      isNullable,
+      isArray,
+    )) => ClickHouse.getClickHouseFieldType(~fieldType, ~isNullable, ~isArray))
   )
-)
 
 // Registration parses the types it is given and never reaches the server, so
 // none of this needs a ClickHouse behind it.
@@ -94,11 +98,12 @@ let register = chTypes =>
 
 describe("ClickHouse column type contract", () => {
   it("Rust parses every type the DDL emits", t => {
-    let failed = everyEmittedType->Array.filter(chType =>
-      switch register([chType]) {
-      | _ => false
-      | exception _ => true
-      }
+    let failed = everyEmittedType->Array.filter(
+      chType =>
+        switch register([chType]) {
+        | _ => false
+        | exception _ => true
+        },
     )
     t.expect(failed).toEqual([])
   })

--- a/packages/envio-tests/test/lib_tests/ClickHouse_test.res
+++ b/packages/envio-tests/test/lib_tests/ClickHouse_test.res
@@ -165,6 +165,17 @@ describe("databaseEngineName", () => {
   })
 })
 
+// The ClickHouse checkpoints columns are declared separately from the Postgres
+// ones, so a column added to `InternalTable.Checkpoints` reaches Postgres
+// automatically and ClickHouse not at all — with both sides self-consistent,
+// nothing else would report the omission.
+describe("ClickHouse checkpoints columns", () => {
+  Async.it("cover every column the checkpoints table declares, in its order", async t => {
+    let declared = InternalTable.Checkpoints.table.fields->Array.map(Table.getUserDefinedFieldName)
+    t.expect(ClickHouse.checkpointColumns->Array.map(({name}) => name)).toEqual(declared)
+  })
+})
+
 describe("Test ClickHouse SQL generation functions", () => {
   describe("makeCreateCheckpointsTableQuery", () => {
     Async.it(

--- a/packages/envio/src/Sink.res
+++ b/packages/envio/src/Sink.res
@@ -28,7 +28,7 @@ let makeClickHouse = (
   {
     name: "clickhouse",
     initialize: (~chainConfigs as _=[], ~entities=[], ~enums=[]) => {
-      ClickHouse.initialize(sink, ~registry, ~database, ~entities, ~enums, ~chainIdMode)
+      ClickHouse.initialize(sink, ~registry, ~database, ~entities, ~enums)
     },
     resume: (~checkpointId) => {
       ClickHouse.resume(sink, ~database, ~checkpointId)

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -387,8 +387,10 @@ let stageUpdatesOrThrow = (
     let table = sink->entityTable(~registry, ~entityConfig)
     let tableName = table.name
     let cacheKey = `${entityConfig.name}|${scope->Internal.chainScopeToString}`
-    let {convertSetOrThrow, convertDeleteOrThrow} = switch registry.converters
-    ->Utils.Dict.dangerouslyGetNonOption(cacheKey) {
+    let {
+      convertSetOrThrow,
+      convertDeleteOrThrow,
+    } = switch registry.converters->Utils.Dict.dangerouslyGetNonOption(cacheKey) {
     | Some(cached) => cached
     | None =>
       let cached = makeConverters(~entityConfig, ~scope)
@@ -406,6 +408,7 @@ let stageUpdatesOrThrow = (
 
     try {
       let builders = table.columns->Array.map(ClickHouseSink.makeBuilder(_, ~rows))
+      let columns = builders->Array.length
       for row in 0 to rows - 1 {
         let change = changes->Array.getUnsafe(row)
         // The entity history table is the source of truth for ClickHouse, so
@@ -423,9 +426,10 @@ let stageUpdatesOrThrow = (
           convertSetOrThrow(change)
         | Delete(_) => convertDeleteOrThrow(change)
         }
-        builders->Array.forEach(builder =>
+        for column in 0 to columns - 1 {
+          let builder = builders->Array.getUnsafe(column)
           builder->ClickHouseSink.writeValue(~row, values->Dict.getUnsafe(builder.name))
-        )
+        }
       }
       Some(sink->stageBuilders(~table, ~builders, ~rows))
     } catch {
@@ -662,8 +666,11 @@ let initialize = async (
   ~database: string,
   ~entities: array<Internal.entityConfig>,
   ~enums as _: array<Table.enumConfig<Table.enum>>,
-  ~chainIdMode: ChainId.mode=Int32,
 ) => {
+  // The registry is what the tables are registered against, so taking the mode
+  // from anywhere else would let the DDL declare one chain-id type while the
+  // encoder sends another.
+  let chainIdMode = registry.chainIdMode
   try {
     let databaseEngine = Env.ClickHouse.databaseEngine()
     let databaseEngineClause = switch databaseEngine {
@@ -692,10 +699,9 @@ let initialize = async (
     switch databaseEngine {
     | Some(engineSpec) => {
         let expectedEngineName = engineSpec->databaseEngineName
-        let existing =
-          await sink->ClickHouseSink.query(
-            `SELECT engine FROM system.databases WHERE name = '${database}' FORMAT TabSeparated`,
-          )
+        let existing = await sink->ClickHouseSink.query(
+          `SELECT engine FROM system.databases WHERE name = '${database}' FORMAT TabSeparated`,
+        )
         switch existing->String.trim {
         | "" => ()
         | engine if engine !== expectedEngineName =>
@@ -742,7 +748,12 @@ let initialize = async (
       ),
     )->Utils.Promise.ignoreValue
     await sink->ClickHouseSink.exec(
-      makeCreateCheckpointsTableQuery(~database, ~replicated, ~onCluster=ddlOnCluster, ~chainIdMode),
+      makeCreateCheckpointsTableQuery(
+        ~database,
+        ~replicated,
+        ~onCluster=ddlOnCluster,
+        ~chainIdMode,
+      ),
     )
 
     // The client pools HTTP connections, so consecutive statements may reach
@@ -769,9 +780,7 @@ let initialize = async (
     // Registered here rather than on first use, so a column type this encoder
     // cannot hold stops the indexer at startup, with nothing written.
     let _ = sink->checkpointsTable(~registry)
-    entities->Array.forEach(entityConfig =>
-      ignore(sink->entityTable(~registry, ~entityConfig))
-    )
+    entities->Array.forEach(entityConfig => ignore(sink->entityTable(~registry, ~entityConfig)))
 
     Logging.trace("ClickHouse storage initialization completed successfully")
   } catch {
@@ -799,10 +808,9 @@ let resume = async (sink, ~database: string, ~checkpointId: Internal.checkpointI
 
     // Get all history tables. TabSeparated answers one name per line, which is
     // all this reads.
-    let tables =
-      await sink->ClickHouseSink.query(
-        `SHOW TABLES FROM ${database} LIKE '${EntityHistory.historyTablePrefix}%' FORMAT TabSeparated`,
-      )
+    let tables = await sink->ClickHouseSink.query(
+      `SHOW TABLES FROM ${database} LIKE '${EntityHistory.historyTablePrefix}%' FORMAT TabSeparated`,
+    )
 
     // Delete rows with checkpoint IDs higher than the target for each history table
     await Promise.all(

--- a/packages/envio/src/bindings/ClickHouseSink.res
+++ b/packages/envio/src/bindings/ClickHouseSink.res
@@ -3,11 +3,10 @@
 //
 // A table is registered once, before any batch: Rust parses its column types
 // and hands back a handle. A batch then crosses the boundary as that handle
-// plus one payload per column — a typed array for numeric columns, one
-// concatenated string plus per-row lengths for text-ish ones — instead of a JS
-// object per row, and without re-sending the shape. Rust encodes RowBinary and
-// sends it from a tokio task, so neither the encode nor the HTTP round trip
-// runs on the Node main thread.
+// plus one payload per column — a typed array for numeric columns, an array of
+// strings for text-ish ones — instead of a JS object per row, and without
+// re-sending the shape. Rust encodes RowBinary and sends it from a tokio task,
+// so neither the encode nor the HTTP round trip runs on the Node main thread.
 
 type t
 
@@ -43,8 +42,7 @@ type columnValuesInput = {
   numbers?: Float64Array.t,
   unsigned64?: BigUint64Array.t,
   signed64?: BigInt64Array.t,
-  text?: string,
-  lengths?: Uint32Array.t,
+  texts?: array<string>,
   nulls?: Uint8Array.t,
 }
 
@@ -133,7 +131,6 @@ type builder = {
   unsigned: BigUint64Array.t,
   signed: BigInt64Array.t,
   texts: array<string>,
-  lengths: Uint32Array.t,
   // Allocated on the first null; a column with none sends no mask at all.
   mutable nulls: option<Uint8Array.t>,
   rows: int,
@@ -150,7 +147,6 @@ let makeBuilder = ({name, chType, kind}: column, ~rows) => {
     unsigned: BigUint64Array.fromLength(kind === U64 ? rows : empty),
     signed: BigInt64Array.fromLength(kind === I64 ? rows : empty),
     texts: kind === Text ? Array.make(~length=rows, "") : [],
-    lengths: Uint32Array.fromLength(kind === Text ? rows : empty),
     nulls: None,
     rows,
   }
@@ -165,37 +161,6 @@ let markNull = (builder, ~row) => {
     nulls
   }
   nulls->TypedArray.set(row, 1)
-}
-
-%%private(let isHighSurrogate = unit => unit >= 0xD800 && unit <= 0xDBFF)
-%%private(let isLowSurrogate = unit => unit >= 0xDC00 && unit <= 0xDFFF)
-let replacementCharacter = "\u{FFFD}"
-
-// A lone surrogate is not a character, and napi already substitutes U+FFFD for
-// one on the way to UTF-8 — which costs the value nothing, since both are a
-// single UTF-16 unit. What no value survives on its own is the concatenation:
-// a value ending in a high surrogate followed by one starting with a low
-// surrogate spells a real pair across the seam, which napi then encodes as one
-// 4-byte character where the two lengths each claim a unit, and the span scan
-// rejects the whole column. Only a first or last unit can have its other half in
-// a neighbouring value, so substituting at the two ends is the whole fix.
-let withoutBoundarySurrogates = text => {
-  let last = text->String.length - 1
-  if last < 0 {
-    text
-  } else {
-    let leading = text->String.charCodeAtUnsafe(0)->isLowSurrogate
-    let trailing = text->String.charCodeAtUnsafe(last)->isHighSurrogate
-    switch (leading, trailing) {
-    | (false, false) => text
-    | _ if last === 0 => replacementCharacter
-    | _ =>
-      (leading ? replacementCharacter : text->String.charAt(0)) ++
-      text->String.slice(~start=1, ~end=last) ++ (
-        trailing ? replacementCharacter : text->String.charAt(last)
-      )
-    }
-  }
 }
 
 // RowBinary carries the raw integer, so a value the column cannot hold is not
@@ -232,10 +197,7 @@ let writeValue = (builder, ~row, value: unknown) =>
         row,
         value->checkedBigInt(~builder, ~min=-9223372036854775808n, ~max=9223372036854775807n),
       )
-    | Text =>
-      let text = value->toText->withoutBoundarySurrogates
-      builder.texts->Array.setUnsafe(row, text)
-      builder.lengths->TypedArray.set(row, text->String.length)
+    | Text => builder.texts->Array.setUnsafe(row, value->toText)
     }
   }
 
@@ -245,12 +207,6 @@ let builderPayload = (builder): columnValuesInput => {
   | F64 => {...base, numbers: builder.floats}
   | U64 => {...base, unsigned64: builder.unsigned}
   | I64 => {...base, signed64: builder.signed}
-  | Text => {
-      ...base,
-      // One concatenated string keeps the crossing to a single napi read; Rust
-      // splits it with the UTF-16 lengths a JS string reports for free.
-      text: builder.texts->Array.joinUnsafe(""),
-      lengths: builder.lengths,
-    }
+  | Text => {...base, texts: builder.texts}
   }
 }


### PR DESCRIPTION
## Summary

Refactors ClickHouse text column handling to pass individual strings instead of concatenated data with UTF-16 length markers, and improves insert retry logic to distinguish retriable from terminal failures based on ClickHouse error codes.

## Key Changes

**Text Column Encoding**
- Changed `ColumnValuesInput` to accept `texts: Vec<String>` instead of `text: String` + `lengths: Uint32Array`
- Removed UTF-16 length scanning logic (`spans_from_utf16_lengths`) — napi now converts each JS string to UTF-8 individually
- Simplified `ColumnValues::Text` from `{data, spans}` to just `Vec<String>`
- Updated ReScript bindings to pass array of strings instead of concatenated string with per-row lengths

**Insert Retry Logic**
- Introduced `InsertFailure` struct to track both the error and whether it's retriable
- Added `is_retriable()` function that checks ClickHouse error codes against a whitelist (TIMEOUT_EXCEEDED, MEMORY_LIMIT_EXCEEDED, etc.)
- Changed `post_rows()` to return `Result<(), InsertFailure>` instead of `Result<()>`
- Improved error reporting: counts failed attempts instead of accumulating full error messages
- Only retries failures that another attempt could resolve; terminal failures (e.g., table doesn't exist) fail immediately

**Encoding Performance**
- Moved text column encoding from `block_in_place` to `spawn_blocking` to avoid blocking the tokio runtime
- Changed `Column` to use `Cow<'a, str>` and `Cow<'a, ChType>` to borrow from schema instead of cloning
- Added fast path for `UInt64 → UInt64` and `Int64 → Int64` conversions (no bounds checking needed)

**Test Coverage**
- Added test verifying non-retriable failures (e.g., "table does not exist") are not retried
- Updated text column test helpers to use new string array format
- Removed tests for UTF-16 span boundary handling (no longer needed)

## Implementation Details

The retry logic now distinguishes between:
- **Retriable**: Network errors, timeouts, server overload, memory limits, unknown status
- **Terminal**: Syntax errors, missing tables, permission denied, and any error code not in the whitelist

This prevents wasting retries on failures the server has already judged as permanent, while still retrying transient issues that halving the batch might help with (e.g., memory pressure).

The text column change reduces complexity by letting napi handle UTF-8 conversion per-string rather than requiring Rust to scan UTF-16 lengths and reconstruct byte spans. This also removes the ceiling V8 puts on single string length.

https://claude.ai/code/session_019BqtQzXQRr3d3DHuSPcmRH