### PR TITLE
Disable deduplication for replicated ClickHouse tables

### DIFF
--- a/packages/envio-tests/test/lib_tests/ClickHouse_test.res
+++ b/packages/envio-tests/test/lib_tests/ClickHouse_test.res
@@ -203,7 +203,8 @@ ORDER BY (id)`
   \`events_processed\` UInt64
 )
 ENGINE = ReplicatedMergeTree
-ORDER BY (id)`
+ORDER BY (id)
+SETTINGS replicated_deduplication_window = 0`
 
         t.expect(query, ~message="Replicated checkpoints table SQL should match exactly").toBe(
           expectedQuery,
@@ -227,7 +228,8 @@ ORDER BY (id)`
   \`events_processed\` UInt64
 )
 ENGINE = ReplicatedMergeTree
-ORDER BY (id)`
+ORDER BY (id)
+SETTINGS replicated_deduplication_window = 0`
 
         t.expect(
           query,
@@ -321,7 +323,8 @@ ORDER BY (id, envio_checkpoint_id)`
   \`envio_change\` Enum8('SET', 'DELETE')
 )
 ENGINE = ReplicatedMergeTree
-ORDER BY (id, envio_checkpoint_id)`
+ORDER BY (id, envio_checkpoint_id)
+SETTINGS replicated_deduplication_window = 0`
 
         t.expect(query, ~message="Replicated entity history table SQL should match exactly").toBe(
           expectedQuery,

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -357,6 +357,17 @@ let setUpdatesOrThrow = async (
 // The '{cluster}' macro resolves to each node's configured cluster name.
 let onClusterClause = (~onCluster: bool) => onCluster ? ` ON CLUSTER '{cluster}'` : ""
 
+// ReplicatedMergeTree drops an insert whose block hash is already in Keeper, and
+// mutations don't clear those hashes. Crash recovery trims the history tail past
+// the committed Postgres checkpoint with ALTER ... DELETE and then replays it, so
+// an identical replayed block would be discarded while still reporting success —
+// a permanent gap that nothing surfaces. Trim-then-replay is what makes recovery
+// correct here, and the duplicates dedup would have caught are already collapsed
+// by the entity view's `LIMIT 1 BY`. Plain MergeTree goes by
+// non_replicated_deduplication_window (0 by default), so it needs no clause.
+let replicatedTableSettingsClause = (~replicated: bool) =>
+  replicated ? "\nSETTINGS replicated_deduplication_window = 0" : ""
+
 // Strip both engine arguments `(...)` and a trailing `SETTINGS ...` clause to
 // get the bare engine name, e.g. `Replicated('/p','{shard}','{replica}') SETTINGS x=1`
 // and `Replicated SETTINGS x=1` both yield `Replicated`.
@@ -494,7 +505,7 @@ let makeCreateHistoryTableQuery = (
     )}${skippingIndexDefinitions}
 )
 ENGINE = ${tableEngine}${partitionByClause}
-ORDER BY (${orderByColumns})${ttlClause}`
+ORDER BY (${orderByColumns})${ttlClause}${replicatedTableSettingsClause(~replicated)}`
 }
 
 // Generate CREATE TABLE query for checkpoints
@@ -538,7 +549,7 @@ let makeCreateCheckpointsTableQuery = (
     )}
 )
 ENGINE = ${tableEngine}
-ORDER BY (${idField})`
+ORDER BY (${idField})${replicatedTableSettingsClause(~replicated)}`
 }
 
 // Generate CREATE VIEW query for entity current state


### PR DESCRIPTION
## Summary

Fixes crash recovery in replicated ClickHouse deployments by disabling the replicated deduplication window, which was causing permanent data gaps when recovery replayed identical blocks.

## Problem

ReplicatedMergeTree uses block hashes stored in Keeper to deduplicate inserts. During crash recovery, Envio trims history past the committed Postgres checkpoint with `ALTER ... DELETE`, then replays those rows. However, the replicated deduplication window retains hashes from the deleted blocks, causing identical replayed blocks to be silently discarded — a permanent gap that goes undetected.

## Solution

- Added `replicatedTableSettingsClause()` helper that appends `SETTINGS replicated_deduplication_window = 0` to replicated table definitions
- Applied the clause to both history and checkpoints table creation queries when `replicated=true`
- Plain MergeTree tables are unaffected (they use `non_replicated_deduplication_window`, defaulting to 0)

## Changes

- `packages/envio/src/bindings/ClickHouse.res`: Added settings clause helper and integrated it into `makeCreateHistoryTableQuery` and `makeCreateCheckpointsTableQuery`
- `packages/envio-tests/test/lib_tests/ClickHouse_test.res`: Updated expected SQL output in three test cases to include the new settings clause for replicated tables

https://claude.ai/code/session_01FxENSmjGmgqypwewznFE5j

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replicated ClickHouse table setup by disabling the deduplication window for checkpoint and entity history tables.
  * Applied the corrected configuration consistently for tables created with or without cluster settings.
  * Non-replicated tables remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->