### PR TITLE
Auto-derive HyperSync endpoints for known SVM cluster IDs

### DIFF
--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -1013,8 +1013,9 @@ pub mod svm {
     #[serde(deny_unknown_fields)]
     pub struct HypersyncConfig {
         #[schemars(
-            description = "URL of the HyperSync endpoint (default: the public Solana HyperSync \
-                           endpoint at https://solana.hypersync.xyz)"
+            description = "URL of the HyperSync endpoint (defaults to the public endpoint of the \
+                           chain id: https://solana.hypersync.xyz for `solana`, \
+                           https://solana-devnet.hypersync.xyz for `solana-devnet`)"
         )]
         pub url: String,
     }
@@ -1053,6 +1054,16 @@ pub mod svm {
         }
     }
 
+    /// The public HyperSync endpoint for a cluster Envio knows by id, so
+    /// `hypersync_config` can be omitted for Solana mainnet and devnet.
+    pub fn default_hypersync_endpoint(chain_id: u64) -> Option<String> {
+        match chain_id {
+            SOLANA_MAINNET_CHAIN_ID => Some("https://solana.hypersync.xyz".to_string()),
+            SOLANA_DEVNET_CHAIN_ID => Some("https://solana-devnet.hypersync.xyz".to_string()),
+            _ => None,
+        }
+    }
+
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
     #[serde(deny_unknown_fields)]
     pub struct Chain {
@@ -1060,8 +1071,8 @@ pub mod svm {
             description = "Identifies the Svm cluster: the label \"solana\" (7565164) or \
                            \"solana-devnet\" (7565165), or an explicit number of your choosing \
                            for other clusters (up to Number.MAX_SAFE_INTEGER). Svm has no native \
-                           numeric chain id, so the label ids are assigned by Envio and match \
-                           the ids used for HyperSync usage attribution."
+                           numeric chain id, so the label ids are assigned by Envio and match the \
+                           ids used for HyperSync usage attribution."
         )]
         pub id: ChainId,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -1101,10 +1112,13 @@ pub mod svm {
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
     #[serde(deny_unknown_fields)]
     pub struct Experimental {
+        #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
-            description = "HyperSync Config for fetching historical instructions on this chain."
+            description = "HyperSync Config for fetching historical instructions on this chain. \
+                           Optional for the `solana` and `solana-devnet` chain ids, which default \
+                           to their public HyperSync endpoints; required for any other chain id."
         )]
-        pub hypersync_config: HypersyncConfig,
+        pub hypersync_config: Option<HypersyncConfig>,
         #[schemars(description = "Solana programs to index on this chain.")]
         pub programs: Vec<Program>,
     }
@@ -1728,7 +1742,7 @@ chains:
             let chain = &cfg.chains[0];
             let experimental = chain.experimental.as_ref().unwrap();
             assert_eq!(
-                experimental.hypersync_config.url.as_str(),
+                experimental.hypersync_config.as_ref().unwrap().url.as_str(),
                 "https://solana.hypersync.xyz"
             );
             let programs = &experimental.programs;

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -12,7 +12,7 @@ use super::{
             RpcSelection,
         },
         fuel::{EventConfig as FuelEventConfig, HumanConfig as FuelConfig},
-        HumanConfig,
+        svm, HumanConfig,
     },
     hypersync_endpoints,
     validation::{self, validate_names_valid_rescript},
@@ -1411,12 +1411,24 @@ impl SystemConfig {
             HumanConfig::Svm(ref svm_config) => {
                 validation::validate_deserialized_svm_config_yaml(svm_config)?;
                 for network in &svm_config.chains {
+                    let chain_id = network.id.to_u64();
+                    let hypersync_endpoint_url = network
+                        .experimental
+                        .as_ref()
+                        .map(|e| match &e.hypersync_config {
+                            Some(hypersync_config) => Ok(hypersync_config.url.clone()),
+                            None => svm::default_hypersync_endpoint(chain_id).ok_or_else(|| {
+                                anyhow!(
+                                    "Chain {chain_id} has no default HyperSync endpoint. Set \
+                                     `experimental.hypersync_config.url` explicitly, or use the \
+                                     `solana` / `solana-devnet` chain id."
+                                )
+                            }),
+                        })
+                        .transpose()?;
                     let sync_source = DataSource::Svm {
                         rpc: network.rpc.clone(),
-                        hypersync_endpoint_url: network
-                            .experimental
-                            .as_ref()
-                            .map(|e| e.hypersync_config.url.clone()),
+                        hypersync_endpoint_url,
                     };
 
                     let programs = network
@@ -1501,7 +1513,7 @@ impl SystemConfig {
                     }
 
                     let chain = Chain {
-                        id: network.id.to_u64(),
+                        id: chain_id,
                         skip: network.skip.unwrap_or(false),
                         start_block: network.start_block,
                         end_block: network.end_block,

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
@@ -9,8 +9,6 @@ chains:
     # and set this to ~30k slots below it for a quick backfill (~30s).
     start_block: 417920000
     experimental:
-      hypersync_config:
-        url: https://solana.hypersync.xyz
       programs:
         - name: TokenMetadata
           program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
@@ -4,9 +4,6 @@ description: Indexes Metaplex Token Metadata creates and updates on Solana mainn
 ecosystem: svm
 chains:
   - id: solana
-    # Adjust just before first run: query the current height with
-    #   curl -s https://solana.hypersync.xyz/height
-    # and set this to ~30k slots below it for a quick backfill (~30s).
     start_block: 417920000
     experimental:
       programs:

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -1371,6 +1371,88 @@ chains:
       "A chain must define a data source: either an \`rpc\` endpoint or an \`experimental\` HyperSync config. Both are missing.",
     )
   })
+
+  it("derives the HyperSync endpoint from a known SVM cluster id", t => {
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
+name: derived-svm-endpoint
+ecosystem: svm
+chains:
+  - id: solana
+    start_block: 0
+    experimental:
+      programs:
+        - name: Mainnet
+          program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+          instructions: []
+  - id: solana-devnet
+    start_block: 0
+    experimental:
+      programs:
+        - name: Devnet
+          program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+          instructions: []
+`,
+    )
+    t.expect(
+      config.chainMap
+      ->ChainMap.values
+      ->Array.map(chain => (
+        chain.id->ChainId.toString,
+        switch chain.sourceConfig {
+        | Config.SvmSourceConfig({hypersync}) => hypersync->Option.getOr("missing")
+        | _ => "unexpected source"
+        },
+      )),
+    ).toEqual([
+      ("7565164", "https://solana.hypersync.xyz"),
+      ("7565165", "https://solana-devnet.hypersync.xyz"),
+    ])
+  })
+
+  it("keeps an explicit HyperSync URL over the derived one", t => {
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
+name: explicit-svm-endpoint
+ecosystem: svm
+chains:
+  - id: solana
+    start_block: 0
+    experimental:
+      hypersync_config:
+        url: https://custom.hypersync.test
+      programs:
+        - name: Mainnet
+          program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+          instructions: []
+`,
+    )
+    let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
+    switch chain.sourceConfig {
+    | Config.SvmSourceConfig({hypersync: Some(url)}) =>
+      t.expect(url).toBe("https://custom.hypersync.test")
+    | _ => t.expect("unexpected source").toBe("SVM HyperSync source")
+    }
+  })
+
+  it("requires an explicit HyperSync URL for an unknown SVM cluster id", t => {
+    expectParseError(
+      t,
+      `
+name: unknown-svm-cluster
+ecosystem: svm
+chains:
+  - id: 42
+    start_block: 0
+    experimental:
+      programs:
+        - name: Program
+          program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+          instructions: []
+`,
+      "Chain 42 has no default HyperSync endpoint. Set \`experimental.hypersync_config.url\` explicitly, or use the \`solana\` / \`solana-devnet\` chain id.",
+    )
+  })
 })
 
 describe("schema validation errors through config YAML", () => {

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -297,8 +297,15 @@
       "type": "object",
       "properties": {
         "hypersync_config": {
-          "description": "HyperSync Config for fetching historical instructions on this chain.",
-          "$ref": "#/$defs/HypersyncConfig"
+          "description": "HyperSync Config for fetching historical instructions on this chain. Optional for the `solana` and `solana-devnet` chain ids, which default to their public HyperSync endpoints; required for any other chain id.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HypersyncConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "programs": {
           "description": "Solana programs to index on this chain.",
@@ -310,7 +317,6 @@
       },
       "additionalProperties": false,
       "required": [
-        "hypersync_config",
         "programs"
       ]
     },
@@ -318,7 +324,7 @@
       "type": "object",
       "properties": {
         "url": {
-          "description": "URL of the HyperSync endpoint (default: the public Solana HyperSync endpoint at https://solana.hypersync.xyz)",
+          "description": "URL of the HyperSync endpoint (defaults to the public endpoint of the chain id: https://solana.hypersync.xyz for `solana`, https://solana-devnet.hypersync.xyz for `solana-devnet`)",
           "type": "string"
         }
       },


### PR DESCRIPTION
## Summary

Makes the `experimental.hypersync_config` optional for Solana mainnet and devnet by auto-deriving their public HyperSync endpoints from the chain ID. Unknown cluster IDs now require an explicit URL, with a clear error message guiding users to either specify it or use a known chain ID.

## Changes

- **Config schema**: Made `hypersync_config` optional in SVM `Experimental` struct; added `default_hypersync_endpoint()` function to map known chain IDs (7565164 for `solana`, 7565165 for `solana-devnet`) to their public endpoints
- **Validation**: Updated `system_config.rs` to derive the endpoint from the chain ID when `hypersync_config` is omitted, or error with actionable guidance for unknown clusters
- **Documentation**: Updated schema descriptions and JSON schema to reflect the new optional behavior and default endpoints
- **Template**: Removed redundant `hypersync_config` from the Metaplex template since it now defaults for `solana`
- **Tests**: Added three test cases covering endpoint derivation, explicit URL override, and error handling for unknown clusters

## Implementation Details

The derivation happens during config parsing in `system_config.rs`, after YAML deserialization. If a chain has no explicit `hypersync_config.url` and the chain ID is unknown, validation fails with a message directing users to set the URL explicitly or use `solana` / `solana-devnet`. Explicit URLs always take precedence over derived defaults.

https://claude.ai/code/session_0111C3Z2FrDhJzeHG1bBZhEp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HyperSync endpoints are now selected automatically for Solana mainnet and devnet configurations.
  * Custom HyperSync URLs continue to take precedence when provided.
  * HyperSync configuration is now optional for supported Solana clusters.

* **Bug Fixes**
  * Configurations using unsupported chain IDs now provide a clear error when no endpoint is specified.

* **Documentation**
  * Updated configuration schema descriptions to document default endpoints and custom endpoint requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->