### PR TITLE
fix: don't crash serializing a null/undefined BigInt column

### DIFF
--- a/packages/envio/src/Utils.res
+++ b/packages/envio/src/Utils.res
@@ -787,7 +787,17 @@ module BigInt = {
         | Some(bigInt) => bigInt
         | None => s.fail("The string is not valid BigInt")
         },
-      serializer: bigint => bigint->BigInt.toString,
+      // The batched Postgres writer (PgStorage's S.unnest path, used for every
+      // table insert/upsert that has no array field) can call this serializer
+      // directly on a `null`/`undefined` column value for a nullable BigInt
+      // field, and `.toString()` on that throws. Reproduced indexing a real
+      // subgraph's nullable BigInt entity fields via `envio dev` against
+      // HyperSync — see the linked PR description for the repro and the
+      // exact crash trace.
+      serializer: bigint =>
+        bigint === %raw(`null`) || bigint === %raw(`undefined`)
+          ? bigint->magic
+          : bigint->BigInt.toString,
     })
 }
 


### PR DESCRIPTION
## What

`Utils.BigInt.schema`'s serializer called `.toString()` on its input unconditionally:

```diff
-      serializer: bigint => bigint->BigInt.toString,
+      serializer: bigint =>
+        bigint === %raw(`null`) || bigint === %raw(`undefined`)
+          ? bigint->magic
+          : bigint->BigInt.toString,
```

If that input is ever a genuine `null`/`undefined` — a nullable BigInt entity field a handler hasn't set yet — the unguarded version throws `TypeError: Cannot read properties of null (reading 'toString')`, and the whole batched write fails with a `Persistence.StorageError`. The fix is a ~10-line, purely additive change: a null/undefined guard before the `.toString()` call, so the value passes through untouched instead of crashing.

## The case

While testing the `v3.7.0-subgraph` alpha release (`pnpx envio@3.7.0-subgraph dev` — run an existing subgraph verbatim), I ran it against a real production subgraph (Katana network's pre-staking subgraph) indexing live mainnet data via HyperSync, and hit this repeatedly:

```
[ERROR]: Failed writing batch to the database
  err: {
    "message": "Failed to insert items into table \"VKatLock\"",
    "RE_EXN_ID": "Persistence.StorageError",
    "reason": {
      "type": "TypeError",
      "message": "Cannot read properties of null (reading 'toString')",
      "stack":
          TypeError: Cannot read properties of null (reading 'toString')
              at Array.s (.../envio/src/Utils.res.mjs:672:23)
              at Object.eval [as convertOrThrow] (eval at compile (.../rescript-schema/src/S_Core.res.mjs:591:10), <anonymous>:3:411)
              at setOrThrow (.../envio/src/PgStorage.res.mjs:494:48)
              ...
    }
  }
```

The entity in question (`VKatLock`) has a nullable BigInt field (`withdrawnValue: BigInt`) that one handler (`handleVKatDeposit`) never touches — it's only set later by a different handler (`handleVKatWithdraw`), once the position is actually withdrawn. That's an entirely ordinary, spec-legal subgraph schema — The Graph has no trouble with a field nothing has set yet. Under HyperIndex it eventually crashes the indexer partway through a historical sync, once that field gets written as `null`.

The same subgraph has three more fields with this exact shape (`PreStaker.sharesReceived` / `.reason` / `.processedAt` — all set only once a separate event fires later), so this isn't a one-off edge case; any subgraph with a "set once a later event confirms it" field is likely to hit it during a real sync.

## Validation

- **Reproduced repeatedly** running the unmodified subgraph via `envio dev` against real Katana mainnet data (chain id `747474`, HyperSync), tracing the exact crash to this serializer via targeted instrumentation (a temporary `console.error` in the same spot, confirming the call stack and the `null`/`undefined` value on every occurrence).
- **Fix validated end-to-end**: with the fix applied, the same indexer processed the full range this used to crash in — 81 occurrences that would otherwise have failed the batch — and synced cleanly to 40.9M/40.93M blocks (99%+ of chain head) with zero errors. Confirmed again on a fresh resume with the exact diff in this PR (no instrumentation).
- **Isolating this to a minimal test in `envio-tests` turned out to be harder than expected**: a native (non-subgraph) indexer writing an entity via `context.Entity.set({...})` and genuinely omitting a nullable BigInt key — the same shape, exercised the same way through `PgStorage.setOrThrow` and through a real simulated `indexer.onEvent` handler + batch flush — does **not** trigger this. Only the real subgraph-compat pipeline (subgraph.yaml → translated schema → AS/WASM → the graph-ts shim's `toRow()` → `PgStorage`) does, and `createTestIndexer()`/`InternalTestIndexer.fromSubgraph` (the harness the existing `Subgraph*_test.res` files use, including `SubgraphNullableField_test.res`, which specifically covers "a field nothing has set") is hardwired to an in-memory store, never real Postgres — so it structurally can't catch a Postgres-serialization bug like this one, however it's constructed. I didn't want to guess at the exact mechanism further without deeper context on `graph-ts.ts`/`S.unnest`'s interaction, so this PR is the source fix plus this write-up rather than a matching regression test — happy to pair on adding one if there's an appetite for wiring a Postgres-backed subgraph test harness.

## Where I found the crash site

`packages/envio/src/PgStorage.res`'s `setOrThrow`, for any table with no array field (i.e. most tables, including `VKatLock`), builds `S.compile(S.unnest(dbSchema), ...)` and calls it directly on the batch. Whatever the exact path is that lets a `null` reach this serializer unguarded, hardening the serializer itself is a safe, self-evidently-correct fix regardless: a schema's value serializer should never assume its input is non-null when the same codebase composes nullable wrappers around scalar schemas elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)