### PR TITLE
test: stop asserting 401 on HyperSync height endpoint (edge no longer blocks malformed tokens)

### DIFF
--- a/packages/envio-tests/test/HyperSyncClient_test.res
+++ b/packages/envio-tests/test/HyperSyncClient_test.res
@@ -157,33 +157,38 @@ describe("HyperSync client getEventItems (live)", () => {
   })
 })
 
-describe("HyperSync client query with corrupted token", () => {
-  // The edge deliberately stopped replying 401 to malformed tokens on /height
-  // and the height SSE endpoints (so token issues can't block CI), but the
-  // query endpoint still replies 401. Feed that real server error through
-  // EvmHyperSyncSource.isUnauthorizedError so the check can't silently drift
-  // away from the message shape the client produces for a 401, which would
-  // break getHeightOrThrow's block-forever guard.
-  Async.itWithOptions(
-    "is detected by EvmHyperSyncSource.isUnauthorizedError",
-    {timeout: 30_000},
-    async t => {
-      let client = HyperSyncClient.make(
-        ~url="https://eth.hypersync.xyz",
-        ~apiToken="this-is-a-corrupted-token",
-        ~httpReqTimeoutMillis=5000,
-        // The client retries every failed query with backoff before
-        // surfacing the error; shrink the backoff so the 401 surfaces fast.
-        ~retryBaseMs=1,
-        ~retryBackoffMs=1,
-        ~retryCeilingMs=2,
-        ~eventRegistrations=[transferEventRegistration],
-        ~enableChecksumAddresses=false,
-        ~addressStore,
-      )
+describe("HyperSync client with corrupted token", () => {
+  let makeCorruptedTokenClient = () =>
+    HyperSyncClient.make(
+      ~url="https://eth.hypersync.xyz",
+      ~apiToken="this-is-a-corrupted-token",
+      ~httpReqTimeoutMillis=5000,
+      ~eventRegistrations=[transferEventRegistration],
+      ~enableChecksumAddresses=false,
+      ~addressStore,
+    )
 
+  Async.it(
+    "getHeight doesn't validate the token",
+    async t => {
+      // The edge deliberately stopped rejecting malformed tokens on /height and
+      // the height SSE endpoints, so a token issue can't stall an indexer that
+      // only polls the height. If that ever regresses, getHeightOrThrow blocks
+      // forever on the 401 instead of retrying.
+      let height = await makeCorruptedTokenClient().getHeight()
+
+      t.expect(height > 0).toEqual(true)
+    },
+  )
+
+  Async.it(
+    "query error is detected by EvmHyperSyncSource.isUnauthorizedError",
+    async t => {
+      // The query endpoint still replies 401. Feed that real server error
+      // through isUnauthorizedError so the check can't silently drift away from
+      // the message shape the client produces for a 401.
       let detected = try {
-        let _ = await runQuery(~client)
+        let _ = await runQuery(~client=makeCorruptedTokenClient())
         false
       } catch {
       | JsExn(e) => e->JsExn.message->Option.getOr("")->EvmHyperSyncSource.isUnauthorizedError

--- a/packages/envio-tests/test/HyperSyncClient_test.res
+++ b/packages/envio-tests/test/HyperSyncClient_test.res
@@ -157,24 +157,33 @@ describe("HyperSync client getEventItems (live)", () => {
   })
 })
 
-describe("HyperSync client getHeight with corrupted token", () => {
-  // A corrupted token makes the server reply 401, so getHeight throws. The error
-  // must keep matching EvmHyperSyncSource.isUnauthorizedError, otherwise
-  // getHeightOrThrow's block-forever guard silently stops working.
-  Async.it(
+describe("HyperSync client query with corrupted token", () => {
+  // The edge deliberately stopped replying 401 to malformed tokens on /height
+  // and the height SSE endpoints (so token issues can't block CI), but the
+  // query endpoint still replies 401. Feed that real server error through
+  // EvmHyperSyncSource.isUnauthorizedError so the check can't silently drift
+  // away from the message shape the client produces for a 401, which would
+  // break getHeightOrThrow's block-forever guard.
+  Async.itWithOptions(
     "is detected by EvmHyperSyncSource.isUnauthorizedError",
+    {timeout: 30_000},
     async t => {
       let client = HyperSyncClient.make(
         ~url="https://eth.hypersync.xyz",
         ~apiToken="this-is-a-corrupted-token",
         ~httpReqTimeoutMillis=5000,
-        ~eventRegistrations=[],
+        // The client retries every failed query with backoff before
+        // surfacing the error; shrink the backoff so the 401 surfaces fast.
+        ~retryBaseMs=1,
+        ~retryBackoffMs=1,
+        ~retryCeilingMs=2,
+        ~eventRegistrations=[transferEventRegistration],
         ~enableChecksumAddresses=false,
         ~addressStore,
       )
 
       let detected = try {
-        let _ = await client.getHeight()
+        let _ = await runQuery(~client)
         false
       } catch {
       | JsExn(e) => e->JsExn.message->Option.getOr("")->EvmHyperSyncSource.isUnauthorizedError

--- a/packages/envio/src/sources/EvmHyperSyncSource.res
+++ b/packages/envio/src/sources/EvmHyperSyncSource.res
@@ -1,7 +1,8 @@
 open Source
 
-// Surfaced by HyperSyncClient.getHeight (Rust) when HyperSync rejects the API
-// token. The corrupted-token test feeds the real server error through this
+// Surfaced by the HyperSync client (Rust) when HyperSync rejects the API
+// token. The corrupted-token test feeds the real server error (from the query
+// endpoint; the edge no longer 401s malformed tokens on /height) through this
 // check so it can't silently drift away from what getHeightOrThrow guards on.
 let isUnauthorizedError = (message: string) => message->String.includes("401 Unauthorized")
 


### PR DESCRIPTION
The HyperSync edge was deliberately changed (by Jason) so that malformed tokens sent to /height and the height SSE endpoints no longer return 401: they get HTTP 200 and a real height, precisely so token issues can't block CI. Verified with curl: GET /height with a corrupted bearer token returns 200 with a height, while POST /query with the same token still returns 401 with a token-malformed error body.

That removed the premise of the corrupted-token getHeight test in HyperSyncClient_test.res, which expected getHeight to throw a 401-shaped error; it failed on every branch including main. The isUnauthorizedError contract still matters: on a 401 message, getHeightOrThrow logs an error and blocks forever instead of retrying, so the check must keep matching what the client actually produces.

The test now runs a real query against eth.hypersync.xyz with the corrupted token and asserts the surfaced error matches EvmHyperSyncSource.isUnauthorizedError, keeping the live drift protection without depending on height-endpoint auth. Client retry backoff is shrunk in the test so the 401 surfaces in a few seconds. The stale comment on isUnauthorizedError is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded authorization coverage for malformed tokens.
  * Confirmed height requests continue to succeed with malformed tokens, while query requests return the expected unauthorized error.
  * Removed query retry overrides to make authorization failures surface promptly and consistently.

* **Documentation**
  * Clarified that malformed-token authorization errors originate from the HyperSync query endpoint, rather than the height endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->