### PR TITLE
ci: drop in-memory storage run from envio-tests

### DIFF
--- a/.github/workflows/build_and_verify.yml
+++ b/.github/workflows/build_and_verify.yml
@@ -174,13 +174,19 @@ jobs:
         working-directory: packages/e2e-tests
         run: pnpm test:templates
 
-  # Scenario integration tests
-  # envio-tests runs once per storage backend; GraphQL/Hasura coverage lives in
-  # the e2e-test job
-  scenarios-test:
+  # The scenario suite is backend-agnostic, so it runs once per storage
+  # backend, one runner each. A scenario that can't run on a backend skips
+  # itself with a reason. The ClickHouse leg still needs Postgres: ClickHouse
+  # is a sink attached to Postgres storage, not a replacement for it.
+  envio-tests:
     runs-on: ubuntu-latest
     needs: build-envio-package
     timeout-minutes: 9
+
+    strategy:
+      fail-fast: false
+      matrix:
+        storage: [postgres, clickhouse]
 
     services:
       postgres:
@@ -215,19 +221,54 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/prepare-envio-artifacts
 
-      # The scenario suite is backend-agnostic, so it runs twice. A
-      # scenario that can't run on a backend skips itself with a reason.
-      - name: envio-tests (postgres)
+      - name: envio-tests (${{ matrix.storage }})
         working-directory: packages/envio-tests
         run: pnpm test
         env:
-          ENVIO_TEST_STORAGE: postgres
+          ENVIO_TEST_STORAGE: ${{ matrix.storage }}
 
-      - name: envio-tests (clickhouse)
-        working-directory: packages/envio-tests
-        run: pnpm test
+      - name: Test Failure Notification
+        uses: rjstone/discord-webhook-notify@c2597273488aeda841dd1e891321952b51f7996f # v2.2.1
+        if: failure() && github.event_name == 'push'
+        with:
+          severity: error
+          description: |
+            - **Repository:** [${{ github.repository }}](${{ github.server_url }}/${{ github.repository }})
+            - **Workflow:** [${{ github.workflow }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            - **Event:** ${{ github.event_name }}
+            - **Branch:** ${{ github.ref_name }}
+            - **Commit:** [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+            - **Triggering Actor:** ${{ github.triggering_actor }}
+          details: "envio-tests (${{ matrix.storage }}) Failed on main!"
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+
+  # Scenario integration tests
+  # GraphQL/Hasura coverage lives in the e2e-test job
+  scenarios-test:
+    runs-on: ubuntu-latest
+    needs: build-envio-package
+    timeout-minutes: 9
+
+    services:
+      postgres:
+        image: postgres:16
         env:
-          ENVIO_TEST_STORAGE: clickhouse
+          POSTGRES_PASSWORD: testing
+          POSTGRES_DB: envio-dev
+          POSTGRES_USER: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5433:5432
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: ./.github/actions/prepare-envio-artifacts
 
       - name: CLI subprocess tests
         working-directory: packages/e2e-tests

--- a/.github/workflows/build_and_verify.yml
+++ b/.github/workflows/build_and_verify.yml
@@ -215,14 +215,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/prepare-envio-artifacts
 
-      # The scenario suite is backend-agnostic, so it runs three times. A
+      # The scenario suite is backend-agnostic, so it runs twice. A
       # scenario that can't run on a backend skips itself with a reason.
-      - name: envio-tests (memory)
-        working-directory: packages/envio-tests
-        run: pnpm test
-        env:
-          ENVIO_TEST_STORAGE: memory
-
       - name: envio-tests (postgres)
         working-directory: packages/envio-tests
         run: pnpm test


### PR DESCRIPTION
Removes the `envio-tests (memory)` step from `build_and_verify.yml`. The scenario suite now runs twice in CI — postgres and clickhouse — instead of three times.

`ENVIO_TEST_STORAGE: memory` remains supported locally (it's the default when the env var is unset in `IndexerRunner.res`), it just no longer gets its own CI run.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qcKVr817wjmCZiYK4EWHH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated verification across PostgreSQL and ClickHouse storage backends.
  - Added separate coverage for scenario, CLI, and code-generation tests using PostgreSQL.
  - Improved failure notifications to identify which storage backend encountered an issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->