### PR TITLE
Build the envio native addon once per vitest run

### DIFF
--- a/packages/envio-tests/test/helpers/globalSetup.ts
+++ b/packages/envio-tests/test/helpers/globalSetup.ts
@@ -1,6 +1,43 @@
+import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+
+// Build the addon once before worker forks exist. Each fork otherwise runs
+// `cargo build --lib` and can sit on cargo's lock through vitest's teardown.
+function buildDevAddon(): void {
+  const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "..",
+    ".."
+  );
+  const cliDir = path.join(repoRoot, "packages", "cli");
+  if (!fs.existsSync(path.join(cliDir, "Cargo.toml"))) {
+    return;
+  }
+
+  execSync("cargo build --lib", { cwd: cliDir, stdio: "inherit" });
+
+  const libName =
+    process.platform === "darwin"
+      ? "libenvio.dylib"
+      : process.platform === "win32"
+        ? "envio.dll"
+        : "libenvio.so";
+  const srcPath = path.join(repoRoot, "target", "debug", libName);
+  const nodePath = path.join(repoRoot, "target", "debug", "envio.node");
+  if (!fs.existsSync(srcPath)) {
+    return;
+  }
+  if (
+    !fs.existsSync(nodePath) ||
+    fs.statSync(nodePath).mtimeMs < fs.statSync(srcPath).mtimeMs
+  ) {
+    fs.copyFileSync(srcPath, nodePath);
+  }
+}
 
 // `fromUserApi` keeps its generated modules for the whole run so vitest
 // can render code frames from them. Clearing here — once, before any worker
@@ -9,4 +46,5 @@ import { fileURLToPath } from "node:url";
 export default function setup(): void {
   const tmpDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", ".tmp");
   fs.rmSync(tmpDir, { recursive: true, force: true });
+  buildDevAddon();
 }

--- a/packages/envio-tests/vitest.config.ts
+++ b/packages/envio-tests/vitest.config.ts
@@ -1,4 +1,9 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const devAddon = path.join(repoRoot, "target", "debug", "envio.node");
 
 export default defineConfig({
   test: {
@@ -15,6 +20,9 @@ export default defineConfig({
     hookTimeout: 30_000,
     setupFiles: ["test/setup.ts"],
     globalSetup: ["test/helpers/globalSetup.ts", "test/helpers/GlobalSetup.res.mjs"],
+    env: {
+      ENVIO_DEV_ADDON: devAddon,
+    },
     passWithNoTests: true,
     server: {
       deps: {

--- a/packages/envio/src/Core.res
+++ b/packages/envio/src/Core.res
@@ -84,6 +84,10 @@ let loadDevAddon: ({..}, string) => addon = %raw(`function(req, envioDir) {
   var path = Nodepath;
   var fs = Nodefs;
 
+  // Vitest test.env points workers at the addon globalSetup already built.
+  var preBuilt = process.env.ENVIO_DEV_ADDON;
+  if (preBuilt && fs.existsSync(preBuilt)) return req(preBuilt);
+
   var repoRoot = null;
   var dir = path.resolve(envioDir);
   for (var i = 0; i < 10; i++) {


### PR DESCRIPTION
## Why

`envio-tests` uses vitest forks. Each fork used to run `cargo build --lib` on first native-addon load. Cargo serializes those builds on its lockfile, so a fork can sit inside `execSync` through vitest teardown and get killed. The file that fork was running then disappears from the totals with no failing test.

## Change

- `globalSetup` builds the addon once, before any worker exists, and copies it to `target/debug/envio.node`.
- Vitest sets `ENVIO_DEV_ADDON` to that path.
- `loadDevAddon` returns that artifact when the env var is set, instead of building again.

No indexer behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Test runs now automatically prepare the required native addon before workers start.
  - Test configuration uses the development addon when available, improving consistency across local environments and platforms.

- **Chores**
  - Improved development fallback behavior so the addon can be discovered or built automatically when no prebuilt version is available.
  - Existing temporary test-directory cleanup remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->