### PR TITLE
Rebuild the CLI when template files change

### DIFF
--- a/packages/cli/build.rs
+++ b/packages/cli/build.rs
@@ -1,5 +1,9 @@
 extern crate napi_build;
 
 fn main() {
+    // `include_dir!` embeds the template tree without telling Cargo what it
+    // read, so a new or edited template file otherwise leaves the previous
+    // binary in place and `envio init` writes a project missing that file.
+    println!("cargo:rerun-if-changed=templates");
     napi_build::setup();
 }


### PR DESCRIPTION
## Why

The CLI embeds `packages/cli/templates` with `include_dir!`. Cargo does not see those files as inputs, so adding or editing a template (for example a new IDL under `envio init`) can leave the previous binary in place. `envio init` then writes a project without that file.

## Change

`build.rs` emits `cargo:rerun-if-changed=templates`.

No runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build updates so changes to template files are detected and trigger the necessary rebuild process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->