### PR TITLE
docs: correct Solana status and HyperSync chain count in the README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -69,7 +69,7 @@ A few things already running in production:
 
 **Multichain indexing**
 - Index EVM, SVM, and Fuel blockchains from a single indexer
-- 70+ EVM chains with native HyperSync support, plus any EVM chain via RPC
+- 85+ EVM chains with native HyperSync support, plus any EVM chain via RPC
 - Real-time indexing with reorg handling built in
 
 **Developer experience**
@@ -129,7 +129,7 @@ HyperSync can also be used directly for custom data pipelines in Python, Rust, N
 
 ## Supported networks
 
-HyperIndex supports any EVM-compatible L1, L2, or L3, plus Fuel and Solana (experimental). 70+ chains have native HyperSync support for maximum speed. For any EVM chain not on the HyperSync list, RPC-based indexing works out of the box.
+HyperIndex supports any EVM-compatible L1, L2, or L3, plus Fuel and Solana (beta). 85+ chains have native HyperSync support for maximum speed. For any EVM chain not on the HyperSync list, RPC-based indexing works out of the box. Solana indexing runs on HyperSync for Solana, with instruction-level handlers and IDL-aware decoding.
 
 [Full network list →](https://docs.envio.dev/docs/HyperIndex/supported-networks)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -69,7 +69,7 @@ A few things already running in production:
 
 **Multichain indexing**
 - Index EVM, SVM, and Fuel blockchains from a single indexer
-- 85+ EVM chains with native HyperSync support, plus any EVM chain via RPC
+- 79+ EVM chains with first-class HyperSync support, plus any EVM chain via RPC
 - Real-time indexing with reorg handling built in
 
 **Developer experience**
@@ -129,7 +129,7 @@ HyperSync can also be used directly for custom data pipelines in Python, Rust, N
 
 ## Supported networks
 
-HyperIndex supports any EVM-compatible L1, L2, or L3, plus Fuel and Solana (beta). 85+ chains have native HyperSync support for maximum speed. For any EVM chain not on the HyperSync list, RPC-based indexing works out of the box. Solana indexing runs on HyperSync for Solana, with instruction-level handlers and IDL-aware decoding.
+HyperIndex supports any EVM-compatible L1, L2, or L3, plus Fuel and Solana (beta). 79+ chains have first-class HyperSync support for maximum speed. For any EVM chain not on the HyperSync list, RPC-based indexing works out of the box. Solana indexing runs on HyperSync for Solana, with instruction-level handlers and IDL-aware decoding.
 
 [Full network list →](https://docs.envio.dev/docs/HyperIndex/supported-networks)
 


### PR DESCRIPTION
The README's Supported networks section labelled Solana experimental and described it without its data source. It also cited 70+ native HyperSync chains.

This file is the repo README via the root `README.md` symlink, so it renders on the repo landing page and is indexed. It is one of the sources SQD's [comparison page](https://sqd.dev/compare/sqd-vs-envio/) cites.

## Changes

`packages/cli/README.md`, two lines:

- **Line 132** — Solana relabelled from `(experimental)` to `(beta)`, with a sentence noting it runs on HyperSync for Solana with instruction-level handlers and IDL-aware decoding. Chain count 70+ to 79+.
- **Line 72** — chain count 70+ to 79+, for consistency with line 132.

## Verification

Checked in Chrome against the live rendered pages.

- [envio.dev/chains](https://envio.dev/chains) states "First-class HyperSync and HyperRPC support on 79+ chains" and "Explore 79 supported chains".
- [Solana docs](https://docs.envio.dev/docs/HyperIndex/solana) confirm beta status, HyperSync as the data source, `indexer.onInstruction`, and IDL-aware decoding.
- The existing `docs.envio.dev/docs/HyperIndex/supported-networks` link resolves, not a 404.

Line 55 also says 70+ chains, but that describes Chain Density, an external tool, so it is left alone.

Companion to [enviodev/.github#2](https://github.com/enviodev/.github/pull/2), which corrects the same Solana claims on the org profile.
