### PR TITLE
Stage ClickHouse rows column by column instead of through a row record

### DIFF
--- a/packages/envio-tests/test/lib_tests/ClickHouseStaging_test.res
+++ b/packages/envio-tests/test/lib_tests/ClickHouseStaging_test.res
@@ -1,18 +1,14 @@
 open Vitest
 
-// A batch is staged column by column, in the order the table registered them,
-// and each column's values are read straight off the change rather than out
-// of a serialized row. The whole staged payload is pinned at once: a column
-// reading another's values, or a row shape reading the wrong one, shows up as
-// the payload differing rather than as a store holding the wrong data.
-//
-// Registration never reaches the server, so none of this needs a ClickHouse.
-
 let config = InternalTestIndexer.fromUserApi(
   ~schema=`
 enum Kind {
   A
   B
+}
+
+type User {
+  id: ID!
 }
 
 type Row {
@@ -25,10 +21,15 @@ type Row {
   tags: [String!]!
   optKind: Kind
   doc: Json!
+  owner: User!
+  blob: Bytes!
+  optBlob: Bytes
+  chunks: [Bytes!]!
 }
 `,
   ~configYaml=`
 name: clickhouse-staging
+bytes_type: uint8array
 disable_default_cross_chain: true
 storage:
   postgres:
@@ -56,10 +57,19 @@ type row = {
   tags: array<string>,
   optKind: option<string>,
   doc: JSON.t,
+  owner_id: string,
+  blob: Uint8Array.t,
+  optBlob: option<Uint8Array.t>,
+  chunks: array<Uint8Array.t>,
 }
 
 let entity = (row: row) => row->(Utils.magic: row => Internal.entity)
 let entityId = (id: string) => id->(Utils.magic: string => EntityId.t)
+
+let blobA = Uint8Array.fromArray([1, 2, 3])
+let blobC = Uint8Array.fromArray([4, 5])
+let optBlobA = Uint8Array.fromArray([9])
+let emptyBytes = Uint8Array.fromLength(0)
 
 let changes = [
   Change.Set({
@@ -75,6 +85,10 @@ let changes = [
       tags: ["x", "y"],
       optKind: Some("A"),
       doc: %raw(`{"k": 1}`),
+      owner_id: "alice",
+      blob: blobA,
+      optBlob: Some(optBlobA),
+      chunks: [Uint8Array.fromArray([1, 2]), Uint8Array.fromArray([3])],
     }),
   }),
   Change.Delete({entityId: entityId("b"), checkpointId: 2n}),
@@ -91,92 +105,94 @@ let changes = [
       tags: [],
       optKind: None,
       doc: %raw(`[1]`),
+      owner_id: "carol",
+      blob: blobC,
+      optBlob: None,
+      chunks: [],
     }),
   }),
 ]
 
-let sink = ClickHouse.makeSink(
-  ~host="http://127.0.0.1:1",
-  ~username="default",
-  ~password="",
-  ~database="unused",
-  ~chainIdMode=Int32,
-)
-
-let toArray = (typed: 'typed): array<'a> =>
-  typed->(Utils.magic: 'typed => Iterator.t<'a>)->Array.fromIterator
-
-// One plain value per column: its name, what the typed array holds, and the
-// null bits when any row set one.
-let payload = (builder: ClickHouseSink.builder) => {
-  let values: array<unknown> = switch builder.kind {
-  | F64 => builder.floats->toArray
-  | U64 => builder.unsigned->toArray
-  | I64 => builder.signed->toArray
-  | Text => builder.texts->(Utils.magic: array<string> => array<unknown>)
-  }
-  (builder.name, values, builder.nulls->Option.map(toArray))
-}
-
-let staged = (~scope) => {
-  let registry = ClickHouse.makeRegistry()
-  let table = sink->ClickHouse.entityTable(~registry, ~entityConfig)
-  let converters = ClickHouse.makeConverters(~entityConfig, ~scope, ~table)
-  ClickHouse.fillBuilders(~table, ~converters, ~changes)->Array.map(payload)
-}
-
-let u = (value: 'a) => value->(Utils.magic: 'a => unknown)
-
 describe("ClickHouse staging", () => {
   it("writes every column of every row shape into its own position", t => {
-    t.expect(staged(~scope=Chain(ChainId.fromInt(137)))).toEqual([
-      ("id", [u("a"), u("b"), u("c")], None),
-      ("some_int", [u(5.), u(0.), u(7.)], Some([0, 1, 0])),
-      ("opt_float", [u(1.5), u(0.), u(0.)], Some([0, 1, 1])),
-      ("flag", [u(1.), u(0.), u(0.)], Some([0, 1, 0])),
-      ("at", [u(1000.), u(0.), u(2000.)], Some([0, 1, 0])),
-      ("big", [u("10"), u(""), u("20")], Some([0, 1, 0])),
-      ("tags", [u(`["x","y"]`), u(""), u("[]")], Some([0, 1, 0])),
-      ("opt_kind", [u("A"), u(""), u("")], Some([0, 1, 1])),
-      ("doc", [u(`{"k":1}`), u(""), u("[1]")], Some([0, 1, 0])),
-      ("chain_id", [u(137.), u(137.), u(137.)], None),
-      ("envio_checkpoint_id", [u(1n), u(2n), u(3n)], None),
-      ("envio_change", [u("SET"), u("DELETE"), u("SET")], None),
-    ])
-  })
+    let registry = ClickHouse.makeRegistry()
+    let table =
+      ClickHouse.makeSink(
+        ~host="http://127.0.0.1:1",
+        ~username="default",
+        ~password="",
+        ~database="unused",
+        ~chainIdMode=Int32,
+      )->ClickHouse.entityTable(~registry, ~entityConfig)
 
-  // The converters are built against the columns the table registered, so a
-  // column with no source in the entity is refused up front rather than
-  // written from whatever value happens to sit at its index.
-  it("refuses a registered column the entity has no value for", t => {
-    let table = ClickHouseSink.makeTable(
-      ~name="envio_history_Row",
-      {handle: 0, names: ["id", "surprise"], kinds: [3, 3], nullable: [false, false]},
-    )
-    let message = try {
-      let _ = ClickHouse.makeConverters(~entityConfig, ~scope=Chain(ChainId.fromInt(137)), ~table)
-      "built without complaint"
-    } catch {
-    | exn => (exn->Utils.prettifyExn->(Utils.magic: exn => {"message": string}))["message"]
-    }
-    t.expect(message).toBe(
-      "ClickHouse table \"envio_history_Row\" registered a column \"surprise\" that entity \"Row\" has no value for",
-    )
-  })
+    let captured = ref(([]: array<ClickHouseSink.columnValuesInput>))
+    let sink = {
+      "stage": (_table, _rows, columns: array<ClickHouseSink.columnValuesInput>) => {
+        captured := columns
+        1
+      },
+    }->(Utils.magic: {..} => ClickHouseSink.t)
 
-  it("refuses a table that registered no column for one of the entity's fields", t => {
-    let table = ClickHouseSink.makeTable(
-      ~name="envio_history_Row",
-      {handle: 0, names: ["id"], kinds: [3], nullable: [false]},
+    let _ = ClickHouse.stageUpdatesOrThrow(
+      sink,
+      ~registry,
+      ~changes,
+      ~entityConfig,
+      ~scope=Chain(ChainId.fromInt(137)),
     )
-    let message = try {
-      let _ = ClickHouse.makeConverters(~entityConfig, ~scope=Chain(ChainId.fromInt(137)), ~table)
-      "built without complaint"
-    } catch {
-    | exn => (exn->Utils.prettifyExn->(Utils.magic: exn => {"message": string}))["message"]
-    }
-    t.expect(message).toBe(
-      "ClickHouse table \"envio_history_Row\" registered no column for field \"someInt\" of entity \"Row\"",
-    )
+
+    t.expect((table.columns->Array.map(({name}) => name), captured.contents)).toEqual((
+      [
+        "id",
+        "some_int",
+        "opt_float",
+        "flag",
+        "at",
+        "big",
+        "tags",
+        "opt_kind",
+        "doc",
+        "owner_id",
+        "blob",
+        "opt_blob",
+        "chunks",
+        "chain_id",
+        "envio_checkpoint_id",
+        "envio_change",
+      ],
+      [
+        {texts: ["a", "b", "c"]},
+        {
+          numbers: Float64Array.fromArray([5., 0., 7.]),
+          nulls: Uint8Array.fromArray([0, 1, 0]),
+        },
+        {
+          numbers: Float64Array.fromArray([1.5, 0., 0.]),
+          nulls: Uint8Array.fromArray([0, 1, 1]),
+        },
+        {
+          numbers: Float64Array.fromArray([1., 0., 0.]),
+          nulls: Uint8Array.fromArray([0, 1, 0]),
+        },
+        {
+          numbers: Float64Array.fromArray([1000., 0., 2000.]),
+          nulls: Uint8Array.fromArray([0, 1, 0]),
+        },
+        {texts: ["10", "", "20"], nulls: Uint8Array.fromArray([0, 1, 0])},
+        {texts: [`["x","y"]`, "", "[]"], nulls: Uint8Array.fromArray([0, 1, 0])},
+        {texts: ["A", "", ""], nulls: Uint8Array.fromArray([0, 1, 1])},
+        {texts: [`{"k":1}`, "", "[1]"], nulls: Uint8Array.fromArray([0, 1, 0])},
+        {texts: ["alice", "", "carol"], nulls: Uint8Array.fromArray([0, 1, 0])},
+        {bytes: [blobA, emptyBytes, blobC], nulls: Uint8Array.fromArray([0, 1, 0])},
+        {
+          bytes: [optBlobA, emptyBytes, emptyBytes],
+          nulls: Uint8Array.fromArray([0, 1, 1]),
+        },
+        {texts: ["[[1,2],[3]]", "", "[]"], nulls: Uint8Array.fromArray([0, 1, 0])},
+        {numbers: Float64Array.fromArray([137., 137., 137.])},
+        {unsigned64: BigUint64Array.fromArray([1n, 2n, 3n])},
+        {texts: ["SET", "DELETE", "SET"]},
+      ],
+    ))
   })
 })

--- a/packages/envio-tests/test/lib_tests/ClickHouseStaging_test.res
+++ b/packages/envio-tests/test/lib_tests/ClickHouseStaging_test.res
@@ -1,0 +1,182 @@
+open Vitest
+
+// A batch is staged column by column, in the order the table registered them,
+// and each column's values are read straight off the change rather than out
+// of a serialized row. The whole staged payload is pinned at once: a column
+// reading another's values, or a row shape reading the wrong one, shows up as
+// the payload differing rather than as a store holding the wrong data.
+//
+// Registration never reaches the server, so none of this needs a ClickHouse.
+
+let config = InternalTestIndexer.fromUserApi(
+  ~schema=`
+enum Kind {
+  A
+  B
+}
+
+type Row {
+  id: ID!
+  someInt: Int!
+  optFloat: Float
+  flag: Boolean!
+  at: Timestamp!
+  big: BigInt!
+  tags: [String!]!
+  optKind: Kind
+  doc: Json!
+}
+`,
+  ~configYaml=`
+name: clickhouse-staging
+disable_default_cross_chain: true
+storage:
+  postgres:
+    default: true
+  clickhouse:
+    default: true
+    column_name_format: snake_case
+chains:
+  - id: 1
+    start_block: 0
+  - id: 137
+    start_block: 0
+`,
+).config
+
+let entityConfig = config.userEntitiesByName->Dict.getUnsafe("Row")
+
+type row = {
+  id: string,
+  someInt: int,
+  optFloat: option<float>,
+  flag: bool,
+  at: Date.t,
+  big: bigint,
+  tags: array<string>,
+  optKind: option<string>,
+  doc: JSON.t,
+}
+
+let entity = (row: row) => row->(Utils.magic: row => Internal.entity)
+let entityId = (id: string) => id->(Utils.magic: string => EntityId.t)
+
+let changes = [
+  Change.Set({
+    entityId: entityId("a"),
+    checkpointId: 1n,
+    entity: entity({
+      id: "a",
+      someInt: 5,
+      optFloat: Some(1.5),
+      flag: true,
+      at: Date.fromTime(1000.),
+      big: 10n,
+      tags: ["x", "y"],
+      optKind: Some("A"),
+      doc: %raw(`{"k": 1}`),
+    }),
+  }),
+  Change.Delete({entityId: entityId("b"), checkpointId: 2n}),
+  Change.Set({
+    entityId: entityId("c"),
+    checkpointId: 3n,
+    entity: entity({
+      id: "c",
+      someInt: 7,
+      optFloat: None,
+      flag: false,
+      at: Date.fromTime(2000.),
+      big: 20n,
+      tags: [],
+      optKind: None,
+      doc: %raw(`[1]`),
+    }),
+  }),
+]
+
+let sink = ClickHouse.makeSink(
+  ~host="http://127.0.0.1:1",
+  ~username="default",
+  ~password="",
+  ~database="unused",
+  ~chainIdMode=Int32,
+)
+
+let toArray = (typed: 'typed): array<'a> =>
+  typed->(Utils.magic: 'typed => Iterator.t<'a>)->Array.fromIterator
+
+// One plain value per column: its name, what the typed array holds, and the
+// null bits when any row set one.
+let payload = (builder: ClickHouseSink.builder) => {
+  let values: array<unknown> = switch builder.kind {
+  | F64 => builder.floats->toArray
+  | U64 => builder.unsigned->toArray
+  | I64 => builder.signed->toArray
+  | Text => builder.texts->(Utils.magic: array<string> => array<unknown>)
+  }
+  (builder.name, values, builder.nulls->Option.map(toArray))
+}
+
+let staged = (~scope) => {
+  let registry = ClickHouse.makeRegistry()
+  let table = sink->ClickHouse.entityTable(~registry, ~entityConfig)
+  let converters = ClickHouse.makeConverters(~entityConfig, ~scope, ~table)
+  ClickHouse.fillBuilders(~table, ~converters, ~changes)->Array.map(payload)
+}
+
+let u = (value: 'a) => value->(Utils.magic: 'a => unknown)
+
+describe("ClickHouse staging", () => {
+  it("writes every column of every row shape into its own position", t => {
+    t.expect(staged(~scope=Chain(ChainId.fromInt(137)))).toEqual([
+      ("id", [u("a"), u("b"), u("c")], None),
+      ("some_int", [u(5.), u(0.), u(7.)], Some([0, 1, 0])),
+      ("opt_float", [u(1.5), u(0.), u(0.)], Some([0, 1, 1])),
+      ("flag", [u(1.), u(0.), u(0.)], Some([0, 1, 0])),
+      ("at", [u(1000.), u(0.), u(2000.)], Some([0, 1, 0])),
+      ("big", [u("10"), u(""), u("20")], Some([0, 1, 0])),
+      ("tags", [u(`["x","y"]`), u(""), u("[]")], Some([0, 1, 0])),
+      ("opt_kind", [u("A"), u(""), u("")], Some([0, 1, 1])),
+      ("doc", [u(`{"k":1}`), u(""), u("[1]")], Some([0, 1, 0])),
+      ("chain_id", [u(137.), u(137.), u(137.)], None),
+      ("envio_checkpoint_id", [u(1n), u(2n), u(3n)], None),
+      ("envio_change", [u("SET"), u("DELETE"), u("SET")], None),
+    ])
+  })
+
+  // The converters are built against the columns the table registered, so a
+  // column with no source in the entity is refused up front rather than
+  // written from whatever value happens to sit at its index.
+  it("refuses a registered column the entity has no value for", t => {
+    let table = ClickHouseSink.makeTable(
+      ~name="envio_history_Row",
+      {handle: 0, names: ["id", "surprise"], kinds: [3, 3], nullable: [false, false]},
+    )
+    let message = try {
+      let _ = ClickHouse.makeConverters(~entityConfig, ~scope=Chain(ChainId.fromInt(137)), ~table)
+      "built without complaint"
+    } catch {
+    | exn => (exn->Utils.prettifyExn->(Utils.magic: exn => {"message": string}))["message"]
+    }
+    t.expect(message).toBe(
+      "ClickHouse table \"envio_history_Row\" registered a column \"surprise\" that entity \"Row\" has no value for",
+    )
+  })
+
+  it("refuses a table that registered no column for one of the entity's fields", t => {
+    let table = ClickHouseSink.makeTable(
+      ~name="envio_history_Row",
+      {handle: 0, names: ["id"], kinds: [3], nullable: [false]},
+    )
+    let message = try {
+      let _ = ClickHouse.makeConverters(~entityConfig, ~scope=Chain(ChainId.fromInt(137)), ~table)
+      "built without complaint"
+    } catch {
+    | exn => (exn->Utils.prettifyExn->(Utils.magic: exn => {"message": string}))["message"]
+    }
+    t.expect(message).toBe(
+      "ClickHouse table \"envio_history_Row\" registered no column for field \"someInt\" of entity \"Row\"",
+    )
+  })
+})

--- a/packages/envio-tests/test/lib_tests/ColumnNameFormat_test.res
+++ b/packages/envio-tests/test/lib_tests/ColumnNameFormat_test.res
@@ -148,28 +148,6 @@ VALUES($1,$2,$3,$4,$5)ON CONFLICT("id","envio_checkpoint_id") DO UPDATE SET "env
     ])
   })
 
-  it("serializes ClickHouse set updates with ClickHouse column keys", t => {
-    let setUpdateSchema = EntityHistory.makeSetUpdateSchema(
-      ~idSchema=snapshotEntity.table->Table.getIdSchema,
-      ClickHouse.makeClickHouseEntitySchema(snapshotEntity.table),
-    )
-    let json =
-      Change.Set({
-        entityId: "1"->EntityId.unsafeOfString,
-        entity: snapshot1->(Utils.magic: snapshot => Internal.entity),
-        checkpointId: 5n,
-      })->S.reverseConvertToJsonOrThrow(setUpdateSchema)
-    t.expect(json).toEqual(
-      %raw(`{
-        "envio_change": "SET",
-        "envio_checkpoint_id": "5",
-        "id": "1",
-        "transactionIndex": 5,
-        "tokenOwner_id": "user-1"
-      }`),
-    )
-  })
-
   it("renames ClickHouse columns independently from Postgres", t => {
     let tokenEntity = reverseFormatConfig.userEntitiesByName->Dict.getUnsafe("Token")
     let pgQuery = PgStorage.makeCreateTableQuery(

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -1,35 +1,36 @@
-let makeClickHouseEntitySchema = (table: Table.table, ~skipColumn: option<string>=?): S.t<
-  Internal.entity,
-> => {
+let clickHouseFieldSchema = (f: Table.field) => {
+  let shaped = baseSchema =>
+    if f.isNullable {
+      Utils.Schema.nullTolerant(baseSchema)->S.toUnknown
+    } else if f.isArray {
+      S.array(baseSchema)->S.toUnknown
+    } else {
+      baseSchema
+    }
+  switch f.fieldType {
+  | Date => shaped(Utils.Schema.clickHouseDate->S.toUnknown)
+  // The sink takes the Uint8Arrays themselves, where the table schema
+  // binds a list as a Postgres array literal and is not a JSON schema.
+  | Bytea => shaped(S.json(~validate=false)->S.toUnknown)
+  | ChainId => ChainId.schema->S.toUnknown
+  // Not wrapped in `S.null` even when the field is nullable: the column
+  // is a String either way, and both ways of saying nothing travel as
+  // the text of JSON null.
+  | Json if !f.isArray => Utils.Schema.clickHouseJson->S.toUnknown
+  | _ => f.fieldSchema
+  }
+}
+
+let makeClickHouseEntitySchema = (table: Table.table): S.t<Internal.entity> => {
   S.object(s => {
     let dict = Dict.make()
     table.fields->Array.forEach(field => {
       switch field {
-      | Field(f) if Some(f->Table.getClickHouseDbFieldName) != skipColumn => {
-          let fieldName = f->Table.getClickHouseDbFieldName
-          let shaped = baseSchema =>
-            if f.isNullable {
-              Utils.Schema.nullTolerant(baseSchema)->S.toUnknown
-            } else if f.isArray {
-              S.array(baseSchema)->S.toUnknown
-            } else {
-              baseSchema
-            }
-          let fieldSchema = switch f.fieldType {
-          | Date => shaped(Utils.Schema.clickHouseDate->S.toUnknown)
-          // The sink takes the Uint8Arrays themselves, where the table schema
-          // binds a list as a Postgres array literal and is not a JSON schema.
-          | Bytea => shaped(S.json(~validate=false)->S.toUnknown)
-          | ChainId => ChainId.schema->S.toUnknown
-          // Not wrapped in `S.null` even when the field is nullable: the column
-          // is a String either way, and both ways of saying nothing travel as
-          // the text of JSON null.
-          | Json if !f.isArray => Utils.Schema.clickHouseJson->S.toUnknown
-          | _ => f.fieldSchema
-          }
-          dict->Dict.set(f->Table.getApiFieldName, s.field(fieldName, fieldSchema))
-        }
-      | Field(_) => ()
+      | Field(f) =>
+        dict->Dict.set(
+          f->Table.getApiFieldName,
+          s.field(f->Table.getClickHouseDbFieldName, clickHouseFieldSchema(f)),
+        )
       | DerivedFrom(_) => ()
       }
     })
@@ -161,9 +162,14 @@ let entitySpec = (~entityConfig: Internal.entityConfig): ClickHouseSink.entitySp
   }
 }
 
+// One reader per registered column, in registration order: a row is staged by
+// asking each column for its value rather than serializing the row to a record
+// the columns are then looked up in.
+type cell = Change.t<Internal.entity> => unknown
+
 type converters = {
-  convertSetOrThrow: Change.t<Internal.entity> => dict<unknown>,
-  convertDeleteOrThrow: Change.t<Internal.entity> => dict<unknown>,
+  setCells: array<cell>,
+  deleteCells: array<cell>,
 }
 
 type registry = {
@@ -178,52 +184,105 @@ let makeRegistry = () => {
   converters: Dict.make(),
 }
 
-let compileToColumnValues = schema =>
-  S.compile(schema, ~input=Value, ~output=Json, ~typeValidation=false, ~mode=Sync)->(
-    Utils.magic: (Change.t<Internal.entity> => JSON.t) => Change.t<Internal.entity> => dict<unknown>
-  )
+@get external changeEntity: Change.t<Internal.entity> => dict<unknown> = "entity"
 
+%%private(let absent: unknown = %raw(`undefined`))
+
+%%private(
+  let compileSerializer = schema =>
+    S.compile(schema, ~input=Value, ~output=Json, ~typeValidation=false, ~mode=Sync)->(
+      Utils.magic: (unknown => JSON.t) => unknown => unknown
+    )
+)
+
+// Built against the columns the table registered, so each column is matched to
+// its source by name once here and by position on every row after. A column
+// with no source, or a field with no column, is refused up front: matched by
+// position alone, either would stage one column's values under another's name.
 let makeConverters = (
   ~entityConfig: Internal.entityConfig,
   ~scope: Internal.chainScope,
+  ~table: ClickHouseSink.table,
 ): converters => {
-  let idSchema = entityConfig.table->Table.getIdSchema
-  let chainIdTag = switch (
-    entityConfig.table->Table.getChainIdField,
-    scope->Internal.chainScopeChainId,
-  ) {
-  | (Some(field), Some(chainId)) => Some((field->Table.getClickHouseDbFieldName, chainId))
+  let {name: tableName, columns} = table
+  let table = entityConfig.table
+  let chainIdTag = switch (table->Table.getChainIdField, scope->Internal.chainScopeChainId) {
+  | (Some(field), Some(chainId)) =>
+    Some((field->Table.getClickHouseDbFieldName, chainId->(Utils.magic: ChainId.t => unknown)))
   | _ => None
   }
+  let fieldsByColumn = Dict.make()
+  table.fields->Array.forEach(field =>
+    switch field {
+    | Table.Field(f) => fieldsByColumn->Dict.set(f->Table.getClickHouseDbFieldName, f)
+    | DerivedFrom(_) => ()
+    }
+  )
 
-  {
-    convertSetOrThrow: compileToColumnValues(
-      EntityHistory.makeSetUpdateSchema(
-        ~idSchema,
-        ~chainIdTag?,
-        makeClickHouseEntitySchema(
-          entityConfig.table,
-          ~skipColumn=?chainIdTag->Option.map(((column, _)) => column),
-        ),
-      ),
-    ),
-    convertDeleteOrThrow: compileToColumnValues(
-      S.object(s => {
-        s.tag(EntityHistory.changeFieldName, EntityHistory.RowAction.DELETE)
-        switch chainIdTag {
-        | Some((column, chainId)) => s.tag(column, chainId)
-        | None => ()
+  let setCells = []
+  let deleteCells = []
+  columns->Array.forEach(({name}) => {
+    let (set, delete) = if name === EntityHistory.checkpointIdFieldName {
+      let cell = change => change->Change.getCheckpointId->(Utils.magic: bigint => unknown)
+      (cell, cell)
+    } else if name === EntityHistory.changeFieldName {
+      (
+        _ => (EntityHistory.RowAction.SET :> string)->(Utils.magic: string => unknown),
+        _ => (EntityHistory.RowAction.DELETE :> string)->(Utils.magic: string => unknown),
+      )
+    } else {
+      switch (chainIdTag, fieldsByColumn->Utils.Dict.dangerouslyGetNonOption(name)) {
+      | (Some((column, chainId)), _) if column === name => (_ => chainId, _ => chainId)
+      | (_, Some(f)) =>
+        let serialize = compileSerializer(clickHouseFieldSchema(f))
+        let apiName = f->Table.getApiFieldName
+        if apiName === Table.idFieldName {
+          let cell = change =>
+            serialize(change->Change.getEntityId->(Utils.magic: EntityId.t => unknown))
+          (cell, cell)
+        } else {
+          (change => serialize(change->changeEntity->Dict.getUnsafe(apiName)), _ => absent)
         }
-        Change.Delete({
-          entityId: s.field(Table.idFieldName, idSchema),
-          checkpointId: s.field(
-            EntityHistory.checkpointIdFieldName,
-            EntityHistory.unsafeCheckpointIdSchema,
-          ),
-        })
-      }),
-    ),
+      | (_, None) =>
+        JsError.throwWithMessage(
+          `ClickHouse table "${tableName}" registered a column "${name}" that entity "${entityConfig.name}" has no value for`,
+        )
+      }
+    }
+    setCells->Array.push(set)
+    deleteCells->Array.push(delete)
+  })
+
+  fieldsByColumn->Dict.forEachWithKey((f, column) =>
+    if !(columns->Array.some(registered => registered.name === column)) {
+      JsError.throwWithMessage(
+        `ClickHouse table "${tableName}" registered no column for field "${f.fieldName}" of entity "${entityConfig.name}"`,
+      )
+    }
+  )
+
+  {setCells, deleteCells}
+}
+
+let fillBuilders = (
+  ~table: ClickHouseSink.table,
+  ~converters,
+  ~changes: array<Change.t<Internal.entity>>,
+) => {
+  let rows = changes->Array.length
+  let builders = table.columns->Array.map(ClickHouseSink.makeBuilder(_, ~rows))
+  let columns = builders->Array.length
+  for row in 0 to rows - 1 {
+    let change = changes->Array.getUnsafe(row)
+    let (cells, write) = switch change {
+    | Change.Set(_) => (converters.setCells, ClickHouseSink.writeValue)
+    | Delete(_) => (converters.deleteCells, ClickHouseSink.writeDeletedValue)
+    }
+    for column in 0 to columns - 1 {
+      builders->Array.getUnsafe(column)->write(~row, (cells->Array.getUnsafe(column))(change))
+    }
   }
+  builders
 }
 
 let entityTable = (sink, ~registry, ~entityConfig: Internal.entityConfig) =>
@@ -300,31 +359,16 @@ let stageUpdatesOrThrow = (
     let table = sink->entityTable(~registry, ~entityConfig)
     let tableName = table.name
     let cacheKey = `${entityConfig.name}|${scope->Internal.chainScopeToString}`
-    let {
-      convertSetOrThrow,
-      convertDeleteOrThrow,
-    } = switch registry.converters->Utils.Dict.dangerouslyGetNonOption(cacheKey) {
+    let converters = switch registry.converters->Utils.Dict.dangerouslyGetNonOption(cacheKey) {
     | Some(cached) => cached
     | None =>
-      let cached = makeConverters(~entityConfig, ~scope)
+      let cached = makeConverters(~entityConfig, ~scope, ~table)
       registry.converters->Dict.set(cacheKey, cached)
       cached
     }
 
     try {
-      let builders = table.columns->Array.map(ClickHouseSink.makeBuilder(_, ~rows))
-      let columns = builders->Array.length
-      for row in 0 to rows - 1 {
-        let change = changes->Array.getUnsafe(row)
-        let (values, write) = switch change {
-        | Change.Set(_) => (convertSetOrThrow(change), ClickHouseSink.writeValue)
-        | Delete(_) => (convertDeleteOrThrow(change), ClickHouseSink.writeDeletedValue)
-        }
-        for column in 0 to columns - 1 {
-          let builder = builders->Array.getUnsafe(column)
-          builder->write(~row, values->Dict.getUnsafe(builder.name))
-        }
-      }
+      let builders = fillBuilders(~table, ~converters, ~changes)
       Some(sink->stageBuilders(~table, ~builders, ~rows))
     } catch {
     | exn =>

--- a/packages/envio/src/bindings/ClickHouse.res
+++ b/packages/envio/src/bindings/ClickHouse.res
@@ -9,13 +9,8 @@ let clickHouseFieldSchema = (f: Table.field) => {
     }
   switch f.fieldType {
   | Date => shaped(Utils.Schema.clickHouseDate->S.toUnknown)
-  // The sink takes the Uint8Arrays themselves, where the table schema
-  // binds a list as a Postgres array literal and is not a JSON schema.
   | Bytea => shaped(S.json(~validate=false)->S.toUnknown)
   | ChainId => ChainId.schema->S.toUnknown
-  // Not wrapped in `S.null` even when the field is nullable: the column
-  // is a String either way, and both ways of saying nothing travel as
-  // the text of JSON null.
   | Json if !f.isArray => Utils.Schema.clickHouseJson->S.toUnknown
   | _ => f.fieldSchema
   }
@@ -162,9 +157,6 @@ let entitySpec = (~entityConfig: Internal.entityConfig): ClickHouseSink.entitySp
   }
 }
 
-// One reader per registered column, in registration order: a row is staged by
-// asking each column for its value rather than serializing the row to a record
-// the columns are then looked up in.
 type cell = Change.t<Internal.entity> => unknown
 
 type converters = {
@@ -195,95 +187,99 @@ let makeRegistry = () => {
     )
 )
 
-// Built against the columns the table registered, so each column is matched to
-// its source by name once here and by position on every row after. A column
-// with no source, or a field with no column, is refused up front: matched by
-// position alone, either would stage one column's values under another's name.
-let makeConverters = (
-  ~entityConfig: Internal.entityConfig,
-  ~scope: Internal.chainScope,
-  ~table: ClickHouseSink.table,
-): converters => {
-  let {name: tableName, columns} = table
-  let table = entityConfig.table
-  let chainIdTag = switch (table->Table.getChainIdField, scope->Internal.chainScopeChainId) {
-  | (Some(field), Some(chainId)) =>
-    Some((field->Table.getClickHouseDbFieldName, chainId->(Utils.magic: ChainId.t => unknown)))
-  | _ => None
-  }
-  let fieldsByColumn = Dict.make()
-  table.fields->Array.forEach(field =>
-    switch field {
-    | Table.Field(f) => fieldsByColumn->Dict.set(f->Table.getClickHouseDbFieldName, f)
-    | DerivedFrom(_) => ()
+%%private(
+  let makeConverters = (
+    ~entityConfig: Internal.entityConfig,
+    ~scope: Internal.chainScope,
+    ~table: ClickHouseSink.table,
+  ): converters => {
+    let {name: tableName, columns} = table
+    let sourceTable = entityConfig.table
+    let chainIdTag = switch (
+      sourceTable->Table.getChainIdField,
+      scope->Internal.chainScopeChainId,
+    ) {
+    | (Some(field), Some(chainId)) =>
+      Some((field->Table.getClickHouseDbFieldName, chainId->(Utils.magic: ChainId.t => unknown)))
+    | _ => None
     }
-  )
+    let fieldsByColumn = Dict.make()
+    sourceTable.fields->Array.forEach(field =>
+      switch field {
+      | Table.Field(f) => fieldsByColumn->Dict.set(f->Table.getClickHouseDbFieldName, f)
+      | DerivedFrom(_) => ()
+      }
+    )
 
-  let setCells = []
-  let deleteCells = []
-  columns->Array.forEach(({name}) => {
-    let (set, delete) = if name === EntityHistory.checkpointIdFieldName {
-      let cell = change => change->Change.getCheckpointId->(Utils.magic: bigint => unknown)
-      (cell, cell)
-    } else if name === EntityHistory.changeFieldName {
-      (
-        _ => (EntityHistory.RowAction.SET :> string)->(Utils.magic: string => unknown),
-        _ => (EntityHistory.RowAction.DELETE :> string)->(Utils.magic: string => unknown),
-      )
-    } else {
-      switch (chainIdTag, fieldsByColumn->Utils.Dict.dangerouslyGetNonOption(name)) {
-      | (Some((column, chainId)), _) if column === name => (_ => chainId, _ => chainId)
-      | (_, Some(f)) =>
-        let serialize = compileSerializer(clickHouseFieldSchema(f))
-        let apiName = f->Table.getApiFieldName
-        if apiName === Table.idFieldName {
-          let cell = change =>
-            serialize(change->Change.getEntityId->(Utils.magic: EntityId.t => unknown))
-          (cell, cell)
-        } else {
-          (change => serialize(change->changeEntity->Dict.getUnsafe(apiName)), _ => absent)
+    let setCells = []
+    let deleteCells = []
+    let registeredNames = columns->Array.map(column => column.name)->Utils.Set.fromArray
+    columns->Array.forEach(({name}) => {
+      let (set, delete) = if name === EntityHistory.checkpointIdFieldName {
+        let cell = change => change->Change.getCheckpointId->(Utils.magic: bigint => unknown)
+        (cell, cell)
+      } else if name === EntityHistory.changeFieldName {
+        (
+          _ => (EntityHistory.RowAction.SET :> string)->(Utils.magic: string => unknown),
+          _ => (EntityHistory.RowAction.DELETE :> string)->(Utils.magic: string => unknown),
+        )
+      } else {
+        switch (chainIdTag, fieldsByColumn->Utils.Dict.dangerouslyGetNonOption(name)) {
+        | (Some((column, chainId)), _) if column === name => (_ => chainId, _ => chainId)
+        | (_, Some(f)) =>
+          let serialize = compileSerializer(clickHouseFieldSchema(f))
+          let apiName = f->Table.getApiFieldName
+          if apiName === Table.idFieldName {
+            let cell = change =>
+              serialize(change->Change.getEntityId->(Utils.magic: EntityId.t => unknown))
+            (cell, cell)
+          } else {
+            (change => serialize(change->changeEntity->Dict.getUnsafe(apiName)), _ => absent)
+          }
+        | (_, None) =>
+          JsError.throwWithMessage(
+            `ClickHouse table "${tableName}" registered a column "${name}" that entity "${entityConfig.name}" has no value for`,
+          )
         }
-      | (_, None) =>
+      }
+      setCells->Array.push(set)
+      deleteCells->Array.push(delete)
+    })
+
+    fieldsByColumn->Dict.forEachWithKey((f, column) =>
+      if !(registeredNames->Utils.Set.has(column)) {
         JsError.throwWithMessage(
-          `ClickHouse table "${tableName}" registered a column "${name}" that entity "${entityConfig.name}" has no value for`,
+          `ClickHouse table "${tableName}" registered no column for field "${f.fieldName}" of entity "${entityConfig.name}"`,
         )
       }
-    }
-    setCells->Array.push(set)
-    deleteCells->Array.push(delete)
-  })
+    )
 
-  fieldsByColumn->Dict.forEachWithKey((f, column) =>
-    if !(columns->Array.some(registered => registered.name === column)) {
-      JsError.throwWithMessage(
-        `ClickHouse table "${tableName}" registered no column for field "${f.fieldName}" of entity "${entityConfig.name}"`,
-      )
-    }
-  )
-
-  {setCells, deleteCells}
-}
-
-let fillBuilders = (
-  ~table: ClickHouseSink.table,
-  ~converters,
-  ~changes: array<Change.t<Internal.entity>>,
-) => {
-  let rows = changes->Array.length
-  let builders = table.columns->Array.map(ClickHouseSink.makeBuilder(_, ~rows))
-  let columns = builders->Array.length
-  for row in 0 to rows - 1 {
-    let change = changes->Array.getUnsafe(row)
-    let (cells, write) = switch change {
-    | Change.Set(_) => (converters.setCells, ClickHouseSink.writeValue)
-    | Delete(_) => (converters.deleteCells, ClickHouseSink.writeDeletedValue)
-    }
-    for column in 0 to columns - 1 {
-      builders->Array.getUnsafe(column)->write(~row, (cells->Array.getUnsafe(column))(change))
-    }
+    {setCells, deleteCells}
   }
-  builders
-}
+)
+
+%%private(
+  let fillBuilders = (
+    ~table: ClickHouseSink.table,
+    ~converters,
+    ~changes: array<Change.t<Internal.entity>>,
+  ) => {
+    let rows = changes->Array.length
+    let builders = table.columns->Array.map(ClickHouseSink.makeBuilder(_, ~rows))
+    let columns = builders->Array.length
+    for row in 0 to rows - 1 {
+      let change = changes->Array.getUnsafe(row)
+      let (cells, write) = switch change {
+      | Change.Set(_) => (converters.setCells, ClickHouseSink.writeValue)
+      | Delete(_) => (converters.deleteCells, ClickHouseSink.writeDeletedValue)
+      }
+      for column in 0 to columns - 1 {
+        builders->Array.getUnsafe(column)->write(~row, (cells->Array.getUnsafe(column))(change))
+      }
+    }
+    builders
+  }
+)
 
 let entityTable = (sink, ~registry, ~entityConfig: Internal.entityConfig) =>
   switch registry.entities->Utils.Dict.dangerouslyGetNonOption(entityConfig.name) {
@@ -359,15 +355,14 @@ let stageUpdatesOrThrow = (
     let table = sink->entityTable(~registry, ~entityConfig)
     let tableName = table.name
     let cacheKey = `${entityConfig.name}|${scope->Internal.chainScopeToString}`
-    let converters = switch registry.converters->Utils.Dict.dangerouslyGetNonOption(cacheKey) {
-    | Some(cached) => cached
-    | None =>
-      let cached = makeConverters(~entityConfig, ~scope, ~table)
-      registry.converters->Dict.set(cacheKey, cached)
-      cached
-    }
-
     try {
+      let converters = switch registry.converters->Utils.Dict.dangerouslyGetNonOption(cacheKey) {
+      | Some(cached) => cached
+      | None =>
+        let cached = makeConverters(~entityConfig, ~scope, ~table)
+        registry.converters->Dict.set(cacheKey, cached)
+        cached
+      }
       let builders = fillBuilders(~table, ~converters, ~changes)
       Some(sink->stageBuilders(~table, ~builders, ~rows))
     } catch {


### PR DESCRIPTION
## Why

ClickHouse staging built a throwaway named record for every history row, then hashed each cell by column name on the JS thread. A batch of a few thousand rows paid for that twice: one dict per row, one lookup per cell.

Each registered column now has a reader built once per entity and scope. A row is staged by calling those readers in registration order. Alignment is a name match at build time, then position on every row.

## Scope

- `packages/envio/src/bindings/ClickHouse.res` builds `setCells` / `deleteCells` in `table.columns` order. `clickHouseFieldSchema` is shared by those readers and `makeClickHouseEntitySchema`. It keeps the main-line Bytea passthrough (`S.json(~validate=false)`, not `fieldSchema`) and the Json mapping. `resume` still passes `historyTables`, `replicated`, and `databaseEngine`.
- `makeConverters` and `fillBuilders` are private. Converter build runs inside the `Persistence.StorageError` try.
- `packages/envio-tests/test/lib_tests/ClickHouseStaging_test.res` registers a real table, mocks `stage`, and pins column names plus the `columnValuesInput` list. The fixture covers snake_case, a linked `owner: User!`, Bytes scalars and `[Bytes!]!`, SET/DELETE, and the chain-id tag.
- `ColumnNameFormat_test.res` no longer serializes through `makeSetUpdateSchema`. That stack is not the ClickHouse write path.

Out of scope: changing ClickHouse DDL, resume, or the checkpoint column list.

## Tradeoffs

The leftover-field check still exists for a table that `registerEntityTable` cannot produce. It is cheap, private, and wrapped as `StorageError`. Unreachable from user YAML, so it is not a user-API test.

## Blast Radius

ClickHouse-backed indexers only. Handlers, YAML, and schema stay the same. Rows should match what the old record path wrote. A sloppy rebase onto `#1620` / `#1609` would have dropped Bytes or catalog-less resume. This branch is rebased onto current main and keeps both.

## Verification

```
cd packages/envio-tests && pnpm rescript && pnpm vitest run \
  test/lib_tests/ClickHouseStaging_test.res \
  test/lib_tests/ColumnNameFormat_test.res \
  test/lib_tests/ClickHouse_test.res \
  test/lib_tests/ClickHouseColumnKind_test.res \
  test/ConfigCrossChain_test.res
```

53 tests passed (20 in the ClickHouse lib files, 33 in ConfigCrossChain). Postgres on 5433 is only for vitest global setup. Staging itself never talks to a server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ClickHouse staging now supports binary (`Bytea`) column values.
  - Staged entity changes preserve column ordering, typed values, null markers, metadata, checkpoints, and change types.
  - Set and delete operations now handle entity IDs, chain IDs, serialized values, and deleted values consistently.

- **Bug Fixes**
  - Improved validation for mismatched entity fields and database columns.
  - Improved handling of table-specific data conversions during staging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->