### PR TITLE
Test event and parameter named "error"

### DIFF
--- a/packages/cli/src/config_parsing/chain_helpers.rs
+++ b/packages/cli/src/config_parsing/chain_helpers.rs
@@ -385,6 +385,9 @@ pub enum Network {
     #[subenum(HypersyncChain, NetworkWithExplorer)]
     Sophon = 50104,
 
+    #[subenum(HypersyncChain)]
+    StablesKinshipGrass = 988,
+
     StatusSepolia = 1660990954,
 
     #[subenum(HypersyncChain)]
@@ -604,6 +607,7 @@ impl Network {
             | Network::Injective
             | Network::Megaeth
             | Network::SeiTestnet
+            | Network::StablesKinshipGrass
             | Network::StatusSepolia
             | Network::Tempo
             | Network::Tron

--- a/packages/envio-tests/test/ErrorEventName_test.res
+++ b/packages/envio-tests/test/ErrorEventName_test.res
@@ -1,0 +1,56 @@
+// https://github.com/enviodev/hyperindex/issues/655
+let _ = InternalTestIndexer.fromUserApi(
+  ~configYaml=`
+name: error-event
+chains:
+  - id: 1
+    start_block: 0
+    contracts:
+      - name: Token
+        address: "0x1111111111111111111111111111111111111111"
+        events:
+          - event: error(address indexed to, uint256 error)
+`,
+  ~schema=`
+type Account {
+  id: ID!
+  balance: BigInt!
+}
+`,
+  ~handlers=`
+import { indexer } from "envio";
+
+indexer.onEvent({ contract: "Token", event: "error" }, async ({ event, context }) => {
+  context.Account.set({
+    id: event.params.to,
+    balance: event.params.error,
+  });
+});
+`,
+  ~test=`
+import { describe, it } from "vitest";
+import { createTestIndexer, type Account, TestHelpers } from "envio";
+
+const { Addresses } = TestHelpers;
+
+describe("error in event signature", () => {
+  it("indexes an event and a param named error", async (t) => {
+    const indexer = createTestIndexer();
+    const to = Addresses.defaultAddress;
+
+    await indexer.process({
+      chains: {
+        1: {
+          simulate: [
+            { contract: "Token", event: "error", params: { to, error: 5n } },
+          ],
+        },
+      },
+    });
+
+    const expected: Account = { id: to, balance: 5n };
+    t.expect(await indexer.Account.getOrThrow(to)).toEqual(expected);
+  });
+});
+`,
+)


### PR DESCRIPTION
Regression fixture for https://github.com/enviodev/hyperindex/issues/655: an EVM event named `error` carrying a param named `error`.

Investigation result: the case already works on `main`, so this PR only pins it. `error` is not a ReScript keyword, so `RecordField::to_valid_rescript_name` leaves it untouched, and it does not belong in `RESERVED_NAMES` either — that list covers `Object.prototype` members plus `enum`, names that stay broken after codegen capitalizes them. An event named `error` capitalizes to a `module Error` nested in the contract module, which shadows nothing that matters.

Verified two ways:

- The fixture here (user API rung): config parse, type-check of handler and test source against the generated `types.d.ts`, and end-to-end processing.
- Locally, adding `Error(address indexed to, uint256 error)` to `scenarios/test_codegen` — codegen emits `type params = {to: Address.t, error: bigint}`, and both `rescript` and `tsc --noEmit` pass. Not committed; the fixture above covers it.

https://claude.ai/code/session_01FRHpWvkmdnC6cxxMupuAst

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the StablesKinshipGrass network (chain ID 988).

* **Tests**
  * Added regression coverage for indexing events named `error` with parameters also named `error`.
  * Verifies generated configuration, schema, event handling, simulated input, and resulting account state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->