### PR TITLE
Make the contract mapping a value, not a convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ scenarios/**/lib/*
 scenarios/**/node_modules/*
 
 rescript.lock
+
+# Transient git worktrees created for background agents.
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,20 @@
 - Scenario projects: `scenarios/` — `test_codegen`, `e2e_test`, `fuel_test`, `svm_test`.
 - To edit runtime code, edit templates under `packages/cli/templates/` or `packages/envio/`, not the codegen output under `<project>/.envio/`.
 - Prefer reading `.res` modules directly; ignore compiled `.js` artifacts.
+- The napi boundary between the Rust addon (`#[napi]` exports) and ReScript (`Core.addon`) is internal, not a published API. Change both sides freely to get the better shape — don't keep an awkward export for compatibility. The addon must be rebuilt for ReScript tests to see the change (see below).
+
+### Building the native addon
+
+ReScript tests call into the Rust addon, so a Rust change needs a rebuild before they see it:
+
+```
+SVM_TARGET_PLATFORM=linux-amd64 cargo build --lib
+mkdir -p node_modules/envio-linux-x64
+cp target/debug/libenvio.so node_modules/envio-linux-x64/envio.node
+printf '{"name":"envio-linux-x64","version":"0.0.1-dev","main":"envio.node"}\n' > node_modules/envio-linux-x64/package.json
+```
+
+`Core.loadAddon` resolves the platform package by name, which is why the debug build is staged into `node_modules` rather than loaded from `target/`.
 
 ## Testing and Development
 

--- a/packages/cli/src/address_store.rs
+++ b/packages/cli/src/address_store.rs
@@ -691,46 +691,11 @@ impl AddressStore {
         AddressSet::new(self.inner.clone(), ids)
     }
 
-    /// A set over exactly these addresses, in set order. Addresses the store
-    /// doesn't hold are skipped. Every set of a chain must come from that
-    /// chain's one store — ids are store-scoped, so sets from different stores
-    /// can't be merged.
-    #[napi]
-    pub fn make_set_of(&self, addresses: Vec<String>) -> AddressSet {
-        let store = self.read();
-        let mut ids: Vec<u64> = addresses
-            .iter()
-            .filter_map(|address| address_key(store.ecosystem, address))
-            // Every contract the address is registered for, not just one of
-            // them: a set built from addresses must hold the same entries the
-            // contract-scoped selections would.
-            .flat_map(|key| store.live_ids(&key))
-            .collect();
-        // An address the caller repeated is still one entry: a set that held it
-        // twice would double every count and send the address twice in a query.
-        ids.sort_unstable();
-        ids.dedup();
-        let ids = store.sorted_ids(ids);
-        drop(store);
-        AddressSet::new(self.inner.clone(), ids)
-    }
-
     /// A set holding nothing — what an address-free (wildcard) partition
     /// carries, so every partition is queried through the same handle.
     #[napi]
     pub fn empty_set(&self) -> AddressSet {
         AddressSet::new(self.inner.clone(), Vec::new())
-    }
-
-    /// The distinct effective start blocks of a contract's addresses, ascending.
-    #[napi]
-    pub fn start_block_groups(&self, contract_name: String) -> Vec<StartBlockGroup> {
-        let store = self.read();
-        let Some(contract_idx) = store.contract_idx(&contract_name) else {
-            return Vec::new();
-        };
-        let ids = store.sorted_live_ids(0, |entry| entry.contract_idx == contract_idx);
-        group_start_blocks(&store, &ids)
     }
 
     /// Live registration counts for the contracts this chain has something to
@@ -1771,29 +1736,6 @@ mod tests {
     }
 
     #[test]
-    fn make_set_of_ignores_repeated_addresses() {
-        let store = store();
-        store.register_seed(vec![reg(A, "C", 10)]);
-        let set = store.make_set_of(vec![A.to_string(), A.to_string()]);
-        assert_eq!((set.size(), set.count_for("C".to_string())), (1, 1));
-    }
-
-    #[test]
-    fn make_set_of_takes_every_owner_of_an_address() {
-        let store = store();
-        store.register_seed(vec![reg(A, "C", 10), reg(A, "D", 10), reg(B, "C", 10)]);
-        let set = store.make_set_of(vec![A.to_string()]);
-        assert_eq!(
-            (
-                set.size(),
-                set.count_for("C".to_string()),
-                set.count_for("D".to_string()),
-            ),
-            (2, 1, 1)
-        );
-    }
-
-    #[test]
     fn registering_for_a_contract_the_chain_doesnt_index_is_an_error() {
         let store = store();
         assert!(store.register_batch(vec![reg(A, "Unknown", 10)]).is_err());
@@ -2066,7 +2008,8 @@ mod tests {
         assert_eq!(
             (
                 store
-                    .start_block_groups("C".to_string())
+                    .make_set("C".to_string(), None)
+                    .start_block_groups()
                     .into_iter()
                     .map(|g| (g.start_block, g.count))
                     .collect::<Vec<_>>(),
@@ -2336,7 +2279,8 @@ mod tests {
     fn contains_at_scopes_the_gate_to_the_set() {
         let store = store();
         store.register_seed(vec![reg(A, "C", 300), reg(B, "C", 300)]);
-        let set = store.make_set_of(vec![A.to_string()]);
+        // A partition holding the first of C's two addresses.
+        let set = store.make_set("C".to_string(), None).slice(0, Some(1));
         assert_eq!(
             (
                 set.contains_at(A.to_string(), "C".to_string(), 300),
@@ -2408,11 +2352,10 @@ mod tests {
                 // Registered for D chain-wide, but this set holds only C's
                 // registration of it.
                 set.contains_at(A.to_string(), "D".to_string(), 100),
-                store.make_set_of(vec![A.to_string()]).contains_at(
-                    A.to_string(),
-                    "D".to_string(),
-                    100
-                ),
+                store
+                    .make_set("C".to_string(), None)
+                    .merge(&store.make_set("D".to_string(), None))
+                    .contains_at(A.to_string(), "D".to_string(), 100),
             ),
             (true, false, true)
         );

--- a/packages/cli/src/address_store.rs
+++ b/packages/cli/src/address_store.rs
@@ -100,33 +100,24 @@ fn ecosystem_by_name(name: &str, should_checksum: bool) -> napi::Result<Ecosyste
     }
 }
 
-/// Address keys packed into one buffer — the columnar form `seed_rows` takes
-/// and the write path binds to a `BYTEA[]`.
-#[napi(object)]
-pub struct PackedAddresses {
-    pub bytes: Buffer,
-    pub lengths: Vec<u32>,
-}
-
-/// Encodes address strings to their store keys. The one encoder: config
-/// addresses reach storage through here, so the bytes a row holds and the bytes
-/// a store keys on can't fork.
+/// Encodes address strings to their store keys, one buffer per address. The one
+/// encoder: config addresses reach storage through here, so the bytes a row
+/// holds and the bytes a store keys on can't fork.
 #[napi]
-pub fn pack_addresses(ecosystem: String, addresses: Vec<String>) -> napi::Result<PackedAddresses> {
+pub fn encode_addresses(ecosystem: String, addresses: Vec<String>) -> napi::Result<Vec<Buffer>> {
     let ecosystem = ecosystem_by_name(&ecosystem, false)?;
-    let mut bytes = Vec::new();
-    let mut lengths = Vec::with_capacity(addresses.len());
-    for address in addresses.iter() {
-        let key = address_key(ecosystem, address).ok_or_else(|| {
-            napi::Error::from_reason(format!("Address \"{address}\" is not a valid address."))
-        })?;
-        lengths.push(key.len() as u32);
-        bytes.extend_from_slice(&key);
-    }
-    Ok(PackedAddresses {
-        bytes: bytes.into(),
-        lengths,
-    })
+    addresses
+        .iter()
+        .map(|address| {
+            address_key(ecosystem, address)
+                .map(|key| key.to_vec().into())
+                .ok_or_else(|| {
+                    napi::Error::from_reason(format!(
+                        "Address \"{address}\" is not a valid address."
+                    ))
+                })
+        })
+        .collect()
 }
 
 /// Walks a packed address column, yielding one key slice per row. Every column
@@ -171,23 +162,8 @@ fn key_slices<'a>(
     Ok(slices)
 }
 
-/// Splits packed address keys into one buffer per row — the form the write
-/// path binds to a `BYTEA[]`.
-#[napi]
-pub fn split_addresses(
-    ecosystem: String,
-    bytes: Buffer,
-    lengths: Vec<u32>,
-) -> napi::Result<Vec<Buffer>> {
-    let ecosystem = ecosystem_by_name(&ecosystem, false)?;
-    Ok(key_slices(ecosystem, &bytes, &lengths)?
-        .into_iter()
-        .map(|key| key.to_vec().into())
-        .collect())
-}
-
 /// Renders packed address keys back to the canonical strings the JS side shows.
-/// The inverse of `pack_addresses`, and the only decoder.
+/// The inverse of `encode_addresses`, and the only decoder.
 #[napi]
 pub fn render_addresses(
     ecosystem: String,
@@ -722,7 +698,7 @@ impl AddressStore {
     #[napi]
     pub fn make_set_of(&self, addresses: Vec<String>) -> AddressSet {
         let store = self.read();
-        let ids: Vec<u64> = addresses
+        let mut ids: Vec<u64> = addresses
             .iter()
             .filter_map(|address| address_key(store.ecosystem, address))
             // Every contract the address is registered for, not just one of
@@ -730,6 +706,10 @@ impl AddressStore {
             // contract-scoped selections would.
             .flat_map(|key| store.live_ids(&key))
             .collect();
+        // An address the caller repeated is still one entry: a set that held it
+        // twice would double every count and send the address twice in a query.
+        ids.sort_unstable();
+        ids.dedup();
         let ids = store.sorted_ids(ids);
         drop(store);
         AddressSet::new(self.inner.clone(), ids)
@@ -1552,6 +1532,25 @@ mod tests {
     const B: &str = "0x00000000000000000000000000000000000000bb";
     const C: &str = "0x00000000000000000000000000000000000000cc";
 
+    struct Packed {
+        bytes: Buffer,
+        lengths: Vec<u32>,
+    }
+
+    /// The packed column `seed_rows` and `render_addresses` read, built the way
+    /// storage builds it: encode each address, then concatenate.
+    fn pack_addresses(ecosystem: String, addresses: Vec<String>) -> napi::Result<Packed> {
+        let keys = encode_addresses(ecosystem, addresses)?;
+        Ok(Packed {
+            lengths: keys.iter().map(|key| key.len() as u32).collect(),
+            bytes: keys
+                .iter()
+                .flat_map(|key| key.iter().copied())
+                .collect::<Vec<u8>>()
+                .into(),
+        })
+    }
+
     fn contracts(entries: &[(&str, Option<i64>)]) -> Vec<AddressStoreContract> {
         entries
             .iter()
@@ -1772,6 +1771,14 @@ mod tests {
     }
 
     #[test]
+    fn make_set_of_ignores_repeated_addresses() {
+        let store = store();
+        store.register_seed(vec![reg(A, "C", 10)]);
+        let set = store.make_set_of(vec![A.to_string(), A.to_string()]);
+        assert_eq!((set.size(), set.count_for("C".to_string())), (1, 1));
+    }
+
+    #[test]
     fn make_set_of_takes_every_owner_of_an_address() {
         let store = store();
         store.register_seed(vec![reg(A, "C", 10), reg(A, "D", 10), reg(B, "C", 10)]);
@@ -1893,9 +1900,7 @@ mod tests {
                 )
                 .unwrap(),
                 render_addresses("svm".to_string(), false, vec![].into(), vec![]).unwrap(),
-                split_addresses("svm".to_string(), vec![].into(), vec![])
-                    .unwrap()
-                    .len(),
+                encode_addresses("svm".to_string(), vec![]).unwrap().len(),
             ),
             (Vec::<String>::new(), Vec::<String>::new(), 0)
         );

--- a/packages/cli/src/config_parsing/entity_parsing.rs
+++ b/packages/cli/src/config_parsing/entity_parsing.rs
@@ -1,9 +1,6 @@
 use super::{
     field_types::{Field as PGField, Primitive as PGPrimitive},
-    validation::{
-        check_enums_for_internal_reserved_words, check_names_from_schema_for_reserved_words,
-        is_valid_postgres_db_name,
-    },
+    validation::{check_names_from_schema_for_reserved_words, is_valid_postgres_db_name},
 };
 use crate::{
     constants::project_paths::DEFAULT_SCHEMA_PATH,
@@ -124,8 +121,7 @@ impl Schema {
     }
 
     fn validate(self) -> anyhow::Result<Self> {
-        self.check_enum_type_defs()?
-            .check_schema_for_reserved_words()?
+        self.check_schema_for_reserved_words()?
             .check_duplicate_naming_between_enums_and_entities()?
             .check_capitalized_entity_name_collisions()?
             .check_related_type_defs_exist()?
@@ -140,16 +136,6 @@ impl Schema {
     }
     fn get_all_entity_type_names(&self) -> Vec<String> {
         self.entities.keys().cloned().collect()
-    }
-
-    fn check_enum_type_defs(self) -> anyhow::Result<Self> {
-        match check_enums_for_internal_reserved_words(self.get_all_enum_type_names()) {
-            reserved_enum_types_used if reserved_enum_types_used.is_empty() => Ok(self),
-            reserved_enum_types_used => Err(anyhow!(
-                "Schema contains the following reserved enum names: {}",
-                reserved_enum_types_used.join(", ")
-            )),
-        }
     }
 
     fn check_schema_for_reserved_words(self) -> anyhow::Result<Self> {

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -2231,9 +2231,9 @@ impl Contract {
     ) -> Result<Self> {
         // Every ecosystem builds its contracts through here, unlike
         // `validate_deserialized_config_yaml`, which only sees EVM configs.
-        validate_names_valid_rescript(&vec![name.clone()], "contract".to_string())?;
+        validate_names_valid_rescript(std::slice::from_ref(&name), "contract".to_string())?;
         validate_names_valid_rescript(
-            &events.iter().map(|e| e.name.clone()).collect(),
+            &events.iter().map(|e| e.name.clone()).collect::<Vec<_>>(),
             "event".to_string(),
         )?;
 

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -2229,6 +2229,9 @@ impl Contract {
         events: Vec<Event>,
         abi: Abi,
     ) -> Result<Self> {
+        // Every ecosystem builds its contracts through here, unlike
+        // `validate_deserialized_config_yaml`, which only sees EVM configs.
+        validate_names_valid_rescript(&vec![name.clone()], "contract".to_string())?;
         validate_names_valid_rescript(
             &events.iter().map(|e| e.name.clone()).collect(),
             "event".to_string(),

--- a/packages/cli/src/config_parsing/validation.rs
+++ b/packages/cli/src/config_parsing/validation.rs
@@ -527,6 +527,24 @@ mod tests {
         assert_eq!(flagged_words, vec!["lazy", "open", "catch"]);
     }
 
+    // `__proto__` is a valid identifier and reads like an ordinary name, but a
+    // JS object keyed by it answers from its prototype instead of from what was
+    // stored — so a contract named that would silently resolve to a bogus id
+    // wherever the generated code indexes a plain object by contract name.
+    #[test]
+    fn contract_named_like_a_prototype_key_is_rejected() {
+        let result = super::validate_names_valid_rescript(
+            &vec!["MyContract".to_string(), "__proto__".to_string()],
+            "contract".to_string(),
+        );
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "The config contains reserved words for contract names: \"__proto__\". They are used \
+             for the generated code and must be valid identifiers, containing only alphanumeric \
+             characters and underscores."
+        );
+    }
+
     #[test]
     fn test_contract_names_validation() {
         let valid_result = super::validate_names_valid_rescript(

--- a/packages/cli/src/config_parsing/validation.rs
+++ b/packages/cli/src/config_parsing/validation.rs
@@ -34,7 +34,7 @@ fn are_contract_names_unique(contract_names: &[String]) -> bool {
 
 // Names from the config and the schema both become generated identifiers, so
 // they are held to the same list.
-fn check_reserved_words(words: &Vec<String>) -> Vec<String> {
+fn check_reserved_words(words: &[String]) -> Vec<String> {
     words
         .iter()
         .filter(|word| RESERVED_NAMES.contains(&word.as_str()))
@@ -67,7 +67,7 @@ fn is_valid_identifier(s: &str) -> bool {
 
 // Check if all names in the config file are valid.
 pub fn validate_names_valid_rescript(
-    names_from_config: &Vec<String>,
+    names_from_config: &[String],
     part_of_config: String,
 ) -> anyhow::Result<()> {
     let detected_reserved_words = check_reserved_words(names_from_config);

--- a/packages/cli/src/config_parsing/validation.rs
+++ b/packages/cli/src/config_parsing/validation.rs
@@ -527,10 +527,6 @@ mod tests {
         assert_eq!(flagged_words, vec!["lazy", "open", "catch"]);
     }
 
-    // `__proto__` is a valid identifier and reads like an ordinary name, but a
-    // JS object keyed by it answers from its prototype instead of from what was
-    // stored — so a contract named that would silently resolve to a bogus id
-    // wherever the generated code indexes a plain object by contract name.
     #[test]
     fn contract_named_like_a_prototype_key_is_rejected() {
         let result = super::validate_names_valid_rescript(

--- a/packages/cli/src/config_parsing/validation.rs
+++ b/packages/cli/src/config_parsing/validation.rs
@@ -1,12 +1,8 @@
 // use super::chain_helpers;
 use super::human_config::{self, evm::HumanConfig};
-use crate::constants::reserved_keywords::{
-    ENVIO_INTERNAL_RESERVED_POSTGRES_TYPES, JAVASCRIPT_RESERVED_WORDS, RESCRIPT_RESERVED_WORDS,
-    TYPESCRIPT_RESERVED_WORDS,
-};
+use crate::constants::reserved_keywords::RESERVED_NAMES;
 use anyhow::{anyhow, Context};
 use regex::Regex;
-use std::collections::HashSet;
 
 // It must start with a letter or underscore.
 // It can contain letters, numbers, and underscores.
@@ -36,27 +32,14 @@ fn are_contract_names_unique(contract_names: &[String]) -> bool {
     true
 }
 
-// Check for reserved words in a string, to be applied for schema and config.
-// Words from config and schema are used in the codegen and eventually in eventHandlers for the user, thus cannot contain any reserved words.
+// Names from the config and the schema both become generated identifiers, so
+// they are held to the same list.
 fn check_reserved_words(words: &Vec<String>) -> Vec<String> {
-    let mut flagged_words = Vec::new();
-    // Creating a deduplicated set of reserved words from javascript, typescript and rescript
-    let mut set = HashSet::new();
-    set.extend(JAVASCRIPT_RESERVED_WORDS.iter());
-    set.extend(TYPESCRIPT_RESERVED_WORDS.iter());
-    set.extend(RESCRIPT_RESERVED_WORDS.iter());
-
-    let words_set: Vec<&str> = set.into_iter().cloned().collect();
-
-    // Find all alphanumeric words in the YAML string
-    for word in words {
-        let word = word.as_str();
-        if words_set.contains(&word) {
-            flagged_words.push(word.to_string());
-        }
-    }
-
-    flagged_words
+    words
+        .iter()
+        .filter(|word| RESERVED_NAMES.contains(&word.as_str()))
+        .cloned()
+        .collect()
 }
 
 fn is_valid_identifier(s: &str) -> bool {
@@ -353,28 +336,8 @@ pub fn validate_deserialized_svm_config_yaml(
     Ok(())
 }
 
-pub fn check_enums_for_internal_reserved_words(enum_name_words: Vec<String>) -> Vec<String> {
-    enum_name_words
-        .into_iter()
-        .filter(|word| ENVIO_INTERNAL_RESERVED_POSTGRES_TYPES.contains(&word.as_str()))
-        .collect()
-}
-
-// Checking that schema does not include any reserved words
 pub fn check_names_from_schema_for_reserved_words(schema_words: Vec<String>) -> Vec<String> {
-    // Checking that schema does not include any reserved words
-    let mut detected_reserved_words_in_schema = Vec::new();
-    // Creating a deduplicated set of reserved words from javascript or rescript
-    let mut word_set: HashSet<&str> = HashSet::new();
-    word_set.extend(JAVASCRIPT_RESERVED_WORDS.iter());
-    word_set.extend(RESCRIPT_RESERVED_WORDS.iter());
-    for word in schema_words {
-        if word_set.contains(word.as_str()) {
-            detected_reserved_words_in_schema.push(word);
-        }
-    }
-
-    detected_reserved_words_in_schema
+    check_reserved_words(&schema_words)
 }
 
 pub fn check_schema_enums_are_valid_postgres(enum_names: &Vec<String>) -> Vec<String> {
@@ -479,8 +442,8 @@ mod tests {
             "like".to_string(),
             "break".to_string(),
             "import".to_string(),
-            "and".to_string(),
-            "symbol".to_string(),
+            "constructor".to_string(),
+            "enum".to_string(),
             "plus".to_string(),
             "unreserved".to_string(),
             "word".to_string(),
@@ -488,10 +451,7 @@ mod tests {
             "match.".to_string(),
         ];
         let flagged_words = super::check_reserved_words(&words);
-        assert_eq!(
-            flagged_words,
-            vec!["string", "with", "break", "import", "and", "symbol"]
-        );
+        assert_eq!(flagged_words, vec!["constructor", "enum"]);
     }
 
     #[test]
@@ -519,12 +479,12 @@ mod tests {
 
     #[test]
     fn test_names_from_schema_for_reserved_words() {
-        let names_from_schema = "Greeting id greetings lastGreeting lazy open catch"
+        let names_from_schema = "Greeting id greetings lastGreeting lazy open constructor"
             .split(" ")
             .map(|s| s.to_string())
             .collect();
         let flagged_words = super::check_names_from_schema_for_reserved_words(names_from_schema);
-        assert_eq!(flagged_words, vec!["lazy", "open", "catch"]);
+        assert_eq!(flagged_words, vec!["constructor"]);
     }
 
     #[test]
@@ -558,17 +518,17 @@ mod tests {
                 "foo".to_string(),
                 "MyContract".to_string(),
                 "_Bar".to_string(),
-                "Let".to_string(),
                 "module".to_string(),
-                "this".to_string(),
+                "constructor".to_string(),
+                "enum".to_string(),
                 "1".to_string(),
             ],
             "contract".to_string(),
         );
         assert_eq!(
             reserved_names.unwrap_err().to_string(),
-            "The config contains reserved words for contract names: \"module\", \"this\". They \
-             are used for the generated code and must be valid identifiers, containing only \
+            "The config contains reserved words for contract names: \"constructor\", \"enum\". \
+             They are used for the generated code and must be valid identifiers, containing only \
              alphanumeric characters and underscores."
         );
 

--- a/packages/cli/src/constants.rs
+++ b/packages/cli/src/constants.rs
@@ -57,15 +57,29 @@ pub mod reserved_keywords {
     /// emits is capitalized first, which is why a keyword of the generated
     /// languages is not on this list — only names that stay broken after that.
     pub const RESERVED_NAMES: &[&str] = &[
-        // Generated code indexes plain objects by these names, and an object
-        // answers a prototype key from its prototype rather than from what was
-        // stored — so the lookup resolves to a bogus value instead of the one
-        // assigned to it. `constructor` is neutralized wherever a name is
-        // capitalized; `__proto__` starts with an underscore and survives
-        // capitalization untouched, which also makes it an illegal ReScript
-        // module name and variant constructor.
+        // Every own property of `Object.prototype`. Generated code indexes
+        // plain objects by these names, and an object answers a prototype key
+        // from its prototype rather than from what was stored, so the lookup
+        // resolves to a bogus value instead of the one assigned to it — an
+        // entity named `toString` reaches the test indexer's per-entity change
+        // bucket as `Object.prototype.toString` and the write throws on its
+        // missing `sets` array. The whole family, not the subset that happens
+        // to read like a keyword: the failure is the prototype lookup, not the
+        // spelling. `__proto__` additionally survives capitalization untouched,
+        // which makes it an illegal ReScript module name and variant
+        // constructor on top of the lookup problem.
+        "__defineGetter__",
+        "__defineSetter__",
+        "__lookupGetter__",
+        "__lookupSetter__",
         "__proto__",
         "constructor",
+        "hasOwnProperty",
+        "isPrototypeOf",
+        "propertyIsEnumerable",
+        "toLocaleString",
+        "toString",
+        "valueOf",
         // Every entity is re-exported from the `envio` module under its
         // capitalized name, where `Enum` is already taken.
         "enum",

--- a/packages/cli/src/constants.rs
+++ b/packages/cli/src/constants.rs
@@ -25,6 +25,11 @@ pub mod links {
 
 pub mod reserved_keywords {
     pub const JAVASCRIPT_RESERVED_WORDS: &[&str] = &[
+        // Not a keyword, but generated code indexes plain objects by these
+        // names, and an object answers `__proto__` from its prototype rather
+        // than from what was stored — so a name like this resolves to a bogus
+        // value instead of the one assigned to it.
+        "__proto__",
         "abstract",
         "arguments",
         "await",

--- a/packages/cli/src/constants.rs
+++ b/packages/cli/src/constants.rs
@@ -24,140 +24,6 @@ pub mod links {
 }
 
 pub mod reserved_keywords {
-    pub const JAVASCRIPT_RESERVED_WORDS: &[&str] = &[
-        // Not a keyword, but generated code indexes plain objects by these
-        // names, and an object answers `__proto__` from its prototype rather
-        // than from what was stored — so a name like this resolves to a bogus
-        // value instead of the one assigned to it.
-        "__proto__",
-        "abstract",
-        "arguments",
-        "await",
-        "boolean",
-        "break",
-        "byte",
-        "case",
-        "catch",
-        "char",
-        "class",
-        "const",
-        "continue",
-        "debugger",
-        "default",
-        "delete",
-        "do",
-        "double",
-        "else",
-        "enum",
-        "eval",
-        "export",
-        "extends",
-        "false",
-        "final",
-        "finally",
-        "float",
-        "for",
-        "function",
-        "goto",
-        "if",
-        "implements",
-        "import",
-        "in",
-        "instanceof",
-        "int",
-        "interface",
-        "let",
-        "long",
-        "native",
-        "new",
-        "null",
-        "package",
-        "private",
-        "protected",
-        "public",
-        "return",
-        "short",
-        "static",
-        "super",
-        "switch",
-        "synchronized",
-        "this",
-        "throw",
-        "throws",
-        "transient",
-        "true",
-        "try",
-        "typeof",
-        "var",
-        "void",
-        "volatile",
-        "while",
-        "with",
-        "yield",
-    ];
-
-    pub const TYPESCRIPT_RESERVED_WORDS: &[&str] = &[
-        "any",
-        "as",
-        "boolean",
-        "break",
-        "case",
-        "catch",
-        "class",
-        "const",
-        "constructor",
-        "continue",
-        "declare",
-        "default",
-        "delete",
-        "do",
-        "else",
-        "enum",
-        "export",
-        "extends",
-        "false",
-        "finally",
-        "for",
-        "from",
-        "function",
-        "get",
-        "if",
-        "implements",
-        "import",
-        "in",
-        "instanceof",
-        "interface",
-        "let",
-        "module",
-        "new",
-        "null",
-        "number",
-        "of",
-        "package",
-        "private",
-        "protected",
-        "public",
-        "require",
-        "return",
-        "set",
-        "static",
-        "string",
-        "super",
-        "switch",
-        "symbol",
-        "this",
-        "throw",
-        "true",
-        "try",
-        "type",
-        "typeof",
-        "var",
-        "void",
-        "while",
-        "with",
-        "yield",
-    ];
-
     pub const RESCRIPT_RESERVED_WORDS: &[&str] = &[
         "and",
         "as",
@@ -187,5 +53,21 @@ pub mod reserved_keywords {
         "with",
     ];
 
-    pub const ENVIO_INTERNAL_RESERVED_POSTGRES_TYPES: &[&str] = &[];
+    /// Names a config or schema may not use. Every other identifier codegen
+    /// emits is capitalized first, which is why a keyword of the generated
+    /// languages is not on this list — only names that stay broken after that.
+    pub const RESERVED_NAMES: &[&str] = &[
+        // Generated code indexes plain objects by these names, and an object
+        // answers a prototype key from its prototype rather than from what was
+        // stored — so the lookup resolves to a bogus value instead of the one
+        // assigned to it. `constructor` is neutralized wherever a name is
+        // capitalized; `__proto__` starts with an underscore and survives
+        // capitalization untouched, which also makes it an illegal ReScript
+        // module name and variant constructor.
+        "__proto__",
+        "constructor",
+        // Every entity is re-exported from the `envio` module under its
+        // capitalized name, where `Enum` is already taken.
+        "enum",
+    ];
 }

--- a/packages/envio-tests/test/ContractRegisterAddress_test.res
+++ b/packages/envio-tests/test/ContractRegisterAddress_test.res
@@ -14,6 +14,9 @@ chains:
       - name: SimpleNft
         events:
           - event: Transfer(address indexed from, address indexed to, uint256 indexed tokenId)
+      - name: OtherNft
+        events:
+          - event: Transfer(address indexed from, address indexed to, uint256 indexed tokenId)
 `,
   ~schema=`
 type Probe {
@@ -52,10 +55,19 @@ indexer.contractRegister({ contract: "Gravatar", event: "FactoryEvent" }, async 
     case "checksumsAddress":
       context.chain.SimpleNft.add(event.params.contract);
       return;
+    case "registersTwice":
+      context.chain.SimpleNft.add(event.params.contract);
+      context.chain.SimpleNft.add(event.params.contract);
+      return;
+    case "registersForTwoContracts":
+      context.chain.SimpleNft.add(event.params.contract);
+      context.chain.OtherNft.add(event.params.contract);
+      return;
   }
 });
 
 indexer.onEvent({ contract: "SimpleNft", event: "Transfer" }, async () => {});
+indexer.onEvent({ contract: "OtherNft", event: "Transfer" }, async () => {});
 `,
   ~test=`
 import { describe, it } from "vitest";
@@ -123,6 +135,30 @@ describe("contractRegister address handling", () => {
     t.expect(result.changes[0]?.addresses).toEqual({
       sets: [
         { address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", contract: "SimpleNft" },
+      ],
+    });
+  });
+
+  it("keeps the same address registered twice for one contract a single registration", async (t) => {
+    const indexer = createTestIndexer();
+    const result = await run(indexer, { contract: dcAddress, testCase: "registersTwice" });
+
+    t.expect(result.changes[0]?.addresses).toEqual({
+      sets: [{ address: dcAddress, contract: "SimpleNft" }],
+    });
+  });
+
+  it("registers one address once per contract that claims it", async (t) => {
+    const indexer = createTestIndexer();
+    const result = await run(indexer, {
+      contract: dcAddress,
+      testCase: "registersForTwoContracts",
+    });
+
+    t.expect(result.changes[0]?.addresses).toEqual({
+      sets: [
+        { address: dcAddress, contract: "SimpleNft" },
+        { address: dcAddress, contract: "OtherNft" },
       ],
     });
   });

--- a/packages/envio-tests/test/ReservedNames_test.res
+++ b/packages/envio-tests/test/ReservedNames_test.res
@@ -1,0 +1,64 @@
+// Names that are keywords in the generated languages reach codegen capitalized,
+// so they land in identifier positions as `Module`/`Lazy`/`Type` and the
+// generated ReScript and TypeScript both accept them.
+let _ = InternalTestIndexer.fromUserApi(
+  ~configYaml=`
+name: reserved-names
+chains:
+  - id: 1
+    start_block: 0
+    contracts:
+      - name: Token
+        address: "0x1111111111111111111111111111111111111111"
+        events:
+          - event: module(address indexed to, uint256 value)
+`,
+  ~schema=`
+enum type {
+  open
+  switch
+}
+type lazy {
+  id: ID!
+  balance: BigInt!
+  kind: type!
+}
+`,
+  ~handlers=`
+import { indexer } from "envio";
+
+indexer.onEvent({ contract: "Token", event: "module" }, async ({ event, context }) => {
+  context.Lazy.set({
+    id: event.params.to,
+    balance: event.params.value,
+    kind: "open",
+  });
+});
+`,
+  ~test=`
+import { describe, it } from "vitest";
+import { createTestIndexer, type Lazy, TestHelpers } from "envio";
+
+const { Addresses } = TestHelpers;
+
+describe("keyword names", () => {
+  it("indexes an event, entity and enum named after language keywords", async (t) => {
+    const indexer = createTestIndexer();
+    const to = Addresses.defaultAddress;
+
+    await indexer.process({
+      chains: {
+        1: {
+          simulate: [
+            { contract: "Token", event: "module", params: { to, value: 5n } },
+          ],
+        },
+      },
+    });
+
+    const expected: Lazy = { id: to, balance: 5n, kind: "open" };
+    t.expect(await indexer.Lazy.getOrThrow(to)).toEqual(expected);
+  });
+});
+`,
+)

--- a/packages/envio-tests/test/SharedAddressRouting_test.res
+++ b/packages/envio-tests/test/SharedAddressRouting_test.res
@@ -63,22 +63,20 @@ let onEventRegistrations = () => {
 // The chain's store as production builds it: every config contract under its
 // canonical id, seeded with the config's addresses.
 let makeSource = (~url) => {
-  let contractNames = Config.canonicalContractNames(
-    ~chainConfigs=parsed.config.chainMap->ChainMap.values,
-  )
+  let contractMapping = parsed.config.contractMapping
   let addressStore = AddressStore.make(
     ~ecosystem=Ecosystem.Evm,
     ~shouldChecksum=false,
     ~contracts=AddressStore.contractsOf(
       ~onEventRegistrations=onEventRegistrations(),
-      ~contractNames,
+      ~contractMapping,
     ),
   )
   let chainConfig = parsed.config.chainMap->ChainMap.values->Array.getUnsafe(0)
   let _ =
     addressStore->AddressStore.seedRows(
       chainConfig
-      ->ChainState.configStorageRows(~ecosystem=Evm, ~contractNames)
+      ->ChainState.configStorageRows(~ecosystem=Evm, ~contractMapping)
       ->AddressRows.seedRowsOf,
     )
   let source = EvmHyperSyncSource.make({

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -1718,6 +1718,20 @@ type constructor { id: ID! }
       "Config parse error: Failed converting schema doc to schema struct: Schema contains the following reserved keywords: constructor",
     ),
     (
+      "rejects an entity named toString",
+      `
+type toString { id: ID! }
+`,
+      "Config parse error: Failed converting schema doc to schema struct: Schema contains the following reserved keywords: toString",
+    ),
+    (
+      "rejects an entity named hasOwnProperty",
+      `
+type hasOwnProperty { id: ID! }
+`,
+      "Config parse error: Failed converting schema doc to schema struct: Schema contains the following reserved keywords: hasOwnProperty",
+    ),
+    (
       // `Enum` is already exported by the `envio` module, and every entity is
       // re-exported there under its capitalized name.
       "rejects an entity whose capitalized name collides with an envio export",

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -200,6 +200,31 @@ chains:
     )
   })
 
+  // Codegen capitalizes every config name before it reaches an identifier
+  // position, so a keyword of the generated languages is only ever a keyword in
+  // the YAML.
+  it("accepts contract and event names that are keywords of the generated languages", t => {
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
+name: keyword-config
+chains:
+  - id: 1
+    start_block: 0
+    contracts:
+      - name: let
+        address: "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
+        events:
+          - event: module()
+          - event: switch()
+`,
+    )
+    t.expect(
+      (config.chainMap->ChainMap.values->Array.getUnsafe(0)).contracts->Array.map(
+        contract => (contract.name, contract.events->Array.map(event => event.name)),
+      ),
+    ).toEqual([("Let", ["module", "switch"])])
+  })
+
   it("rejects an address listed twice for one contract", t => {
     expectParseError(
       t,
@@ -890,14 +915,14 @@ chains:
       `
 name: reserved-contract-name
 contracts:
-  - name: module
+  - name: constructor
     events:
       - event: Transfer()
 chains:
   - id: 1
     start_block: 0
 `,
-      "Config parse error: The config contains reserved words for contract names: \"module\". They are used for the generated code and must be valid identifiers, containing only alphanumeric characters and underscores.",
+      "Config parse error: The config contains reserved words for contract names: \"constructor\". They are used for the generated code and must be valid identifiers, containing only alphanumeric characters and underscores.",
     ),
     (
       "rejects configs where every chain is skipped",
@@ -1680,6 +1705,26 @@ type user { id: ID! }
 type User { id: ID! }
 `,
       "Config parse error: Failed converting schema doc to schema struct: Schema contains entities whose names collide when capitalized. Each entity is exposed on the handler context under its capitalized name, so these must be unique: User (from User, user)",
+    ),
+    (
+      // The test indexer buckets a batch's changes in a dict keyed by entity
+      // name, and a plain object answers `constructor` from its prototype — so
+      // the bucket comes back as `Object` and the write throws on a missing
+      // `sets` array.
+      "rejects an entity named like an Object prototype key",
+      `
+type constructor { id: ID! }
+`,
+      "Config parse error: Failed converting schema doc to schema struct: Schema contains the following reserved keywords: constructor",
+    ),
+    (
+      // `Enum` is already exported by the `envio` module, and every entity is
+      // re-exported there under its capitalized name.
+      "rejects an entity whose capitalized name collides with an envio export",
+      `
+type enum { id: ID! }
+`,
+      "Config parse error: Failed converting schema doc to schema struct: Schema contains the following reserved keywords: enum",
     ),
   ]->Array.forEach(((name, schema, message)) => {
     it(name, t => expectParseError(t, ~schema, baseYaml, message))

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -180,10 +180,6 @@ chains:
     ])
   })
 
-  // Generated code indexes plain objects by contract name, and an object serves
-  // `__proto__` from its prototype rather than from what was stored — so the
-  // name has to be refused here, where every other unusable name is, rather
-  // than worked around at each lookup.
   it("rejects a contract named like an Object prototype key", t => {
     expectParseError(
       t,

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -171,14 +171,37 @@ chains:
 `,
     )
     t.expect(
-      (config.chainMap->ChainMap.values->Array.getUnsafe(0)).contracts->Array.map(contract => (
-        contract.name,
-        contract.addresses,
-      )),
+      (config.chainMap->ChainMap.values->Array.getUnsafe(0)).contracts->Array.map(
+        contract => (contract.name, contract.addresses),
+      ),
     ).toEqual([
       ("AaveToken", ["0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"->Address.unsafeFromString]),
       ("AaveV3", ["0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"->Address.unsafeFromString]),
     ])
+  })
+
+  // Generated code indexes plain objects by contract name, and an object serves
+  // `__proto__` from its prototype rather than from what was stored — so the
+  // name has to be refused here, where every other unusable name is, rather
+  // than worked around at each lookup.
+  it("rejects a contract named like an Object prototype key", t => {
+    expectParseError(
+      t,
+      `
+name: proto-contract
+contracts:
+  - name: __proto__
+    events:
+      - event: Transfer()
+chains:
+  - id: 1
+    start_block: 0
+    contracts:
+      - name: __proto__
+        address: "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
+`,
+      "Config parse error: The config contains reserved words for contract names: \"__proto__\". They are used for the generated code and must be valid identifiers, containing only alphanumeric characters and underscores.",
+    )
   })
 
   it("rejects an address listed twice for one contract", t => {

--- a/packages/envio-tests/test/helpers/IndexerRunner.res
+++ b/packages/envio-tests/test/helpers/IndexerRunner.res
@@ -155,6 +155,7 @@ let run = async (
 
     await persistence->Persistence.init(
       ~chainConfigs=config.chainMap->ChainMap.values,
+      ~contractMapping=config.contractMapping,
       ~envioInfo=JSON.Encode.object(Dict.make()),
       ~resetCommand="envio dev -r",
       ~runCommand=Some("envio dev"),
@@ -394,9 +395,6 @@ let run = async (
             InternalTable.EnvioAddresses.makeGetRowsQuery(~pgSchema),
           ))->(Utils.magic: unknown => array<AddressRows.row>)
         }
-        let contractNames = Config.canonicalContractNames(
-          ~chainConfigs=config.chainMap->ChainMap.values,
-        )
         let addresses = Core.getAddon().renderAddresses(
           ~ecosystem=(config.ecosystem.name :> string),
           ~shouldChecksum=!config.lowercaseAddresses,
@@ -406,7 +404,7 @@ let run = async (
         rows->Array.mapWithIndex((row, idx): addressRow => {
           chainId: row.chainId->ChainId.normalizeOrThrow,
           address: addresses->Array.getUnsafe(idx),
-          contractName: contractNames->Array.getUnsafe(row.contractId),
+          contractName: config.contractMapping->ContractMapping.nameOfOrThrow(row.contractId),
           registrationBlock: row.registrationBlock,
         })
       },

--- a/packages/envio-tests/test/helpers/MockStorage.res
+++ b/packages/envio-tests/test/helpers/MockStorage.res
@@ -88,6 +88,7 @@ let make = (methods: array<method>, ~dbEntities=[], ~storedEnvioInfo=None) => {
         ~chainConfigs=[],
         ~entities=[],
         ~enums=[],
+        ~contractMapping as _,
         ~envioInfo,
       ) => {
         initializeCalls
@@ -192,9 +193,7 @@ let toPersistence = (storageMock: t, ~config: Config.t) => {
     ...PgStorage.makePersistenceFromConfig(~config, ~storage=storageMock.storage),
     storageStatus: Ready({
       cleanRun: false,
-      contractNames: Config.canonicalContractNames(
-        ~chainConfigs=config.chainMap->ChainMap.values,
-      ),
+      contractMapping: config.contractMapping,
       cache: Dict.make(),
       chains: [],
       reorgCheckpoints: [],

--- a/packages/envio-tests/test/helpers/NativeDecoder.res
+++ b/packages/envio-tests/test/helpers/NativeDecoder.res
@@ -16,8 +16,8 @@ let decodeLogs = async (
 ): array<EvmRpcClient.rpcEventItem> => {
   // logIndex must be unique per log within the block — the client dedups a
   // page's items by (blockNumber, logIndex).
-  let logJsons = logs->Array.mapWithIndex(((topics, data), i) =>
-    JSON.Object(
+  let logJsons =
+    logs->Array.mapWithIndex(((topics, data), i) => JSON.Object(
       Dict.fromArray([
         ("address", JSON.String(mockAddress)),
         ("topics", JSON.Array(topics->Array.map(t => JSON.String(t)))),
@@ -29,22 +29,19 @@ let decodeLogs = async (
         ("logIndex", JSON.String(`0x${i->Int.toString(~radix=16)}`)),
         ("removed", JSON.Boolean(false)),
       ]),
-    )
-  )
+    ))
   await MockRpcServer.withScenario(
     ~name="native decoder logs",
     ~calls=[
-      MockRpcServer.expectCall(
-        ~method="eth_getLogs",
-        ~reply=RpcResult(JSON.Array(logJsons)),
-      ),
+      MockRpcServer.expectCall(~method="eth_getLogs", ~reply=RpcResult(JSON.Array(logJsons))),
     ],
     async mock => {
       // One entry per contract, not per registration: two events on one
       // contract are still one contract, and the store keys its ids on that.
-      let contractNames = Core.getAddon().canonicalContractNames(
-        eventRegistrations->Array.map(reg => reg.contractName),
-      )
+      let contractNames =
+        ContractMapping.make(
+          ~names=eventRegistrations->Array.map(reg => reg.contractName),
+        )->ContractMapping.names
       let addressStore = AddressStore.make(
         ~ecosystem=Ecosystem.Evm,
         ~shouldChecksum=false,

--- a/packages/envio-tests/test/helpers/TestAddresses.res
+++ b/packages/envio-tests/test/helpers/TestAddresses.res
@@ -2,17 +2,17 @@
 // `ChainState.makeInternal` does in production: one store per chain, built from
 // that chain's registrations, holding every address the chain indexes.
 
-// The canonical contract list a chain's store is built from — every contract
-// the config declares, in the order their ids come from.
-let contractNames = (
+// The contract mapping a chain's store is built from — every contract the
+// config declares, under the ids their names canonicalize to.
+let contractMapping = (
   ~onEventRegistrations: array<Internal.onEventRegistration>=[],
   // Config contracts the chain has no events for. Registering an address for a
   // name outside the store's contracts throws, so a test exercising the
   // no-events path declares it here.
   ~configContractNames: array<string>=[],
 ) =>
-  Core.getAddon().canonicalContractNames(
-    onEventRegistrations
+  ContractMapping.make(
+    ~names=onEventRegistrations
     ->Array.map(reg => reg.eventConfig.contractName)
     ->Array.concat(configContractNames),
   )
@@ -25,25 +25,23 @@ let addressRows = (
   ~configContractNames: array<string>=[],
   ~ecosystem: Ecosystem.name=Evm,
 ): AddressRows.seedRows => {
-  let contractNames = contractNames(~onEventRegistrations, ~configContractNames)
-  let packed = Core.getAddon().packAddresses(
+  let contractMapping = contractMapping(~onEventRegistrations, ~configContractNames)
+  let keys = Core.getAddon().encodeAddresses(
     ~ecosystem=(ecosystem :> string),
     ~addresses=addresses->Array.map(a => a.address),
   )
-  {
-    addresses: packed.bytes,
-    lengths: packed.lengths,
-    contractIds: addresses->Array.map(a =>
-      switch contractNames->Array.indexOf(a.contractName) {
-      | -1 =>
-        JsError.throwWithMessage(
-          `Test address registered for "${a.contractName}", which the store doesn't hold.`,
-        )
-      | id => id
-      }
+  addresses
+  ->Array.mapWithIndex((a, idx): AddressRows.row => {
+    // The seed form is per-chain, so any chain id serves — `seedRowsOf` drops it.
+    chainId: ChainId.fromInt(0),
+    address: keys->Array.getUnsafe(idx),
+    contractId: contractMapping->ContractMapping.idOfOrThrow(
+      a.contractName,
+      ~context=" registered by a test address",
     ),
-    registrationBlocks: addresses->Array.map(a => a.registrationBlock),
-  }
+    registrationBlock: a.registrationBlock,
+  })
+  ->AddressRows.seedRowsOf
 }
 
 let makeStore = (
@@ -60,7 +58,7 @@ let makeStore = (
     ~shouldChecksum,
     ~contracts=AddressStore.contractsOf(
       ~onEventRegistrations,
-      ~contractNames=contractNames(~onEventRegistrations, ~configContractNames),
+      ~contractMapping=contractMapping(~onEventRegistrations, ~configContractNames),
     ),
   )
   // Config addresses, like `FetchState.make` seeds them: already stored, so

--- a/packages/envio-tests/test/helpers/TestAddresses.res
+++ b/packages/envio-tests/test/helpers/TestAddresses.res
@@ -95,9 +95,29 @@ function (contractName, addresses) {
   );
 }`)
 
+// A real set over exactly these addresses, composed from the operations
+// production narrows a set with: the chain's contract sets merged, then sliced
+// down to the addresses asked for. An address several contracts index appears
+// once per owner, as it does in a partition that holds all of them.
+let realSetOf = (store: AddressStore.t, addresses: array<Address.t>) => {
+  let all =
+    store
+    ->AddressStore.contractCounts
+    ->Array.reduce(store->AddressStore.emptySet, (acc, {contractName}) =>
+      acc->AddressSet.merge(store->AddressStore.makeSet(~contractName))
+    )
+  all
+  ->AddressSet.addresses
+  ->Array.reduceWithIndex(store->AddressStore.emptySet, (acc, address, idx) =>
+    addresses->Array.includes(address)
+      ? acc->AddressSet.merge(all->AddressSet.slice(~offset=idx, ~limit=Some(1)))
+      : acc
+  )
+}
+
 let setOf = (~store: option<AddressStore.t>=?, ~contractName=?, addresses) =>
   switch store {
-  | Some(store) => store->AddressStore.makeSetOf(addresses)
+  | Some(store) => store->realSetOf(addresses)
   | None => fakeSetOf(~contractName?, addresses)
   }
 

--- a/packages/envio-tests/test/helpers/TestIndexerState.res
+++ b/packages/envio-tests/test/helpers/TestIndexerState.res
@@ -28,7 +28,7 @@ let readyPersistence = (~config=config, ~storage) => {
   ...PgStorage.makePersistenceFromConfig(~config, ~storage),
   storageStatus: Persistence.Ready({
     cleanRun: false,
-    contractNames: Config.canonicalContractNames(~chainConfigs=config.chainMap->ChainMap.values),
+    contractMapping: config.contractMapping,
     cache: Dict.make(),
     chains: [],
     reorgCheckpoints: [],

--- a/packages/envio-tests/test/lib_tests/AddressStore_test.res
+++ b/packages/envio-tests/test/lib_tests/AddressStore_test.res
@@ -88,7 +88,7 @@ describe("AddressStore", () => {
         contract(~address=addr(1), ~contractName="A", ~registrationBlock=10),
       ],
     )
-    let set = store->AddressStore.makeSetOf([addr(0)])
+    let set = TestAddresses.setOf(~store, [addr(0)])
     t.expect({
       "inSet": set->AddressSet.containsAt(addr(0), "A", 5),
       // Registered for A, but held by another partition.

--- a/packages/envio-tests/test/lib_tests/AddressStore_test.res
+++ b/packages/envio-tests/test/lib_tests/AddressStore_test.res
@@ -119,18 +119,18 @@ describe("AddressStore", () => {
       // whichever order the registrations arrive in.
       "noneThenSome": AddressStore.contractsOf(
         ~onEventRegistrations=[reg(~contractName="A"), reg(~contractName="A", ~startBlock=100)],
-        ~contractNames=["A"],
+        ~contractMapping=ContractMapping.make(~names=["A"]),
       ),
       "someThenNone": AddressStore.contractsOf(
         ~onEventRegistrations=[reg(~contractName="A", ~startBlock=100), reg(~contractName="A")],
-        ~contractNames=["A"],
+        ~contractMapping=ContractMapping.make(~names=["A"]),
       ),
       "allRestricted": AddressStore.contractsOf(
         ~onEventRegistrations=[
           reg(~contractName="A", ~startBlock=100),
           reg(~contractName="A", ~startBlock=50),
         ],
-        ~contractNames=["A"],
+        ~contractMapping=ContractMapping.make(~names=["A"]),
       ),
       // Contracts stay independent, and their ids follow the canonical list
       // rather than the order registrations arrive in.
@@ -140,18 +140,18 @@ describe("AddressStore", () => {
           reg(~contractName="A"),
           reg(~contractName="B", ~startBlock=50),
         ],
-        ~contractNames=["A", "B"],
+        ~contractMapping=ContractMapping.make(~names=["A", "B"]),
       ),
       // A contract only the config names is registrable but never fetched.
       "configOnly": AddressStore.contractsOf(
         ~onEventRegistrations=[reg(~contractName="A")],
-        ~contractNames=["A", "NoEvents"],
+        ~contractMapping=ContractMapping.make(~names=["A", "NoEvents"]),
       ),
       // A wildcard event is fetched without consulting addresses, so
       // registering one changes nothing about what's queried.
       "wildcardOnly": AddressStore.contractsOf(
         ~onEventRegistrations=[reg(~contractName="A", ~isWildcard=true)],
-        ~contractNames=["A"],
+        ~contractMapping=ContractMapping.make(~names=["A"]),
       ),
     }).toEqual({
       "noneThenSome": [
@@ -316,11 +316,11 @@ describe("AddressStore", () => {
       contract(~address=addr(0), ~contractName="B", ~registrationBlock=-1),
       contract(~address=addr(1), ~contractName="B", ~registrationBlock=-1),
     ]
-    let contractNames = TestAddresses.contractNames(~onEventRegistrations)
+    let contractMapping = TestAddresses.contractMapping(~onEventRegistrations)
     let store = AddressStore.make(
       ~ecosystem=Evm,
       ~shouldChecksum=true,
-      ~contracts=AddressStore.contractsOf(~onEventRegistrations, ~contractNames),
+      ~contracts=AddressStore.contractsOf(~onEventRegistrations, ~contractMapping),
     )
     let fetchState = FetchState.make(
       ~onEventRegistrations,

--- a/packages/envio-tests/test/lib_tests/ChainState_test.res
+++ b/packages/envio-tests/test/lib_tests/ChainState_test.res
@@ -59,9 +59,7 @@ let makeChainState = (resumedChainState, ~reorgCheckpoints=[]) =>
     ~isInReorgThreshold=false,
     ~isRealtime=false,
     ~config=TestConfig.default,
-    ~contractNames=Config.canonicalContractNames(
-      ~chainConfigs=TestConfig.default.chainMap->ChainMap.values,
-    ),
+    ~contractMapping=TestConfig.default.contractMapping,
     ~registrationsByChainId,
   )
 

--- a/packages/envio-tests/test/lib_tests/ColumnNameFormat_test.res
+++ b/packages/envio-tests/test/lib_tests/ColumnNameFormat_test.res
@@ -255,6 +255,7 @@ ORDER BY (id, envio_checkpoint_id)`,
     ~ecosystem=Evm,
     )
     let _ = await storage.initialize(
+      ~contractMapping=config.contractMapping,
       ~entities=config.userEntities,
       ~enums=config.allEnums->Array.concat([
         EntityHistory.RowAction.config->Table.fromGenericEnumConfig,

--- a/packages/envio-tests/test/lib_tests/ContractMapping_test.res
+++ b/packages/envio-tests/test/lib_tests/ContractMapping_test.res
@@ -46,11 +46,8 @@ describe("ContractMapping", () => {
     )
   )
 
-  // The resume gate compares the mapping storage holds against the config's.
-  // Comparing the two name lists joined on a separator calls the first pair
-  // below equal, and every stored address row would then be attributed to the
-  // wrong contract. A real config.yaml can't declare a contract named "A,B", so
-  // the mapping itself is the only rung this aliasing is reachable from.
+  // A comma-bearing name is unreachable from a real config.yaml, so the mapping
+  // is the only rung this can be tested from.
   it("compares mappings elementwise, not as a joined string", t =>
     t.expect({
       "commaBearingNameVsTwoNames": ContractMapping.fromStoredNames([
@@ -73,15 +70,10 @@ describe("ContractMapping", () => {
     })
   )
 
-  // A stored mapping is the id order its rows were written against, so it must
-  // survive the round trip untouched — re-canonicalizing would paper over a
-  // mapping that no longer matches those rows.
   it("keeps a stored mapping in the order it was stored", t =>
     t.expect(ContractMapping.fromStoredNames(["B", "A"])->ContractMapping.names).toEqual(["B", "A"])
   )
 
-  // Ids are 0-based positions in a smallint column. Building the mapping is
-  // where the ceiling is enforced, so every storage inherits the same limit.
   it("refuses more contracts than a smallint id can hold", t =>
     t->toThrowErrorEqual(
       () =>

--- a/packages/envio-tests/test/lib_tests/ContractMapping_test.res
+++ b/packages/envio-tests/test/lib_tests/ContractMapping_test.res
@@ -21,6 +21,20 @@ describe("ContractMapping", () => {
     })
   })
 
+  // Ids are looked up by indexing a dict, and a plain JS object answers
+  // `__proto__` from its prototype instead of from what was stored — so this
+  // name would resolve to an object cast as an id, silently attributing every
+  // one of its addresses to a contract that doesn't exist. Config validation
+  // lets the name through: it's a valid identifier and isn't a reserved word.
+  it("resolves a contract named like an Object prototype key", t => {
+    let mapping = ContractMapping.make(~names=["__proto__", "constructor", "A"])
+    t.expect(
+      mapping
+      ->ContractMapping.names
+      ->Array.map(name => (name, mapping->ContractMapping.idOfOrThrow(name))),
+    ).toEqual([("A", 0), ("__proto__", 1), ("constructor", 2)])
+  })
+
   it("throws for a name no contract claims", t =>
     t->toThrowErrorEqual(
       () => ContractMapping.make(~names=["A"])->ContractMapping.idOfOrThrow("B"),

--- a/packages/envio-tests/test/lib_tests/ContractMapping_test.res
+++ b/packages/envio-tests/test/lib_tests/ContractMapping_test.res
@@ -21,20 +21,6 @@ describe("ContractMapping", () => {
     })
   })
 
-  // Ids are looked up by indexing a dict, and a plain JS object answers
-  // `__proto__` from its prototype instead of from what was stored — so this
-  // name would resolve to an object cast as an id, silently attributing every
-  // one of its addresses to a contract that doesn't exist. Config validation
-  // lets the name through: it's a valid identifier and isn't a reserved word.
-  it("resolves a contract named like an Object prototype key", t => {
-    let mapping = ContractMapping.make(~names=["__proto__", "constructor", "A"])
-    t.expect(
-      mapping
-      ->ContractMapping.names
-      ->Array.map(name => (name, mapping->ContractMapping.idOfOrThrow(name))),
-    ).toEqual([("A", 0), ("__proto__", 1), ("constructor", 2)])
-  })
-
   it("throws for a name no contract claims", t =>
     t->toThrowErrorEqual(
       () => ContractMapping.make(~names=["A"])->ContractMapping.idOfOrThrow("B"),

--- a/packages/envio-tests/test/lib_tests/ContractMapping_test.res
+++ b/packages/envio-tests/test/lib_tests/ContractMapping_test.res
@@ -1,0 +1,100 @@
+open Vitest
+
+describe("ContractMapping", () => {
+  it("assigns ids by canonical order, whatever order the config declares", t => {
+    let mapping = ContractMapping.make(~names=["B", "A"])
+    t.expect({
+      "names": mapping->ContractMapping.names,
+      "idOfA": mapping->ContractMapping.idOfOrThrow("A"),
+      "idOfB": mapping->ContractMapping.idOfOrThrow("B"),
+      "nameOf0": mapping->ContractMapping.nameOfOrThrow(0),
+      "hasUnknown": mapping->ContractMapping.has("C"),
+      "size": mapping->ContractMapping.size,
+      // Declaration order must not reach the ids: both orders map identically.
+      "matchesReversedDeclaration": mapping->ContractMapping.isEqual(
+        ContractMapping.make(~names=["A", "B"]),
+      ),
+    }).toEqual({
+      "names": ["A", "B"],
+      "idOfA": 0,
+      "idOfB": 1,
+      "nameOf0": "A",
+      "hasUnknown": false,
+      "size": 2,
+      "matchesReversedDeclaration": true,
+    })
+  })
+
+  it("throws for a name no contract claims", t =>
+    t->toThrowErrorEqual(
+      () => ContractMapping.make(~names=["A"])->ContractMapping.idOfOrThrow("B"),
+      `Contract "B" is missing from the indexer's contract list.`,
+    )
+  )
+
+  it("throws for a name no contract claims, naming what asked", t =>
+    t->toThrowErrorEqual(
+      () =>
+        ContractMapping.make(~names=["A"])->ContractMapping.idOfOrThrow(
+          "B",
+          ~context=" has event registrations but",
+        ),
+      `Contract "B" has event registrations but is missing from the indexer's contract list.`,
+    )
+  )
+
+  it("throws for an id outside the list", t =>
+    t->toThrowErrorEqual(
+      () => ContractMapping.make(~names=["A"])->ContractMapping.nameOfOrThrow(1),
+      `Contract id 1 is outside the indexer's contract list.`,
+    )
+  )
+
+  // The resume gate compares the mapping storage holds against the config's.
+  // Comparing the two name lists joined on a separator calls the first pair
+  // below equal, and every stored address row would then be attributed to the
+  // wrong contract. A real config.yaml can't declare a contract named "A,B", so
+  // the mapping itself is the only rung this aliasing is reachable from.
+  it("compares mappings elementwise, not as a joined string", t =>
+    t.expect({
+      "commaBearingNameVsTwoNames": ContractMapping.fromStoredNames([
+        "A,B",
+      ])->ContractMapping.isEqual(ContractMapping.fromStoredNames(["A", "B"])),
+      "same": ContractMapping.fromStoredNames(["A", "B"])->ContractMapping.isEqual(
+        ContractMapping.fromStoredNames(["A", "B"]),
+      ),
+      "reordered": ContractMapping.fromStoredNames(["A", "B"])->ContractMapping.isEqual(
+        ContractMapping.fromStoredNames(["B", "A"]),
+      ),
+      "shorter": ContractMapping.fromStoredNames(["A"])->ContractMapping.isEqual(
+        ContractMapping.fromStoredNames(["A", "B"]),
+      ),
+    }).toEqual({
+      "commaBearingNameVsTwoNames": false,
+      "same": true,
+      "reordered": false,
+      "shorter": false,
+    })
+  )
+
+  // A stored mapping is the id order its rows were written against, so it must
+  // survive the round trip untouched — re-canonicalizing would paper over a
+  // mapping that no longer matches those rows.
+  it("keeps a stored mapping in the order it was stored", t =>
+    t.expect(ContractMapping.fromStoredNames(["B", "A"])->ContractMapping.names).toEqual(["B", "A"])
+  )
+
+  // Ids are 0-based positions in a smallint column. Building the mapping is
+  // where the ceiling is enforced, so every storage inherits the same limit.
+  it("refuses more contracts than a smallint id can hold", t =>
+    t->toThrowErrorEqual(
+      () =>
+        ContractMapping.make(
+          ~names=Array.make(~length=ContractMapping.maxContracts + 1, "")->Array.mapWithIndex(
+            (_, i) => `C${i->Int.toString}`,
+          ),
+        ),
+      `The indexer declares 32769 contracts, more than the 32768 a smallint contract id can hold.`,
+    )
+  )
+})

--- a/packages/envio-tests/test/lib_tests/ContractMapping_test.res
+++ b/packages/envio-tests/test/lib_tests/ContractMapping_test.res
@@ -8,8 +8,6 @@ describe("ContractMapping", () => {
       "idOfA": mapping->ContractMapping.idOfOrThrow("A"),
       "idOfB": mapping->ContractMapping.idOfOrThrow("B"),
       "nameOf0": mapping->ContractMapping.nameOfOrThrow(0),
-      "hasUnknown": mapping->ContractMapping.has("C"),
-      "size": mapping->ContractMapping.size,
       // Declaration order must not reach the ids: both orders map identically.
       "matchesReversedDeclaration": mapping->ContractMapping.isEqual(
         ContractMapping.make(~names=["A", "B"]),
@@ -19,8 +17,6 @@ describe("ContractMapping", () => {
       "idOfA": 0,
       "idOfB": 1,
       "nameOf0": "A",
-      "hasUnknown": false,
-      "size": 2,
       "matchesReversedDeclaration": true,
     })
   })

--- a/packages/envio-tests/test/lib_tests/EntityIdType_test.res
+++ b/packages/envio-tests/test/lib_tests/EntityIdType_test.res
@@ -342,7 +342,7 @@ describe("Test indexer reports deleted ids with the entity's id type", () => {
       entities: Dict.make(),
       entityConfigs,
       addresses: AddressRows.Table.make(),
-      contractNames: [],
+      contractMapping: ContractMapping.empty,
       processChanges: [],
     }
   }

--- a/packages/envio-tests/test/lib_tests/EnvioAddressesTable_test.res
+++ b/packages/envio-tests/test/lib_tests/EnvioAddressesTable_test.res
@@ -27,7 +27,7 @@ let enums =
   config.allEnums->Array.concat([EntityHistory.RowAction.config->Table.fromGenericEnumConfig])
 
 let chainId = (config.chainMap->ChainMap.values->Array.getUnsafe(0)).id
-let contractNames = Config.canonicalContractNames(~chainConfigs=config.chainMap->ChainMap.values)
+let contractMapping = config.contractMapping
 
 let createdSchemas = []
 
@@ -54,6 +54,7 @@ let setup = async () => {
   )
   let _ = await storage.initialize(
     ~chainConfigs=config.chainMap->ChainMap.values,
+    ~contractMapping,
     ~entities=config.userEntities,
     ~enums,
     ~envioInfo=JSON.Encode.object(Dict.make()),
@@ -70,13 +71,12 @@ let configAddress =
 // One row per (chain, address, contract), with the keys encoded exactly as the
 // address store encodes them.
 let row = (~address: Address.t, ~contractName, ~registrationBlock): AddressRows.row => {
-  let packed = Core.getAddon().packAddresses(~ecosystem="evm", ~addresses=[address])
   {
     chainId,
     address: Core.getAddon()
-    .splitAddresses(~ecosystem="evm", ~bytes=packed.bytes, ~lengths=packed.lengths)
+    .encodeAddresses(~ecosystem="evm", ~addresses=[address])
     ->Array.getUnsafe(0),
-    contractId: contractNames->Array.indexOf(contractName),
+    contractId: contractMapping->ContractMapping.idOfOrThrow(contractName),
     registrationBlock,
   }
 }
@@ -93,7 +93,7 @@ let storedRows = async (~pgSchema) => {
   )
   rows->Array.mapWithIndex((row, idx) => (
     rendered->Array.getUnsafe(idx),
-    contractNames->Array.getUnsafe(row.contractId),
+    contractMapping->ContractMapping.nameOfOrThrow(row.contractId),
     row.registrationBlock,
   ))
 }
@@ -151,6 +151,7 @@ describe("envio_addresses", () => {
     let message = try {
       await persistence->Persistence.init(
         ~chainConfigs=config.chainMap->ChainMap.values,
+        ~contractMapping=config.contractMapping,
         ~envioInfo=JSON.Encode.object(Dict.make()),
         ~resetCommand="envio local db-migrate setup",
         ~runCommand=None,
@@ -174,7 +175,7 @@ describe("envio_addresses", () => {
       ~pgSchema,
       ~rows=[
         shared,
-        {...shared, contractId: contractNames->Array.indexOf("NftFactory")},
+        {...shared, contractId: contractMapping->ContractMapping.idOfOrThrow("NftFactory")},
       ],
     )
     // A retried batch write re-inserts what it already wrote.

--- a/packages/envio-tests/test/lib_tests/Persistence_test.res
+++ b/packages/envio-tests/test/lib_tests/Persistence_test.res
@@ -29,7 +29,7 @@ describe("Test Persistence layer init", () => {
 
     let envioInfo = JSON.Encode.object(Dict.make())
     let p =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~contractMapping=ContractMapping.empty, ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
 
     t.expect(
       storageMock.isInitializedCalls,
@@ -73,7 +73,7 @@ describe("Test Persistence layer init", () => {
 
     let initialState: Persistence.initialState = {
       cleanRun: true,
-      contractNames: [],
+      contractMapping: ContractMapping.empty,
       chains: [],
       cache: Dict.make(),
       reorgCheckpoints: [],
@@ -91,7 +91,7 @@ describe("Test Persistence layer init", () => {
     // Can resolve the promise now
     await p
 
-    await persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
+    await persistence->Persistence.init(~chainConfigs=[], ~contractMapping=ContractMapping.empty, ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
     t.expect(
       (
         storageMock.isInitializedCalls->Array.length,
@@ -105,6 +105,7 @@ describe("Test Persistence layer init", () => {
       persistence->Persistence.init(
         ~reset=true,
         ~chainConfigs=[],
+        ~contractMapping=ContractMapping.empty,
         ~envioInfo,
         ~resetCommand=resetCmd, ~runCommand=runCmd,
       )
@@ -139,12 +140,12 @@ describe("Test Persistence layer init", () => {
     let persistence = Persistence.make(~userEntities=[], ~allEnums=[], ~storage=storageMock.storage)
 
     let p =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~contractMapping=ContractMapping.empty, ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
     // Additional calls to init should not do anything
     let _ =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~contractMapping=ContractMapping.empty, ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
     let _ =
-      persistence->Persistence.init(~chainConfigs=[], ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
+      persistence->Persistence.init(~chainConfigs=[], ~contractMapping=ContractMapping.empty, ~envioInfo, ~resetCommand=resetCmd, ~runCommand=runCmd)
 
     storageMock.resolveIsInitialized(true)
     // The compat gate reads the stored config snapshot before resuming, so the
@@ -153,7 +154,7 @@ describe("Test Persistence layer init", () => {
 
     let initialState: Persistence.initialState = {
       cleanRun: false,
-      contractNames: [],
+      contractMapping: ContractMapping.empty,
       chains: [],
       cache: Dict.make(),
       reorgCheckpoints: [],
@@ -196,6 +197,7 @@ Although it should load effect caches metadata.`,
       async () =>
         switch await persistence->Persistence.init(
           ~chainConfigs=[],
+          ~contractMapping=ContractMapping.empty,
           ~envioInfo=current,
           ~resetCommand,
           ~runCommand,
@@ -208,7 +210,7 @@ Although it should load effect caches metadata.`,
     await Utils.delay(0)
     let initialState: Persistence.initialState = {
       cleanRun: false,
-      contractNames: [],
+      contractMapping: ContractMapping.empty,
       chains: [],
       cache: Dict.make(),
       reorgCheckpoints: [],

--- a/packages/envio-tests/test/lib_tests/PgIndexes_test.res
+++ b/packages/envio-tests/test/lib_tests/PgIndexes_test.res
@@ -92,6 +92,7 @@ let setup = async (~pgSchema, ~fixtures=[], ~sql as client=sql, ~entities=allEnt
   let storage = makeStorage(~sql=client, pgSchema)
   let _ = await storage.initialize(
     ~chainConfigs=config.chainMap->ChainMap.values,
+    ~contractMapping=config.contractMapping,
     ~entities,
     ~enums,
     ~envioInfo=JSON.Encode.object(Dict.make()),

--- a/packages/envio-tests/test/lib_tests/SimulateSource_test.res
+++ b/packages/envio-tests/test/lib_tests/SimulateSource_test.res
@@ -101,13 +101,13 @@ describe("SimulateSource routing", () => {
     let first = await getItems(
       ~items,
       ~store,
-      ~addressSet=store->AddressStore.makeSetOf([addr(0)]),
+      ~addressSet=TestAddresses.setOf(~store, [addr(0)]),
       ~selection,
     )
     let second = await getItems(
       ~items,
       ~store,
-      ~addressSet=store->AddressStore.makeSetOf([addr(1)]),
+      ~addressSet=TestAddresses.setOf(~store, [addr(1)]),
       ~selection,
     )
 
@@ -134,7 +134,7 @@ describe("SimulateSource routing", () => {
         item(~registration=regA, ~blockNumber=49, ~srcAddress=addr(0)),
         item(~registration=regA, ~blockNumber=50, ~srcAddress=addr(0)),
       ],
-      ~addressSet=store->AddressStore.makeSetOf([addr(0)]),
+      ~addressSet=TestAddresses.setOf(~store, [addr(0)]),
       ~selection,
     )
 
@@ -217,13 +217,13 @@ describe("SimulateSource routing", () => {
     let partitionScoped = await getItems(
       ~items,
       ~store,
-      ~addressSet=store->AddressStore.makeSetOf([addr(0)]),
+      ~addressSet=TestAddresses.setOf(~store, [addr(0)]),
       ~selection,
     )
     let clientFiltered = await getItems(
       ~items,
       ~store,
-      ~addressSet=store->AddressStore.makeSetOf([addr(0)]),
+      ~addressSet=TestAddresses.setOf(~store, [addr(0)]),
       ~selection={...selection, clientFilteredContracts: ["A"]},
     )
 
@@ -253,7 +253,7 @@ describe("SimulateSource routing", () => {
         item(~registration=regOpen, ~blockNumber=100, ~srcAddress=addr(0)),
         item(~registration=regRestricted, ~blockNumber=100, ~srcAddress=addr(0)),
       ],
-      ~addressSet=store->AddressStore.makeSetOf([addr(0)]),
+      ~addressSet=TestAddresses.setOf(~store, [addr(0)]),
       ~selection={dependsOnAddresses: true, onEventRegistrations: [regOpen, regRestricted]},
     )
 
@@ -269,7 +269,7 @@ describe("SimulateSource routing", () => {
       ~onEventRegistrations=[regFirst, regSecond],
       ~addresses=[contract(~address=addr(0), ~contractName="A")],
     )
-    let addressSet = store->AddressStore.makeSetOf([addr(0)])
+    let addressSet = TestAddresses.setOf(~store, [addr(0)])
     let items = [
       item(~registration=regFirst, ~blockNumber=10, ~srcAddress=addr(0)),
       item(~registration=regSecond, ~blockNumber=10, ~srcAddress=addr(0)),

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -68,27 +68,21 @@ type t = {
 let configStorageRows = (
   chainConfig: Config.chain,
   ~ecosystem: Ecosystem.name,
-  ~contractNames: array<string>,
+  ~contractMapping: ContractMapping.t,
 ): array<AddressRows.row> => {
   let addresses = []
   let contractIds = []
   chainConfig.contracts->Array.forEach(contract => {
-    let contractId = switch contractNames->Array.indexOf(contract.name) {
-    | -1 =>
-      JsError.throwWithMessage(
-        `Contract "${contract.name}" is missing from the indexer's contract list.`,
-      )
-    | id => id
-    }
+    let contractId = contractMapping->ContractMapping.idOfOrThrow(contract.name)
     contract.addresses->Array.forEach(address => {
       addresses->Array.push(address)->ignore
       contractIds->Array.push(contractId)->ignore
     })
   })
-  let packed = Core.getAddon().packAddresses(~ecosystem=(ecosystem :> string), ~addresses)
-  Core.getAddon()
-  .splitAddresses(~ecosystem=(ecosystem :> string), ~bytes=packed.bytes, ~lengths=packed.lengths)
-  ->Array.mapWithIndex((address, idx) => {
+  Core.getAddon().encodeAddresses(
+    ~ecosystem=(ecosystem :> string),
+    ~addresses,
+  )->Array.mapWithIndex((address, idx) => {
     AddressRows.chainId: chainConfig.id,
     address,
     contractId: contractIds->Array.getUnsafe(idx),
@@ -165,11 +159,9 @@ let make = (
 let makeInternal = (
   ~chainConfig: Config.chain,
   ~addressRows: AddressRows.seedRows,
-  // Every chain's contracts, not just one chain's: `context.chain.X.add`
-  // accepts any config contract, whichever chain declared it, so every chain's
-  // address store has to hold the whole set — under the same ids, since a
-  // persisted row names its contract by id.
-  ~contractNames: array<string>,
+  // Passed rather than read off `config`, because a resume must use the mapping
+  // storage holds: the ids stored rows carry, not the ids this config derives.
+  ~contractMapping: ContractMapping.t,
   ~startBlock,
   ~endBlock,
   ~firstEventBlock=None,
@@ -211,7 +203,7 @@ let makeInternal = (
   let addressStore = AddressStore.make(
     ~ecosystem=config.ecosystem.name,
     ~shouldChecksum=!lowercaseAddresses,
-    ~contracts=AddressStore.contractsOf(~onEventRegistrations, ~contractNames),
+    ~contracts=AddressStore.contractsOf(~onEventRegistrations, ~contractMapping),
   )
 
   let fetchState = FetchState.make(
@@ -392,7 +384,7 @@ let makeFromDbState = (
   ~isInReorgThreshold,
   ~isRealtime,
   ~config,
-  ~contractNames,
+  ~contractMapping,
   ~registrationsByChainId,
   ~reducedPollingInterval=?,
 ) => {
@@ -407,7 +399,7 @@ let makeFromDbState = (
 
   makeInternal(
     ~addressRows=resumedChainState.addressRows,
-    ~contractNames,
+    ~contractMapping,
     ~chainConfig,
     ~startBlock=resumedChainState.startBlock,
     ~endBlock=resumedChainState.endBlock,
@@ -838,9 +830,9 @@ let applyTransactionGroups = async (store: TransactionStore.t, g: transactionGro
       g.payloadGroups->Array.forEachWithIndex((payloads, i) => {
         let tx = txs->Array.getUnsafe(i)
         payloads->Array.forEach(payload => payload->Internal.setPayloadTransaction(tx))
-        switch (
-          tx->(Utils.magic: Internal.eventTransaction => dict<unknown>)
-        )->Dict.get("accountActivities") {
+        switch tx
+        ->(Utils.magic: Internal.eventTransaction => dict<unknown>)
+        ->Dict.get("accountActivities") {
         | Some(_) => payloads->Array.forEach(payload => Svm.attachAccountActivities(payload, tx))
         | None => ()
         }

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -6,7 +6,7 @@ type t
 let configStorageRows: (
   Config.chain,
   ~ecosystem: Ecosystem.name,
-  ~contractNames: array<string>,
+  ~contractMapping: ContractMapping.t,
 ) => array<AddressRows.row>
 
 let make: (
@@ -37,7 +37,7 @@ let makeFromDbState: (
   ~isInReorgThreshold: bool,
   ~isRealtime: bool,
   ~config: Config.t,
-  ~contractNames: array<string>,
+  ~contractMapping: ContractMapping.t,
   ~registrationsByChainId: HandlerRegister.registrationsByChainId,
   ~reducedPollingInterval: int=?,
 ) => t

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -107,6 +107,9 @@ type t = {
   // they can express fits an INTEGER.
   chainIdMode: ChainId.mode,
   chainMap: ChainMap.t<chain>,
+  // Derived from every chain's contracts, so an id means the same contract on
+  // every chain and on every restart.
+  contractMapping: ContractMapping.t,
   defaultChain: option<chain>,
   ecosystem: Ecosystem.t,
   enableRawEvents: bool,
@@ -562,6 +565,14 @@ let publicConfigSchema = S.schema(s =>
     "entities": s.matches(S.option(S.array(entityJsonSchema))),
   }
 )
+
+let contractMappingOf = (~chainConfigs: array<chain>): ContractMapping.t => {
+  let names = []
+  chainConfigs->Array.forEach(chain =>
+    chain.contracts->Array.forEach(contract => names->Array.push(contract.name)->ignore)
+  )
+  ContractMapping.make(~names)
+}
 
 let fromPublic = (publicConfigJson: JSON.t) => {
   let maxAddrInPartition = Env.maxAddrInPartition
@@ -1043,6 +1054,7 @@ let fromPublic = (publicConfigJson: JSON.t) => {
     storage: globalStorage,
     chainIdMode: publicConfig["chainIdMode"]->Option.getOr(Int32),
     chainMap,
+    contractMapping: contractMappingOf(~chainConfigs=chains),
     defaultChain: chains->Array.get(0),
     enableRawEvents: publicConfig["rawEvents"]->Option.getOr(false),
     ecosystem,
@@ -1127,17 +1139,6 @@ let getEventConfig = (config: t, ~contractName, ~eventName, ~chainId: option<Cha
       ->Option.flatMap(contract => contract.events->Array.find(e => e.name == eventName))
     }
   })
-}
-
-// The canonical contract ids: a name's position in this list is the id
-// `envio_contracts` stores and every address row references. Byte order, so the
-// ids never depend on the order contracts happen to be declared in.
-let canonicalContractNames = (~chainConfigs: array<chain>): array<string> => {
-  let names = []
-  chainConfigs->Array.forEach(chain =>
-    chain.contracts->Array.forEach(contract => names->Array.push(contract.name)->ignore)
-  )
-  Core.getAddon().canonicalContractNames(names)
 }
 
 let shouldSaveHistory = (config, ~isInReorgThreshold) =>

--- a/packages/envio/src/ContractMapping.res
+++ b/packages/envio/src/ContractMapping.res
@@ -1,0 +1,72 @@
+// The contract name <-> id mapping every stored address row references: a
+// name's position in `names` is the id `envio_contracts` holds and
+// `envio_addresses.contract_id` points at. Ids must mean the same thing on
+// every chain and across restarts, so a mapping is built once — from the whole
+// config, never from a filtered subset — and read everywhere else.
+type t = {
+  // Id order. Index i is the name of contract id i.
+  names: array<string>,
+  idByName: dict<int>,
+}
+
+let indexNames = (names: array<string>): t => {
+  let idByName = Dict.make()
+  names->Array.forEachWithIndex((name, id) => idByName->Dict.set(name, id))
+  {names, idByName}
+}
+
+// Ids are 0-based positions in a smallint column, so 32768 contracts fit.
+let maxContracts = 32768
+
+// Names in any order; the codec puts them in byte order so the ids never depend
+// on the order contracts happen to be declared in.
+let make = (~names: array<string>): t => {
+  let canonical = Core.getAddon().canonicalContractNames(names)
+  if canonical->Array.length > maxContracts {
+    JsError.throwWithMessage(
+      `The indexer declares ${canonical
+        ->Array.length
+        ->Int.toString} contracts, more than the ${maxContracts->Int.toString} a smallint contract id can hold.`,
+    )
+  }
+  indexNames(canonical)
+}
+
+// What a storage holds before it has been initialized: no contract has an id
+// yet, so every lookup fails rather than resolving against a stale mapping.
+let empty = indexNames([])
+
+// A mapping read back from storage. Taken verbatim: the stored order *is* the
+// id order the stored rows were written against, so re-canonicalizing it would
+// paper over a mapping that no longer matches those rows.
+let fromStoredNames = indexNames
+
+let names = (mapping: t) => mapping.names
+
+let size = (mapping: t) => mapping.names->Array.length
+
+let idOf = (mapping: t, name) => mapping.idByName->Utils.Dict.dangerouslyGetNonOption(name)
+
+let has = (mapping: t, name) => mapping->idOf(name)->Option.isSome
+
+let idOfOrThrow = (mapping: t, name, ~context="") =>
+  switch mapping->idOf(name) {
+  | Some(id) => id
+  | None =>
+    JsError.throwWithMessage(
+      `Contract "${name}"${context} is missing from the indexer's contract list.`,
+    )
+  }
+
+let nameOfOrThrow = (mapping: t, id) =>
+  switch mapping.names->Array.get(id) {
+  | Some(name) => name
+  | None =>
+    JsError.throwWithMessage(
+      `Contract id ${id->Int.toString} is outside the indexer's contract list.`,
+    )
+  }
+
+let isEqual = (a: t, b: t) =>
+  a.names->Array.length === b.names->Array.length &&
+    a.names->Array.everyWithIndex((name, idx) => b.names->Array.getUnsafe(idx) === name)

--- a/packages/envio/src/ContractMapping.res
+++ b/packages/envio/src/ContractMapping.res
@@ -43,14 +43,8 @@ let fromStoredNames = indexNames
 
 let names = (mapping: t) => mapping.names
 
-let size = (mapping: t) => mapping.names->Array.length
-
-let idOf = (mapping: t, name) => mapping.idByName->Utils.Dict.dangerouslyGetNonOption(name)
-
-let has = (mapping: t, name) => mapping->idOf(name)->Option.isSome
-
 let idOfOrThrow = (mapping: t, name, ~context="") =>
-  switch mapping->idOf(name) {
+  switch mapping.idByName->Utils.Dict.dangerouslyGetNonOption(name) {
   | Some(id) => id
   | None =>
     JsError.throwWithMessage(

--- a/packages/envio/src/ContractMapping.res
+++ b/packages/envio/src/ContractMapping.res
@@ -10,7 +10,11 @@ type t = {
 }
 
 let indexNames = (names: array<string>): t => {
-  let idByName = Dict.make()
+  // Prototype-free, because ids are looked up by indexing this: a plain object
+  // answers `__proto__` from its prototype rather than from what was stored,
+  // and a contract may legitimately be named that — it's a valid identifier and
+  // no reserved word rejects it.
+  let idByName: dict<int> = Utils.Object.createNullObject()
   names->Array.forEachWithIndex((name, id) => idByName->Dict.set(name, id))
   {names, idByName}
 }

--- a/packages/envio/src/ContractMapping.res
+++ b/packages/envio/src/ContractMapping.res
@@ -10,11 +10,7 @@ type t = {
 }
 
 let indexNames = (names: array<string>): t => {
-  // Prototype-free, because ids are looked up by indexing this: a plain object
-  // answers `__proto__` from its prototype rather than from what was stored,
-  // and a contract may legitimately be named that — it's a valid identifier and
-  // no reserved word rejects it.
-  let idByName: dict<int> = Utils.Object.createNullObject()
+  let idByName = Dict.make()
   names->Array.forEachWithIndex((name, id) => idByName->Dict.set(name, id))
   {names, idByName}
 }

--- a/packages/envio/src/Core.res
+++ b/packages/envio/src/Core.res
@@ -26,12 +26,6 @@ type fromUserApiResult = {
   indexerCode: Null.t<string>,
 }
 
-// Address keys packed back to back, with the length of each.
-type packedAddresses = {
-  bytes: NodeJs.Buffer.t,
-  lengths: array<int>,
-}
-
 type addon = {
   getConfigJson: (~configPath: Null.t<string>, ~directory: Null.t<string>) => string,
   encodeIndexedTopic: (~abiType: string, ~value: unknown) => EvmTypes.Hex.t,
@@ -55,12 +49,7 @@ type addon = {
   mockHyperSyncServer: mockHyperSyncServerCtor,
   // Address keys are encoded and rendered only in Rust — the store's key is
   // exactly what a persisted row holds, so a JS-side codec could fork from it.
-  packAddresses: (~ecosystem: string, ~addresses: array<Address.t>) => packedAddresses,
-  splitAddresses: (
-    ~ecosystem: string,
-    ~bytes: NodeJs.Buffer.t,
-    ~lengths: array<int>,
-  ) => array<NodeJs.Buffer.t>,
+  encodeAddresses: (~ecosystem: string, ~addresses: array<Address.t>) => array<NodeJs.Buffer.t>,
   renderAddresses: (
     ~ecosystem: string,
     ~shouldChecksum: bool,

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -272,7 +272,7 @@ let makeFromDbState = (
         ~isInReorgThreshold,
         ~isRealtime,
         ~config,
-        ~contractNames=initialState.contractNames,
+        ~contractMapping=initialState.contractMapping,
         ~registrationsByChainId,
         ~reducedPollingInterval?,
       ),
@@ -814,7 +814,7 @@ let markCommitted = (state: t, ~upToCheckpointId) => {
 }
 
 let stageRegisteredAddresses = (state: t, rows: array<AddressRows.staged>) =>
-  state.registeredAddresses = state.registeredAddresses->Array.concat(rows)
+  state.registeredAddresses->Array.pushMany(rows)
 
 let snapshotRegisteredAddresses = (state: t, ~upToCheckpointId) =>
   state.registeredAddresses->Array.filter(row => row.checkpointId <= upToCheckpointId)

--- a/packages/envio/src/Main.res
+++ b/packages/envio/src/Main.res
@@ -195,20 +195,19 @@ let buildChainsObject = (~config: Config.t) => {
             | None =>
               switch getInitialState() {
               | Some(initialState) =>
-                switch (
-                  initialState.chains->Array.find(c => c.id === chainConfig.id),
-                  initialState.contractNames->Array.indexOf(contract.name),
-                ) {
-                | (Some(chainState), contractId) if contractId >= 0 =>
+                switch initialState.chains->Array.find(c => c.id === chainConfig.id) {
+                | Some(chainState) =>
                   Core.getAddon().renderContractAddresses(
                     ~ecosystem=(config.ecosystem.name :> string),
                     ~shouldChecksum=!config.lowercaseAddresses,
                     ~bytes=chainState.addressRows.addresses,
                     ~lengths=chainState.addressRows.lengths,
                     ~contractIds=chainState.addressRows.contractIds,
-                    ~contractId,
+                    ~contractId=initialState.contractMapping->ContractMapping.idOfOrThrow(
+                      contract.name,
+                    ),
                   )
-                | _ => contract.addresses
+                | None => contract.addresses
                 }
               | None => contract.addresses
               }
@@ -589,6 +588,7 @@ let migrate = async (~reset) => {
   await persistence->Persistence.init(
     ~reset,
     ~chainConfigs=config.chainMap->ChainMap.values,
+    ~contractMapping=config.contractMapping,
     ~envioInfo=getEnvioInfo(),
     ~resetCommand="envio local db-migrate setup",
     ~runCommand=None,
@@ -640,6 +640,7 @@ let start = async (
   await persistence->Persistence.init(
     ~reset,
     ~chainConfigs=config.chainMap->ChainMap.values,
+    ~contractMapping=config.contractMapping,
     ~envioInfo=getEnvioInfo(),
     ~resetCommand=isDevelopmentMode ? "envio dev -r" : "envio start -r",
     ~runCommand=Some(isDevelopmentMode ? "envio dev" : "envio start"),

--- a/packages/envio/src/MemoryStorage.res
+++ b/packages/envio/src/MemoryStorage.res
@@ -52,7 +52,7 @@ type t = {
   addresses: AddressRows.Table.t,
   // The canonical contract mapping, assigned at initialize and read back on a
   // resume just as the stored one is.
-  mutable contractNames: array<string>,
+  mutable contractMapping: ContractMapping.t,
   mutable isInitialized: bool,
 }
 
@@ -66,7 +66,7 @@ let make = (): t => {
   effectCache: Dict.make(),
   envioInfo: None,
   addresses: AddressRows.Table.make(),
-  contractNames: [],
+  contractMapping: ContractMapping.empty,
   isInitialized: false,
 }
 
@@ -123,15 +123,20 @@ let registerEntities = (state: t, ~entities: array<Internal.entityConfig>) =>
 
 // Seeds the config's contract addresses, mirroring what PgStorage.initialize
 // writes into `envio_addresses`.
-let seedConfigAddresses = (state: t, ~chainConfigs: array<Config.chain>, ~ecosystem) => {
+let seedConfigAddresses = (
+  state: t,
+  ~chainConfigs: array<Config.chain>,
+  ~contractMapping,
+  ~ecosystem,
+) => {
   // Initialize starts from an empty schema — the Postgres DDL drops and
   // recreates one — so a re-initialize must not stack a second copy of the
   // config's addresses on what a previous one left behind.
   state.addresses->AddressRows.Table.clear
-  state.contractNames = Config.canonicalContractNames(~chainConfigs)
+  state.contractMapping = contractMapping
   chainConfigs->Array.forEach(chainConfig =>
     state.addresses->AddressRows.Table.insertMany(
-      chainConfig->ChainState.configStorageRows(~ecosystem, ~contractNames=state.contractNames),
+      chainConfig->ChainState.configStorageRows(~ecosystem, ~contractMapping),
     )
   )
 }
@@ -190,7 +195,7 @@ let reorgCheckpoints = (state: t): array<Internal.reorgCheckpoint> =>
 
 let toInitialState = (state: t, ~cleanRun): Persistence.initialState => {
   cleanRun,
-  contractNames: state.contractNames,
+  contractMapping: state.contractMapping,
   cache: state.cache,
   chains: state->toInitialChainStates,
   checkpointId: state->committedCheckpointId,
@@ -526,9 +531,9 @@ let getRollbackProgressDiff = (state: t, ~rollbackTargetCheckpointId) => {
 let toStorage = (state: t, ~config: Config.t): Persistence.storage => {
   name: "memory",
   isInitialized: async () => state.isInitialized,
-  initialize: async (~chainConfigs=[], ~entities=[], ~enums as _=[], ~envioInfo) => {
+  initialize: async (~chainConfigs=[], ~entities=[], ~enums as _=[], ~contractMapping, ~envioInfo) => {
     state->registerEntities(~entities)
-    state->seedConfigAddresses(~chainConfigs, ~ecosystem=config.ecosystem.name)
+    state->seedConfigAddresses(~chainConfigs, ~contractMapping, ~ecosystem=config.ecosystem.name)
     chainConfigs->Array.forEach(chainConfig =>
       state.chains->Dict.set(
         chainConfig.id->ChainId.toString,
@@ -577,7 +582,7 @@ let toStorage = (state: t, ~config: Config.t): Persistence.storage => {
     state.cache->clear
     state.checkpoints = []
     state.addresses->AddressRows.Table.clear
-    state.contractNames = []
+    state.contractMapping = ContractMapping.empty
     state.envioInfo = None
     state.isInitialized = false
   },

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -35,10 +35,9 @@ type initialChainState = {
 
 type initialState = {
   cleanRun: bool,
-  // The stored contract mapping: a name's position is the id its addresses'
-  // rows carry. On a resume this is what the database holds, not what the
-  // config would derive — the ids must never reshuffle under stored rows.
-  contractNames: array<string>,
+  // On a resume this is what the database holds, not what the config would
+  // derive — the ids must never reshuffle under stored rows.
+  contractMapping: ContractMapping.t,
   cache: dict<effectCacheRecord>,
   chains: array<initialChainState>,
   checkpointId: Internal.checkpointId,
@@ -96,6 +95,7 @@ type storage = {
     ~chainConfigs: array<Config.chain>=?,
     ~entities: array<Internal.entityConfig>=?,
     ~enums: array<Table.enumConfig<Table.enum>>=?,
+    ~contractMapping: ContractMapping.t,
     ~envioInfo: JSON.t,
   ) => promise<initialState>,
   // The public config snapshot stored by the last successful initialize, for
@@ -220,7 +220,15 @@ let make = (
 }
 
 let init = {
-  async (persistence, ~chainConfigs, ~envioInfo, ~resetCommand, ~runCommand, ~reset=false) => {
+  async (
+    persistence,
+    ~chainConfigs,
+    ~contractMapping,
+    ~envioInfo,
+    ~resetCommand,
+    ~runCommand,
+    ~reset=false,
+  ) => {
     try {
       let shouldRun = switch persistence.storageStatus {
       | Unknown => true
@@ -242,6 +250,7 @@ let init = {
             ~entities=persistence.allEntities,
             ~enums=persistence.allEnums,
             ~chainConfigs,
+            ~contractMapping,
             ~envioInfo,
           )
           Logging.info(`The indexer storage is ready. Starting indexing!`)
@@ -281,21 +290,13 @@ let init = {
           }
           Config.throwIfIncompatible(changedPaths, ~resetCommand, ~runCommand, ~hasClickhouse)
           let initialState = await persistence.storage.resumeInitialState()
+
           // Belt and braces on top of the config diff: every stored address row
           // names its contract by the id this mapping assigns, so a mapping
           // that no longer matches the config would silently attribute
-          // addresses to the wrong contract. Both lists are in canonical order,
-          // so comparing them joined is comparing the mappings themselves.
-          if (
-            initialState.contractNames->Array.joinUnsafe(",") !==
-              Config.canonicalContractNames(~chainConfigs)->Array.joinUnsafe(",")
-          ) {
-            Config.throwIfIncompatible(
-              ["contracts"],
-              ~resetCommand,
-              ~runCommand,
-              ~hasClickhouse,
-            )
+          // addresses to the wrong contract.
+          if !(initialState.contractMapping->ContractMapping.isEqual(contractMapping)) {
+            Config.throwIfIncompatible(["contracts"], ~resetCommand, ~runCommand, ~hasClickhouse)
           }
           persistence.storageStatus = Ready(initialState)
           let progress = Dict.make()

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1241,6 +1241,7 @@ let rec writeBatch = async (
             sql->InternalTable.Checkpoints.rollback(~pgSchema, ~rollbackTargetCheckpointId),
           )
           ->ignore
+
           // Addresses are insert-only, so undoing their registrations is a
           // delete rather than a history replay. It runs before the batch's own
           // inserts in the same transaction, so a re-registered address lands
@@ -1694,6 +1695,7 @@ let make = (
     ~chainConfigs=[],
     ~entities=[],
     ~enums=[],
+    ~contractMapping,
     ~envioInfo,
   ): Persistence.initialState => {
     // Per-entity storage routing: PG owns tables only for entities that
@@ -1747,18 +1749,9 @@ let make = (
     // Execute all queries within a single transaction for integrity.
     // The envio_info row is written in the same transaction so a successful
     // initialize is atomic — no schema can come up without the matching row.
-    let contractNames = Config.canonicalContractNames(~chainConfigs)
-    // Ids are 0-based positions in a smallint column, so 32768 contracts fit.
-    if contractNames->Array.length > 32768 {
-      JsError.throwWithMessage(
-        `The indexer declares ${contractNames
-          ->Array.length
-          ->Int.toString} contracts, more than the 32768 a smallint contract id can hold.`,
-      )
-    }
     let rowsByChain =
       chainConfigs->Array.map(chainConfig =>
-        chainConfig->ChainState.configStorageRows(~ecosystem, ~contractNames)
+        chainConfig->ChainState.configStorageRows(~ecosystem, ~contractMapping)
       )
     let configAddressRows = rowsByChain->Array.flat
 
@@ -1770,7 +1763,11 @@ let make = (
       // but it's just how it worked before.
       let _ = await Promise.all(queries->Array.map(query => sql->Postgres.unsafe(query)))
       await InternalTable.EnvioInfo.write(sql, ~pgSchema, ~envioInfo)
-      await InternalTable.EnvioContracts.insert(sql, ~pgSchema, ~contractNames)
+      await InternalTable.EnvioContracts.insert(
+        sql,
+        ~pgSchema,
+        ~contractNames=contractMapping->ContractMapping.names,
+      )
       if configAddressRows->Utils.Array.notEmpty {
         await InternalTable.EnvioAddresses.insert(
           sql,
@@ -1795,8 +1792,11 @@ let make = (
       cleanRun: true,
       cache,
       reorgCheckpoints: [],
-      contractNames,
-      chains: chainConfigs->Array.mapWithIndex((chainConfig, idx): Persistence.initialChainState => {
+      contractMapping,
+      chains: chainConfigs->Array.mapWithIndex((
+        chainConfig,
+        idx,
+      ): Persistence.initialChainState => {
         id: chainConfig.id,
         startBlock: chainConfig.startBlock,
         endBlock: chainConfig.endBlock,
@@ -2195,9 +2195,12 @@ let make = (
   }
 
   let resumeInitialState = async (): Persistence.initialState => {
-    let (cache, chains, checkpointIdResult, reorgCheckpoints, contractNames) = await Promise.all5((
+    let (cache, chains, checkpointIdResult, reorgCheckpoints, contractMapping) = await Promise.all5((
       restoreEffectCache(~withUpload=false),
-      InternalTable.Chains.getInitialState(sql, ~pgSchema)->Promise.thenResolve(rawInitialStates => {
+      InternalTable.Chains.getInitialState(
+        sql,
+        ~pgSchema,
+      )->Promise.thenResolve(rawInitialStates => {
         rawInitialStates->Array.map((rawInitialState): Persistence.initialChainState => {
           id: rawInitialState.id,
           startBlock: rawInitialState.startBlock,
@@ -2229,7 +2232,9 @@ let make = (
       InternalTable.EnvioContracts.read(sql, ~pgSchema)->Promise.thenResolve(stored =>
         // `readEnvioInfo` already refused the resume without this table, so a
         // missing one here means the gate was skipped, not an old schema.
-        stored->Option.getOrThrow(~message=`Resumed without a stored contract mapping.`)
+        stored
+        ->Option.getOrThrow(~message=`Resumed without a stored contract mapping.`)
+        ->ContractMapping.fromStoredNames
       ),
     ))
 
@@ -2257,7 +2262,7 @@ let make = (
       cache,
       chains,
       checkpointId,
-      contractNames,
+      contractMapping,
     }
   }
 

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -38,8 +38,7 @@ type testIndexerState = {
   entities: dict<dict<Internal.entity>>,
   entityConfigs: dict<Internal.entityConfig>,
   addresses: AddressRows.Table.t,
-  // The canonical contract mapping, a name's position being its id.
-  contractNames: array<string>,
+  contractMapping: ContractMapping.t,
   mutable processChanges: array<unknown>,
 }
 
@@ -124,7 +123,7 @@ let handleWriteBatch = (
       checkpointId->BigInt.toString,
       {
         "address": rendered->Array.getUnsafe(idx),
-        "contract": state.contractNames->Array.getUnsafe(row.contractId),
+        "contract": state.contractMapping->ContractMapping.nameOfOrThrow(row.contractId),
       },
     )
   })
@@ -245,7 +244,7 @@ let makeInitialState = (
   ~config: Config.t,
   ~processConfigChains: dict<chainConfig>,
   ~addressRowsByChain: dict<AddressRows.seedRows>,
-  ~contractNames: array<string>,
+  ~contractMapping: ContractMapping.t,
 ): Persistence.initialState => {
   let chainKeys = processConfigChains->Dict.keysToArray
   let chains = chainKeys->Array.map(chainIdStr => {
@@ -276,7 +275,7 @@ let makeInitialState = (
 
   {
     cleanRun: true,
-    contractNames,
+    contractMapping,
     cache: Dict.make(),
     chains,
     checkpointId: InternalTable.Checkpoints.initialCheckpointId,
@@ -573,7 +572,13 @@ let makeInMemoryStorage = (~state: testIndexerState): Persistence.storage => {
   // The runner injects the config-derived initial state by setting
   // `persistence.storageStatus = Ready(...)` directly, bypassing `Persistence.init`,
   // so neither of these is reached.
-  initialize: async (~chainConfigs as _=?, ~entities as _=?, ~enums as _=?, ~envioInfo as _) =>
+  initialize: async (
+    ~chainConfigs as _=?,
+    ~entities as _=?,
+    ~enums as _=?,
+    ~contractMapping as _,
+    ~envioInfo as _,
+  ) =>
     JsError.throwWithMessage(
       "TestIndexer: initialize should not be called; the initial state is derived from config.",
     ),
@@ -684,12 +689,12 @@ let createTestIndexer = (): t<'processConfig> => {
 
   // Populate the config's addresses, mirroring PgStorage.initialize
   let chainConfigs = config.chainMap->ChainMap.values
-  let contractNames = Config.canonicalContractNames(~chainConfigs)
+  let contractMapping = config.contractMapping
   let ecosystem = config.ecosystem.name
   let addresses = AddressRows.Table.make()
   chainConfigs->Array.forEach(chainConfig =>
     addresses->AddressRows.Table.insertMany(
-      chainConfig->ChainState.configStorageRows(~ecosystem, ~contractNames),
+      chainConfig->ChainState.configStorageRows(~ecosystem, ~contractMapping),
     )
   )
 
@@ -699,7 +704,7 @@ let createTestIndexer = (): t<'processConfig> => {
     entities,
     entityConfigs,
     addresses,
-    contractNames,
+    contractMapping,
     processChanges: [],
   }
 
@@ -774,7 +779,7 @@ let createTestIndexer = (): t<'processConfig> => {
                 `Cannot access ${contract.name}.addresses while indexer.process() is running. ` ++ "Wait for process() to complete before reading contract addresses.",
               )
             }
-            let contractId = state.contractNames->Array.indexOf(contract.name)
+            let contractId = state.contractMapping->ContractMapping.idOfOrThrow(contract.name)
             state.addresses
             ->AddressRows.Table.rows
             ->Array.filter(row => row.chainId === chainConfig.id && row.contractId === contractId)
@@ -879,7 +884,7 @@ let createTestIndexer = (): t<'processConfig> => {
             ~config,
             ~processConfigChains=chains,
             ~addressRowsByChain=addressRowsByChain(state),
-            ~contractNames=state.contractNames,
+            ~contractMapping=state.contractMapping,
           )
 
           // No endBlock means auto-exit mode: process one block checkpoint at a

--- a/packages/envio/src/db/InternalTable.res
+++ b/packages/envio/src/db/InternalTable.res
@@ -17,6 +17,19 @@ let isUndefinedTable = exn =>
   | _ => false
   }
 
+// The array type an unnest binds a chain-id column to. Resolved from the
+// config's mode, so every internal query casts the parameter the same way the
+// column was created.
+let chainIdArrayType = (~pgSchema, ~chainIdMode: ChainId.mode) =>
+  Table.getPgFieldType(
+    ~fieldType=ChainId,
+    ~pgSchema,
+    ~isArray=true,
+    ~isNumericArrayAsText=false,
+    ~isNullable=false,
+    ~chainIdMode,
+  )
+
 // The canonical contract ids. Written once at initialize from the config's
 // contract names in byte order, so an id names the same contract on every
 // chain and across restarts; read back on resume, where the stored mapping is
@@ -51,14 +64,15 @@ SELECT * FROM unnest($1::${(SmallInt: Postgres.columnType :> string)}[],$2::${(T
   // resume has to stop at the compat check rather than at a missing column.
   let read = async (sql, ~pgSchema): option<array<string>> =>
     try {
-      let rows: array<{"name": string}> = await sql->Postgres.unsafe(
+      let rows: array<{
+        "name": string,
+      }> = await sql->Postgres.unsafe(
         `SELECT "name" FROM "${pgSchema}"."${table.tableName}" ORDER BY "id";`,
       )
       Some(rows->Array.map(row => row["name"]))
     } catch {
     | exn => isUndefinedTable(exn) ? None : throw(exn)
     }
-
 }
 
 // Every address the indexer indexes, one row per (chain, address, contract).
@@ -81,14 +95,7 @@ module EnvioAddresses = {
   )
 
   let makeInsertQuery = (~pgSchema, ~chainIdMode: ChainId.mode=Int32) => {
-    let chainIdArrayType = Table.getPgFieldType(
-      ~fieldType=ChainId,
-      ~pgSchema,
-      ~isArray=true,
-      ~isNumericArrayAsText=false,
-      ~isNullable=false,
-      ~chainIdMode,
-    )
+    let chainIdArrayType = chainIdArrayType(~pgSchema, ~chainIdMode)
     // Idempotent: a batch write retried after a failed transaction re-inserts
     // rows the store still holds.
     `INSERT INTO "${pgSchema}"."${table.tableName}" ("chain_id", "address", "contract_id", "registration_block")
@@ -96,7 +103,12 @@ SELECT * FROM unnest($1::${chainIdArrayType},$2::${(Bytea: Postgres.columnType :
 ON CONFLICT ("chain_id", "address", "contract_id") DO NOTHING;`
   }
 
-  let insert = (sql, ~pgSchema, ~rows: array<AddressRows.row>, ~chainIdMode: ChainId.mode=Int32) => {
+  let insert = (
+    sql,
+    ~pgSchema,
+    ~rows: array<AddressRows.row>,
+    ~chainIdMode: ChainId.mode=Int32,
+  ) => {
     let chainIds = []
     let addresses = []
     let contractIds = []
@@ -121,14 +133,7 @@ ON CONFLICT ("chain_id", "address", "contract_id") DO NOTHING;`
   }
 
   let makeDeleteQuery = (~pgSchema, ~chainIdMode: ChainId.mode=Int32) => {
-    let chainIdArrayType = Table.getPgFieldType(
-      ~fieldType=ChainId,
-      ~pgSchema,
-      ~isArray=true,
-      ~isNumericArrayAsText=false,
-      ~isNullable=false,
-      ~chainIdMode,
-    )
+    let chainIdArrayType = chainIdArrayType(~pgSchema, ~chainIdMode)
     `DELETE FROM "${pgSchema}"."${table.tableName}"
 USING unnest($1::${chainIdArrayType},$2::${(Bytea: Postgres.columnType :> string)}[],$3::${(SmallInt: Postgres.columnType :> string)}[]) AS dead(chain_id, address, contract_id)
 WHERE "${table.tableName}"."chain_id" = dead.chain_id
@@ -139,7 +144,12 @@ WHERE "${table.tableName}"."chain_id" = dead.chain_id
   // A rollback removes exactly the registrations the address store dropped, by
   // primary key — so the table needs no index beyond the one it already has,
   // and the two halves of a rollback can't disagree about what to remove.
-  let delete = (sql, ~pgSchema, ~keys: array<AddressRows.key>, ~chainIdMode: ChainId.mode=Int32) => {
+  let delete = (
+    sql,
+    ~pgSchema,
+    ~keys: array<AddressRows.key>,
+    ~chainIdMode: ChainId.mode=Int32,
+  ) => {
     let chainIds = []
     let addresses = []
     let contractIds = []
@@ -151,11 +161,9 @@ WHERE "${table.tableName}"."chain_id" = dead.chain_id
     sql
     ->Postgres.preparedUnsafe(
       makeDeleteQuery(~pgSchema, ~chainIdMode),
-      (
-        chainIds,
-        sql->Postgres.typed(addresses, Postgres.byteaArrayOid),
-        contractIds,
-      )->(Utils.magic: ((array<ChainId.t>, unknown, array<int>)) => unknown),
+      (chainIds, sql->Postgres.typed(addresses, Postgres.byteaArrayOid), contractIds)->(
+        Utils.magic: ((array<ChainId.t>, unknown, array<int>)) => unknown
+      ),
     )
     ->Utils.Promise.ignoreValue
   }
@@ -599,14 +607,7 @@ WHERE cp."${(#block_hash: field :> string)}" IS NOT NULL
   }
 
   let makeInsertCheckpointQuery = (~pgSchema, ~chainIdMode: ChainId.mode=Int32) => {
-    let chainIdArrayType = Table.getPgFieldType(
-      ~fieldType=ChainId,
-      ~pgSchema,
-      ~isArray=true,
-      ~isNumericArrayAsText=false,
-      ~isNullable=false,
-      ~chainIdMode,
-    )
+    let chainIdArrayType = chainIdArrayType(~pgSchema, ~chainIdMode)
     `INSERT INTO "${pgSchema}"."${table.tableName}" ("${(#id: field :> string)}", "${(#chain_id: field :> string)}", "${(#block_number: field :> string)}", "${(#block_hash: field :> string)}", "${(#events_processed: field :> string)}")
 SELECT * FROM unnest($1::${(BigInt: Postgres.columnType :> string)}[],$2::${chainIdArrayType},$3::${(Integer: Postgres.columnType :> string)}[],$4::${(Text: Postgres.columnType :> string)}[],$5::${(Integer: Postgres.columnType :> string)}[]);`
   }

--- a/packages/envio/src/sources/AddressStore.res
+++ b/packages/envio/src/sources/AddressStore.res
@@ -107,10 +107,9 @@ let make = (~ecosystem: Ecosystem.name, ~shouldChecksum: bool, ~contracts: array
 // never fetched.
 let contractsOf = (
   ~onEventRegistrations: array<Internal.onEventRegistration>,
-  // The canonical contract names, in id order. Every store of every chain holds
-  // the same contracts under the same ids, so a persisted `contract_id` means
-  // the same thing wherever it's read.
-  ~contractNames: array<string>,
+  // Every store of every chain holds the same contracts under the same ids, so
+  // a persisted `contract_id` means the same thing wherever it's read.
+  ~contractMapping: ContractMapping.t,
 ): array<contract> => {
   // Only ever holds a declared start block, so a missing key is unambiguous —
   // storing `None` in a dict would be indistinguishable from "not seen yet".
@@ -119,11 +118,9 @@ let contractsOf = (
   let addressDependent = Utils.Set.make()
   onEventRegistrations->Array.forEach(reg => {
     let name = reg.eventConfig.contractName
-    if !(contractNames->Array.includes(name)) {
-      JsError.throwWithMessage(
-        `Contract "${name}" has event registrations but is missing from the indexer's contract list.`,
-      )
-    }
+    contractMapping
+    ->ContractMapping.idOfOrThrow(name, ~context=" has event registrations but")
+    ->ignore
     if reg.dependsOnAddresses {
       addressDependent->Utils.Set.add(name)->ignore
     }
@@ -139,7 +136,9 @@ let contractsOf = (
       )
     }
   })
-  contractNames->Array.mapWithIndex((name, id) => {
+  contractMapping
+  ->ContractMapping.names
+  ->Array.mapWithIndex((name, id) => {
     id,
     name,
     startBlock: unrestricted->Utils.Set.has(name)

--- a/packages/envio/src/sources/AddressStore.res
+++ b/packages/envio/src/sources/AddressStore.res
@@ -154,10 +154,6 @@ let contractsOf = (
 // every partition is queried through the same handle.
 @send external emptySet: t => AddressSet.t = "emptySet"
 
-// A set over exactly these addresses, in set order. Every set of a chain must
-// come from that chain's one store — ids are store-scoped, so sets from
-// different stores can't be merged.
-@send external makeSetOf: (t, array<Address.t>) => AddressSet.t = "makeSetOf"
 @send
 external registerBatchRaw: (t, array<registration>) => array<rawVerdict> = "registerBatch"
 @send external seedBatchRaw: (t, array<registration>) => array<rawVerdict> = "seedBatch"


### PR DESCRIPTION
Review cleanup on top of #1566. Targets that branch rather than `main` so the diff here is just the cleanup.

## 1. The contract mapping becomes a value

The name → id mapping every stored address row references was a bare `array<string>`, re-derived at four call sites (each a napi crossing) and resolved by ad-hoc `Array.indexOf` with three different answers for a name that isn't in it: `ChainState.configStorageRows` threw, `Main.res` fell back to the config's addresses, and `TestIndexer` fed an unchecked `-1` into a filter that quietly returned nothing.

`ContractMapping` is now a type, built once from the whole config and carried on `Config.t`. Storages take it rather than deriving it, so a call site that passes a filtered chain list can no longer produce ids that mismatch stored rows. The `> 32768` smallint guard moved into the constructor, so all three storages inherit it instead of only Postgres. Lookups are dict hits with one missing-name policy: throw, naming the contract.

**Correctness fix:** the resume gate compared the stored mapping against the config's by joining both lists on a comma, so one contract named `A,B` compared equal to two contracts `A` and `B` — the exact silent misattribution the gate exists to prevent. It compares elementwise now.

## 2. Reserved names: 90 words → the 13 that actually break

The three reserved-word lists (JavaScript, TypeScript, ReScript) rejected 90 names across contract, event, entity, enum-type and enum-value positions. Every one was tested empirically, through the real pipeline: a scenario project running `envio codegen` → `rescript build` (warnings-as-errors) → `tsc --noEmit`, plus the generated DDL executed against a live Postgres. Not a proxy.

**87 of them are safe.** Every config and schema name reaches an identifier position capitalized, so a keyword of the generated languages is only ever a keyword in the YAML. A contract may now be named `class` or `let`, an entity `lazy`, an enum `type` with values `open` and `switch`.

**Three classes genuinely break, and two were live bugs the old lists missed:**

- **Every own property of `Object.prototype`** (`toString`, `valueOf`, `hasOwnProperty`, `constructor`, `__proto__`, …). The test indexer buckets a batch's changes in a plain object keyed by entity name, so these resolve from the prototype instead of the bucket and the write throws on a missing `sets` array. The failure is the prototype lookup, not the spelling — so the whole family is reserved, not just the members that happen to read like keywords. `constructor` was previously accepted because the schema path omitted the TypeScript list; `toString` was never in any list.
- **`enum`** — every entity is re-exported from the `envio` module capitalized, where `Enum` is already taken (`TS2300: Duplicate identifier`).
- **`__proto__`** additionally survives capitalization untouched, making it an illegal ReScript module name and variant constructor on top of the lookup problem.

`RESCRIPT_RESERVED_WORDS` stays — `type_schema.rs::to_valid_rescript_name` still needs it to *escape* field and param names (`@as("module") module_`). The dead `ENVIO_INTERNAL_RESERVED_POSTGRES_TYPES` is gone, and the config and schema paths now share one list, which is what fixes the `constructor` bug.

## 3. Test-only surface removed from the napi boundary

`make_set_of` / `makeSetOf` had zero production callers — production builds address sets only via `emptySet`, `makeSet`, `merge`, `slice`, `filterByContracts` and `filterByRegistrationBlock`; nothing constructs one from address strings. The duplicate-address case it guarded is unreachable from any user-facing API: registering the same address twice for one contract returns `Duplicate`, the same address for two contracts makes two entries with distinct sort keys, and config-level duplicates are rejected at parse. That is now covered outside-in, by handler source calling `context.chain.SimpleNft.add()`, instead of by a test poking the export.

The export and its ReScript external are gone, along with `AddressStore::start_block_groups`, which had no ReScript binding at all (production uses the `AddressSet`-level one).

## 4. Efficiency and duplication

- `pack_addresses` / `split_addresses` collapse into one `encode_addresses`. The old pair concatenated every config address into one buffer and immediately sliced it back apart, after which `seedRowsOf` concatenated the same bytes again — three encodings per initialize, in every storage, to arrive back where the first call started.
- One `chainIdArrayType` helper replaces three verbatim copies of the same eight-argument derivation.
- `stageRegisteredAddresses` appends in place instead of reallocating the whole pending buffer once per progressed chain per batch.

`CLAUDE.md` now records that the napi boundary is internal and free to reshape, plus how to rebuild the addon so ReScript tests see a Rust change.

## Deliberately not done

Splitting `EnvioAddresses` / `EnvioContracts` DDL out to drop `SmallInt` / `Bytea` from the shared `Table.fieldType`. Both tables go through the same generic `makeCreateTableQuery` list and a generic chain-id typing test, so hand-writing their DDL would add special-casing to a currently uniform list rather than remove it.

## Testing

545 Rust tests, 116 ReScript test files / 1208 tests. `cargo clippy -- -D warnings` and `cargo fmt --check` clean at CI's scope. Every behavioural change here started from a test watched failing first.

## Follow-up worth filing (not fixed here)

**Lowercase contract names are entirely broken**, unrelated to reserved words. Generated TypeScript keys contracts by the original name (`codegen_templates.rs:1334`) while the runtime registry keys them capitalized. With `- name: token`, `indexer.onEvent({ contract: "token", … })` type-checks and then throws at runtime (*Configured contracts: Token*), while `"Token"` fails type-checking (*Type '"Token"' is not assignable to type '"token"'*). Both spellings are rejected, so the name cannot be used at all. `packages/cli/test/configs/lowercase-contract-name.yaml` exercises the parse but never the handler surface. The fix belongs in the TypeScript emitter and would move generated types broadly, so it deserves its own change.