### PR TITLE
Improve HyperSync health check to detect all chain drift

### DIFF
--- a/packages/cli/src/config_parsing/chain_helpers.rs
+++ b/packages/cli/src/config_parsing/chain_helpers.rs
@@ -221,7 +221,10 @@ pub enum Network {
     #[subenum(HypersyncChain)]
     Katana = 747474,
 
-    #[subenum(HypersyncChain, NetworkWithExplorer)]
+    // HyperSync no longer serves Kroma (255.hypersync.xyz refuses
+    // connections and it's gone from active_chains), so it's not a
+    // HypersyncChain. Still resolvable via explorer.
+    #[subenum(NetworkWithExplorer)]
     Kroma = 255,
 
     #[subenum(HypersyncChain, NetworkWithExplorer)]

--- a/packages/cli/src/scripts/print_missing_networks.rs
+++ b/packages/cli/src/scripts/print_missing_networks.rs
@@ -8,6 +8,14 @@ use strum::IntoEnumIterator;
 
 const HIDDEN_TIERS: &[&str] = &["INTERNAL", "HIDDEN", "EXPERIMENTAL"];
 
+// Chains whose endpoints answer on <id>.hypersync.xyz but which the
+// active_chains listing omits. Reporting them as drift would be a false
+// alarm.
+const UNLISTED_BUT_SERVED: &[u64] = &[
+    HypersyncChain::Xdc as u64,
+    HypersyncChain::XdcTestnet as u64,
+];
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum Ecosystem {
@@ -34,7 +42,7 @@ impl Chain {
 
 pub struct Diff {
     pub missing_chains: Vec<String>,
-    pub extra_chains: Vec<String>,
+    pub extra_chains: Vec<HypersyncChain>,
 }
 
 impl Diff {
@@ -85,12 +93,8 @@ impl Diff {
         let mut extra_chains = Vec::new();
         for network in HypersyncChain::iter() {
             let network_id = network as u64;
-            if !api_chain_ids.contains(&network_id) {
-                extra_chains.push(format!(
-                    "{:?} (ID: {})",
-                    network.get_plain_name(),
-                    network_id
-                ));
+            if !api_chain_ids.contains(&network_id) && !UNLISTED_BUT_SERVED.contains(&network_id) {
+                extra_chains.push(network);
             }
         }
 
@@ -124,11 +128,15 @@ impl Diff {
                      (remove the HypersyncChain subEnum from the chain_helpers.rs file):"
                 );
                 for chain in &self.extra_chains {
-                    println!("- {}", chain);
+                    println!("- {}", format_extra_chain(chain));
                 }
             }
         }
     }
+}
+
+pub fn format_extra_chain(chain: &HypersyncChain) -> String {
+    format!("{:?} (ID: {})", chain.get_plain_name(), *chain as u64)
 }
 
 pub async fn run() -> Result<()> {

--- a/packages/cli/src/scripts/print_missing_networks.rs
+++ b/packages/cli/src/scripts/print_missing_networks.rs
@@ -136,7 +136,7 @@ impl Diff {
 }
 
 pub fn format_extra_chain(chain: &HypersyncChain) -> String {
-    format!("{:?} (ID: {})", chain.get_plain_name(), *chain as u64)
+    format!("{} (ID: {})", chain.get_plain_name(), *chain as u64)
 }
 
 pub async fn run() -> Result<()> {

--- a/packages/cli/tests/hypersync_health.rs
+++ b/packages/cli/tests/hypersync_health.rs
@@ -4,7 +4,7 @@
 
 use envio::config_parsing::chain_helpers::HypersyncChain;
 use envio::config_parsing::hypersync_endpoints::network_to_hypersync_url;
-use envio::scripts::print_missing_networks::Diff;
+use envio::scripts::print_missing_networks::{format_extra_chain, Diff};
 use strum::IntoEnumIterator;
 
 async fn fetch_hypersync_health(hypersync_endpoint: &str) -> anyhow::Result<bool> {
@@ -23,18 +23,36 @@ const MAX_RETRIES: u32 = 3;
 async fn all_supported_endpoints_are_healthy() {
     // Iterating HypersyncChain::iter() alone only covers chains already in
     // the enum, so chains added to the HyperSync API but missing from the
-    // enum slip through. Fail the test in that case before probing
-    // endpoints.
+    // enum slip through, and chains the API dropped stay in the enum until
+    // their endpoint dies. Fail on either kind of drift before probing.
     let diff = Diff::get()
         .await
         .expect("Failed to fetch chain diff from HyperSync API");
+    let mut drift = Vec::new();
     if !diff.missing_chains.is_empty() {
-        panic!(
+        drift.push(format!(
             "HyperSync API has chains absent from the Network enum:\n{}",
             diff.missing_chains.join("\n")
-        );
+        ));
+    }
+    if !diff.extra_chains.is_empty() {
+        drift.push(format!(
+            "Network enum has HypersyncChain entries the API no longer lists \
+             (drop their HypersyncChain subenum):\n{}",
+            diff.extra_chains
+                .iter()
+                .map(format_extra_chain)
+                .collect::<Vec<_>>()
+                .join("\n")
+        ));
+    }
+    if !drift.is_empty() {
+        panic!("{}", drift.join("\n\n"));
     }
 
+    // Probe every endpoint before reporting, so one dead chain doesn't mask
+    // the rest.
+    let mut failures = Vec::new();
     for network in HypersyncChain::iter() {
         let url = network_to_hypersync_url(&network);
         let mut last_err = None;
@@ -59,10 +77,17 @@ async fn all_supported_endpoints_are_healthy() {
             }
         }
         if let Some(e) = last_err {
-            panic!(
-                "Failed to fetch health for {} after {} retries: {:?}",
+            failures.push(format!(
+                "Failed to fetch health for {} after {} retries: {:#}",
                 url, MAX_RETRIES, e
-            );
+            ));
         }
+    }
+    if !failures.is_empty() {
+        panic!(
+            "{} unhealthy endpoints:\n{}",
+            failures.len(),
+            failures.join("\n")
+        );
     }
 }

--- a/packages/cli/tests/hypersync_health.rs
+++ b/packages/cli/tests/hypersync_health.rs
@@ -24,7 +24,8 @@ async fn all_supported_endpoints_are_healthy() {
     // Iterating HypersyncChain::iter() alone only covers chains already in
     // the enum, so chains added to the HyperSync API but missing from the
     // enum slip through, and chains the API dropped stay in the enum until
-    // their endpoint dies. Fail on either kind of drift before probing.
+    // their endpoint dies. Report either kind of drift alongside the probe
+    // results.
     let diff = Diff::get()
         .await
         .expect("Failed to fetch chain diff from HyperSync API");
@@ -46,12 +47,8 @@ async fn all_supported_endpoints_are_healthy() {
                 .join("\n")
         ));
     }
-    if !drift.is_empty() {
-        panic!("{}", drift.join("\n\n"));
-    }
-
-    // Probe every endpoint before reporting, so one dead chain doesn't mask
-    // the rest.
+    // Probe every endpoint before reporting, so neither drift nor one dead
+    // chain masks the rest.
     let mut failures = Vec::new();
     for network in HypersyncChain::iter() {
         let url = network_to_hypersync_url(&network);
@@ -84,10 +81,13 @@ async fn all_supported_endpoints_are_healthy() {
         }
     }
     if !failures.is_empty() {
-        panic!(
-            "{} unhealthy endpoints:\n{}",
+        drift.push(format!(
+            "Unhealthy endpoints ({}):\n{}",
             failures.len(),
             failures.join("\n")
-        );
+        ));
+    }
+    if !drift.is_empty() {
+        panic!("{}", drift.join("\n\n"));
     }
 }


### PR DESCRIPTION
## Summary

Enhance the HyperSync health check test to detect and report both types of chain drift: chains added to the HyperSync API but missing from the `Network` enum, and chains in the enum that the API no longer serves. Also improve error reporting to show all failures at once rather than panicking on the first one.

## Key Changes

- **Expanded drift detection**: The health check now detects both missing chains (API has chains not in enum) and extra chains (enum has chains API dropped). Both are reported together before probing endpoints.
- **Better error aggregation**: Instead of panicking on the first unhealthy endpoint, the test now probes all endpoints and reports all failures together with a count.
- **Extracted formatting logic**: Created `format_extra_chain()` helper function to format chain information consistently, used by both the health check and the `print_missing_networks` script.
- **Allowlist for unlisted chains**: Added `UNLISTED_BUT_SERVED` constant to exclude chains like Xdc and XdcTestnet that are served by HyperSync but omitted from the `active_chains` API listing (false alarms).
- **Updated Kroma chain**: Removed `HypersyncChain` subenum from Kroma (ID 255) since HyperSync no longer serves it. Kept `NetworkWithExplorer` since it's still resolvable via explorer.
- **Type change**: `Diff.extra_chains` now stores `Vec<HypersyncChain>` instead of pre-formatted strings, allowing callers to format as needed.

## Implementation Details

- The health check now accumulates drift issues and endpoint failures in vectors before panicking, providing comprehensive diagnostics in a single error message.
- Comments clarify the purpose of drift detection and the rationale for probing all endpoints before reporting.
- The `format_extra_chain()` function centralizes the formatting of chain information (name and ID) to avoid duplication.

https://claude.ai/code/session_01KatRv5tk57QsiimvphXx2L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected network validation for XDC chains so served networks are not incorrectly reported as extra.
  * Updated Kroma support classification to reflect that its HyperSync endpoint is unavailable.

* **Diagnostics**
  * Improved HyperSync health checks to detect both missing and unlisted networks.
  * All endpoints are now checked before failures are reported.
  * Drift and endpoint failures are consolidated into a single, clearer report.
  * Improved formatting for reported extra chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->