### PR TITLE
Fix SVM instruction.logs arriving as null; drop undecodable instructions

### DIFF
--- a/packages/cli/src/svm_hypersync_source/borsh_decoder.rs
+++ b/packages/cli/src/svm_hypersync_source/borsh_decoder.rs
@@ -41,11 +41,11 @@ pub(crate) struct InstructionSchemaInput {
 /// query response instead of crossing the napi boundary one instruction at a
 /// time.
 ///
-/// POC policy: any decode failure (unknown discriminator, account-count
-/// mismatch, trailing bytes, unresolved type) yields `None` so the indexer
-/// keeps running. Real on-chain calls drift from schemas in small ways
-/// (Metaplex `rent` slot was optional in some versions, etc.); a single bad
-/// row should not kill the worker.
+/// Any decode failure (unknown discriminator, account-count mismatch, trailing
+/// bytes, unresolved type) yields `None` rather than an error: real on-chain
+/// calls drift from schemas in small ways (Metaplex `rent` slot was optional in
+/// some versions, etc.), and a single bad row should not kill the worker. The
+/// caller drops such an instruction instead of running handlers on empty args.
 pub(crate) fn decode_with_schema(
     schema: &UpstreamSchema,
     instruction: &UpstreamInstructionCall,

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -30,7 +30,7 @@ use crate::block_store::BlockStore;
 use crate::config_parsing::human_config::svm::{ArgDef, ArgType};
 use crate::request_stats::{rate_limited_err, source_behind_head_err, RequestStat};
 use crate::transaction_store::TransactionStore;
-use borsh_decoder::{DecodedInstructionJson, InstructionSchemaInput};
+use borsh_decoder::InstructionSchemaInput;
 use config::SvmClientConfig;
 use query::SvmQuery;
 use selection::{route_instruction, SelectionBuilder, SvmOnEventRegistrationInput};
@@ -509,10 +509,13 @@ pub struct EventItem {
     pub program_id: String,
     pub accounts: Vec<String>,
     /// Raw instruction data, `0x`-prefixed hex; decoded params ride on
-    /// `decoded` when the registration carries a Borsh schema.
+    /// `args_json` when the registration carries a Borsh schema.
     pub data: String,
     pub is_inner: bool,
-    pub decoded: Option<DecodedInstructionJson>,
+    /// Borsh-decoded args as a JSON object literal, `{}` when the routed
+    /// registration reads no args or the program carries no schema. An
+    /// instruction the schema rejects never becomes an item at all.
+    pub args_json: String,
     /// Logs scoped to this instruction; `Some` only when the routed
     /// registration selected `fields.log`.
     pub logs: Option<Vec<LogItem>>,
@@ -602,9 +605,18 @@ fn build_event_items(
             continue;
         }
         let decoded = if routed.iter().any(|reg| reg.selects_args) {
-            schemas
-                .get(&instr.executing_account)
-                .and_then(|schema| borsh_decoder::decode_with_schema(schema, raw))
+            match schemas.get(&instr.executing_account) {
+                Some(schema) => match borsh_decoder::decode_with_schema(schema, raw) {
+                    Some(decoded) => Some(decoded),
+                    // Args were asked for and the schema rejected the data, so
+                    // there is nothing truthful to hand a handler. Drop the
+                    // instruction rather than run it with empty args - for
+                    // every registration it routed to, not just the ones
+                    // reading args.
+                    None => continue,
+                },
+                None => None,
+            }
         } else {
             None
         };
@@ -633,10 +645,9 @@ fn build_event_items(
                 accounts: instr.account_arguments.clone(),
                 data: to_hex(&instr.data),
                 is_inner: instr.is_inner,
-                decoded: if reg.selects_args {
-                    decoded.clone()
-                } else {
-                    None
+                args_json: match &decoded {
+                    Some(decoded) if reg.selects_args => decoded.args_json.clone(),
+                    _ => "{}".to_string(),
                 },
                 logs: if !reg.log_columns.is_empty() {
                     logs.as_deref()
@@ -1081,9 +1092,48 @@ mod tests {
         .unwrap();
         let decoded = items
             .iter()
-            .map(|item| (item.on_event_registration_index, item.decoded.is_some()))
+            .map(|item| (item.on_event_registration_index, item.args_json.as_str()))
             .collect::<Vec<_>>();
-        assert_eq!(decoded, vec![(0, true), (1, false)]);
+        assert_eq!(decoded, vec![(0, r#"{"amount":"1"}"#), (1, "{}")]);
+    }
+
+    #[test]
+    fn an_instruction_the_schema_cannot_decode_is_dropped() {
+        let (store, set) = fixture(&["TokenMetadata", "Other"]);
+        let mut with_args = reg_input(0, "0x21", false);
+        with_args.instruction_fields = vec!["args".to_string()];
+        with_args.args_json = Some(r#"[{"name":"amount","type":"u64"}]"#.to_string());
+        // Fans out to a second registration that reads no args: the whole
+        // instruction goes, not just the args-reading half of it.
+        let mut without_args = with_args.clone();
+        without_args.index = 1;
+        without_args.instruction_name = "I1".to_string();
+        without_args.instruction_fields = vec![];
+        without_args.contract_name = "Other".to_string();
+        let schemas = build_schemas(&[with_args.clone(), without_args.clone()]).unwrap();
+        let built = SelectionBuilder::from_registrations(
+            &[with_args, without_args],
+            &store.handle().read().unwrap(),
+        )
+        .unwrap()
+        .build(&[0, 1])
+        .unwrap();
+        // A u64 arg needs eight bytes after the discriminator; this carries one.
+        let mut truncated = committed_instruction(&[0x21, 1]);
+        truncated.account_arguments = Some(vec![]);
+        let address_store = store.handle();
+        let address_store = address_store.read().unwrap();
+        let items = build_event_items(
+            std::slice::from_ref(&truncated),
+            vec![],
+            &built,
+            &schemas,
+            set.cache(),
+            &Default::default(),
+            &address_store,
+        )
+        .unwrap();
+        assert_eq!(items.len(), 0);
     }
 
     #[test]

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -972,7 +972,12 @@ mod tests {
         );
     }
 
+    // Ignored: this is the standing reproduction of a gap that is still open -
+    // there is no fix to assert yet, and the only key left to join on
+    // (program_id) attaches a log to every invocation of that program in the
+    // transaction, which is a semantic call the payload spec has to make.
     #[test]
+    #[ignore = "logs of a null-instruction_address range never reach the instruction"]
     fn logs_without_an_instruction_address_still_reach_the_instruction() {
         // SQD/RPC-ingested ranges - which is what the head of Solana is served
         // from - return log rows with a null `instruction_address`, so the

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -973,6 +973,43 @@ mod tests {
     }
 
     #[test]
+    fn logs_without_an_instruction_address_still_reach_the_instruction() {
+        // SQD/RPC-ingested ranges - which is what the head of Solana is served
+        // from - return log rows with a null `instruction_address`, so the
+        // (slot, transactionIndex, path) key matches nothing and the handler
+        // gets no logs at all. Verified against solana.hypersync.xyz: at slot
+        // ~441_370_000 not one log row carries the column.
+        let (store, set) = fixture(&["TokenMetadata"]);
+        let built = SelectionBuilder::from_registrations(
+            &[reg_input(0, "0x21", true)],
+            &store.handle().read().unwrap(),
+        )
+        .unwrap()
+        .build(&[0])
+        .unwrap();
+        let instr = committed_instruction(&[0x21]);
+        let log = simple::Log {
+            slot: Some(42),
+            transaction_index: Some(7),
+            instruction_address: None,
+            kind: Some(simple::LogKind::Log),
+            message: Some("Instruction: Swap".to_string()),
+            ..Default::default()
+        };
+        let items = route(&store, &set, &[instr], vec![log], &built).unwrap();
+        assert_eq!(
+            items[0].logs.as_ref().map(|logs| logs
+                .iter()
+                .map(|l| (l.kind.clone(), l.message.clone()))
+                .collect::<Vec<_>>()),
+            Some(vec![(
+                Some("log".to_string()),
+                Some("Instruction: Swap".to_string())
+            )])
+        );
+    }
+
+    #[test]
     fn kind_only_log_selection_omits_message() {
         let (store, set) = fixture(&["TokenMetadata"]);
         let mut input = reg_input(0, "0x21", false);

--- a/packages/envio-tests/test/SvmHandlersApi_test.res
+++ b/packages/envio-tests/test/SvmHandlersApi_test.res
@@ -438,7 +438,7 @@ if (0) {
       },
     },
     async ({ instruction }) => {
-      expectType<TypeEqual<typeof instruction.args, { readonly amountIn: string; readonly minAmountOut: string } | undefined>>(true);
+      expectType<TypeEqual<typeof instruction.args, { readonly amountIn: string; readonly minAmountOut: string }>>(true);
       expectType<TypeEqual<typeof instruction.accounts.source.address, string>>(true);
       expectType<TypeEqual<typeof instruction.accounts.source.accountName, "source">>(true);
       expectType<TypeEqual<typeof instruction.accounts.source.instructionAccountIndex, number>>(true);

--- a/packages/envio-tests/test/SvmHyperSyncClient_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncClient_test.res
@@ -40,7 +40,7 @@ describe_skip("SvmHyperSyncClient live", () => {
 
     let blockTimeBySlot = Dict.make()
     resp.data.blocks->Array.forEach(b =>
-      switch b.blockTime {
+      switch b.blockTime->Null.toOption {
       | Some(time) => blockTimeBySlot->Dict.set(b.slot->Int.toString, time)
       | None => ()
       }

--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -66,7 +66,7 @@ let mockResponse: SvmHyperSyncClient.EventItems.response = {
     {
       slot,
       blockhash: blockHash,
-      blockTime,
+      blockTime: Null.make(blockTime),
     },
   ],
   items: [
@@ -79,12 +79,13 @@ let mockResponse: SvmHyperSyncClient.EventItems.response = {
       accounts: [],
       data: "0x21",
       isInner: false,
-      decoded: {
-        name: "CreateMetadataAccountV3",
+      decoded: Null.make({
+        SvmHyperSyncClient.ResponseTypes.name: "CreateMetadataAccountV3",
         argsJson: `{"amount":"1"}`,
         accountsJson: `{"metadata":"${metaplexProgramId}"}`,
         extraAccounts: [],
-      },
+      }),
+      logs: Null.null,
     },
   ],
 }

--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -79,12 +79,7 @@ let mockResponse: SvmHyperSyncClient.EventItems.response = {
       accounts: [],
       data: "0x21",
       isInner: false,
-      decoded: Null.make({
-        SvmHyperSyncClient.ResponseTypes.name: "CreateMetadataAccountV3",
-        argsJson: `{"amount":"1"}`,
-        accountsJson: `{"metadata":"${metaplexProgramId}"}`,
-        extraAccounts: [],
-      }),
+      argsJson: `{"amount":"1"}`,
       logs: Null.null,
     },
   ],

--- a/packages/envio-tests/test/SvmInstructionPayload_test.res
+++ b/packages/envio-tests/test/SvmInstructionPayload_test.res
@@ -209,6 +209,36 @@ describe("SVM instruction payload assembly", () => {
     t.expect(instruction.logs).toEqual(Some([]))
   })
 
+  // The addon sends Rust `None` as `null`, never `undefined`, so an item whose
+  // logs didn't attach carries `logs: null` - not a missing key.
+  it("emits an empty logs array when the item carries a null logs field", t => {
+    let reg = registrations()->Array.getUnsafe(0)
+    let eventConfig =
+      reg.eventConfig->(Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig)
+    let item: SvmHyperSyncClient.EventItems.item = {
+      onEventRegistrationIndex: 0,
+      slot: 10,
+      transactionIndex: 1,
+      path: [0],
+      programId: "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8",
+      accounts: [],
+      data: "0x09",
+      isInner: false,
+    }
+    (item->(Utils.magic: SvmHyperSyncClient.EventItems.item => dict<unknown>))->Dict.set(
+      "logs",
+      %raw(`null`),
+    )
+    let instruction = SvmHyperSyncSource.toSvmInstruction(
+      item,
+      ~programName="Swapper",
+      ~instructionName="swap",
+      ~eventConfig,
+      ~fieldSelection=reg.fieldSelection,
+    )
+    t.expect(instruction.logs).toEqual(Some([]))
+  })
+
   it("omits unselected log keys on the payload", t => {
     let reg = registrations()->Array.getUnsafe(1)
     let eventConfig =

--- a/packages/envio-tests/test/SvmInstructionPayload_test.res
+++ b/packages/envio-tests/test/SvmInstructionPayload_test.res
@@ -115,7 +115,7 @@ describe("SVM instruction payload assembly", () => {
       accounts: ["Src111111111111111111111111111111111111111", "Dst111111111111111111111111111111111111111"],
       data: "0x09",
       isInner: false,
-      decoded: Null.null,
+      argsJson: "{}",
       logs: Null.null,
     }
     let instruction = SvmHyperSyncSource.toSvmInstruction(
@@ -144,7 +144,7 @@ describe("SVM instruction payload assembly", () => {
         accountName: "destination",
         instructionAccountIndex: 1,
       },
-      "args": None,
+      "args": Some(%raw(`{}`)),
       "discriminator": "0x09",
       "path": Some([0]),
       "accountArguments": Some(
@@ -157,7 +157,7 @@ describe("SVM instruction payload assembly", () => {
     })
   })
 
-  it("sets args from a successful decode and leaves them undefined when decode failed", t => {
+  it("parses args from the decoded JSON, and reads an undecoded item as empty args", t => {
     let reg = registrations()->Array.getUnsafe(0)
     let eventConfig =
       reg.eventConfig->(Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig)
@@ -170,32 +170,27 @@ describe("SVM instruction payload assembly", () => {
       accounts: [],
       data: "0x09",
       isInner: false,
-      decoded: Null.null,
+      argsJson: "{}",
       logs: Null.null,
     }
     let decoded = SvmHyperSyncSource.toSvmInstruction(
-      {
-        ...base,
-        decoded: Null.make({
-          SvmHyperSyncClient.ResponseTypes.name: "swap",
-          argsJson: `{"amountIn":"1"}`,
-          accountsJson: "{}",
-          extraAccounts: [],
-        }),
-      },
+      {...base, argsJson: `{"amountIn":"1"}`},
       ~programName="Swapper",
       ~instructionName="swap",
       ~eventConfig,
       ~fieldSelection=reg.fieldSelection,
     )
-    let failed = SvmHyperSyncSource.toSvmInstruction(
+    let undecoded = SvmHyperSyncSource.toSvmInstruction(
       base,
       ~programName="Swapper",
       ~instructionName="swap",
       ~eventConfig,
       ~fieldSelection=reg.fieldSelection,
     )
-    t.expect((decoded.args, failed.args)).toEqual((Some(%raw(`{"amountIn":"1"}`)), None))
+    t.expect((decoded.args, undecoded.args)).toEqual((
+      Some(%raw(`{"amountIn":"1"}`)),
+      Some(%raw(`{}`)),
+    ))
   })
 
   // NAPI sends Rust `None` as `null`: an instruction whose logs didn't attach
@@ -214,7 +209,7 @@ describe("SVM instruction payload assembly", () => {
         accounts: [],
         data: "0x09",
         isInner: false,
-        decoded: Null.null,
+        argsJson: "{}",
         logs: Null.null,
       },
       ~programName="Swapper",
@@ -239,7 +234,7 @@ describe("SVM instruction payload assembly", () => {
         accounts: [],
         data: "0x09",
         isInner: false,
-        decoded: Null.null,
+        argsJson: "{}",
         logs: Null.make([
           {SvmHyperSyncClient.EventItems.kind: Null.make("data"), message: Null.null},
         ]),

--- a/packages/envio-tests/test/SvmInstructionPayload_test.res
+++ b/packages/envio-tests/test/SvmInstructionPayload_test.res
@@ -115,6 +115,8 @@ describe("SVM instruction payload assembly", () => {
       accounts: ["Src111111111111111111111111111111111111111", "Dst111111111111111111111111111111111111111"],
       data: "0x09",
       isInner: false,
+      decoded: Null.null,
+      logs: Null.null,
     }
     let instruction = SvmHyperSyncSource.toSvmInstruction(
       item,
@@ -168,9 +170,19 @@ describe("SVM instruction payload assembly", () => {
       accounts: [],
       data: "0x09",
       isInner: false,
+      decoded: Null.null,
+      logs: Null.null,
     }
     let decoded = SvmHyperSyncSource.toSvmInstruction(
-      {...base, decoded: {name: "swap", argsJson: `{"amountIn":"1"}`, accountsJson: "{}", extraAccounts: []}},
+      {
+        ...base,
+        decoded: Null.make({
+          SvmHyperSyncClient.ResponseTypes.name: "swap",
+          argsJson: `{"amountIn":"1"}`,
+          accountsJson: "{}",
+          extraAccounts: [],
+        }),
+      },
       ~programName="Swapper",
       ~instructionName="swap",
       ~eventConfig,
@@ -186,7 +198,9 @@ describe("SVM instruction payload assembly", () => {
     t.expect((decoded.args, failed.args)).toEqual((Some(%raw(`{"amountIn":"1"}`)), None))
   })
 
-  it("emits an empty logs array when log fields are selected and none are scoped", t => {
+  // NAPI sends Rust `None` as `null`: an instruction whose logs didn't attach
+  // arrives with `logs: null`, not with the key missing.
+  it("emits an empty logs array when log fields are selected and the logs are null", t => {
     let reg = registrations()->Array.getUnsafe(0)
     let eventConfig =
       reg.eventConfig->(Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig)
@@ -200,37 +214,9 @@ describe("SVM instruction payload assembly", () => {
         accounts: [],
         data: "0x09",
         isInner: false,
+        decoded: Null.null,
+        logs: Null.null,
       },
-      ~programName="Swapper",
-      ~instructionName="swap",
-      ~eventConfig,
-      ~fieldSelection=reg.fieldSelection,
-    )
-    t.expect(instruction.logs).toEqual(Some([]))
-  })
-
-  // The addon sends Rust `None` as `null`, never `undefined`, so an item whose
-  // logs didn't attach carries `logs: null` - not a missing key.
-  it("emits an empty logs array when the item carries a null logs field", t => {
-    let reg = registrations()->Array.getUnsafe(0)
-    let eventConfig =
-      reg.eventConfig->(Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig)
-    let item: SvmHyperSyncClient.EventItems.item = {
-      onEventRegistrationIndex: 0,
-      slot: 10,
-      transactionIndex: 1,
-      path: [0],
-      programId: "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8",
-      accounts: [],
-      data: "0x09",
-      isInner: false,
-    }
-    (item->(Utils.magic: SvmHyperSyncClient.EventItems.item => dict<unknown>))->Dict.set(
-      "logs",
-      %raw(`null`),
-    )
-    let instruction = SvmHyperSyncSource.toSvmInstruction(
-      item,
       ~programName="Swapper",
       ~instructionName="swap",
       ~eventConfig,
@@ -253,7 +239,10 @@ describe("SVM instruction payload assembly", () => {
         accounts: [],
         data: "0x09",
         isInner: false,
-        logs: [{kind: "data", message: "hello"}],
+        decoded: Null.null,
+        logs: Null.make([
+          {SvmHyperSyncClient.EventItems.kind: Null.make("data"), message: Null.null},
+        ]),
       },
       ~programName="Swapper",
       ~instructionName="swap",

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -1411,7 +1411,7 @@ export type SvmInstruction<
   readonly args: SvmInstrField<
     Fields,
     "args",
-    ProgInstr extends { readonly args: infer A } ? A | undefined : unknown | undefined
+    ProgInstr extends { readonly args: infer A } ? A : unknown
   >;
   readonly accounts: SvmInstrField<
     Fields,

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -382,8 +382,8 @@ let parse = (
       ))
       let logs = item.logs->Option.map(logs =>
         logs->Array.map((log): SvmHyperSyncClient.EventItems.log => {
-          kind: ?log.kind,
-          message: ?log.message,
+          kind: log.kind->Null.fromOption,
+          message: log.message->Null.fromOption,
         })
       )
 
@@ -463,8 +463,8 @@ let parse = (
             accounts: accountArguments,
             data,
             isInner: item.isInner->Option.getOr(false),
-            ?decoded,
-            ?logs,
+            decoded: decoded->Null.fromOption,
+            logs: logs->Null.fromOption,
           },
           ~programName,
           ~instructionName,

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -372,14 +372,7 @@ let parse = (
         }
       }
       let data = item.data->Option.getOr(svmEventConfig.discriminator->Option.getOr("0x"))
-      let decoded = item.args->Option.map(args => (
-        {
-          SvmHyperSyncClient.ResponseTypes.name: instructionName,
-          argsJson: args->JSON.stringify,
-          accountsJson: "{}",
-          extraAccounts: [],
-        }: SvmHyperSyncClient.ResponseTypes.decodedInstruction
-      ))
+      let argsJson = item.args->Option.mapOr("{}", args => args->JSON.stringify)
       let logs = item.logs->Option.map(logs =>
         logs->Array.map((log): SvmHyperSyncClient.EventItems.log => {
           kind: log.kind->Null.fromOption,
@@ -463,7 +456,7 @@ let parse = (
             accounts: accountArguments,
             data,
             isInner: item.isInner->Option.getOr(false),
-            decoded: decoded->Null.fromOption,
+            argsJson,
             logs: logs->Null.fromOption,
           },
           ~programName,

--- a/packages/envio/src/sources/SvmHyperSyncClient.res
+++ b/packages/envio/src/sources/SvmHyperSyncClient.res
@@ -144,7 +144,7 @@ module ResponseTypes = {
   type block = {
     slot: int,
     blockhash: string,
-    blockTime?: int,
+    blockTime: Null.t<int>,
   }
 
   /// Borsh-decoded view attached by the Rust client. `argsJson`/`accountsJson`
@@ -164,16 +164,16 @@ module ResponseTypes = {
     executingAccount: string,
     accountArguments: array<string>,
     data: string,
-    d1?: string,
-    d2?: string,
-    d4?: string,
-    d8?: string,
+    d1: Null.t<string>,
+    d2: Null.t<string>,
+    d4: Null.t<string>,
+    d8: Null.t<string>,
     isInner: bool,
     /** Success of the parent transaction, not of this invocation. */
     txSuccess: bool,
     /** Per-invocation failure reason (e.g. "custom program error: 0x1"). */
-    error?: string,
-    computeUnitsConsumed?: bigint,
+    error: Null.t<string>,
+    computeUnitsConsumed: Null.t<bigint>,
   }
 
   type queryResponseData = {
@@ -206,9 +206,11 @@ module EventItems = {
     clientFilteredContracts: option<array<string>>,
   }
 
+  // NAPI encodes Rust `None` as `null`, never `undefined`, so an unselected
+  // key arrives as an explicit null rather than a missing field.
   type log = {
-    kind?: string,
-    message?: string,
+    kind: Null.t<string>,
+    message: Null.t<string>,
   }
 
   // One routed instruction; `block` and `transaction` are materialised from
@@ -222,9 +224,9 @@ module EventItems = {
     accounts: array<string>,
     data: string,
     isInner: bool,
-    decoded?: ResponseTypes.decodedInstruction,
-    // Present only when the routed registration selected `fields.log`.
-    logs?: array<log>,
+    decoded: Null.t<ResponseTypes.decodedInstruction>,
+    // Non-null only when the routed registration selected `fields.log`.
+    logs: Null.t<array<log>>,
   }
 
   type response = {

--- a/packages/envio/src/sources/SvmHyperSyncClient.res
+++ b/packages/envio/src/sources/SvmHyperSyncClient.res
@@ -147,15 +147,6 @@ module ResponseTypes = {
     blockTime: Null.t<int>,
   }
 
-  /// Borsh-decoded view attached by the Rust client. `argsJson`/`accountsJson`
-  /// are stringified to side-step napi-rs's lack of native JSON passthrough.
-  type decodedInstruction = {
-    name: string,
-    argsJson: string,
-    accountsJson: string,
-    extraAccounts: array<string>,
-  }
-
   type instructionCall = {
     slot: int,
     transactionIndex: int,
@@ -224,7 +215,10 @@ module EventItems = {
     accounts: array<string>,
     data: string,
     isInner: bool,
-    decoded: Null.t<ResponseTypes.decodedInstruction>,
+    // Borsh-decoded args as a JSON object literal, `{}` when the routed
+    // registration reads no args. An instruction the schema rejects is dropped
+    // in Rust, so a selected `args` is always decoded.
+    argsJson: string,
     // Non-null only when the routed registration selected `fields.log`.
     logs: Null.t<array<log>>,
   }

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -40,13 +40,13 @@ let namedAccounts = (
 let selectedLog = (log: SvmHyperSyncClient.EventItems.log, ~logFields: Utils.Set.t<string>): Envio.svmLog => {
   let out = Dict.make()
   if logFields->Utils.Set.has("kind") {
-    switch log.kind {
+    switch log.kind->Null.toOption {
     | Some(kind) => out->Dict.set("kind", kind)
     | None => ()
     }
   }
   if logFields->Utils.Set.has("message") {
-    switch log.message {
+    switch log.message->Null.toOption {
     | Some(message) => out->Dict.set("message", message)
     | None => ()
     }
@@ -89,7 +89,7 @@ let toSvmInstruction = (
     out->setField("isInner", item.isInner)
   }
   if hasSelection("args") {
-    out->setField("args", item.decoded->Option.map(parseArgs))
+    out->setField("args", item.decoded->Null.toOption->Option.map(parseArgs))
   }
   if hasSelection("accounts") {
     out->setField(
@@ -104,7 +104,7 @@ let toSvmInstruction = (
     out->setField(
       "logs",
       item.logs
-      ->Option.getOr([])
+      ->Null.getOr([])
       ->Array.map(log => selectedLog(log, ~logFields=fieldSelection.logFields)),
     )
   }

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -10,11 +10,6 @@ type options = {
   addressStore: AddressStore.t,
 }
 
-let parseArgs = (d: SvmHyperSyncClient.ResponseTypes.decodedInstruction): JSON.t =>
-  try JSON.parseOrThrow(d.argsJson) catch {
-  | _ => JSON.Object(Dict.make())
-  }
-
 let namedAccounts = (
   ~idlNames: array<string>,
   ~accountArguments: array<string>,
@@ -89,7 +84,7 @@ let toSvmInstruction = (
     out->setField("isInner", item.isInner)
   }
   if hasSelection("args") {
-    out->setField("args", item.decoded->Null.toOption->Option.map(parseArgs))
+    out->setField("args", item.argsJson->JSON.parseOrThrow)
   }
   if hasSelection("accounts") {
     out->setField(

--- a/scenarios/svm_flow_xray/src/handlers/flow.ts
+++ b/scenarios/svm_flow_xray/src/handlers/flow.ts
@@ -6,8 +6,8 @@ const addrPath = (a: readonly number[]): string => a.join(".");
 const parentOf = (a: readonly number[]): string | undefined =>
   a.length <= 1 ? undefined : a.slice(0, -1).join(".");
 
-// Decoded args are best-effort (borsh decode can fail on IDL drift), so every
-// numeric read is treated as possibly-absent: BigInt(undefined) would throw and
+// An instruction the IDL can't decode never reaches a handler, but an arg the
+// IDL declares optional still can be absent: BigInt(undefined) would throw and
 // kill the handler for an entire protocol.
 const bi = (x: unknown): bigint | undefined =>
   x === undefined || x === null ? undefined : BigInt(x as string | number | bigint);


### PR DESCRIPTION
## Summary

A user on an SVM indexer with `fields.log` selected reported `instruction.logs === null` on every match. Two independent defects; one fixed here, one reproduced and left open.

## 1. NAPI null vs ReScript undefined (fixed)

`SvmHyperSyncClient.EventItems` declared its Rust-sourced fields with `?`, which ReScript reads as undefined-based options. NAPI always sets the key and encodes Rust `None` as `null` (`ToNapiValue for Option`), so every null matched `Some`:

- `logs` fell through `Option.getOr([])` into `Array.map` — a `TypeError` on any instruction whose logs didn't attach (surfaced as `logs: null` in 3.7.0).
- `decoded` fell into `parseArgs`, whose `try/catch` swallowed the TypeError and put `{}` on `instruction.args`.
- an unselected `kind`/`message` landed on the payload as an explicit null instead of being omitted.

Retyped as `Null.t`, so the boundary shape can't be written any other way. The payload tests now build items the way the addon sends them. The inbound direction (ReScript → Rust) keeps its `?` fields: NAPI's `FromNapiValue for Option` maps both `undefined` and `null` to `None`.

Also corrected `block.blockTime` and `instructionCall.d1`–`d8`/`error`/`computeUnitsConsumed`, which were lying the same way.

## 2. Log rows carry no `instruction_address` at the head of Solana (reproduced, not fixed)

`build_event_items` keys logs by `(slot, transaction_index, instruction_address)` and skips rows missing any of the three. Checked against `solana.hypersync.xyz` with the field selection the source sends:

| from_slot | log rows | with `instruction_address` |
|---|---|---|
| 403M (store start) | 2099 | 0 |
| 410M | 2040 | 0 |
| 415M | 179 | 0 |
| 420M | 1109 | 1109 |
| 430M | 1443 | 1443 |
| 438M | 1595 | 0 |
| head (441.37M) | 2205 | 0 |

SQD/RPC-ingested ranges — the head among them — don't carry the column, so every log is dropped. `logs_without_an_instruction_address_still_reach_the_instruction` is the standing reproduction, `#[ignore]`d because there is no fix to assert yet: the only other join key the log table has is `program_id`, and that attaches a log to every invocation of that program in the transaction (measured at 420M: 84 of 397 `(slot, tx, program_id)` groups span more than one instruction). Reconstructing depth from `invoke`/`success` delimiters is not possible either — those kinds appear nowhere in the data, only `log`/`data`/`other`.

With this PR the handler reliably gets `logs: []` there instead of `null`, which is correct but still empty.

## 3. Instructions the Borsh schema rejects are dropped

A registration reading `fields.instruction: ["args"]` used to get the instruction either way — a decode failure left `args` unset and the handler ran on an instruction it couldn't read. Such an instruction is now dropped before it becomes an item, for every registration it routed to, not only the ones reading args.

Since decode failure no longer reaches the payload, `decoded` collapses from a nullable struct (whose `name`, `accountsJson` and `extraAccounts` no JS reader ever touched) to a flat, non-nullable `argsJson` string — `{}` when the registration reads no args. `SvmInstruction["args"]` loses its `| undefined`.

## Verification

- `cargo test --lib svm_hypersync_source` — 51 passed, 2 ignored
- `cargo clippy --lib` — no new warnings
- envio-tests full suite — 1186 passed, 24 skipped