### PR TITLE
Consolidate emitter abstraction across ecosystems

### DIFF
--- a/packages/cli/src/address_store.rs
+++ b/packages/cli/src/address_store.rs
@@ -364,14 +364,12 @@ impl StoreInner {
 
 /// A contract an address may be registered for: every contract the config
 /// declares, on any chain, since `context.chain.<Contract>.add` validates
-/// against that whole set. Fixed at construction.
+/// against that whole set. Fixed at construction, in canonical id order — a
+/// contract's position is the `contract_idx` every entry and every persisted
+/// address row carries, so a stored id names the same contract whichever
+/// chain's store reads it.
 #[napi(object)]
 pub struct AddressStoreContract {
-    /// The contract's canonical id — its row in `envio_contracts`, and the
-    /// `contract_idx` every entry and every persisted address row carries. The
-    /// list must be ordered by it, so a stored id always names the same
-    /// contract whichever chain's store reads it.
-    pub id: u32,
     pub name: String,
     /// The minimum `startBlock` across the contract's registrations on this
     /// chain; absent means block 0, since partitions never query below the
@@ -866,20 +864,6 @@ impl AddressStore {
         let mut contract_idx_by_name = HashMap::with_capacity(contracts.len());
         let mut contract_depends_on_addresses = Vec::with_capacity(contracts.len());
         for contract in contracts {
-            // Structural, not incidental: a `contract_idx` is written into
-            // every persisted address row, so a list whose ids drifted from
-            // its positions would attribute stored addresses to the wrong
-            // contract on the next resume. An error rather than a panic — the
-            // indexer has to be able to report it, not abort the process.
-            if contract.id as usize != contract_names.len() {
-                return Err(napi::Error::from_reason(format!(
-                    "Address store contracts must be ordered by their canonical id: contract \
-                     \"{}\" carries id {} at position {}.",
-                    contract.name,
-                    contract.id,
-                    contract_names.len(),
-                )));
-            }
             if contract_idx_by_name.contains_key(&contract.name) {
                 return Err(napi::Error::from_reason(format!(
                     "Contract \"{}\" is listed twice in the address store's contract list.",
@@ -1120,6 +1104,36 @@ impl Owners<'_> {
 
     pub fn is_empty(&self) -> bool {
         self.first.is_none()
+    }
+}
+
+/// The emitter facts every ecosystem's address gate reads off an item: its
+/// store key, the contracts this partition's set says own that key (empty when
+/// the partition doesn't hold it), and the block the item fired at.
+pub struct Emitter<'a> {
+    pub key: &'a [u8],
+    pub owners: Owners<'a>,
+    pub block: i64,
+}
+
+impl Emitter<'_> {
+    /// Whether one registration accepts this emitter: the registration has
+    /// started, and — unless it is wildcard — this partition's set owns the
+    /// emitter for the registration's contract (or, when the contract is
+    /// client-filtered, the store alone vouches for it) and the store has it
+    /// indexed at the item's block.
+    pub fn matches_registration(
+        &self,
+        store: &StoreInner,
+        contract_idx: u32,
+        is_wildcard: bool,
+        start_block: Option<i64>,
+        force_wildcard: bool,
+    ) -> bool {
+        crate::registration_start_block::has_started(start_block, self.block)
+            && (is_wildcard
+                || ((force_wildcard || self.owners.contains(contract_idx))
+                    && store.is_indexed_at(self.key, contract_idx, self.block)))
     }
 }
 
@@ -1420,9 +1434,7 @@ pub(crate) mod test_support {
             ecosystem,
             entries
                 .iter()
-                .enumerate()
-                .map(|(idx, (name, _))| AddressStoreContract {
-                    id: idx as u32,
+                .map(|(name, _)| AddressStoreContract {
                     name: name.to_string(),
                     start_block: None,
                     depends_on_addresses: true,
@@ -1519,9 +1531,7 @@ mod tests {
     fn contracts(entries: &[(&str, Option<i64>)]) -> Vec<AddressStoreContract> {
         entries
             .iter()
-            .enumerate()
-            .map(|(idx, (name, start_block))| AddressStoreContract {
-                id: idx as u32,
+            .map(|(name, start_block)| AddressStoreContract {
                 name: name.to_string(),
                 start_block: *start_block,
                 depends_on_addresses: true,
@@ -1532,9 +1542,8 @@ mod tests {
     /// A contract nothing on this chain fetches by address — either it has no
     /// events here, or they're all wildcard. Registered and persisted like any
     /// other, never fetched.
-    fn address_independent_contract(id: u32, name: &str) -> AddressStoreContract {
+    fn address_independent_contract(name: &str) -> AddressStoreContract {
         AddressStoreContract {
-            id,
             name: name.to_string(),
             start_block: None,
             depends_on_addresses: false,
@@ -1760,7 +1769,7 @@ mod tests {
             false,
             vec![
                 contracts(&[("C", None)]).remove(0),
-                address_independent_contract(1, "D"),
+                address_independent_contract("D"),
             ],
         )
         .unwrap();

--- a/packages/cli/src/evm_hypersync_source/decode.rs
+++ b/packages/cli/src/evm_hypersync_source/decode.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use hypersync_client::format::{Data, Hex, LogArgument};
 use hypersync_client::simple_types;
 
-use crate::address_store::{AddressStore, Owners, SetCache, StoreInner};
+use crate::address_store::{AddressStore, Emitter, SetCache, StoreInner};
 use crate::evm_hypersync_source::selection::TopicSelectionInput;
 use crate::evm_hypersync_source::types::{
     sol_value_to_param, Log, OnEventRegistrationInput, ParamMeta, ParamValue,
@@ -27,15 +27,6 @@ enum TopicConstraint {
     /// here. The store answers only the temporal half, dropping a value
     /// registered after the log's block that a merged partition over-fetched.
     ContractAddresses,
-}
-
-/// The emitter facts every address gate reads off a log: its binary address,
-/// the contracts this partition's set says own that address (empty when the
-/// partition doesn't hold it), and the log's block.
-pub(crate) struct LogAddress<'a> {
-    pub key: &'a [u8],
-    pub owners: Owners<'a>,
-    pub block_number: i64,
 }
 
 /// The 20 address bytes of a padded indexed topic, or `None` when the topic's
@@ -200,21 +191,24 @@ impl OnEventRegistration {
         topic0: &[u8; 32],
         topic_count: u8,
         topics: &[Option<LogArgument>],
-        address: &LogAddress,
+        address: &Emitter,
         force_wildcard: bool,
         cache: &SetCache,
         store: &StoreInner,
     ) -> bool {
         self.sighash == *topic0
             && self.topic_count == topic_count
-            && crate::registration_start_block::has_started(self.start_block, address.block_number)
-            && (self.is_wildcard
-                || ((force_wildcard || address.owners.contains(self.contract_idx))
-                    && store.is_indexed_at(address.key, self.contract_idx, address.block_number)))
+            && address.matches_registration(
+                store,
+                self.contract_idx,
+                self.is_wildcard,
+                self.start_block,
+                force_wildcard,
+            )
             && self.topic_filters.matches(
                 topics,
                 self.contract_idx,
-                address.block_number,
+                address.block,
                 force_wildcard,
                 cache,
                 store,
@@ -340,7 +334,7 @@ impl SelectionDecoder {
     pub(crate) fn route_and_decode_napi(
         &self,
         log: &Log,
-        address: &LogAddress,
+        address: &Emitter,
         store: &StoreInner,
     ) -> Result<Vec<RoutedEvent>> {
         let topics: Vec<Option<LogArgument>> = log
@@ -361,7 +355,7 @@ impl SelectionDecoder {
     pub(crate) fn route_and_decode_simple(
         &self,
         log: &simple_types::Log,
-        address: &LogAddress,
+        address: &Emitter,
         store: &StoreInner,
     ) -> Result<Vec<RoutedEvent>> {
         let data = log.data.as_ref().context("get log.data")?;
@@ -385,7 +379,7 @@ impl SelectionDecoder {
         &self,
         topics: &[Option<LogArgument>],
         data: &Data,
-        address: &LogAddress,
+        address: &Emitter,
         store: &StoreInner,
     ) -> Result<Vec<RoutedEvent>> {
         let topic0 = topics
@@ -490,6 +484,7 @@ fn build_event_decoder(sighash: [u8; 32], params: &[ParamMeta]) -> Result<DynSol
 mod tests {
     use super::*;
     use crate::address_store::test_support::evm_store;
+    use crate::address_store::Owners;
 
     const VALID_SIGHASH: &str =
         "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
@@ -525,21 +520,21 @@ mod tests {
 
     /// The registered emitter, owned per the partition's set by the contract
     /// at `contract_idx` — its position in the store's contract list.
-    fn owned(contract_idx: u32) -> LogAddress<'static> {
-        LogAddress {
+    fn owned(contract_idx: u32) -> Emitter<'static> {
+        Emitter {
             key: &EMITTER_KEY,
             owners: Owners::single(contract_idx),
-            block_number: 0,
+            block: 0,
         }
     }
 
     /// An emitter the partition's set doesn't hold. Contract-bound
     /// registrations reject it; wildcards still see it.
-    fn unowned() -> LogAddress<'static> {
-        LogAddress {
+    fn unowned() -> Emitter<'static> {
+        Emitter {
             key: &FOREIGN_KEY,
             owners: Owners::default(),
-            block_number: 0,
+            block: 0,
         }
     }
 
@@ -619,7 +614,7 @@ mod tests {
     }
 
     /// Route one log, holding the store read lock the way a response does.
-    fn route(decoder: &SelectionDecoder, log: &Log, address: &LogAddress) -> Vec<RoutedEvent> {
+    fn route(decoder: &SelectionDecoder, log: &Log, address: &Emitter) -> Vec<RoutedEvent> {
         let store = decoder.lock_store();
         decoder
             .route_and_decode_napi(log, address, &store)
@@ -787,10 +782,10 @@ mod tests {
         .unwrap();
         let decoder = selection_of(&core, &[0, 1], &Default::default()).unwrap();
         let log = value_log(VALID_SIGHASH);
-        let at = |block_number| LogAddress {
+        let at = |block| Emitter {
             key: &EMITTER_KEY,
             owners: Owners::single(0),
-            block_number,
+            block,
         };
 
         assert_eq!(
@@ -821,10 +816,10 @@ mod tests {
                 "Owned".to_string()
             ]);
         let decoder = selection_of(&core, &[0, 1], &client_filtered).unwrap();
-        let registered = LogAddress {
+        let registered = Emitter {
             key: &EMITTER_KEY,
             owners: Owners::default(),
-            block_number: 0,
+            block: 0,
         };
         let log = value_log(VALID_SIGHASH);
         assert_eq!(
@@ -849,7 +844,6 @@ mod tests {
         let address_store = crate::address_store::AddressStore::new_evm(
             false,
             vec![crate::address_store::AddressStoreContract {
-                id: 0,
                 name: "Owned".to_string(),
                 start_block: None,
                 depends_on_addresses: true,
@@ -869,10 +863,10 @@ mod tests {
         .unwrap();
         let decoder = selection_of(&core, &[0], &Default::default()).unwrap();
         let log = value_log(VALID_SIGHASH);
-        let at = |block_number| LogAddress {
+        let at = |block| Emitter {
             key: &EMITTER_KEY,
             owners: Owners::single(0),
-            block_number,
+            block,
         };
         assert_eq!(
             (
@@ -1045,13 +1039,13 @@ mod tests {
         }
     }
 
-    /// An emitter no contract owns, at `block_number` — for wildcard marker
+    /// An emitter no contract owns, at `block` — for wildcard marker
     /// registrations, where only the log's block feeds the gate.
-    fn at_block(block_number: i64) -> LogAddress<'static> {
-        LogAddress {
+    fn at_block(block: i64) -> Emitter<'static> {
+        Emitter {
             key: &FOREIGN_KEY,
             owners: Owners::default(),
-            block_number,
+            block,
         }
     }
 
@@ -1063,7 +1057,6 @@ mod tests {
         let address_store = crate::address_store::AddressStore::new_evm(
             false,
             vec![crate::address_store::AddressStoreContract {
-                id: 0,
                 name: "C".to_string(),
                 start_block: None,
                 depends_on_addresses: true,

--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use hypersync_client::{simple_types, RateLimitResponse};
 use napi_derive::napi;
 
-use crate::address_store::{AddressSet, AddressStore, SetCache};
+use crate::address_store::{AddressSet, AddressStore, Emitter, SetCache};
 use crate::block_hash_pagination::{paginate_block_hashes, HashPage};
 use crate::block_store::BlockStore;
 use crate::request_stats::{rate_limited_err, RequestStat};
@@ -18,7 +18,7 @@ pub(crate) mod selection;
 pub(crate) mod types;
 
 use config::ClientConfig;
-use decode::{Decoder, LogAddress, SelectionDecoder};
+use decode::{Decoder, SelectionDecoder};
 use query::{BlockField, LogField, LogFilter, LogSelection, Query, TransactionField};
 use selection::{BuiltLogSelection, SelectionBuilder};
 use types::{encode_address, Block, OnEventRegistrationInput, ParamValue, RollbackGuard};
@@ -476,10 +476,10 @@ fn process_response(
             // and the effectiveStartBlock gate cost one hash lookup each — no
             // round-trip through the address string.
             let address_key = log.address.as_ref().context("log.address missing")?;
-            let address = LogAddress {
+            let address = Emitter {
                 key: address_key.as_slice(),
                 owners: set_cache.owners_of(address_key.as_slice()),
-                block_number: flat.block_number,
+                block: flat.block_number,
             };
             // Only structurally malformed logs (missing topic0, bad topic bytes)
             // surface here; per-registration decode failures are dropped inside

--- a/packages/cli/src/evm_rpc_source/mod.rs
+++ b/packages/cli/src/evm_rpc_source/mod.rs
@@ -9,8 +9,8 @@ mod classify;
 mod client;
 mod interval;
 
-use crate::address_store::{AddressSet, AddressStore, SetCache};
-use crate::evm_hypersync_source::decode::{Decoder, LogAddress, SelectionDecoder};
+use crate::address_store::{AddressSet, AddressStore, Emitter, SetCache};
+use crate::evm_hypersync_source::decode::{Decoder, SelectionDecoder};
 use crate::evm_hypersync_source::selection::{BuiltLogSelection, SelectionBuilder};
 use crate::evm_hypersync_source::types::{
     encode_address, Log as DecoderLog, OnEventRegistrationInput, ParamValue,
@@ -514,10 +514,10 @@ impl EvmRpcClient {
                     .context("log.blockNumber")?
                     .try_into()
                     .context("log.blockNumber exceeds i64::MAX")?;
-                let log_address = LogAddress {
+                let log_address = Emitter {
                     key: &address_key,
                     owners: set_cache.owners_of(&address_key),
-                    block_number,
+                    block: block_number,
                 };
                 // Per-registration decode failures are dropped inside
                 // `route_and_decode`; only structurally malformed logs error,

--- a/packages/cli/src/fuel_hypersync_source/mod.rs
+++ b/packages/cli/src/fuel_hypersync_source/mod.rs
@@ -8,16 +8,13 @@ mod config;
 mod selection;
 mod types;
 
-use crate::address_store::{AddressSet, AddressStore, SetCache, StoreInner};
+use crate::address_store::{AddressSet, AddressStore, Emitter, SetCache, StoreInner};
 use crate::block_store::{BlockStore, FuelBlockRow};
 use crate::hex::decode_prefixed;
 use config::ClientConfig;
 use hyperfuel_client::format::{Hash, Hex};
 use hyperfuel_client::net_types;
-use selection::{
-    BuiltSelection, FuelOnEventRegistrationInput, ReceiptAddress, RegistrationKind,
-    SelectionBuilder,
-};
+use selection::{BuiltSelection, FuelOnEventRegistrationInput, RegistrationKind, SelectionBuilder};
 use types::{convert_response, Block, ConvertError, RawReceipt};
 
 #[napi]
@@ -263,10 +260,10 @@ fn route_receipts(
         // receipt only reaches wildcard registrations.
         let contract_id = Hash::decode_hex(&src_address).ok();
         let key: &[u8] = contract_id.as_deref().map_or(&[], |bytes| &bytes[..]);
-        let address = ReceiptAddress {
+        let address = Emitter {
             key,
             owners: set_cache.owners_of(key),
-            block_height: receipt.block_height,
+            block: receipt.block_height,
         };
 
         for reg in &built.registrations {

--- a/packages/cli/src/fuel_hypersync_source/selection.rs
+++ b/packages/cli/src/fuel_hypersync_source/selection.rs
@@ -5,7 +5,7 @@ use hyperfuel_client::format::{Hash, Hex};
 use hyperfuel_client::net_types;
 use napi_derive::napi;
 
-use crate::address_store::{AddressSet, Owners, StoreInner};
+use crate::address_store::{AddressSet, Emitter, StoreInner};
 
 // FuelVM receipt type codes (see FuelSDK.receiptType on the JS side).
 const RECEIPT_CALL: u8 = 0;
@@ -89,15 +89,6 @@ pub(crate) struct Registration {
     pub kind: RegistrationKind,
 }
 
-/// The emitter facts a receipt's owner gate reads: the root contract id's store
-/// key (its 32 raw bytes), the contracts this partition's set says own it, and
-/// the receipt's block height.
-pub(crate) struct ReceiptAddress<'a> {
-    pub key: &'a [u8],
-    pub owners: Owners<'a>,
-    pub block_height: i64,
-}
-
 impl Registration {
     /// Whether a receipt belongs to this registration: matching receipt type
     /// (and `rb` for LogData), at or after the registration's own start block,
@@ -111,7 +102,7 @@ impl Registration {
         &self,
         receipt_type: u8,
         rb: Option<u64>,
-        address: &ReceiptAddress,
+        address: &Emitter,
         force_wildcard: bool,
         store: &StoreInner,
     ) -> bool {
@@ -122,10 +113,13 @@ impl Registration {
             kind => kind.receipt_types().contains(&receipt_type),
         };
         kind_matches
-            && crate::registration_start_block::has_started(self.start_block, address.block_height)
-            && (self.is_wildcard
-                || ((force_wildcard || address.owners.contains(self.contract_idx))
-                    && store.is_indexed_at(address.key, self.contract_idx, address.block_height)))
+            && address.matches_registration(
+                store,
+                self.contract_idx,
+                self.is_wildcard,
+                self.start_block,
+                force_wildcard,
+            )
     }
 }
 
@@ -345,7 +339,7 @@ impl SelectionBuilder {
 mod tests {
     use super::*;
     use crate::address_store::test_support::{fuel_store, set_of};
-    use crate::address_store::AddressStore;
+    use crate::address_store::{AddressStore, Owners};
 
     const ADDR_1: &str = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcde1";
     const ADDR_2: &str = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcde2";
@@ -384,21 +378,21 @@ mod tests {
     }
 
     /// A receipt emitter with the contracts the partition's set claims it for.
-    fn emitter<'a>(set: &'a AddressSet, key: &'a Hash) -> ReceiptAddress<'a> {
-        ReceiptAddress {
+    fn emitter<'a>(set: &'a AddressSet, key: &'a Hash) -> Emitter<'a> {
+        Emitter {
             key: &key[..],
             owners: set.cache().owners_of(&key[..]),
-            block_height: 0,
+            block: 0,
         }
     }
 
     /// An emitter no contract owns.
     const UNOWNED_KEY: [u8; 32] = [0xff; 32];
-    fn unowned() -> ReceiptAddress<'static> {
-        ReceiptAddress {
+    fn unowned() -> Emitter<'static> {
+        Emitter {
             key: &UNOWNED_KEY,
             owners: Owners::default(),
-            block_height: 0,
+            block: 0,
         }
     }
 
@@ -551,10 +545,10 @@ mod tests {
             c1_reg.matches(
                 RECEIPT_MINT,
                 None,
-                &ReceiptAddress {
+                &Emitter {
                     key: &key[..],
                     owners: Owners::default(),
-                    block_height: 0,
+                    block: 0,
                 },
                 true,
                 &address_store,
@@ -662,7 +656,7 @@ mod tests {
             .unwrap();
         let address_store = store.handle();
         let address_store = address_store.read().unwrap();
-        let route = |address: &ReceiptAddress| -> Vec<i64> {
+        let route = |address: &Emitter| -> Vec<i64> {
             built
                 .registrations
                 .iter()
@@ -682,7 +676,6 @@ mod tests {
         // Fuel gets the same temporal gate as EVM: a receipt from before the
         // contract's registration block never reaches its handler.
         let store = AddressStore::new_fuel(vec![crate::address_store::AddressStoreContract {
-            id: 0,
             name: "Owned".to_string(),
             start_block: None,
             depends_on_addresses: true,
@@ -703,10 +696,10 @@ mod tests {
         let address_store = store.handle();
         let address_store = address_store.read().unwrap();
         let owned_key = key_of(ADDR_1);
-        let at = |block_height| ReceiptAddress {
+        let at = |block| Emitter {
             key: &owned_key[..],
             owners: Owners::single(0),
-            block_height,
+            block,
         };
         let reg = &built.registrations[0];
         assert_eq!(
@@ -738,11 +731,11 @@ mod tests {
         let address_store = store.handle();
         let address_store = address_store.read().unwrap();
         let owned_key = key_of(ADDR_1);
-        let at = |block_height| {
-            let address = ReceiptAddress {
+        let at = |block| {
+            let address = Emitter {
                 key: &owned_key[..],
                 owners: Owners::single(0),
-                block_height,
+                block,
             };
             built
                 .registrations

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -24,7 +24,7 @@ use hypersync_client_solana::RateLimitInfo;
 use hypersync_solana_net_types::field_selection::SolanaFieldSelection;
 use hypersync_solana_net_types::query::SolanaQuery;
 
-use crate::address_store::{AddressSet, AddressStore, SetCache, StoreInner};
+use crate::address_store::{AddressSet, AddressStore, Emitter, SetCache, StoreInner};
 use crate::block_hash_pagination::{paginate_block_hashes, HashPage};
 use crate::block_store::BlockStore;
 use crate::config_parsing::human_config::svm::{ArgDef, ArgType};
@@ -586,10 +586,10 @@ fn build_event_items(
         }
         let slot = i64::try_from(instr.slot).context("instruction.slot overflow")?;
         let program_key = instr.executing_account.as_bytes();
-        let address = selection::InstructionAddress {
+        let address = Emitter {
             key: program_key,
             owners: set_cache.owners_of(program_key),
-            slot,
+            block: slot,
         };
         let routed = route_instruction(
             &built.registrations,

--- a/packages/cli/src/svm_hypersync_source/selection.rs
+++ b/packages/cli/src/svm_hypersync_source/selection.rs
@@ -10,7 +10,7 @@ use napi_derive::napi;
 use super::fields;
 use super::mod_helpers::hex_to_bytes;
 use super::types::required;
-use crate::address_store::{Owners, StoreInner};
+use crate::address_store::{Emitter, StoreInner};
 
 /// One instruction call with the fields routing and item building read, lifted
 /// out of the client's all-`Option` row once per instruction: base58 is
@@ -226,15 +226,18 @@ impl Registration {
     fn matches_scope(
         &self,
         instr: &InstructionCall,
-        address: &InstructionAddress,
+        address: &Emitter,
         force_wildcard: bool,
         store: &StoreInner,
     ) -> bool {
         self.program_id == instr.executing_account
-            && crate::registration_start_block::has_started(self.start_block, address.slot)
-            && (self.is_wildcard
-                || ((force_wildcard || address.owners.contains(self.contract_idx))
-                    && store.is_indexed_at(address.key, self.contract_idx, address.slot)))
+            && address.matches_registration(
+                store,
+                self.contract_idx,
+                self.is_wildcard,
+                self.start_block,
+                force_wildcard,
+            )
             && self
                 .is_inner
                 .is_none_or(|is_inner| is_inner == instr.is_inner)
@@ -453,7 +456,7 @@ impl SelectionBuilder {
 pub(crate) fn route_instruction(
     registrations: &[Arc<Registration>],
     instr: &InstructionCall,
-    address: &InstructionAddress,
+    address: &Emitter,
     client_filtered: &crate::client_filtered_contracts::ClientFilteredContracts,
     store: &StoreInner,
 ) -> Vec<Arc<Registration>> {
@@ -482,15 +485,6 @@ pub(crate) fn route_instruction(
         .filter(|reg| reg.discriminator.is_none() && scoped(reg))
         .cloned()
         .collect()
-}
-
-/// The emitter facts an instruction's owner gate reads: the program id's store
-/// key (its base58 bytes), the contracts this partition's set says own it, and
-/// the slot the instruction sits at.
-pub(crate) struct InstructionAddress<'a> {
-    pub key: &'a [u8],
-    pub owners: Owners<'a>,
-    pub slot: i64,
 }
 
 #[cfg(test)]
@@ -586,10 +580,10 @@ mod tests {
         let address_store = store.handle();
         let address_store = address_store.read().unwrap();
         let key = instr.executing_account.as_bytes();
-        let address = InstructionAddress {
+        let address = Emitter {
             key,
             owners: set.cache().owners_of(key),
-            slot: instr.slot as i64,
+            block: instr.slot as i64,
         };
         route_instruction(
             &built.registrations,
@@ -851,7 +845,6 @@ mod tests {
         let mut owned = reg(0, PROG_A, Some("0x21"), false);
         owned.contract_name = "Owned".to_string();
         let store = AddressStore::new_svm(vec![crate::address_store::AddressStoreContract {
-            id: 0,
             name: "Owned".to_string(),
             start_block: None,
             depends_on_addresses: true,

--- a/packages/envio-tests/test/HyperSyncClient_test.res
+++ b/packages/envio-tests/test/HyperSyncClient_test.res
@@ -46,8 +46,8 @@ let addressStore = AddressStore.make(
   ~ecosystem=Ecosystem.Evm,
   ~shouldChecksum=false,
   ~contracts=[
-    {id: 0, name: "ERC20", startBlock: None, dependsOnAddresses: true},
-    {id: 1, name: "Unrelated", startBlock: None, dependsOnAddresses: true},
+    {name: "ERC20", startBlock: None, dependsOnAddresses: true},
+    {name: "Unrelated", startBlock: None, dependsOnAddresses: true},
   ],
 )
 let _ = addressStore->AddressStore.seedBatch([

--- a/packages/envio-tests/test/HyperSyncSourceContract_test.res
+++ b/packages/envio-tests/test/HyperSyncSourceContract_test.res
@@ -85,7 +85,7 @@ let makeSource = (~url, ~lowercaseAddresses=true) => {
   let addressStore = AddressStore.make(
     ~ecosystem=Ecosystem.Evm,
     ~shouldChecksum=!lowercaseAddresses,
-    ~contracts=[{id: 0, name: "Token", startBlock: None, dependsOnAddresses: true}],
+    ~contracts=[{name: "Token", startBlock: None, dependsOnAddresses: true}],
   )
   let _ = addressStore->AddressStore.seedBatch([
     {

--- a/packages/envio-tests/test/HyperSync_test.res
+++ b/packages/envio-tests/test/HyperSync_test.res
@@ -10,7 +10,7 @@ let testApiToken =
 let addressStore = AddressStore.make(
   ~ecosystem=Ecosystem.Evm,
   ~shouldChecksum=true,
-  ~contracts=[{id: 0, name: "ERC20", startBlock: None, dependsOnAddresses: true}],
+  ~contracts=[{name: "ERC20", startBlock: None, dependsOnAddresses: true}],
 )
 
 describe_skip("Test Hyperliquid broken transaction response", () => {

--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -97,7 +97,7 @@ let capturedRegistrationInputs: array<array<SvmHyperSyncClient.Registration.inpu
 let addressStore = AddressStore.make(
   ~ecosystem=Ecosystem.Svm,
   ~shouldChecksum=false,
-  ~contracts=[{id: 0, name: "TokenMetadata", startBlock: None, dependsOnAddresses: true}],
+  ~contracts=[{name: "TokenMetadata", startBlock: None, dependsOnAddresses: true}],
 )
 
 let makeMockClient = (~response=mockResponse): SvmHyperSyncClient.t => {

--- a/packages/envio-tests/test/helpers/IndexerRunner.res
+++ b/packages/envio-tests/test/helpers/IndexerRunner.res
@@ -395,12 +395,11 @@ let run = async (
             InternalTable.EnvioAddresses.makeGetRowsQuery(~pgSchema),
           ))->(Utils.magic: unknown => array<AddressRows.row>)
         }
-        let addresses = Core.getAddon().renderAddresses(
-          ~ecosystem=(config.ecosystem.name :> string),
-          ~shouldChecksum=!config.lowercaseAddresses,
-          ~bytes=NodeJs.Buffer.concat(rows->Array.map(row => row.address)),
-          ~lengths=rows->Array.map(row => row.address->NodeJs.Buffer.length),
-        )
+        let addresses =
+          rows->AddressRows.render(
+            ~ecosystem=(config.ecosystem.name :> string),
+            ~shouldChecksum=!config.lowercaseAddresses,
+          )
         rows->Array.mapWithIndex((row, idx): addressRow => {
           chainId: row.chainId->ChainId.normalizeOrThrow,
           address: addresses->Array.getUnsafe(idx),

--- a/packages/envio-tests/test/helpers/NativeDecoder.res
+++ b/packages/envio-tests/test/helpers/NativeDecoder.res
@@ -45,8 +45,7 @@ let decodeLogs = async (
       let addressStore = AddressStore.make(
         ~ecosystem=Ecosystem.Evm,
         ~shouldChecksum=false,
-        ~contracts=contractNames->Array.mapWithIndex((name, id): AddressStore.contract => {
-          id,
+        ~contracts=contractNames->Array.map((name): AddressStore.contract => {
           name,
           startBlock: None,
           dependsOnAddresses: true,

--- a/packages/envio-tests/test/lib_tests/AddressStore_test.res
+++ b/packages/envio-tests/test/lib_tests/AddressStore_test.res
@@ -155,24 +155,24 @@ describe("AddressStore", () => {
       ),
     }).toEqual({
       "noneThenSome": [
-        ({id: 0, name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract),
+        ({name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract),
       ],
       "someThenNone": [
-        ({id: 0, name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract),
+        ({name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract),
       ],
       "allRestricted": [
-        ({id: 0, name: "A", startBlock: Some(50), dependsOnAddresses: true}: AddressStore.contract),
+        ({name: "A", startBlock: Some(50), dependsOnAddresses: true}: AddressStore.contract),
       ],
       "perContract": [
-        ({id: 0, name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract),
-        ({id: 1, name: "B", startBlock: Some(50), dependsOnAddresses: true}: AddressStore.contract),
+        ({name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract),
+        ({name: "B", startBlock: Some(50), dependsOnAddresses: true}: AddressStore.contract),
       ],
       "configOnly": [
-        ({id: 0, name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract),
-        ({id: 1, name: "NoEvents", startBlock: None, dependsOnAddresses: false}: AddressStore.contract),
+        ({name: "A", startBlock: None, dependsOnAddresses: true}: AddressStore.contract),
+        ({name: "NoEvents", startBlock: None, dependsOnAddresses: false}: AddressStore.contract),
       ],
       "wildcardOnly": [
-        ({id: 0, name: "A", startBlock: None, dependsOnAddresses: false}: AddressStore.contract),
+        ({name: "A", startBlock: None, dependsOnAddresses: false}: AddressStore.contract),
       ],
     })
   })

--- a/packages/envio-tests/test/lib_tests/EnvioAddressesTable_test.res
+++ b/packages/envio-tests/test/lib_tests/EnvioAddressesTable_test.res
@@ -85,12 +85,7 @@ let storedRows = async (~pgSchema) => {
   let rows: array<AddressRows.row> = await sql->Postgres.unsafe(
     InternalTable.EnvioAddresses.makeGetRowsQuery(~pgSchema),
   )
-  let rendered = Core.getAddon().renderAddresses(
-    ~ecosystem="evm",
-    ~shouldChecksum=true,
-    ~bytes=NodeJs.Buffer.concat(rows->Array.map(row => row.address)),
-    ~lengths=rows->Array.map(row => row.address->NodeJs.Buffer.length),
-  )
+  let rendered = rows->AddressRows.render(~ecosystem="evm", ~shouldChecksum=true)
   rows->Array.mapWithIndex((row, idx) => (
     rendered->Array.getUnsafe(idx),
     contractMapping->ContractMapping.nameOfOrThrow(row.contractId),

--- a/packages/envio-tests/test/lib_tests/EvmRpcClient_test.res
+++ b/packages/envio-tests/test/lib_tests/EvmRpcClient_test.res
@@ -236,7 +236,7 @@ describe("EvmRpcClient - getNextPage via napi", () => {
     let store = AddressStore.make(
       ~ecosystem=Ecosystem.Evm,
       ~shouldChecksum=false,
-      ~contracts=[{id: 0, name: "ERC20", startBlock: None, dependsOnAddresses: true}],
+      ~contracts=[{name: "ERC20", startBlock: None, dependsOnAddresses: true}],
     )
     let _ = store->AddressStore.seedBatch([
       {

--- a/packages/envio/src/AddressRows.res
+++ b/packages/envio/src/AddressRows.res
@@ -69,12 +69,20 @@ let seedRowsOf = (rows: array<row>): seedRows => {
   }
 }
 
-// Groups stored rows per chain, keyed by the normalized chain id string.
+// Groups stored rows per chain, keyed by the normalized chain id string. Rows
+// arrive clustered per chain, so each run of one chain's rows normalizes its id
+// once — normalizing is a schema parse, and a resume reads millions of rows.
 let group = (rows: array<row>): dict<seedRows> => {
   let rowsByChain: dict<array<row>> = Dict.make()
-  rows->Array.forEach(row =>
-    rowsByChain->Utils.Dict.push(row.chainId->ChainId.normalizeOrThrow->ChainId.toString, row)
-  )
+  let runChainId = ref(None)
+  let runKey = ref("")
+  rows->Array.forEach(row => {
+    if runChainId.contents !== Some(row.chainId) {
+      runChainId := Some(row.chainId)
+      runKey := row.chainId->ChainId.normalizeOrThrow->ChainId.toString
+    }
+    rowsByChain->Utils.Dict.push(runKey.contents, row)
+  })
   rowsByChain->Utils.Dict.mapValues(seedRowsOf)
 }
 
@@ -89,8 +97,7 @@ module Table = {
 
   let make = (): t => Dict.make()
 
-  let clear = (table: t) =>
-    table->Dict.keysToArray->Array.forEach(key => table->Utils.Dict.deleteInPlace(key))
+  let clear = (table: t) => table->Utils.Dict.clearInPlace
 
   // Keeps the row already stored under the key, exactly as the write path's
   // ON CONFLICT DO NOTHING does — a replayed insert must not restate the

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -90,6 +90,20 @@ let configStorageRows = (
   })
 }
 
+// Seeds an in-memory address table with every chain's config-declared
+// addresses, the twin of what `PgStorage.initialize` writes in one insert.
+let seedConfigAddresses = (
+  table: AddressRows.Table.t,
+  ~chainConfigs: array<Config.chain>,
+  ~ecosystem: Ecosystem.name,
+  ~contractMapping: ContractMapping.t,
+) =>
+  chainConfigs->Array.forEach(chainConfig =>
+    table->AddressRows.Table.insertMany(
+      chainConfig->configStorageRows(~ecosystem, ~contractMapping),
+    )
+  )
+
 let validateOnEventRegistrations = (
   ~chainId: ChainId.t,
   registrations: array<Internal.onEventRegistration>,

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -9,6 +9,13 @@ let configStorageRows: (
   ~contractMapping: ContractMapping.t,
 ) => array<AddressRows.row>
 
+let seedConfigAddresses: (
+  AddressRows.Table.t,
+  ~chainConfigs: array<Config.chain>,
+  ~ecosystem: Ecosystem.name,
+  ~contractMapping: ContractMapping.t,
+) => unit
+
 let make: (
   ~chainConfig: Config.chain,
   ~fetchState: FetchState.t,

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -2931,7 +2931,6 @@ let rollback = (
     }
   }
 
-  // Recreate partitions from deleted partition addresses
   let optimizedPartitions = createPartitions(
     ~registeringSetsByContract,
     ~addressStore,
@@ -2945,7 +2944,6 @@ let rollback = (
     ~knownHeight=fetchState.knownHeight,
   )
 
-  // Step 4: Update state
   let rolledBack = {
     ...fetchState,
     // TODO: Test this. Currently it's not tested.

--- a/packages/envio/src/MemoryStorage.res
+++ b/packages/envio/src/MemoryStorage.res
@@ -134,11 +134,7 @@ let seedConfigAddresses = (
   // config's addresses on what a previous one left behind.
   state.addresses->AddressRows.Table.clear
   state.contractMapping = contractMapping
-  chainConfigs->Array.forEach(chainConfig =>
-    state.addresses->AddressRows.Table.insertMany(
-      chainConfig->ChainState.configStorageRows(~ecosystem, ~contractMapping),
-    )
-  )
+  state.addresses->ChainState.seedConfigAddresses(~chainConfigs, ~ecosystem, ~contractMapping)
 }
 
 let addressRowsByChain = (state: t) => state.addresses->AddressRows.Table.groupByChain
@@ -573,8 +569,7 @@ let toStorage = (state: t, ~config: Config.t): Persistence.storage => {
     ),
   dumpEffectCache: async () => (),
   reset: async () => {
-    let clear = dict =>
-      dict->Dict.keysToArray->Array.forEach(key => dict->Utils.Dict.deleteInPlace(key))
+    let clear = Utils.Dict.clearInPlace
     state.entities->clear
     state.history->clear
     state.chains->clear

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -687,16 +687,11 @@ let createTestIndexer = (): t<'processConfig> => {
     entityConfigs->Dict.set(entityConfig.name, entityConfig)
   })
 
-  // Populate the config's addresses, mirroring PgStorage.initialize
   let chainConfigs = config.chainMap->ChainMap.values
   let contractMapping = config.contractMapping
   let ecosystem = config.ecosystem.name
   let addresses = AddressRows.Table.make()
-  chainConfigs->Array.forEach(chainConfig =>
-    addresses->AddressRows.Table.insertMany(
-      chainConfig->ChainState.configStorageRows(~ecosystem, ~contractMapping),
-    )
-  )
+  addresses->ChainState.seedConfigAddresses(~chainConfigs, ~ecosystem, ~contractMapping)
 
   let state = {
     processInProgress: false,

--- a/packages/envio/src/Utils.res
+++ b/packages/envio/src/Utils.res
@@ -199,6 +199,13 @@ module Dict = {
     }
   `)
 
+  let clearInPlace: dict<'a> => unit = %raw(`(dict) => {
+      for (const key in dict) {
+        delete dict[key];
+      }
+    }
+  `)
+
   let unsafeDeleteUndefinedFieldsInPlace: 'a => unit = %raw(`(dict) => {
       for (var key in dict) {
         if (dict[key] === undefined) {

--- a/packages/envio/src/sources/AddressStore.res
+++ b/packages/envio/src/sources/AddressStore.res
@@ -13,10 +13,9 @@ type t
 // chain, since `context.chain.<Contract>.add` validates against that whole set
 // — a name outside it makes the store throw. `dependsOnAddresses` is whether
 // this chain fetches for the contract by address, which is what makes the store
-// able to answer `fetchable` on a verdict. `id` is the contract's canonical id,
-// and the list must be ordered by it: that id is what every persisted address
-// row names its contract by.
-type contract = {id: int, name: string, startBlock: option<int>, dependsOnAddresses: bool}
+// able to answer `fetchable` on a verdict. The list is in canonical id order: a
+// contract's position is what every persisted address row names it by.
+type contract = {name: string, startBlock: option<int>, dependsOnAddresses: bool}
 
 type registration = {
   address: Address.t,
@@ -138,8 +137,7 @@ let contractsOf = (
   })
   contractMapping
   ->ContractMapping.names
-  ->Array.mapWithIndex((name, id) => {
-    id,
+  ->Array.map(name => {
     name,
     startBlock: unrestricted->Utils.Set.has(name)
       ? None


### PR DESCRIPTION
## Summary

Unifies the emitter representation across EVM, Fuel, and SVM ecosystems by introducing a single `Emitter` struct in the address store that replaces ecosystem-specific types (`LogAddress`, `ReceiptAddress`, `InstructionAddress`). This eliminates duplication and centralizes the logic for matching registrations.

## Key Changes

- **New `Emitter` struct** in `address_store.rs`: Generic representation with `key`, `owners`, and `block` fields, replacing three ecosystem-specific types
- **Centralized registration matching**: Moved matching logic into `Emitter::matches_registration()` method, eliminating duplicated gate checks across ecosystems
- **Removed `AddressStoreContract.id` field**: The contract's position in the list now serves as its canonical id, eliminating redundancy and the need for validation that ids match positions
- **Updated all ecosystem sources** to use `Emitter`:
  - EVM: `evm_hypersync_source/decode.rs` and `evm_rpc_source/mod.rs`
  - Fuel: `fuel_hypersync_source/selection.rs` and `fuel_hypersync_source/mod.rs`
  - SVM: `svm_hypersync_source/selection.rs` and `svm_hypersync_source/mod.rs`
- **ReScript address rendering**: Extracted `AddressRows.render()` function to replace repeated calls to the native addon, improving code clarity
- **Performance optimization in `AddressRows.group()`**: Caches chain id normalization across rows in a run, avoiding redundant schema parses during resume operations
- **Utility improvements**: Added `Utils.Dict.clearInPlace` for efficient dictionary clearing

## Notable Implementation Details

- The `Emitter::matches_registration()` method encapsulates the complete gate logic: start block validation, ownership checks (with wildcard and client-filtered contract handling), and store indexing verification
- All test helpers updated to use the new `Emitter` struct with consistent field names (`block` instead of `block_number`/`block_height`/`slot`)
- The removal of `id` from `AddressStoreContract` simplifies the contract list invariant: contracts are implicitly ordered by their canonical id, which is their array position

https://claude.ai/code/session_016hfD2fTFJpChos1rBJzvNg