### PR TITLE
Refactor height feed stream handling and error reporting

### DIFF
--- a/packages/envio-tests/test/HeightStream_test.res
+++ b/packages/envio-tests/test/HeightStream_test.res
@@ -481,24 +481,6 @@ describe("HeightStream reconnect driver", () => {
   })
 })
 
-module NodeHttp = {
-  type incomingMessage
-  type serverResponse
-  type t
-  type address = {port: int}
-
-  @module("node:http")
-  external createServer: ((incomingMessage, serverResponse) => unit) => t = "createServer"
-
-  @send external listen: (t, int, string, unit => unit) => unit = "listen"
-  @send external close: (t, unit => unit) => unit = "close"
-  @send external address: t => address = "address"
-  @send external writeHead: (serverResponse, int, dict<string>) => unit = "writeHead"
-  @send external write: (serverResponse, string) => unit = "write"
-  @send external endWith: (serverResponse, string) => unit = "end"
-  @send external end: (serverResponse, unit) => unit = "end"
-}
-
 module WsServer = {
   type socket
   type t
@@ -514,25 +496,11 @@ module WsServer = {
   @send external toString: 'data => string = "toString"
 }
 
-let waitUntil = async (predicate: unit => bool) => {
-  let deadline = Performance.now() +. 5_000.
-  let rec loop = async () =>
-    if predicate() {
-      ()
-    } else if Performance.now() > deadline {
-      JsError.throwWithMessage("Timed out waiting for the height stream")
-    } else {
-      await Utils.delay(5)
-      await loop()
-    }
-  await loop()
-}
-
 let listenHttp = handler => {
-  let server = NodeHttp.createServer(handler)
+  let server = MockRpcServer.createServer(handler)
   Promise.make((resolve, _reject) =>
-    server->NodeHttp.listen(0, "127.0.0.1", () =>
-      resolve((server, `http://127.0.0.1:${(server->NodeHttp.address).port->Int.toString}`))
+    server->MockRpcServer.listenOnHost(0, "127.0.0.1", () =>
+      resolve((server, `http://127.0.0.1:${(server->MockRpcServer.address).port->Int.toString}`))
     )
   )
 }
@@ -550,8 +518,8 @@ let listenWs = onConnection => {
 describe("HyperSyncSSE", () => {
   Async.it("Reports the HTTP status as the failure reason", async t => {
     let (server, url) = await listenHttp((_request, response) => {
-      response->NodeHttp.writeHead(401, Dict.fromArray([("Content-Type", "text/plain")]))
-      response->NodeHttp.endWith("unauthorized")
+      response->MockRpcServer.writeHead(401, Dict.fromArray([("Content-Type", "text/plain")]))
+      response->MockRpcServer.end_("unauthorized")
     })
     let statuses = []
     // The status alone can't tell an operator which of a provider's many 401s
@@ -570,23 +538,23 @@ describe("HyperSyncSSE", () => {
       },
     )
 
-    await waitUntil(() => statuses->Array.length > 0)
+    await Scenario.waitUntil(() => statuses->Array.length > 0, ~message="the height stream")
     unsubscribe()
-    await Promise.make((resolve, _reject) => server->NodeHttp.close(() => resolve()))
+    await Promise.make((resolve, _reject) => server->MockRpcServer.close(() => resolve()))
 
     t.expect((statuses, detailed)).toStrictEqual((["down:401"], [true]))
   })
 
   Async.it("Delivers heights and reports a clean stream end as closed", async t => {
     let (server, url) = await listenHttp((_request, response) => {
-      response->NodeHttp.writeHead(
+      response->MockRpcServer.writeHead(
         200,
         Dict.fromArray([("Content-Type", "text/event-stream"), ("Cache-Control", "no-cache")]),
       )
-      response->NodeHttp.write("event: height\ndata: 123\n\n")
+      response->MockRpcServer.write("event: height\ndata: 123\n\n")
       // Ending the response drops the stream without an HTTP error, which is
       // how a load balancer rotating connections shows up.
-      response->NodeHttp.end()
+      response->MockRpcServer.endStream()
     })
     let statuses = []
     let heights = []
@@ -597,9 +565,12 @@ describe("HyperSyncSSE", () => {
       ~onStatus=status => statuses->Array.push(status->reasonLabel)->ignore,
     )
 
-    await waitUntil(() => statuses->Array.includes("down:closed"))
+    await Scenario.waitUntil(
+      () => statuses->Array.includes("down:closed"),
+      ~message="the height stream",
+    )
     unsubscribe()
-    await Promise.make((resolve, _reject) => server->NodeHttp.close(() => resolve()))
+    await Promise.make((resolve, _reject) => server->MockRpcServer.close(() => resolve()))
 
     t.expect((statuses, heights)).toStrictEqual((["live", "down:closed"], [123]))
   })
@@ -625,7 +596,7 @@ describe("EvmRpcWs", () => {
       ~onStatus=status => statuses->Array.push(status->reasonLabel)->ignore,
     )
 
-    await waitUntil(() => heights->Array.length > 0)
+    await Scenario.waitUntil(() => heights->Array.length > 0, ~message="the height stream")
     unsubscribe()
     await Promise.make((resolve, _reject) => server->WsServer.close(() => resolve()))
 
@@ -652,6 +623,59 @@ describe("EvmRpcWs", () => {
     t.expect(statuses).toStrictEqual([])
   })
 
+  Async.it("Treats a frame it cannot make sense of as unreadable, not as a rejection", async t => {
+    // Valid JSON, but none of the shapes this stream knows. Reporting it as a
+    // rejected subscription would name a cause the provider never gave.
+    let (server, url) = await listenWs(socket =>
+      socket->WsServer.onMessage(_data =>
+        socket->WsServer.send(`{"jsonrpc":"2.0","hello":"world"}`)
+      )
+    )
+    let statuses = []
+    let unsubscribe = EvmRpcWs.subscribe(
+      ~wsUrl=url,
+      ~onHeight=_ => (),
+      ~onStatus=status => statuses->Array.push(status->reasonLabel)->ignore,
+    )
+
+    await Utils.delay(200)
+    unsubscribe()
+    await Promise.make((resolve, _reject) => server->WsServer.close(() => resolve()))
+
+    t.expect(statuses).toStrictEqual([])
+  })
+
+  Async.it("Keeps a delivering connection through an error meant for something else", async t => {
+    let (server, url) = await listenWs(socket =>
+      socket->WsServer.onMessage(data =>
+        if data->WsServer.toString->String.includes("eth_subscribe") {
+          socket->WsServer.send(`{"jsonrpc":"2.0","id":1,"result":"0xsub"}`)
+          // Nothing to do with the subscription this stream asked for: a
+          // provider talking about some other request, or about itself.
+          socket->WsServer.send(
+            `{"jsonrpc":"2.0","id":7,"error":{"code":-32005,"message":"rate limited"}}`,
+          )
+          socket->WsServer.send(
+            `{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0xsub","result":{"number":"0x2a"}}}`,
+          )
+        }
+      )
+    )
+    let statuses = []
+    let heights = []
+    let unsubscribe = EvmRpcWs.subscribe(
+      ~wsUrl=url,
+      ~onHeight=height => heights->Array.push(height)->ignore,
+      ~onStatus=status => statuses->Array.push(status->reasonLabel)->ignore,
+    )
+
+    await Scenario.waitUntil(() => heights->Array.length > 0, ~message="the height stream")
+    unsubscribe()
+    await Promise.make((resolve, _reject) => server->WsServer.close(() => resolve()))
+
+    t.expect((statuses, heights)).toStrictEqual((["live"], [42]))
+  })
+
   Async.it("Reports a rejected eth_subscribe without giving up", async t => {
     let (server, url) = await listenWs(socket =>
       socket->WsServer.onMessage(_data =>
@@ -668,7 +692,7 @@ describe("EvmRpcWs", () => {
     )
 
     // Long enough for the first retry to reconnect and be rejected again.
-    await waitUntil(() => statuses->Array.length > 1)
+    await Scenario.waitUntil(() => statuses->Array.length > 1, ~message="the height stream")
     unsubscribe()
     await Promise.make((resolve, _reject) => server->WsServer.close(() => resolve()))
 

--- a/packages/envio-tests/test/helpers/MockRpcServer.res
+++ b/packages/envio-tests/test/helpers/MockRpcServer.res
@@ -34,6 +34,10 @@ type address = {port: int}
 @send external writeHead: (res, int, dict<string>) => unit = "writeHead"
 @send external end_: (res, string) => unit = "end"
 @send external destroy: res => unit = "destroy"
+// For a streamed body (an SSE feed arrives in chunks and ends without a final
+// payload), which the request/response RPC handlers below never need.
+@send external write: (res, string) => unit = "write"
+@send external endStream: (res, unit) => unit = "end"
 
 @module("node:util")
 external isDeepStrictEqual: (JSON.t, JSON.t) => bool = "isDeepStrictEqual"

--- a/packages/envio-tests/test/lib_tests/HeightFeed_test.res
+++ b/packages/envio-tests/test/lib_tests/HeightFeed_test.res
@@ -30,7 +30,7 @@ describe("HeightFeed answers a waiter", () => {
     mock.resolveGetHeightOrThrow(101)
     await Utils.delay(0)
 
-    t.expect((pollsBeforeAnswer, heights, (feed->HeightFeed.sample).knownHeight)).toStrictEqual((
+    t.expect((pollsBeforeAnswer, heights, feed->HeightFeed.knownHeight)).toStrictEqual((
       1,
       [101],
       101,
@@ -65,7 +65,7 @@ describe("HeightFeed answers a waiter", () => {
     feed->HeightFeed.recordHeight(105)
     await Utils.delay(0)
 
-    t.expect((heights, (feed->HeightFeed.sample).knownHeight)).toStrictEqual(([105], 105))
+    t.expect((heights, feed->HeightFeed.knownHeight)).toStrictEqual(([105], 105))
   })
 
   Async.it("Immediately when it already knows a higher height", async t => {
@@ -139,7 +139,7 @@ describe("HeightFeed polls only for someone", () => {
     t.expect((
       catchUpPolls,
       mock.getHeightOrThrowCalls->Array.length,
-      (feed->HeightFeed.sample).knownHeight,
+      feed->HeightFeed.knownHeight,
     )).toStrictEqual((1, 1, 105))
   })
 
@@ -415,7 +415,7 @@ describe("HeightFeed stream state", () => {
       subscriptions,
       mock.heightSubscriptionCalls->Array.length,
       mock.heightSubscriptionCloseCalls->Array.length,
-      (feed->HeightFeed.sample).stream,
+      feed->HeightFeed.sample,
     )).toStrictEqual((
       1,
       1,
@@ -446,6 +446,57 @@ describe("HeightFeed stream state", () => {
     // Being benched is a capability verdict, not an outage: the source can still
     // answer a height poll, and until another source answers it is what there is.
     t.expect((pollsWhileLive, mock.getHeightOrThrowCalls->Array.length)).toStrictEqual((2, 3))
+  })
+
+  Async.it("Polls straight away when a live connection drops mid-interval", async t => {
+    let mock = MockSource.make(
+      [#getHeightOrThrow, #createHeightSubscription],
+      ~pollingInterval=10_000,
+    )
+    let (feed, _stats) = makeFeed(mock)
+    feed->HeightFeed.enableStream
+    let (_heights, subscription) = feed->watch(~knownHeight=100, ~interval=() => 10_000)
+
+    mock.setHeightSubscriptionStatus(Live)
+    mock.resolveGetHeightOrThrow(100)
+    await Utils.delay(0)
+
+    // Poked, so a loop runs beside the live stream. Its poll answers below the
+    // floor and it settles in for an interval chosen while that connection was
+    // still the thing covering this source.
+    subscription.poke()
+    mock.resolveGetHeightOrThrow(100)
+    await Utils.delay(0)
+    let pollsWhileSleeping = mock.getHeightOrThrowCalls->Array.length
+
+    mock.setHeightSubscriptionStatus(Down({reason: "closed"}))
+    await Utils.delay(0)
+
+    t.expect((pollsWhileSleeping, mock.getHeightOrThrowCalls->Array.length)).toStrictEqual((3, 4))
+  })
+
+  Async.it("Sits out the backoff when the stream drops while polls are failing", async t => {
+    let mock = MockSource.make(
+      [#getHeightOrThrow, #createHeightSubscription],
+      ~pollingInterval=10_000,
+    )
+    let (feed, _stats) = makeFeed(mock, ~getHeightRetryInterval=(~retry as _) => 10_000)
+    feed->HeightFeed.enableStream
+    let (_heights, _unsubscribe) = feed->watch(~knownHeight=100, ~interval=() => 10_000)
+
+    mock.setHeightSubscriptionStatus(Live)
+    // Both the catch-up and the loop's poll fail, so the loop is sleeping off
+    // the backoff the endpoint earned rather than a polling interval.
+    mock.rejectGetHeightOrThrow(JsError.make("down"))
+    await Utils.delay(0)
+    let pollsWhileBackingOff = mock.getHeightOrThrowCalls->Array.length
+
+    // The stream dropping is usually the same endpoint's doing, so it is no
+    // reason to ask again ahead of schedule.
+    mock.setHeightSubscriptionStatus(Down({reason: "closed"}))
+    await Utils.delay(0)
+
+    t.expect((pollsWhileBackingOff, mock.getHeightOrThrowCalls->Array.length)).toStrictEqual((2, 2))
   })
 
   Async.it("Keeps polling when a replaced connection's catch-up lands late", async t => {
@@ -492,7 +543,7 @@ describe("HeightFeed stream state", () => {
     mock.setHeightSubscriptionStatus(Down({reason: "closed"}))
     mock.setHeightSubscriptionStatus(Down({reason: "connect-failed"}))
 
-    t.expect((whileNeverConnected.stream, (feed->HeightFeed.sample).stream)).toStrictEqual((
+    t.expect((whileNeverConnected, feed->HeightFeed.sample)).toStrictEqual((
       Some({HeightFeed.connectCount: 0, disconnects: []}),
       Some({HeightFeed.connectCount: 1, disconnects: [("closed", 1)]}),
     ))
@@ -505,7 +556,7 @@ describe("HeightFeed stream state", () => {
 
     t.expect((
       mock.heightSubscriptionCalls->Array.length,
-      (feed->HeightFeed.sample).stream,
+      feed->HeightFeed.sample,
     )).toStrictEqual((0, None))
   })
 })

--- a/packages/envio-tests/test/lib_tests/Metrics_test.res
+++ b/packages/envio-tests/test/lib_tests/Metrics_test.res
@@ -512,7 +512,7 @@ envio_source_request_total{source="HyperSync",chainId="1",method="heightPush"} 7
 # TYPE envio_source_request_seconds_total counter
 envio_source_request_seconds_total{source="HyperSync",chainId="1",method="getLogs"} 33.75
 
-# HELP envio_source_height_stream_connects_total The number of times a source's height subscription connected. One more connect than disconnects means the stream is up, equal counts mean it is down and the indexer is polling instead, and zero means it has never come up.
+# HELP envio_source_height_stream_connects_total The number of times a source's height subscription connected. Compare against the disconnects total, which is absent until the first disconnect and counts as zero while it is: one more connect than disconnects means the stream is up, equal counts mean it is down and the indexer is polling instead, and zero connects means it has never come up.
 # TYPE envio_source_height_stream_connects_total counter
 envio_source_height_stream_connects_total{source="HyperSync",chainId="1"} 3
 

--- a/packages/envio-tests/test/lib_tests/SourceManager_test.res
+++ b/packages/envio-tests/test/lib_tests/SourceManager_test.res
@@ -3687,6 +3687,12 @@ describe("SourceManager height subscription", () => {
     fallback.resolveGetHeightOrThrow(105)
     let firstHeight = await first
 
+    // The fake clock is process-wide, and the poll loops other tests in this file
+    // start outlive the waits that made them. Clearing here scopes the count
+    // below to the wait under test: everything it goes on to arm is armed after
+    // this point.
+    Vi.clearAllTimers()
+
     // The fallback already knows a height past this one, so recruiting it
     // answers the wait inside the stall callback that recruited it. Anything the
     // callback goes on to do belongs to a wait that is over — and a timer armed
@@ -3700,9 +3706,9 @@ describe("SourceManager height subscription", () => {
     await Vi.advanceTimersByTimeAsync(stallTimeout)
     let secondHeight = await second
 
-    // Let the poll sync still had out come back, so its loop retires and takes
-    // that poll's deadline with it. What is left pending after that is only what
-    // the wait itself armed.
+    // Let the poll sync still had out come back, so its loop retires rather than
+    // sitting on the answer. What is pending after that is only what the wait
+    // itself armed.
     sync.resolveGetHeightOrThrow(100)
     await Vi.advanceTimersByTimeAsync(0)
     let timersLeftBehind = Vi.getTimerCount()

--- a/packages/envio/src/Metrics.res
+++ b/packages/envio/src/Metrics.res
@@ -269,11 +269,6 @@ let renderMetrics = (b: builder, metrics: t) => {
     byLabels->Dict.toArray
   }
 
-  let addTo = (byLabels: dict<int>, labels, count) =>
-    byLabels->Dict.set(
-      labels,
-      byLabels->Utils.Dict.dangerouslyGetNonOption(labels)->Option.getOr(0) + count,
-    )
   // Zero connects is the one count worth rendering flat: it is a stream that
   // has never come up, which the disconnects say nothing about — retries at a
   // connection that never opened are not disconnections — and which is
@@ -282,7 +277,10 @@ let renderMetrics = (b: builder, metrics: t) => {
   let heightStreamConnects = {
     let byLabels: dict<int> = Dict.make()
     metrics.sourceHeightStreams->Array.forEach(s =>
-      byLabels->addTo(sourceLabels(~source=s.source, ~chainId=s.chainId), s.connectCount)
+      byLabels->Utils.Dict.incrementBy(
+        sourceLabels(~source=s.source, ~chainId=s.chainId),
+        s.connectCount,
+      )
     )
     byLabels->Dict.toArray
   }
@@ -290,7 +288,7 @@ let renderMetrics = (b: builder, metrics: t) => {
     let byLabels: dict<int> = Dict.make()
     metrics.sourceHeightStreams->Array.forEach(s =>
       s.disconnectsByReason->Array.forEach(((reason, count)) =>
-        byLabels->addTo(
+        byLabels->Utils.Dict.incrementBy(
           sourceLabels(~source=s.source, ~chainId=s.chainId, ~extra=("reason", reason)),
           count,
         )
@@ -515,7 +513,7 @@ let renderMetrics = (b: builder, metrics: t) => {
   if heightStreamConnects->Array.length > 0 {
     b->series(
       ~name="envio_source_height_stream_connects_total",
-      ~help="The number of times a source's height subscription connected. One more connect than disconnects means the stream is up, equal counts mean it is down and the indexer is polling instead, and zero means it has never come up.",
+      ~help="The number of times a source's height subscription connected. Compare against the disconnects total, which is absent until the first disconnect and counts as zero while it is: one more connect than disconnects means the stream is up, equal counts mean it is down and the indexer is polling instead, and zero connects means it has never come up.",
       ~kind="counter",
       ~entries=heightStreamConnects,
       ~value=count => count->Int.toFloat,

--- a/packages/envio/src/Utils.res
+++ b/packages/envio/src/Utils.res
@@ -25,6 +25,19 @@ external importPathWithJson: (
 let jitter = delay =>
   delay === 0 ? 0 : delay / 2 + (Math.random() *. (delay / 2)->Int.toFloat)->Float.toInt
 
+// Keeps the doubling from overflowing on something that has been failing for
+// days. Every caller's delay reaches its cap long before this.
+let maxBackoffExponent = 20
+
+// `base` doubled `exp` times, capped. One ramp shape for everything that backs
+// off, so the cap and the overflow guard can't be right in one place and missing
+// in the next.
+let expBackoff = (~base, ~exp, ~maxMillis) =>
+  Pervasives.min(
+    base * Math.pow(2.0, ~exp=Pervasives.min(exp, maxBackoffExponent)->Int.toFloat)->Float.toInt,
+    maxMillis,
+  )
+
 let delay = milliseconds =>
   Promise.make((resolve, _) => {
     let _interval = setTimeout(_ => {
@@ -103,6 +116,15 @@ module Dict = {
    */
   @get_index
   external dangerouslyGetNonOption: (dict<'a>, string) => option<'a> = ""
+
+  let incrementBy = (dict, key, count) =>
+    dict->Dict.set(
+      key,
+      switch dict->dangerouslyGetNonOption(key) {
+      | Some(current) => current + count
+      | None => count
+      },
+    )
 
   let getOrInsertEmptyDict = (dict, key) => {
     switch dict->dangerouslyGetNonOption(key) {

--- a/packages/envio/src/bindings/Vitest.res
+++ b/packages/envio/src/bindings/Vitest.res
@@ -188,4 +188,7 @@ module Vi = {
 
   @module("vitest") @scope("vi")
   external getTimerCount: unit => int = "getTimerCount"
+
+  @module("vitest") @scope("vi")
+  external clearAllTimers: unit => unit = "clearAllTimers"
 }

--- a/packages/envio/src/sources/EvmRpcWs.res
+++ b/packages/envio/src/sources/EvmRpcWs.res
@@ -1,19 +1,19 @@
-/*
-WebSocket-based implementation for real-time block height tracking.
-Uses eth_subscribe("newHeads") for low-latency block detection.
-*/
-
 // newHeads carries no keep-alive, so this has to tolerate slow chains rather
 // than the seconds an SSE ping allows.
 let staleTimeout = 60_000
 
+// The id of the one request this stream ever sends, which is what tells an error
+// meant for it apart from one about anything else sharing the socket.
+let subscribeRequestId = 1
+
 type wsMessage =
   | NewHead(int)
-  | SubscriptionConfirmed(string)
-  | ErrorResponse
+  | SubscriptionConfirmed
+  // An error frame, carrying the id of the request it answers when it names one.
+  | ErrorResponse(option<int>)
 
 let subscribeRequestJson =
-  {"jsonrpc": "2.0", "id": 1, "method": "eth_subscribe", "params": ["newHeads"]}
+  {"jsonrpc": "2.0", "id": subscribeRequestId, "method": "eth_subscribe", "params": ["newHeads"]}
   ->(Utils.magic: {
     "jsonrpc": string,
     "id": int,
@@ -42,11 +42,19 @@ let wsMessageSchema = S.union([
     )
   }),
   S.object(s => {
-    SubscriptionConfirmed(s.field("result", S.string))
+    let _ = s.field("result", S.string)
+    SubscriptionConfirmed
   }),
   S.object(s => {
-    let _ = s.field("error", S.unknown)
-    ErrorResponse
+    // Nullable, not merely optional: JSON-RPC answers a request whose id it
+    // could not read with an explicit null, and that is still an error frame.
+    let id = s.field("id", S.nullable(S.int))
+    // The error member as JSON-RPC defines it, rather than `S.unknown`: a
+    // missing field parses as `undefined`, which `S.unknown` accepts, and this
+    // arm would then match every frame the ones above turned down — including
+    // one nobody can read.
+    let _ = s.field("error", S.object(s => s.field("code", S.int)))
+    ErrorResponse(id)
   }),
 ])
 
@@ -65,8 +73,13 @@ let subscribe = (~wsUrl, ~onHeight, ~onStatus) =>
       switch message {
       | Some(NewHead(blockNumber)) => driver.onHeight(blockNumber)
       // An open socket isn't usable until the node accepts the subscription.
-      | Some(SubscriptionConfirmed(_)) => driver.onConnected()
-      | Some(ErrorResponse) => driver.onFailure(~reason="subscribe-rejected", ~detail=event.data)
+      | Some(SubscriptionConfirmed) => driver.onConnected()
+      | Some(ErrorResponse(Some(id))) if id === subscribeRequestId =>
+        driver.onFailure(~reason="subscribe-rejected", ~detail=event.data)
+      // A provider reporting trouble with something other than the subscription
+      // this socket asked for — a rate limit, a request nobody here made. Read
+      // fine, so not unreadable, and not this stream's to tear itself down over.
+      | Some(ErrorResponse(_)) => ()
       | None => driver.onUnreadable(~detail=event.data)
       }
     })

--- a/packages/envio/src/sources/HeightFeed.res
+++ b/packages/envio/src/sources/HeightFeed.res
@@ -4,12 +4,9 @@ while one is connected, polled while one isn't. Callers register interest and ge
 called back; they never learn which path answered.
 
 Callbacks rather than promises because this is subscription lifecycle. A waiter
-that loses a race has to be *removed*, and a promise reaction cannot be — the
-guards the wait loop used to carry (resolver arrays filtered after the fact, a
-settled flag, counting catch-ups to retire a poll loop) were all working around
-that. The transports and the HeightStream driver underneath are already
-callback-based; the promise boundary is one level up, in
-SourceManager.waitForNewBlock.
+that loses a race has to be *removed*, and a promise reaction cannot be. The
+transports and the HeightStream driver underneath are already callback-based;
+the promise boundary is one level up, in SourceManager.waitForNewBlock.
 */
 
 type waiter = {
@@ -65,6 +62,9 @@ type t = {
   // A stopped feed never subscribes again: `stop` is the capability verdict that
   // benched its source.
   mutable stopped: bool,
+  // Whether an operator has been told once that this source's stream sends
+  // something this cannot read. The condition repeats every staleness window.
+  mutable unreadableWarned: bool,
 }
 
 let make = (~source: Source.t, ~recordRequestStats, ~getHeightRetryInterval): t => {
@@ -84,22 +84,18 @@ let make = (~source: Source.t, ~recordRequestStats, ~getHeightRetryInterval): t 
   connects: 0,
   disconnects: Dict.make(),
   stopped: false,
+  unreadableWarned: false,
 }
 
 type streamSample = {connectCount: int, disconnects: array<(string, int)>}
-type sample = {
-  knownHeight: int,
-  // None for a source that cannot subscribe at all, so a chain that only ever
-  // polls renders none of the height stream families rather than sitting at
-  // zero on them.
-  stream: option<streamSample>,
-}
 
 let knownHeight = (feed: t) => feed.knownHeight
 
-let sample = (feed: t): sample => {
-  knownHeight: feed.knownHeight,
-  stream: switch feed.source.createHeightSubscription {
+// None for a source that cannot subscribe at all, so a chain that only ever
+// polls renders none of the height stream families rather than sitting at zero
+// on them.
+let sample = (feed: t): option<streamSample> =>
+  switch feed.source.createHeightSubscription {
   | Some(_) =>
     Some({
       connectCount: feed.connects,
@@ -111,8 +107,7 @@ let sample = (feed: t): sample => {
       ->Array.toSorted(((a, _), (b, _)) => String.compare(a, b)),
     })
   | None => None
-  },
-}
+  }
 
 let shouldPoll = (feed: t) =>
   feed.waiters->Array.length > 0 &&
@@ -224,6 +219,28 @@ let nextRetryInterval = (feed: t) => {
   retryInterval
 }
 
+// What an answer means for the feed, whoever asked for it. The poll loop and a
+// connect's catch-up both reach this, and an answer is worth the same from
+// either: the endpoint responded, and it responded with the head.
+let recordAnswer = (feed: t, ~generation, res: Source.getHeightResponse) => {
+  feed.recordRequestStats(res.requestStats)
+  feed.pollRetry = 0
+  // Fetching the head is the whole job a connect's catch-up exists to do, so any
+  // answer closes that gap too — as long as it was asked for the connection
+  // still in place. Without this a stream whose delivery lags the polling
+  // interval would never clear the flag: the poll would reach each head first,
+  // and the push behind it would arrive already known. A catch-up that lands
+  // after its connection was replaced would otherwise retire the polling
+  // covering a replacement that has delivered nothing.
+  if generation === feed.connectionGeneration {
+    feed.connectionUnproven = false
+  }
+  feed->recordHeight(res.height)
+  // Answering may have been the last of the loop's reasons to run. Costs nothing
+  // when the loop itself is the caller: it only sleeps after this returns.
+  feed->wakeIfIdle
+}
+
 // One poll, with the escalating backoff a failing endpoint earns: it is usually
 // the same endpoint whose stream just dropped, so asking again at the polling
 // interval would lean on something already in trouble.
@@ -239,17 +256,7 @@ let pollOnce = async (feed: t) => {
       })
       retryInterval
     | Some(res) =>
-      feed.recordRequestStats(res.requestStats)
-      feed.pollRetry = 0
-      // Fetching the head is the whole job a connect's catch-up exists to do, so
-      // a poll that answers closes that gap too — as long as it was asked for
-      // the connection still in place. Without this a stream whose delivery lags
-      // the polling interval would never clear the flag: the poll would reach
-      // each head first, and the push behind it would arrive already known.
-      if generation === feed.connectionGeneration {
-        feed.connectionUnproven = false
-      }
-      feed->recordHeight(res.height)
+      feed->recordAnswer(~generation, res)
       feed->currentInterval
     }
   } catch {
@@ -293,16 +300,9 @@ let startPolling = (feed: t) =>
 
 // Counted per reason so envio_source_height_stream_disconnects_total shows what
 // ended each connection: a rotation, or the kind of trouble a flapping stream is
-// in. Only a connection that was delivering can be lost, so every caller checks
-// that first.
-let recordDisconnect = (feed: t, ~reason) =>
-  feed.disconnects->Dict.set(
-    reason,
-    switch feed.disconnects->Utils.Dict.dangerouslyGetNonOption(reason) {
-    | Some(count) => count + 1
-    | None => 1
-    },
-  )
+// in. Only a connection that was delivering can be lost, which is what
+// `markStreamDown` checks before reaching here.
+let recordDisconnect = (feed: t, ~reason) => feed.disconnects->Utils.Dict.incrementBy(reason, 1)
 
 // One poll on every connect, closing the gap left by heights emitted before this
 // connection existed: eth_subscribe only ever delivers the *next* block. The one
@@ -318,50 +318,66 @@ let catchUp = async (feed: t, ~generation) =>
         "msg": `Height stream catch-up from ${feed.source.name} source did not answer within ${(pollTimeoutMillis /
             1000)->Int.toString}s. Polling continues until the stream delivers.`,
       })
-    | Some(res) =>
-      feed.recordRequestStats(res.requestStats)
-      // The endpoint answered, which is what the poll ramp measures — it makes
-      // no difference which of the two asked.
-      feed.pollRetry = 0
-      // A height is a height whoever fetched it, so this counts either way.
-      feed->recordHeight(res.height)
-
-      // Only the connection that asked is proven by the answer. A catch-up that
-      // lands after its connection was replaced would otherwise retire the
-      // polling covering a replacement that has delivered nothing.
-      if generation === feed.connectionGeneration {
-        feed.connectionUnproven = false
-        feed->wakeIfIdle
-      }
+    | Some(res) => feed->recordAnswer(~generation, res)
     }
   } catch {
   | exn =>
-    // Deliberately leaves the stream unproven: nothing else is fetching the
-    // height, so the poll loop has to keep covering it.
+    // Deliberately leaves the stream unproven, and deliberately does not advance
+    // the poll ramp: nothing else is fetching the height, so the loop has to
+    // keep covering it, and it is running alongside this against the same
+    // endpoint. Two failures in one round is still one round.
     feed.logger->Logging.childTrace({
       "msg": `Height stream catch-up from ${feed.source.name} source failed. Polling continues until the stream delivers.`,
       "err": exn->Utils.prettifyExn,
     })
   }
 
-let handlePushedHeight = (feed: t, height) =>
-  if height > feed.knownHeight {
-    feed.recordRequestStats([{Source.method: "heightPush", seconds: 0.}])
+let handlePushedHeight = (feed: t, height) => {
+  let advances = height > feed.knownHeight
+  feed.recordRequestStats([
+    {Source.method: advances ? "heightPush" : "heightPushIgnored", seconds: 0.},
+  ])
 
-    // A height that advances accounts for the gap a connect leaves as well as
-    // showing the stream is delivering.
+  // A height that advances accounts for the gap a connect leaves. One that does
+  // not is the head a stream re-emits on reconnect, which its catch-up is
+  // already fetching — but either way it is the stream delivering, which is all
+  // the silence behind a poke ever claimed otherwise.
+  if advances {
     feed.connectionUnproven = false
-    feed.waiters->Array.forEach(waiter => waiter.poked = false)
-    feed->recordHeight(height)
-    feed->wakeIfIdle
-  } else {
-    feed.recordRequestStats([{Source.method: "heightPushIgnored", seconds: 0.}])
-    // Not a height worth having — the head a stream re-emits on reconnect is
-    // what its catch-up is already fetching — but it is the stream delivering,
-    // which is all the silence behind a poke ever claimed otherwise.
-    feed.waiters->Array.forEach(waiter => waiter.poked = false)
-    feed->wakeIfIdle
   }
+  feed.waiters->Array.forEach(waiter => waiter.poked = false)
+  feed->recordHeight(height)
+  feed->wakeIfIdle
+}
+
+// Everything a connection going away means for the feed. The stream reporting
+// it and this module closing it leave the same state behind, so they share it:
+// nothing is pushing, nothing is proven, and what the waiters concluded about
+// the connection that is gone says nothing about the one that replaces it.
+let markStreamDown = (feed: t, ~reason) => {
+  // A stream that is down stays down through every failed retry, and each of
+  // those reports Down again. Counting them would make the total measure how
+  // long an outage lasted rather than how many there were, and would leave a
+  // stream that has never connected disconnecting without ever connecting.
+  let lostConnection = feed.streamLive
+  if lostConnection {
+    feed->recordDisconnect(~reason)
+  }
+  feed.streamLive = false
+  feed.connectionUnproven = false
+  // The connection they gave up on is gone; the one that replaces it starts with
+  // a catch-up of its own to prove it.
+  feed.waiters->Array.forEach(waiter => waiter.poked = false)
+  feed.connectionGeneration = feed.connectionGeneration + 1
+  // A loop already running may be sleeping off an interval chosen while that
+  // connection was still covering this source. Not while polls are failing,
+  // though: that sleep is the backoff a struggling endpoint earned, and the
+  // stream dropping is usually the same endpoint's doing.
+  if lostConnection && feed.pollRetry === 0 {
+    feed->wake
+  }
+  feed->startPolling
+}
 
 let handleStatus = (feed: t, status: Source.heightSubscriptionStatus) =>
   switch status {
@@ -380,24 +396,22 @@ let handleStatus = (feed: t, status: Source.heightSubscriptionStatus) =>
       feed->catchUp(~generation=feed.connectionGeneration)->Promise.ignore
     }
   | Down({reason} as down) =>
-    // A stream that is down stays down through every failed retry, and each of
-    // those reports Down again. Counting them would make the total measure how
-    // long an outage lasted rather than how many there were, and would leave a
-    // stream that has never connected disconnecting without ever connecting.
-    if feed.streamLive {
-      feed->recordDisconnect(~reason)
-    }
-    feed.streamLive = false
-    feed.connectionUnproven = false
-    // The connection they gave up on is gone; the one that replaces it starts
-    // with a catch-up of its own to prove it.
-    feed.waiters->Array.forEach(waiter => waiter.poked = false)
-    feed.connectionGeneration = feed.connectionGeneration + 1
-    feed->startPolling
+    feed->markStreamDown(~reason)
+
     // The counters say a stream is flapping and how often, but only the
     // provider's own words say why, and a frame nobody could read is
-    // unrecoverable from a bucketed label.
-    feed.logger->Logging.childTrace({
+    // unrecoverable from a bucketed label. An outage is the indexer's to absorb
+    // — it polls instead — but a provider sending heights in a shape this does
+    // not parse never heals on its own, and silently polling forever against a
+    // stream that could be working is worth one line an operator can see. Once:
+    // it repeats every staleness window for as long as the shape is wrong.
+    let log = if reason === HeightStream.unreadableReason && !feed.unreadableWarned {
+      feed.unreadableWarned = true
+      Logging.childWarn
+    } else {
+      Logging.childTrace
+    }
+    feed.logger->log({
       "msg": `Height subscription for ${feed.source.name} source went down (${reason}). Polling for the height until it reconnects.`,
       "reason": reason,
       "detail": down.detail,
@@ -428,20 +442,13 @@ let stop = (feed: t) => {
     unsubscribe()
     feed.unsubscribe = None
 
-    // Closing a live connection is a disconnect like any other, and leaving it
-    // uncounted would leave the source reporting one more connect than
-    // disconnects — a stream still delivering — for the rest of the process.
-    if feed.streamLive {
-      feed->recordDisconnect(~reason="unsubscribed")
-    }
-    feed.streamLive = false
-    feed.connectionUnproven = false
-    feed.waiters->Array.forEach(waiter => waiter.poked = false)
-    feed.connectionGeneration = feed.connectionGeneration + 1
-    // Whoever is still waiting has nothing pushing for them now. Being benched
-    // is a capability verdict, not an outage: the source can still answer a
-    // height poll, and until another one answers the wait it is what there is.
-    feed->startPolling
+    // Counted as a disconnect like any other: leaving it out would leave the
+    // source reporting one more connect than disconnects — a stream still
+    // delivering — for the rest of the process. Being benched is a capability
+    // verdict, not an outage, so whoever is still waiting keeps being polled
+    // for: the source can still answer a height poll, and until another source
+    // answers the wait it is what there is.
+    feed->markStreamDown(~reason="unsubscribed")
   | None => ()
   }
 }
@@ -458,13 +465,11 @@ let onHeightAbove = (feed: t, ~knownHeight, ~interval, ~onHeight): subscription 
   } else {
     let waiter = {knownHeight, onHeight, interval, poked: false}
     feed.waiters->Array.push(waiter)->ignore
-    if feed.polling {
-      // A loop is already running. If it is sleeping off an interval started for
-      // someone else, this waiter should not have to sit out the remainder.
-      feed->wake
-    } else {
-      feed->startPolling
-    }
+    // Both self-guarding, and between them they cover either state: a loop
+    // sleeping off an interval started for someone else ends it here rather than
+    // making this waiter sit out the remainder, and no loop at all starts one.
+    feed->wake
+    feed->startPolling
     {
       unsubscribe: () => {
         // Removing by reference is what makes this idempotent, including from

--- a/packages/envio/src/sources/HeightStream.res
+++ b/packages/envio/src/sources/HeightStream.res
@@ -31,9 +31,6 @@ type driver = {
 // genuinely in trouble.
 let baseRetryMillis = 250
 let maxRetryMillis = 60_000
-// Keeps the doubling from overflowing on a stream that has been failing for
-// days. The delay reaches maxRetryMillis long before this.
-let maxRetryExponent = 20
 // Floor for how long a connection has to serve to have been worth making, as a
 // fraction of the window we would wait before calling it dead. Both transports
 // deliver something the moment they connect — HyperSync sends the head, a
@@ -48,6 +45,9 @@ let provenStaleFraction = 4
 // lasted — the same measure the backoff already trusts.
 let closedReason = "closed"
 let rotatedReason = "rotated"
+// A stream whose frames the transport could not read. Unlike the other reasons
+// this one never heals on its own, so its consumer says so out loud.
+let unreadableReason = "unreadable"
 // A frame nobody could read ends up in a log line, so cap what a provider can
 // put there.
 let maxDetailLength = 200
@@ -59,11 +59,7 @@ let maxDetailLength = 200
 let retryDelayFor = count =>
   count <= 0
     ? 0
-    : Pervasives.min(
-        baseRetryMillis *
-        Math.pow(2.0, ~exp=Pervasives.min(count - 1, maxRetryExponent)->Int.toFloat)->Float.toInt,
-        maxRetryMillis,
-      )
+    : Utils.expBackoff(~base=baseRetryMillis, ~exp=count - 1, ~maxMillis=maxRetryMillis)
 
 let truncateDetail = detail =>
   detail->String.length > maxDetailLength
@@ -130,7 +126,7 @@ let subscribe = (
           // Distinguishes a provider whose message shape we don't understand
           // from a chain that simply has nothing to report.
           switch unreadableDetail.contents {
-          | Some(detail) => fail(~reason="unreadable", ~detail)
+          | Some(detail) => fail(~reason=unreadableReason, ~detail)
           | None => fail(~reason="stale")
           }
         }, staleTimeout))

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -142,7 +142,7 @@ type heightStreamSample = {
 let getHeightStreamSamples = (sourceManager: t): array<heightStreamSample> => {
   let samples = []
   sourceManager.sourcesState->Array.forEach(sourceState =>
-    switch (sourceState.feed->HeightFeed.sample).stream {
+    switch sourceState.feed->HeightFeed.sample {
     | Some({connectCount, disconnects}) =>
       samples->Array.push({
         sourceName: sourceState.source.name,
@@ -540,7 +540,7 @@ let maxRetryBackoffMillis = 60_000
 // 100ms doubling up to the cap. `backoffBeforeRetry` still applies the caller's
 // floor and the cap on top.
 let retryBackoffMillis = retry =>
-  Pervasives.min(100. *. 2. ** retry->Int.toFloat, maxRetryBackoffMillis->Int.toFloat)->Float.toInt
+  Utils.expBackoff(~base=100, ~exp=retry, ~maxMillis=maxRetryBackoffMillis)
 
 // Floor for the retries driven by a condition the source reported itself
 // (behind the head, inconsistent response). Unlike a caller-supplied backoff of


### PR DESCRIPTION
## Summary

Refactors the height feed's stream state management to improve code organization and error reporting. Extracts common stream lifecycle logic into reusable functions, adds explicit tracking for unreadable stream errors, and improves WebSocket message parsing to distinguish between subscription errors and unrelated provider errors.

## Key Changes

- **Extract `recordAnswer` function**: Consolidates the logic for processing height responses (whether from polling or catch-up) into a single function, eliminating duplication between `pollOnce` and `catchUp`.

- **Extract `markStreamDown` function**: Centralizes stream disconnection handling (recording disconnect reason, clearing connection state, incrementing generation, managing polling) used by both explicit stream failures and graceful shutdown.

- **Add `unreadableWarned` flag**: Tracks whether an operator has been warned about unreadable stream frames. Logs a warning (instead of trace) once per staleness window when a provider sends frames in an unparseable format, since this condition never self-heals.

- **Improve WebSocket error handling**: Refines `EvmRpcWs` message parsing to:
  - Distinguish between subscription errors (id matches `subscribeRequestId`) and unrelated provider errors
  - Properly parse error frames with required `error.code` field instead of accepting any frame with an `error` member
  - Ignore errors meant for other requests on the shared socket

- **Simplify `sample` return type**: Changes `sample` from returning a record with `knownHeight` and optional `stream` to returning only the optional `streamSample`. Adds a separate `knownHeight` accessor function.

- **Refactor `onHeightAbove` subscription logic**: Simplifies the conditional logic for starting/waking the polling loop by always calling both `wake` and `startPolling` (both are self-guarding).

- **Extract `expBackoff` utility**: Centralizes exponential backoff calculation with overflow protection into `Utils`, replacing inline calculations in `HeightStream`.

- **Add `Dict.incrementBy` helper**: Provides a reusable pattern for incrementing counter values in dictionaries.

- **Update test infrastructure**: Moves HTTP server bindings from test-local `NodeHttp` module to shared `MockRpcServer`, adds `Scenario.waitUntil` helper, and adds test cases for unreadable frames and error handling.

## Notable Implementation Details

- The `recordAnswer` function is called from both polling and catch-up paths, ensuring consistent state updates regardless of which path answered the height query.

- Stream down detection now properly handles the case where a live connection drops mid-interval: if polling was sleeping off an interval chosen while the connection was active, it wakes immediately to resume polling.

- Unreadable stream errors are logged at warn level once per staleness window (when the condition repeats), helping operators identify provider format issues that require manual intervention.

- WebSocket error frame parsing now requires a valid `error.code` field, preventing false positives from frames that happen to have an `error` member but aren't actually error responses.

https://claude.ai/code/session_01XpvPa6MtAZmuVxDxkupZ96