### PR TITLE
Isolate multichain rollbacks when schema has no cross-chain entities

### DIFF
--- a/packages/envio-tests/test/ConfigCrossChain_test.res
+++ b/packages/envio-tests/test/ConfigCrossChain_test.res
@@ -295,7 +295,11 @@ describe("Per-chain entity DDL", () => {
 describe("Per-chain rollback and delete SQL", () => {
   it("Keys the removed-ids query on (id, chain id)", t => {
     t.expect(
-      PgStorage.makeGetRollbackRemovedIdsQuery(~entityConfig=counter, ~pgSchema="public"),
+      PgStorage.makeGetRollbackRemovedIdsQuery(
+        ~entityConfig=counter,
+        ~pgSchema="public",
+        ~scope=Global,
+      ),
     ).toBe(
       `SELECT DISTINCT "id", "chainId"
   FROM "public"."envio_history_Counter"
@@ -310,7 +314,11 @@ describe("Per-chain rollback and delete SQL", () => {
   })
 
   it("Dedups the pre-target restore per (id, chain id)", t => {
-    let query = PgStorage.makeGetRollbackPreTargetRowsQuery(~entityConfig=counter, ~pgSchema="public")
+    let query = PgStorage.makeGetRollbackPreTargetRowsQuery(
+      ~entityConfig=counter,
+      ~pgSchema="public",
+      ~scope=Global,
+    )
     t.expect((
       query->String.includes(`SELECT DISTINCT ON ("id", "chainId")`),
       query->String.includes(`ORDER BY "id", "chainId", "envio_checkpoint_id" DESC`),
@@ -397,6 +405,7 @@ describe("Per-chain entities under snake_case columns", () => {
       PgStorage.makeGetRollbackRemovedIdsQuery(
         ~entityConfig=snakeCounter,
         ~pgSchema="public",
+        ~scope=Global,
       )->String.includes(`SELECT DISTINCT "id", "chain_id"`),
     )).toEqual((
       `CREATE TABLE IF NOT EXISTS "public"."Counter"("id" TEXT NOT NULL, "count" NUMERIC NOT NULL, "chain_id" INTEGER NOT NULL, PRIMARY KEY("id", "chain_id"));`,

--- a/packages/envio-tests/test/IsolatedRollback_test.res
+++ b/packages/envio-tests/test/IsolatedRollback_test.res
@@ -1,0 +1,807 @@
+open Vitest
+
+// A schema with no cross-chain entity means a reorg on one chain can never have
+// changed a row another chain owns. The rollback then stays isolated to the
+// reorg chain: every sibling keeps its progress, entities, history and
+// checkpoints, and is never asked to re-index a block it already processed.
+
+type counter = {
+  id: string,
+  count: bigint,
+  @as("chainId") chainId: int,
+}
+type total = {id: string, count: bigint}
+
+type counterOps = {set: {"id": string, "count": bigint} => unit}
+type handlerContext = {
+  @as("Counter") counter: counterOps,
+  @as("Total") total: counterOps,
+}
+
+let asContext = (context: Internal.handlerContext) =>
+  context->(Utils.magic: Internal.handlerContext => handlerContext)
+
+let chainYaml = chainId =>
+  `
+  - id: ${chainId->Int.toString}
+    rpc:
+      url: https://rpc${chainId->Int.toString}.example.test
+      for: sync
+    start_block: 1
+    max_reorg_depth: 200
+    contracts:
+      - name: Token
+        address: "0x0000000000000000000000000000000000000001"`
+
+let makeConfigYaml = (~name, ~extra="") =>
+  `
+name: ${name}
+rollback_on_reorg: true
+disable_default_cross_chain: true${extra}
+contracts:
+  - name: Token
+    events:
+      - event: Transfer()
+chains:${chainYaml(100)}${chainYaml(1337)}
+`
+
+let perChainSchema = `
+type Counter {
+  id: ID!
+  count: BigInt!
+}
+`
+
+let scenario = Scenario.make(
+  ~schema=perChainSchema,
+  ~configYaml=makeConfigYaml(~name="isolated-rollback"),
+)
+
+// One cross-chain entity is enough to couple the chains: a value chain 1337
+// wrote can be what chain 100 read and overwrote, so its reorg has to take
+// every chain back with it.
+let crossChainScenario = Scenario.make(
+  ~schema=perChainSchema ++ `
+type Total @crossChain {
+  id: ID!
+  count: BigInt!
+}
+`,
+  ~configYaml=makeConfigYaml(~name="isolated-rollback-cross-chain"),
+)
+
+// The sink is append-only: an isolated rollback reaches it as the diff rows the
+// next batch carries, and its current-state view has to resolve to the same
+// thing Postgres holds.
+let clickHouseScenario = Scenario.make(
+  ~schema=perChainSchema,
+  ~configYaml=makeConfigYaml(~name="isolated-rollback-clickhouse"),
+  ~unsupported=[{backend: #postgres, reason: "asserts against a ClickHouse server"}],
+)
+
+let fullHistoryScenario = Scenario.make(
+  ~schema=perChainSchema,
+  ~configYaml=makeConfigYaml(
+    ~name="isolated-rollback-full-history",
+    ~extra="\nsave_full_history: true",
+  ),
+)
+
+let methods: array<MockSource.method> = [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes]
+
+let setCounter = (~block, ~count: bigint): MockSource.itemMock => {
+  blockNumber: block,
+  logIndex: 0,
+  handler: async args => {
+    let context = args.context->asContext
+    context.counter.set({"id": "total", "count": count})
+  },
+}
+
+let setCounterAndTotal = (~block, ~count: bigint): MockSource.itemMock => {
+  blockNumber: block,
+  logIndex: 0,
+  handler: async args => {
+    let context = args.context->asContext
+    context.counter.set({"id": "total", "count": count})
+    context.total.set({"id": "total", "count": count})
+  },
+}
+
+let progressByChain = async (indexer: IndexerRunner.t) => {
+  let metrics = await indexer.metric("envio_progress_block")
+  metrics->Array.toSorted((a: IndexerRunner.metric, b) =>
+    String.compare(
+      a.labels->Dict.get("chainId")->Option.getOr(""),
+      b.labels->Dict.get("chainId")->Option.getOr(""),
+    )
+  )
+}
+
+let counters = (indexer: IndexerRunner.t): promise<array<counter>> => indexer.query("Counter")
+let counterHistory = (indexer: IndexerRunner.t): promise<array<Change.t<counter>>> =>
+  indexer.queryHistory("Counter")
+
+// Brings both chains into the reorg threshold and up to block 102, with chain
+// 1337 writing block 102 first — so chain 100's block-102 checkpoint carries a
+// higher id than the chain-1337 rows a reorg on 1337 has to delete.
+let driveBothChainsToBlock102 = async (
+  ~t,
+  ~indexer: IndexerRunner.t,
+  ~source100: MockSource.t,
+  ~source1337: MockSource.t,
+  ~item: (~block: int, ~count: bigint) => MockSource.itemMock,
+) => {
+  await Utils.delay(0)
+  let _ = await Promise.all2((
+    Scenario.enterReorgThreshold(~t, ~indexer, ~source=source100),
+    Scenario.enterReorgThreshold(~t, ~indexer, ~source=source1337),
+  ))
+
+  // Chain 100 leads (the progress tie breaks by ascending chain id), so its
+  // post-threshold query is the one holding the fetch budget.
+  source100.resolveGetItemsOrThrow([item(~block=101, ~count=100n)], ~latestFetchedBlockNumber=101)
+  await MockSource.waitItemsQuery(source1337)
+  source1337.resolveGetItemsOrThrow([item(~block=101, ~count=1337n)], ~latestFetchedBlockNumber=101)
+  await indexer.getBatchWritePromise()
+
+  source1337.resolveGetItemsOrThrow(
+    [item(~block=102, ~count=13372n)],
+    ~latestFetchedBlockNumber=102,
+  )
+  await indexer.getBatchWritePromise()
+  source100.resolveGetItemsOrThrow([item(~block=102, ~count=1002n)], ~latestFetchedBlockNumber=102)
+  await indexer.getBatchWritePromise()
+}
+
+// Reorgs `source` at block 102: the range covering 103 comes back reporting a
+// different hash for 102, and blocks 100 and 101 survive the depth search.
+//
+// The rollback resets every chain's in-flight queries, so the sibling's are
+// voided in the mock first — otherwise its pre-rollback queries stay pending
+// there and the ones it re-issues can't be told apart from them.
+let reorgAtBlock102 = async (
+  ~indexer: IndexerRunner.t,
+  ~source: MockSource.t,
+  ~sibling: MockSource.t,
+) => {
+  sibling.dropPendingCalls()
+  source.resolveGetItemsOrThrow(
+    [],
+    ~filter=MockSource.coveringBlock(103),
+    ~prevRangeLastBlock={blockNumber: 102, blockHash: "0x102a"},
+  )
+  await Utils.delay(0)
+  await Utils.delay(0)
+  source.resolveGetBlockHashes([
+    {blockNumber: 100, blockHash: "0x0100", blockTimestamp: 100},
+    {blockNumber: 101, blockHash: "0x0101", blockTimestamp: 101},
+  ])
+  await indexer.getRollbackReadyPromise()
+}
+
+// The rollback diff only reaches the database with the next batch, so the reorg
+// chain re-delivers block 102 to flush it.
+let reindexBlock102 = async (~indexer: IndexerRunner.t, ~source: MockSource.t, ~count) => {
+  source.resolveGetItemsOrThrow(
+    [setCounter(~block=102, ~count)],
+    ~filter=MockSource.coveringBlock(102),
+    ~latestFetchedBlockNumber=102,
+  )
+  await indexer.getBatchWritePromise()
+}
+
+let blockHash = blockNumber => Js.Null.Value(MockSource.evmBlockHash(`0x0${blockNumber}`))
+
+describe("Isolated multichain rollback", () => {
+  scenario->Scenario.it(
+    "Rolls back the reorg chain alone and leaves its sibling untouched",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+
+      t.expect(
+        await Promise.all4((
+          indexer.queryCheckpoints(),
+          counters(indexer),
+          counterHistory(indexer),
+          progressByChain(indexer),
+        )),
+        ~message="Both chains reached block 102, with their checkpoints interleaved",
+      ).toEqual((
+        [
+          {
+            id: 3n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 4n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 5n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 6n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+        ],
+        [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 13372n, chainId: 1337}],
+        [
+          Set({
+            checkpointId: 3n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 100n, chainId: 100},
+          }),
+          Set({
+            checkpointId: 4n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 1337n, chainId: 1337},
+          }),
+          Set({
+            checkpointId: 5n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 13372n, chainId: 1337},
+          }),
+          Set({
+            checkpointId: 6n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 1002n, chainId: 100},
+          }),
+        ],
+        [
+          {value: "102", labels: Dict.fromArray([("chainId", "100")])},
+          {value: "102", labels: Dict.fromArray([("chainId", "1337")])},
+        ],
+      ))
+
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+
+      t.expect(
+        (
+          await progressByChain(indexer),
+          // The lowest block chain 100 is asked for once it re-issues the
+          // queries the rollback dropped: it kept block 102, so it never goes
+          // back below 103.
+          source100.getItemsOrThrowCalls
+          ->Array.map(call => call.payload["fromBlock"])
+          ->Array.toSorted(Int.compare)
+          ->Array.get(0),
+        ),
+        ~message="Only chain 1337 lost progress",
+      ).toEqual((
+        [
+          {value: "102", labels: Dict.fromArray([("chainId", "100")])},
+          {value: "101", labels: Dict.fromArray([("chainId", "1337")])},
+        ],
+        Some(103),
+      ))
+
+      await reindexBlock102(~indexer, ~source=source1337, ~count=999n)
+
+      t.expect(
+        await Promise.all4((
+          indexer.queryCheckpoints(),
+          counters(indexer),
+          counterHistory(indexer),
+          progressByChain(indexer),
+        )),
+        ~message="Chain 1337 re-indexed above chain 100's untouched rows",
+      ).toEqual((
+        [
+          {
+            id: 3n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 4n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 6n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 8n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+        ],
+        [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
+        [
+          Set({
+            checkpointId: 3n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 100n, chainId: 100},
+          }),
+          Set({
+            checkpointId: 4n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 1337n, chainId: 1337},
+          }),
+          Set({
+            checkpointId: 6n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 1002n, chainId: 100},
+          }),
+          Set({
+            checkpointId: 8n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 999n, chainId: 1337},
+          }),
+        ],
+        [
+          {value: "102", labels: Dict.fromArray([("chainId", "100")])},
+          {value: "102", labels: Dict.fromArray([("chainId", "1337")])},
+        ],
+      ))
+    },
+  )
+
+  crossChainScenario->Scenario.it(
+    "Falls back to a global rollback when one entity is cross-chain",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(
+        ~t,
+        ~indexer,
+        ~source100,
+        ~source1337,
+        ~item=setCounterAndTotal,
+      )
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+
+      // Chain 100 has to give back block 102 as well: its own write to `Total`
+      // sat on top of the chain-1337 write the reorg took away.
+      t.expect(
+        (
+          await progressByChain(indexer),
+          source100.getItemsOrThrowCalls->Array.some(call => call.payload["fromBlock"] === 102),
+        ),
+        ~message="Both chains lost block 102",
+      ).toEqual((
+        [
+          {value: "101", labels: Dict.fromArray([("chainId", "100")])},
+          {value: "101", labels: Dict.fromArray([("chainId", "1337")])},
+        ],
+        true,
+      ))
+
+      source100.resolveGetItemsOrThrow(
+        [setCounterAndTotal(~block=102, ~count=1002n)],
+        ~filter=MockSource.coveringBlock(102),
+        ~latestFetchedBlockNumber=102,
+      )
+      await indexer.getBatchWritePromise()
+      source1337.resolveGetItemsOrThrow(
+        [setCounterAndTotal(~block=102, ~count=999n)],
+        ~filter=MockSource.coveringBlock(102),
+        ~latestFetchedBlockNumber=102,
+      )
+      await indexer.getBatchWritePromise()
+
+      t.expect(
+        await Promise.all3((
+          indexer.queryCheckpoints(),
+          counters(indexer),
+          (indexer.query("Total"): promise<array<total>>),
+        )),
+        ~message="Every checkpoint above the target went, on both chains",
+      ).toEqual((
+        [
+          {
+            id: 3n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 4n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 8n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 9n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+        ],
+        [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
+        [{id: "total", count: 999n}],
+      ))
+    },
+  )
+
+  // The second rollback's target sits below checkpoints the first one's chain
+  // has since re-indexed. Deleting by checkpoint id alone would take those with
+  // it; only the reorg chain's rows may go.
+  scenario->Scenario.it(
+    "Keeps a sibling's re-indexed rows when a later reorg targets a lower checkpoint",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+      await reindexBlock102(~indexer, ~source=source1337, ~count=999n)
+
+      await reorgAtBlock102(~indexer, ~source=source100, ~sibling=source1337)
+      await reindexBlock102(~indexer, ~source=source100, ~count=1003n)
+
+      t.expect(
+        await Promise.all4((
+          indexer.queryCheckpoints(),
+          counters(indexer),
+          counterHistory(indexer),
+          progressByChain(indexer),
+        )),
+        ~message="Chain 1337's re-indexed rows outlived chain 100's rollback to a lower checkpoint",
+      ).toEqual((
+        [
+          {
+            id: 3n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 4n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 8n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 10n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+        ],
+        [{id: "total", count: 1003n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
+        [
+          Set({
+            checkpointId: 3n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 100n, chainId: 100},
+          }),
+          Set({
+            checkpointId: 4n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 1337n, chainId: 1337},
+          }),
+          Set({
+            checkpointId: 8n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 999n, chainId: 1337},
+          }),
+          Set({
+            checkpointId: 10n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 1003n, chainId: 100},
+          }),
+        ],
+        [
+          {value: "102", labels: Dict.fromArray([("chainId", "100")])},
+          {value: "102", labels: Dict.fromArray([("chainId", "1337")])},
+        ],
+      ))
+    },
+  )
+
+  // Two isolated rollbacks can't be merged: the second diff replaces the first,
+  // and its deletes only reach its own chain. Widening to a global rollback is
+  // what keeps the first one's rows from being stranded above their target.
+  scenario->Scenario.it(
+    "Widens to a global rollback when a second reorg lands before the first is written",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+
+      // No batch progresses in between, so the first diff is still unwritten
+      // when the second reorg computes its own.
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+      await reorgAtBlock102(~indexer, ~source=source100, ~sibling=source1337)
+
+      t.expect(
+        await progressByChain(indexer),
+        ~message="Both chains went back past the lower of the two targets",
+      ).toEqual([
+        {value: "101", labels: Dict.fromArray([("chainId", "100")])},
+        {value: "100", labels: Dict.fromArray([("chainId", "1337")])},
+      ])
+
+      source100.resolveGetItemsOrThrow(
+        [setCounter(~block=102, ~count=1003n)],
+        ~filter=MockSource.coveringBlock(102),
+        ~latestFetchedBlockNumber=102,
+      )
+      await indexer.getBatchWritePromise()
+      source1337.resolveGetItemsOrThrow(
+        [setCounter(~block=101, ~count=1337n), setCounter(~block=102, ~count=999n)],
+        ~filter=MockSource.coveringBlock(101),
+        ~latestFetchedBlockNumber=102,
+      )
+      await indexer.getBatchWritePromise()
+
+      t.expect(
+        await Promise.all3((
+          indexer.queryCheckpoints(),
+          counters(indexer),
+          counterHistory(indexer),
+        )),
+        ~message="Nothing above the lower target survived on either chain",
+      ).toEqual((
+        [
+          {
+            id: 3n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 8n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 9n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 10n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+        ],
+        [{id: "total", count: 1003n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
+        [
+          Set({
+            checkpointId: 3n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 100n, chainId: 100},
+          }),
+          Set({
+            checkpointId: 8n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 1003n, chainId: 100},
+          }),
+          Set({
+            checkpointId: 9n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 1337n, chainId: 1337},
+          }),
+          Set({
+            checkpointId: 10n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 999n, chainId: 1337},
+          }),
+        ],
+      ))
+    },
+  )
+
+  scenario->Scenario.it(
+    "Resumes from the checkpoints an isolated rollback left behind",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+      await reindexBlock102(~indexer, ~source=source1337, ~count=999n)
+
+      source100.setAutoHeight(300)
+      source1337.setAutoHeight(300)
+      let restarted = await indexer.restart()
+      await Utils.delay(0)
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      t.expect(
+        (
+          await Promise.all2((counters(restarted), progressByChain(restarted))),
+          source100.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+          source1337.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+        ),
+        ~message="Both chains resume from block 103 with their rows intact",
+      ).toEqual((
+        (
+          [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
+          [
+            {value: "102", labels: Dict.fromArray([("chainId", "100")])},
+            {value: "102", labels: Dict.fromArray([("chainId", "1337")])},
+          ],
+        ),
+        [103],
+        [103],
+      ))
+    },
+  )
+
+  fullHistoryScenario->Scenario.it(
+    "Keeps the sibling's full history when save_full_history is on",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+      await reindexBlock102(~indexer, ~source=source1337, ~count=999n)
+
+      t.expect(
+        await Promise.all3((
+          counterHistory(indexer),
+          counters(indexer),
+          indexer.queryCheckpoints(),
+        )),
+        ~message="Chain 100 kept every history row and checkpoint it ever wrote",
+      ).toEqual((
+        [
+          Set({
+            checkpointId: 3n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 100n, chainId: 100},
+          }),
+          Set({
+            checkpointId: 4n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 1337n, chainId: 1337},
+          }),
+          Set({
+            checkpointId: 6n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 1002n, chainId: 100},
+          }),
+          Set({
+            checkpointId: 8n,
+            entityId: "total"->EntityId.unsafeOfString,
+            entity: {id: "total", count: 999n, chainId: 1337},
+          }),
+        ],
+        [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
+        [
+          {
+            id: 1n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 100,
+            blockHash: blockHash("100"),
+            eventsProcessed: 0,
+          },
+          {
+            id: 2n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 100,
+            blockHash: blockHash("100"),
+            eventsProcessed: 0,
+          },
+          {
+            id: 3n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 4n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 101,
+            blockHash: blockHash("101"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 6n,
+            chainId: 100->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+          {
+            id: 8n,
+            chainId: 1337->ChainId.fromInt,
+            blockNumber: 102,
+            blockHash: blockHash("102"),
+            eventsProcessed: 1,
+          },
+        ],
+      ))
+    },
+  )
+
+  clickHouseScenario->Scenario.it(
+    "Mirrors the isolated rollback into the ClickHouse sink",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+      await reindexBlock102(~indexer, ~source=source1337, ~count=999n)
+      await indexer.waitUntilIdle()
+
+      let database = TestClickHouse.currentDatabase()
+      t.expect(
+        (
+          await TestClickHouse.query(
+            `SELECT id, count, chainId FROM \`${database}\`.\`Counter\` ORDER BY chainId FORMAT JSONEachRow`,
+          )
+        )->String.trim,
+        ~message="The view resolves chain 100's untouched row and chain 1337's re-indexed one",
+      ).toEqual(`{"id":"total","count":"1002","chainId":100}
+{"id":"total","count":"999","chainId":1337}`)
+    },
+  )
+})

--- a/packages/envio-tests/test/IsolatedRollback_test.res
+++ b/packages/envio-tests/test/IsolatedRollback_test.res
@@ -108,8 +108,10 @@ let setCounterAndTotal = (~block, ~count: bigint): MockSource.itemMock => {
   },
 }
 
-let progressByChain = async (indexer: IndexerRunner.t) => {
-  let metrics = await indexer.metric("envio_progress_block")
+// Per-chain metrics come back in no particular order, so every read is sorted
+// by the chain label the assertions are written in.
+let metricByChain = async (indexer: IndexerRunner.t, name) => {
+  let metrics = await indexer.metric(name)
   metrics->Array.toSorted((a: IndexerRunner.metric, b) =>
     String.compare(
       a.labels->Dict.get("chainId")->Option.getOr(""),
@@ -117,6 +119,9 @@ let progressByChain = async (indexer: IndexerRunner.t) => {
     )
   )
 }
+
+let progressByChain = indexer => indexer->metricByChain("envio_progress_block")
+let eventsByChain = indexer => indexer->metricByChain("envio_progress_events")
 
 let counters = (indexer: IndexerRunner.t): promise<array<counter>> => indexer.query("Counter")
 let counterHistory = (indexer: IndexerRunner.t): promise<array<Change.t<counter>>> =>
@@ -154,31 +159,62 @@ let driveBothChainsToBlock102 = async (
   await indexer.getBatchWritePromise()
 }
 
-// Reorgs `source` at block 102: the range covering 103 comes back reporting a
-// different hash for 102, and blocks 100 and 101 survive the depth search.
+// Reorgs `source` at `atBlock`: the range above it comes back reporting a
+// different hash, and the depth search re-fetches `scanned` — the blocks the
+// chain still has hashes for. A block listed as `#valid` answers with the hash
+// already stored and `#orphaned` with a different one, so the rollback targets
+// the highest valid block among them.
 //
-// The rollback resets every chain's in-flight queries, so the sibling's are
+// A rollback that reaches `sibling` resets its in-flight queries, so those are
 // voided in the mock first — otherwise its pre-rollback queries stay pending
-// there and the ones it re-issues can't be told apart from them.
-let reorgAtBlock102 = async (
+// there and the ones it re-issues can't be told apart from them. An isolated
+// rollback leaves the sibling indexing, and passes no `sibling` to void.
+let reorgAt = async (
   ~indexer: IndexerRunner.t,
   ~source: MockSource.t,
-  ~sibling: MockSource.t,
+  ~sibling: option<MockSource.t>=?,
+  ~atBlock,
+  ~scanned: array<(int, [#valid | #orphaned])>=[],
 ) => {
-  sibling.dropPendingCalls()
+  sibling->Option.forEach(sibling => sibling.dropPendingCalls())
+  let reorgsBefore = source.reorgCallCount()
   source.resolveGetItemsOrThrow(
     [],
-    ~filter=MockSource.coveringBlock(103),
-    ~prevRangeLastBlock={blockNumber: 102, blockHash: "0x102a"},
+    ~filter=MockSource.coveringBlock(atBlock + 1),
+    ~prevRangeLastBlock={blockNumber: atBlock, blockHash: `0x${atBlock->Int.toString}a`},
   )
-  await Utils.delay(0)
-  await Utils.delay(0)
-  source.resolveGetBlockHashes([
-    {blockNumber: 100, blockHash: "0x0100", blockTimestamp: 100},
-    {blockNumber: 101, blockHash: "0x0101", blockTimestamp: 101},
-  ])
+  // The depth search drops the source's orphaned-chain state before it reads
+  // any hash, so this is the one point both shapes of the search pass through —
+  // and the only thing separating "the rollback hasn't started" from "there is
+  // no rollback" for a search that never asks for a hash at all.
+  await Scenario.waitUntil(
+    () => source.reorgCallCount() > reorgsBefore,
+    ~message="the reorg to be detected and the rollback's depth search to start",
+  )
+  // With nothing left hashed inside the threshold the search skips the lookup
+  // and falls straight back to the threshold's lower edge, so an empty
+  // `scanned` waits for no call.
+  if scanned->Array.length > 0 {
+    await Scenario.waitUntil(
+      () => source.getBlockHashesCalls->Array.length > 0,
+      ~message="the rollback's depth search to re-fetch the scanned block hashes",
+    )
+    source.resolveGetBlockHashes(
+      scanned->Array.map(((blockNumber, fate)): BlockStore.inputBlock => {
+        blockNumber,
+        blockHash: switch fate {
+        | #valid => `0x${blockNumber->Int.toString}`
+        | #orphaned => `0x${blockNumber->Int.toString}a`
+        },
+        blockTimestamp: blockNumber,
+      }),
+    )
+  }
   await indexer.getRollbackReadyPromise()
 }
+
+let reorgAtBlock102 = (~indexer, ~source, ~sibling) =>
+  reorgAt(~indexer, ~source, ~sibling, ~atBlock=102, ~scanned=[(100, #valid), (101, #valid)])
 
 // The rollback diff only reaches the database with the next batch, so the reorg
 // chain re-delivers block 102 to flush it.
@@ -191,8 +227,41 @@ let reindexBlock102 = async (~indexer: IndexerRunner.t, ~source: MockSource.t, ~
   await indexer.getBatchWritePromise()
 }
 
-// The three shapes every assertion below is made of, so a case reads as the
-// rows it expects rather than as the records that spell them.
+// Chain 1337's only event sits far above the pre-threshold boundary, with chain
+// 100 left just ahead of it so the fetch budget still comes back to 1337. Once
+// the block-100 checkpoints are pruned, chain 1337 has nothing at or below the
+// block a reorg deeper than that event takes it back to, so the rollback finds
+// no checkpoint to target and falls back to the fork block itself.
+let driveToDistantChain1337 = async (
+  ~t,
+  ~indexer: IndexerRunner.t,
+  ~source100: MockSource.t,
+  ~source1337: MockSource.t,
+) => {
+  await Utils.delay(0)
+  let _ = await Promise.all2((
+    Scenario.enterReorgThreshold(~t, ~indexer, ~source=source100),
+    Scenario.enterReorgThreshold(~t, ~indexer, ~source=source1337),
+  ))
+
+  source100.resolveGetItemsOrThrow(
+    [setCounter(~block=101, ~count=100n)],
+    ~latestFetchedBlockNumber=101,
+  )
+  await MockSource.waitItemsQuery(source1337)
+  source1337.resolveGetItemsOrThrow(
+    [setCounter(~block=150, ~count=1337n)],
+    ~latestFetchedBlockNumber=150,
+  )
+  await indexer.getBatchWritePromise()
+
+  source100.resolveGetItemsOrThrow(
+    [setCounter(~block=102, ~count=1002n)],
+    ~latestFetchedBlockNumber=151,
+  )
+  await indexer.getBatchWritePromise()
+}
+
 let checkpoint = (~id, ~chain, ~block, ~events): InternalTable.Checkpoints.t => {
   id,
   chainId: chain->ChainId.fromInt,
@@ -414,9 +483,12 @@ describe("Isolated multichain rollback", () => {
       await reorgAtBlock102(~indexer, ~source=source100, ~sibling=source1337)
 
       t.expect(
-        await progressByChain(indexer),
-        ~message="Both chains went back past the lower of the two targets",
-      ).toEqual(progress(~chain100="101", ~chain1337="100"))
+        (await progressByChain(indexer), await eventsByChain(indexer)),
+        ~message="Both chains went back past the lower of the two targets, events with them",
+      ).toEqual((
+        progress(~chain100="101", ~chain1337="100"),
+        progress(~chain100="1", ~chain1337="0"),
+      ))
 
       source100.resolveGetItemsOrThrow(
         [setCounter(~block=102, ~count=1003n)],
@@ -592,6 +664,68 @@ describe("Isolated multichain rollback", () => {
         ),
         ~message="Chain 100 resumes at the block the first, superseded rollback took it back to",
       ).toEqual((progress(~chain100="101", ~chain1337="101"), [102], [102]))
+    },
+  )
+
+  // A rollback never moves a chain forward. When the superseded diff took its
+  // chain below every checkpoint that chain has left, the rollback replacing it
+  // recomputes that chain's progress from those same checkpoints — a block the
+  // chain is no longer at. Only the chain that reorged this time is clamped to
+  // its own fork block, so the superseded chain has to be held down by where the
+  // first rollback already left it.
+  //
+  // Run on the cross-chain schema because the first rollback has to take both
+  // chains back: an isolated one leaves the sibling ahead, and the reorg chain
+  // then holds the fetch budget as the furthest behind, so the sibling never
+  // gets to reorg on top of it. The scope reaches the same recompute either way.
+  crossChainScenario->Scenario.it(
+    "Keeps a superseded chain below the checkpoints the new rollback recomputes from",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveToDistantChain1337(~t, ~indexer, ~source100, ~source1337)
+
+      // Chain 1337 forks below block 150, its only checkpoint: nothing of its
+      // own is at or under the fork, so the rollback has no checkpoint to target
+      // and falls back to the fork block, clamping the block-150 checkpoint's
+      // recomputed 149 down to 100.
+      await reorgAt(
+        ~indexer,
+        ~source=source1337,
+        ~sibling=source100,
+        ~atBlock=150,
+        ~scanned=[(100, #valid), (150, #orphaned)],
+      )
+
+      t.expect(
+        await progressByChain(indexer),
+        ~message="Chain 1337 went back to the fork block, below its only checkpoint",
+      ).toEqual(progress(~chain100="100", ~chain1337="100"))
+
+      // No batch has carried that diff, so this reorg supersedes it. Chain 1337
+      // is no longer the reorg chain, so its progress is recomputed from the
+      // block-150 checkpoint still in the database — 49 blocks above where the
+      // superseded rollback left it.
+      await reorgAt(~indexer, ~source=source100, ~sibling=source1337, ~atBlock=100)
+
+      t.expect(
+        (await progressByChain(indexer), await eventsByChain(indexer)),
+        ~message="Chain 1337 stays at the fork block the superseded rollback took it to",
+      ).toEqual((
+        progress(~chain100="100", ~chain1337="100"),
+        progress(~chain100="0", ~chain1337="0"),
+      ))
+
+      t.expect(
+        source1337.getItemsOrThrowCalls
+        ->Array.map(call => call.payload["fromBlock"])
+        ->Array.toSorted(Int.compare)
+        ->Array.get(0),
+        ~message="Chain 1337 re-fetches from just above the fork, not from its lost checkpoint",
+      ).toEqual(Some(101))
     },
   )
 

--- a/packages/envio-tests/test/IsolatedRollback_test.res
+++ b/packages/envio-tests/test/IsolatedRollback_test.res
@@ -191,6 +191,7 @@ let reorgAt = async (
     () => source.reorgCallCount() > reorgsBefore,
     ~message="the reorg to be detected and the rollback's depth search to start",
   )
+
   // With nothing left hashed inside the threshold the search skips the lookup
   // and falls straight back to the threshold's lower edge, so an empty
   // `scanned` waits for no call.

--- a/packages/envio-tests/test/IsolatedRollback_test.res
+++ b/packages/envio-tests/test/IsolatedRollback_test.res
@@ -194,6 +194,113 @@ let reindexBlock102 = async (~indexer: IndexerRunner.t, ~source: MockSource.t, ~
 let blockHash = blockNumber => Js.Null.Value(MockSource.evmBlockHash(`0x0${blockNumber}`))
 
 describe("Isolated multichain rollback", () => {
+  // The diff rides on the next batch whatever produced it, and a sibling that
+  // never stopped indexing produces one long before the reorg chain has
+  // re-fetched anything. That batch has no progress of its own for the reorg
+  // chain, so the rollback has to carry it: otherwise the chain's stored
+  // progress outlives the checkpoints backing it, and a restart resumes past
+  // blocks it never re-indexed.
+  scenario->Scenario.it(
+    "Persists the rolled-back progress when a sibling's batch carries the diff",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+
+      // Only chain 100 progresses, so its batch is what carries the diff.
+      source100.resolveGetItemsOrThrow(
+        [],
+        ~filter=MockSource.coveringBlock(103),
+        ~latestFetchedBlockNumber=104,
+      )
+      await indexer.getBatchWritePromise()
+
+      source100.setAutoHeight(300)
+      source1337.setAutoHeight(300)
+      let restarted = await indexer.restart()
+      await Utils.delay(0)
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      t.expect(
+        (
+          await Promise.all2((counters(restarted), progressByChain(restarted))),
+          source1337.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+          source100.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+        ),
+        ~message="Chain 1337 resumes at the block the rollback took it back to",
+      ).toEqual((
+        (
+          [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 1337n, chainId: 1337}],
+          [
+            {value: "104", labels: Dict.fromArray([("chainId", "100")])},
+            {value: "101", labels: Dict.fromArray([("chainId", "1337")])},
+          ],
+        ),
+        [102],
+        [105],
+      ))
+    },
+  )
+
+  // Same write, with the reorg chain's sibling rolled back too: it is in the
+  // rollback's progress rows *and* in the batch's, so the batch's later value
+  // has to be the one that stands.
+  crossChainScenario->Scenario.it(
+    "Lets a batch's own progress win over the rollback's for the same chain",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(
+        ~t,
+        ~indexer,
+        ~source100,
+        ~source1337,
+        ~item=setCounterAndTotal,
+      )
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+
+      // The global rollback took chain 100 back to 101 as well; it re-fetches
+      // past that before chain 1337 gets anywhere, and carries the diff.
+      source100.resolveGetItemsOrThrow(
+        [],
+        ~filter=MockSource.coveringBlock(102),
+        ~latestFetchedBlockNumber=104,
+      )
+      await indexer.getBatchWritePromise()
+
+      source100.setAutoHeight(300)
+      source1337.setAutoHeight(300)
+      let restarted = await indexer.restart()
+      await Utils.delay(0)
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      t.expect(
+        (
+          await progressByChain(restarted),
+          source1337.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+          source100.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+        ),
+        ~message="Chain 100 resumes from what its batch reached, chain 1337 from where the rollback left it",
+      ).toEqual((
+        [
+          {value: "104", labels: Dict.fromArray([("chainId", "100")])},
+          {value: "101", labels: Dict.fromArray([("chainId", "1337")])},
+        ],
+        [102],
+        [105],
+      ))
+    },
+  )
+
   scenario->Scenario.it(
     "Rolls back the reorg chain alone and leaves its sibling untouched",
     ~sources=[{chain: 100, methods}, {chain: 1337, methods}],

--- a/packages/envio-tests/test/IsolatedRollback_test.res
+++ b/packages/envio-tests/test/IsolatedRollback_test.res
@@ -191,9 +191,270 @@ let reindexBlock102 = async (~indexer: IndexerRunner.t, ~source: MockSource.t, ~
   await indexer.getBatchWritePromise()
 }
 
-let blockHash = blockNumber => Js.Null.Value(MockSource.evmBlockHash(`0x0${blockNumber}`))
+// The three shapes every assertion below is made of, so a case reads as the
+// rows it expects rather than as the records that spell them.
+let checkpoint = (~id, ~chain, ~block, ~events): InternalTable.Checkpoints.t => {
+  id,
+  chainId: chain->ChainId.fromInt,
+  blockNumber: block,
+  blockHash: Js.Null.Value(MockSource.evmBlockHash(`0x0${block->Int.toString}`)),
+  eventsProcessed: events,
+}
+
+let counterSet = (~checkpointId, ~chain, ~count): Change.t<counter> => Set({
+  checkpointId,
+  entityId: "total"->EntityId.unsafeOfString,
+  entity: {id: "total", count, chainId: chain},
+})
+
+let progress = (~chain100, ~chain1337): array<IndexerRunner.metric> => [
+  {value: chain100, labels: Dict.fromArray([("chainId", "100")])},
+  {value: chain1337, labels: Dict.fromArray([("chainId", "1337")])},
+]
 
 describe("Isolated multichain rollback", () => {
+  scenario->Scenario.it(
+    "Rolls back the reorg chain alone and leaves its sibling untouched",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+
+      t.expect(
+        await Promise.all4((
+          indexer.queryCheckpoints(),
+          counters(indexer),
+          counterHistory(indexer),
+          progressByChain(indexer),
+        )),
+        ~message="Both chains reached block 102, with their checkpoints interleaved",
+      ).toEqual((
+        [
+          checkpoint(~id=3n, ~chain=100, ~block=101, ~events=1),
+          checkpoint(~id=4n, ~chain=1337, ~block=101, ~events=1),
+          checkpoint(~id=5n, ~chain=1337, ~block=102, ~events=1),
+          checkpoint(~id=6n, ~chain=100, ~block=102, ~events=1),
+        ],
+        [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 13372n, chainId: 1337}],
+        [
+          counterSet(~checkpointId=3n, ~chain=100, ~count=100n),
+          counterSet(~checkpointId=4n, ~chain=1337, ~count=1337n),
+          counterSet(~checkpointId=5n, ~chain=1337, ~count=13372n),
+          counterSet(~checkpointId=6n, ~chain=100, ~count=1002n),
+        ],
+        progress(~chain100="102", ~chain1337="102"),
+      ))
+
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+
+      t.expect(
+        (
+          await progressByChain(indexer),
+          // The lowest block chain 100 is asked for once it re-issues the
+          // queries the rollback dropped: it kept block 102, so it never goes
+          // back below 103.
+          source100.getItemsOrThrowCalls
+          ->Array.map(call => call.payload["fromBlock"])
+          ->Array.toSorted(Int.compare)
+          ->Array.get(0),
+        ),
+        ~message="Only chain 1337 lost progress",
+      ).toEqual((progress(~chain100="102", ~chain1337="101"), Some(103)))
+
+      await reindexBlock102(~indexer, ~source=source1337, ~count=999n)
+
+      t.expect(
+        await Promise.all4((
+          indexer.queryCheckpoints(),
+          counters(indexer),
+          counterHistory(indexer),
+          progressByChain(indexer),
+        )),
+        ~message="Chain 1337 re-indexed above chain 100's untouched rows",
+      ).toEqual((
+        [
+          checkpoint(~id=3n, ~chain=100, ~block=101, ~events=1),
+          checkpoint(~id=4n, ~chain=1337, ~block=101, ~events=1),
+          checkpoint(~id=6n, ~chain=100, ~block=102, ~events=1),
+          checkpoint(~id=8n, ~chain=1337, ~block=102, ~events=1),
+        ],
+        [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
+        [
+          counterSet(~checkpointId=3n, ~chain=100, ~count=100n),
+          counterSet(~checkpointId=4n, ~chain=1337, ~count=1337n),
+          counterSet(~checkpointId=6n, ~chain=100, ~count=1002n),
+          counterSet(~checkpointId=8n, ~chain=1337, ~count=999n),
+        ],
+        progress(~chain100="102", ~chain1337="102"),
+      ))
+    },
+  )
+  crossChainScenario->Scenario.it(
+    "Falls back to a global rollback when one entity is cross-chain",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(
+        ~t,
+        ~indexer,
+        ~source100,
+        ~source1337,
+        ~item=setCounterAndTotal,
+      )
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+
+      // Chain 100 has to give back block 102 as well: its own write to `Total`
+      // sat on top of the chain-1337 write the reorg took away.
+      t.expect(
+        (
+          await progressByChain(indexer),
+          source100.getItemsOrThrowCalls->Array.some(call => call.payload["fromBlock"] === 102),
+        ),
+        ~message="Both chains lost block 102",
+      ).toEqual((progress(~chain100="101", ~chain1337="101"), true))
+
+      source100.resolveGetItemsOrThrow(
+        [setCounterAndTotal(~block=102, ~count=1002n)],
+        ~filter=MockSource.coveringBlock(102),
+        ~latestFetchedBlockNumber=102,
+      )
+      await indexer.getBatchWritePromise()
+      source1337.resolveGetItemsOrThrow(
+        [setCounterAndTotal(~block=102, ~count=999n)],
+        ~filter=MockSource.coveringBlock(102),
+        ~latestFetchedBlockNumber=102,
+      )
+      await indexer.getBatchWritePromise()
+
+      t.expect(
+        await Promise.all3((
+          indexer.queryCheckpoints(),
+          counters(indexer),
+          (indexer.query("Total"): promise<array<total>>),
+        )),
+        ~message="Every checkpoint above the target went, on both chains",
+      ).toEqual((
+        [
+          checkpoint(~id=3n, ~chain=100, ~block=101, ~events=1),
+          checkpoint(~id=4n, ~chain=1337, ~block=101, ~events=1),
+          checkpoint(~id=8n, ~chain=100, ~block=102, ~events=1),
+          checkpoint(~id=9n, ~chain=1337, ~block=102, ~events=1),
+        ],
+        [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
+        [{id: "total", count: 999n}],
+      ))
+    },
+  )
+  // The second rollback's target sits below checkpoints the first one's chain
+  // has since re-indexed. Deleting by checkpoint id alone would take those with
+  // it; only the reorg chain's rows may go.
+  scenario->Scenario.it(
+    "Keeps a sibling's re-indexed rows when a later reorg targets a lower checkpoint",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+      await reindexBlock102(~indexer, ~source=source1337, ~count=999n)
+
+      await reorgAtBlock102(~indexer, ~source=source100, ~sibling=source1337)
+      await reindexBlock102(~indexer, ~source=source100, ~count=1003n)
+
+      t.expect(
+        await Promise.all4((
+          indexer.queryCheckpoints(),
+          counters(indexer),
+          counterHistory(indexer),
+          progressByChain(indexer),
+        )),
+        ~message="Chain 1337's re-indexed rows outlived chain 100's rollback to a lower checkpoint",
+      ).toEqual((
+        [
+          checkpoint(~id=3n, ~chain=100, ~block=101, ~events=1),
+          checkpoint(~id=4n, ~chain=1337, ~block=101, ~events=1),
+          checkpoint(~id=8n, ~chain=1337, ~block=102, ~events=1),
+          checkpoint(~id=10n, ~chain=100, ~block=102, ~events=1),
+        ],
+        [{id: "total", count: 1003n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
+        [
+          counterSet(~checkpointId=3n, ~chain=100, ~count=100n),
+          counterSet(~checkpointId=4n, ~chain=1337, ~count=1337n),
+          counterSet(~checkpointId=8n, ~chain=1337, ~count=999n),
+          counterSet(~checkpointId=10n, ~chain=100, ~count=1003n),
+        ],
+        progress(~chain100="102", ~chain1337="102"),
+      ))
+    },
+  )
+  // Two isolated rollbacks can't be merged: the second diff replaces the first,
+  // and its deletes only reach its own chain. Widening to a global rollback is
+  // what keeps the first one's rows from being stranded above their target.
+  scenario->Scenario.it(
+    "Widens to a global rollback when a second reorg lands before the first is written",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+
+      // No batch progresses in between, so the first diff is still unwritten
+      // when the second reorg computes its own.
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+      await reorgAtBlock102(~indexer, ~source=source100, ~sibling=source1337)
+
+      t.expect(
+        await progressByChain(indexer),
+        ~message="Both chains went back past the lower of the two targets",
+      ).toEqual(progress(~chain100="101", ~chain1337="100"))
+
+      source100.resolveGetItemsOrThrow(
+        [setCounter(~block=102, ~count=1003n)],
+        ~filter=MockSource.coveringBlock(102),
+        ~latestFetchedBlockNumber=102,
+      )
+      await indexer.getBatchWritePromise()
+      source1337.resolveGetItemsOrThrow(
+        [setCounter(~block=101, ~count=1337n), setCounter(~block=102, ~count=999n)],
+        ~filter=MockSource.coveringBlock(101),
+        ~latestFetchedBlockNumber=102,
+      )
+      await indexer.getBatchWritePromise()
+
+      t.expect(
+        await Promise.all3((
+          indexer.queryCheckpoints(),
+          counters(indexer),
+          counterHistory(indexer),
+        )),
+        ~message="Nothing above the lower target survived on either chain",
+      ).toEqual((
+        [
+          checkpoint(~id=3n, ~chain=100, ~block=101, ~events=1),
+          checkpoint(~id=8n, ~chain=100, ~block=102, ~events=1),
+          checkpoint(~id=9n, ~chain=1337, ~block=101, ~events=1),
+          checkpoint(~id=10n, ~chain=1337, ~block=102, ~events=1),
+        ],
+        [{id: "total", count: 1003n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
+        [
+          counterSet(~checkpointId=3n, ~chain=100, ~count=100n),
+          counterSet(~checkpointId=8n, ~chain=100, ~count=1003n),
+          counterSet(~checkpointId=9n, ~chain=1337, ~count=1337n),
+          counterSet(~checkpointId=10n, ~chain=1337, ~count=999n),
+        ],
+      ))
+    },
+  )
   // The diff rides on the next batch whatever produced it, and a sibling that
   // never stopped indexing produces one long before the reorg chain has
   // re-fetched anything. That batch has no progress of its own for the reorg
@@ -236,17 +497,13 @@ describe("Isolated multichain rollback", () => {
       ).toEqual((
         (
           [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 1337n, chainId: 1337}],
-          [
-            {value: "104", labels: Dict.fromArray([("chainId", "100")])},
-            {value: "101", labels: Dict.fromArray([("chainId", "1337")])},
-          ],
+          progress(~chain100="104", ~chain1337="101"),
         ),
         [102],
         [105],
       ))
     },
   )
-
   // Same write, with the reorg chain's sibling rolled back too: it is in the
   // rollback's progress rows *and* in the batch's, so the batch's later value
   // has to be the one that stands.
@@ -290,471 +547,9 @@ describe("Isolated multichain rollback", () => {
           source100.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
         ),
         ~message="Chain 100 resumes from what its batch reached, chain 1337 from where the rollback left it",
-      ).toEqual((
-        [
-          {value: "104", labels: Dict.fromArray([("chainId", "100")])},
-          {value: "101", labels: Dict.fromArray([("chainId", "1337")])},
-        ],
-        [102],
-        [105],
-      ))
+      ).toEqual((progress(~chain100="104", ~chain1337="101"), [102], [105]))
     },
   )
-
-  scenario->Scenario.it(
-    "Rolls back the reorg chain alone and leaves its sibling untouched",
-    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
-    ~reorgThresholdReadyTolerance=0,
-    async (~t, ~indexer, ~source) => {
-      let source100 = source(100)
-      let source1337 = source(1337)
-
-      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
-
-      t.expect(
-        await Promise.all4((
-          indexer.queryCheckpoints(),
-          counters(indexer),
-          counterHistory(indexer),
-          progressByChain(indexer),
-        )),
-        ~message="Both chains reached block 102, with their checkpoints interleaved",
-      ).toEqual((
-        [
-          {
-            id: 3n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 4n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 5n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 6n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-        ],
-        [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 13372n, chainId: 1337}],
-        [
-          Set({
-            checkpointId: 3n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 100n, chainId: 100},
-          }),
-          Set({
-            checkpointId: 4n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 1337n, chainId: 1337},
-          }),
-          Set({
-            checkpointId: 5n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 13372n, chainId: 1337},
-          }),
-          Set({
-            checkpointId: 6n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 1002n, chainId: 100},
-          }),
-        ],
-        [
-          {value: "102", labels: Dict.fromArray([("chainId", "100")])},
-          {value: "102", labels: Dict.fromArray([("chainId", "1337")])},
-        ],
-      ))
-
-      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
-
-      t.expect(
-        (
-          await progressByChain(indexer),
-          // The lowest block chain 100 is asked for once it re-issues the
-          // queries the rollback dropped: it kept block 102, so it never goes
-          // back below 103.
-          source100.getItemsOrThrowCalls
-          ->Array.map(call => call.payload["fromBlock"])
-          ->Array.toSorted(Int.compare)
-          ->Array.get(0),
-        ),
-        ~message="Only chain 1337 lost progress",
-      ).toEqual((
-        [
-          {value: "102", labels: Dict.fromArray([("chainId", "100")])},
-          {value: "101", labels: Dict.fromArray([("chainId", "1337")])},
-        ],
-        Some(103),
-      ))
-
-      await reindexBlock102(~indexer, ~source=source1337, ~count=999n)
-
-      t.expect(
-        await Promise.all4((
-          indexer.queryCheckpoints(),
-          counters(indexer),
-          counterHistory(indexer),
-          progressByChain(indexer),
-        )),
-        ~message="Chain 1337 re-indexed above chain 100's untouched rows",
-      ).toEqual((
-        [
-          {
-            id: 3n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 4n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 6n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 8n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-        ],
-        [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
-        [
-          Set({
-            checkpointId: 3n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 100n, chainId: 100},
-          }),
-          Set({
-            checkpointId: 4n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 1337n, chainId: 1337},
-          }),
-          Set({
-            checkpointId: 6n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 1002n, chainId: 100},
-          }),
-          Set({
-            checkpointId: 8n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 999n, chainId: 1337},
-          }),
-        ],
-        [
-          {value: "102", labels: Dict.fromArray([("chainId", "100")])},
-          {value: "102", labels: Dict.fromArray([("chainId", "1337")])},
-        ],
-      ))
-    },
-  )
-
-  crossChainScenario->Scenario.it(
-    "Falls back to a global rollback when one entity is cross-chain",
-    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
-    ~reorgThresholdReadyTolerance=0,
-    async (~t, ~indexer, ~source) => {
-      let source100 = source(100)
-      let source1337 = source(1337)
-
-      await driveBothChainsToBlock102(
-        ~t,
-        ~indexer,
-        ~source100,
-        ~source1337,
-        ~item=setCounterAndTotal,
-      )
-      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
-
-      // Chain 100 has to give back block 102 as well: its own write to `Total`
-      // sat on top of the chain-1337 write the reorg took away.
-      t.expect(
-        (
-          await progressByChain(indexer),
-          source100.getItemsOrThrowCalls->Array.some(call => call.payload["fromBlock"] === 102),
-        ),
-        ~message="Both chains lost block 102",
-      ).toEqual((
-        [
-          {value: "101", labels: Dict.fromArray([("chainId", "100")])},
-          {value: "101", labels: Dict.fromArray([("chainId", "1337")])},
-        ],
-        true,
-      ))
-
-      source100.resolveGetItemsOrThrow(
-        [setCounterAndTotal(~block=102, ~count=1002n)],
-        ~filter=MockSource.coveringBlock(102),
-        ~latestFetchedBlockNumber=102,
-      )
-      await indexer.getBatchWritePromise()
-      source1337.resolveGetItemsOrThrow(
-        [setCounterAndTotal(~block=102, ~count=999n)],
-        ~filter=MockSource.coveringBlock(102),
-        ~latestFetchedBlockNumber=102,
-      )
-      await indexer.getBatchWritePromise()
-
-      t.expect(
-        await Promise.all3((
-          indexer.queryCheckpoints(),
-          counters(indexer),
-          (indexer.query("Total"): promise<array<total>>),
-        )),
-        ~message="Every checkpoint above the target went, on both chains",
-      ).toEqual((
-        [
-          {
-            id: 3n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 4n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 8n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 9n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-        ],
-        [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
-        [{id: "total", count: 999n}],
-      ))
-    },
-  )
-
-  // The second rollback's target sits below checkpoints the first one's chain
-  // has since re-indexed. Deleting by checkpoint id alone would take those with
-  // it; only the reorg chain's rows may go.
-  scenario->Scenario.it(
-    "Keeps a sibling's re-indexed rows when a later reorg targets a lower checkpoint",
-    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
-    ~reorgThresholdReadyTolerance=0,
-    async (~t, ~indexer, ~source) => {
-      let source100 = source(100)
-      let source1337 = source(1337)
-
-      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
-      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
-      await reindexBlock102(~indexer, ~source=source1337, ~count=999n)
-
-      await reorgAtBlock102(~indexer, ~source=source100, ~sibling=source1337)
-      await reindexBlock102(~indexer, ~source=source100, ~count=1003n)
-
-      t.expect(
-        await Promise.all4((
-          indexer.queryCheckpoints(),
-          counters(indexer),
-          counterHistory(indexer),
-          progressByChain(indexer),
-        )),
-        ~message="Chain 1337's re-indexed rows outlived chain 100's rollback to a lower checkpoint",
-      ).toEqual((
-        [
-          {
-            id: 3n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 4n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 8n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 10n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-        ],
-        [{id: "total", count: 1003n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
-        [
-          Set({
-            checkpointId: 3n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 100n, chainId: 100},
-          }),
-          Set({
-            checkpointId: 4n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 1337n, chainId: 1337},
-          }),
-          Set({
-            checkpointId: 8n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 999n, chainId: 1337},
-          }),
-          Set({
-            checkpointId: 10n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 1003n, chainId: 100},
-          }),
-        ],
-        [
-          {value: "102", labels: Dict.fromArray([("chainId", "100")])},
-          {value: "102", labels: Dict.fromArray([("chainId", "1337")])},
-        ],
-      ))
-    },
-  )
-
-  // Two isolated rollbacks can't be merged: the second diff replaces the first,
-  // and its deletes only reach its own chain. Widening to a global rollback is
-  // what keeps the first one's rows from being stranded above their target.
-  scenario->Scenario.it(
-    "Widens to a global rollback when a second reorg lands before the first is written",
-    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
-    ~reorgThresholdReadyTolerance=0,
-    async (~t, ~indexer, ~source) => {
-      let source100 = source(100)
-      let source1337 = source(1337)
-
-      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
-
-      // No batch progresses in between, so the first diff is still unwritten
-      // when the second reorg computes its own.
-      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
-      await reorgAtBlock102(~indexer, ~source=source100, ~sibling=source1337)
-
-      t.expect(
-        await progressByChain(indexer),
-        ~message="Both chains went back past the lower of the two targets",
-      ).toEqual([
-        {value: "101", labels: Dict.fromArray([("chainId", "100")])},
-        {value: "100", labels: Dict.fromArray([("chainId", "1337")])},
-      ])
-
-      source100.resolveGetItemsOrThrow(
-        [setCounter(~block=102, ~count=1003n)],
-        ~filter=MockSource.coveringBlock(102),
-        ~latestFetchedBlockNumber=102,
-      )
-      await indexer.getBatchWritePromise()
-      source1337.resolveGetItemsOrThrow(
-        [setCounter(~block=101, ~count=1337n), setCounter(~block=102, ~count=999n)],
-        ~filter=MockSource.coveringBlock(101),
-        ~latestFetchedBlockNumber=102,
-      )
-      await indexer.getBatchWritePromise()
-
-      t.expect(
-        await Promise.all3((
-          indexer.queryCheckpoints(),
-          counters(indexer),
-          counterHistory(indexer),
-        )),
-        ~message="Nothing above the lower target survived on either chain",
-      ).toEqual((
-        [
-          {
-            id: 3n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 8n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 9n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 10n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-        ],
-        [{id: "total", count: 1003n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
-        [
-          Set({
-            checkpointId: 3n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 100n, chainId: 100},
-          }),
-          Set({
-            checkpointId: 8n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 1003n, chainId: 100},
-          }),
-          Set({
-            checkpointId: 9n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 1337n, chainId: 1337},
-          }),
-          Set({
-            checkpointId: 10n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 999n, chainId: 1337},
-          }),
-        ],
-      ))
-    },
-  )
-
   scenario->Scenario.it(
     "Resumes from the checkpoints an isolated rollback left behind",
     ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
@@ -784,17 +579,13 @@ describe("Isolated multichain rollback", () => {
       ).toEqual((
         (
           [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
-          [
-            {value: "102", labels: Dict.fromArray([("chainId", "100")])},
-            {value: "102", labels: Dict.fromArray([("chainId", "1337")])},
-          ],
+          progress(~chain100="102", ~chain1337="102"),
         ),
         [103],
         [103],
       ))
     },
   )
-
   fullHistoryScenario->Scenario.it(
     "Keeps the sibling's full history when save_full_history is on",
     ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
@@ -816,76 +607,23 @@ describe("Isolated multichain rollback", () => {
         ~message="Chain 100 kept every history row and checkpoint it ever wrote",
       ).toEqual((
         [
-          Set({
-            checkpointId: 3n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 100n, chainId: 100},
-          }),
-          Set({
-            checkpointId: 4n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 1337n, chainId: 1337},
-          }),
-          Set({
-            checkpointId: 6n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 1002n, chainId: 100},
-          }),
-          Set({
-            checkpointId: 8n,
-            entityId: "total"->EntityId.unsafeOfString,
-            entity: {id: "total", count: 999n, chainId: 1337},
-          }),
+          counterSet(~checkpointId=3n, ~chain=100, ~count=100n),
+          counterSet(~checkpointId=4n, ~chain=1337, ~count=1337n),
+          counterSet(~checkpointId=6n, ~chain=100, ~count=1002n),
+          counterSet(~checkpointId=8n, ~chain=1337, ~count=999n),
         ],
         [{id: "total", count: 1002n, chainId: 100}, {id: "total", count: 999n, chainId: 1337}],
         [
-          {
-            id: 1n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 100,
-            blockHash: blockHash("100"),
-            eventsProcessed: 0,
-          },
-          {
-            id: 2n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 100,
-            blockHash: blockHash("100"),
-            eventsProcessed: 0,
-          },
-          {
-            id: 3n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 4n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 101,
-            blockHash: blockHash("101"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 6n,
-            chainId: 100->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
-          {
-            id: 8n,
-            chainId: 1337->ChainId.fromInt,
-            blockNumber: 102,
-            blockHash: blockHash("102"),
-            eventsProcessed: 1,
-          },
+          checkpoint(~id=1n, ~chain=100, ~block=100, ~events=0),
+          checkpoint(~id=2n, ~chain=1337, ~block=100, ~events=0),
+          checkpoint(~id=3n, ~chain=100, ~block=101, ~events=1),
+          checkpoint(~id=4n, ~chain=1337, ~block=101, ~events=1),
+          checkpoint(~id=6n, ~chain=100, ~block=102, ~events=1),
+          checkpoint(~id=8n, ~chain=1337, ~block=102, ~events=1),
         ],
       ))
     },
   )
-
   clickHouseScenario->Scenario.it(
     "Mirrors the isolated rollback into the ClickHouse sink",
     ~sources=[{chain: 100, methods}, {chain: 1337, methods}],

--- a/packages/envio-tests/test/IsolatedRollback_test.res
+++ b/packages/envio-tests/test/IsolatedRollback_test.res
@@ -550,6 +550,51 @@ describe("Isolated multichain rollback", () => {
       ).toEqual((progress(~chain100="104", ~chain1337="101"), [102], [105]))
     },
   )
+  // The widened rollback recomputes progress from the checkpoints, and a chain
+  // the superseded diff already moved can land on exactly the block it is
+  // already at. It is still a chain whose stored progress the write has to
+  // correct, so the superseded diff's rows have to survive into this one.
+  scenario->Scenario.it(
+    "Keeps a superseded diff's progress for a chain the new one leaves where it found it",
+    ~sources=[{chain: 100, methods}, {chain: 1337, methods}],
+    ~reorgThresholdReadyTolerance=0,
+    async (~t, ~indexer, ~source) => {
+      let source100 = source(100)
+      let source1337 = source(1337)
+
+      await driveBothChainsToBlock102(~t, ~indexer, ~source100, ~source1337, ~item=setCounter)
+
+      // Chain 100 first, so its target (checkpoint 3) is below chain 1337's
+      // (checkpoint 4) and the widened rollback lands on chain 100's own —
+      // leaving chain 100 at the 101 the first diff already took it to.
+      await reorgAtBlock102(~indexer, ~source=source100, ~sibling=source1337)
+      await reorgAtBlock102(~indexer, ~source=source1337, ~sibling=source100)
+
+      source1337.resolveGetItemsOrThrow(
+        [setCounter(~block=101, ~count=1337n)],
+        ~filter=MockSource.coveringBlock(101),
+        ~latestFetchedBlockNumber=101,
+      )
+      await indexer.getBatchWritePromise()
+
+      source100.setAutoHeight(300)
+      source1337.setAutoHeight(300)
+      let restarted = await indexer.restart()
+      await Utils.delay(0)
+      await Utils.delay(0)
+      await Utils.delay(0)
+
+      t.expect(
+        (
+          await progressByChain(restarted),
+          source100.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+          source1337.getItemsOrThrowCalls->Array.map(call => call.payload["fromBlock"]),
+        ),
+        ~message="Chain 100 resumes at the block the first, superseded rollback took it back to",
+      ).toEqual((progress(~chain100="101", ~chain1337="101"), [102], [102]))
+    },
+  )
+
   scenario->Scenario.it(
     "Resumes from the checkpoints an isolated rollback left behind",
     ~sources=[{chain: 100, methods}, {chain: 1337, methods}],

--- a/packages/envio-tests/test/LoadLayer_test.res
+++ b/packages/envio-tests/test/LoadLayer_test.res
@@ -1081,6 +1081,7 @@ describe("LoadLayer effect scope isolation", () => {
     indexerState->IndexerState.beginRollbackDiff(
       ~targetCheckpointId=0n,
       ~diffCheckpointId=0n,
+      ~scope=Global,
       ~progressBlockNumberByChainId=Dict.make(),
       ~rolledBackAddresses=[],
     )

--- a/packages/envio-tests/test/LoadLayer_test.res
+++ b/packages/envio-tests/test/LoadLayer_test.res
@@ -1082,7 +1082,7 @@ describe("LoadLayer effect scope isolation", () => {
       ~targetCheckpointId=0n,
       ~diffCheckpointId=0n,
       ~scope=Global,
-      ~progressBlockNumberByChainId=Dict.make(),
+      ~progressedChains=[],
       ~rolledBackAddresses=[],
     )
 

--- a/packages/envio-tests/test/Rollback_test.res
+++ b/packages/envio-tests/test/Rollback_test.res
@@ -2985,11 +2985,11 @@ describe("E2E rollback tests", () => {
         }
         storage.getRollbackTargetCheckpoint(~reorgChainId, ~lastKnownValidBlockNumber)
       },
-      getRollbackProgressDiff: (~rollbackTargetCheckpointId) => {
+      getRollbackProgressDiff: (~scope, ~rollbackTargetCheckpointId) => {
         if stallWriteBatch.contents->Option.isSome {
           rollbackReadBeforeFlush := true
         }
-        storage.getRollbackProgressDiff(~rollbackTargetCheckpointId)
+        storage.getRollbackProgressDiff(~scope, ~rollbackTargetCheckpointId)
       },
       writeBatch: (
         ~batch,

--- a/packages/envio-tests/test/SiblingRollbackStuckChain_test.res
+++ b/packages/envio-tests/test/SiblingRollbackStuckChain_test.res
@@ -5,9 +5,9 @@ open Vitest
 // prepareReorg/rollback rebuild the chain's partitions. Afterwards the chain
 // must keep fetching — the incident on chain 42161 froze here: waits kept
 // resolving block after block while getNextQuery never produced a query again.
-let scenario = Scenario.make(
-  ~configYaml=`
-name: sibling-rollback
+let configYaml = (~name, ~extra="") =>
+  `
+name: ${name}${extra}
 contracts:
   - name: Token
     events:
@@ -33,18 +33,35 @@ chains:
     contracts:
       - name: Token
         address: "0x0000000000000000000000000000000000000001"
-`,
-  ~schema=`
+`
+
+let schema = `
 type Counter {
   id: ID!
   count: BigInt!
 }
-`,
-  ~handlers=`
+`
+
+let handlers = `
 import { indexer } from "envio";
 
 indexer.onEvent({ contract: "Token", event: "Transfer" }, async () => {});
-`,
+`
+
+// The default cross-chain Counter keeps this on the global rollback path, where
+// the sibling chain is rolled back along with the reorg chain.
+let scenario = Scenario.make(~configYaml=configYaml(~name="sibling-rollback"), ~schema, ~handlers)
+
+// The same incident with a per-chain schema, where the rollback stays isolated
+// to the reorg chain: the sibling keeps its progress, and must still carry on
+// fetching after its in-flight response is dropped.
+let perChainScenario = Scenario.make(
+  ~configYaml=configYaml(
+    ~name="sibling-rollback-per-chain",
+    ~extra="\ndisable_default_cross_chain: true",
+  ),
+  ~schema,
+  ~handlers,
 )
 
 type counterOps = {set: {"id": string, "count": bigint} => unit}
@@ -76,174 +93,219 @@ let registerToken = (~block): MockSource.itemMock => {
   },
 }
 
+// What the sibling's rollback did to the victim chain: the progress it was left
+// with, and then the range it fetched once it was free to run again.
+type victimAftermath = {
+  progressAfterRollback: option<string>,
+  maxFromBlock: int,
+  minFromBlock: int,
+}
+
+let sources: array<Scenario.sourceMock> = [
+  {chain: 1, methods: [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes], pollingInterval: 1},
+  {chain: 137, methods: [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes], pollingInterval: 1},
+]
+
 describe("Sibling-chain rollback with an in-flight query", () => {
+  // Drives both chains to the head, leaves a victim-chain query in flight and
+  // reorgs the sibling under it. Shared by the two schemas, which differ only in
+  // how far the resulting rollback reaches.
+  let runIncident = async (
+    ~t: Vitest.testContext,
+    ~indexer: IndexerRunner.t,
+    ~source: (int, ~index: int=?) => MockSource.t,
+  ) => {
+    let victim = source(1)
+    let sibling = source(137)
+    victim.resolveGetHeightOrThrow(300)
+    sibling.resolveGetHeightOrThrow(300)
+    await Utils.delay(0)
+    await Utils.delay(0)
+
+    // Drive both chains to head 300 through the reorg-threshold transition,
+    // resolving every query as it appears.
+    let drainTo = async (source: MockSource.t, ~latest, ~items=[]) => {
+      let attempts = ref(0)
+      while source.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
+        attempts := attempts.contents + 1
+        await Utils.delay(0)
+      }
+      // Both partitions get the same response, the way the incident chain saw
+      // the same factory events through every address partition.
+      source.getItemsOrThrowCalls
+      ->Utils.Array.copy
+      ->Array.forEach(call => call.resolve(items, ~latestFetchedBlockNumber=latest))
+      await Utils.delay(0)
+      await Utils.delay(0)
+    }
+
+    // Pre-threshold queries stop at 100 (head - maxReorgDepth).
+    await drainTo(victim, ~latest=100)
+    await drainTo(sibling, ~latest=100)
+    await indexer.getBatchWritePromise()
+
+    // Post-threshold queries reach the head. The victim's response also
+    // registers a dynamic Token address at block 250, spawning a catch-up
+    // partition mid-response like the incident chain's factory events.
+    await drainTo(
+      victim,
+      ~latest=300,
+      ~items=[setCounter(~block=200, ~count=1n), registerToken(~block=250)],
+    )
+    await drainTo(sibling, ~latest=300, ~items=[setCounter(~block=200, ~count=2n)])
+    // Serve the dynamic partition's catch-up queries until the chain is quiet.
+    let attempts = ref(0)
+    while attempts.contents < 200 {
+      attempts := attempts.contents + 1
+      if victim.getItemsOrThrowCalls->Array.length > 0 {
+        victim.drainItemsQueries(~latestFetchedBlockNumber=300)
+      }
+      await Utils.delay(0)
+    }
+    await indexer.getBatchWritePromise()
+    await indexer.waitUntilReady()
+
+    // New block on the victim chain. The first partition queries it; its
+    // response lands, which schedules the tick that sends the second
+    // partition's query — that one stays in flight through the rollback,
+    // like partition 7 in the incident.
+    // The chain re-polls at its own cadence through the rollback, so give it a
+    // standing answer rather than one answer per poll.
+    victim.setAutoHeight(301)
+    let attempts = ref(0)
+    while victim.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
+      attempts := attempts.contents + 1
+      await Utils.delay(0)
+    }
+    victim.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=301)
+    let attempts = ref(0)
+    while victim.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
+      attempts := attempts.contents + 1
+      await Utils.delay(0)
+    }
+    t.expect(
+      victim.getItemsOrThrowCalls->Array.length,
+      ~message="the second victim partition should now be querying the new head block",
+    ).toEqual(1)
+
+    // Reorg on the sibling chain: block 300 comes back with a different hash.
+    sibling.setAutoHeight(301)
+    let attempts = ref(0)
+    while sibling.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
+      attempts := attempts.contents + 1
+      await Utils.delay(0)
+    }
+    sibling.resolveGetItemsOrThrow(
+      [],
+      ~latestFetchedBlockNumber=301,
+      ~prevRangeLastBlock={blockNumber: 300, blockHash: "0x300a"},
+    )
+    await Utils.delay(0)
+    // The victim's in-flight response lands inside the rollback window —
+    // after the reorg was detected but before the rollback applied.
+    switch victim.getItemsOrThrowCalls->Array.length {
+    | 0 => ()
+    | _ => victim.drainItemsQueries(~latestFetchedBlockNumber=301)
+    }
+    // The rollback target usually comes from the recorded safe checkpoints;
+    // serve getBlockHashes only if the depth search asks for it.
+    let attempts = ref(0)
+    while sibling.getBlockHashesCalls->Array.length === 0 && attempts.contents < 100 {
+      attempts := attempts.contents + 1
+      await Utils.delay(0)
+    }
+    if sibling.getBlockHashesCalls->Array.length > 0 {
+      sibling.resolveGetBlockHashes([
+        {blockNumber: 100, blockHash: "0x100", blockTimestamp: 100},
+        {blockNumber: 200, blockHash: "0x200", blockTimestamp: 200},
+      ])
+    }
+    await indexer.getRollbackReadyPromise()
+
+    // The rollback dropped the victim's pending query bookkeeping; its
+    // response arrives now, carrying the old epoch, and is discarded.
+    switch victim.getItemsOrThrowCalls->Array.length {
+    | 0 => ()
+    | _ => victim.drainItemsQueries(~latestFetchedBlockNumber=301)
+    }
+    await Utils.delay(0)
+    await Utils.delay(0)
+
+    let progressAfterRollback =
+      (await indexer.metric("envio_progress_block"))
+      ->Array.find(metric => metric.labels->Dict.get("chainId") === Some("1"))
+      ->Option.map(metric => metric.value)
+
+    // Both chains must resume fetching after the rollback and refetch their
+    // rolled-back ranges — including re-registering the pruned dynamic
+    // address when block 250 is re-delivered. The victim chain is wedged if
+    // it never catches back up to the head.
+    victim.setAutoHeight(302)
+    sibling.setAutoHeight(302)
+    let victimMaxFromBlock = ref(0)
+    let victimMinFromBlock = ref(Int.Constants.maxValue)
+    let attempts = ref(0)
+    while victimMaxFromBlock.contents < 302 && attempts.contents < 3000 {
+      attempts := attempts.contents + 1
+      victim.getItemsOrThrowCalls
+      ->Utils.Array.copy
+      ->Array.forEach(call => {
+        let fromBlock = call.payload["fromBlock"]
+        let toBlock = call.payload["toBlock"]->Option.getOr(302)
+        if fromBlock > victimMaxFromBlock.contents {
+          victimMaxFromBlock := fromBlock
+        }
+        if fromBlock < victimMinFromBlock.contents {
+          victimMinFromBlock := fromBlock
+        }
+        let latest = Pervasives.min(toBlock, 302)
+        call.resolve(
+          fromBlock <= 250 && 250 <= latest ? [registerToken(~block=250)] : [],
+          ~latestFetchedBlockNumber=latest,
+        )
+      })
+      if sibling.getItemsOrThrowCalls->Array.length > 0 {
+        sibling.drainItemsQueries(~latestFetchedBlockNumber=302)
+      }
+      await Utils.delay(1)
+    }
+
+    {
+      progressAfterRollback,
+      maxFromBlock: victimMaxFromBlock.contents,
+      minFromBlock: victimMinFromBlock.contents,
+    }
+  }
+
   scenario->Scenario.it(
     "chain keeps fetching after its in-flight response is dropped by a sibling rollback",
-    ~sources=[
-      {chain: 1, methods: [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes], pollingInterval: 1},
-      {
-        chain: 137,
-        methods: [#getHeightOrThrow, #getItemsOrThrow, #getBlockHashes],
-        pollingInterval: 1,
-      },
-    ],
+    ~sources,
     // Two addresses on chain 1 -> two partitions, so one partition's query
     // can stay in flight while the other's response lands.
     ~maxAddrInPartition=1,
     ~reducedPollingInterval=1,
     async (~t, ~indexer, ~source) => {
-      let victim = source(1)
-      let sibling = source(137)
-      victim.resolveGetHeightOrThrow(300)
-      sibling.resolveGetHeightOrThrow(300)
-      await Utils.delay(0)
-      await Utils.delay(0)
-
-      // Drive both chains to head 300 through the reorg-threshold transition,
-      // resolving every query as it appears.
-      let drainTo = async (source: MockSource.t, ~latest, ~items=[]) => {
-        let attempts = ref(0)
-        while source.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
-          attempts := attempts.contents + 1
-          await Utils.delay(0)
-        }
-        // Both partitions get the same response, the way the incident chain saw
-        // the same factory events through every address partition.
-        source.getItemsOrThrowCalls
-        ->Utils.Array.copy
-        ->Array.forEach(call => call.resolve(items, ~latestFetchedBlockNumber=latest))
-        await Utils.delay(0)
-        await Utils.delay(0)
-      }
-
-      // Pre-threshold queries stop at 100 (head - maxReorgDepth).
-      await drainTo(victim, ~latest=100)
-      await drainTo(sibling, ~latest=100)
-      await indexer.getBatchWritePromise()
-
-      // Post-threshold queries reach the head. The victim's response also
-      // registers a dynamic Token address at block 250, spawning a catch-up
-      // partition mid-response like the incident chain's factory events.
-      await drainTo(
-        victim,
-        ~latest=300,
-        ~items=[setCounter(~block=200, ~count=1n), registerToken(~block=250)],
-      )
-      await drainTo(sibling, ~latest=300, ~items=[setCounter(~block=200, ~count=2n)])
-      // Serve the dynamic partition's catch-up queries until the chain is quiet.
-      let attempts = ref(0)
-      while attempts.contents < 200 {
-        attempts := attempts.contents + 1
-        if victim.getItemsOrThrowCalls->Array.length > 0 {
-          victim.drainItemsQueries(~latestFetchedBlockNumber=300)
-        }
-        await Utils.delay(0)
-      }
-      await indexer.getBatchWritePromise()
-      await indexer.waitUntilReady()
-
-      // New block on the victim chain. The first partition queries it; its
-      // response lands, which schedules the tick that sends the second
-      // partition's query — that one stays in flight through the rollback,
-      // like partition 7 in the incident.
-      // The chain re-polls at its own cadence through the rollback, so give it a
-      // standing answer rather than one answer per poll.
-      victim.setAutoHeight(301)
-      let attempts = ref(0)
-      while victim.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
-        attempts := attempts.contents + 1
-        await Utils.delay(0)
-      }
-      victim.resolveGetItemsOrThrow([], ~latestFetchedBlockNumber=301)
-      let attempts = ref(0)
-      while victim.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
-        attempts := attempts.contents + 1
-        await Utils.delay(0)
-      }
-      t.expect(
-        victim.getItemsOrThrowCalls->Array.length,
-        ~message="the second victim partition should now be querying the new head block",
-      ).toEqual(1)
-
-      // Reorg on the sibling chain: block 300 comes back with a different hash.
-      sibling.setAutoHeight(301)
-      let attempts = ref(0)
-      while sibling.getItemsOrThrowCalls->Array.length === 0 && attempts.contents < 1000 {
-        attempts := attempts.contents + 1
-        await Utils.delay(0)
-      }
-      sibling.resolveGetItemsOrThrow(
-        [],
-        ~latestFetchedBlockNumber=301,
-        ~prevRangeLastBlock={blockNumber: 300, blockHash: "0x300a"},
-      )
-      await Utils.delay(0)
-      // The victim's in-flight response lands inside the rollback window —
-      // after the reorg was detected but before the rollback applied.
-      switch victim.getItemsOrThrowCalls->Array.length {
-      | 0 => ()
-      | _ => victim.drainItemsQueries(~latestFetchedBlockNumber=301)
-      }
-      // The rollback target usually comes from the recorded safe checkpoints;
-      // serve getBlockHashes only if the depth search asks for it.
-      let attempts = ref(0)
-      while sibling.getBlockHashesCalls->Array.length === 0 && attempts.contents < 100 {
-        attempts := attempts.contents + 1
-        await Utils.delay(0)
-      }
-      if sibling.getBlockHashesCalls->Array.length > 0 {
-        sibling.resolveGetBlockHashes([
-          {blockNumber: 100, blockHash: "0x100", blockTimestamp: 100},
-          {blockNumber: 200, blockHash: "0x200", blockTimestamp: 200},
-        ])
-      }
-      await indexer.getRollbackReadyPromise()
-
-      // The rollback dropped the victim's pending query bookkeeping; its
-      // response arrives now, carrying the old epoch, and is discarded.
-      switch victim.getItemsOrThrowCalls->Array.length {
-      | 0 => ()
-      | _ => victim.drainItemsQueries(~latestFetchedBlockNumber=301)
-      }
-      await Utils.delay(0)
-      await Utils.delay(0)
-
-      // Both chains must resume fetching after the rollback and refetch their
-      // rolled-back ranges — including re-registering the pruned dynamic
-      // address when block 250 is re-delivered. The victim chain is wedged if
-      // it never catches back up to the head.
-      victim.setAutoHeight(302)
-      sibling.setAutoHeight(302)
-      let victimMaxFromBlock = ref(0)
-      let attempts = ref(0)
-      while victimMaxFromBlock.contents < 302 && attempts.contents < 3000 {
-        attempts := attempts.contents + 1
-        victim.getItemsOrThrowCalls
-        ->Utils.Array.copy
-        ->Array.forEach(
-          call => {
-            let fromBlock = call.payload["fromBlock"]
-            let toBlock = call.payload["toBlock"]->Option.getOr(302)
-            if fromBlock > victimMaxFromBlock.contents {
-              victimMaxFromBlock := fromBlock
-            }
-            let latest = Pervasives.min(toBlock, 302)
-            call.resolve(
-              fromBlock <= 250 && 250 <= latest ? [registerToken(~block=250)] : [],
-              ~latestFetchedBlockNumber=latest,
-            )
-          },
-        )
-        if sibling.getItemsOrThrowCalls->Array.length > 0 {
-          sibling.drainItemsQueries(~latestFetchedBlockNumber=302)
-        }
-        await Utils.delay(1)
-      }
+      let aftermath = await runIncident(~t, ~indexer, ~source)
 
       t.expect(
-        victimMaxFromBlock.contents >= 302,
-        ~message="the victim chain should catch back up to the head after the sibling rollback",
-      ).toBe(true)
+        (aftermath.progressAfterRollback, aftermath.maxFromBlock >= 302, aftermath.minFromBlock),
+        ~message="the victim chain gives back the progress the global rollback took, then catches up again",
+      ).toEqual((Some("249"), true, 250))
+    },
+  )
+
+  perChainScenario->Scenario.it(
+    "chain keeps fetching and is never rolled back when the reorg stays isolated",
+    ~sources,
+    ~maxAddrInPartition=1,
+    ~reducedPollingInterval=1,
+    async (~t, ~indexer, ~source) => {
+      let aftermath = await runIncident(~t, ~indexer, ~source)
+
+      t.expect(
+        (aftermath.progressAfterRollback, aftermath.maxFromBlock >= 302, aftermath.minFromBlock),
+        ~message="the victim chain keeps its progress and only re-issues the query the rollback dropped",
+      ).toEqual((Some("300"), true, 301))
     },
   )
 })

--- a/packages/envio-tests/test/helpers/MockStorage.res
+++ b/packages/envio-tests/test/helpers/MockStorage.res
@@ -164,9 +164,9 @@ let make = (methods: array<method>, ~dbEntities=[]) => {
       ) => (),
       getRollbackTargetCheckpoint: (~reorgChainId as _, ~lastKnownValidBlockNumber as _) =>
         JsError.throwWithMessage("Not implemented"),
-      getRollbackProgressDiff: (~rollbackTargetCheckpointId as _) =>
+      getRollbackProgressDiff: (~scope as _, ~rollbackTargetCheckpointId as _) =>
         JsError.throwWithMessage("Not implemented"),
-      getRollbackData: (~entityConfig as _, ~rollbackTargetCheckpointId as _) =>
+      getRollbackData: (~entityConfig as _, ~scope as _, ~rollbackTargetCheckpointId as _) =>
         JsError.throwWithMessage("Not implemented"),
       writeBatch: (
         ~batch as _,

--- a/packages/envio-tests/test/lib_tests/PgStorage_test.res
+++ b/packages/envio-tests/test/lib_tests/PgStorage_test.res
@@ -788,7 +788,8 @@ FROM "test_schema"."envio_checkpoints" cp
 INNER JOIN reorg_chains rc 
   ON cp."chain_id" = rc.id
 WHERE cp."block_hash" IS NOT NULL
-  AND cp."block_number" >= rc.safe_block;`
+  AND cp."block_number" >= rc.safe_block
+ORDER BY cp."id";`
 
         t.expect(
           query,

--- a/packages/envio-tests/test/lib_tests/PgStorage_test.res
+++ b/packages/envio-tests/test/lib_tests/PgStorage_test.res
@@ -1025,6 +1025,7 @@ LIMIT 1;`
       async t => {
         let query = InternalTable.Checkpoints.makeGetRollbackProgressDiffQuery(
           ~pgSchema="test_schema",
+          ~scope=Global,
         )
 
         let expectedQuery = `SELECT 

--- a/packages/envio/src/Batch.res
+++ b/packages/envio/src/Batch.res
@@ -189,6 +189,15 @@ let addReorgCheckpoints = (
   }
 }
 
+// Checkpoint ids are handed out in ascending order as each chain's items are
+// walked in block order, so within a chain a higher id always means a later
+// block. Rollback preserves that: it deletes the chain's ids above its target
+// before any higher one is allocated, so the ids the re-indexed blocks get are
+// above everything the chain still holds. An isolated rollback leans on the
+// invariant — it deletes by `chain_id = c AND id > target`, which is only the
+// chain's stale suffix if ids and blocks agree on order within the chain. Ids
+// interleave freely *across* chains, which is exactly why that predicate can't
+// be the id bound alone.
 let prepareBatch = (
   ~checkpointIdBeforeBatch,
   ~chainsBeforeBatch: dict<chainBeforeBatch>,

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -1205,21 +1205,17 @@ let markReady = (cs: t, ~readyAt) =>
     cs.timestampCaughtUpToHeadOrEndblock = Some(readyAt)
   }
 
-// Roll a chain back to a reorg target. With a progress diff, restore fetch/
-// safe-checkpoint/progress state to `newProgressBlockNumber`. A reorg chain
-// with no diff entry still rewinds fetch state + stores to the target -
-// otherwise the stale block hash stays in the store and re-triggers the same
-// reorg.
-// Returns the address registrations the storage has to delete along with it —
-// the store is what decides which ones died, so the two halves of a rollback
-// can't disagree.
-let rollback = (
-  cs: t,
-  ~newProgressBlockNumber,
-  ~eventsProcessedDiff,
-  ~rollbackTargetBlockNumber,
-  ~isReorgChain,
-): array<AddressRows.key> => {
+type progressDiff = {blockNumber: int, eventsProcessed: float}
+
+type rolledBackTo =
+  | RecomputedProgress(progressDiff)
+  | ForkBlock(int)
+  | Untouched
+
+// Returns the address registrations the storage has to delete along with the
+// chain — the store is what decides which ones died, so the two halves of a
+// rollback can't disagree.
+let rollback = (cs: t, ~rolledBackTo: rolledBackTo): array<AddressRows.key> => {
   let rollbackTo = targetBlockNumber => {
     let {fetchState, rolledBackAddresses} =
       cs.fetchState->FetchState.rollback(
@@ -1234,24 +1230,15 @@ let rollback = (
     })
   }
 
-  switch newProgressBlockNumber {
-  | Some(newProgressBlockNumber) =>
+  switch rolledBackTo {
+  | RecomputedProgress({blockNumber, eventsProcessed}) =>
     // A rollback only ever takes a chain back. The diff recomputes progress from
     // the checkpoints still in the database, so a chain that an unwritten
     // rollback already took below them — to a fork block only that rollback
     // knew — would be handed their MIN back and moved forward onto blocks it
     // never re-indexed.
-    let newProgressBlockNumber = Pervasives.min(
-      newProgressBlockNumber,
-      cs.committedProgressBlockNumber,
-    )
-    let newTotalEventsProcessed =
-      cs.numEventsProcessed -.
-      // Both dicts are populated together per progress-diff row, so a chain with
-      // a progress diff always has an events-processed diff too.
-      eventsProcessedDiff->Option.getOrThrow(
-        ~message="Missing events-processed diff for rolled-back chain",
-      )
+    let newProgressBlockNumber = Pervasives.min(blockNumber, cs.committedProgressBlockNumber)
+    let newTotalEventsProcessed = cs.numEventsProcessed -. eventsProcessed
 
     switch cs.safeCheckpointTracking {
     | Some(safeCheckpointTracking) =>
@@ -1269,19 +1256,15 @@ let rollback = (
     cs.processingBlockNumber = newProgressBlockNumber
     cs.numEventsProcessed = newTotalEventsProcessed
     rolledBackAddresses
-  | None =>
-    if isReorgChain {
-      let rolledBackAddresses = rollbackTo(rollbackTargetBlockNumber)
-      cs.transactionStore->TransactionStore.rollback(rollbackTargetBlockNumber)
-      cs.blockStore->BlockStore.rollback(rollbackTargetBlockNumber)
-      cs.committedProgressBlockNumber = Pervasives.min(
-        cs.committedProgressBlockNumber,
-        rollbackTargetBlockNumber,
-      )
-      cs.processingBlockNumber = Pervasives.min(cs.processingBlockNumber, rollbackTargetBlockNumber)
-      rolledBackAddresses
-    } else {
-      []
-    }
+  | ForkBlock(forkBlock) =>
+    // Rewinds the stores too, not just progress: otherwise the stale block hash
+    // survives and re-triggers the same reorg.
+    let rolledBackAddresses = rollbackTo(forkBlock)
+    cs.transactionStore->TransactionStore.rollback(forkBlock)
+    cs.blockStore->BlockStore.rollback(forkBlock)
+    cs.committedProgressBlockNumber = Pervasives.min(cs.committedProgressBlockNumber, forkBlock)
+    cs.processingBlockNumber = Pervasives.min(cs.processingBlockNumber, forkBlock)
+    rolledBackAddresses
+  | Untouched => []
   }
 }

--- a/packages/envio/src/ChainState.res
+++ b/packages/envio/src/ChainState.res
@@ -1236,6 +1236,15 @@ let rollback = (
 
   switch newProgressBlockNumber {
   | Some(newProgressBlockNumber) =>
+    // A rollback only ever takes a chain back. The diff recomputes progress from
+    // the checkpoints still in the database, so a chain that an unwritten
+    // rollback already took below them — to a fork block only that rollback
+    // knew — would be handed their MIN back and moved forward onto blocks it
+    // never re-indexed.
+    let newProgressBlockNumber = Pervasives.min(
+      newProgressBlockNumber,
+      cs.committedProgressBlockNumber,
+    )
     let newTotalEventsProcessed =
       cs.numEventsProcessed -.
       // Both dicts are populated together per progress-diff row, so a chain with

--- a/packages/envio/src/ChainState.resi
+++ b/packages/envio/src/ChainState.resi
@@ -157,10 +157,18 @@ let enterReorgThreshold: t => unit
 let advanceAfterBatch: (t, ~batch: Batch.t, ~enteringReorgThreshold: bool) => unit
 let applyBatchProgress: (t, ~batch: Batch.t, ~blockTimestampName: string) => unit
 let markReady: (t, ~readyAt: Date.t) => unit
-let rollback: (
-  t,
-  ~newProgressBlockNumber: option<int>,
-  ~eventsProcessedDiff: option<float>,
-  ~rollbackTargetBlockNumber: int,
-  ~isReorgChain: bool,
-) => array<AddressRows.key>
+// What a rollback's progress diff says about one chain: the block its surviving
+// checkpoints put it back to, and the events the deleted ones carried away. One
+// record because one diff row yields both — they are never known separately.
+type progressDiff = {blockNumber: int, eventsProcessed: float}
+
+// Where a rollback leaves one chain.
+type rolledBackTo =
+  | RecomputedProgress(progressDiff)
+  // The reorg chain with no checkpoint left at or below the target, so only the
+  // fork block says where it goes.
+  | ForkBlock(int)
+  // A chain this rollback doesn't reach.
+  | Untouched
+
+let rollback: (t, ~rolledBackTo: rolledBackTo) => array<AddressRows.key>

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -127,12 +127,6 @@ type t = {
   userEntitiesByName: dict<Internal.entityConfig>,
   userEntities: array<Internal.entityConfig>,
   allEnums: array<Table.enumConfig<Table.enum>>,
-  // With no cross-chain entity, a reorg on one chain can never have changed a
-  // row another chain owns, so its rollback stays isolated to that chain instead
-  // of dragging every sibling back with it. A single chain has no sibling to
-  // spare, and narrowing its rollback would only buy it a predicate that always
-  // holds.
-  isIsolatedMultichain: bool,
 }
 
 type rpcSourceFor = | @as("sync") Sync | @as("fallback") Fallback | @as("realtime") Realtime
@@ -1073,10 +1067,16 @@ let fromPublic = (publicConfigJson: JSON.t) => {
     userEntitiesByName,
     userEntities,
     allEnums,
-    isIsolatedMultichain: chains->Array.length > 1 &&
-      userEntities->Array.every(entityConfig => !entityConfig.crossChain),
   }
 }
+
+// With no cross-chain entity, a reorg on one chain can never have changed a row
+// another chain owns, so its rollback stays isolated to that chain instead of
+// dragging every sibling back with it. A single chain has no sibling to spare,
+// and narrowing its rollback would only buy it a predicate that always holds.
+let isIsolatedMultichain = (config: t) =>
+  config.chainMap->ChainMap.keys->Array.length > 1 &&
+    config.userEntities->Array.every(entityConfig => !entityConfig.crossChain)
 
 // Canonicalize a user-provided address to the configured casing so it matches
 // addresses parsed from config.yaml during routing. HyperSync/RPC data arrives

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -127,9 +127,11 @@ type t = {
   userEntitiesByName: dict<Internal.entityConfig>,
   userEntities: array<Internal.entityConfig>,
   allEnums: array<Table.enumConfig<Table.enum>>,
-  // With several chains and no cross-chain entity, a reorg on one chain can
-  // never have changed a row another chain owns, so its rollback stays isolated
-  // to that chain instead of dragging every sibling back with it.
+  // With no cross-chain entity, a reorg on one chain can never have changed a
+  // row another chain owns, so its rollback stays isolated to that chain instead
+  // of dragging every sibling back with it. A single chain has no sibling to
+  // spare, and narrowing its rollback would only buy it a predicate that always
+  // holds.
   isIsolatedMultichain: bool,
 }
 

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -127,6 +127,10 @@ type t = {
   userEntitiesByName: dict<Internal.entityConfig>,
   userEntities: array<Internal.entityConfig>,
   allEnums: array<Table.enumConfig<Table.enum>>,
+  // With several chains and no cross-chain entity, a reorg on one chain can
+  // never have changed a row another chain owns, so its rollback stays isolated
+  // to that chain instead of dragging every sibling back with it.
+  isIsolatedMultichain: bool,
 }
 
 type rpcSourceFor = | @as("sync") Sync | @as("fallback") Fallback | @as("realtime") Realtime
@@ -1067,6 +1071,8 @@ let fromPublic = (publicConfigJson: JSON.t) => {
     userEntitiesByName,
     userEntities,
     allEnums,
+    isIsolatedMultichain: chains->Array.length > 1 &&
+      userEntities->Array.every(entityConfig => !entityConfig.crossChain),
   }
 }
 

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -127,7 +127,7 @@ let dropCommittedEffects = (
 
 let prepareRollbackDiff = async (
   state: IndexerState.t,
-  ~scope,
+  ~rollbackScope: RollbackScope.t,
   ~rollbackTargetCheckpointId,
   ~rollbackDiffCheckpointId,
   ~progressedChains,
@@ -136,7 +136,7 @@ let prepareRollbackDiff = async (
   state->IndexerState.beginRollbackDiff(
     ~targetCheckpointId=rollbackTargetCheckpointId,
     ~diffCheckpointId=rollbackDiffCheckpointId,
-    ~scope,
+    ~scope=rollbackScope,
     ~progressedChains,
     ~rolledBackAddresses,
   )
@@ -154,7 +154,7 @@ let prepareRollbackDiff = async (
   ->Array.map(async entityConfig => {
     let (removals, restoredEntities) = await persistence.storage.getRollbackData(
       ~entityConfig,
-      ~scope,
+      ~scope=rollbackScope,
       ~rollbackTargetCheckpointId,
     )
 

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -130,14 +130,14 @@ let prepareRollbackDiff = async (
   ~scope,
   ~rollbackTargetCheckpointId,
   ~rollbackDiffCheckpointId,
-  ~progressBlockNumberByChainId,
+  ~progressedChains,
   ~rolledBackAddresses,
 ) => {
   state->IndexerState.beginRollbackDiff(
     ~targetCheckpointId=rollbackTargetCheckpointId,
     ~diffCheckpointId=rollbackDiffCheckpointId,
     ~scope,
-    ~progressBlockNumberByChainId,
+    ~progressedChains,
     ~rolledBackAddresses,
   )
   let persistence = state->IndexerState.persistence

--- a/packages/envio/src/InMemoryStore.res
+++ b/packages/envio/src/InMemoryStore.res
@@ -127,6 +127,7 @@ let dropCommittedEffects = (
 
 let prepareRollbackDiff = async (
   state: IndexerState.t,
+  ~scope,
   ~rollbackTargetCheckpointId,
   ~rollbackDiffCheckpointId,
   ~progressBlockNumberByChainId,
@@ -135,6 +136,7 @@ let prepareRollbackDiff = async (
   state->IndexerState.beginRollbackDiff(
     ~targetCheckpointId=rollbackTargetCheckpointId,
     ~diffCheckpointId=rollbackDiffCheckpointId,
+    ~scope,
     ~progressBlockNumberByChainId,
     ~rolledBackAddresses,
   )
@@ -152,6 +154,7 @@ let prepareRollbackDiff = async (
   ->Array.map(async entityConfig => {
     let (removals, restoredEntities) = await persistence.storage.getRollbackData(
       ~entityConfig,
+      ~scope,
       ~rollbackTargetCheckpointId,
     )
 

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -793,6 +793,9 @@ let drainBatchRun = (state: t): Batch.t => {
   }
 }
 
+// The rollback diff staged for the next write, if one hasn't been written yet.
+let pendingRollback = (state: t): option<Persistence.rollback> => state.rollback
+
 // Take the pending rollback diff to write, clearing it from the store.
 let takeRollback = (state: t): option<Persistence.rollback> => {
   let rollback = state.rollback
@@ -814,6 +817,7 @@ let beginRollbackDiff = (
   state: t,
   ~targetCheckpointId,
   ~diffCheckpointId,
+  ~scope,
   ~progressBlockNumberByChainId,
   ~rolledBackAddresses,
 ) => {
@@ -832,6 +836,7 @@ let beginRollbackDiff = (
   state.rollback = Some({
     targetCheckpointId,
     diffCheckpointId,
+    scope,
     progressBlockNumberByChainId,
     rolledBackAddresses,
   })

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -793,7 +793,6 @@ let drainBatchRun = (state: t): Batch.t => {
   }
 }
 
-// The rollback diff staged for the next write, if one hasn't been written yet.
 let pendingRollback = (state: t): option<Persistence.rollback> => state.rollback
 
 // Take the pending rollback diff to write, clearing it from the store.
@@ -840,11 +839,10 @@ let beginRollbackDiff = (
   // chain wins, being the later reading of the same chain state.
   let progressedChains = switch state.rollback {
   | Some({progressedChains: pending}) =>
-    pending
-    ->Array.filter(({chainId}) =>
-      !(progressedChains->Array.some(chain => chain.chainId === chainId))
-    )
-    ->Array.concat(progressedChains)
+    let byChainId = Dict.make()
+    pending->Array.forEach(chain => byChainId->ChainId.Dict.set(chain.chainId, chain))
+    progressedChains->Array.forEach(chain => byChainId->ChainId.Dict.set(chain.chainId, chain))
+    byChainId->Dict.valuesToArray
   | None => progressedChains
   }
   state.rollback = Some({

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -818,7 +818,7 @@ let beginRollbackDiff = (
   ~targetCheckpointId,
   ~diffCheckpointId,
   ~scope,
-  ~progressedChains,
+  ~progressedChains: array<InternalTable.Chains.progressedChain>,
   ~rolledBackAddresses,
 ) => {
   let perChainEntities = state.allEntities->EntityTables.perChain
@@ -832,6 +832,20 @@ let beginRollbackDiff = (
   let rolledBackAddresses = switch state.rollback {
   | Some({rolledBackAddresses: pending}) => pending->Array.concat(rolledBackAddresses)
   | None => rolledBackAddresses
+  }
+  // Same for the chains: this rollback recomputes progress from the checkpoints,
+  // so a chain the pending diff already moved can land on exactly the block it
+  // is now at and go unreported here. Its stored progress still needs
+  // correcting, so the pending rows carry over — this rollback's row for a
+  // chain wins, being the later reading of the same chain state.
+  let progressedChains = switch state.rollback {
+  | Some({progressedChains: pending}) =>
+    pending
+    ->Array.filter(({chainId}) =>
+      !(progressedChains->Array.some(chain => chain.chainId === chainId))
+    )
+    ->Array.concat(progressedChains)
+  | None => progressedChains
   }
   state.rollback = Some({
     targetCheckpointId,

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -818,7 +818,7 @@ let beginRollbackDiff = (
   ~targetCheckpointId,
   ~diffCheckpointId,
   ~scope,
-  ~progressBlockNumberByChainId,
+  ~progressedChains,
   ~rolledBackAddresses,
 ) => {
   let perChainEntities = state.allEntities->EntityTables.perChain
@@ -837,7 +837,7 @@ let beginRollbackDiff = (
     targetCheckpointId,
     diffCheckpointId,
     scope,
-    progressBlockNumberByChainId,
+    progressedChains,
     rolledBackAddresses,
   })
 }

--- a/packages/envio/src/IndexerState.resi
+++ b/packages/envio/src/IndexerState.resi
@@ -144,7 +144,7 @@ let beginRollbackDiff: (
   ~targetCheckpointId: Internal.checkpointId,
   ~diffCheckpointId: Internal.checkpointId,
   ~scope: RollbackScope.t,
-  ~progressBlockNumberByChainId: dict<int>,
+  ~progressedChains: array<InternalTable.Chains.progressedChain>,
   ~rolledBackAddresses: array<AddressRows.key>,
 ) => unit
 let recordWriteFailure: (t, exn) => unit

--- a/packages/envio/src/IndexerState.resi
+++ b/packages/envio/src/IndexerState.resi
@@ -136,12 +136,14 @@ let recordRollbackSuccess: (t, ~timeSeconds: float, ~rollbackedProcessedEvents: 
 // Store domain operations.
 let queueProcessedBatch: (t, ~batch: Batch.t) => unit
 let drainBatchRun: t => Batch.t
+let pendingRollback: t => option<Persistence.rollback>
 let takeRollback: t => option<Persistence.rollback>
 let markCommitted: (t, ~upToCheckpointId: Internal.checkpointId) => unit
 let beginRollbackDiff: (
   t,
   ~targetCheckpointId: Internal.checkpointId,
   ~diffCheckpointId: Internal.checkpointId,
+  ~scope: RollbackScope.t,
   ~progressBlockNumberByChainId: dict<int>,
   ~rolledBackAddresses: array<AddressRows.key>,
 ) => unit

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -67,9 +67,13 @@ type rollback = {
   // The address registrations the rollback dropped, as the chains' address
   // stores resolved them. Deleted by primary key in the same transaction.
   rolledBackAddresses: array<AddressRows.key>,
-  // Last valid block per chain affected by the rollback. Read by
-  // `RollbackCommit.fire` once the diff is durably written.
-  progressBlockNumberByChainId: dict<int>,
+  // Where the rollback left every chain it moved. Written with the diff rather
+  // than waiting for a batch of those chains' own: the batch that carries the
+  // diff can belong to a chain the rollback never touched, and a chain whose
+  // stored progress outlived the checkpoints backing it would resume past
+  // blocks it never re-indexed. Also what `RollbackCommit.fire` reports once
+  // the diff is durably written.
+  progressedChains: array<InternalTable.Chains.progressedChain>,
 }
 
 // One flush group: the changes an entity accumulated within a single chain

--- a/packages/envio/src/Persistence.res
+++ b/packages/envio/src/Persistence.res
@@ -61,6 +61,9 @@ type updatedEffectCache = {
 type rollback = {
   targetCheckpointId: Internal.checkpointId,
   diffCheckpointId: Internal.checkpointId,
+  // How far the deletes reach. An isolated rollback must leave a sibling
+  // chain's rows alone, so the scope travels with the diff to the write.
+  scope: RollbackScope.t,
   // The address registrations the rollback dropped, as the chains' address
   // stores resolved them. Deleted by primary key in the same transaction.
   rolledBackAddresses: array<AddressRows.key>,
@@ -146,6 +149,7 @@ type storage = {
   ) => promise<option<Internal.checkpointId>>,
   // Get rollback progress diff
   getRollbackProgressDiff: (
+    ~scope: RollbackScope.t,
     ~rollbackTargetCheckpointId: Internal.checkpointId,
   ) => promise<
     array<{
@@ -159,6 +163,7 @@ type storage = {
   // before handing them back.
   getRollbackData: (
     ~entityConfig: Internal.entityConfig,
+    ~scope: RollbackScope.t,
     ~rollbackTargetCheckpointId: Internal.checkpointId,
   ) => promise<(array<rollbackRemoval>, array<Internal.entity>)>,
   // Write batch to storage

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1027,6 +1027,11 @@ let executeSet = (
   }
 }
 
+// The column a rollback narrows to when it is isolated to one chain. None for a
+// cross-chain entity, which the isolated path never sees.
+let rollbackChainIdColumn = (entityConfig: Internal.entityConfig) =>
+  entityConfig.table->Table.getChainIdField->Option.map(Table.getPgDbFieldName)
+
 let rec writeBatch = async (
   sql,
   ~batch: Batch.t,
@@ -1296,7 +1301,7 @@ let rec writeBatch = async (
     //valid event identifier, where all rows created after this eventIdentifier should
     //be deleted
     let rollbackTables = switch rollback {
-    | Some({targetCheckpointId: rollbackTargetCheckpointId, rolledBackAddresses}) =>
+    | Some({targetCheckpointId: rollbackTargetCheckpointId, scope, rolledBackAddresses}) =>
       Some(
         sql => {
           // Postgres owns history tables only for Postgres-backed entities;
@@ -1309,12 +1314,14 @@ let rec writeBatch = async (
                 ~pgSchema,
                 ~entityName=entityConfig.name,
                 ~entityIndex=entityConfig.index,
+                ~chainIdColumn=rollbackChainIdColumn(entityConfig),
+                ~scope,
                 ~rollbackTargetCheckpointId,
               )
             })
           promises
           ->Array.push(
-            sql->InternalTable.Checkpoints.rollback(~pgSchema, ~rollbackTargetCheckpointId),
+            sql->InternalTable.Checkpoints.rollback(~pgSchema, ~scope, ~rollbackTargetCheckpointId),
           )
           ->ignore
 
@@ -1476,7 +1483,11 @@ let rollbackKeyColumns = (entityConfig: Internal.entityConfig) =>
   | None => [Table.idFieldName]
   }
 
-let makeGetRollbackPreTargetRowsQuery = (~entityConfig: Internal.entityConfig, ~pgSchema) => {
+let makeGetRollbackPreTargetRowsQuery = (
+  ~entityConfig: Internal.entityConfig,
+  ~pgSchema,
+  ~scope: RollbackScope.t,
+) => {
   let dataFieldNames = entityConfig.table.fields->Array.filterMap(fieldOrDerived =>
     switch fieldOrDerived {
     | Field(field) => field->Table.getPgDbFieldName->Some
@@ -1503,7 +1514,9 @@ let makeGetRollbackPreTargetRowsQuery = (~entityConfig: Internal.entityConfig, ~
 
   `SELECT DISTINCT ON (${keyColumnsCommaSeparated}) ${dataFieldsCommaSeparated}, "${EntityHistory.changeFieldName}"
   FROM "${pgSchema}"."${historyTableName}"
-  WHERE "${EntityHistory.checkpointIdFieldName}" <= $1
+  WHERE "${EntityHistory.checkpointIdFieldName}" <= $1${scope->RollbackScope.predicate(
+      ~chainIdColumn=rollbackChainIdColumn(entityConfig),
+    )}
     AND EXISTS (
       SELECT 1
       FROM "${pgSchema}"."${historyTableName}" h
@@ -1515,7 +1528,11 @@ let makeGetRollbackPreTargetRowsQuery = (~entityConfig: Internal.entityConfig, ~
 
 // Returns entity IDs that were created after the rollback target and have no history before it.
 // DELETE rows at or before the target are returned by the restore query and classified in ReScript.
-let makeGetRollbackRemovedIdsQuery = (~entityConfig: Internal.entityConfig, ~pgSchema) => {
+let makeGetRollbackRemovedIdsQuery = (
+  ~entityConfig: Internal.entityConfig,
+  ~pgSchema,
+  ~scope: RollbackScope.t,
+) => {
   let historyTableName = EntityHistory.historyTableName(
     ~entityName=entityConfig.name,
     ~entityIndex=entityConfig.index,
@@ -1528,7 +1545,9 @@ let makeGetRollbackRemovedIdsQuery = (~entityConfig: Internal.entityConfig, ~pgS
 
   `SELECT DISTINCT ${keyColumns->Array.map(c => `"${c}"`)->Array.joinUnsafe(", ")}
   FROM "${pgSchema}"."${historyTableName}"
-  WHERE "${EntityHistory.checkpointIdFieldName}" > $1
+  WHERE "${EntityHistory.checkpointIdFieldName}" > $1${scope->RollbackScope.predicate(
+      ~chainIdColumn=rollbackChainIdColumn(entityConfig),
+    )}
     AND NOT EXISTS (
       SELECT 1
       FROM "${pgSchema}"."${historyTableName}" h
@@ -2380,26 +2399,33 @@ let make = (
       ~lastKnownValidBlockNumber,
     )
 
-  let getRollbackProgressDiff = (~rollbackTargetCheckpointId) =>
-    InternalTable.Checkpoints.getRollbackProgressDiff(sql, ~pgSchema, ~rollbackTargetCheckpointId)
+  let getRollbackProgressDiff = (~scope, ~rollbackTargetCheckpointId) =>
+    InternalTable.Checkpoints.getRollbackProgressDiff(
+      sql,
+      ~pgSchema,
+      ~scope,
+      ~rollbackTargetCheckpointId,
+    )
 
   let getRollbackData = async (
     ~entityConfig: Internal.entityConfig,
+    ~scope,
     ~rollbackTargetCheckpointId,
   ) => {
+    let params = scope->RollbackScope.params(~targetCheckpointId=rollbackTargetCheckpointId)
     let (removedIdRows, rollbackRows) = await Promise.all2((
       // Get IDs of entities that should be deleted (created after rollback target with no prior history)
       sql
       ->Postgres.preparedUnsafe(
-        makeGetRollbackRemovedIdsQuery(~entityConfig, ~pgSchema),
-        [rollbackTargetCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
+        makeGetRollbackRemovedIdsQuery(~entityConfig, ~pgSchema, ~scope),
+        params,
       )
       ->(Utils.magic: promise<unknown> => promise<array<unknown>>),
       // Get the latest pre-target row, including its SET or DELETE action.
       sql
       ->Postgres.preparedUnsafe(
-        makeGetRollbackPreTargetRowsQuery(~entityConfig, ~pgSchema),
-        [rollbackTargetCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
+        makeGetRollbackPreTargetRowsQuery(~entityConfig, ~pgSchema, ~scope),
+        params,
       )
       ->(Utils.magic: promise<unknown> => promise<array<unknown>>),
     ))

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1027,11 +1027,6 @@ let executeSet = (
   }
 }
 
-// The column a rollback narrows to when it is isolated to one chain. None for a
-// cross-chain entity, which the isolated path never sees.
-let rollbackChainIdColumn = (entityConfig: Internal.entityConfig) =>
-  entityConfig.table->Table.getChainIdField->Option.map(Table.getPgDbFieldName)
-
 let rec writeBatch = async (
   sql,
   ~batch: Batch.t,
@@ -1319,7 +1314,7 @@ let rec writeBatch = async (
                 ~pgSchema,
                 ~entityName=entityConfig.name,
                 ~entityIndex=entityConfig.index,
-                ~chainIdColumn=rollbackChainIdColumn(entityConfig),
+                ~chainIdColumn=entityConfig.table->Table.getPgChainIdColumn,
                 ~scope,
                 ~rollbackTargetCheckpointId,
               )
@@ -1530,7 +1525,7 @@ let makeGetRollbackPreTargetRowsQuery = (
   `SELECT DISTINCT ON (${keyColumnsCommaSeparated}) ${dataFieldsCommaSeparated}, "${EntityHistory.changeFieldName}"
   FROM "${pgSchema}"."${historyTableName}"
   WHERE "${EntityHistory.checkpointIdFieldName}" <= $1${scope->RollbackScope.predicate(
-      ~chainIdColumn=rollbackChainIdColumn(entityConfig),
+      ~chainIdColumn=entityConfig.table->Table.getPgChainIdColumn,
     )}
     AND EXISTS (
       SELECT 1
@@ -1561,7 +1556,7 @@ let makeGetRollbackRemovedIdsQuery = (
   `SELECT DISTINCT ${keyColumns->Array.map(c => `"${c}"`)->Array.joinUnsafe(", ")}
   FROM "${pgSchema}"."${historyTableName}"
   WHERE "${EntityHistory.checkpointIdFieldName}" > $1${scope->RollbackScope.predicate(
-      ~chainIdColumn=rollbackChainIdColumn(entityConfig),
+      ~chainIdColumn=entityConfig.table->Table.getPgChainIdColumn,
     )}
     AND NOT EXISTS (
       SELECT 1

--- a/packages/envio/src/PgStorage.res
+++ b/packages/envio/src/PgStorage.res
@@ -1301,7 +1301,12 @@ let rec writeBatch = async (
     //valid event identifier, where all rows created after this eventIdentifier should
     //be deleted
     let rollbackTables = switch rollback {
-    | Some({targetCheckpointId: rollbackTargetCheckpointId, scope, rolledBackAddresses}) =>
+    | Some({
+        targetCheckpointId: rollbackTargetCheckpointId,
+        scope,
+        rolledBackAddresses,
+        progressedChains,
+      }) =>
       Some(
         sql => {
           // Postgres owns history tables only for Postgres-backed entities;
@@ -1324,6 +1329,16 @@ let rec writeBatch = async (
             sql->InternalTable.Checkpoints.rollback(~pgSchema, ~scope, ~rollbackTargetCheckpointId),
           )
           ->ignore
+
+          // Runs before the batch's own progress write below, so a chain the
+          // batch also progressed keeps the batch's later value.
+          if progressedChains->Utils.Array.notEmpty {
+            promises
+            ->Array.push(
+              sql->InternalTable.Chains.setProgressedChains(~pgSchema, ~progressedChains),
+            )
+            ->ignore
+          }
 
           // Addresses are insert-only, so undoing their registrations is a
           // delete rather than a history replay. It runs before the batch's own

--- a/packages/envio/src/PruneStaleHistory.res
+++ b/packages/envio/src/PruneStaleHistory.res
@@ -103,7 +103,7 @@ let pruneEntities = async (state: IndexerState.t, ~entities, ~safeCheckpointId) 
     switch await persistence.storage.pruneStaleEntityHistory(
       ~entityName=entityConfig.name,
       ~entityIndex=entityConfig.index,
-      ~chainIdColumn=entityConfig.table->Table.getChainIdField->Option.map(Table.getPgDbFieldName),
+      ~chainIdColumn=entityConfig.table->Table.getPgChainIdColumn,
       ~safeCheckpointId,
     ) {
     | () =>

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -127,6 +127,26 @@ and executeRollback = async (
     }
   }
 
+  // The diff computed here replaces a pending one rather than merging with it,
+  // so its deletes have to cover everything that one would have deleted. A
+  // lower target covers a higher one within the same scope, but two scopes
+  // naming different chains only meet at Global. The flush above leaves a
+  // pending diff only when no batch has come along to carry it.
+  let (scope, rollbackTargetCheckpointId) = {
+    let scope = (state->IndexerState.config).isIsolatedMultichain
+      ? RollbackScope.Isolated(reorgChain)
+      : Global
+    switch state->IndexerState.pendingRollback {
+    | None => (scope, rollbackTargetCheckpointId)
+    | Some({scope: pendingScope, targetCheckpointId: pendingTargetCheckpointId}) => (
+        scope == pendingScope ? scope : Global,
+        rollbackTargetCheckpointId < pendingTargetCheckpointId
+          ? rollbackTargetCheckpointId
+          : pendingTargetCheckpointId,
+      )
+    }
+  }
+
   let eventsProcessedDiffByChain = Dict.make()
   let newProgressBlockNumberPerChain = Dict.make()
   let rollbackedProcessedEvents = ref(0.)
@@ -134,7 +154,7 @@ and executeRollback = async (
   {
     let rollbackProgressDiff = await (
       state->IndexerState.persistence
-    ).storage.getRollbackProgressDiff(~rollbackTargetCheckpointId)
+    ).storage.getRollbackProgressDiff(~scope, ~rollbackTargetCheckpointId)
     for idx in 0 to rollbackProgressDiff->Array.length - 1 {
       let diff = rollbackProgressDiff->Array.getUnsafe(idx)
       eventsProcessedDiffByChain->ChainId.Dict.set(
@@ -192,6 +212,7 @@ and executeRollback = async (
   })
 
   let diff = await state->InMemoryStore.prepareRollbackDiff(
+    ~scope,
     ~rollbackTargetCheckpointId,
     ~rollbackDiffCheckpointId=state->IndexerState.committedCheckpointId->BigInt.add(1n),
     ~progressBlockNumberByChainId=newProgressBlockNumberPerChain,

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -40,15 +40,6 @@ let getLastKnownValidBlock = async (
   }
 }
 
-// A chain the rollback moved: where it leaves the chain — written with the diff,
-// since the batch that carries it may belong to a chain the rollback never
-// touched — and what it took away, for the log.
-type rolledBackChain = {
-  progress: InternalTable.Chains.progressedChain,
-  fromBlock: int,
-  rollbackedEvents: float,
-}
-
 let rec rollback = async (
   state: IndexerState.t,
   ~scheduleFetch,
@@ -142,14 +133,13 @@ and executeRollback = async (
   // different chains only meet at Global. The flush above leaves a diff pending
   // only when no batch has come along to carry it.
   let (scope, rollbackTargetCheckpointId) = {
-    let scope: RollbackScope.t = (state->IndexerState.config).isIsolatedMultichain
+    let scope: RollbackScope.t = (state->IndexerState.config)->Config.isIsolatedMultichain
       ? Isolated(reorgChain)
       : Global
     switch state->IndexerState.pendingRollback {
     | None => (scope, rollbackTargetCheckpointId)
     | Some({scope: pendingScope, targetCheckpointId: pendingTarget}) =>
-      let target =
-        rollbackTargetCheckpointId < pendingTarget ? rollbackTargetCheckpointId : pendingTarget
+      let target = Pervasives.min(rollbackTargetCheckpointId, pendingTarget)
       if scope == pendingScope {
         (scope, target)
       } else {
@@ -191,7 +181,9 @@ and executeRollback = async (
     }
   }
 
-  let rolledBackChains: array<rolledBackChain> = []
+  // Where the rollback leaves each chain it moved, written with the diff: the
+  // batch that carries it may belong to a chain the rollback never touched.
+  let rolledBackChains: array<InternalTable.Chains.progressedChain> = []
   let rolledBackAddresses = []
   state
   ->IndexerState.chainStates
@@ -214,38 +206,32 @@ and executeRollback = async (
     if fromBlock !== toBlock {
       rolledBackChains
       ->Array.push({
-        progress: {
-          chainId,
-          progressBlockNumber: toBlock,
-          sourceBlockNumber: cs->ChainState.knownHeight,
-          totalEventsProcessed: cs->ChainState.numEventsProcessed,
-        },
-        fromBlock,
-        rollbackedEvents: eventsProcessedDiffByChain
+        chainId,
+        progressBlockNumber: toBlock,
+        sourceBlockNumber: cs->ChainState.knownHeight,
+        totalEventsProcessed: cs->ChainState.numEventsProcessed,
+      })
+      ->ignore
+      logger->Logging.childInfo({
+        "msg": "Rollbacked",
+        "chainId": chainId,
+        "fromBlock": fromBlock,
+        "toBlock": toBlock,
+        "rollbackedEvents": eventsProcessedDiffByChain
         ->ChainId.Dict.dangerouslyGetNonOption(chainId)
         ->Option.getOr(0.),
       })
-      ->ignore
     }
   })
 
   let diff = await state->InMemoryStore.prepareRollbackDiff(
-    ~scope,
+    ~rollbackScope=scope,
     ~rollbackTargetCheckpointId,
     ~rollbackDiffCheckpointId=state->IndexerState.committedCheckpointId->BigInt.add(1n),
-    ~progressedChains=rolledBackChains->Array.map(({progress}) => progress),
+    ~progressedChains=rolledBackChains,
     ~rolledBackAddresses,
   )
 
-  rolledBackChains->Array.forEach(({progress, fromBlock, rollbackedEvents}) => {
-    logger->Logging.childInfo({
-      "msg": "Rollbacked",
-      "chainId": progress.chainId,
-      "fromBlock": fromBlock,
-      "toBlock": progress.progressBlockNumber,
-      "rollbackedEvents": rollbackedEvents,
-    })
-  })
   logger->Logging.childTrace({
     "msg": "Rollback entity changes",
     "deleted": diff["deletedEntities"],

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -128,22 +128,26 @@ and executeRollback = async (
   }
 
   // The diff computed here replaces a pending one rather than merging with it,
-  // so its deletes have to cover everything that one would have deleted. A
-  // lower target covers a higher one within the same scope, but two scopes
-  // naming different chains only meet at Global. The flush above leaves a
-  // pending diff only when no batch has come along to carry it.
+  // so its deletes have to cover everything that one would have deleted. A lower
+  // target covers a higher one within the same scope, but two scopes naming
+  // different chains only meet at Global. The flush above leaves a diff pending
+  // only when no batch has come along to carry it.
   let (scope, rollbackTargetCheckpointId) = {
-    let scope = (state->IndexerState.config).isIsolatedMultichain
-      ? RollbackScope.Isolated(reorgChain)
-      : Global
+    let scope: RollbackScope.t =
+      (state->IndexerState.config).isIsolatedMultichain ? Isolated(reorgChain) : Global
     switch state->IndexerState.pendingRollback {
     | None => (scope, rollbackTargetCheckpointId)
-    | Some({scope: pendingScope, targetCheckpointId: pendingTargetCheckpointId}) => (
-        scope == pendingScope ? scope : Global,
-        rollbackTargetCheckpointId < pendingTargetCheckpointId
-          ? rollbackTargetCheckpointId
-          : pendingTargetCheckpointId,
-      )
+    | Some({scope: pendingScope, targetCheckpointId: pendingTarget}) =>
+      let target =
+        rollbackTargetCheckpointId < pendingTarget ? rollbackTargetCheckpointId : pendingTarget
+      if scope == pendingScope {
+        (scope, target)
+      } else {
+        logger->Logging.childInfo(
+          "Widening the rollback to every chain: another chain's rollback is still unwritten",
+        )
+        (Global, target)
+      }
     }
   }
 

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -133,8 +133,9 @@ and executeRollback = async (
   // different chains only meet at Global. The flush above leaves a diff pending
   // only when no batch has come along to carry it.
   let (scope, rollbackTargetCheckpointId) = {
-    let scope: RollbackScope.t =
-      (state->IndexerState.config).isIsolatedMultichain ? Isolated(reorgChain) : Global
+    let scope: RollbackScope.t = (state->IndexerState.config).isIsolatedMultichain
+      ? Isolated(reorgChain)
+      : Global
     switch state->IndexerState.pendingRollback {
     | None => (scope, rollbackTargetCheckpointId)
     | Some({scope: pendingScope, targetCheckpointId: pendingTarget}) =>
@@ -182,6 +183,9 @@ and executeRollback = async (
   }
 
   let rolledBackChains = []
+  // Where the rollback leaves each chain it moves. Travels with the diff, since
+  // the batch that carries it may belong to a chain the rollback never touched.
+  let progressedChains: array<InternalTable.Chains.progressedChain> = []
   let rolledBackAddresses = []
   state
   ->IndexerState.chainStates
@@ -202,6 +206,14 @@ and executeRollback = async (
     rolledBackAddresses->Array.pushMany(killedAddresses)->ignore
     let toBlock = cs->ChainState.committedProgressBlockNumber
     if fromBlock !== toBlock {
+      progressedChains
+      ->Array.push({
+        chainId,
+        progressBlockNumber: toBlock,
+        sourceBlockNumber: cs->ChainState.knownHeight,
+        totalEventsProcessed: cs->ChainState.numEventsProcessed,
+      })
+      ->ignore
       rolledBackChains
       ->Array.push({
         "chainId": chainId,
@@ -219,7 +231,7 @@ and executeRollback = async (
     ~scope,
     ~rollbackTargetCheckpointId,
     ~rollbackDiffCheckpointId=state->IndexerState.committedCheckpointId->BigInt.add(1n),
-    ~progressBlockNumberByChainId=newProgressBlockNumberPerChain,
+    ~progressedChains,
     ~rolledBackAddresses,
   )
 

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -40,6 +40,15 @@ let getLastKnownValidBlock = async (
   }
 }
 
+// A chain the rollback moved: where it leaves the chain — written with the diff,
+// since the batch that carries it may belong to a chain the rollback never
+// touched — and what it took away, for the log.
+type rolledBackChain = {
+  progress: InternalTable.Chains.progressedChain,
+  fromBlock: int,
+  rollbackedEvents: float,
+}
+
 let rec rollback = async (
   state: IndexerState.t,
   ~scheduleFetch,
@@ -182,10 +191,7 @@ and executeRollback = async (
     }
   }
 
-  let rolledBackChains = []
-  // Where the rollback leaves each chain it moves. Travels with the diff, since
-  // the batch that carries it may belong to a chain the rollback never touched.
-  let progressedChains: array<InternalTable.Chains.progressedChain> = []
+  let rolledBackChains: array<rolledBackChain> = []
   let rolledBackAddresses = []
   state
   ->IndexerState.chainStates
@@ -206,20 +212,16 @@ and executeRollback = async (
     rolledBackAddresses->Array.pushMany(killedAddresses)->ignore
     let toBlock = cs->ChainState.committedProgressBlockNumber
     if fromBlock !== toBlock {
-      progressedChains
-      ->Array.push({
-        chainId,
-        progressBlockNumber: toBlock,
-        sourceBlockNumber: cs->ChainState.knownHeight,
-        totalEventsProcessed: cs->ChainState.numEventsProcessed,
-      })
-      ->ignore
       rolledBackChains
       ->Array.push({
-        "chainId": chainId,
-        "fromBlock": fromBlock,
-        "toBlock": toBlock,
-        "rollbackedEvents": eventsProcessedDiffByChain
+        progress: {
+          chainId,
+          progressBlockNumber: toBlock,
+          sourceBlockNumber: cs->ChainState.knownHeight,
+          totalEventsProcessed: cs->ChainState.numEventsProcessed,
+        },
+        fromBlock,
+        rollbackedEvents: eventsProcessedDiffByChain
         ->ChainId.Dict.dangerouslyGetNonOption(chainId)
         ->Option.getOr(0.),
       })
@@ -231,17 +233,17 @@ and executeRollback = async (
     ~scope,
     ~rollbackTargetCheckpointId,
     ~rollbackDiffCheckpointId=state->IndexerState.committedCheckpointId->BigInt.add(1n),
-    ~progressedChains,
+    ~progressedChains=rolledBackChains->Array.map(({progress}) => progress),
     ~rolledBackAddresses,
   )
 
-  rolledBackChains->Array.forEach(rolledBack => {
+  rolledBackChains->Array.forEach(({progress, fromBlock, rollbackedEvents}) => {
     logger->Logging.childInfo({
       "msg": "Rollbacked",
-      "chainId": rolledBack["chainId"],
-      "fromBlock": rolledBack["fromBlock"],
-      "toBlock": rolledBack["toBlock"],
-      "rollbackedEvents": rolledBack["rollbackedEvents"],
+      "chainId": progress.chainId,
+      "fromBlock": fromBlock,
+      "toBlock": progress.progressBlockNumber,
+      "rollbackedEvents": rollbackedEvents,
     })
   })
   logger->Logging.childTrace({

--- a/packages/envio/src/Rollback.res
+++ b/packages/envio/src/Rollback.res
@@ -133,9 +133,8 @@ and executeRollback = async (
   // different chains only meet at Global. The flush above leaves a diff pending
   // only when no batch has come along to carry it.
   let (scope, rollbackTargetCheckpointId) = {
-    let scope: RollbackScope.t = (state->IndexerState.config)->Config.isIsolatedMultichain
-      ? Isolated(reorgChain)
-      : Global
+    let scope: RollbackScope.t =
+      state->IndexerState.config->Config.isIsolatedMultichain ? Isolated(reorgChain) : Global
     switch state->IndexerState.pendingRollback {
     | None => (scope, rollbackTargetCheckpointId)
     | Some({scope: pendingScope, targetCheckpointId: pendingTarget}) =>
@@ -151,8 +150,7 @@ and executeRollback = async (
     }
   }
 
-  let eventsProcessedDiffByChain = Dict.make()
-  let newProgressBlockNumberPerChain = Dict.make()
+  let progressDiffByChain: dict<ChainState.progressDiff> = Dict.make()
   let rollbackedProcessedEvents = ref(0.)
 
   {
@@ -161,21 +159,17 @@ and executeRollback = async (
     ).storage.getRollbackProgressDiff(~scope, ~rollbackTargetCheckpointId)
     for idx in 0 to rollbackProgressDiff->Array.length - 1 {
       let diff = rollbackProgressDiff->Array.getUnsafe(idx)
-      eventsProcessedDiffByChain->ChainId.Dict.set(
+      let eventsProcessed = Float.fromString(diff["events_processed_diff"])->Option.getOrThrow
+      rollbackedProcessedEvents := rollbackedProcessedEvents.contents +. eventsProcessed
+      progressDiffByChain->ChainId.Dict.set(
         diff["chain_id"],
         {
-          let eventsProcessedDiff =
-            Float.fromString(diff["events_processed_diff"])->Option.getOrThrow
-          rollbackedProcessedEvents := rollbackedProcessedEvents.contents +. eventsProcessedDiff
-          eventsProcessedDiff
-        },
-      )
-      newProgressBlockNumberPerChain->ChainId.Dict.set(
-        diff["chain_id"],
-        if rollbackTargetCheckpointId === 0n && diff["chain_id"] === reorgChain {
-          Pervasives.min(diff["new_progress_block_number"], rollbackTargetBlockNumber)
-        } else {
-          diff["new_progress_block_number"]
+          blockNumber: if rollbackTargetCheckpointId === 0n && diff["chain_id"] === reorgChain {
+            Pervasives.min(diff["new_progress_block_number"], rollbackTargetBlockNumber)
+          } else {
+            diff["new_progress_block_number"]
+          },
+          eventsProcessed,
         },
       )
     }
@@ -190,17 +184,13 @@ and executeRollback = async (
   ->Utils.Dict.forEach(cs => {
     let chainId = (cs->ChainState.chainConfig).id
     let fromBlock = cs->ChainState.committedProgressBlockNumber
-    let killedAddresses =
-      cs->ChainState.rollback(
-        ~newProgressBlockNumber=newProgressBlockNumberPerChain->ChainId.Dict.dangerouslyGetNonOption(
-          chainId,
-        ),
-        ~eventsProcessedDiff=eventsProcessedDiffByChain->ChainId.Dict.dangerouslyGetNonOption(
-          chainId,
-        ),
-        ~rollbackTargetBlockNumber,
-        ~isReorgChain=chainId === reorgChain,
-      )
+    let progressDiff = progressDiffByChain->ChainId.Dict.dangerouslyGetNonOption(chainId)
+    let killedAddresses = cs->ChainState.rollback(
+      ~rolledBackTo=switch progressDiff {
+      | Some(progressDiff) => RecomputedProgress(progressDiff)
+      | None => chainId === reorgChain ? ForkBlock(rollbackTargetBlockNumber) : Untouched
+      },
+    )
     rolledBackAddresses->Array.pushMany(killedAddresses)->ignore
     let toBlock = cs->ChainState.committedProgressBlockNumber
     if fromBlock !== toBlock {
@@ -217,9 +207,7 @@ and executeRollback = async (
         "chainId": chainId,
         "fromBlock": fromBlock,
         "toBlock": toBlock,
-        "rollbackedEvents": eventsProcessedDiffByChain
-        ->ChainId.Dict.dangerouslyGetNonOption(chainId)
-        ->Option.getOr(0.),
+        "rollbackedEvents": progressDiff->Option.mapOr(0., diff => diff.eventsProcessed),
       })
     }
   })
@@ -242,7 +230,11 @@ and executeRollback = async (
     ~rollbackedProcessedEvents=rollbackedProcessedEvents.contents,
   )
 
-  state->IndexerState.completeRollback(~eventsProcessedDiffByChain)
+  state->IndexerState.completeRollback(
+    ~eventsProcessedDiffByChain=progressDiffByChain->Utils.Dict.mapValues(diff =>
+      diff.eventsProcessed
+    ),
+  )
   scheduleFetch()
   scheduleProcessing()
 }

--- a/packages/envio/src/RollbackCommit.res
+++ b/packages/envio/src/RollbackCommit.res
@@ -20,15 +20,13 @@ let register = (callback: callback) => {
     }
 }
 
-// Fired after a rollback diff is durably written, once per affected chain.
-// `progressBlockNumberByChainId` is the last valid block per chain, taken from
-// the in-memory store's rollback object. A throwing callback bubbles to the
-// write loop's onError, crashing the indexer like a failed write.
-let fire = async (~progressBlockNumberByChainId: dict<int>) => {
-  let _ = await progressBlockNumberByChainId
-  ->Dict.toArray
-  ->Array.flatMap(((chainIdKey, rollbackToBlock)) => {
-    let args = {chainId: chainIdKey->ChainId.normalizeOrThrow, rollbackToBlock}
+// Fired after a rollback diff is durably written, once per affected chain, with
+// the last valid block the rollback left that chain at. A throwing callback
+// bubbles to the write loop's onError, crashing the indexer like a failed write.
+let fire = async (~progressedChains: array<InternalTable.Chains.progressedChain>) => {
+  let _ = await progressedChains
+  ->Array.flatMap(({chainId, progressBlockNumber}) => {
+    let args = {chainId, rollbackToBlock: progressBlockNumber}
     callbacks->Array.map(callback => callback(args))
   })
   ->Promise.all

--- a/packages/envio/src/TestIndexer.res
+++ b/packages/envio/src/TestIndexer.res
@@ -636,11 +636,11 @@ let makeInMemoryStorage = (~state: testIndexerState): Persistence.storage => {
     JsError.throwWithMessage(
       "TestIndexer: Rollback is not supported. The runner forces rollbackOnReorg off, so this should be unreachable.",
     ),
-  getRollbackProgressDiff: async (~rollbackTargetCheckpointId as _) =>
+  getRollbackProgressDiff: async (~scope as _, ~rollbackTargetCheckpointId as _) =>
     JsError.throwWithMessage(
       "TestIndexer: Rollback is not supported. The runner forces rollbackOnReorg off, so this should be unreachable.",
     ),
-  getRollbackData: async (~entityConfig as _, ~rollbackTargetCheckpointId as _) =>
+  getRollbackData: async (~entityConfig as _, ~scope as _, ~rollbackTargetCheckpointId as _) =>
     JsError.throwWithMessage(
       "TestIndexer: Rollback is not supported. The runner forces rollbackOnReorg off, so this should be unreachable.",
     ),

--- a/packages/envio/src/Writing.res
+++ b/packages/envio/src/Writing.res
@@ -158,8 +158,8 @@ let runOneWrite = async (state: IndexerState.t) => {
     state->IndexerState.markCommitted(~upToCheckpointId)
 
     switch rollback {
-    | Some({progressBlockNumberByChainId}) if RollbackCommit.callbacks->Utils.Array.notEmpty =>
-      await RollbackCommit.fire(~progressBlockNumberByChainId)
+    | Some({progressedChains}) if RollbackCommit.callbacks->Utils.Array.notEmpty =>
+      await RollbackCommit.fire(~progressedChains)
     | _ => ()
     }
 

--- a/packages/envio/src/db/EntityHistory.res
+++ b/packages/envio/src/db/EntityHistory.res
@@ -195,6 +195,8 @@ let rollback = (
   ~pgSchema,
   ~entityName,
   ~entityIndex,
+  ~chainIdColumn,
+  ~scope: RollbackScope.t,
   ~rollbackTargetCheckpointId: Internal.checkpointId,
 ) => {
   sql
@@ -202,8 +204,8 @@ let rollback = (
     `DELETE FROM "${pgSchema}"."${historyTableName(
         ~entityName,
         ~entityIndex,
-      )}" WHERE "${checkpointIdFieldName}" > $1;`,
-    [rollbackTargetCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
+      )}" WHERE "${checkpointIdFieldName}" > $1${scope->RollbackScope.predicate(~chainIdColumn)};`,
+    scope->RollbackScope.params(~targetCheckpointId=rollbackTargetCheckpointId),
   )
   ->Utils.Promise.ignoreValue
 }

--- a/packages/envio/src/db/EntityHistory.res
+++ b/packages/envio/src/db/EntityHistory.res
@@ -173,7 +173,7 @@ let backfillHistory = (
   ~ids: array<EntityId.t>,
 ) => {
   let idPgType = table->Table.getIdPgFieldType(~pgSchema)
-  let chainIdColumn = table->Table.getChainIdField->Option.map(Table.getPgDbFieldName)
+  let chainIdColumn = table->Table.getPgChainIdColumn
   let params = [table->Table.encodeIdsToJson(ids)->(Utils.magic: JSON.t => unknown)]
   sql
   ->Postgres.preparedUnsafe(

--- a/packages/envio/src/db/InternalTable.res
+++ b/packages/envio/src/db/InternalTable.res
@@ -635,11 +635,22 @@ SELECT * FROM unnest($1::${(BigInt: Postgres.columnType :> string)}[],$2::${chai
     ->Utils.Promise.ignoreValue
   }
 
-  let rollback = (sql, ~pgSchema, ~rollbackTargetCheckpointId: Internal.checkpointId) => {
+  // The chain a checkpoint belongs to, named once for the queries that narrow a
+  // rollback to it.
+  let chainIdColumn = Some((#chain_id: field :> string))
+
+  let rollback = (
+    sql,
+    ~pgSchema,
+    ~scope: RollbackScope.t,
+    ~rollbackTargetCheckpointId: Internal.checkpointId,
+  ) => {
     sql
     ->Postgres.preparedUnsafe(
-      `DELETE FROM "${pgSchema}"."${table.tableName}" WHERE "${(#id: field :> string)}" > $1;`,
-      [rollbackTargetCheckpointId->BigInt.toString]->(Utils.magic: array<string> => unknown),
+      `DELETE FROM "${pgSchema}"."${table.tableName}" WHERE "${(#id: field :> string)}" > $1${scope->RollbackScope.predicate(
+          ~chainIdColumn,
+        )};`,
+      scope->RollbackScope.params(~targetCheckpointId=rollbackTargetCheckpointId),
     )
     ->Utils.Promise.ignoreValue
   }
@@ -684,25 +695,26 @@ LIMIT 1;`
     })
   }
 
-  let makeGetRollbackProgressDiffQuery = (~pgSchema) => {
+  let makeGetRollbackProgressDiffQuery = (~pgSchema, ~scope: RollbackScope.t) => {
     `SELECT 
   "${(#chain_id: field :> string)}"::float8 as "${(#chain_id: field :> string)}",
   SUM("${(#events_processed: field :> string)}") as events_processed_diff,
   MIN("${(#block_number: field :> string)}") - 1 as new_progress_block_number
 FROM "${pgSchema}"."${table.tableName}"
-WHERE "${(#id: field :> string)}" > $1
+WHERE "${(#id: field :> string)}" > $1${scope->RollbackScope.predicate(~chainIdColumn)}
 GROUP BY "${(#chain_id: field :> string)}";`
   }
 
   let getRollbackProgressDiff = (
     sql,
     ~pgSchema,
+    ~scope: RollbackScope.t,
     ~rollbackTargetCheckpointId: Internal.checkpointId,
   ) => {
     sql
     ->Postgres.preparedUnsafe(
-      makeGetRollbackProgressDiffQuery(~pgSchema),
-      [rollbackTargetCheckpointId->BigInt.toString]->Obj.magic,
+      makeGetRollbackProgressDiffQuery(~pgSchema, ~scope),
+      scope->RollbackScope.params(~targetCheckpointId=rollbackTargetCheckpointId),
     )
     ->(
       Utils.magic: promise<unknown> => promise<

--- a/packages/envio/src/db/InternalTable.res
+++ b/packages/envio/src/db/InternalTable.res
@@ -644,8 +644,7 @@ SELECT * FROM unnest($1::${(BigInt: Postgres.columnType :> string)}[],$2::${chai
     ->Utils.Promise.ignoreValue
   }
 
-  // The chain a checkpoint belongs to, named once for the queries that narrow a
-  // rollback to it.
+  // Optional to match the entity tables', where a cross-chain entity has none.
   let chainIdColumn = Some((#chain_id: field :> string))
 
   let rollback = (

--- a/packages/envio/src/db/InternalTable.res
+++ b/packages/envio/src/db/InternalTable.res
@@ -568,6 +568,10 @@ module Checkpoints = {
   )
 
   let makeGetReorgCheckpointsQuery = (~pgSchema): string => {
+    // Ordered by id, which within a chain is block order: both consumers of
+    // these rows — the safe-checkpoint scan and the block-store seed — read them
+    // as ascending. Physical row order can't stand in for that, since a rollback
+    // frees space that later checkpoints are written back into.
     // Use CTE to pre-filter chains and compute safe_block once per chain
     // This is faster because:
     // 1. Chains table is small, so filtering it first is cheap
@@ -590,7 +594,8 @@ FROM "${pgSchema}"."${table.tableName}" cp
 INNER JOIN reorg_chains rc 
   ON cp."${(#chain_id: field :> string)}" = rc.id
 WHERE cp."${(#block_hash: field :> string)}" IS NOT NULL
-  AND cp."${(#block_number: field :> string)}" >= rc.safe_block;` // Include safe_block checkpoint to use it for safe checkpoint tracking
+  AND cp."${(#block_number: field :> string)}" >= rc.safe_block
+ORDER BY cp."${(#id: field :> string)}";` // Include safe_block checkpoint to use it for safe checkpoint tracking
   }
 
   let makeCommitedCheckpointIdQuery = (~pgSchema) => {

--- a/packages/envio/src/db/InternalTable.res
+++ b/packages/envio/src/db/InternalTable.res
@@ -568,10 +568,14 @@ module Checkpoints = {
   )
 
   let makeGetReorgCheckpointsQuery = (~pgSchema): string => {
+    // The safe_block checkpoint itself is included, so it can be used for safe
+    // checkpoint tracking.
+    //
     // Ordered by id, which within a chain is block order: both consumers of
     // these rows — the safe-checkpoint scan and the block-store seed — read them
     // as ascending. Physical row order can't stand in for that, since a rollback
     // frees space that later checkpoints are written back into.
+    //
     // Use CTE to pre-filter chains and compute safe_block once per chain
     // This is faster because:
     // 1. Chains table is small, so filtering it first is cheap
@@ -595,7 +599,7 @@ INNER JOIN reorg_chains rc
   ON cp."${(#chain_id: field :> string)}" = rc.id
 WHERE cp."${(#block_hash: field :> string)}" IS NOT NULL
   AND cp."${(#block_number: field :> string)}" >= rc.safe_block
-ORDER BY cp."${(#id: field :> string)}";` // Include safe_block checkpoint to use it for safe checkpoint tracking
+ORDER BY cp."${(#id: field :> string)}";`
   }
 
   let makeCommitedCheckpointIdQuery = (~pgSchema) => {

--- a/packages/envio/src/db/RollbackScope.res
+++ b/packages/envio/src/db/RollbackScope.res
@@ -1,0 +1,29 @@
+// How far across chains a reorg rollback reaches. `Isolated` is only chosen for
+// a schema with no cross-chain entity, where a reorg on one chain can't have
+// changed a row another chain owns — every sibling then keeps its progress,
+// entities, history and checkpoints.
+type t =
+  | Global
+  | Isolated(ChainId.t)
+
+// Appended to the WHERE of a rollback query, which binds its target checkpoint
+// as $1. An isolated rollback binds its chain id as $2 so only the rows that
+// chain owns match.
+let predicate = (scope, ~chainIdColumn: option<string>) =>
+  switch (scope, chainIdColumn) {
+  | (Global, _) => ""
+  | (Isolated(_), Some(column)) => ` AND "${column}" = $2`
+  | (Isolated(_), None) =>
+    JsError.throwWithMessage(
+      "Internal error: a rollback isolated to one chain needs a chain-id column to narrow to.",
+    )
+  }
+
+// The parameters such a query binds, in the order `predicate` reads them.
+let params = (scope, ~targetCheckpointId: Internal.checkpointId): unknown => {
+  let targetCheckpointId = targetCheckpointId->BigInt.toString->(Utils.magic: string => unknown)
+  switch scope {
+  | Global => [targetCheckpointId]
+  | Isolated(chainId) => [targetCheckpointId, chainId->(Utils.magic: ChainId.t => unknown)]
+  }->(Utils.magic: array<unknown> => unknown)
+}

--- a/packages/envio/src/db/Table.res
+++ b/packages/envio/src/db/Table.res
@@ -288,7 +288,7 @@ let getChainIdField = (table): option<field> =>
     }
   )
 
-// The chain-id column as Postgres spells it. None for a cross-chain entity.
+// None for a cross-chain entity, whose rows no single chain owns.
 let getPgChainIdColumn = table => table->getChainIdField->Option.map(getPgDbFieldName)
 
 let getFieldByName = (table, fieldName) =>

--- a/packages/envio/src/db/Table.res
+++ b/packages/envio/src/db/Table.res
@@ -288,6 +288,9 @@ let getChainIdField = (table): option<field> =>
     }
   )
 
+// The chain-id column as Postgres spells it. None for a cross-chain entity.
+let getPgChainIdColumn = table => table->getChainIdField->Option.map(getPgDbFieldName)
+
 let getFieldByName = (table, fieldName) =>
   table.fields->Array.find(field => field->getUserDefinedFieldName === fieldName)
 


### PR DESCRIPTION
## Summary

When a schema contains no cross-chain entities, a reorg on one chain cannot have modified rows owned by another chain. This change implements isolated rollbacks for such schemas: only the reorg chain loses progress and re-indexes, while sibling chains keep their progress, entities, history, and checkpoints untouched.

## Key Changes

- **RollbackScope type** (`RollbackScope.res`): New module to distinguish between `Global` rollbacks (affecting all chains) and `Isolated` rollbacks (affecting only the reorg chain). The scope travels with the rollback diff to the database write, where it narrows the DELETE queries to only the affected chain.

- **Config.isIsolatedMultichain flag**: Computed during config parsing to detect schemas with no cross-chain entities. Used to choose between isolated and global rollback scopes.

- **Rollback diff computation** (`Rollback.res`): When computing a new rollback, checks if a pending diff exists. If both diffs target the same scope, merges them by taking the lower checkpoint. If scopes differ (isolated vs. global), widens to a global rollback to ensure correctness when multiple reorgs are unwritten.

- **Progress handling** (`Persistence.rs`, `IndexerState.res`): Rollback diffs now carry `progressedChains` — the chains the rollback moved and where it left them. These are written to the database before the batch's own progress, so a batch that also progressed keeps its later value.

- **Database queries** (`PgStorage.res`, `InternalTable.res`): Rollback DELETE queries now accept a `scope` parameter. For isolated rollbacks, the WHERE clause adds a chain-id filter (`AND "chain_id" = $2`) to delete only rows the reorg chain owns. Checkpoint queries now order by id to ensure consistent ordering across restarts.

- **Test coverage** (`IsolatedRollback_test.res`): Comprehensive test suite covering isolated rollbacks, cross-chain coupling, multiple sequential reorgs, and restart scenarios. Also updated `SiblingRollbackStuckChain_test.res` to test both global and isolated rollback paths.

## Implementation Details

- Isolated rollbacks only apply when `disable_default_cross_chain: true` is set in the config and no explicit cross-chain entities exist.
- When a second reorg lands before the first diff is written, the rollback widens to global if the scopes differ, ensuring all affected rows are cleaned up.
- Sibling chains' in-flight queries are dropped during rollback (as before), but they resume from their unchanged progress rather than being rolled back.
- The rollback diff's progress rows are written before the batch's own progress, allowing a batch to override the rollback's progress for chains it also indexed.

https://claude.ai/code/session_016y4YSjoXSqjE13QMaukZ2Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added isolated multichain rollback support, allowing rollbacks to target individual chains.
  - Rollback handling now supports global and chain-specific scopes.
  - Improved preservation and restoration of per-chain block and event progress.

- **Bug Fixes**
  - Improved rollback deletion, history restoration, checkpoint handling, and progress synchronization.
  - Fixed recovery for stuck, distant, or superseded chains.

- **Documentation**
  - Added guidance on checkpoint ordering and rollback behavior.

- **Tests**
  - Expanded coverage for multichain rollback, persistence, reindexing, restarts, and database synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->