### PR TITLE
Refactor column resolution and improve schema error reporting

### DIFF
--- a/packages/cli/src/config_parsing/entity_parsing.rs
+++ b/packages/cli/src/config_parsing/entity_parsing.rs
@@ -21,6 +21,7 @@ use graphql_parser::schema::{
 use graphql_parser::Pos;
 use serde::{Serialize, Serializer};
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     fmt::{self},
     path::PathBuf,
@@ -46,6 +47,14 @@ impl Schema {
         }
     }
 
+    /// Entities in name order, so a validation error doesn't depend on which
+    /// one the hash map happened to yield first.
+    pub fn entities_by_name(&self) -> Vec<&Entity> {
+        let mut entities: Vec<&Entity> = self.entities.values().collect();
+        entities.sort_by(|a, b| a.name.cmp(&b.name));
+        entities
+    }
+
     pub fn new(entities: Vec<Entity>, enums: Vec<GraphQLEnum>) -> anyhow::Result<Self> {
         let entities = unique_hashmap::from_vec_no_duplicates(
             entities.into_iter().map(|e| (e.name.clone(), e)).collect(),
@@ -61,10 +70,10 @@ impl Schema {
 }
 
 /// `schema.graphql:12:3` — where in the schema an error was raised, so an
-/// editor or terminal can jump straight to it. `Pos` is already 1-based. Used
-/// as anyhow context, which supplies the `: ` that follows it.
+/// editor or terminal can jump straight to it. `Pos` is 1-based and renders as
+/// `line:column`. Used as anyhow context, which supplies the `: ` that follows.
 fn at(source: &str, position: Pos) -> String {
-    format!("{source}:{}:{}", position.line, position.column)
+    format!("{source}:{position}")
 }
 
 /// Renders `Invalid `<directive>` on `<Entity>`: <problem>.` with a single
@@ -79,39 +88,148 @@ fn directive_error(
     anyhow!("Invalid `{directive}` on `{entity}`: {problem}.\n  {suggestion}")
 }
 
+/// A column an entity directive named, together with the field it resolved to.
+/// The chain id envio appends has no `Field` behind it.
+struct ResolvedColumn<'a> {
+    column: EntityColumn,
+    field: Option<&'a Field>,
+}
+
+/// Resolves the column names an entity directive lists against the columns the
+/// entity's table actually has: the fields it declares, plus the chain id envio
+/// appends to a per-chain entity.
+struct ColumnResolver<'a> {
+    entity: &'a str,
+    fields: &'a [Field],
+    has_chain_id_column: bool,
+    cross_chain: bool,
+}
+
+impl<'a> ColumnResolver<'a> {
+    fn resolve(&self, directive: &str, column: &str) -> anyhow::Result<ResolvedColumn<'a>> {
+        if let Some(field) = self.fields.iter().find(|f| f.name == column) {
+            if field.field_type.is_derived_from() {
+                return Err(directive_error(
+                    self.entity,
+                    directive,
+                    &format!("`{column}` is a @derivedFrom field, which has no column"),
+                    "Use a stored field instead.",
+                ));
+            }
+            return Ok(ResolvedColumn {
+                column: EntityColumn::Declared(column.to_string()),
+                field: Some(field),
+            });
+        }
+        if self.has_chain_id_column && column == CHAIN_ID_FIELD_NAME {
+            return Ok(ResolvedColumn {
+                column: EntityColumn::ChainId,
+                field: None,
+            });
+        }
+        Err(directive_error(
+            self.entity,
+            directive,
+            &format!("`{column}` is not a column of the entity"),
+            &self.unknown_column_suggestion(column),
+        ))
+    }
+
+    /// Resolves a directive's column list, rejecting a column listed twice.
+    /// `builds` names what the list is building, for the error.
+    fn resolve_distinct<T>(
+        &self,
+        directive: &str,
+        builds: &str,
+        columns: impl IntoIterator<Item = (String, T)>,
+    ) -> anyhow::Result<Vec<(ResolvedColumn<'a>, T)>> {
+        let mut seen = HashSet::new();
+        columns
+            .into_iter()
+            .map(|(written_as, payload)| {
+                if !seen.insert(written_as.clone()) {
+                    return Err(directive_error(
+                        self.entity,
+                        directive,
+                        &format!("`{written_as}` is listed twice"),
+                        &format!(
+                            "List each column once — repeating it adds nothing to the {builds}."
+                        ),
+                    ));
+                }
+                Ok((self.resolve(directive, &written_as)?, payload))
+            })
+            .collect()
+    }
+
+    fn unknown_column_suggestion(&self, column: &str) -> String {
+        if RESERVED_CHAIN_ID_FIELD_NAMES.contains(&column) {
+            return if self.has_chain_id_column {
+                format!(
+                    "Spell the chain column as `{CHAIN_ID_FIELD_NAME}`, the way it's named in the \
+                     schema, whatever `column_name_format` the storage uses."
+                )
+            } else if self.cross_chain {
+                format!(
+                    "envio only appends a chain column to per-chain entities, and `{}` is \
+                     `@crossChain`. Drop `@crossChain`, or declare a `{CHAIN_ID_FIELD_NAME}` field \
+                     yourself.",
+                    self.entity
+                )
+            } else {
+                format!(
+                    "envio only appends a chain column to per-chain entities, and entities are \
+                     cross-chain unless config.yaml sets `disable_default_cross_chain: true`. Set \
+                     it, or declare a `{CHAIN_ID_FIELD_NAME}` field yourself."
+                )
+            };
+        }
+
+        // Derived fields are left out: they have no column, so pointing at one
+        // would only trade this error for another.
+        let mut available: Vec<String> = self
+            .fields
+            .iter()
+            .filter(|f| f.name != "id" && !f.field_type.is_derived_from())
+            .map(|f| format!("`{}`", f.name))
+            .collect();
+        if self.has_chain_id_column {
+            available.push(format!("`{CHAIN_ID_FIELD_NAME}`"));
+        }
+        if available.is_empty() {
+            "The entity declares no columns besides `id`.".to_string()
+        } else {
+            format!("Available columns: {}.", available.join(", "))
+        }
+    }
+}
+
 /// Resolves the columns a `clickhouse.orderBy` lists into the sorting key they
 /// become, rejecting anything ClickHouse can't sort by.
 fn resolve_order_by(
-    entity: &str,
-    fields: &[Field],
-    resolve_column: &dyn Fn(&str, &str) -> anyhow::Result<EntityColumn>,
+    resolver: &ColumnResolver,
     columns: Vec<String>,
 ) -> anyhow::Result<Vec<EntityColumn>> {
     const DIRECTIVE: &str = "clickhouse.orderBy";
 
-    let mut seen = HashSet::new();
-    columns
+    resolver
+        .resolve_distinct(
+            DIRECTIVE,
+            "sorting key",
+            columns.into_iter().map(|c| (c, ())),
+        )?
         .into_iter()
-        .map(|column| {
-            if !seen.insert(column.clone()) {
+        .map(|(resolved, ())| {
+            if resolved.column.field_name() == "id" {
                 return Err(directive_error(
-                    entity,
-                    DIRECTIVE,
-                    &format!("`{column}` is listed twice"),
-                    "List each column once — repeating it adds nothing to the sorting key.",
-                ));
-            }
-            if column == "id" {
-                return Err(directive_error(
-                    entity,
+                    resolver.entity,
                     DIRECTIVE,
                     "`id` is already the sorting key when no `orderBy` is given",
                     "List only the columns to sort by instead of `id`.",
                 ));
             }
-            let resolved = resolve_column(DIRECTIVE, &column)?;
-            check_clickhouse_sortable(entity, fields, &resolved)?;
-            Ok(resolved)
+            check_clickhouse_sortable(resolver.entity, &resolved)?;
+            Ok(resolved.column)
         })
         .collect()
 }
@@ -120,20 +238,13 @@ fn resolve_order_by(
 /// (`allow_nullable_key` is off by default, arrays are never allowed). The
 /// appended chain id is a plain non-null integer, so only a declared field can
 /// trip either.
-fn check_clickhouse_sortable(
-    entity: &str,
-    fields: &[Field],
-    column: &EntityColumn,
-) -> anyhow::Result<()> {
+fn check_clickhouse_sortable(entity: &str, resolved: &ResolvedColumn) -> anyhow::Result<()> {
     const DIRECTIVE: &str = "clickhouse.orderBy";
 
-    let EntityColumn::Declared(name) = column else {
+    let Some(field) = resolved.field else {
         return Ok(());
     };
-    let field = fields
-        .iter()
-        .find(|f| &f.name == name)
-        .expect("a resolved Declared column names a field of the entity");
+    let name = &field.name;
 
     if field.field_type.is_optional() {
         return Err(directive_error(
@@ -143,7 +254,7 @@ fn check_clickhouse_sortable(
             "Make the field non-nullable to sort by it.",
         ));
     }
-    if field.field_type.to_user_defined_field_type().is_array() {
+    if field.field_type.is_array() {
         return Err(directive_error(
             entity,
             DIRECTIVE,
@@ -156,33 +267,31 @@ fn check_clickhouse_sortable(
 
 impl MultiFieldIndex {
     fn resolve(
-        entity: &str,
-        fields: &[Field],
-        resolve_column: &dyn Fn(&str, &str) -> anyhow::Result<EntityColumn>,
+        resolver: &ColumnResolver,
         columns: Vec<(String, IndexFieldDirection)>,
     ) -> anyhow::Result<Self> {
         const DIRECTIVE: &str = "@index";
 
-        let mut seen = HashSet::new();
-        let columns = columns
-            .into_iter()
-            .map(|(written_as, direction)| {
-                if !seen.insert(written_as.clone()) {
-                    return Err(directive_error(
-                        entity,
-                        DIRECTIVE,
-                        &format!("`{written_as}` is listed twice"),
-                        "List each column once — repeating it adds nothing to the index.",
-                    ));
-                }
-                Ok(IndexField {
-                    column: resolve_column(DIRECTIVE, &written_as)?,
+        let entity = resolver.entity;
+        if columns.is_empty() {
+            return Err(directive_error(
+                entity,
+                DIRECTIVE,
+                "no columns are listed",
+                "List the columns to index, e.g. `@index(fields: [\"tokenId\", \"owner\"])`.",
+            ));
+        }
+
+        let resolved = Self(
+            resolver
+                .resolve_distinct(DIRECTIVE, "index", columns)?
+                .into_iter()
+                .map(|(resolved, direction)| IndexField {
+                    column: resolved.column,
                     direction,
                 })
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
-        let resolved = Self(columns);
+                .collect(),
+        );
 
         // A lone column is a plain single index, and two of them are never
         // worth building.
@@ -194,7 +303,8 @@ impl MultiFieldIndex {
                 "Remove the `@index` directive on it.",
             )),
             Some(EntityColumn::Declared(name))
-                if fields
+                if resolver
+                    .fields
                     .iter()
                     .any(|f| &f.name == name && f.field_type.has_indexed_directive()) =>
             {
@@ -283,7 +393,7 @@ impl Schema {
 
         let schema_path = path_utils::get_config_path_relative_to_root(
             project_paths,
-            PathBuf::from(relative_schema_path_from_config),
+            PathBuf::from(&relative_schema_path_from_config),
         )
         .context("Failed creating a relative path to schema")?;
 
@@ -295,11 +405,12 @@ impl Schema {
 
         // Errors name the schema by the path the project actually uses, so a
         // `schema:` override in config.yaml points at the file the user edited.
+        // A schema outside the project root keeps the path as configured rather
+        // than falling back to an absolute one, which would differ per machine.
         let source = schema_path
             .strip_prefix(&project_paths.project_root)
-            .unwrap_or(&schema_path)
-            .display()
-            .to_string();
+            .map(|relative| relative.display().to_string())
+            .unwrap_or(relative_schema_path_from_config);
 
         Self::from_string_at(&schema_string, default_cross_chain, &source)
     }
@@ -313,7 +424,15 @@ impl Schema {
         default_cross_chain: bool,
         source: &str,
     ) -> anyhow::Result<Self> {
-        let schema_doc = graphql_parser::parse_schema::<String>(schema_string)
+        // graphql_parser counts a comment line's `\r` and its `\n` as two line
+        // breaks, so a CRLF schema with comments reports positions past where
+        // the error is.
+        let schema_string = if schema_string.contains('\r') {
+            Cow::Owned(schema_string.replace("\r\n", "\n"))
+        } else {
+            Cow::Borrowed(schema_string)
+        };
+        let schema_doc = graphql_parser::parse_schema::<String>(&schema_string)
             .context("Failed to parse schema as document")?;
 
         Self::from_document(schema_doc, default_cross_chain, source)
@@ -662,6 +781,19 @@ impl ClickHouseEntityStorage {
     }
 }
 
+/// Whether an entity's rows are shared across chains. Every entity is unless
+/// config.yaml sets `disable_default_cross_chain: true`, which leaves only the
+/// ones carrying `@crossChain`. The rest are per-chain, and those are the ones
+/// envio appends the chain-id column to.
+pub fn is_cross_chain(cross_chain_directive: bool, default_cross_chain: bool) -> bool {
+    default_cross_chain || cross_chain_directive
+}
+
+/// Postgres silently truncates longer identifiers, which can collide two
+/// distinct columns and breaks the Hasura `custom_name` mapping, keyed by the
+/// untruncated name.
+pub const MAX_PG_IDENTIFIER_LENGTH: usize = 63;
+
 /// The name envio gives the chain-id column it appends to a per-chain entity.
 /// Storage may spell the column differently (`column_name_format: snake_case`),
 /// but a directive always names it the way the schema would.
@@ -734,91 +866,35 @@ impl Entity {
             .fields
             .iter()
             .map(|field| {
-                Field::from_obj_field(field).context(format!(
-                    "{}: Failed parsing field {} on entity {name}",
-                    at(source, field.position),
-                    field.name
-                ))
+                Field::from_obj_field(field).with_context(|| {
+                    format!(
+                        "{}: Failed parsing field {} on entity {name}",
+                        at(source, field.position),
+                        field.name
+                    )
+                })
             })
             .collect::<anyhow::Result<Vec<Field>>>()?;
 
-        validate_entity_shape(name, &fields).context(at_entity.clone())?;
+        validate_entity_shape(name, &fields).with_context(|| at_entity.clone())?;
 
-        let cross_chain = parse_flag_directive(obj, "crossChain")?;
-        let has_chain_id_column = !(default_cross_chain || cross_chain);
-
-        let resolve_column = |directive: &str, column: &str| -> anyhow::Result<EntityColumn> {
-            if let Some(field) = fields.iter().find(|f| f.name == column) {
-                if field.field_type.is_derived_from() {
-                    return Err(directive_error(
-                        name,
-                        directive,
-                        &format!("`{column}` is a @derivedFrom field, which has no column"),
-                        "Use a stored field instead.",
-                    ));
-                }
-                return Ok(EntityColumn::Declared(column.to_string()));
-            }
-            if has_chain_id_column && column == CHAIN_ID_FIELD_NAME {
-                return Ok(EntityColumn::ChainId);
-            }
-
-            let problem = format!("`{column}` is not a column of the entity");
-            let suggestion = if RESERVED_CHAIN_ID_FIELD_NAMES.contains(&column) {
-                if has_chain_id_column {
-                    format!(
-                        "Spell the chain column as `{CHAIN_ID_FIELD_NAME}`, the way it's named in \
-                         the schema, whatever `column_name_format` the storage uses."
-                    )
-                } else if cross_chain {
-                    format!(
-                        "envio only appends a chain column to per-chain entities, and `{name}` is \
-                         `@crossChain`. Drop `@crossChain`, or declare a `{CHAIN_ID_FIELD_NAME}` \
-                         field yourself."
-                    )
-                } else {
-                    format!(
-                        "envio only appends a chain column to per-chain entities, and entities \
-                         are cross-chain unless config.yaml sets `disable_default_cross_chain: \
-                         true`. Set it, or declare a `{CHAIN_ID_FIELD_NAME}` field yourself."
-                    )
-                }
-            } else {
-                // Derived fields are left out: they have no column, so pointing
-                // at one would only trade this error for another.
-                let mut available: Vec<String> = fields
-                    .iter()
-                    .filter(|f| f.name != "id" && !f.field_type.is_derived_from())
-                    .map(|f| format!("`{}`", f.name))
-                    .collect();
-                if has_chain_id_column {
-                    available.push(format!("`{CHAIN_ID_FIELD_NAME}`"));
-                }
-                if available.is_empty() {
-                    "The entity declares no columns besides `id`.".to_string()
-                } else {
-                    format!("Available columns: {}.", available.join(", "))
-                }
-            };
-            Err(directive_error(name, directive, &problem, &suggestion))
+        let cross_chain = parse_flag_directive(obj, "crossChain", source)?;
+        let internal = parse_flag_directive(obj, "internal", source)?;
+        let resolver = ColumnResolver {
+            entity: name,
+            fields: &fields,
+            has_chain_id_column: !is_cross_chain(cross_chain, default_cross_chain),
+            cross_chain,
         };
 
-        let multi_field_indexes = obj
-            .directives
-            .iter()
-            .filter(|directive| directive.name == "index")
-            .map(|directive| {
-                let at_directive = at(source, directive.position);
-                let columns = parse_index_directive_columns(directive)
-                    .context(format!("{at_directive}: Invalid `@index` on `{name}`"))?;
-                MultiFieldIndex::resolve(name, &fields, &resolve_column, columns)
-                    .context(at_directive)
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
-        let mut seen = HashSet::new();
-        for index in &multi_field_indexes {
-            if !seen.insert(index) {
+        let mut multi_field_indexes: Vec<MultiFieldIndex> = Vec::new();
+        for directive in obj.directives.iter().filter(|d| d.name == "index") {
+            let at_directive = at(source, directive.position);
+            let columns = parse_index_directive_columns(directive)
+                .with_context(|| format!("{at_directive}: Invalid `@index` on `{name}`"))?;
+            let index = MultiFieldIndex::resolve(&resolver, columns)
+                .with_context(|| at_directive.clone())?;
+            if multi_field_indexes.contains(&index) {
                 return Err(directive_error(
                     name,
                     "@index",
@@ -828,8 +904,9 @@ impl Entity {
                     ),
                     "Remove the duplicate `@index` directive.",
                 ))
-                .context(at_entity.clone());
+                .context(at_directive);
             }
+            multi_field_indexes.push(index);
         }
 
         // Points at the `@storage` directive when there is one; without it
@@ -842,8 +919,7 @@ impl Entity {
                 || at_entity.clone(),
                 |directive| at(source, directive.position),
             );
-        let (postgres, clickhouse) =
-            parse_storage_directive(obj, &fields, &resolve_column).context(at_storage)?;
+        let (postgres, clickhouse) = parse_storage_directive(obj, &resolver).context(at_storage)?;
 
         Ok(Self {
             name: name.to_string(),
@@ -853,7 +929,7 @@ impl Entity {
             postgres,
             clickhouse,
             cross_chain,
-            internal: parse_flag_directive(obj, "internal")?,
+            internal,
         })
     }
 }
@@ -868,9 +944,7 @@ fn parse_index_directive_columns(
         Some((_, Value::List(fields))) => fields
             .iter()
             .map(|v| match v {
-                // Simple string: "fieldName" (default ASC)
                 Value::String(field_name) => Ok((field_name.clone(), IndexFieldDirection::Asc)),
-                // List with direction: ["fieldName", "DESC"]
                 Value::List(parts) => {
                     if parts.len() != 2 {
                         return Err(anyhow!(
@@ -925,6 +999,19 @@ fn parse_index_directive_columns(
 impl Entity {
     pub fn has_storage_directive(&self) -> bool {
         self.postgres.is_some() || self.clickhouse.is_some()
+    }
+
+    /// Whether this entity's rows are written to ClickHouse. A storage
+    /// directive's omitted backend resolves to false at runtime (Config.res
+    /// `Option.getOr(false)`), so a directive routes to ClickHouse only when it
+    /// enables the backend — a boolean `true` or the table options object.
+    /// Without a directive the entity follows the backend's `default`.
+    pub fn uses_clickhouse(&self, clickhouse_default: bool) -> bool {
+        if self.has_storage_directive() {
+            self.clickhouse.as_ref().is_some_and(|c| c.is_enabled())
+        } else {
+            clickhouse_default
+        }
     }
 
     /// Returns the fields of this [`Entity`] in schema-defined order.
@@ -1078,9 +1165,10 @@ fn validate_entity_shape(name: &str, fields: &[Field]) -> anyhow::Result<()> {
         }
     }
 
-    if name.len() > 63 {
+    if name.len() > MAX_PG_IDENTIFIER_LENGTH {
         return Err(anyhow!(
-            "Entity name '{name}' is too long. It must be less than 64 characters."
+            "Entity name '{name}' is too long. It must be less than {} characters.",
+            MAX_PG_IDENTIFIER_LENGTH + 1
         ));
     }
 
@@ -1098,32 +1186,37 @@ const STORAGE_DIRECTIVE_HINT: &str =
 /// checked elsewhere — `@crossChain` legality depends on the config's
 /// `disable_default_cross_chain`, and `@internal` relationship rules live in
 /// `system_config.rs`.
-fn parse_flag_directive(obj: &ObjectType<String>, directive_name: &str) -> anyhow::Result<bool> {
+fn parse_flag_directive(
+    obj: &ObjectType<String>,
+    directive_name: &str,
+    source: &str,
+) -> anyhow::Result<bool> {
     let directives: Vec<&Directive<'_, String>> = obj
         .directives
         .iter()
         .filter(|directive| directive.name == directive_name)
         .collect();
 
-    match directives.len() {
-        0 => Ok(false),
-        1 => {
-            let directive = directives[0];
+    match directives.as_slice() {
+        [] => Ok(false),
+        [directive] => {
             if let Some((arg_name, _)) = directive.arguments.first() {
                 return Err(anyhow!(
                     "Invalid @{directive_name} directive on `{}`. It takes no arguments, but got \
                      `{}`.",
                     obj.name,
                     arg_name
-                ));
+                ))
+                .context(at(source, directive.position));
             }
             Ok(true)
         }
-        _ => Err(anyhow!(
+        [_, duplicate, ..] => Err(anyhow!(
             "Invalid @{directive_name} directive on `{}`. Only one @{directive_name} directive is \
              allowed per entity.",
             obj.name
-        )),
+        ))
+        .context(at(source, duplicate.position)),
     }
 }
 
@@ -1135,8 +1228,7 @@ fn parse_flag_directive(obj: &ObjectType<String>, directive_name: &str) -> anyho
 /// missing-in-multi-storage-mode) happen later in `system_config.rs`.
 fn parse_storage_directive(
     obj: &ObjectType<String>,
-    fields: &[Field],
-    resolve_column: &dyn Fn(&str, &str) -> anyhow::Result<EntityColumn>,
+    resolver: &ColumnResolver,
 ) -> anyhow::Result<(Option<bool>, Option<ClickHouseEntityStorage>)> {
     let storage_directives: Vec<&Directive<'_, String>> = obj
         .directives
@@ -1194,8 +1286,7 @@ fn parse_storage_directive(
                 clickhouse = Some(ClickHouseEntityStorage::Enabled(*b))
             }
             ("clickhouse", Value::Object(arg_fields)) => {
-                let options =
-                    parse_clickhouse_table_options(&obj.name, arg_fields, fields, resolve_column)?;
+                let options = parse_clickhouse_table_options(arg_fields, resolver)?;
                 // An options object with nothing set only enables the backend,
                 // so normalize it to the boolean form: it serializes identically
                 // to `clickhouse: true` and won't diff a stored config.
@@ -1232,11 +1323,10 @@ fn parse_storage_directive(
 }
 
 fn parse_clickhouse_table_options(
-    entity_name: &str,
     arg_fields: &std::collections::BTreeMap<String, Value<'_, String>>,
-    fields: &[Field],
-    resolve_column: &dyn Fn(&str, &str) -> anyhow::Result<EntityColumn>,
+    resolver: &ColumnResolver,
 ) -> anyhow::Result<ClickHouseTableOptions> {
+    let entity_name = resolver.entity;
     let expression = |key: &str, value: &Value<'_, String>| match value {
         Value::String(expr) if !expr.trim().is_empty() => Ok(expr.trim().to_string()),
         _ => Err(anyhow!(
@@ -1272,12 +1362,7 @@ fn parse_clickhouse_table_options(
                         ));
                     }
                 };
-                options.order_by = Some(resolve_order_by(
-                    entity_name,
-                    fields,
-                    resolve_column,
-                    field_names,
-                )?);
+                options.order_by = Some(resolve_order_by(resolver, field_names)?);
             }
             "skippingIndexes" => {
                 let items = match value {
@@ -1607,8 +1692,7 @@ impl Field {
             pg_type_modifications,
         };
 
-        let field_type = FieldType::from_obj_field_type(&field.field_type, params)
-            .context(format!("Failed parsing field {}", field.name))?;
+        let field_type = FieldType::from_obj_field_type(&field.field_type, params)?;
 
         Ok(Field {
             name: field.name.clone(),
@@ -1675,7 +1759,7 @@ impl Field {
             .multi_field_indexes
             .iter()
             .filter_map(MultiFieldIndex::as_single)
-            .any(|column| column == &EntityColumn::Declared(self.name.clone()));
+            .any(|column| matches!(column, EntityColumn::Declared(name) if name == &self.name));
 
         has_indexed_directive || has_single_field_index_directive
     }
@@ -1743,6 +1827,17 @@ impl Field {
 pub enum IndexFieldDirection {
     Asc,
     Desc,
+}
+
+impl IndexFieldDirection {
+    /// The spelling the generated ReScript and the stored config share, as
+    /// opposed to `Display`, which renders the lowercase SQL keyword.
+    pub fn as_pascal_str(&self) -> &'static str {
+        match self {
+            Self::Asc => "Asc",
+            Self::Desc => "Desc",
+        }
+    }
 }
 
 impl fmt::Display for IndexFieldDirection {

--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -101,6 +101,15 @@ pub struct BaseConfig {
     pub disable_default_cross_chain: Option<bool>,
 }
 
+impl BaseConfig {
+    /// Entities and effect caches are shared across chains unless the config
+    /// opts out. Decides which entities get an appended chain-id column, so the
+    /// schema parser and the validators have to agree on it.
+    pub fn default_cross_chain(&self) -> bool {
+        !self.disable_default_cross_chain.unwrap_or(false)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct StorageConfig {

--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -1,6 +1,5 @@
 use super::{
-    entity_parsing::{self, IndexFieldDirection},
-    field_types,
+    entity_parsing, field_types,
     human_config::{self, evm::For, ColumnNameFormat},
     system_config::{
         self, field_type_to_arg_type, named_field_to_arg_def, Abi, ChainIdMode, Ecosystem,
@@ -843,10 +842,7 @@ impl SystemConfig {
                             .iter()
                             .map(|f| CompositeIndexJson {
                                 field_name: f.column.field_name().to_string(),
-                                direction: match f.direction {
-                                    IndexFieldDirection::Asc => "Asc".to_string(),
-                                    IndexFieldDirection::Desc => "Desc".to_string(),
-                                },
+                                direction: f.direction.as_pascal_str().to_string(),
                             })
                             .collect()
                     })

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -1,8 +1,8 @@
 use super::{
     chain_helpers::get_max_reorg_depth_from_id,
     entity_parsing::{
-        ClickHouseEntityStorage, Entity, EntityColumn, GqlScalar, GraphQLEnum, Schema,
-        RESERVED_CHAIN_ID_FIELD_NAMES,
+        self, ClickHouseEntityStorage, Entity, EntityColumn, GqlScalar, GraphQLEnum, Schema,
+        MAX_PG_IDENTIFIER_LENGTH, RESERVED_CHAIN_ID_FIELD_NAMES,
     },
     env_interpolation::interpolate_config_variables,
     human_config::{
@@ -256,9 +256,14 @@ impl ConfigSource for MemoryConfigSource<'_> {
         _configured_path: &Option<String>,
         default_cross_chain: bool,
     ) -> Result<Schema> {
-        match self.schema.map(str::trim) {
-            None | Some("") => Ok(Schema::empty()),
-            Some(schema) => Schema::from_string(schema, default_cross_chain),
+        // Parsed as given: schema errors carry the line and column they were
+        // raised at, and trimming first would report them against text the
+        // caller never wrote.
+        match self.schema {
+            Some(schema) if !schema.trim().is_empty() => {
+                Schema::from_string(schema, default_cross_chain)
+            }
+            _ => Ok(Schema::empty()),
         }
     }
 
@@ -566,11 +571,6 @@ pub fn validate_relationship_storage(storage: &Storage, schema: &Schema) -> anyh
     ))
 }
 
-// Postgres truncates longer identifiers silently, which can collide two
-// distinct columns and breaks the Hasura custom_name mapping (it is keyed
-// by the untruncated name).
-const MAX_PG_IDENTIFIER_LENGTH: usize = 63;
-
 /// Resolved column names can break table creation in ways schema.graphql
 /// validation can't see: distinct fields may collide on the same column
 /// (`tokenId` and an entity reference `token` both become `token_id`), shadow
@@ -706,11 +706,21 @@ pub fn chain_id_column_name(format: human_config::ColumnNameFormat) -> &'static 
     }
 }
 
-/// Whether an entity's rows are shared across chains. With the default
-/// cross-chain mode every entity is; otherwise only those carrying
-/// `@crossChain`.
 pub fn entity_is_cross_chain(entity: &Entity, default_cross_chain: bool) -> bool {
-    default_cross_chain || entity.cross_chain
+    entity_parsing::is_cross_chain(entity.cross_chain, default_cross_chain)
+}
+
+/// What to add to a field so ClickHouse stores it as a numeric Decimal. A
+/// BigDecimal needs both parameters — `@config(precision:)` alone is rejected
+/// by the field parser, so naming only it would send the user in a circle.
+fn precision_fix(stored: &GqlScalar) -> String {
+    match stored {
+        GqlScalar::BigDecimal(_) => format!(
+            "Add `@config(precision: N, scale: M)` with M <= N <= \
+             {CLICKHOUSE_DECIMAL_MAX_PRECISION}"
+        ),
+        _ => format!("Add `@config(precision: N)` with N <= {CLICKHOUSE_DECIMAL_MAX_PRECISION}"),
+    }
 }
 
 /// ClickHouse stores a BigInt or BigDecimal whose precision is unset (or
@@ -739,16 +749,8 @@ pub fn validate_clickhouse_sorting_key_scalars(
         _ => false,
     };
 
-    let mut entities: Vec<&Entity> = schema.entities.values().collect();
-    entities.sort_by(|a, b| a.name.cmp(&b.name));
-
-    for entity in &entities {
-        let uses_clickhouse = if entity.has_storage_directive() {
-            entity.clickhouse.as_ref().is_some_and(|c| c.is_enabled())
-        } else {
-            clickhouse_default
-        };
-        if !uses_clickhouse {
+    for entity in schema.entities_by_name() {
+        if !entity.uses_clickhouse(clickhouse_default) {
             continue;
         }
 
@@ -765,9 +767,13 @@ pub fn validate_clickhouse_sorting_key_scalars(
                     let EntityColumn::Declared(field_name) = column else {
                         continue;
                     };
-                    let field = entity
-                        .get_field(field_name)
-                        .expect("resolved orderBy names a declared field");
+                    let field = entity.get_field(field_name).ok_or_else(|| {
+                        anyhow!(
+                            "Invalid storage for `{}`. `clickhouse.orderBy` sorts by \
+                             `{field_name}`, which is not a field of the entity.",
+                            entity.name
+                        )
+                    })?;
                     let stored =
                         schema.resolve_stored_scalar(&field.field_type.get_underlying_scalar())?;
                     if stored_as_string(&stored) {
@@ -775,15 +781,14 @@ pub fn validate_clickhouse_sorting_key_scalars(
                             "Invalid storage for `{}`. `clickhouse.orderBy` sorts by \
                              `{field_name}`, which stores a {stored} that ClickHouse keeps as a \
                              String (sorted lexicographically, not numerically) unless a \
-                             precision is set. Add `@config(precision: N)` with N <= \
-                             {CLICKHOUSE_DECIMAL_MAX_PRECISION} to the {stored} it stores so it \
-                             sorts as a numeric Decimal.",
-                            entity.name
+                             precision is set. {} to the {stored} it stores so it sorts as a \
+                             numeric Decimal.",
+                            entity.name,
+                            precision_fix(&stored)
                         ));
                     }
                 }
             }
-            // No custom orderBy, so `id` is the sorting key.
             None => {
                 if let Ok(id_scalar @ GqlScalar::BigInt(_)) = entity.get_id_scalar() {
                     if stored_as_string(&id_scalar) {
@@ -960,22 +965,9 @@ pub fn validate_clickhouse_nullable_arrays(
         return Ok(());
     };
 
-    let mut entities: Vec<&Entity> = schema.entities.values().collect();
-    entities.sort_by(|a, b| a.name.cmp(&b.name));
-
     let mut offending: Vec<String> = vec![];
-    for entity in &entities {
-        // A storage directive's omitted backend resolves to false at runtime
-        // (Config.res `Option.getOr(false)`), so a directive routes to
-        // ClickHouse only when it enables the backend (boolean `true` or the
-        // table options object form). Without a directive the entity follows
-        // the backend's `default`.
-        let uses_clickhouse = if entity.has_storage_directive() {
-            entity.clickhouse.as_ref().is_some_and(|c| c.is_enabled())
-        } else {
-            clickhouse.entity_default
-        };
-        if !uses_clickhouse {
+    for entity in schema.entities_by_name() {
+        if !entity.uses_clickhouse(clickhouse.entity_default) {
             continue;
         }
         for field in entity.get_fields() {
@@ -1114,7 +1106,7 @@ impl SystemConfig {
         let mut contracts: ContractMap = HashMap::new();
 
         let base_config = human_config.get_base_config();
-        let default_cross_chain = !base_config.disable_default_cross_chain.unwrap_or(false);
+        let default_cross_chain = base_config.default_cross_chain();
         let storage = Storage::resolve(base_config.storage.as_ref())?;
         validate_entity_storage(&storage, &schema)?;
         validate_relationship_storage(&storage, &schema)?;
@@ -1672,7 +1664,7 @@ impl SystemConfig {
         };
 
         let base_config = human_config.get_base_config();
-        let default_cross_chain = !base_config.disable_default_cross_chain.unwrap_or(false);
+        let default_cross_chain = base_config.default_cross_chain();
         let schema = source.load_schema(&base_config.schema, default_cross_chain)?;
         Self::from_human_config_with_source(human_config, schema, source)
     }

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     config_parsing::{
         chain_helpers::Network,
-        entity_parsing::{Entity, Field, GraphQLEnum, IndexField, IndexFieldDirection},
+        entity_parsing::{Entity, Field, GraphQLEnum, IndexField},
         event_parsing::abi_to_rescript_type,
         field_types,
         human_config::HumanConfig,
@@ -223,10 +223,7 @@ impl CompositeIndexFieldTemplate {
     fn from_index_field(index_field: &IndexField) -> Self {
         Self {
             field_name: index_field.column.field_name().to_string(),
-            direction: match index_field.direction {
-                IndexFieldDirection::Asc => "Asc".to_string(),
-                IndexFieldDirection::Desc => "Desc".to_string(),
-            },
+            direction: index_field.direction.as_pascal_str().to_string(),
         }
     }
 }

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -1389,7 +1389,7 @@ type Token {
   value: BigInt!
 }
 `,
-      "schema.graphql:1:1: No 'id' field found on entity Token. Please add an 'id' field to your entity.",
+      "schema.graphql:2:1: No 'id' field found on entity Token. Please add an 'id' field to your entity.",
     ),
     (
       "rejects duplicate fields",
@@ -1400,7 +1400,7 @@ type Token {
   value: String!
 }
 `,
-      "schema.graphql:1:1: Found fields with duplicate names on Entity Token: 'value'",
+      "schema.graphql:2:1: Found fields with duplicate names on Entity Token: 'value'",
     ),
     (
       "rejects an index that references a missing field",
@@ -1409,7 +1409,7 @@ type Token @index(fields: ["missing"]) {
   id: ID!
 }
 `,
-      `schema.graphql:1:12: Invalid \`@index\` on \`Token\`: \`missing\` is not a column of the entity.
+      `schema.graphql:2:12: Invalid \`@index\` on \`Token\`: \`missing\` is not a column of the entity.
   The entity declares no columns besides \`id\`.`,
     ),
     (
@@ -1419,7 +1419,7 @@ type Token @storage(redis: true) {
   id: ID!
 }
 `,
-      "schema.graphql:1:12: Invalid @storage directive on \`Token\`. Unknown argument \`redis\`. Expected args from {postgres, clickhouse}: \`postgres\` takes a boolean, \`clickhouse\` takes a boolean or a table options object, e.g. @storage(postgres: true, clickhouse: true) or @storage(clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}).",
+      "schema.graphql:2:12: Invalid @storage directive on \`Token\`. Unknown argument \`redis\`. Expected args from {postgres, clickhouse}: \`postgres\` takes a boolean, \`clickhouse\` takes a boolean or a table options object, e.g. @storage(postgres: true, clickhouse: true) or @storage(clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}).",
     ),
     (
       "rejects entities routed to a disabled backend",
@@ -1438,7 +1438,7 @@ type Token {
   owner: String @derivedFrom(field: "tokens") @index
 }
 `,
-      "schema.graphql:3:3: Failed parsing field owner on entity Token: A field cannot be both @derivedFrom and @index: owner",
+      "schema.graphql:4:3: Failed parsing field owner on entity Token: A field cannot be both @derivedFrom and @index: owner",
     ),
     (
       "rejects id fields with an index directive",
@@ -1447,7 +1447,7 @@ type Token {
   id: ID! @index
 }
 `,
-      "schema.graphql:2:3: Failed parsing field id on entity Token: The field 'id' or 'ID' cannot be indexed or derivedFrom. Please remove the @index or @derivedFrom directive from field id",
+      "schema.graphql:3:3: Failed parsing field id on entity Token: The field 'id' or 'ID' cannot be indexed or derivedFrom. Please remove the @index or @derivedFrom directive from field id",
     ),
     (
       "rejects duplicate derivedFrom directives",
@@ -1457,7 +1457,7 @@ type Token {
   owner: String @derivedFrom(field: "one") @derivedFrom(field: "two")
 }
 `,
-      "schema.graphql:3:3: Failed parsing field owner on entity Token: Cannot use more than one of the same directive on field owner",
+      "schema.graphql:4:3: Failed parsing field owner on entity Token: Cannot use more than one of the same directive on field owner",
     ),
     (
       "rejects duplicate field index directives",
@@ -1467,7 +1467,7 @@ type Token {
   value: String @index @index
 }
 `,
-      "schema.graphql:3:3: Failed parsing field value on entity Token: Cannot use more than one of the same directive on field value",
+      "schema.graphql:4:3: Failed parsing field value on entity Token: Cannot use more than one of the same directive on field value",
     ),
     (
       "rejects duplicate entity index definitions",
@@ -1477,7 +1477,7 @@ type Token @index(fields: ["value"]) @index(fields: ["value"]) {
   value: String!
 }
 `,
-      `schema.graphql:1:1: Invalid \`@index\` on \`Token\`: the index over \`value\` is declared twice.
+      `schema.graphql:2:38: Invalid \`@index\` on \`Token\`: the index over \`value\` is declared twice.
   Remove the duplicate \`@index\` directive.`,
     ),
     (
@@ -1488,7 +1488,7 @@ type Token @index(fields: ["value"]) {
   value: String! @index
 }
 `,
-      `schema.graphql:1:12: Invalid \`@index\` on \`Token\`: \`value\` is already marked \`@index\` on the field.
+      `schema.graphql:2:12: Invalid \`@index\` on \`Token\`: \`value\` is already marked \`@index\` on the field.
   Keep one of them — the \`@index\` on the field, or \`@index(fields: ["value"])\` on the entity.`,
     ),
     (
@@ -1503,7 +1503,7 @@ type Token {
   owner: User!
 }
 `,
-      `schema.graphql:1:11: Invalid \`@index\` on \`User\`: \`tokens\` is a @derivedFrom field, which has no column.
+      `schema.graphql:2:11: Invalid \`@index\` on \`User\`: \`tokens\` is a @derivedFrom field, which has no column.
   Use a stored field instead.`,
     ),
     (
@@ -1514,7 +1514,7 @@ type Token @index(fields: [["value", "SIDEWAYS"]]) {
   value: String!
 }
 `,
-      "schema.graphql:1:12: Invalid `@index` on `Token`: Failed to get fields in index: Index direction must be \"ASC\" or \"DESC\", got \"SIDEWAYS\"",
+      "schema.graphql:2:12: Invalid `@index` on `Token`: Failed to get fields in index: Index direction must be \"ASC\" or \"DESC\", got \"SIDEWAYS\"",
     ),
     (
       "rejects malformed directional index entries",
@@ -1524,7 +1524,7 @@ type Token @index(fields: [["value", "DESC", "extra"]]) {
   value: String!
 }
 `,
-      "schema.graphql:1:12: Invalid `@index` on `Token`: Failed to get fields in index: Index field with direction must be a list of exactly 2 elements: [\"fieldName\", \"ASC\" or \"DESC\"]. Got 3 elements.",
+      "schema.graphql:2:12: Invalid `@index` on `Token`: Failed to get fields in index: Index field with direction must be a list of exactly 2 elements: [\"fieldName\", \"ASC\" or \"DESC\"]. Got 3 elements.",
     ),
     (
       "rejects config directives on unsupported scalar types",
@@ -1534,7 +1534,7 @@ type Token {
   value: String @config(precision: 76)
 }
 `,
-      "schema.graphql:3:3: Failed parsing field value on entity Token: The config directive is only applicable to BigInt and BigDecimal scalar types. Field 'value'",
+      "schema.graphql:4:3: Failed parsing field value on entity Token: The config directive is only applicable to BigInt and BigDecimal scalar types. Field 'value'",
     ),
     (
       "rejects unknown BigInt config arguments",
@@ -1544,7 +1544,7 @@ type Token {
   value: BigInt @config(scale: 2)
 }
 `,
-      "schema.graphql:3:3: Failed parsing field value on entity Token: The config directive on a BigInt should only have a 'precision' parameter. Unknown parameter 'scale'. Field 'value'",
+      "schema.graphql:4:3: Failed parsing field value on entity Token: The config directive on a BigInt should only have a 'precision' parameter. Unknown parameter 'scale'. Field 'value'",
     ),
     (
       "rejects unknown BigDecimal config arguments",
@@ -1554,7 +1554,7 @@ type Token {
   value: BigDecimal @config(precision: 20, scale: 2, rounding: 1)
 }
 `,
-      "schema.graphql:3:3: Failed parsing field value on entity Token: The config directive on a BigDecimal should only have 'precision' and 'scale' parameters. Unknown parameter(s) 'rounding'. Field 'value'",
+      "schema.graphql:4:3: Failed parsing field value on entity Token: The config directive on a BigDecimal should only have 'precision' and 'scale' parameters. Unknown parameter(s) 'rounding'. Field 'value'",
     ),
     (
       "requires both BigDecimal config arguments",
@@ -1564,7 +1564,7 @@ type Token {
   value: BigDecimal @config(precision: 20)
 }
 `,
-      "schema.graphql:3:3: Failed parsing field value on entity Token: The config directive on a BigDecimal must have both 'precision' and 'scale' parameters. Field 'value'",
+      "schema.graphql:4:3: Failed parsing field value on entity Token: The config directive on a BigDecimal must have both 'precision' and 'scale' parameters. Field 'value'",
     ),
     (
       "rejects non-boolean storage arguments",
@@ -1573,7 +1573,7 @@ type Token @storage(postgres: "yes") {
   id: ID!
 }
 `,
-      "schema.graphql:1:12: Invalid @storage directive on \`Token\`. Argument \`postgres\` must be a boolean. Expected args from {postgres, clickhouse}: \`postgres\` takes a boolean, \`clickhouse\` takes a boolean or a table options object, e.g. @storage(postgres: true, clickhouse: true) or @storage(clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}).",
+      "schema.graphql:2:12: Invalid @storage directive on \`Token\`. Argument \`postgres\` must be a boolean. Expected args from {postgres, clickhouse}: \`postgres\` takes a boolean, \`clickhouse\` takes a boolean or a table options object, e.g. @storage(postgres: true, clickhouse: true) or @storage(clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}).",
     ),
     (
       "rejects duplicate storage directives",
@@ -1582,7 +1582,7 @@ type Token @storage(postgres: true) @storage(clickhouse: true) {
   id: ID!
 }
 `,
-      "schema.graphql:1:12: Invalid @storage directive on \`Token\`. Only one @storage directive is allowed per entity. Expected args from {postgres, clickhouse}: \`postgres\` takes a boolean, \`clickhouse\` takes a boolean or a table options object, e.g. @storage(postgres: true, clickhouse: true) or @storage(clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}).",
+      "schema.graphql:2:12: Invalid @storage directive on \`Token\`. Only one @storage directive is allowed per entity. Expected args from {postgres, clickhouse}: \`postgres\` takes a boolean, \`clickhouse\` takes a boolean or a table options object, e.g. @storage(postgres: true, clickhouse: true) or @storage(clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}).",
     ),
     (
       "rejects duplicate storage arguments",
@@ -1591,7 +1591,7 @@ type Token @storage(postgres: true, postgres: false) {
   id: ID!
 }
 `,
-      "schema.graphql:1:12: Invalid @storage directive on \`Token\`. Argument \`postgres\` is specified more than once. Expected args from {postgres, clickhouse}: \`postgres\` takes a boolean, \`clickhouse\` takes a boolean or a table options object, e.g. @storage(postgres: true, clickhouse: true) or @storage(clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}).",
+      "schema.graphql:2:12: Invalid @storage directive on \`Token\`. Argument \`postgres\` is specified more than once. Expected args from {postgres, clickhouse}: \`postgres\` takes a boolean, \`clickhouse\` takes a boolean or a table options object, e.g. @storage(postgres: true, clickhouse: true) or @storage(clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}).",
     ),
     (
       "rejects storage directives that disable every backend",
@@ -1600,7 +1600,7 @@ type Token @storage(postgres: false, clickhouse: false) {
   id: ID!
 }
 `,
-      "schema.graphql:1:12: @storage on \`Token\` enables no storage. At least one of {postgres, clickhouse} must be true.",
+      "schema.graphql:2:12: @storage on \`Token\` enables no storage. At least one of {postgres, clickhouse} must be true.",
     ),
     (
       "rejects unknown clickhouse table options",
@@ -1609,7 +1609,7 @@ type Token @storage(clickhouse: {indexGranularity: 1024}) {
   id: ID!
 }
 `,
-      "schema.graphql:1:12: Invalid @storage directive on \`Token\`. Unknown \`clickhouse\` option \`indexGranularity\`. Expected options from {partitionBy, orderBy, ttl, skippingIndexes}, e.g. clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}.",
+      "schema.graphql:2:12: Invalid @storage directive on \`Token\`. Unknown \`clickhouse\` option \`indexGranularity\`. Expected options from {partitionBy, orderBy, ttl, skippingIndexes}, e.g. clickhouse: {partitionBy: \"toYYYYMM(timestamp)\", orderBy: [\"timestamp\"], ttl: \"timestamp + INTERVAL 2 YEAR\"}.",
     ),
     (
       "rejects empty storage directives",
@@ -1618,7 +1618,7 @@ type Token @storage {
   id: ID!
 }
 `,
-      "schema.graphql:1:12: @storage on \`Token\` enables no storage. At least one of {postgres, clickhouse} must be true.",
+      "schema.graphql:2:12: @storage on \`Token\` enables no storage. At least one of {postgres, clickhouse} must be true.",
     ),
     (
       // Entities are exposed on the handler context under their capitalized

--- a/packages/envio-tests/test/lib_tests/ClickHouseOrderByDirective_test.res
+++ b/packages/envio-tests/test/lib_tests/ClickHouseOrderByDirective_test.res
@@ -1,9 +1,8 @@
 open Vitest
 
-// `@storage(clickhouse: {orderBy})` names the columns that lead the history
-// table's sorting key. A ClickHouse sorting key can't hold a nullable, array or
-// String-stored column, so those are rejected against the schema rather than
-// left to fail at CREATE TABLE.
+// A ClickHouse sorting key can't hold a nullable, array or String-stored
+// column, so those are rejected against the schema rather than left to fail at
+// CREATE TABLE.
 
 let parse = schema =>
   InternalTestIndexer.fromUserApi(
@@ -38,7 +37,7 @@ type Token @storage(clickhouse: {orderBy: ["missing"]}) {
   timestamp: Timestamp!
 }
 `),
-    ).toBe(`schema.graphql:1:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`missing\` is not a column of the entity.
+    ).toBe(`schema.graphql:2:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`missing\` is not a column of the entity.
   Available columns: \`timestamp\`.`)
   })
 
@@ -49,7 +48,7 @@ type Token @storage(clickhouse: {orderBy: ["id"]}) {
   id: ID!
 }
 `),
-    ).toBe(`schema.graphql:1:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`id\` is already the sorting key when no \`orderBy\` is given.
+    ).toBe(`schema.graphql:2:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`id\` is already the sorting key when no \`orderBy\` is given.
   List only the columns to sort by instead of \`id\`.`)
   })
 
@@ -61,7 +60,7 @@ type Token @storage(clickhouse: {orderBy: ["timestamp", "timestamp"]}) {
   timestamp: Timestamp!
 }
 `),
-    ).toBe(`schema.graphql:1:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`timestamp\` is listed twice.
+    ).toBe(`schema.graphql:2:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`timestamp\` is listed twice.
   List each column once — repeating it adds nothing to the sorting key.`)
   })
 
@@ -73,7 +72,7 @@ type Token @storage(clickhouse: {orderBy: ["timestamp"]}) {
   timestamp: Timestamp
 }
 `),
-    ).toBe(`schema.graphql:1:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`timestamp\` is nullable, and ClickHouse won't sort by a nullable column.
+    ).toBe(`schema.graphql:2:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`timestamp\` is nullable, and ClickHouse won't sort by a nullable column.
   Make the field non-nullable to sort by it.`)
   })
 
@@ -85,7 +84,7 @@ type Token @storage(clickhouse: {orderBy: ["tags"]}) {
   tags: [String!]!
 }
 `),
-    ).toBe(`schema.graphql:1:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`tags\` is an array, and ClickHouse won't sort by an array column.
+    ).toBe(`schema.graphql:2:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`tags\` is an array, and ClickHouse won't sort by an array column.
   Sort by a scalar field instead.`)
   })
 
@@ -102,7 +101,7 @@ type Transfer @storage(clickhouse: true) {
   token: Token!
 }
 `),
-    ).toBe(`schema.graphql:1:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`transfers\` is a @derivedFrom field, which has no column.
+    ).toBe(`schema.graphql:2:12: Invalid \`clickhouse.orderBy\` on \`Token\`: \`transfers\` is a @derivedFrom field, which has no column.
   Use a stored field instead.`)
   })
 })
@@ -132,13 +131,13 @@ type Token @storage(clickhouse: {orderBy: ["amount"]}) {
 
   it("Rejects a BigDecimal with no precision", t => {
     t.expect(parseError(schema("BigDecimal", ""))).toBe(
-      "Invalid storage for `Token`. `clickhouse.orderBy` sorts by `amount`, which stores a BigDecimal that ClickHouse keeps as a String (sorted lexicographically, not numerically) unless a precision is set. Add `@config(precision: N)` with N <= 38 to the BigDecimal it stores so it sorts as a numeric Decimal.",
+      "Invalid storage for `Token`. `clickhouse.orderBy` sorts by `amount`, which stores a BigDecimal that ClickHouse keeps as a String (sorted lexicographically, not numerically) unless a precision is set. Add `@config(precision: N, scale: M)` with M <= N <= 38 to the BigDecimal it stores so it sorts as a numeric Decimal.",
     )
   })
 
   it("Rejects a BigDecimal whose scale overflows its precision", t => {
     t.expect(parseError(schema("BigDecimal", " @config(precision: 10, scale: 20)"))).toBe(
-      "Invalid storage for `Token`. `clickhouse.orderBy` sorts by `amount`, which stores a BigDecimal that ClickHouse keeps as a String (sorted lexicographically, not numerically) unless a precision is set. Add `@config(precision: N)` with N <= 38 to the BigDecimal it stores so it sorts as a numeric Decimal.",
+      "Invalid storage for `Token`. `clickhouse.orderBy` sorts by `amount`, which stores a BigDecimal that ClickHouse keeps as a String (sorted lexicographically, not numerically) unless a precision is set. Add `@config(precision: N, scale: M)` with M <= N <= 38 to the BigDecimal it stores so it sorts as a numeric Decimal.",
     )
   })
 

--- a/packages/envio-tests/test/lib_tests/EntityIndexDirective_test.res
+++ b/packages/envio-tests/test/lib_tests/EntityIndexDirective_test.res
@@ -1,8 +1,7 @@
 open Vitest
 
-// `@index(fields:)` reaches storage as a composite index over resolved column
-// names, so these assert the indexes the tables end up with rather than the
-// shape the directive parsed into.
+// Asserted against the indexes the tables end up with: a directive that parses
+// into the right shape can still resolve to a column the table lacks.
 
 let parse = schema =>
   InternalTestIndexer.fromUserApi(
@@ -119,7 +118,7 @@ describe("@index(fields:) rejections", () => {
   it("Names the columns available when the entity has no such field", t => {
     t.expect(
       parseError(schemaWith(`@index(fields: ["missing", "tokenId"])`)),
-    ).toBe(`schema.graphql:1:17: Invalid \`@index\` on \`TestEntity\`: \`missing\` is not a column of the entity.
+    ).toBe(`schema.graphql:2:17: Invalid \`@index\` on \`TestEntity\`: \`missing\` is not a column of the entity.
   Available columns: \`tokenId\`, \`collection\`.`)
   })
 
@@ -137,21 +136,21 @@ type Token {
   owner: User!
 }
 `),
-    ).toBe(`schema.graphql:1:11: Invalid \`@index\` on \`User\`: \`tokens\` is a @derivedFrom field, which has no column.
+    ).toBe(`schema.graphql:2:11: Invalid \`@index\` on \`User\`: \`tokens\` is a @derivedFrom field, which has no column.
   Use a stored field instead.`)
   })
 
   it("Rejects id, which the primary key already indexes", t => {
     t.expect(
       parseError(schemaWith(`@index(fields: ["id"])`)),
-    ).toBe(`schema.graphql:1:17: Invalid \`@index\` on \`TestEntity\`: \`id\` is the primary key, so it is already indexed.
+    ).toBe(`schema.graphql:2:17: Invalid \`@index\` on \`TestEntity\`: \`id\` is the primary key, so it is already indexed.
   Remove the \`@index\` directive on it.`)
   })
 
   it("Rejects a column listed twice in one index", t => {
     t.expect(
       parseError(schemaWith(`@index(fields: ["tokenId", "tokenId"])`)),
-    ).toBe(`schema.graphql:1:17: Invalid \`@index\` on \`TestEntity\`: \`tokenId\` is listed twice.
+    ).toBe(`schema.graphql:2:17: Invalid \`@index\` on \`TestEntity\`: \`tokenId\` is listed twice.
   List each column once — repeating it adds nothing to the index.`)
   })
 
@@ -160,8 +159,15 @@ type Token {
       parseError(
         schemaWith(`@index(fields: ["tokenId", "collection"]) @index(fields: ["tokenId", "collection"])`),
       ),
-    ).toBe(`schema.graphql:1:1: Invalid \`@index\` on \`TestEntity\`: the index over \`tokenId\`, \`collection\` is declared twice.
+    ).toBe(`schema.graphql:2:59: Invalid \`@index\` on \`TestEntity\`: the index over \`tokenId\`, \`collection\` is declared twice.
   Remove the duplicate \`@index\` directive.`)
+  })
+
+  it("Rejects an index over no columns", t => {
+    t.expect(
+      parseError(schemaWith(`@index(fields: [])`)),
+    ).toBe(`schema.graphql:2:17: Invalid \`@index\` on \`TestEntity\`: no columns are listed.
+  List the columns to index, e.g. \`@index(fields: ["tokenId", "owner"])\`.`)
   })
 
   it("Rejects a column indexed both on the field and on the entity", t => {
@@ -172,7 +178,7 @@ type TestEntity @index(fields: ["tokenId"]) {
   tokenId: Int! @index
 }
 `),
-    ).toBe(`schema.graphql:1:17: Invalid \`@index\` on \`TestEntity\`: \`tokenId\` is already marked \`@index\` on the field.
+    ).toBe(`schema.graphql:2:17: Invalid \`@index\` on \`TestEntity\`: \`tokenId\` is already marked \`@index\` on the field.
   Keep one of them — the \`@index\` on the field, or \`@index(fields: ["tokenId"])\` on the entity.`)
   })
 })

--- a/packages/envio-tests/test/lib_tests/PerChainDirectiveFields_test.res
+++ b/packages/envio-tests/test/lib_tests/PerChainDirectiveFields_test.res
@@ -111,7 +111,7 @@ type Transfer @storage(clickhouse: {orderBy: ["chain_id"]}) {
 }
 `,
       ),
-    ).toBe(`schema.graphql:1:15: Invalid \`clickhouse.orderBy\` on \`Transfer\`: \`chain_id\` is not a column of the entity.
+    ).toBe(`schema.graphql:2:15: Invalid \`clickhouse.orderBy\` on \`Transfer\`: \`chain_id\` is not a column of the entity.
   Spell the chain column as \`chainId\`, the way it's named in the schema, whatever \`column_name_format\` the storage uses.`)
   })
 
@@ -126,7 +126,7 @@ type Transfer @crossChain @storage(clickhouse: {orderBy: ["chainId"]}) {
 }
 `,
       ),
-    ).toBe(`schema.graphql:1:27: Invalid \`clickhouse.orderBy\` on \`Transfer\`: \`chainId\` is not a column of the entity.
+    ).toBe(`schema.graphql:2:27: Invalid \`clickhouse.orderBy\` on \`Transfer\`: \`chainId\` is not a column of the entity.
   envio only appends a chain column to per-chain entities, and \`Transfer\` is \`@crossChain\`. Drop \`@crossChain\`, or declare a \`chainId\` field yourself.`)
   })
 
@@ -141,7 +141,7 @@ type Transfer @storage(clickhouse: {orderBy: ["chainId"]}) {
 }
 `,
       ),
-    ).toBe(`schema.graphql:1:15: Invalid \`clickhouse.orderBy\` on \`Transfer\`: \`chainId\` is not a column of the entity.
+    ).toBe(`schema.graphql:2:15: Invalid \`clickhouse.orderBy\` on \`Transfer\`: \`chainId\` is not a column of the entity.
   envio only appends a chain column to per-chain entities, and entities are cross-chain unless config.yaml sets \`disable_default_cross_chain: true\`. Set it, or declare a \`chainId\` field yourself.`)
   })
 
@@ -186,7 +186,7 @@ type Transfer @storage(clickhouse: {orderBy: ["blockNumber"]}) {
 }
 `,
       ),
-    ).toBe(`schema.graphql:1:15: Invalid \`clickhouse.orderBy\` on \`Transfer\`: \`blockNumber\` is not a column of the entity.
+    ).toBe(`schema.graphql:2:15: Invalid \`clickhouse.orderBy\` on \`Transfer\`: \`blockNumber\` is not a column of the entity.
   Available columns: \`timestamp\`, \`chainId\`.`)
   })
 })
@@ -225,7 +225,7 @@ type Transfer @index(fields: ["chainId"]) {
 }
 `,
       ),
-    ).toBe(`schema.graphql:1:15: Invalid \`@index\` on \`Transfer\`: \`chainId\` is already part of the primary key, and on its own it has one value per chain — too few to index by.
+    ).toBe(`schema.graphql:2:15: Invalid \`@index\` on \`Transfer\`: \`chainId\` is already part of the primary key, and on its own it has one value per chain — too few to index by.
   List it with another field, e.g. \`@index(fields: ["chainId", "timestamp"])\`.`)
   })
 
@@ -240,7 +240,7 @@ type Transfer @crossChain @index(fields: ["chainId", "timestamp"]) {
 }
 `,
       ),
-    ).toBe(`schema.graphql:1:27: Invalid \`@index\` on \`Transfer\`: \`chainId\` is not a column of the entity.
+    ).toBe(`schema.graphql:2:27: Invalid \`@index\` on \`Transfer\`: \`chainId\` is not a column of the entity.
   envio only appends a chain column to per-chain entities, and \`Transfer\` is \`@crossChain\`. Drop \`@crossChain\`, or declare a \`chainId\` field yourself.`)
   })
 
@@ -255,7 +255,7 @@ type Transfer @index(fields: ["db_write_timestamp", "timestamp"]) {
 }
 `,
       ),
-    ).toBe(`schema.graphql:1:15: Invalid \`@index\` on \`Transfer\`: \`db_write_timestamp\` is not a column of the entity.
+    ).toBe(`schema.graphql:2:15: Invalid \`@index\` on \`Transfer\`: \`db_write_timestamp\` is not a column of the entity.
   Available columns: \`timestamp\`, \`chainId\`.`)
   })
 })

--- a/packages/envio-tests/test/lib_tests/SchemaErrorLocation_test.res
+++ b/packages/envio-tests/test/lib_tests/SchemaErrorLocation_test.res
@@ -20,9 +20,6 @@ chains:
   }
 
 describe("Schema error locations", () => {
-  // Counted by hand against the schema below: `Second` starts line 7, and its
-  // `@index` sits at column 15 — `type Second @index(...)`, with `@` the 13th
-  // character. Both are 1-based.
   it("Points at the line and column of the offending directive", t => {
     t.expect(
       parseError(`type First {
@@ -65,5 +62,57 @@ type Second {
     ).toBe(
       "schema.graphql:2:3: Failed parsing field id on entity First: The field 'id' or 'ID' cannot be indexed or derivedFrom. Please remove the @index or @derivedFrom directive from field id",
     )
+  })
+
+  it("Counts the leading blank lines the caller wrote", t => {
+    t.expect(
+      parseError(`
+
+type First @index(fields: ["missing"]) {
+  id: ID!
+  value: String!
+}
+`),
+    ).toBe(`schema.graphql:3:12: Invalid \`@index\` on \`First\`: \`missing\` is not a column of the entity.
+  Available columns: \`value\`.`)
+  })
+
+  it("Counts a comment line once when the schema uses CRLF", t => {
+    t.expect(
+      parseError(
+        `# a comment
+type First @index(fields: ["missing"]) {
+  id: ID!
+  value: String!
+}
+`->String.replaceAll("\n", "\r\n"),
+      ),
+    ).toBe(`schema.graphql:2:12: Invalid \`@index\` on \`First\`: \`missing\` is not a column of the entity.
+  Available columns: \`value\`.`)
+  })
+
+  it("Points at the repeated directive for a flag declared twice", t => {
+    t.expect(
+      parseError(`type First @crossChain @crossChain {
+  id: ID!
+}
+`),
+    ).toBe(
+      "schema.graphql:1:24: Invalid @crossChain directive on `First`. Only one @crossChain directive is allowed per entity.",
+    )
+  })
+
+  it("Points at the duplicate index rather than the entity holding it", t => {
+    t.expect(
+      parseError(`type First
+  @index(fields: ["a", "b"])
+  @index(fields: ["a", "b"]) {
+  id: ID!
+  a: String!
+  b: String!
+}
+`),
+    ).toBe(`schema.graphql:3:3: Invalid \`@index\` on \`First\`: the index over \`a\`, \`b\` is declared twice.
+  Remove the duplicate \`@index\` directive.`)
   })
 })


### PR DESCRIPTION
## Summary

This PR refactors the schema entity parsing to centralize column resolution logic and improves error reporting by fixing line/column position tracking for CRLF line endings and preserving the original schema path for out-of-project schemas.

## Key Changes

- **Centralized column resolution**: Extracted `ColumnResolver` struct to handle resolving column names against entity fields and the implicit chain-id column, eliminating duplicated logic across `@index`, `clickhouse.orderBy`, and `@storage` directives.

- **Fixed CRLF handling**: Added preprocessing to normalize CRLF (`\r\n`) to LF (`\n`) before parsing, since `graphql_parser` counts both characters as separate line breaks, causing position misreporting in schemas with Windows line endings.

- **Improved error context**: 
  - Flag directives (`@crossChain`, `@internal`) now report the position of duplicate directives rather than the entity
  - Duplicate `@index` directives point to the duplicate rather than the entity
  - `parse_flag_directive` now takes `source` parameter to provide position context

- **Schema path handling**: Schemas outside the project root now preserve the configured path in error messages rather than falling back to absolute paths, which would differ per machine.

- **Deterministic validation**: Added `entities_by_name()` method to return entities sorted by name, ensuring validation errors don't depend on hash map iteration order.

- **Extracted constants and helpers**:
  - Moved `MAX_PG_IDENTIFIER_LENGTH` to public module for reuse
  - Added `is_cross_chain()` helper function
  - Added `uses_clickhouse()` method on `Entity`
  - Added `as_pascal_str()` method on `IndexFieldDirection`
  - Added `default_cross_chain()` method on `BaseConfig`

- **Simplified position formatting**: Changed `at()` function to use `Display` impl of `Pos` instead of manual formatting.

- **Test updates**: Updated test expectations to reflect corrected line/column positions and added new tests for CRLF handling, leading blank lines, and duplicate directive error positioning.

## Implementation Details

The `ColumnResolver` struct encapsulates:
- Entity name and fields
- Whether the entity has an implicit chain-id column
- Whether the entity is cross-chain

This allows directive parsing to consistently resolve column names and provide contextual error messages about available columns, handling the special case of reserved chain-id field names with appropriate suggestions.

The refactoring maintains backward compatibility while improving code maintainability and error quality.

https://claude.ai/code/session_015ccCjYSTWx6nc9RpiJhsKx