### PR TITLE
Optimize ClickHouse view deduplication sort order

### DIFF
--- a/packages/cli/src/clickhouse/ddl.rs
+++ b/packages/cli/src/clickhouse/ddl.rs
@@ -315,8 +315,21 @@ pub fn create_view(
         .collect();
     let entity_fields = entity_fields.join(", ");
 
+    // The dedup key leads the sort so the rows a `LIMIT 1 BY` group needs
+    // arrive together: the history table is sorted by that key already (or by a
+    // prefix of it, under a custom `orderBy`), so ClickHouse reads in order and
+    // a `LIMIT n` over the view stops after n groups instead of sorting every
+    // version in the table first. Sorting by the checkpoint alone forced that
+    // full sort on every read. The checkpoint stays last and descending, which
+    // is what makes the surviving row per key the latest one.
+    let dedup_sort = format!(
+        "{}, {} DESC",
+        dedup_key.join(", "),
+        quoted(&history.checkpoint_id_column)
+    );
+
     format!(
-        "CREATE VIEW IF NOT EXISTS {db}.{}{} AS\nSELECT {entity_fields}\nFROM (\n  SELECT {entity_fields}, {}\n  FROM {db}.{}\n  WHERE {} <= (SELECT max({}) FROM {db}.{})\n  ORDER BY {} DESC\n  LIMIT 1 BY {}\n)\nWHERE {} = {}",
+        "CREATE VIEW IF NOT EXISTS {db}.{}{} AS\nSELECT {entity_fields}\nFROM (\n  SELECT {entity_fields}, {}\n  FROM {db}.{}\n  WHERE {} <= (SELECT max({}) FROM {db}.{})\n  ORDER BY {dedup_sort}\n  LIMIT 1 BY {}\n)\nWHERE {} = {}",
         quoted(&entity.name),
         topology.on_cluster(),
         quoted(&history.change_column),
@@ -324,7 +337,6 @@ pub fn create_view(
         quoted(&history.checkpoint_id_column),
         quoted(&history.id_column),
         quoted(&history.checkpoints_table),
-        quoted(&history.checkpoint_id_column),
         dedup_key.join(", "),
         quoted(&history.change_column),
         literal(&history.set_variant),
@@ -719,7 +731,7 @@ mod tests {
              SELECT `id`, `balance`, `envio_change`\n  \
              FROM `test_db`.`envio_history_Account`\n  \
              WHERE `envio_checkpoint_id` <= (SELECT max(`id`) FROM `test_db`.`envio_checkpoints`)\n  \
-             ORDER BY `envio_checkpoint_id` DESC\n  \
+             ORDER BY `id`, `envio_checkpoint_id` DESC\n  \
              LIMIT 1 BY `id`\n\
              )\n\
              WHERE `envio_change` = 'SET'"
@@ -744,8 +756,9 @@ mod tests {
             vec![column("id", "String"), column("chain_id", "ChainId")],
         );
         entity.chain_id_column = Some("chain_id".to_string());
-        assert!(create_view(&entity, "test_db", &history_schema(), plain())
-            .contains("LIMIT 1 BY `id`, `chain_id`"));
+        let sql = create_view(&entity, "test_db", &history_schema(), plain());
+        assert!(sql.contains("ORDER BY `id`, `chain_id`, `envio_checkpoint_id` DESC"));
+        assert!(sql.contains("LIMIT 1 BY `id`, `chain_id`"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Optimize the `ORDER BY` clause in ClickHouse deduplication views to avoid full table sorts on every read. The dedup key now leads the sort, allowing ClickHouse to use the pre-sorted history table and stop after finding `n` groups with `LIMIT n BY`, rather than sorting all versions first.

## Changes
- Restructured the `ORDER BY` clause to sort by dedup key first, then checkpoint ID descending
  - Dedup key columns are now listed first in the sort order
  - Checkpoint ID remains last and descending (ensures latest row per key survives)
  - This leverages the fact that the history table is already sorted by the dedup key (or a prefix of it)
- Updated test expectations to verify the new sort order includes both dedup key and checkpoint ID columns
- Added explanatory comment documenting the performance rationale

## Implementation Details
The change moves from sorting only by checkpoint ID (which forced a full sort) to sorting by `dedup_key, checkpoint_id DESC`. This allows ClickHouse to read rows in order and stop after finding the required number of groups, rather than sorting every version in the table on each read.

https://claude.ai/code/session_01S2pBya461nVWxChRms2VuN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected history view ordering to prioritize the deduplication key, then sort by the latest checkpoint.
  * Added coverage for ordering behavior in standard and per-chain deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->