### PR TITLE
Strengthen ClickHouse data integrity and error handling

### DIFF
--- a/packages/cli/src/clickhouse/ch_type.rs
+++ b/packages/cli/src/clickhouse/ch_type.rs
@@ -10,6 +10,8 @@ use std::fmt;
 
 use anyhow::{bail, Result};
 
+use crate::config_parsing::system_config::ChainIdMode;
+
 /// How wide an `Enum` column's variant list can get before it needs two bytes.
 /// ClickHouse's `Enum8` spans -128..=127, but envio numbers from 1, so 127 is
 /// what a one-byte column holds.
@@ -80,25 +82,6 @@ pub fn decimal_bytes(precision: u32) -> Result<usize> {
         10..=18 => Ok(8),
         19..=MAX_DECIMAL_PRECISION => Ok(16),
         other => bail!("unsupported Decimal precision {other}"),
-    }
-}
-
-/// Whether the chain id column is an `Int32` or a `UInt64`, which the config
-/// picks and every chain-scoped table follows.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum ChainIdMode {
-    #[default]
-    Int32,
-    Int64,
-}
-
-impl ChainIdMode {
-    pub fn parse(mode: &str) -> Result<Self> {
-        match mode {
-            "Int32" => Ok(ChainIdMode::Int32),
-            "Int64" => Ok(ChainIdMode::Int64),
-            other => bail!("unknown chain id mode `{other}`"),
-        }
     }
 }
 

--- a/packages/cli/src/clickhouse/ddl.rs
+++ b/packages/cli/src/clickhouse/ddl.rs
@@ -12,8 +12,9 @@ use anyhow::{bail, Result};
 use napi_derive::napi;
 use regex::{Captures, Regex};
 
-use super::ch_type::{ChType, ChainIdMode, FieldSpec};
+use super::ch_type::{ChType, FieldSpec};
 use super::{literal, quoted};
+use crate::config_parsing::system_config::ChainIdMode;
 
 /// A column of an entity's history table: the name it goes by in ClickHouse,
 /// the schema field name that `@storage(clickhouse: {...})` expressions
@@ -460,6 +461,15 @@ pub(crate) mod test_support {
         }
     }
 
+    /// A replicated cluster on a plain database, where every statement carries
+    /// its own `ON CLUSTER` to reach the replicas.
+    pub fn replicated() -> Topology {
+        Topology {
+            replicated: true,
+            ddl_on_cluster: true,
+        }
+    }
+
     pub fn column(name: &str, field_type: &str) -> ColumnSpec {
         ColumnSpec {
             name: name.to_string(),
@@ -534,12 +544,8 @@ mod tests {
     #[test]
     fn a_replicated_table_carries_the_engine_cluster_and_dedup_settings() {
         let entity = entity("Account", vec![column("id", "String")]);
-        let topology = Topology {
-            replicated: true,
-            ddl_on_cluster: true,
-        };
         assert_eq!(
-            render(&entity, topology),
+            render(&entity, replicated()),
             "CREATE TABLE IF NOT EXISTS `test_db`.`envio_history_Account` ON CLUSTER '{cluster}' (\n  \
              `id` String,\n  \
              `envio_checkpoint_id` UInt64,\n  \
@@ -669,6 +675,23 @@ mod tests {
         );
     }
 
+    /// The checkpoints table is replicated on the same terms as the history
+    /// tables it covers: created on the connected node alone, a restart that
+    /// lands on another replica reads a checkpoint the rows there never had.
+    #[test]
+    fn a_replicated_checkpoints_table_carries_the_engine_cluster_and_dedup_settings() {
+        let columns = [column("id", "UInt64")];
+        assert_eq!(
+            create_checkpoints_table(&typed(&columns), "test_db", &history_schema(), replicated()),
+            "CREATE TABLE IF NOT EXISTS `test_db`.`envio_checkpoints` ON CLUSTER '{cluster}' (\n  \
+             `id` UInt64\n\
+             )\n\
+             ENGINE = ReplicatedMergeTree\n\
+             ORDER BY (`id`)\n\
+             SETTINGS replicated_deduplication_window = 0"
+        );
+    }
+
     #[test]
     fn creates_a_view_over_the_history_table() {
         let entity = entity(
@@ -687,6 +710,19 @@ mod tests {
              LIMIT 1 BY `id`\n\
              )\n\
              WHERE `envio_change` = 'SET'"
+        );
+    }
+
+    /// A view is metadata, so a replica that never ran the statement has no way
+    /// to answer a read of the entity at all.
+    #[test]
+    fn a_replicated_view_is_created_on_the_cluster() {
+        let entity = entity("Account", vec![column("id", "String")]);
+        assert_eq!(
+            create_view(&entity, "test_db", &history_schema(), replicated())
+                .lines()
+                .next(),
+            Some("CREATE VIEW IF NOT EXISTS `test_db`.`Account` ON CLUSTER '{cluster}' AS")
         );
     }
 

--- a/packages/cli/src/clickhouse/mock_server.rs
+++ b/packages/cli/src/clickhouse/mock_server.rs
@@ -10,10 +10,20 @@ use tokio::net::{TcpListener, TcpStream};
 
 use crate::mock_http;
 
+/// Answers a statement — the SQL arrives in the request body — with the status
+/// and body to send back.
+pub type StatementFn = dyn Fn(&str) -> (u16, String) + Send + Sync;
+
 #[derive(Default)]
 struct State {
     /// Bodies of the inserts the server accepted, in arrival order.
     accepted: Vec<Vec<u8>>,
+    /// How a statement — anything that is not an insert — is answered. `None`
+    /// refuses it, which is what a sink taking its column types from the caller
+    /// should never provoke.
+    statements: Option<Arc<StatementFn>>,
+    /// Statements the server was asked, in arrival order.
+    statements_seen: Vec<String>,
     /// Inserts still to be rejected before the server starts accepting.
     reject_next: usize,
     /// The body a rejection carries, which is what tells the sink whether the
@@ -53,14 +63,29 @@ impl MockClickHouse {
     /// of ClickHouse: a body with no `Code:` in it leaves the status as the only
     /// thing the sink can read the verdict from.
     pub async fn rejecting_with_status(reject_next: usize, status: u16, rejection: &str) -> Self {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let url = format!("http://{}", listener.local_addr().unwrap());
-        let state = Arc::new(Mutex::new(State {
+        Self::serving(State {
             reject_next,
             rejection: rejection.to_string(),
             rejection_status: status,
             ..Default::default()
-        }));
+        })
+        .await
+    }
+
+    /// Answers statements with `statements` rather than refusing them, for the
+    /// schema and recovery paths, which are made of them. Inserts are accepted.
+    pub async fn answering_statements(statements: Arc<StatementFn>) -> Self {
+        Self::serving(State {
+            statements: Some(statements),
+            ..Default::default()
+        })
+        .await
+    }
+
+    async fn serving(state: State) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let state = Arc::new(Mutex::new(state));
 
         let accept_state = state.clone();
         tokio::spawn(async move {
@@ -115,6 +140,11 @@ impl MockClickHouse {
     /// from the caller should stay at zero.
     pub fn queries_seen(&self) -> usize {
         self.state.lock().unwrap().queries
+    }
+
+    /// The statements the server was asked, in arrival order.
+    pub fn statements_seen(&self) -> Vec<String> {
+        self.state.lock().unwrap().statements_seen.clone()
     }
 
     /// Request line and headers of every request the server handled.
@@ -176,11 +206,20 @@ async fn serve(mut stream: TcpStream, state: Arc<Mutex<State>>) -> std::io::Resu
             };
             rejection.unwrap_or((200, String::new()))
         } else {
-            state.lock().unwrap().queries += 1;
-            (
-                400,
-                "the sink should not be querying the server".to_string(),
-            )
+            let statement = String::from_utf8_lossy(&request.body).to_string();
+            let answer = {
+                let mut state = state.lock().unwrap();
+                state.queries += 1;
+                state.statements_seen.push(statement.clone());
+                state.statements.clone()
+            };
+            match answer {
+                Some(answer) => answer(&statement),
+                None => (
+                    400,
+                    "the sink should not be querying the server".to_string(),
+                ),
+            }
         };
         mock_http::write_response(
             &mut stream,

--- a/packages/cli/src/clickhouse/mod.rs
+++ b/packages/cli/src/clickhouse/mod.rs
@@ -294,7 +294,8 @@ pub struct ClickHouseSinkOptions {
     pub username: String,
     pub password: String,
     pub database: String,
-    /// `"Int32"` or `"Int64"`, which every chain-scoped column follows.
+    /// `"int32"` or `"int64"` — the form the config serializes the mode in —
+    /// which every chain-scoped column follows.
     pub chain_id_mode: String,
     /// The column and table names the runtime's history format fixes.
     pub history: ddl::HistorySchema,

--- a/packages/cli/src/clickhouse/mod.rs
+++ b/packages/cli/src/clickhouse/mod.rs
@@ -42,7 +42,8 @@ use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi::{Env, Status};
 use napi_derive::napi;
 
-use ch_type::{ChType, ChainIdMode, ColumnKind, FieldSpec};
+use crate::config_parsing::system_config::ChainIdMode;
+use ch_type::{ChType, ColumnKind, FieldSpec};
 use row_binary::{Column, ColumnValues, EncodedRows};
 
 /// Retries an insert this many times before giving up, as the JS client did.
@@ -625,16 +626,8 @@ impl ClickHouseSink {
 
         if let Some(engine_spec) = &database_engine {
             let expected = ddl::database_engine_name(engine_spec);
-            let existing = self
-                .post_statement(format!(
-                    "SELECT engine FROM system.databases WHERE name = {} \
-                     FORMAT TabSeparated",
-                    literal(&self.database)
-                ))
-                .await?;
-            match existing.trim() {
-                "" => {}
-                engine if engine != expected => bail!(
+            match self.existing_database_engine().await?.as_deref() {
+                Some(engine) if engine != expected => bail!(
                     "ClickHouse database \"{}\" exists with engine \"{engine}\" but \
                      ENVIO_CLICKHOUSE_DATABASE_ENGINE specifies \"{expected}\" (from \
                      \"{engine_spec}\"). Drop the database manually to change its engine.",
@@ -729,23 +722,39 @@ impl ClickHouseSink {
         Ok(())
     }
 
+    /// The engine of the storage database, or `None` when there is no such
+    /// database. A server that cannot be reached is neither: that fails.
+    async fn existing_database_engine(&self) -> Result<Option<String>> {
+        let answer = self
+            .post_statement(format!(
+                "SELECT engine FROM system.databases WHERE name = {} FORMAT TabSeparated",
+                literal(&self.database)
+            ))
+            .await?;
+        Ok(match answer.trim() {
+            "" => None,
+            engine => Some(engine.to_string()),
+        })
+    }
+
     async fn resume_inner(&self, checkpoint_id: &str) -> Result<()> {
         // Interpolated into every statement below, so it has to be the number it
         // claims to be rather than trusted for being internal.
         if checkpoint_id.is_empty() || !checkpoint_id.bytes().all(|b| b.is_ascii_digit()) {
             bail!("`{checkpoint_id}` is not a checkpoint id");
         }
-        let database_ident = quoted(&self.database);
-        self.post_statement(format!("USE {database_ident}"))
-            .await
-            .with_context(|| {
-                format!(
-                    "ClickHouse storage database \"{}\" not found. Please run \
-                     'envio start -r' to reinitialize the indexer (it'll also drop Postgres \
-                     database).",
-                    self.database
-                )
-            })?;
+        // Asked of `system.databases` rather than by running `USE`, whose
+        // failure is the same whether the database is gone or the server is
+        // briefly unreachable. Only the first is answered by reinitializing,
+        // and that answer drops the Postgres database with it.
+        if self.existing_database_engine().await?.is_none() {
+            bail!(
+                "ClickHouse storage database \"{}\" not found. Please run \
+                 'envio start -r' to reinitialize the indexer (it'll also drop Postgres \
+                 database).",
+                self.database
+            );
+        }
 
         // `startsWith` rather than `LIKE`: the prefix holds underscores, which
         // LIKE reads as single-character wildcards. TabSeparated answers one
@@ -879,8 +888,12 @@ impl ClickHouseSink {
         if encoded.rows() == 0 {
             return Ok(());
         }
+        // Named here rather than left to the server's message: a batch inserts
+        // every entity's table at once, and what comes back — a proxy's status,
+        // a timeout — need not mention the table it answered for.
         self.insert_with_retry(&schema.table, &schema.insert_query, &encoded)
             .await
+            .with_context(|| format!("Failed inserting into ClickHouse table `{}`", schema.table))
     }
 
     /// Sends the batch, retrying what fails. What goes back depends on the
@@ -1106,7 +1119,7 @@ mod tests {
             username: "default".to_string(),
             password: String::new(),
             database: "mock".to_string(),
-            chain_id_mode: "Int32".to_string(),
+            chain_id_mode: "int32".to_string(),
             history: ddl::HistorySchema {
                 id_column: "id".to_string(),
                 checkpoint_id_column: "envio_checkpoint_id".to_string(),
@@ -1167,6 +1180,133 @@ mod tests {
         assert_eq!(
             err.reason,
             "Column `t` of ClickHouse table `envio_checkpoints`: unsupported field type `Tuple`"
+        );
+    }
+
+    /// Answers the statements `resume` runs: the existence probe with `engine`
+    /// — empty for a database that is not there — and the table listing with
+    /// `tables`. Everything past those is a trim, which answers with nothing.
+    fn resume_answers(engine: &str, tables: &[&str]) -> Arc<mock_server::StatementFn> {
+        let engine = engine.to_string();
+        let tables = tables.join("\n");
+        Arc::new(move |statement: &str| {
+            if statement.contains("system.databases") {
+                (200, engine.clone())
+            } else if statement.contains("system.tables") {
+                (200, tables.clone())
+            } else {
+                (200, String::new())
+            }
+        })
+    }
+
+    /// A ClickHouse that cannot be reached is not a ClickHouse whose database is
+    /// gone. Only the second is answered by reinitializing, and that answer
+    /// drops the Postgres database with it — so an outage must not print it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_resume_that_cannot_reach_the_server_does_not_report_a_missing_database() {
+        let unreachable = ClickHouseSink::build(
+            options("http://127.0.0.1:1".to_string()),
+            Tuning::default(),
+            Arc::new(|_: &str| {}),
+        )
+        .unwrap();
+
+        let err = unreachable.resume("42".to_string()).await.unwrap_err();
+
+        assert_eq!(
+            (
+                err.reason.contains("start -r"),
+                err.reason.contains("ClickHouse request failed"),
+            ),
+            (false, true),
+            "got: {}",
+            err.reason
+        );
+    }
+
+    /// The same for a server that answers, but through something that is not
+    /// ClickHouse: a proxy's own error says nothing about the database.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_resume_a_proxy_refuses_does_not_report_a_missing_database() {
+        let server = mock_server::MockClickHouse::answering_statements(Arc::new(|_: &str| {
+            (502, "upstream connect error".to_string())
+        }))
+        .await;
+        let sink = sink_for(&server, 4);
+
+        let err = sink.resume("42".to_string()).await.unwrap_err();
+
+        assert_eq!(
+            (
+                err.reason.contains("start -r"),
+                err.reason.contains("upstream connect error"),
+            ),
+            (false, true),
+            "got: {}",
+            err.reason
+        );
+    }
+
+    /// A database that really is gone is the one case the advice fits.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_resume_against_a_database_that_is_gone_says_how_to_reinitialize() {
+        let server =
+            mock_server::MockClickHouse::answering_statements(resume_answers("", &[])).await;
+        let sink = sink_for(&server, 4);
+
+        let err = sink.resume("42".to_string()).await.unwrap_err();
+
+        assert_eq!(
+            (
+                err.reason.contains("start -r"),
+                err.reason.contains("\"mock\" not found"),
+            ),
+            (true, true),
+            "got: {}",
+            err.reason
+        );
+    }
+
+    /// The trim itself: every history table the prefix matches, then the
+    /// checkpoints those rows belonged to.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_resume_trims_every_history_table_and_then_the_checkpoints() {
+        let server = mock_server::MockClickHouse::answering_statements(resume_answers(
+            "Atomic",
+            &["envio_history_a", "envio_history_b"],
+        ))
+        .await;
+        let sink = sink_for(&server, 4);
+
+        sink.resume("42".to_string()).await.unwrap();
+
+        let mut trims: Vec<String> = server
+            .statements_seen()
+            .into_iter()
+            .filter(|statement| statement.starts_with("ALTER") || statement.starts_with("DELETE"))
+            .collect();
+        // The history tables are trimmed concurrently, so only the checkpoints
+        // coming last is an ordering the test can hold to.
+        let checkpoints = trims.pop();
+        trims.sort();
+        assert_eq!(
+            (trims, checkpoints),
+            (
+                vec![
+                    "ALTER TABLE `mock`.`envio_history_a` DELETE WHERE `envio_checkpoint_id` > 42 \
+                     SETTINGS mutations_sync = 2"
+                        .to_string(),
+                    "ALTER TABLE `mock`.`envio_history_b` DELETE WHERE `envio_checkpoint_id` > 42 \
+                     SETTINGS mutations_sync = 2"
+                        .to_string(),
+                ],
+                Some(
+                    "DELETE FROM `mock`.`envio_checkpoints` WHERE `id` > 42 \
+                     SETTINGS mutations_sync = 2"
+                        .to_string()
+                )
+            )
         );
     }
 
@@ -1245,12 +1385,15 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(
-            err.reason.contains("Unknown staged ClickHouse batch"),
+        assert_eq!(
+            (
+                err.reason.contains("Unknown staged ClickHouse batch"),
+                sink.staged.lock().unwrap().len()
+            ),
+            (true, 0),
             "expected an unknown-handle error, got: {}",
             err.reason
         );
-        assert_eq!(sink.staged.lock().unwrap().len(), 0);
     }
 
     // A rejected insert is replaced by its two halves, so the rows in the half
@@ -1415,10 +1558,13 @@ mod tests {
         assert_eq!(
             (
                 err.reason.contains("mock rejection"),
+                // A batch writes every entity's table at once, so the server's
+                // message is only actionable beside the table it answered for.
+                err.reason.contains("envio_checkpoints"),
                 server.accepted_strings()
             ),
-            (true, Vec::<String>::new()),
-            "expected the server's message, got: {}",
+            (true, true, Vec::<String>::new()),
+            "expected the server's message and the table, got: {}",
             err.reason
         );
     }

--- a/packages/cli/src/clickhouse/row_binary.rs
+++ b/packages/cli/src/clickhouse/row_binary.rs
@@ -208,9 +208,8 @@ const POW10: [i128; 39] = {
 
 /// What the column accepts. RowBinary is just the raw integer, so nothing on the
 /// server side rejects an out-of-range value: it wraps into whatever the bytes
-/// happen to mean. The JSONEachRow path this replaced had ClickHouse do the
-/// check, so the encoder has to do it here or an `Int!` set to 3e9 lands as a
-/// negative number.
+/// happen to mean. Checking here is the only check there is — without it an
+/// `Int!` set to 3e9 lands as a negative number.
 fn int_bounds(ch_type: &ChType) -> Result<(i128, i128)> {
     Ok(match ch_type {
         ChType::Int32 => (i32::MIN as i128, i32::MAX as i128),
@@ -226,13 +225,10 @@ fn int_bounds(ch_type: &ChType) -> Result<(i128, i128)> {
                 .context("Decimal precision is wider than the value the encoder carries")?;
             (1 - limit, limit - 1)
         }
-        ChType::Enum { variants } => {
-            if ChType::enum_bytes(variants) == 1 {
-                (i8::MIN as i128, i8::MAX as i128)
-            } else {
-                (i16::MIN as i128, i16::MAX as i128)
-            }
-        }
+        // The variants the column declares, not the width they are stored in:
+        // ClickHouse fails a read of a discriminant no variant uses, so one
+        // that fits the byte is no more storable than one that does not.
+        ChType::Enum { variants } => (1, variants.len() as i128),
         other => bail!("{other:?} is not an integer column"),
     })
 }
@@ -316,10 +312,8 @@ fn encode_json_value(out: &mut Vec<u8>, ch_type: &ChType, value: &serde_json::Va
         }
         (ChType::String, Value::String(text)) => put_string(out, text),
         // A String column holds whatever text it is given, and a `[Json!]!`
-        // field's elements are arbitrary JSON. ClickHouse folded these into the
-        // column itself on the JSONEachRow path (its
-        // `input_format_json_read_*_as_strings` defaults), so rendering them
-        // here keeps a schema that used to index from failing to encode.
+        // field's elements are arbitrary JSON — an object or a number is a value
+        // the schema allows there, so it is rendered rather than refused.
         (ChType::String, _) => put_string(out, &value.to_string()),
         (ChType::Enum { .. } | ChType::Decimal { .. }, Value::String(text)) => {
             encode_text_scalar(out, ch_type, text)?
@@ -340,6 +334,13 @@ fn encode_json_value(out: &mut Vec<u8>, ch_type: &ChType, value: &serde_json::Va
                 None => decimal_to_i128(&number.to_string(), *scale)?,
             };
             put_int(out, scaled, ch_type)?
+        }
+        // An enum element names its variant. A bare number is the stored
+        // discriminant instead, which is not what any producer here sends and
+        // not something this can check the column's variants against — the
+        // arm below would take it for an integer column's value.
+        (ChType::Enum { .. }, _) => {
+            bail!("`{value}` is not a value a {ch_type:?} element can hold")
         }
         // The integer columns, whose elements JSON carries natively. Feeding the
         // number straight in keeps the encode loop off a render-to-text and
@@ -363,9 +364,9 @@ fn fixed_width(ch_type: &ChType) -> Result<usize> {
     })
 }
 
-/// Writes the type's zero value — what ClickHouse would substitute for a column
-/// omitted from a JSONEachRow row. A DELETE change carries only its id and
-/// checkpoint, so every other column takes this path.
+/// Writes the type's zero value, which is what a column the row leaves out
+/// stores. A DELETE change carries only its id and checkpoint, so every other
+/// column takes this path.
 fn put_default(out: &mut Vec<u8>, ch_type: &ChType) -> Result<()> {
     match ch_type {
         ChType::Nullable(_) => out.push(1),
@@ -401,7 +402,18 @@ fn encode_cell(out: &mut Vec<u8>, column: &Column, row: usize) -> Result<()> {
     }
 
     match (&column.values, ch_type) {
-        (ColumnValues::F64(v), ChType::Float64) => out.extend_from_slice(&v[row].to_le_bytes()),
+        (ColumnValues::F64(v), ChType::Float64) => {
+            let value = v[row];
+            // The one column whose bytes NaN and Infinity would go into
+            // unchanged. ClickHouse stores them, and from then on an aggregate
+            // over the column is NaN and a JSON-format read has no form to
+            // render it in — so the value a handler never meant to write would
+            // be the one nothing downstream can get rid of.
+            if !value.is_finite() {
+                bail!("{value} is not a value a Float64 column can hold");
+            }
+            out.extend_from_slice(&value.to_le_bytes())
+        }
         (ColumnValues::F64(v), other) => {
             let value = v[row];
             // A non-integral float would truncate silently; the column has no
@@ -468,8 +480,8 @@ pub fn encode(columns: &[Column], rows: usize) -> Result<EncodedRows> {
             );
         }
     }
-    // Two thirds of the JSONEachRow size is a good enough first guess; growing
-    // once beats re-allocating per row.
+    // A rough average cell width: overshooting wastes a little memory for the
+    // length of one batch, while undershooting re-allocates as rows are written.
     let mut body = Vec::with_capacity(rows * columns.len() * 12);
     let mut row_offsets = Vec::with_capacity(rows);
     for row in 0..rows {
@@ -647,6 +659,58 @@ mod tests {
         assert!(format!("{err:#}").contains("not a variant"));
     }
 
+    // An enum element names its variant, the same as a scalar enum does. A bare
+    // number is the stored discriminant instead, which nothing here can check
+    // against the variants the column declares — and RowBinary carries whatever
+    // it is given, so a number no variant uses would land in the column and
+    // fail every read of the table afterwards.
+    #[test]
+    fn rejects_an_enum_element_given_as_a_number() {
+        let err = encode(
+            &[text_column(
+                "kinds",
+                "Array(Enum8('SET' = 1, 'DELETE' = 2))",
+                &["[1]"],
+            )],
+            1,
+        )
+        .unwrap_err();
+        assert_eq!(
+            format!("{err:#}"),
+            "encoding column `kinds` row 0: `1` is not a value a Enum { variants: [\"SET\", \
+             \"DELETE\"] } element can hold"
+        );
+    }
+
+    #[test]
+    fn encodes_an_enum_element_that_names_its_variant() {
+        let encoded = encode(
+            &[text_column(
+                "kinds",
+                "Array(Enum8('SET' = 1, 'DELETE' = 2))",
+                &["[\"DELETE\",\"SET\"]"],
+            )],
+            1,
+        )
+        .unwrap();
+        assert_eq!(encoded.body, vec![2, 2, 1]);
+    }
+
+    // The bound an enum column accepts is the variants it declares, not the
+    // width they are stored in: ClickHouse rejects reads of a discriminant no
+    // variant uses, so 0 and 3 are as unstorable here as 300 is.
+    #[test]
+    fn rejects_a_discriminant_no_enum_variant_uses() {
+        let ch_type = ChType::Enum {
+            variants: vec!["SET".to_string(), "DELETE".to_string()],
+        };
+        let refused: Vec<bool> = [0i128, 1, 2, 3]
+            .into_iter()
+            .map(|value| put_int(&mut Vec::new(), value, &ch_type).is_err())
+            .collect();
+        assert_eq!(refused, vec![true, false, false, true]);
+    }
+
     #[test]
     fn encodes_nullable_with_a_leading_flag() {
         let mut column = text_column("s", "Nullable(String)", &["", "ab"]);
@@ -711,10 +775,42 @@ mod tests {
         );
     }
 
+    // A Float64 column is the one place the bytes for NaN and Infinity would go
+    // in unchanged, and ClickHouse stores them: an aggregate over the column is
+    // NaN from then on, and a JSON-format read has no form to render them in.
+    // The same value inside an `Array(Float64)` is refused, so the scalar column
+    // cannot be the one that quietly takes it.
+    #[test]
+    fn rejects_a_non_finite_float_for_a_float_column() {
+        let refused: Vec<String> = [f64::NAN, f64::INFINITY, f64::NEG_INFINITY]
+            .into_iter()
+            .map(|value| {
+                let err = encode(&[f64_column("latest", "Float64", &[value])], 1).unwrap_err();
+                format!("{err:#}")
+            })
+            .collect();
+        assert_eq!(
+            refused,
+            vec![
+                "encoding column `latest` row 0: NaN is not a value a Float64 column can hold"
+                    .to_string(),
+                "encoding column `latest` row 0: inf is not a value a Float64 column can hold"
+                    .to_string(),
+                "encoding column `latest` row 0: -inf is not a value a Float64 column can hold"
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn encodes_a_finite_float() {
+        let encoded = encode(&[f64_column("latest", "Float64", &[1.5])], 1).unwrap();
+        assert_eq!(encoded.body, 1.5f64.to_le_bytes().to_vec());
+    }
+
     // A `[Json!]!` field maps to Array(String), and its elements are whatever
-    // the handler put there. The JSONEachRow path this replaced had ClickHouse
-    // fold a non-string element into the column's text, so a schema that
-    // indexed fine before must not start failing to encode.
+    // the handler put there — so a non-string element is a schema the encoder
+    // has to keep taking, not a mistake to refuse.
     #[test]
     fn a_json_element_of_a_string_array_is_stored_as_its_text() {
         let encoded = encode(
@@ -894,8 +990,7 @@ mod tests {
     }
 
     // RowBinary is the raw integer, so nothing downstream notices a value that
-    // does not fit — it silently becomes a different number. These are the cases
-    // ClickHouse itself used to reject on the JSONEachRow path.
+    // does not fit — it silently becomes a different number.
     #[test]
     fn rejects_an_integer_wider_than_its_column() {
         let too_big = encode(&[f64_column("n", "Int32", &[3e9])], 1).unwrap_err();

--- a/packages/cli/src/clickhouse/row_binary.rs
+++ b/packages/cli/src/clickhouse/row_binary.rs
@@ -227,8 +227,17 @@ fn int_bounds(ch_type: &ChType) -> Result<(i128, i128)> {
         }
         // The variants the column declares, not the width they are stored in:
         // ClickHouse fails a read of a discriminant no variant uses, so one
-        // that fits the byte is no more storable than one that does not.
-        ChType::Enum { variants } => (1, variants.len() as i128),
+        // that fits the byte is no more storable than one that does not. The
+        // width still caps it — an enum with more variants than its widest
+        // discriminant can hold has no column that could store them all.
+        ChType::Enum { variants } => {
+            let width_max = if ChType::enum_bytes(variants) == 1 {
+                i8::MAX as i128
+            } else {
+                i16::MAX as i128
+            };
+            (1, (variants.len() as i128).min(width_max))
+        }
         other => bail!("{other:?} is not an integer column"),
     })
 }
@@ -410,7 +419,10 @@ fn encode_cell(out: &mut Vec<u8>, column: &Column, row: usize) -> Result<()> {
             // render it in — so the value a handler never meant to write would
             // be the one nothing downstream can get rid of.
             if !value.is_finite() {
-                bail!("{value} is not a value a Float64 column can hold");
+                bail!(
+                    "{value} is not a value a Float64 column can hold. Store a finite number, \
+                     or keep it out of the entity."
+                );
             }
             out.extend_from_slice(&value.to_le_bytes())
         }
@@ -711,6 +723,23 @@ mod tests {
         assert_eq!(refused, vec![true, false, false, true]);
     }
 
+    // Nothing caps how many variants an enum column is declared with, and past
+    // the widest discriminant its storage holds there is no column that could
+    // keep them apart — writing one would truncate to a different variant.
+    #[test]
+    fn rejects_an_enum_discriminant_wider_than_its_storage() {
+        let ch_type = ChType::Enum {
+            variants: (0..=i16::MAX as usize + 1)
+                .map(|index| index.to_string())
+                .collect(),
+        };
+        let refused: Vec<bool> = [1i128, i16::MAX as i128, i16::MAX as i128 + 1]
+            .into_iter()
+            .map(|value| put_int(&mut Vec::new(), value, &ch_type).is_err())
+            .collect();
+        assert_eq!(refused, vec![false, false, true]);
+    }
+
     #[test]
     fn encodes_nullable_with_a_leading_flag() {
         let mut column = text_column("s", "Nullable(String)", &["", "ab"]);
@@ -791,14 +820,12 @@ mod tests {
             .collect();
         assert_eq!(
             refused,
-            vec![
-                "encoding column `latest` row 0: NaN is not a value a Float64 column can hold"
-                    .to_string(),
-                "encoding column `latest` row 0: inf is not a value a Float64 column can hold"
-                    .to_string(),
-                "encoding column `latest` row 0: -inf is not a value a Float64 column can hold"
-                    .to_string(),
-            ]
+            ["NaN", "inf", "-inf"]
+                .map(|value| format!(
+                    "encoding column `latest` row 0: {value} is not a value a Float64 column can \
+                     hold. Store a finite number, or keep it out of the entity."
+                ))
+                .to_vec()
         );
     }
 

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -304,7 +304,7 @@ pub fn get_envio_version(envio_package_dir: Option<&str>) -> Result<String> {
 /// maximum active chain id and carried through the public config, so a resume
 /// against a schema built for the other mode is rejected rather than silently
 /// truncating ids.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ChainIdMode {
     Int32,
@@ -333,6 +333,14 @@ impl ChainIdMode {
         } else {
             Self::Int64
         })
+    }
+
+    /// Reads the mode back out of the form it is serialized in, which is how it
+    /// reaches the ClickHouse sink: through the generated config and the JS
+    /// runtime, both of which carry it as that string.
+    pub fn parse(mode: &str) -> Result<Self> {
+        serde_json::from_value(serde_json::Value::String(mode.to_string()))
+            .with_context(|| format!("unknown chain id mode `{mode}`"))
     }
 }
 

--- a/packages/envio-tests/test/ScenarioClickHouseMissing_test.res
+++ b/packages/envio-tests/test/ScenarioClickHouseMissing_test.res
@@ -50,22 +50,12 @@ type counted = {id: string, amount?: int, label?: string}
 type countedOps = {set: counted => unit}
 type handlerContext = {@as("Counted") counted: countedOps}
 
-let refusal: ref<option<ErrorHandling.t>> = ref(None)
-
-let rec awaitRefusal = async ticks =>
-  switch refusal.contents {
-  | Some(_) as seen => seen
-  | None if ticks > 0 =>
-    await Utils.delay(10)
-    await awaitRefusal(ticks - 1)
-  | None => None
-  }
-
 describe("ClickHouse refuses a required column the handler left unset", () => {
+  let refusal = Scenario.captureRefusal()
   scenario->Scenario.it(
     "fails the write instead of storing the type's zero",
     ~sources=[{chain: 1}],
-    ~onError=errHandler => refusal := Some(errHandler),
+    ~onError=refusal.onError,
     async (~t, ~indexer as _, ~source) => {
       let source = source(1)
       await Utils.delay(0)
@@ -89,14 +79,7 @@ describe("ClickHouse refuses a required column the handler left unset", () => {
         ~latestFetchedBlockNumber=10,
       )
 
-      let failure = switch await awaitRefusal(1000) {
-      | Some({exn: Persistence.StorageError({message, reason})}) =>
-        Some((
-          message,
-          (reason->Utils.prettifyExn->(Utils.magic: exn => {"message": string}))["message"],
-        ))
-      | _ => None
-      }
+      let failure = await refusal.awaitStorageError()
 
       let database = TestClickHouse.currentDatabase()
       let stored = await TestClickHouse.query(

--- a/packages/envio-tests/test/ScenarioClickHouseNaN_test.res
+++ b/packages/envio-tests/test/ScenarioClickHouseNaN_test.res
@@ -46,22 +46,20 @@ type readings = {id: string, samples: array<float>, latest: float}
 type readingsOps = {set: readings => unit}
 type handlerContext = {@as("Readings") readings: readingsOps}
 
-let refusal: ref<option<ErrorHandling.t>> = ref(None)
-
-let rec awaitRefusal = async ticks =>
-  switch refusal.contents {
-  | Some(_) as seen => seen
-  | None if ticks > 0 =>
-    await Utils.delay(10)
-    await awaitRefusal(ticks - 1)
-  | None => None
-  }
+let storedReadings = async () => {
+  let database = TestClickHouse.currentDatabase()
+  let stored = await TestClickHouse.query(
+    `SELECT count() FROM \`${database}\`.\`Readings\` FORMAT TabSeparated`,
+  )
+  stored->String.trim
+}
 
 describe("ClickHouse refuses a float that has no JSON form", () => {
+  let refusal = Scenario.captureRefusal()
   scenario->Scenario.it(
     "names NaN rather than the null it serializes to",
     ~sources=[{chain: 1}],
-    ~onError=errHandler => refusal := Some(errHandler),
+    ~onError=refusal.onError,
     async (~t, ~indexer as _, ~source) => {
       let source = source(1)
       await Utils.delay(0)
@@ -83,24 +81,12 @@ describe("ClickHouse refuses a float that has no JSON form", () => {
         ~latestFetchedBlockNumber=10,
       )
 
-      let failure = switch await awaitRefusal(1000) {
-      | Some({exn: Persistence.StorageError({message, reason})}) =>
-        Some((
-          message,
-          (reason->Utils.prettifyExn->(Utils.magic: exn => {"message": string}))["message"],
-        ))
-      | _ => None
-      }
-
-      let database = TestClickHouse.currentDatabase()
-      let stored = await TestClickHouse.query(
-        `SELECT count() FROM \`${database}\`.\`Readings\` FORMAT TabSeparated`,
-      )
+      let failure = await refusal.awaitStorageError()
 
       t.expect((
         failure->Option.map(((message, _)) => message),
         failure->Option.map(((_, reason)) => reason),
-        stored->String.trim,
+        await storedReadings(),
       )).toEqual((
         Some("Failed to convert items for ClickHouse table \"envio_history_Readings\""),
         Some(
@@ -108,6 +94,51 @@ describe("ClickHouse refuses a float that has no JSON form", () => {
         ),
         "0",
       ))
+    },
+  )
+})
+
+// A Float64 column takes the raw bytes, so nothing on the way rejects the two
+// values the array path above refuses — ClickHouse stores them, and from then on
+// an aggregate over the column is NaN and a JSON read has no form for it.
+describe("ClickHouse refuses a non-finite float in a scalar column", () => {
+  let refusal = Scenario.captureRefusal()
+  scenario->Scenario.it(
+    "fails the write instead of storing a value no reader can render",
+    ~sources=[{chain: 1}],
+    ~onError=refusal.onError,
+    async (~t, ~indexer as _, ~source) => {
+      let source = source(1)
+      await Utils.delay(0)
+      source.resolveGetHeightOrThrow(10)
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      source.resolveGetItemsOrThrow(
+        [
+          {
+            blockNumber: 5,
+            logIndex: 0,
+            handler: async args => {
+              let context = args.context->(Utils.magic: Internal.handlerContext => handlerContext)
+              context.readings.set({id: "nan", samples: [1.5], latest: %raw(`Infinity`)})
+            },
+          },
+        ],
+        ~latestFetchedBlockNumber=10,
+      )
+
+      let failure = await refusal.awaitStorageError()
+
+      t.expect((
+        failure->Option.map(((message, _)) => message),
+        failure->Option.mapOr(false, ((_, reason)) => reason->String.includes("`latest`")),
+        failure->Option.mapOr(
+          false,
+          ((_, reason)) => reason->String.includes("not a value a Float64 column can hold"),
+        ),
+        await storedReadings(),
+      )).toEqual((Some("Failed to write a batch to ClickHouse"), true, true, "0"))
     },
   )
 })

--- a/packages/envio-tests/test/ScenarioClickHousePerChain_test.res
+++ b/packages/envio-tests/test/ScenarioClickHousePerChain_test.res
@@ -9,6 +9,15 @@ let scenario = Scenario.make(
   ~configYaml=`
 name: clickhouse-per-chain
 disable_default_cross_chain: true
+# The chain id column is renamed by the format, so the constant has to reach
+# the column the table actually declares rather than the field's own name.
+storage:
+  postgres:
+    default: true
+    column_name_format: original
+  clickhouse:
+    default: true
+    column_name_format: snake_case
 contracts:
   - name: Token
     events:
@@ -78,11 +87,11 @@ describe("Scenario ClickHouse per-chain entity", () => {
       // The history table rather than the view: the chain id is what the view
       // dedups on, not a column it selects.
       let rows = await TestClickHouse.query(
-        `SELECT id, count, chainId FROM \`${database}\`.\`envio_history_Counter\` ORDER BY chainId FORMAT JSONEachRow`,
+        `SELECT id, count, chain_id FROM \`${database}\`.\`envio_history_Counter\` ORDER BY chain_id FORMAT JSONEachRow`,
       )
       t.expect(
         rows->String.trim,
-      ).toEqual(`{"id":"total","count":"42","chainId":1}\n{"id":"total","count":"7","chainId":137}`)
+      ).toEqual(`{"id":"total","count":"42","chain_id":1}\n{"id":"total","count":"7","chain_id":137}`)
     },
   )
 })

--- a/packages/envio-tests/test/ScenarioClickHousePerChain_test.res
+++ b/packages/envio-tests/test/ScenarioClickHousePerChain_test.res
@@ -1,0 +1,88 @@
+open Vitest
+
+// A per-chain entity's chain id is the scope's rather than the entity's: the
+// handler never sets it, and two chains writing the same id are two rows that
+// only the chain id tells apart. Nothing else asserts on the column, so a write
+// path that dropped it or filled it from the wrong scope would land silently.
+
+let scenario = Scenario.make(
+  ~configYaml=`
+name: clickhouse-per-chain
+disable_default_cross_chain: true
+contracts:
+  - name: Token
+    events:
+      - event: Transfer(address indexed from, address indexed to, uint256 value)
+chains:
+  - id: 1
+    rpc:
+      url: https://rpc.example.test
+      for: sync
+    start_block: 0
+    contracts:
+      - name: Token
+        address: "0x0000000000000000000000000000000000000001"
+  - id: 137
+    rpc:
+      url: https://rpc137.example.test
+      for: sync
+    start_block: 0
+    contracts:
+      - name: Token
+        address: "0x0000000000000000000000000000000000000002"
+`,
+  ~schema=`
+type Counter {
+  id: ID!
+  count: BigInt!
+}
+`,
+  ~unsupported=[
+    {backend: #memory, reason: "asserts against a ClickHouse server"},
+    {backend: #postgres, reason: "asserts against a ClickHouse server"},
+  ],
+)
+
+type counter = {id: string, count: bigint}
+type counterOps = {set: counter => unit}
+type counterContext = {@as("Counter") counter: counterOps}
+
+let setCounter = (~count) => {
+  MockSource.blockNumber: 5,
+  logIndex: 0,
+  handler: async args => {
+    let context = args.context->(Utils.magic: Internal.handlerContext => counterContext)
+    context.counter.set({id: "total", count})
+  },
+}
+
+describe("Scenario ClickHouse per-chain entity", () => {
+  scenario->Scenario.it(
+    "stamps each row with the chain that wrote it",
+    ~sources=[{chain: 1}, {chain: 137}],
+    async (~t, ~indexer, ~source) => {
+      let chain1 = source(1)
+      let chain137 = source(137)
+
+      await Utils.delay(0)
+      chain1.resolveGetHeightOrThrow(10)
+      chain137.resolveGetHeightOrThrow(10)
+
+      await MockSource.waitItemsQuery(chain1)
+      chain1.resolveGetItemsOrThrow([setCounter(~count=42n)], ~latestFetchedBlockNumber=10)
+      await MockSource.waitItemsQuery(chain137)
+      chain137.resolveGetItemsOrThrow([setCounter(~count=7n)], ~latestFetchedBlockNumber=10)
+      await indexer.waitUntilReady()
+
+      let database = TestClickHouse.currentDatabase()
+      // The history table rather than the view: the chain id is what the view
+      // dedups on, not a column it selects.
+      let rows = await TestClickHouse.query(
+        `SELECT id, count, chainId FROM \`${database}\`.\`envio_history_Counter\` ORDER BY chainId FORMAT JSONEachRow`,
+      )
+      t.expect(
+        rows->String.trim,
+      ).toEqual(`{"id":"total","count":"42","chainId":1}\n{"id":"total","count":"7","chainId":137}`)
+    },
+  )
+})

--- a/packages/envio-tests/test/ScenarioClickHouseReject_test.res
+++ b/packages/envio-tests/test/ScenarioClickHouseReject_test.res
@@ -49,27 +49,14 @@ type bounded = {id: string, amount: bigint}
 type boundedOps = {set: bounded => unit}
 type handlerContext = {@as("Bounded") bounded: boundedOps}
 
-// The refusal reaches the loop's error boundary rather than the batch-write
-// promise, so it is read from there.
-let refusal: ref<option<ErrorHandling.t>> = ref(None)
-
-// Waits for the boundary to see it, so the assertion doesn't race the write.
-let rec awaitRefusal = async ticks =>
-  switch refusal.contents {
-  | Some(_) as seen => seen
-  | None if ticks > 0 =>
-    await Utils.delay(10)
-    await awaitRefusal(ticks - 1)
-  | None => None
-  }
-
 describe("ClickHouse refuses a value its column cannot hold", () => {
+  // Swallowed so it doesn't take the test worker down, and kept so the test can
+  // assert on what an operator would have been shown.
+  let refusal = Scenario.captureRefusal()
   scenario->Scenario.it(
     "fails the write instead of storing a different number",
     ~sources=[{chain: 1}],
-    // Swallowed so it doesn't take the test worker down, and kept so the test
-    // can assert on what an operator would have been shown.
-    ~onError=errHandler => refusal := Some(errHandler),
+    ~onError=refusal.onError,
     async (~t, ~indexer as _, ~source) => {
       let source = source(1)
       await Utils.delay(0)
@@ -90,16 +77,7 @@ describe("ClickHouse refuses a value its column cannot hold", () => {
         ],
         ~latestFetchedBlockNumber=10,
       )
-      // The sink wraps the encoder's refusal, so what an operator reads is the
-      // storage error's own message plus the reason underneath it.
-      let failure = switch await awaitRefusal(1000) {
-      | Some({exn: Persistence.StorageError({message, reason})}) =>
-        Some((
-          message,
-          (reason->Utils.prettifyExn->(Utils.magic: exn => {"message": string}))["message"],
-        ))
-      | _ => None
-      }
+      let failure = await refusal.awaitStorageError()
 
       let database = TestClickHouse.currentDatabase()
       let stored = await TestClickHouse.query(

--- a/packages/envio-tests/test/ScenarioClickHouseTypes_test.res
+++ b/packages/envio-tests/test/ScenarioClickHouseTypes_test.res
@@ -123,8 +123,8 @@ let entity = {
   timestamp,
   optTimestamp: Some(timestamp),
   json: %raw(`{"nested": [1, 2]}`),
-  // The case a String element has to hold something that is not a string:
-  // ClickHouse folded these into the column itself on the JSONEachRow path.
+  // The case a String element has to hold something that is not a string,
+  // which the column takes as the element's JSON text.
   arrayOfJson: %raw(`[{"a": 1}, 2, true, "s"]`),
   enumField: "ADMIN",
   optEnumField: None,

--- a/packages/envio-tests/test/helpers/Scenario.res
+++ b/packages/envio-tests/test/helpers/Scenario.res
@@ -322,3 +322,30 @@ let waitUntil = async (predicate, ~message, ~timeoutMs=5000.) => {
     await Utils.delay(1)
   }
 }
+
+// A refused write reaches the indexer's error boundary rather than a promise the
+// test could await, so `onError` captures it there. `awaitStorageError` answers
+// with what an operator would have been shown: the storage error's own message
+// and the reason underneath it.
+type refusal = {
+  onError: ErrorHandling.t => unit,
+  awaitStorageError: unit => promise<option<(string, string)>>,
+}
+
+let captureRefusal = () => {
+  let captured = ref(None)
+  {
+    onError: errHandler => captured := Some(errHandler),
+    awaitStorageError: async () => {
+      await waitUntil(() => captured.contents->Option.isSome, ~message="the write to be refused")
+      switch captured.contents {
+      | Some({exn: Persistence.StorageError({message, reason})}) =>
+        Some((
+          message,
+          (reason->Utils.prettifyExn->(Utils.magic: exn => {"message": string}))["message"],
+        ))
+      | _ => None
+      }
+    },
+  }
+}

--- a/packages/envio-tests/test/helpers/Scenario.res
+++ b/packages/envio-tests/test/helpers/Scenario.res
@@ -337,7 +337,14 @@ let captureRefusal = () => {
   {
     onError: errHandler => captured := Some(errHandler),
     awaitStorageError: async () => {
-      await waitUntil(() => captured.contents->Option.isSome, ~message="the write to be refused")
+      // Generous: the refusal crosses a real ClickHouse round trip and the
+      // indexer's error boundary, and a slow runner missing it fails as a
+      // timeout rather than as the assertion the test is about.
+      await waitUntil(
+        () => captured.contents->Option.isSome,
+        ~message="the write to be refused",
+        ~timeoutMs=15000.,
+      )
       switch captured.contents {
       | Some({exn: Persistence.StorageError({message, reason})}) =>
         Some((

--- a/packages/envio-tests/test/lib_tests/ClickHouseColumnKind_test.res
+++ b/packages/envio-tests/test/lib_tests/ClickHouseColumnKind_test.res
@@ -128,4 +128,18 @@ describe("ClickHouse column type contract", () => {
       Text,
     ])
   })
+
+  // A kind added on the Rust side reaches a build of this one that has never
+  // heard of it. Naming the mismatch is the whole of what this side can do about
+  // it; reading it as the last kind it knows would send the column's values as
+  // text and store them as something else.
+  it("refuses a wire kind it does not know", t => {
+    let message = try {
+      let _ = ClickHouseSink.kindOfOrdinal(4)
+      "decoded without complaint"
+    } catch {
+    | exn => (exn->Utils.prettifyExn->(Utils.magic: exn => {"message": string}))["message"]
+    }
+    t.expect(message).toBe("Unknown ClickHouse column kind 4")
+  })
 })

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -5,12 +5,16 @@
 
 // Serialized keys are the db column names, while the entity values are keyed
 // by API field names (they only differ when column renaming is configured).
-let makeClickHouseEntitySchema = (table: Table.table): S.t<Internal.entity> => {
+// `skipColumn` names a column the row carries as a constant instead — the chain
+// id of a per-chain entity, which the scope knows and the entity never holds.
+let makeClickHouseEntitySchema = (table: Table.table, ~skipColumn: option<string>=?): S.t<
+  Internal.entity,
+> => {
   S.object(s => {
     let dict = Dict.make()
     table.fields->Array.forEach(field => {
       switch field {
-      | Field(f) => {
+      | Field(f) if Some(f->Table.getClickHouseDbFieldName) != skipColumn => {
           let fieldName = f->Table.getClickHouseDbFieldName
           let fieldSchema = switch f.fieldType {
           | Date => {
@@ -28,6 +32,7 @@ let makeClickHouseEntitySchema = (table: Table.table): S.t<Internal.entity> => {
           }
           dict->Dict.set(f->Table.getApiFieldName, s.field(fieldName, fieldSchema))
         }
+      | Field(_) => () // Tagged by the caller
       | DerivedFrom(_) => () // Skip derived fields
       }
     })
@@ -253,23 +258,37 @@ let makeConverters = (
   ~entityConfig: Internal.entityConfig,
   ~scope: Internal.chainScope,
 ): converters => {
-  let chainIdField = entityConfig.table->Table.getChainIdField
-  let scopeChainId = scope->Internal.chainScopeChainId
   let idSchema = entityConfig.table->Table.getIdSchema
+  // Every row a converter writes belongs to one chain, so the column is a
+  // constant of the schema rather than a value read off each row — which is why
+  // these are cached per scope. A cross-chain entity has no such column.
+  let chainIdTag = switch (
+    entityConfig.table->Table.getChainIdField,
+    scope->Internal.chainScopeChainId,
+  ) {
+  | (Some(field), Some(chainId)) => Some((field->Table.getClickHouseDbFieldName, chainId))
+  | _ => None
+  }
 
   {
     convertSetOrThrow: compileToColumnValues(
-      EntityHistory.makeSetUpdateSchema(~idSchema, makeClickHouseEntitySchema(entityConfig.table)),
+      EntityHistory.makeSetUpdateSchema(
+        ~idSchema,
+        ~chainIdTag?,
+        makeClickHouseEntitySchema(
+          entityConfig.table,
+          ~skipColumn=?chainIdTag->Option.map(((column, _)) => column),
+        ),
+      ),
     ),
-    // A delete row carries no entity to stamp, so the chain id is baked into
-    // the schema instead — which is why these are cached per scope. Every
-    // other column is absent and takes its ClickHouse default.
+    // A delete row carries only what identifies it; every other column is
+    // absent and takes its ClickHouse default.
     convertDeleteOrThrow: compileToColumnValues(
       S.object(s => {
         s.tag(EntityHistory.changeFieldName, EntityHistory.RowAction.DELETE)
-        switch (chainIdField, scopeChainId) {
-        | (Some(field), Some(chainId)) => s.tag(field->Table.getClickHouseDbFieldName, chainId)
-        | _ => ()
+        switch chainIdTag {
+        | Some((column, chainId)) => s.tag(column, chainId)
+        | None => ()
         }
         Change.Delete({
           entityId: s.field(Table.idFieldName, idSchema),
@@ -385,14 +404,6 @@ let stageUpdatesOrThrow = (
       cached
     }
 
-    let stampFieldName = switch (
-      entityConfig.table->Table.getChainIdField,
-      scope->Internal.chainScopeChainId,
-    ) {
-    | (Some(field), Some(chainId)) => Some((field.fieldName, chainId))
-    | _ => None
-    }
-
     try {
       let builders = table.columns->Array.map(ClickHouseSink.makeBuilder(_, ~rows))
       let columns = builders->Array.length
@@ -404,16 +415,7 @@ let stageUpdatesOrThrow = (
         // leaves out are absent on purpose; on a SET row the same gap is a
         // field the handler never set, which the writer refuses.
         let (values, write) = switch change {
-        | Change.Set(set) =>
-          let change = switch stampFieldName {
-          | Some((fieldName, chainId)) =>
-            Change.Set({
-              ...set,
-              entity: set.entity->Internal.stampChainId(~fieldName, ~chainId),
-            })
-          | None => change
-          }
-          (convertSetOrThrow(change), ClickHouseSink.writeValue)
+        | Change.Set(_) => (convertSetOrThrow(change), ClickHouseSink.writeValue)
         | Delete(_) => (convertDeleteOrThrow(change), ClickHouseSink.writeDeletedValue)
         }
         for column in 0 to columns - 1 {

--- a/packages/envio/src/bindings/ClickHouseSink.res
+++ b/packages/envio/src/bindings/ClickHouseSink.res
@@ -300,8 +300,6 @@ let markNull = (builder, ~row) => {
     }
 )
 
-// What both writers below read as "the row has no value here", kept in one place
-// so a SET row and a DELETE row cannot start disagreeing about it.
 %%private(let isAbsent = (value: unknown) => value === %raw(`undefined`) || value === %raw(`null`))
 
 // Writes one value of a row the handler set. `undefined`/`null` marks the row's

--- a/packages/envio/src/bindings/ClickHouseSink.res
+++ b/packages/envio/src/bindings/ClickHouseSink.res
@@ -105,10 +105,8 @@ external registerEntityTable: (t, entitySpec) => registeredTable = "registerEnti
 external registerCheckpointsTable: (t, array<columnSpec>) => registeredTable =
   "registerCheckpointsTable"
 
-// Creates the database, the history tables and the views over them.
 @send external initialize: (t, initializeInput) => promise<unit> = "initialize"
 
-// Drops everything written past the checkpoint Postgres committed.
 @send external resume: (t, string) => promise<unit> = "resume"
 
 @send
@@ -132,10 +130,9 @@ let make = (~url, ~username, ~password, ~database, ~chainIdMode: ChainId.mode, ~
       username,
       password,
       database,
-      chainIdMode: switch chainIdMode {
-      | Int32 => "Int32"
-      | Int64 => "Int64"
-      },
+      // Sent in the form it is already serialized in, which is the one Rust
+      // reads it back from.
+      chainIdMode: (chainIdMode :> string),
       history: {
         idColumn: Table.idFieldName,
         checkpointIdColumn: EntityHistory.checkpointIdFieldName,
@@ -156,7 +153,18 @@ type kind =
   | @as(2) I64
   | @as(3) Text
 
-external kindOfOrdinal: int => kind = "%identity"
+// The ordinals cross as bare integers, so a kind Rust added is a kind this side
+// has never heard of — and reading it as one of these would allocate the wrong
+// typed array and store the column's values as something else. Runs once per
+// column of a registered table.
+let kindOfOrdinal = ordinal =>
+  switch ordinal {
+  | 0 => F64
+  | 1 => U64
+  | 2 => I64
+  | 3 => Text
+  | unknown => JsError.throwWithMessage(`Unknown ClickHouse column kind ${unknown->Int.toString}`)
+  }
 
 // A registered table: the handle its batches quote, and its columns with the
 // wire kind Rust resolved for each.
@@ -203,14 +211,11 @@ external asString: unknown => string = "%identity"
 // A JSON-ready value straight out of the entity's ClickHouse schema. Anything
 // that isn't already a string — a `Json` field's object, an array column's
 // elements — becomes its JSON text, which is what the target column stores.
-let toText = (value: unknown, ~column) =>
+let toText = (value: unknown, ~replacer) =>
   switch value->typeof {
   | #string => value->asString
   | #bigint => value->stringOf
-  | _ =>
-    value
-    ->(Utils.magic: unknown => JSON.t)
-    ->JSON.stringify(~replacer=Replacer(jsonSafe(~column)))
+  | _ => value->(Utils.magic: unknown => JSON.t)->JSON.stringify(~replacer)
   }
 
 // One column's storage for one batch, sized to the batch's row count so the
@@ -224,6 +229,9 @@ type builder = {
   unsigned: BigUint64Array.t,
   signed: BigInt64Array.t,
   texts: array<string>,
+  // Built with the builder rather than per cell: the closure closes over the
+  // column name, which is fixed for the whole batch.
+  replacer: JSON.replacer,
   // Allocated on the first null; a column with none sends no mask at all.
   mutable nulls: option<Uint8Array.t>,
   rows: int,
@@ -243,6 +251,7 @@ let makeBuilder = ({name, kind, isNullable}: column, ~rows) => {
   unsigned: kind === U64 ? BigUint64Array.fromLength(rows) : noUnsigned,
   signed: kind === I64 ? BigInt64Array.fromLength(rows) : noSigned,
   texts: kind === Text ? Array.make(~length=rows, "") : [],
+  replacer: Replacer(jsonSafe(~column=name)),
   nulls: None,
   rows,
 }
@@ -287,7 +296,7 @@ let markNull = (builder, ~row) => {
         row,
         value->checkedBigInt(~builder, ~min=-9223372036854775808n, ~max=9223372036854775807n),
       )
-    | Text => builder.texts->Array.setUnsafe(row, value->toText(~column=builder.name))
+    | Text => builder.texts->Array.setUnsafe(row, value->toText(~replacer=builder.replacer))
     }
 )
 
@@ -296,8 +305,12 @@ let markNull = (builder, ~row) => {
 // does not has no way to store: RowBinary carries no "absent", so the row would
 // land holding the type's zero, a value the handler never chose and that nothing
 // downstream could tell from one it did.
+// What both writers below read as "the row has no value here", kept in one place
+// so a SET row and a DELETE row cannot start disagreeing about it.
+%%private(let isAbsent = (value: unknown) => value === %raw(`undefined`) || value === %raw(`null`))
+
 let writeValue = (builder, ~row, value: unknown) =>
-  if value === %raw(`undefined`) || value === %raw(`null`) {
+  if value->isAbsent {
     if builder.isNullable {
       builder->markNull(~row)
     } else {
@@ -313,7 +326,7 @@ let writeValue = (builder, ~row, value: unknown) =>
 // what was deleted. The rest are deliberately absent and take the column's
 // default, so an unset one is not the mistake it would be on a row that set it.
 let writeDeletedValue = (builder, ~row, value: unknown) =>
-  if value === %raw(`undefined`) || value === %raw(`null`) {
+  if value->isAbsent {
     builder->markNull(~row)
   } else {
     builder->writePresent(~row, value)

--- a/packages/envio/src/bindings/ClickHouseSink.res
+++ b/packages/envio/src/bindings/ClickHouseSink.res
@@ -300,15 +300,15 @@ let markNull = (builder, ~row) => {
     }
 )
 
+// What both writers below read as "the row has no value here", kept in one place
+// so a SET row and a DELETE row cannot start disagreeing about it.
+%%private(let isAbsent = (value: unknown) => value === %raw(`undefined`) || value === %raw(`null`))
+
 // Writes one value of a row the handler set. `undefined`/`null` marks the row's
 // null bit, which a column that accepts NULL stores as such — and which one that
 // does not has no way to store: RowBinary carries no "absent", so the row would
 // land holding the type's zero, a value the handler never chose and that nothing
 // downstream could tell from one it did.
-// What both writers below read as "the row has no value here", kept in one place
-// so a SET row and a DELETE row cannot start disagreeing about it.
-%%private(let isAbsent = (value: unknown) => value === %raw(`undefined`) || value === %raw(`null`))
-
 let writeValue = (builder, ~row, value: unknown) =>
   if value->isAbsent {
     if builder.isNullable {

--- a/packages/envio/src/db/EntityHistory.res
+++ b/packages/envio/src/db/EntityHistory.res
@@ -30,11 +30,20 @@ let unsafeCheckpointIdSchema =
     serializer: bigint => bigint->BigInt.toString,
   })
 
-let makeSetUpdateSchema = (~idSchema: S.t<EntityId.t>, entitySchema: S.t<'entity>): S.t<
-  Change.t<'entity>,
-> => {
+// `chainIdTag` carries the (column, chain id) of a per-chain entity whose rows
+// all belong to one chain: the column is then a constant of the schema rather
+// than a field read off every entity.
+let makeSetUpdateSchema = (
+  ~idSchema: S.t<EntityId.t>,
+  ~chainIdTag: option<(string, ChainId.t)>=?,
+  entitySchema: S.t<'entity>,
+): S.t<Change.t<'entity>> => {
   S.object(s => {
     s.tag(changeFieldName, RowAction.SET)
+    switch chainIdTag {
+    | Some((column, chainId)) => s.tag(column, chainId)
+    | None => ()
+    }
     Change.Set({
       checkpointId: s.field(checkpointIdFieldName, unsafeCheckpointIdSchema),
       entityId: s.field(Table.idFieldName, idSchema),


### PR DESCRIPTION
## Summary

This change hardens ClickHouse storage against data corruption and improves error diagnostics by:
1. Validating non-finite floats and enum discriminants before encoding
2. Distinguishing between missing databases and unreachable servers in recovery
3. Properly tagging per-chain entity rows with their scope's chain ID
4. Improving error messages with table context and clearer recovery guidance

## Key Changes

**Data Validation**
- Reject `NaN` and `Infinity` in Float64 scalar columns (they can be stored but become unreadable in aggregates and JSON exports)
- Reject enum discriminants that don't correspond to declared variants (prevents silent corruption on read)
- Reject bare numbers in enum array elements (must use variant names)
- Validate enum discriminants against both variant count and storage width

**Recovery and Diagnostics**
- Extract database existence check into `existing_database_engine()` to distinguish between missing databases and unreachable servers
- Replace `USE database` with explicit existence probe, since both failures look identical but only the first warrants reinitialization
- Add table name context to insert failures via `with_context()`
- Improve error messages to clarify when reinitialization is needed vs. when the server is unreachable

**Per-Chain Entity Handling**
- Move `ChainIdMode` from `ch_type.rs` to `system_config.rs` (its actual source of truth)
- Tag per-chain entity rows with the scope's chain ID as a schema constant rather than reading it from each row
- Skip the chain ID column when building entity schemas for per-chain entities (it's provided by the scope)
- Cache converters per scope to avoid redundant chain ID tagging

**Test Infrastructure**
- Add `MockClickHouse::answering_statements()` to support statement-based testing (schema, recovery paths)
- Add `resume_answers()` helper for testing recovery scenarios
- Add comprehensive tests for recovery edge cases (unreachable server, proxy errors, missing database)
- Add test for per-chain entity chain ID stamping across multiple chains
- Add test for non-finite float rejection in scalar columns
- Refactor test error capture into `Scenario.captureRefusal()` helper

**Code Quality**
- Improve comments to explain non-obvious constraints (enum bounds, NaN handling, chain ID tagging)
- Simplify test assertions using single `assert_eq!` with tuples
- Add `kindOfOrdinal` validation to reject unknown column kinds from Rust side
- Update mock server to track statements for testing schema and recovery operations

## Notable Implementation Details

- Enum bounds checking now validates against variant count (1 to `variants.len()`) rather than just storage width, since ClickHouse rejects reads of unused discriminants
- Float64 validation happens at encode time, not at schema time, to catch values that pass JSON serialization but would corrupt the column
- Per-chain entity chain IDs are baked into the schema per scope rather than read from rows, enabling proper constant tagging in RowBinary encoding
- Recovery now queries `system.databases` instead of running `USE`, allowing the sink to distinguish between a missing database (needs reinitialization) and a server that's briefly unreachable (needs retry)

https://claude.ai/code/session_01HDwzXmb5ri52YtnGN2gPja