### PR TITLE
Fix height stream resource leaks and improve error reporting

### DIFF
--- a/packages/envio-tests/test/HeightStream_test.res
+++ b/packages/envio-tests/test/HeightStream_test.res
@@ -3,6 +3,18 @@ open Vitest
 let statusLabel = (status: Source.heightSubscriptionStatus) =>
   switch status {
   | Live => "live"
+  | Down({reason} as down) =>
+    switch down.detail {
+    | Some(detail) => `down:${reason}:${detail}`
+    | None => `down:${reason}`
+    }
+  }
+
+// A provider's error text is its own, so the transport tests assert only the
+// bucketed reason they have to keep stable.
+let reasonLabel = (status: Source.heightSubscriptionStatus) =>
+  switch status {
+  | Live => "live"
   | Down({reason}) => `down:${reason}`
   }
 
@@ -52,8 +64,8 @@ describe("HeightStream reconnect driver", () => {
 
   Async.it("Backs off exponentially to a 60s cap and never gives up", async t => {
     let harness = makeHarness()
-    // Deliberately longer than the 9 retries the WebSocket stream used to stop
-    // after, so a regression back to giving up fails here.
+    // Long enough that a cap on the number of retries would fail here rather
+    // than leaving the stream quietly dead.
     let schedule = [250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 60_000, 60_000]
 
     let connectsAroundRetry = []
@@ -71,38 +83,10 @@ describe("HeightStream reconnect driver", () => {
     )
   })
 
-  Async.it("Resets the backoff once a connection carries traffic past its first", async t => {
-    let harness = makeHarness()
-    for attempt in 0 to 2 {
-      (harness->driverAt(attempt)).onFailure(~reason="closed")
-      await Vi.advanceTimersByTimeAsync(250 * Math.Int.pow(2, ~exp=attempt))
-    }
-    let reconnected = harness->driverAt(3)
-    reconnected.onConnected()
-    // Two pings, so this connection delivered something past whatever it sends
-    // on connect.
-    await Vi.advanceTimersByTimeAsync(5_000)
-    reconnected.onKeepAlive()
-    await Vi.advanceTimersByTimeAsync(5_000)
-    reconnected.onKeepAlive()
-    reconnected.onFailure(~reason="closed")
-
-    await Vi.advanceTimersByTimeAsync(249)
-    let beforeFirstStep = harness.drivers->Array.length
-    await Vi.advanceTimersByTimeAsync(1)
-    harness.unsubscribe()
-
-    t.expect((beforeFirstStep, harness.drivers->Array.length, harness.statuses)).toStrictEqual((
-      4,
-      5,
-      ["down:closed", "down:closed", "down:closed", "live", "down:closed"],
-    ))
-  })
-
-  Async.it("Resets the backoff for a connection that kept delivering", async t => {
-    // A provider rotating connections faster than the staleness window serves
-    // each one perfectly well, so it must not escalate however long the wait
-    // before it had grown.
+  Async.it("Resets the backoff for a connection that outlived the wait before it", async t => {
+    // One newHeads block over a long life is all a WebSocket connection carries
+    // on a slow chain, and every one of them was worth making, so what it
+    // delivered must not be what decides this.
     let harness = makeHarness(~staleTimeout=60_000)
     (harness->driverAt(0)).onFailure(~reason="closed")
     await Vi.advanceTimersByTimeAsync(250)
@@ -111,9 +95,8 @@ describe("HeightStream reconnect driver", () => {
 
     let rotated = harness->driverAt(2)
     rotated.onConnected()
+    await Vi.advanceTimersByTimeAsync(20_000)
     rotated.onHeight(101)
-    await Vi.advanceTimersByTimeAsync(30_000)
-    rotated.onHeight(102)
     rotated.onFailure(~reason="closed")
 
     await Vi.advanceTimersByTimeAsync(249)
@@ -124,12 +107,12 @@ describe("HeightStream reconnect driver", () => {
     t.expect((beforeBaseDelay, harness.drivers->Array.length)).toStrictEqual((3, 4))
   })
 
-  Async.it("Keeps backing off when connections deliver only their first event", async t => {
+  Async.it("Keeps backing off when connections die younger than the wait before them", async t => {
     let harness = makeHarness()
     // HyperSync sends the head as soon as it connects, so an endpoint that
-    // accepts a connection and drops it still looks like it carried traffic.
-    // Staying open a while doesn't change that — nothing arrived after the head
-    // — which is why this is counted rather than timed.
+    // accepts a connection and drops it has delivered everything a working one
+    // would have by then. How long it held the connection open is what tells
+    // them apart.
     let schedule = [250, 500, 1_000, 2_000]
 
     let connectsAroundRetry = []
@@ -188,7 +171,9 @@ describe("HeightStream reconnect driver", () => {
     let harness = makeHarness()
     let driver = harness->driverAt(0)
     driver.onConnected()
-    driver.onUnreadable()
+    // Carried out to the consumer's log: the reason alone can't say which field
+    // of which frame a provider got wrong.
+    driver.onUnreadable(~detail=`{"height":"not-a-number"}`)
 
     // Keep-alives stop holding the connection open once something unreadable
     // has arrived: on a stream whose heights are all malformed, the pings
@@ -203,15 +188,35 @@ describe("HeightStream reconnect driver", () => {
     // so one stray message must not go on naming later failures.
     let reconnected = harness->driverAt(1)
     reconnected.onConnected()
-    reconnected.onUnreadable()
+    reconnected.onUnreadable(~detail="garbled")
     reconnected.onHeight(101)
     await Vi.advanceTimersByTimeAsync(15_000)
     harness.unsubscribe()
 
     t.expect((harness.statuses, harness.heights)).toStrictEqual((
-      ["live", "down:unreadable", "live", "down:stale"],
+      [
+        "live",
+        `down:unreadable:{"height":"not-a-number"}`,
+        "live",
+        "down:stale",
+      ],
       [101],
     ))
+  })
+
+  Async.it("Trims an unreadable frame that would flood the log", async t => {
+    let harness = makeHarness()
+    let driver = harness->driverAt(0)
+    driver.onConnected()
+    driver.onUnreadable(~detail=String.repeat("x", 500))
+
+    await Vi.advanceTimersByTimeAsync(15_000)
+    harness.unsubscribe()
+
+    t.expect(harness.statuses).toStrictEqual([
+      "live",
+      `down:unreadable:${String.repeat("x", 200)}…`,
+    ])
   })
 
   Async.it("Treats a delivered height as proof the stream is live", async t => {
@@ -423,18 +428,27 @@ describe("HyperSyncHeightStream", () => {
       response->NodeHttp.endWith("unauthorized")
     })
     let statuses = []
+    // The status alone can't tell an operator which of a provider's many 401s
+    // this was, so the transport has to carry its message out too.
+    let detailed = []
     let unsubscribe = HyperSyncHeightStream.subscribe(
       ~hyperSyncUrl=url,
       ~apiToken="bad-token",
       ~onHeight=_ => (),
-      ~onStatus=status => statuses->Array.push(status->statusLabel)->ignore,
+      ~onStatus=status => {
+        statuses->Array.push(status->reasonLabel)->ignore
+        switch status {
+        | Down(down) => detailed->Array.push(down.detail->Option.isSome)->ignore
+        | Live => ()
+        }
+      },
     )
 
     await waitUntil(() => statuses->Array.length > 0)
     unsubscribe()
     await Promise.make((resolve, _reject) => server->NodeHttp.close(() => resolve()))
 
-    t.expect(statuses).toStrictEqual(["down:401"])
+    t.expect((statuses, detailed)).toStrictEqual((["down:401"], [true]))
   })
 
   Async.it("Delivers heights and reports a clean stream end as closed", async t => {
@@ -454,7 +468,7 @@ describe("HyperSyncHeightStream", () => {
       ~hyperSyncUrl=url,
       ~apiToken="test-token",
       ~onHeight=height => heights->Array.push(height)->ignore,
-      ~onStatus=status => statuses->Array.push(status->statusLabel)->ignore,
+      ~onStatus=status => statuses->Array.push(status->reasonLabel)->ignore,
     )
 
     await waitUntil(() => statuses->Array.includes("down:closed"))
@@ -482,7 +496,7 @@ describe("RpcWebSocketHeightStream", () => {
     let unsubscribe = RpcWebSocketHeightStream.subscribe(
       ~wsUrl=url,
       ~onHeight=height => heights->Array.push(height)->ignore,
-      ~onStatus=status => statuses->Array.push(status->statusLabel)->ignore,
+      ~onStatus=status => statuses->Array.push(status->reasonLabel)->ignore,
     )
 
     await waitUntil(() => heights->Array.length > 0)
@@ -502,7 +516,7 @@ describe("RpcWebSocketHeightStream", () => {
     let unsubscribe = RpcWebSocketHeightStream.subscribe(
       ~wsUrl=url,
       ~onHeight=_ => (),
-      ~onStatus=status => statuses->Array.push(status->statusLabel)->ignore,
+      ~onStatus=status => statuses->Array.push(status->reasonLabel)->ignore,
     )
 
     await Utils.delay(200)
@@ -524,7 +538,7 @@ describe("RpcWebSocketHeightStream", () => {
     let unsubscribe = RpcWebSocketHeightStream.subscribe(
       ~wsUrl=url,
       ~onHeight=_ => (),
-      ~onStatus=status => statuses->Array.push(status->statusLabel)->ignore,
+      ~onStatus=status => statuses->Array.push(status->reasonLabel)->ignore,
     )
 
     // Long enough for the first retry to reconnect and be rejected again.

--- a/packages/envio-tests/test/HeightStream_test.res
+++ b/packages/envio-tests/test/HeightStream_test.res
@@ -134,6 +134,66 @@ describe("HeightStream reconnect driver", () => {
     )
   })
 
+  Async.it("Keeps backing off when a connection never reports itself live", async t => {
+    // A gateway that accepts the socket and answers 502 two seconds later, or a
+    // handshake that takes that long to be reset, served nothing at all — only
+    // time a connection spent live can pay for the wait it cost.
+    let harness = makeHarness()
+    let schedule = [250, 500, 1_000, 2_000]
+
+    let connectsAroundRetry = []
+    for attempt in 0 to schedule->Array.length - 1 {
+      await Vi.advanceTimersByTimeAsync(2_000)
+      (harness->driverAt(attempt)).onFailure(~reason="502")
+      await Vi.advanceTimersByTimeAsync(schedule->Array.getUnsafe(attempt) - 1)
+      let beforeDue = harness.drivers->Array.length
+      await Vi.advanceTimersByTimeAsync(1)
+      connectsAroundRetry->Array.push((beforeDue, harness.drivers->Array.length))->ignore
+    }
+    harness.unsubscribe()
+
+    t.expect(connectsAroundRetry).toStrictEqual(
+      schedule->Array.mapWithIndex((_, attempt) => (attempt + 1, attempt + 2)),
+    )
+  })
+
+  Async.it("Keeps backing off when a live connection dies inside the stale window", async t => {
+    // A WebSocket that confirms the subscription and drops seconds later without
+    // a head served no better than one that never connected, however far past a
+    // second it lasted.
+    let harness = makeHarness(~staleTimeout=60_000)
+    let schedule = [250, 500, 1_000, 2_000]
+
+    let connectsAroundRetry = []
+    for attempt in 0 to schedule->Array.length - 1 {
+      let driver = harness->driverAt(attempt)
+      driver.onConnected()
+      await Vi.advanceTimersByTimeAsync(3_000)
+      driver.onFailure(~reason="closed")
+      await Vi.advanceTimersByTimeAsync(schedule->Array.getUnsafe(attempt) - 1)
+      let beforeDue = harness.drivers->Array.length
+      await Vi.advanceTimersByTimeAsync(1)
+      connectsAroundRetry->Array.push((beforeDue, harness.drivers->Array.length))->ignore
+    }
+    harness.unsubscribe()
+
+    t.expect(connectsAroundRetry).toStrictEqual(
+      schedule->Array.mapWithIndex((_, attempt) => (attempt + 1, attempt + 2)),
+    )
+  })
+
+  Async.it("Trims a failure detail that would flood the log", async t => {
+    let harness = makeHarness()
+    (harness->driverAt(0)).onFailure(~reason="subscribe-rejected", ~detail=String.repeat("y", 500))
+
+    await Vi.advanceTimersByTimeAsync(250)
+    harness.unsubscribe()
+
+    t.expect(harness.statuses).toStrictEqual([
+      `down:subscribe-rejected:${String.repeat("y", 200)}…`,
+    ])
+  })
+
   Async.it("Counts a socket that errors and then closes as one failure", async t => {
     let harness = makeHarness()
     let driver = harness->driverAt(0)

--- a/packages/envio/src/Metrics.res
+++ b/packages/envio/src/Metrics.res
@@ -96,8 +96,8 @@ type sourceHeightMetrics = {
   height: int,
 }
 
-// Health of a source's height subscription. Only sources whose stream has
-// failed at least once appear, so a healthy indexer renders none of it.
+// Only sources whose stream has failed at least once appear, so a healthy
+// indexer renders none of it.
 type sourceHeightStreamMetrics = {
   source: string,
   chainId: ChainId.t,
@@ -228,13 +228,23 @@ let renderMetrics = (b: builder, metrics: t) => {
     metrics.storageWrites->Array.map(s => (`{storage="${s.storage->escapeLabelValue}"}`, s))
   let historyPrunes =
     metrics.historyPrunes->Array.map(s => (`{entity="${s.entity->escapeLabelValue}"}`, s))
+  // Every per-source series is keyed by these, so they are built in one place:
+  // a scrape whose label sets disagree between two of them is one nothing can
+  // join on.
+  let sourceLabels = (~source, ~chainId, ~extra=[]) =>
+    "{" ++
+    [("source", source), ("chainId", chainId->ChainId.toString)]
+    ->Array.concat(extra)
+    ->Array.map(((name, value)) => `${name}="${value->escapeLabelValue}"`)
+    ->Array.join(",") ++ "}"
+
   // Two sources can share a name (e.g. primary and fallback RPC urls on the
   // same host), so aggregate by label set — duplicate samples would make
   // Prometheus reject the scrape.
   let sourceRequests = {
     let byLabels: dict<sourceRequestMetrics> = Dict.make()
     metrics.sourceRequests->Array.forEach(s => {
-      let labels = `{source="${s.source->escapeLabelValue}",chainId="${s.chainId->ChainId.toString}",method="${s.method->escapeLabelValue}"}`
+      let labels = sourceLabels(~source=s.source, ~chainId=s.chainId, ~extra=[("method", s.method)])
       switch byLabels->Utils.Dict.dangerouslyGetNonOption(labels) {
       | Some(existing) =>
         byLabels->Dict.set(
@@ -249,7 +259,7 @@ let renderMetrics = (b: builder, metrics: t) => {
   let sources = {
     let byLabels: dict<int> = Dict.make()
     metrics.sourceHeights->Array.forEach(s => {
-      let labels = `{source="${s.source->escapeLabelValue}",chainId="${s.chainId->ChainId.toString}"}`
+      let labels = sourceLabels(~source=s.source, ~chainId=s.chainId)
       switch byLabels->Utils.Dict.dangerouslyGetNonOption(labels) {
       | Some(existing) if existing >= s.height => ()
       | _ => byLabels->Dict.set(labels, s.height)
@@ -258,9 +268,6 @@ let renderMetrics = (b: builder, metrics: t) => {
     byLabels->Dict.toArray
   }
 
-  // Aggregated by label set for the same reason as sourceRequests above: two
-  // sources on a chain can share a name, and duplicate samples would make
-  // Prometheus reject the scrape.
   let addTo = (byLabels: dict<int>, labels, count) =>
     byLabels->Dict.set(
       labels,
@@ -269,10 +276,7 @@ let renderMetrics = (b: builder, metrics: t) => {
   let heightStreamReconnects = {
     let byLabels: dict<int> = Dict.make()
     metrics.sourceHeightStreams->Array.forEach(s =>
-      byLabels->addTo(
-        `{source="${s.source->escapeLabelValue}",chainId="${s.chainId->ChainId.toString}"}`,
-        s.reconnectCount,
-      )
+      byLabels->addTo(sourceLabels(~source=s.source, ~chainId=s.chainId), s.reconnectCount)
     )
     byLabels->Dict.toArray
   }
@@ -281,7 +285,7 @@ let renderMetrics = (b: builder, metrics: t) => {
     metrics.sourceHeightStreams->Array.forEach(s =>
       s.failuresByReason->Array.forEach(((reason, count)) =>
         byLabels->addTo(
-          `{source="${s.source->escapeLabelValue}",chainId="${s.chainId->ChainId.toString}",reason="${reason->escapeLabelValue}"}`,
+          sourceLabels(~source=s.source, ~chainId=s.chainId, ~extra=[("reason", reason)]),
           count,
         )
       )
@@ -510,6 +514,8 @@ let renderMetrics = (b: builder, metrics: t) => {
       ~entries=heightStreamReconnects,
       ~value=count => count->Int.toFloat,
     )
+  }
+  if heightStreamFailures->Array.length > 0 {
     b->series(
       ~name="envio_source_height_stream_failures_total",
       ~help="The number of times a source's height subscription failed, by reason. Routine reconnects and quiet chains land here alongside real trouble, so read it against the reconnect total rather than treating any value as bad: failures climbing while reconnects stay flat is a stream that is down, and the indexer is polling for the height in the meantime.",

--- a/packages/envio/src/Utils.res
+++ b/packages/envio/src/Utils.res
@@ -25,6 +25,25 @@ let delay = milliseconds =>
     }, milliseconds)
   })
 
+// A delay that can be released early. Racing against a plain `delay` leaves the
+// losing timer pending for the rest of its window, holding everything its
+// continuation captured, which on a fast chain is one live timer per block.
+let delayWithCancel = milliseconds => {
+  let timeoutId = ref(None)
+  let promise = Promise.make((resolve, _) => {
+    timeoutId := Some(setTimeout(_ => resolve(), milliseconds))
+  })
+  let cancel = () =>
+    switch timeoutId.contents {
+    | Some(id) => {
+        clearTimeout(id)
+        timeoutId := None
+      }
+    | None => ()
+    }
+  (promise, cancel)
+}
+
 module Object = {
   // Define a type for the property descriptor
   type propertyDescriptor<'a> = {

--- a/packages/envio/src/sources/HeightStream.res
+++ b/packages/envio/src/sources/HeightStream.res
@@ -5,9 +5,9 @@ close function; the driver owns retries, staleness detection and status
 reporting so SSE and WebSocket streams behave identically.
 
 Nothing here logs. A height stream failing is not something an operator has to
-act on — the indexer polls for the height instead — so its health is reported
-through the envio_source_height_stream_* counters, and every failure reason has
-to stand on its own as a metric label.
+act on — the indexer polls for the height instead — so a failure travels out
+through `onStatus`, where its reason becomes a metric label and its detail the
+one log line that says what the provider actually sent.
 */
 
 type driver = {
@@ -19,9 +19,10 @@ type driver = {
   onHeight: int => unit,
   // A message the transport couldn't read. Not a failure by itself, but from
   // then on only a height we can read counts as the connection still being
-  // useful, so a stream of them goes quiet and fails as "unreadable".
-  onUnreadable: unit => unit,
-  onFailure: (~reason: string) => unit,
+  // useful, so a stream of them goes quiet and fails as "unreadable", carrying
+  // the frame that started it.
+  onUnreadable: (~detail: string) => unit,
+  onFailure: (~reason: string, ~detail: string=?) => unit,
 }
 
 // While a stream is down its consumer polls instead, so the retry delay is what
@@ -34,6 +35,20 @@ let maxRetryMillis = 60_000
 // Keeps the doubling from overflowing on a stream that has been failing for
 // days. The delay reaches maxRetryMillis long before this.
 let maxRetryExponent = 20
+// Floor for how long a connection has to last to have been worth making. Both
+// transports deliver something the moment they connect — HyperSync sends the
+// head, a WebSocket confirms the subscription — so an endpoint that accepts and
+// drops has produced everything a working one would have by then, and only
+// staying open tells them apart.
+let minProvenMillis = 1_000
+// A frame nobody could read ends up in a log line, so cap what a provider can
+// put there.
+let maxDetailLength = 200
+
+let truncateDetail = detail =>
+  detail->String.length > maxDetailLength
+    ? detail->String.slice(~start=0, ~end=maxDetailLength) ++ "…"
+    : detail
 
 let subscribe = (
   ~staleTimeout: int,
@@ -44,20 +59,26 @@ let subscribe = (
   ~connect: driver => unit => unit,
 ): (unit => unit) => {
   let closeConnectionRef = ref(None)
-  let unsubscribed = ref(false)
   let failureCount = ref(0)
   // Bumped on every failure, reconnect and unsubscribe. Callbacks from a
   // superseded connection compare against it and no-op, so a socket that
-  // reports an error and then a close only counts as one failure.
+  // reports an error and then a close only counts as one failure, and nothing a
+  // connection reports after unsubscribing is heard.
   let generation = ref(0)
   // A connection is either waiting for traffic or waiting to be retried, never
   // both, so a single slot holds whichever timer is pending.
   let timeoutId = ref(None)
-  // Traffic the current connection has carried. The first event proves nothing:
-  // HyperSync sends the head the moment it connects, so an endpoint that accepts
-  // and drops looks identical to a working one until a second arrives.
-  let trafficCount = ref(0)
-  let sawUnreadable = ref(false)
+  // The frame that stopped this connection being readable, kept for the failure
+  // it will eventually be named after.
+  let unreadableDetail = ref(None)
+  // How long the current connection has to last to count as worth making: the
+  // wait it cost us, floored. Measuring the connection against the wait before
+  // it is what a provider rotating connections clears and an endpoint that
+  // drops immediately can't, and it needs no clock of its own — the bar rises
+  // with the backoff, so an endpoint that always dies at the same age keeps
+  // escalating instead of settling into a reconnect loop at a fixed delay.
+  let provenMillis = ref(minProvenMillis)
+  let connectedAt = ref(Performance.now())
 
   let clearPendingTimeout = () => {
     switch timeoutId.contents {
@@ -90,31 +111,35 @@ let subscribe = (
           timeoutId := None
           // Distinguishes a provider whose message shape we don't understand
           // from a chain that simply has nothing to report.
-          fail(~reason=sawUnreadable.contents ? "unreadable" : "stale", ~windowElapsed=true)
+          switch unreadableDetail.contents {
+          | Some(detail) => fail(~reason="unreadable", ~detail)
+          | None => fail(~reason="stale")
+          }
         }, staleTimeout))
   }
-  and fail = (~reason, ~windowElapsed=false) => {
+  and fail = (~reason, ~detail=?) => {
     generation := generation.contents + 1
     clearPendingTimeout()
     closeConnection()
 
-    // The backoff resets when the connection delivered — which noteTraffic
-    // decides — or when the staleness timer says it waited its window out. The
-    // timer says so rather than leaving it to be re-derived from a clock it can
-    // beat to its own deadline by a fraction of a millisecond. So a chain whose
-    // blocks are further apart than the timeout never escalates, and neither
-    // does a silent or unreadable endpoint, because reaching the timeout is what
-    // already spaces those retries a whole window apart.
-    if windowElapsed {
-      failureCount := 0
-    }
-    failureCount := failureCount.contents + 1
+    // A connection that outlived the wait before it was worth making, whatever
+    // ended it, so the backoff starts over. That covers a load balancer
+    // rotating connections and a chain whose blocks are further apart than the
+    // stale timeout alike, without either having to be recognised.
+    let uptimeMillis = (Performance.now() -. connectedAt.contents)->Float.toInt
+    failureCount := if uptimeMillis >= provenMillis.contents {
+        1
+      } else {
+        failureCount.contents + 1
+      }
 
     let exp = Pervasives.min(failureCount.contents - 1, maxRetryExponent)->Int.toFloat
     let retryMillis = Pervasives.min(
       baseRetryMillis * Math.pow(2.0, ~exp)->Float.toInt,
       maxRetryMillis,
     )
+    provenMillis := Pervasives.max(retryMillis, minProvenMillis)
+
     // Scheduled before reporting, so a consumer that throws can't be what makes
     // the stream give up.
     timeoutId := Some(setTimeout(() => {
@@ -122,14 +147,14 @@ let subscribe = (
           start()
         }, retryMillis))
 
-    onStatus(Down({reason: reason}))
+    onStatus(Down({reason, ?detail}))
   }
   and start = () => {
     generation := generation.contents + 1
-    trafficCount := 0
-    sawUnreadable := false
+    unreadableDetail := None
+    connectedAt := Performance.now()
     let connectionGeneration = generation.contents
-    let isCurrent = () => !unsubscribed.contents && generation.contents === connectionGeneration
+    let isCurrent = () => generation.contents === connectionGeneration
 
     // Armed before connecting, so it covers a connect that never reports
     // anything, and so a synchronous failure inside connect replaces it with
@@ -140,17 +165,6 @@ let subscribe = (
     // onConnected does. Without that, a transport that never reports the
     // connection usable would leave its consumer polling at full rate next to a
     // stream that works.
-    // A connection that carried traffic past its connect burst was worth making,
-    // so the backoff starts over. Counting rather than timing it: any duration
-    // bar is either one a provider rotating connections can't clear, or one an
-    // endpoint that drops immediately can.
-    let noteTraffic = () => {
-      trafficCount := trafficCount.contents + 1
-      if trafficCount.contents > 1 {
-        failureCount := 0
-      }
-    }
-
     let reportedLive = ref(false)
     let goLive = () => {
       armStaleTimeout()
@@ -174,8 +188,7 @@ let subscribe = (
         // indefinitely, never failing and so never reporting anything, while
         // its consumer sat on the staleness backstop. Being wrong about a lone
         // glitch costs one reconnect.
-        if isCurrent() && !sawUnreadable.contents {
-          noteTraffic()
+        if isCurrent() && unreadableDetail.contents->Option.isNone {
           armStaleTimeout()
         },
       onHeight: height =>
@@ -184,18 +197,17 @@ let subscribe = (
           // deliberately doesn't: on a stream whose heights are all malformed,
           // the pings between them would clear this and the staleness that
           // followed would look like a chain with nothing to report.
-          sawUnreadable := false
-          noteTraffic()
+          unreadableDetail := None
           goLive()
           onHeight(height)
         },
-      onUnreadable: () =>
+      onUnreadable: (~detail) =>
         if isCurrent() {
-          sawUnreadable := true
+          unreadableDetail := Some(detail->truncateDetail)
         },
-      onFailure: (~reason) =>
+      onFailure: (~reason, ~detail=?) =>
         if isCurrent() {
-          fail(~reason)
+          fail(~reason, ~detail?)
         },
     }
 
@@ -222,7 +234,6 @@ let subscribe = (
   start()
 
   () => {
-    unsubscribed := true
     generation := generation.contents + 1
     clearPendingTimeout()
     closeConnection()

--- a/packages/envio/src/sources/HeightStream.res
+++ b/packages/envio/src/sources/HeightStream.res
@@ -35,15 +35,28 @@ let maxRetryMillis = 60_000
 // Keeps the doubling from overflowing on a stream that has been failing for
 // days. The delay reaches maxRetryMillis long before this.
 let maxRetryExponent = 20
-// Floor for how long a connection has to last to have been worth making. Both
-// transports deliver something the moment they connect — HyperSync sends the
-// head, a WebSocket confirms the subscription — so an endpoint that accepts and
-// drops has produced everything a working one would have by then, and only
-// staying open tells them apart.
-let minProvenMillis = 1_000
+// Floor for how long a connection has to serve to have been worth making, as a
+// fraction of the window we would wait before calling it dead. Both transports
+// deliver something the moment they connect — HyperSync sends the head, a
+// WebSocket confirms the subscription — so an endpoint that accepts and drops
+// produces everything a working one would have by then, and only staying up
+// tells them apart. A fixed floor can't do it: one low enough to clear on a
+// healthy connection is one a connection that dies seconds in clears too.
+let provenStaleFraction = 4
 // A frame nobody could read ends up in a log line, so cap what a provider can
 // put there.
 let maxDetailLength = 200
+
+// The wait that follows `count` consecutive failures. Zero for a first
+// connection, which nothing preceded.
+let retryDelayFor = count =>
+  count <= 0
+    ? 0
+    : Pervasives.min(
+        baseRetryMillis *
+        Math.pow(2.0, ~exp=Pervasives.min(count - 1, maxRetryExponent)->Int.toFloat)->Float.toInt,
+        maxRetryMillis,
+      )
 
 let truncateDetail = detail =>
   detail->String.length > maxDetailLength
@@ -71,14 +84,12 @@ let subscribe = (
   // The frame that stopped this connection being readable, kept for the failure
   // it will eventually be named after.
   let unreadableDetail = ref(None)
-  // How long the current connection has to last to count as worth making: the
-  // wait it cost us, floored. Measuring the connection against the wait before
-  // it is what a provider rotating connections clears and an endpoint that
-  // drops immediately can't, and it needs no clock of its own — the bar rises
-  // with the backoff, so an endpoint that always dies at the same age keeps
-  // escalating instead of settling into a reconnect loop at a fixed delay.
-  let provenMillis = ref(minProvenMillis)
-  let connectedAt = ref(Performance.now())
+  // When the current connection reported itself live, if it ever did. Time
+  // before that is not service: a handshake that takes seconds to fail, or a
+  // socket that is accepted and then hangs until the staleness timer, would
+  // otherwise be indistinguishable from a connection that worked.
+  let liveAt = ref(None)
+  let minProvenMillis = staleTimeout / provenStaleFraction
 
   let clearPendingTimeout = () => {
     switch timeoutId.contents {
@@ -122,23 +133,25 @@ let subscribe = (
     clearPendingTimeout()
     closeConnection()
 
-    // A connection that outlived the wait before it was worth making, whatever
-    // ended it, so the backoff starts over. That covers a load balancer
-    // rotating connections and a chain whose blocks are further apart than the
-    // stale timeout alike, without either having to be recognised.
-    let uptimeMillis = (Performance.now() -. connectedAt.contents)->Float.toInt
-    failureCount := if uptimeMillis >= provenMillis.contents {
+    // A connection that served for longer than the wait it cost was worth
+    // making, whatever ended it, so the backoff starts over. That covers a load
+    // balancer rotating connections and a chain whose blocks are further apart
+    // than the stale timeout alike, without either having to be recognised. The
+    // bar rises with the backoff, so an endpoint that always dies at the same
+    // age keeps escalating rather than settling into a loop at a fixed delay.
+    let servedMillis = switch liveAt.contents {
+    | Some(since) => (Performance.now() -. since)->Float.toInt
+    | None => 0
+    }
+    let provenMillis = Pervasives.max(retryDelayFor(failureCount.contents), minProvenMillis)
+    failureCount :=
+      if servedMillis >= provenMillis {
         1
       } else {
         failureCount.contents + 1
       }
 
-    let exp = Pervasives.min(failureCount.contents - 1, maxRetryExponent)->Int.toFloat
-    let retryMillis = Pervasives.min(
-      baseRetryMillis * Math.pow(2.0, ~exp)->Float.toInt,
-      maxRetryMillis,
-    )
-    provenMillis := Pervasives.max(retryMillis, minProvenMillis)
+    let retryMillis = retryDelayFor(failureCount.contents)
 
     // Scheduled before reporting, so a consumer that throws can't be what makes
     // the stream give up.
@@ -147,12 +160,12 @@ let subscribe = (
           start()
         }, retryMillis))
 
-    onStatus(Down({reason, ?detail}))
+    onStatus(Down({reason, detail: ?detail->Option.map(truncateDetail)}))
   }
   and start = () => {
     generation := generation.contents + 1
     unreadableDetail := None
-    connectedAt := Performance.now()
+    liveAt := None
     let connectionGeneration = generation.contents
     let isCurrent = () => generation.contents === connectionGeneration
 
@@ -165,11 +178,10 @@ let subscribe = (
     // onConnected does. Without that, a transport that never reports the
     // connection usable would leave its consumer polling at full rate next to a
     // stream that works.
-    let reportedLive = ref(false)
     let goLive = () => {
       armStaleTimeout()
-      if !reportedLive.contents {
-        reportedLive := true
+      if liveAt.contents->Option.isNone {
+        liveAt := Some(Performance.now())
         onStatus(Live)
       }
     }
@@ -203,7 +215,7 @@ let subscribe = (
         },
       onUnreadable: (~detail) =>
         if isCurrent() {
-          unreadableDetail := Some(detail->truncateDetail)
+          unreadableDetail := Some(detail)
         },
       onFailure: (~reason, ~detail=?) =>
         if isCurrent() {

--- a/packages/envio/src/sources/HyperSyncHeightStream.res
+++ b/packages/envio/src/sources/HyperSyncHeightStream.res
@@ -2,15 +2,13 @@
 // connection as dead.
 let staleTimeout = 15_000
 
-// A rejected token still gets its actionable log line, from the query path in
-// EvmHyperSyncSource that hits the same 401.
-let failureReason = (error: EventSource.errorEvent) =>
+let failure = (error: EventSource.errorEvent) =>
   switch (error.code, error.message) {
-  | (Some(code), _) => code->Int.toString
-  | (None, Some(_)) => "error"
+  | (Some(code), message) => (code->Int.toString, message)
+  | (None, Some(message)) => ("error", Some(message))
   // The stream ended without an HTTP error, which is how a load balancer
   // rotating connections shows up.
-  | (None, None) => "closed"
+  | (None, None) => ("closed", None)
   }
 
 let subscribe = (~hyperSyncUrl, ~apiToken, ~onHeight, ~onStatus) =>
@@ -35,12 +33,15 @@ let subscribe = (~hyperSyncUrl, ~apiToken, ~onHeight, ~onStatus) =>
     )
 
     es->EventSource.onopen(_ => driver.onConnected())
-    es->EventSource.onerror(error => driver.onFailure(~reason=error->failureReason))
+    es->EventSource.onerror(error => {
+      let (reason, detail) = error->failure
+      driver.onFailure(~reason, ~detail?)
+    })
     es->EventSource.addEventListener("ping", _ => driver.onKeepAlive())
     es->EventSource.addEventListener("height", event =>
       switch event.data->Int.fromString {
       | Some(height) => driver.onHeight(height)
-      | None => driver.onUnreadable()
+      | None => driver.onUnreadable(~detail=event.data)
       }
     )
 

--- a/packages/envio/src/sources/RpcWebSocketHeightStream.res
+++ b/packages/envio/src/sources/RpcWebSocketHeightStream.res
@@ -71,7 +71,7 @@ let subscribe = (~wsUrl, ~onHeight, ~onStatus) =>
       }
     })
 
-    ws->WebSocket.onerror(_ => driver.onFailure(~reason="error"))
+    ws->WebSocket.onerror(error => driver.onFailure(~reason="error", ~detail=?error->JsExn.message))
     ws->WebSocket.onclose(() => driver.onFailure(~reason="closed"))
 
     () => ws->WebSocket.close

--- a/packages/envio/src/sources/RpcWebSocketHeightStream.res
+++ b/packages/envio/src/sources/RpcWebSocketHeightStream.res
@@ -66,8 +66,8 @@ let subscribe = (~wsUrl, ~onHeight, ~onStatus) =>
       | Some(NewHead(blockNumber)) => driver.onHeight(blockNumber)
       // An open socket isn't usable until the node accepts the subscription.
       | Some(SubscriptionConfirmed(_)) => driver.onConnected()
-      | Some(ErrorResponse) => driver.onFailure(~reason="subscribe-rejected")
-      | None => driver.onUnreadable()
+      | Some(ErrorResponse) => driver.onFailure(~reason="subscribe-rejected", ~detail=event.data)
+      | None => driver.onUnreadable(~detail=event.data)
       }
     })
 

--- a/packages/envio/src/sources/Source.res
+++ b/packages/envio/src/sources/Source.res
@@ -135,8 +135,10 @@ type sourceFor = Sync | Fallback | Realtime
 // fires on every (re)connect, so consumers must treat both as idempotent.
 // `reason` is pre-bucketed for use as a metric label. The shipped transports
 // report an HTTP status, or "closed", "error", "connect-failed", "stale",
-// "unreadable" or "subscribe-rejected".
-type heightSubscriptionStatus = Live | Down({reason: string})
+// "unreadable" or "subscribe-rejected". `detail` is whatever the provider said
+// for this one failure — an error message, or the frame nobody could read — so
+// it belongs in a log line and never in a label.
+type heightSubscriptionStatus = Live | Down({reason: string, detail?: string})
 
 type t = {
   name: string,

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -569,7 +569,7 @@ let handleSubscriptionStatus = (
       // Only a connect that followed a failure is a reconnect. Deriving it from
       // a connect count would miss that a stream whose very first attempt
       // failed has reconnected, and report it as still down for good.
-      if sourceState.heightStreamFailures->Dict.keysToArray->Array.length > 0 {
+      if !(sourceState.heightStreamFailures->Utils.Dict.isEmpty) {
         sourceState.heightStreamReconnects = sourceState.heightStreamReconnects + 1
       }
       // Any height from before this connection is lost, because eth_subscribe

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -41,6 +41,14 @@ let recordRequestStats = (sourceState: sourceState, requestStats: array<Source.r
   })
 }
 
+// Drop a resolver this wait pushed but never used, so a source that keeps not
+// answering doesn't leave one closure per iteration behind it (#1270).
+let dropResolver = (pending, resolver) =>
+  switch resolver.contents {
+  | Some(resolve) => pending->Array.filter(p => p !== resolve)
+  | None => pending
+  }
+
 let resolveHeight = (sourceState: sourceState, height: int) => {
   sourceState.knownHeight = height
   let resolvers = sourceState.pendingHeightResolvers
@@ -177,9 +185,7 @@ let getHeightStreamSamples = (sourceManager: t): array<heightStreamSample> => {
     let failures =
       sourceState.heightStreamFailures
       ->Dict.toArray
-      ->Array.toSorted(((a, _), (b, _)) =>
-        a < b ? Ordering.less : a > b ? Ordering.greater : Ordering.equal
-      )
+      ->Array.toSorted(((a, _), (b, _)) => String.compare(a, b))
     if failures->Array.length > 0 {
       samples->Array.push({
         sourceName: sourceState.source.name,
@@ -492,6 +498,10 @@ let disableSource = (sourceManager: t, sourceState: sourceState) => {
     switch sourceState.unsubscribe {
     | Some(unsubscribe) =>
       unsubscribe()
+      // Cleared so the state can't claim a subscription that has been closed:
+      // a second teardown would call the same close function again, and
+      // `ensureSubscribed` reads this to decide whether one is still live.
+      sourceState.unsubscribe = None
       // The subscription is gone, so the source must not keep looking live to a
       // wait still in flight for it. That wait polls the benched source until
       // another one answers, at the same interval the no-subscription path
@@ -516,8 +526,9 @@ let disableSource = (sourceManager: t, sourceState: sourceState) => {
 // One-shot poll on every height stream connect, closing the gap left by heights
 // emitted before this connection existed. A failure deliberately leaves the
 // count alone: the fallback poller retires against a completed catch-up, so not
-// counting a failed one is what keeps that poller going.
-let catchUpHeight = async (sourceState: sourceState) => {
+// counting a failed one is what keeps that poller going — nothing else is
+// fetching the height while the stream is unproven.
+let catchUpHeight = async (sourceState: sourceState, ~logger) => {
   try {
     let res = await sourceState.source.getHeightOrThrow()
     sourceState->recordRequestStats(res.requestStats)
@@ -526,7 +537,12 @@ let catchUpHeight = async (sourceState: sourceState) => {
     }
     sourceState.heightStreamCatchUps = sourceState.heightStreamCatchUps + 1
   } catch {
-  | _ => ()
+  | exn =>
+    logger->Logging.childTrace({
+      "msg": `Height stream catch-up from ${sourceState.source.name} source failed. The fallback poll keeps running until the stream delivers.`,
+      "source": sourceState.source.name,
+      "err": exn->Utils.prettifyExn,
+    })
   }
 }
 
@@ -544,6 +560,7 @@ let handlePushedHeight = (sourceState: sourceState, pushedHeight: int) =>
 let handleSubscriptionStatus = (
   sourceState: sourceState,
   status: Source.heightSubscriptionStatus,
+  ~logger,
 ) =>
   switch status {
   | Live =>
@@ -558,11 +575,68 @@ let handleSubscriptionStatus = (
       // Any height from before this connection is lost, because eth_subscribe
       // only ever delivers the next block. Ask once rather than leaving the
       // chain blind until the next one is mined.
-      sourceState->catchUpHeight->Promise.ignore
+      sourceState->catchUpHeight(~logger)->Promise.ignore
     }
-  | Down({reason}) =>
+  | Down({reason} as down) =>
     sourceState->recordHeightStreamFailure(~reason)
     sourceState->markSubscriptionDown
+    // The counters say a stream is flapping and how often, but only the
+    // provider's own words say why, and a frame nobody could read is
+    // unrecoverable from a bucketed label.
+    logger->Logging.childTrace({
+      "msg": `Height subscription for ${sourceState.source.name} source went down (${reason}). Polling for the height until it reconnects.`,
+      "source": sourceState.source.name,
+      "reason": reason,
+      "detail": down.detail,
+    })
+  }
+
+// The only place that installs `unsubscribe`, and it has to stay that way: after
+// a rollback two waits run for the same source (the pre-rollback one isn't
+// cancelled), both reach this across an await, and a second assignment would
+// overwrite a live connection's close function — leaving a socket nothing can
+// close, still pushing heights and still retrying, for the life of the process.
+let ensureSubscribed = (sourceState: sourceState, ~isRealtime, ~logger) => {
+  switch (sourceState.source.createHeightSubscription, sourceState.unsubscribe) {
+  | (Some(createSubscription), None) if isRealtime && !sourceState.disabled =>
+    sourceState.unsubscribe = Some(
+      createSubscription(
+        ~onHeight=height => sourceState->handlePushedHeight(height),
+        ~onStatus=status => sourceState->handleSubscriptionStatus(status, ~logger),
+      ),
+    )
+  | _ => ()
+  }
+  sourceState.unsubscribe->Option.isSome
+}
+
+// One height poll with the failure handling both loops below share: they
+// escalate on the same schedule and report the same line, so the interval to
+// wait before the next attempt comes back with the result.
+let pollHeightOnce = async (
+  sourceManager: t,
+  sourceState: sourceState,
+  ~retry: ref<int>,
+  ~logger,
+  ~pollingInterval,
+) =>
+  try {
+    let res = await sourceState.source.getHeightOrThrow()
+    sourceState->recordRequestStats(res.requestStats)
+    retry := 0
+    (Some(res.height), pollingInterval())
+  } catch {
+  | exn =>
+    // An endpoint whose stream just dropped is often the one failing these too,
+    // so escalate rather than asking again every polling interval.
+    let retryInterval = sourceManager.getHeightRetryInterval(~retry=retry.contents)
+    logger->Logging.childTrace({
+      "msg": `Height retrieval from ${sourceState.source.name} source failed. Retrying in ${retryInterval->Int.toString}ms.`,
+      "source": sourceState.source.name,
+      "err": exn->Utils.prettifyExn,
+    })
+    retry := retry.contents + 1
+    (None, retryInterval)
   }
 
 let getSourceNewHeight = async (
@@ -604,6 +678,10 @@ let getSourceNewHeight = async (
         sourceState.pendingHeightResolvers->Array.push(resolve)
       })
 
+      // Released once the race settles: a healthy stream answers within a block
+      // time, and leaving the backstop pending would hold this iteration's
+      // closures for the rest of its window, once per block.
+      let cancelBackstop = ref(None)
       let pollingTrigger = if sourceState.subscriptionLive {
         let subscriptionDown = Promise.make((resolve, _reject) => {
           downResolver := Some(resolve)
@@ -613,10 +691,11 @@ let getSourceNewHeight = async (
         // instead. Jitter it across [stallTimeout/2, stallTimeout) so indexers
         // that go quiet together don't all start polling at the same instant.
         let half = stallTimeout / 2
-        Promise.race([
-          subscriptionDown,
-          Utils.delay(half + (Math.random() *. half->Int.toFloat)->Float.toInt),
-        ])
+        let (backstop, cancel) = Utils.delayWithCancel(
+          half + (Math.random() *. half->Int.toFloat)->Float.toInt,
+        )
+        cancelBackstop := Some(cancel)
+        Promise.race([subscriptionDown, backstop])
       } else {
         // Nothing is pushing heights, so don't wait to start asking for them.
         Promise.resolve()
@@ -624,11 +703,11 @@ let getSourceNewHeight = async (
 
       let pollingFallback = pollingTrigger->Promise.then(async () => {
         let h = ref(iterationHeight)
-        // A reconnect's catch-up poll takes this loop's job over, so polling
-        // past one is wasted load on an endpoint that was struggling a moment
-        // ago. Counting catch-ups rather than reading subscriptionLive keeps the
+        // A reconnect's catch-up poll takes this loop's job over, so polling past
+        // one is wasted load on an endpoint that was struggling a moment ago.
+        // Counting catch-ups rather than reading subscriptionLive keeps the
         // backstop working — that one polls a stream which claims to be live but
-        // has gone quiet — and keeps this loop going when a catch-up fails.
+        // has gone quiet.
         let catchUpsWhenTriggered = sourceState.heightStreamCatchUps
         // Stopping once this iteration's race is over matters: otherwise a
         // source that never returns a new height leaves a poller running for
@@ -640,25 +719,15 @@ let getSourceNewHeight = async (
           sourceState.heightStreamCatchUps === catchUpsWhenTriggered
         let pollRetry = ref(0)
         while shouldPoll() {
-          let interval = try {
-            let res = await source.getHeightOrThrow()
-            sourceState->recordRequestStats(res.requestStats)
-            h := res.height
-            pollRetry := 0
-            pollingInterval()
-          } catch {
-          | exn =>
-            // An endpoint whose stream just dropped is often the one failing
-            // these too, so escalate and report the way the no-subscription
-            // branch does rather than asking again every polling interval.
-            let retryInterval = sourceManager.getHeightRetryInterval(~retry=pollRetry.contents)
-            logger->Logging.childTrace({
-              "msg": `Height retrieval from ${source.name} source failed. Retrying in ${retryInterval->Int.toString}ms.`,
-              "source": source.name,
-              "err": exn->Utils.prettifyExn,
-            })
-            pollRetry := pollRetry.contents + 1
-            retryInterval
+          let (polled, interval) = await sourceManager->pollHeightOnce(
+            sourceState,
+            ~retry=pollRetry,
+            ~logger,
+            ~pollingInterval,
+          )
+          switch polled {
+          | Some(height) => h := height
+          | None => ()
           }
           if shouldPoll() {
             await Utils.delay(interval)
@@ -668,19 +737,15 @@ let getSourceNewHeight = async (
       })
       let height = await Promise.race([subscriptionPromise, pollingFallback])
       settled := true
+      switch cancelBackstop.contents {
+      | Some(cancel) => cancel()
+      | None => ()
+      }
 
-      switch heightResolver.contents {
-      | Some(resolve) =>
-        sourceState.pendingHeightResolvers =
-          sourceState.pendingHeightResolvers->Array.filter(pending => pending !== resolve)
-      | None => ()
-      }
-      switch downResolver.contents {
-      | Some(resolve) =>
-        sourceState.pendingSubscriptionDownResolvers =
-          sourceState.pendingSubscriptionDownResolvers->Array.filter(pending => pending !== resolve)
-      | None => ()
-      }
+      sourceState.pendingHeightResolvers =
+        sourceState.pendingHeightResolvers->dropResolver(heightResolver)
+      sourceState.pendingSubscriptionDownResolvers =
+        sourceState.pendingSubscriptionDownResolvers->dropResolver(downResolver)
 
       if height > newHeight.contents {
         newHeight := height
@@ -694,39 +759,22 @@ let getSourceNewHeight = async (
       }
     | None =>
       // No subscription, use REST polling
-      try {
-        let res = await source.getHeightOrThrow()
-        sourceState->recordRequestStats(res.requestStats)
-        let height = res.height
-
+      let (polled, interval) = await sourceManager->pollHeightOnce(
+        sourceState,
+        ~retry,
+        ~logger,
+        ~pollingInterval,
+      )
+      switch polled {
+      | Some(height) =>
         newHeight := height
-        if height <= knownHeight {
-          retry := 0
-
-          // If createHeightSubscription is available and height hasn't changed,
-          // create subscription instead of polling
-          switch source.createHeightSubscription {
-          | Some(createSubscription) if isRealtime =>
-            let unsubscribe = createSubscription(
-              ~onHeight=height => sourceState->handlePushedHeight(height),
-              ~onStatus=status => sourceState->handleSubscriptionStatus(status),
-            )
-            sourceState.unsubscribe = Some(unsubscribe)
-          | _ =>
-            // Slowdown polling when the chain isn't progressing
-            await Utils.delay(pollingInterval())
-          }
+        // A stream takes over from polling once the chain stops progressing,
+        // so a source that can push heights only subscribes at the head.
+        if height <= knownHeight && !(sourceState->ensureSubscribed(~isRealtime, ~logger)) {
+          // Slowdown polling when the chain isn't progressing
+          await Utils.delay(interval)
         }
-      } catch {
-      | exn =>
-        let retryInterval = sourceManager.getHeightRetryInterval(~retry=retry.contents)
-        logger->Logging.childTrace({
-          "msg": `Height retrieval from ${source.name} source failed. Retrying in ${retryInterval->Int.toString}ms.`,
-          "source": source.name,
-          "err": exn->Utils.prettifyExn,
-        })
-        retry := retry.contents + 1
-        await Utils.delay(retryInterval)
+      | None => await Utils.delay(interval)
       }
     }
   }
@@ -979,6 +1027,11 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isRealtime, ~reduc
     sourceManager.newBlockStallTimeout
   }
 
+  // Released once a source answers, so a wait that resolves in a block time
+  // doesn't leave a stall timer pending — and its whole continuation waiting to
+  // run against a race nobody is listening to — for the rest of the window.
+  let (stallElapsed, cancelStallTimeout) = Utils.delayWithCancel(stallTimeout)
+
   let (source, newBlockHeight) = await Promise.race(
     mainSources
     ->Array.map(async sourceState => {
@@ -996,24 +1049,29 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isRealtime, ~reduc
       )
     })
     ->Array.concat([
-      Utils.delay(stallTimeout)->Promise.then(() => {
-        // Build fallback: non-disabled sources not in mainSources with a valid role, even with recent lastFailedAt
-        let fallbackSources = []
-        sourcesState->Array.forEach(sourceState => {
-          if (
-            !sourceState.disabled &&
-            !(mainSources->Array.includes(sourceState)) &&
-            getSourceRole(
-              ~sourceFor=sourceState.source.sourceFor,
-              ~isRealtime,
-              ~hasRealtime=sourceManager.hasRealtime,
-            )->Option.isSome
-          ) {
-            fallbackSources->Array.push(sourceState)
-          }
-        })
+      stallElapsed->Promise.then(() =>
+        if status.contents === Done {
+          // Nothing to fall back to: a source already answered, and every
+          // getSourceNewHeight started from here would return without asking it
+          // anything. Forever-pending is what the race wants from a losing arm.
+          Promise.make((_resolve, _reject) => ())
+        } else {
+          // Build fallback: non-disabled sources not in mainSources with a valid role, even with recent lastFailedAt
+          let fallbackSources = []
+          sourcesState->Array.forEach(sourceState => {
+            if (
+              !sourceState.disabled &&
+              !(mainSources->Array.includes(sourceState)) &&
+              getSourceRole(
+                ~sourceFor=sourceState.source.sourceFor,
+                ~isRealtime,
+                ~hasRealtime=sourceManager.hasRealtime,
+              )->Option.isSome
+            ) {
+              fallbackSources->Array.push(sourceState)
+            }
+          })
 
-        if status.contents !== Done {
           status := Stalled
 
           switch fallbackSources {
@@ -1028,29 +1086,31 @@ let waitForNewBlock = async (sourceManager: t, ~knownHeight, ~isRealtime, ~reduc
                   ->Int.toString}s. Continuing polling with secondary RPC sources from the configuration.`,
             )
           }
+
+          // Promise.race will be forever pending if fallbackSources is empty
+          // which is good for this use case
+          Promise.race(
+            fallbackSources->Array.map(async sourceState => {
+              (
+                sourceState.source,
+                await sourceManager->getSourceNewHeight(
+                  ~sourceState,
+                  ~knownHeight,
+                  ~stallTimeout,
+                  ~isRealtime,
+                  ~status,
+                  ~logger,
+                  ~reducedPolling,
+                ),
+              )
+            }),
+          )
         }
-        // Promise.race will be forever pending if fallbackSources is empty
-        // which is good for this use case
-        Promise.race(
-          fallbackSources->Array.map(async sourceState => {
-            (
-              sourceState.source,
-              await sourceManager->getSourceNewHeight(
-                ~sourceState,
-                ~knownHeight,
-                ~stallTimeout,
-                ~isRealtime,
-                ~status,
-                ~logger,
-                ~reducedPolling,
-              ),
-            )
-          }),
-        )
-      }),
+      ),
     ]),
   )
 
+  cancelStallTimeout()
   sourceManager.activeSource = source
 
   // Show a higher level log if we displayed a warning/error after newBlockStallTimeout

--- a/scenarios/test_codegen/test/HeightPushMetric_test.res
+++ b/scenarios/test_codegen/test/HeightPushMetric_test.res
@@ -52,6 +52,12 @@ describe("Height subscription push metrics", () => {
         }
         t.expect(subscriptionOpened(), ~message="the height subscription should be open").toBe(true)
 
+        // Both shipped transports report Live the moment they connect, and the
+        // wait polls at full rate next to the stream until one does, so without
+        // this the pushes below are counted on a path no real source takes.
+        sourceMock.setHeightSubscriptionStatus(Live)
+        await Utils.delay(0)
+
         let heightPushSamples = async () => {
           let samples = await indexerMock.metric("envio_source_request_total")
           samples

--- a/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
+++ b/scenarios/test_codegen/test/lib_tests/SourceManager_test.res
@@ -3087,6 +3087,37 @@ describe("SourceManager height subscription", () => {
     let _ = await waiting
   }
 
+  Async.it("Subscribes once when two waits are in flight for the same source", async t => {
+    let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])
+    let sourceManager = SourceManager.make(~isRealtime=true, ~sources=[mock.source])
+
+    // What a rollback leaves behind: dispatch starts a wait for the new stateId
+    // without cancelling the one it superseded, so both run the poll that
+    // precedes subscribing and both come back to find no subscription.
+    let superseded =
+      sourceManager->SourceManager.waitForNewBlock(
+        ~isRealtime=true,
+        ~knownHeight=100,
+        ~reducedPolling=false,
+      )
+    let current =
+      sourceManager->SourceManager.waitForNewBlock(
+        ~isRealtime=true,
+        ~knownHeight=100,
+        ~reducedPolling=false,
+      )
+
+    mock.resolveGetHeightOrThrow(100)
+    await Utils.delay(0)
+    let subscriptions = mock.heightSubscriptionCalls->Array.length
+
+    mock.triggerHeightSubscription(101)
+
+    // A second subscription would overwrite the first one's close function,
+    // leaving a connection nothing can ever close.
+    t.expect((subscriptions, await superseded, await current)).toStrictEqual((1, 101, 101))
+  })
+
   Async.it("Polls immediately when the subscription reports it went down", async t => {
     let stallTimeout = 2_000
     let mock = MockIndexer.Source.make([#getHeightOrThrow, #createHeightSubscription])


### PR DESCRIPTION
## Summary

This PR fixes resource leaks in the height stream subscription system and improves error reporting by carrying detailed failure information through the status callbacks. The changes ensure that pending promises and timers are properly cancelled when no longer needed, preventing memory accumulation on fast chains and during subscription reconnects.

## Key Changes

- **Resource cleanup**: Added `delayWithCancel()` utility to allow early cancellation of pending timers, preventing accumulation of pending promises in the race conditions used throughout the height fetching loop. Timers are now cancelled once their race settles.

- **Resolver cleanup**: Introduced `dropResolver()` helper to properly remove resolved promises from pending arrays, preventing closure accumulation when sources don't answer.

- **Subscription state management**: Fixed `ensureSubscribed()` to prevent overwriting live subscription close functions during rollbacks when multiple waits are in flight. Added explicit `unsubscribe = None` after calling unsubscribe to prevent claiming a closed subscription.

- **Error detail propagation**: Extended `heightSubscriptionStatus` to include optional `detail` field carrying the raw provider error message (e.g., HTTP response body, malformed frame content). Details are truncated to 200 characters to prevent log flooding.

- **Improved failure tracking**: Changed backoff reset logic from counting delivered events to measuring connection uptime against the wait cost. A connection that outlives the retry delay it cost is considered "proven" and resets the backoff, regardless of how many events it delivered. This correctly handles load balancers rotating connections and slow chains.

- **Enhanced logging**: Added detailed trace logs for height stream failures, catch-up poll failures, and subscription status changes, carrying the provider's error detail where available.

- **Test improvements**: Updated height stream tests to verify detail propagation, connection lifetime-based backoff reset, and detail truncation. Removed tests for event-count-based backoff reset as it's replaced by uptime-based logic.

## Notable Implementation Details

- The `provenMillis` threshold rises with backoff escalation, so endpoints that consistently fail at the same age keep escalating rather than settling into a reconnect loop.
- Fallback source polling only triggers if the main race hasn't already settled, preventing unnecessary work when a source has already answered.
- Both shipped transports (HyperSync and RpcWebSocket) now report failure details through the driver interface, making error context available to the SourceManager for logging and metrics.

https://claude.ai/code/session_013QQYw6DZ4Z8M2RjNb8XUP4