### PR TITLE
Support optional and unnamed account slots in SVM instructions

### DIFF
--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -1041,11 +1041,12 @@ pub mod fuel {
 }
 
 pub mod svm {
+    use std::borrow::Cow;
     use std::fmt::Display;
 
     use super::BaseConfig;
-    use schemars::JsonSchema;
-    use serde::{Deserialize, Serialize};
+    use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
+    use serde::{de, Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
     #[serde(deny_unknown_fields)]
@@ -1222,12 +1223,12 @@ pub mod svm {
         pub discriminator: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
-            description = "Optional positional account names. The Nth entry names account slot N \
-                           on the dispatched instruction; surfaces as \
-                           `instruction.accounts.<name>` when `fields.instruction` includes \
-                           `accounts`."
+            description = "Optional positional account slots, in the order the program expects \
+                           them. The Nth entry names account slot N on the dispatched \
+                           instruction; named slots surface as `instruction.accounts.<name>` \
+                           when `fields.instruction` includes `accounts`."
         )]
-        pub accounts: Option<Vec<String>>,
+        pub accounts: Option<Vec<AccountSlot>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
             description = "Optional Borsh argument schema. Each entry names one arg and gives its \
@@ -1236,6 +1237,85 @@ pub mod svm {
                            present."
         )]
         pub args: Option<Vec<ArgDef>>,
+    }
+
+    /// One account slot as written in YAML: `payer`, `?authority` for an
+    /// optional slot, or `_` for one that holds a position without a name. The
+    /// text is kept verbatim; the grammar is read where the instruction is
+    /// resolved, so a defect is reported against the instruction that carries it.
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct AccountSlot(pub String);
+
+    impl Serialize for AccountSlot {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_str(&self.0)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for AccountSlot {
+        fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            struct SlotVisitor;
+
+            impl<'de> de::Visitor<'de> for SlotVisitor {
+                type Value = AccountSlot;
+
+                fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    f.write_str("an account name, `?name` for an optional slot, or `_`")
+                }
+
+                fn visit_str<E: de::Error>(self, value: &str) -> Result<AccountSlot, E> {
+                    Ok(AccountSlot(value.to_string()))
+                }
+
+                /// `- ? authority` and the flow-style `[?authority]` are YAML's
+                /// explicit-key syntax, which parses as a one-entry mapping with
+                /// no value rather than as the string a reader sees.
+                fn visit_map<A: de::MapAccess<'de>>(
+                    self,
+                    mut map: A,
+                ) -> Result<AccountSlot, A::Error> {
+                    let Some((name, value)) = map.next_entry::<String, Option<de::IgnoredAny>>()?
+                    else {
+                        return Err(de::Error::custom(
+                            "expected an account name, got an empty mapping",
+                        ));
+                    };
+                    if value.is_some() || map.next_key::<de::IgnoredAny>()?.is_some() {
+                        return Err(de::Error::custom(format!(
+                            "expected an account name, got a mapping. To mark '{name}' optional, \
+                             write \"?{name}\"."
+                        )));
+                    }
+                    Ok(AccountSlot(format!("?{name}")))
+                }
+            }
+
+            deserializer.deserialize_any(SlotVisitor)
+        }
+    }
+
+    impl JsonSchema for AccountSlot {
+        fn schema_name() -> Cow<'static, str> {
+            "SvmAccountSlot".into()
+        }
+
+        fn json_schema(_: &mut SchemaGenerator) -> Schema {
+            json_schema!({
+                "title": "Account slot",
+                "description": "One positional account slot of the instruction.\n\
+                    - `payer` names a slot the call always carries; it surfaces as \
+                    `instruction.accounts.payer`.\n\
+                    - `?authority` names an optional slot: the key is absent from \
+                    `instruction.accounts` when the call leaves the slot out or fills it with \
+                    the program id.\n\
+                    - `_` holds a position without naming it, so the slots after it keep \
+                    theirs. It is never surfaced and never filterable, and the list may not \
+                    end with one.",
+                "type": "string",
+                "pattern": "^(?:_|\\??[A-Za-z0-9_]*[A-Za-z][A-Za-z0-9_]*)$",
+                "examples": ["payer", "?authority", "_"],
+            })
+        }
     }
 
     /// One named argument of an instruction. Mirrors
@@ -1387,6 +1467,28 @@ mod tests {
         assert_eq!(
             npm_schema, actual_schema,
             "Please run 'make update-generated-docs'"
+        );
+    }
+
+    /// The slot text is the config's own surface, so what a writer emits has
+    /// to read back as the same slots.
+    #[test]
+    fn svm_account_slots_round_trip_through_yaml() {
+        use super::svm::AccountSlot;
+
+        let slots = vec![
+            AccountSlot("payer".to_string()),
+            AccountSlot("?authority".to_string()),
+            AccountSlot("_".to_string()),
+        ];
+        let yaml = serde_yaml::to_string(&slots).unwrap();
+
+        assert_eq!(
+            (
+                yaml.as_str(),
+                serde_yaml::from_str::<Vec<AccountSlot>>(&yaml).unwrap()
+            ),
+            ("- payer\n- ?authority\n- _\n", slots)
         );
     }
 

--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -1239,16 +1239,75 @@ pub mod svm {
         pub args: Option<Vec<ArgDef>>,
     }
 
-    /// One account slot as written in YAML: `payer`, `?authority` for an
-    /// optional slot, or `_` for one that holds a position without a name. The
-    /// text is kept verbatim; the grammar is read where the instruction is
-    /// resolved, so a defect is reported against the instruction that carries it.
+    /// One positional account slot of an instruction.
     #[derive(Debug, Clone, PartialEq)]
-    pub struct AccountSlot(pub String);
+    pub enum AccountSlot {
+        /// Holds a position without naming it: never surfaced to a handler,
+        /// never filterable. The slots after it keep their positions.
+        Unnamed,
+        Required(String),
+        /// Absent when the call carries no such slot, or fills it with the id
+        /// of the program being invoked — the convention Anchor and Codama
+        /// both use.
+        Optional(String),
+    }
+
+    impl AccountSlot {
+        pub fn name(&self) -> Option<&str> {
+            match self {
+                Self::Unnamed => None,
+                Self::Required(name) | Self::Optional(name) => Some(name),
+            }
+        }
+
+        pub fn is_optional(&self) -> bool {
+            matches!(self, Self::Optional(_))
+        }
+
+        /// The YAML slot grammar: `payer`, `?authority`, `_`.
+        fn parse(token: &str) -> Result<Self, String> {
+            let name = |name: &str| {
+                let readable = name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                    && name.chars().any(|c| c.is_ascii_alphabetic());
+                if readable {
+                    Ok(name.to_string())
+                } else {
+                    Err(format!(
+                        "account slot '{token}' is not a name: expected letters, digits and \
+                         underscores, at least one of them a letter. Prefix a name with '?' to \
+                         mark the slot optional, or write '_' to hold a position without naming \
+                         it."
+                    ))
+                }
+            };
+            match token {
+                "_" => Ok(Self::Unnamed),
+                "?_" => Err(
+                    "account slot '?_' marks an unnamed slot optional, which nothing can \
+                     observe. Write '_' to hold the position, or name the slot."
+                        .to_string(),
+                ),
+                _ => match token.strip_prefix('?') {
+                    Some(optional) => Ok(Self::Optional(name(optional)?)),
+                    None => Ok(Self::Required(name(token)?)),
+                },
+            }
+        }
+    }
+
+    impl Display for AccountSlot {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            match self {
+                Self::Unnamed => f.write_str("_"),
+                Self::Required(name) => f.write_str(name),
+                Self::Optional(name) => write!(f, "?{name}"),
+            }
+        }
+    }
 
     impl Serialize for AccountSlot {
         fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            serializer.serialize_str(&self.0)
+            serializer.collect_str(self)
         }
     }
 
@@ -1264,7 +1323,7 @@ pub mod svm {
                 }
 
                 fn visit_str<E: de::Error>(self, value: &str) -> Result<AccountSlot, E> {
-                    Ok(AccountSlot(value.to_string()))
+                    AccountSlot::parse(value).map_err(de::Error::custom)
                 }
 
                 /// `- ? authority` and the flow-style `[?authority]` are YAML's
@@ -1286,7 +1345,7 @@ pub mod svm {
                              write \"?{name}\"."
                         )));
                     }
-                    Ok(AccountSlot(format!("?{name}")))
+                    AccountSlot::parse(&format!("?{name}")).map_err(de::Error::custom)
                 }
             }
 
@@ -1477,9 +1536,9 @@ mod tests {
         use super::svm::AccountSlot;
 
         let slots = vec![
-            AccountSlot("payer".to_string()),
-            AccountSlot("?authority".to_string()),
-            AccountSlot("_".to_string()),
+            AccountSlot::Required("payer".to_string()),
+            AccountSlot::Optional("authority".to_string()),
+            AccountSlot::Unnamed,
         ];
         let yaml = serde_yaml::to_string(&slots).unwrap();
 

--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -1,6 +1,7 @@
 use super::{
     entity_parsing, field_types,
     human_config::{self, evm::For, ColumnNameFormat},
+    svm_catalog::SvmAccountSlot,
     system_config::{
         self, field_type_to_arg_type, named_field_to_arg_def, Abi, ChainIdMode, Ecosystem,
         EventKind, FuelEventKind, SvmAbi, SvmSchemaSource, SystemConfig,
@@ -417,15 +418,34 @@ struct ContractEventItem {
 struct SvmEventItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     discriminator: Option<String>,
-    /// Positional account names, in the order the on-chain program expects.
+    /// Positional account slots, in the order the on-chain program expects.
     /// `[]` means the runtime won't expose `decoded.accounts.<name>`; the
     /// raw `instruction.accounts[i]` array is still available.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    accounts: Vec<String>,
+    accounts: Vec<SvmAccountSlotItem>,
     /// Borsh args layout. `[]` means the runtime won't expose
     /// `decoded.args`; the raw `instruction.data` hex is still available.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     args: Vec<human_config::svm::ArgDef>,
+}
+
+/// One account slot. An unnamed slot carries neither key, so it reaches the
+/// runtime as `{}` — a position to skip over.
+#[derive(Serialize, Debug)]
+struct SvmAccountSlotItem {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    optional: bool,
+}
+
+impl From<&SvmAccountSlot> for SvmAccountSlotItem {
+    fn from(slot: &SvmAccountSlot) -> Self {
+        Self {
+            name: slot.name().map(str::to_string),
+            optional: slot.is_optional(),
+        }
+    }
 }
 
 /// Program-level Borsh schema metadata. Emitted onto `ContractConfig.svm_abi`
@@ -615,7 +635,11 @@ impl SystemConfig {
                                 EventKind::Svm(svm_kind) => {
                                     let svm_item = SvmEventItem {
                                         discriminator: svm_kind.discriminator.clone(),
-                                        accounts: svm_kind.accounts.clone(),
+                                        accounts: svm_kind
+                                            .accounts
+                                            .iter()
+                                            .map(SvmAccountSlotItem::from)
+                                            .collect(),
                                         args: svm_kind
                                             .args
                                             .iter()

--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -1,7 +1,6 @@
 use super::{
     entity_parsing, field_types,
-    human_config::{self, evm::For, ColumnNameFormat},
-    svm_catalog::SvmAccountSlot,
+    human_config::{self, evm::For, svm::AccountSlot, ColumnNameFormat},
     system_config::{
         self, field_type_to_arg_type, named_field_to_arg_def, Abi, ChainIdMode, Ecosystem,
         EventKind, FuelEventKind, SvmAbi, SvmSchemaSource, SystemConfig,
@@ -439,8 +438,8 @@ struct SvmAccountSlotItem {
     optional: bool,
 }
 
-impl From<&SvmAccountSlot> for SvmAccountSlotItem {
-    fn from(slot: &SvmAccountSlot) -> Self {
+impl From<&AccountSlot> for SvmAccountSlotItem {
+    fn from(slot: &AccountSlot) -> Self {
         Self {
             name: slot.name().map(str::to_string),
             optional: slot.is_optional(),

--- a/packages/cli/src/config_parsing/svm_catalog.rs
+++ b/packages/cli/src/config_parsing/svm_catalog.rs
@@ -1,17 +1,53 @@
 use std::collections::{HashMap, HashSet};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use hypersync_client_solana::decode::NamedField as SvmNamedField;
 
 use super::human_config;
 use super::svm_idl::{IxIdl, ProgramIdl, Unusable};
 use super::system_config::yaml_arg_to_named_field;
 
+/// One positional account slot of a configured instruction.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SvmAccountSlot {
+    /// Holds a position without naming it: never surfaced to a handler, never
+    /// filterable. The slots after it keep their positions.
+    Unnamed,
+    Required(String),
+    /// Absent when the call carries no such slot, or fills it with the id of
+    /// the program being invoked — the convention Anchor and Codama both use.
+    Optional(String),
+}
+
+impl SvmAccountSlot {
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Self::Unnamed => None,
+            Self::Required(name) | Self::Optional(name) => Some(name),
+        }
+    }
+
+    pub fn is_optional(&self) -> bool {
+        matches!(self, Self::Optional(_))
+    }
+}
+
+/// The canonical YAML token for a slot — the inverse of `parse_account_slots`.
+impl std::fmt::Display for SvmAccountSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Unnamed => f.write_str("_"),
+            Self::Required(name) => f.write_str(name),
+            Self::Optional(name) => write!(f, "?{name}"),
+        }
+    }
+}
+
 /// What one configured instruction dispatches on and decodes into.
 pub struct ResolvedInstruction {
     /// `None` matches every instruction of the program.
     pub discriminator: Option<Vec<u8>>,
-    pub accounts: Vec<String>,
+    pub accounts: Vec<SvmAccountSlot>,
     pub args: Vec<SvmNamedField>,
 }
 
@@ -23,10 +59,64 @@ impl ResolvedInstruction {
             } else {
                 Some(ix.discriminator.clone())
             },
-            accounts: ix.accounts.iter().map(|a| a.name.clone()).collect(),
+            accounts: ix
+                .accounts
+                .iter()
+                .map(|a| {
+                    if a.optional {
+                        SvmAccountSlot::Optional(a.name.clone())
+                    } else {
+                        SvmAccountSlot::Required(a.name.clone())
+                    }
+                })
+                .collect(),
             args: ix.args.clone(),
         }
     }
+}
+
+/// The YAML slot grammar: `payer`, `?authority`, `_`.
+fn parse_account_slots(tokens: &[human_config::svm::AccountSlot]) -> Result<Vec<SvmAccountSlot>> {
+    let mut slots = Vec::with_capacity(tokens.len());
+    for token in tokens {
+        let text = token.0.as_str();
+        slots.push(if text == "_" {
+            SvmAccountSlot::Unnamed
+        } else if let Some(name) = text.strip_prefix('?') {
+            if name == "_" {
+                bail!(
+                    "account slot '?_' marks an unnamed slot optional, which nothing can \
+                     observe. Write '_' to hold the position, or name the slot."
+                );
+            }
+            SvmAccountSlot::Optional(account_name(name, text)?)
+        } else {
+            SvmAccountSlot::Required(account_name(text, text)?)
+        });
+    }
+    if slots.last() == Some(&SvmAccountSlot::Unnamed) {
+        bail!("the account list ends with '_', a position nothing follows. Drop it.");
+    }
+    let mut seen = HashSet::new();
+    for name in slots.iter().filter_map(SvmAccountSlot::name) {
+        if !seen.insert(name) {
+            bail!("account '{name}' is declared more than once.");
+        }
+    }
+    Ok(slots)
+}
+
+fn account_name(name: &str, token: &str) -> Result<String> {
+    let readable = name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && name.chars().any(|c| c.is_ascii_alphabetic());
+    if !readable {
+        bail!(
+            "account slot '{token}' is not a name: expected letters, digits and underscores, at \
+             least one of them a letter. Prefix a name with '?' to mark the slot optional, or \
+             write '_' to hold a position without naming it."
+        );
+    }
+    Ok(name.to_string())
 }
 
 fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<ResolvedInstruction> {
@@ -35,7 +125,10 @@ fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<Re
         .as_deref()
         .map(|d| crate::hex::decode_optionally_prefixed(d, "discriminator"))
         .transpose()?;
-    let accounts = instr.accounts.clone().unwrap_or_default();
+    let accounts = match &instr.accounts {
+        Some(tokens) => parse_account_slots(tokens)?,
+        None => Vec::new(),
+    };
     let args = match &instr.args {
         Some(args) => args
             .iter()

--- a/packages/cli/src/config_parsing/svm_catalog.rs
+++ b/packages/cli/src/config_parsing/svm_catalog.rs
@@ -3,51 +3,15 @@ use std::collections::{HashMap, HashSet};
 use anyhow::{anyhow, bail, Context, Result};
 use hypersync_client_solana::decode::NamedField as SvmNamedField;
 
-use super::human_config;
+use super::human_config::{self, svm::AccountSlot};
 use super::svm_idl::{IxIdl, ProgramIdl, Unusable};
 use super::system_config::yaml_arg_to_named_field;
-
-/// One positional account slot of a configured instruction.
-#[derive(Debug, Clone, PartialEq)]
-pub enum SvmAccountSlot {
-    /// Holds a position without naming it: never surfaced to a handler, never
-    /// filterable. The slots after it keep their positions.
-    Unnamed,
-    Required(String),
-    /// Absent when the call carries no such slot, or fills it with the id of
-    /// the program being invoked — the convention Anchor and Codama both use.
-    Optional(String),
-}
-
-impl SvmAccountSlot {
-    pub fn name(&self) -> Option<&str> {
-        match self {
-            Self::Unnamed => None,
-            Self::Required(name) | Self::Optional(name) => Some(name),
-        }
-    }
-
-    pub fn is_optional(&self) -> bool {
-        matches!(self, Self::Optional(_))
-    }
-}
-
-/// The canonical YAML token for a slot — the inverse of `parse_account_slots`.
-impl std::fmt::Display for SvmAccountSlot {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::Unnamed => f.write_str("_"),
-            Self::Required(name) => f.write_str(name),
-            Self::Optional(name) => write!(f, "?{name}"),
-        }
-    }
-}
 
 /// What one configured instruction dispatches on and decodes into.
 pub struct ResolvedInstruction {
     /// `None` matches every instruction of the program.
     pub discriminator: Option<Vec<u8>>,
-    pub accounts: Vec<SvmAccountSlot>,
+    pub accounts: Vec<AccountSlot>,
     pub args: Vec<SvmNamedField>,
 }
 
@@ -64,9 +28,9 @@ impl ResolvedInstruction {
                 .iter()
                 .map(|a| {
                     if a.optional {
-                        SvmAccountSlot::Optional(a.name.clone())
+                        AccountSlot::Optional(a.name.clone())
                     } else {
-                        SvmAccountSlot::Required(a.name.clone())
+                        AccountSlot::Required(a.name.clone())
                     }
                 })
                 .collect(),
@@ -75,48 +39,17 @@ impl ResolvedInstruction {
     }
 }
 
-/// The YAML slot grammar: `payer`, `?authority`, `_`.
-fn parse_account_slots(tokens: &[human_config::svm::AccountSlot]) -> Result<Vec<SvmAccountSlot>> {
-    let mut slots = Vec::with_capacity(tokens.len());
-    for token in tokens {
-        let text = token.0.as_str();
-        slots.push(if text == "_" {
-            SvmAccountSlot::Unnamed
-        } else if let Some(name) = text.strip_prefix('?') {
-            if name == "_" {
-                bail!(
-                    "account slot '?_' marks an unnamed slot optional, which nothing can \
-                     observe. Write '_' to hold the position, or name the slot."
-                );
-            }
-            SvmAccountSlot::Optional(account_name(name, text)?)
-        } else {
-            SvmAccountSlot::Required(account_name(text, text)?)
-        });
-    }
-    if slots.last() == Some(&SvmAccountSlot::Unnamed) {
+fn validate_account_slots(slots: &[AccountSlot]) -> Result<()> {
+    if slots.last() == Some(&AccountSlot::Unnamed) {
         bail!("the account list ends with '_', a position nothing follows. Drop it.");
     }
     let mut seen = HashSet::new();
-    for name in slots.iter().filter_map(SvmAccountSlot::name) {
+    for name in slots.iter().filter_map(AccountSlot::name) {
         if !seen.insert(name) {
             bail!("account '{name}' is declared more than once.");
         }
     }
-    Ok(slots)
-}
-
-fn account_name(name: &str, token: &str) -> Result<String> {
-    let readable = name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-        && name.chars().any(|c| c.is_ascii_alphabetic());
-    if !readable {
-        bail!(
-            "account slot '{token}' is not a name: expected letters, digits and underscores, at \
-             least one of them a letter. Prefix a name with '?' to mark the slot optional, or \
-             write '_' to hold a position without naming it."
-        );
-    }
-    Ok(name.to_string())
+    Ok(())
 }
 
 fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<ResolvedInstruction> {
@@ -125,10 +58,8 @@ fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<Re
         .as_deref()
         .map(|d| crate::hex::decode_optionally_prefixed(d, "discriminator"))
         .transpose()?;
-    let accounts = match &instr.accounts {
-        Some(tokens) => parse_account_slots(tokens)?,
-        None => Vec::new(),
-    };
+    let accounts = instr.accounts.clone().unwrap_or_default();
+    validate_account_slots(&accounts)?;
     let args = match &instr.args {
         Some(args) => args
             .iter()

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -44,7 +44,9 @@ use hypersync_client_solana::decode::{
     EnumVariant as SvmEnumVariant, FieldType as SvmFieldType, NamedField as SvmNamedField,
 };
 
-use super::svm_catalog::{instruction_catalog, warn_about_unindexable, ResolvedInstruction};
+use super::svm_catalog::{
+    instruction_catalog, warn_about_unindexable, ResolvedInstruction, SvmAccountSlot,
+};
 use super::svm_idl::{self, ProgramIdl};
 
 type ContractNameKey = String;
@@ -2166,9 +2168,9 @@ pub struct SvmEventKind {
     /// Hex-encoded discriminator (`0x`-prefixed), or `None` to match every
     /// instruction in the program.
     pub discriminator: Option<String>,
-    /// Positional account names. Empty when the user supplied no schema and
-    /// no IDL applies; in that case `decoded.accounts` is `{}`.
-    pub accounts: Vec<String>,
+    /// Positional account slots in declared order. Empty when the user supplied
+    /// no schema and no IDL applies; in that case `decoded.accounts` is `{}`.
+    pub accounts: Vec<SvmAccountSlot>,
     /// Borsh argument layout in declared order. Empty for unknown
     /// instructions; the raw `instruction.data` is still available.
     pub args: Vec<SvmNamedField>,
@@ -3771,7 +3773,7 @@ type Foo {
             )
         }
 
-        /// Name, discriminator, account names, arg names.
+        /// Name, discriminator, account slots as YAML tokens, arg names.
         type SvmEvent = (String, Option<String>, Vec<String>, Vec<String>);
 
         fn svm_events(config: &SystemConfig) -> Vec<SvmEvent> {
@@ -3783,7 +3785,7 @@ type Foo {
                     EventKind::Svm(k) => (
                         e.name.clone(),
                         k.discriminator.clone(),
-                        k.accounts.clone(),
+                        k.accounts.iter().map(ToString::to_string).collect(),
                         k.args.iter().map(|a| a.name.clone()).collect(),
                     ),
                     other => panic!("expected an Svm event kind, got {other:?}"),
@@ -3887,6 +3889,111 @@ type Foo {
             assert_eq!(
                 svm_events(&config),
                 vec![("swap".to_string(), None, Vec::new(), Vec::new(),)]
+            );
+        }
+
+        /// A YAML-only program whose one instruction declares `accounts` as
+        /// the given YAML, read back as the canonical slot tokens.
+        fn account_slots(accounts: &str) -> anyhow::Result<Vec<String>> {
+            let yaml = format!(
+                "name: svm-slots\necosystem: svm\nchains:\n  - id: solana\n    start_block: \
+                 0\n    experimental:\n      hypersync_config:\n        url: \
+                 https://solana.hypersync.xyz\n      programs:\n        - name: Pool\n          \
+                 program_id: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\n          \
+                 instructions:\n            - name: swap\n              discriminator: \
+                 \"0x01\"\n              args: []\n              accounts: {accounts}\n"
+            );
+            let config = SystemConfig::parse_yaml(
+                &yaml,
+                Some("type Foo @entity { id: ID! }"),
+                &HashMap::new(),
+                &HashMap::new(),
+                false,
+            )?;
+            Ok(svm_events(&config).remove(0).2)
+        }
+
+        /// The same slots as a block sequence under `accounts:`.
+        fn block_list(slots: &[&str]) -> String {
+            slots
+                .iter()
+                .map(|slot| format!("\n                - {slot}"))
+                .collect()
+        }
+
+        /// `?name` marks a slot optional and `_` holds a position without a
+        /// name. YAML reads a leading `?` as a plain scalar in a block
+        /// sequence, but as its explicit-key indicator in a flow one — where
+        /// the slot arrives as a one-entry mapping with no value instead.
+        #[test]
+        fn reads_optional_and_unnamed_slots_in_either_yaml_style() {
+            let expected = vec![
+                "payer".to_string(),
+                "?authority".to_string(),
+                "_".to_string(),
+                "mint".to_string(),
+            ];
+
+            assert_eq!(
+                vec![
+                    account_slots(&block_list(&["payer", "?authority", "_", "mint"]))
+                        .expect("block"),
+                    account_slots(&block_list(&["payer", "\"?authority\"", "_", "mint"]))
+                        .expect("quoted"),
+                    account_slots(&block_list(&["payer", "? authority", "_", "mint"]))
+                        .expect("explicit key"),
+                    account_slots("[payer, ?authority, _, mint]").expect("flow"),
+                ],
+                vec![
+                    expected.clone(),
+                    expected.clone(),
+                    expected.clone(),
+                    expected
+                ]
+            );
+        }
+
+        #[test]
+        fn rejects_a_slot_the_grammar_has_no_reading_for() {
+            let cases = [
+                ("optional and unnamed", "[payer, ?_, mint]"),
+                ("trailing unnamed", "[payer, _]"),
+                ("duplicate name", "[payer, mint, payer]"),
+                ("no letter in the name", "[payer, _1]"),
+                ("punctuation in the name", "[payer, mint-authority]"),
+                ("a mapping carrying a value", "[payer, ?mint: yes]"),
+            ];
+
+            assert_eq!(
+                cases
+                    .iter()
+                    .map(|(case, accounts)| format!(
+                        "{case}: {:#}",
+                        account_slots(accounts).expect_err(case)
+                    ))
+                    .collect::<Vec<_>>(),
+                vec![
+                    "optional and unnamed: Program 'Pool', instruction 'swap': account slot '?_' \
+                     marks an unnamed slot optional, which nothing can observe. Write '_' to hold \
+                     the position, or name the slot.",
+                    "trailing unnamed: Program 'Pool', instruction 'swap': the account list ends \
+                     with '_', a position nothing follows. Drop it.",
+                    "duplicate name: Program 'Pool', instruction 'swap': account 'payer' is \
+                     declared more than once.",
+                    "no letter in the name: Program 'Pool', instruction 'swap': account slot '_1' \
+                     is not a name: expected letters, digits and underscores, at least one of \
+                     them a letter. Prefix a name with '?' to mark the slot optional, or write \
+                     '_' to hold a position without naming it.",
+                    "punctuation in the name: Program 'Pool', instruction 'swap': account slot \
+                     'mint-authority' is not a name: expected letters, digits and underscores, at \
+                     least one of them a letter. Prefix a name with '?' to mark the slot \
+                     optional, or write '_' to hold a position without naming it.",
+                    "a mapping carrying a value: Failed to deserialize config. Visit the docs \
+                     for more information https://docs.envio.dev/docs/configuration-file: \
+                     chains[0].experimental.programs[0].instructions[0].accounts[1]: expected an \
+                     account name, got a mapping. To mark 'mint' optional, write \"?mint\". at \
+                     line 16 column 33",
+                ]
             );
         }
 

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -44,9 +44,7 @@ use hypersync_client_solana::decode::{
     EnumVariant as SvmEnumVariant, FieldType as SvmFieldType, NamedField as SvmNamedField,
 };
 
-use super::svm_catalog::{
-    instruction_catalog, warn_about_unindexable, ResolvedInstruction, SvmAccountSlot,
-};
+use super::svm_catalog::{instruction_catalog, warn_about_unindexable, ResolvedInstruction};
 use super::svm_idl::{self, ProgramIdl};
 
 type ContractNameKey = String;
@@ -2170,7 +2168,7 @@ pub struct SvmEventKind {
     pub discriminator: Option<String>,
     /// Positional account slots in declared order. Empty when the user supplied
     /// no schema and no IDL applies; in that case `decoded.accounts` is `{}`.
-    pub accounts: Vec<SvmAccountSlot>,
+    pub accounts: Vec<human_config::svm::AccountSlot>,
     /// Borsh argument layout in declared order. Empty for unknown
     /// instructions; the raw `instruction.data` is still available.
     pub args: Vec<SvmNamedField>,
@@ -3973,21 +3971,28 @@ type Foo {
                     ))
                     .collect::<Vec<_>>(),
                 vec![
-                    "optional and unnamed: Program 'Pool', instruction 'swap': account slot '?_' \
-                     marks an unnamed slot optional, which nothing can observe. Write '_' to hold \
-                     the position, or name the slot.",
+                    "optional and unnamed: Failed to deserialize config. Visit the docs for more \
+                     information https://docs.envio.dev/docs/configuration-file: \
+                     chains[0].experimental.programs[0].instructions[0].accounts[1]: account slot \
+                     '?_' marks an unnamed slot optional, which nothing can observe. Write '_' to \
+                     hold the position, or name the slot. at line 16 column 33",
                     "trailing unnamed: Program 'Pool', instruction 'swap': the account list ends \
                      with '_', a position nothing follows. Drop it.",
                     "duplicate name: Program 'Pool', instruction 'swap': account 'payer' is \
                      declared more than once.",
-                    "no letter in the name: Program 'Pool', instruction 'swap': account slot '_1' \
-                     is not a name: expected letters, digits and underscores, at least one of \
-                     them a letter. Prefix a name with '?' to mark the slot optional, or write \
-                     '_' to hold a position without naming it.",
-                    "punctuation in the name: Program 'Pool', instruction 'swap': account slot \
+                    "no letter in the name: Failed to deserialize config. Visit the docs for more \
+                     information https://docs.envio.dev/docs/configuration-file: \
+                     chains[0].experimental.programs[0].instructions[0].accounts[1]: account slot \
+                     '_1' is not a name: expected letters, digits and underscores, at least one \
+                     of them a letter. Prefix a name with '?' to mark the slot optional, or write \
+                     '_' to hold a position without naming it. at line 16 column 33",
+                    "punctuation in the name: Failed to deserialize config. Visit the docs for \
+                     more information https://docs.envio.dev/docs/configuration-file: \
+                     chains[0].experimental.programs[0].instructions[0].accounts[1]: account slot \
                      'mint-authority' is not a name: expected letters, digits and underscores, at \
                      least one of them a letter. Prefix a name with '?' to mark the slot \
-                     optional, or write '_' to hold a position without naming it.",
+                     optional, or write '_' to hold a position without naming it. at line 16 \
+                     column 33",
                     "a mapping carrying a value: Failed to deserialize config. Visit the docs \
                      for more information https://docs.envio.dev/docs/configuration-file: \
                      chains[0].experimental.programs[0].instructions[0].accounts[1]: expected an \

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -2308,25 +2308,23 @@ type testIndexer = {{
                                 .join("; ");
                             format!("{{ {fields} }}")
                         };
-                        // An optional slot is absent from the payload when the
-                        // call leaves it out, so it is optional on the type too.
-                        // Unnamed slots hold a position and surface nothing.
-                        let named = svm_kind
-                            .accounts
-                            .iter()
-                            .filter_map(|slot| {
-                                let name = slot.name()?;
-                                let optional = if slot.is_optional() { "?" } else { "" };
-                                Some(format!(
-                                    "readonly {}{optional}: string",
-                                    ts_safe_property_name(name)
-                                ))
-                            })
-                            .collect::<Vec<_>>();
-                        let accounts_ts = if named.is_empty() {
+                        let accounts_ts = if svm_kind.accounts.is_empty() {
                             "Readonly<Record<string, string>>".to_string()
                         } else {
-                            format!("{{ {} }}", named.join("; "))
+                            let fields = svm_kind
+                                .accounts
+                                .iter()
+                                .filter_map(|slot| {
+                                    let name = slot.name()?;
+                                    let optional = if slot.is_optional() { "?" } else { "" };
+                                    Some(format!(
+                                        "readonly {}{optional}: string",
+                                        ts_safe_property_name(name)
+                                    ))
+                                })
+                                .collect::<Vec<_>>()
+                                .join("; ");
+                            format!("{{ {fields} }}")
                         };
                         instruction_entries.push(format!(
                             "          \"{instr}\": {{ readonly args: {args}; readonly accounts: \

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -2308,18 +2308,25 @@ type testIndexer = {{
                                 .join("; ");
                             format!("{{ {fields} }}")
                         };
-                        let accounts_ts = if svm_kind.accounts.is_empty() {
+                        // An optional slot is absent from the payload when the
+                        // call leaves it out, so it is optional on the type too.
+                        // Unnamed slots hold a position and surface nothing.
+                        let named = svm_kind
+                            .accounts
+                            .iter()
+                            .filter_map(|slot| {
+                                let name = slot.name()?;
+                                let optional = if slot.is_optional() { "?" } else { "" };
+                                Some(format!(
+                                    "readonly {}{optional}: string",
+                                    ts_safe_property_name(name)
+                                ))
+                            })
+                            .collect::<Vec<_>>();
+                        let accounts_ts = if named.is_empty() {
                             "Readonly<Record<string, string>>".to_string()
                         } else {
-                            let fields = svm_kind
-                                .accounts
-                                .iter()
-                                .map(|name| {
-                                    format!("readonly {}: string", ts_safe_property_name(name))
-                                })
-                                .collect::<Vec<_>>()
-                                .join("; ");
-                            format!("{{ {fields} }}")
+                            format!("{{ {} }}", named.join("; "))
                         };
                         instruction_entries.push(format!(
                             "          \"{instr}\": {{ readonly args: {args}; readonly accounts: \

--- a/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_generated_for_svm.snap
+++ b/packages/cli/src/hbs_templating/snapshots/envio__hbs_templating__codegen_templates__test__internal_config_json_code_generated_for_svm.snap
@@ -34,13 +34,27 @@ expression: json
             "svm": {
               "discriminator": "0x21",
               "accounts": [
-                "metadata",
-                "mint",
-                "mint_authority",
-                "payer",
-                "update_authority",
-                "system_program",
-                "rent"
+                {
+                  "name": "metadata"
+                },
+                {
+                  "name": "mint"
+                },
+                {
+                  "name": "mint_authority"
+                },
+                {
+                  "name": "payer"
+                },
+                {
+                  "name": "update_authority"
+                },
+                {
+                  "name": "system_program"
+                },
+                {
+                  "name": "rent"
+                }
               ]
             }
           },
@@ -51,8 +65,12 @@ expression: json
             "svm": {
               "discriminator": "0x0f",
               "accounts": [
-                "metadata",
-                "update_authority"
+                {
+                  "name": "metadata"
+                },
+                {
+                  "name": "update_authority"
+                }
               ]
             }
           }

--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -292,7 +292,7 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
     )
     let eventConfig = {
       ...eventConfig,
-      accounts: ["metadata", "mint"],
+      accounts: [Required("metadata"), Required("mint")],
       args: %raw(`[{"name": "amount", "type": "u64"}]`),
       fieldSelection: Internal.makeFieldSelection(
         ~blockFields=eventConfig.fieldSelection.blockFields,

--- a/packages/envio-tests/test/SvmOptionalAccountsSimulate_test.res
+++ b/packages/envio-tests/test/SvmOptionalAccountsSimulate_test.res
@@ -1,0 +1,121 @@
+let programId = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"
+let payerPk = "So11111111111111111111111111111111111111112"
+let authorityPk = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+let mintPk = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+
+let _ = InternalTestIndexer.fromUserApi(
+  ~schema=`
+type Swap {
+  id: ID!
+  payer: String!
+  authority: String!
+  mint: String!
+}
+`,
+  ~configYaml=`
+name: svm-optional-accounts-simulate
+ecosystem: svm
+chains:
+  - id: solana
+    start_block: 0
+    experimental:
+      hypersync_config:
+        url: https://solana.hypersync.xyz
+      programs:
+        - name: Swapper
+          program_id: ${programId}
+          instructions:
+            - name: swap
+              discriminator: "0x09"
+              args: []
+              accounts:
+                - payer
+                - ?authority
+                - _
+                - mint
+`,
+  ~handlers=`
+import { indexer } from "envio";
+
+indexer.onInstruction(
+  {
+    program: "Swapper",
+    instruction: "swap",
+    fields: { instruction: ["accounts"] },
+  },
+  async ({ instruction, context }) => {
+    context.Swap.set({
+      id: instruction.block.slot.toString(),
+      payer: instruction.accounts.payer.address,
+      authority: instruction.accounts.authority?.address ?? "absent",
+      mint: instruction.accounts.mint.address,
+    });
+  },
+);
+`,
+  ~test=`
+import { describe, it } from "vitest";
+import { createTestIndexer } from "envio";
+
+describe("SVM optional accounts through simulate", () => {
+  it("leaves an omitted optional account off the payload", async (t) => {
+    const indexer = createTestIndexer();
+    await indexer.process({
+      chains: {
+        7565164: {
+          simulate: [
+            {
+              program: "Swapper",
+              instruction: "swap",
+              slot: 1,
+              accounts: {
+                payer: { address: "${payerPk}" },
+                mint: { address: "${mintPk}" },
+              },
+            },
+            {
+              program: "Swapper",
+              instruction: "swap",
+              slot: 2,
+              accounts: {
+                payer: { address: "${payerPk}" },
+                authority: { address: "${authorityPk}" },
+                mint: { address: "${mintPk}" },
+              },
+            },
+          ],
+        },
+      },
+    });
+    t.expect([await indexer.Swap.getOrThrow("1"), await indexer.Swap.getOrThrow("2")]).toEqual([
+      { id: "1", payer: "${payerPk}", authority: "absent", mint: "${mintPk}" },
+      { id: "2", payer: "${payerPk}", authority: "${authorityPk}", mint: "${mintPk}" },
+    ]);
+  });
+
+  it("refuses a simulated item that leaves out a required account", async (t) => {
+    const indexer = createTestIndexer();
+    await t
+      .expect(
+        indexer.process({
+          chains: {
+            7565164: {
+              simulate: [
+                {
+                  program: "Swapper",
+                  instruction: "swap",
+                  slot: 1,
+                  accounts: { mint: { address: "${mintPk}" } },
+                },
+              ],
+            },
+          },
+        }),
+      )
+      .rejects.toThrow(
+        'simulate: instruction "swap" on program "Swapper" declares the account "payer", and the simulated item leaves it out. Add it to "accounts", or mark the slot optional with "?payer" in config.yaml.',
+      );
+  });
+});
+`,
+)

--- a/packages/envio-tests/test/SvmOptionalAccountsSimulate_test.res
+++ b/packages/envio-tests/test/SvmOptionalAccountsSimulate_test.res
@@ -1,6 +1,7 @@
 let programId = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"
 let payerPk = "So11111111111111111111111111111111111111112"
 let authorityPk = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+let skippedPk = "Sysvar1nstructions1111111111111111111111111"
 let mintPk = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
 
 let _ = InternalTestIndexer.fromUserApi(
@@ -82,6 +83,37 @@ describe("SVM optional accounts through simulate", () => {
                 authority: { address: "${authorityPk}" },
                 mint: { address: "${mintPk}" },
               },
+            },
+          ],
+        },
+      },
+    });
+    t.expect([await indexer.Swap.getOrThrow("1"), await indexer.Swap.getOrThrow("2")]).toEqual([
+      { id: "1", payer: "${payerPk}", authority: "absent", mint: "${mintPk}" },
+      { id: "2", payer: "${payerPk}", authority: "${authorityPk}", mint: "${mintPk}" },
+    ]);
+  });
+
+  // Positional accounts are what a call actually carries, so an item written
+  // that way has to spell an absent optional the way chain does: the id of the
+  // program being invoked, sitting in the slot.
+  it("reads the program id in an optional slot of a positional item as absent", async (t) => {
+    const indexer = createTestIndexer();
+    await indexer.process({
+      chains: {
+        7565164: {
+          simulate: [
+            {
+              program: "Swapper",
+              instruction: "swap",
+              slot: 1,
+              accountArguments: ["${payerPk}", "${programId}", "${skippedPk}", "${mintPk}"],
+            },
+            {
+              program: "Swapper",
+              instruction: "swap",
+              slot: 2,
+              accountArguments: ["${payerPk}", "${authorityPk}", "${skippedPk}", "${mintPk}"],
             },
           ],
         },

--- a/packages/envio-tests/test/SvmOptionalAccountsSimulate_test.res
+++ b/packages/envio-tests/test/SvmOptionalAccountsSimulate_test.res
@@ -125,28 +125,30 @@ describe("SVM optional accounts through simulate", () => {
     ]);
   });
 
-  it("refuses a simulated item that leaves out a required account", async (t) => {
+  // An item names the accounts it has something to say about, not every slot
+  // the layout declares.
+  it("stands the program id in for a slot the item does not name", async (t) => {
     const indexer = createTestIndexer();
-    await t
-      .expect(
-        indexer.process({
-          chains: {
-            7565164: {
-              simulate: [
-                {
-                  program: "Swapper",
-                  instruction: "swap",
-                  slot: 1,
-                  accounts: { mint: { address: "${mintPk}" } },
-                },
-              ],
+    await indexer.process({
+      chains: {
+        7565164: {
+          simulate: [
+            {
+              program: "Swapper",
+              instruction: "swap",
+              slot: 1,
+              accounts: { mint: { address: "${mintPk}" } },
             },
-          },
-        }),
-      )
-      .rejects.toThrow(
-        'simulate: instruction "swap" on program "Swapper" declares the account "payer", and the simulated item leaves it out. Add it to "accounts", or mark the slot optional with "?payer" in config.yaml.',
-      );
+          ],
+        },
+      },
+    });
+    t.expect(await indexer.Swap.getOrThrow("1")).toEqual({
+      id: "1",
+      payer: "${programId}",
+      authority: "absent",
+      mint: "${mintPk}",
+    });
   });
 });
 `,

--- a/packages/envio-tests/test/SvmOptionalAccounts_test.res
+++ b/packages/envio-tests/test/SvmOptionalAccounts_test.res
@@ -1,0 +1,170 @@
+open Vitest
+
+let programId = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"
+let payerPk = "So11111111111111111111111111111111111111112"
+let authorityPk = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+let skippedPk = "Sysvar1nstructions1111111111111111111111111"
+let mintPk = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+
+let configYaml = `
+name: svm-optional-accounts
+ecosystem: svm
+chains:
+  - id: solana
+    start_block: 0
+    experimental:
+      hypersync_config:
+        url: https://solana.hypersync.xyz
+      programs:
+        - name: Swapper
+          program_id: ${programId}
+          instructions:
+            - name: swap
+              discriminator: "0x09"
+              args: []
+              accounts:
+                - payer
+                - ?authority
+                - _
+                - mint
+`
+
+let parsed = InternalTestIndexer.fromUserApi(
+  ~schema=`
+type Swap {
+  id: ID!
+  payer: String!
+  authority: String!
+  mint: String!
+}
+`,
+  ~registerHandlers=true,
+  ~configYaml,
+  ~handlers=`
+import { indexer } from "envio";
+import type { SvmAllFieldsSelection, SvmInstruction, SvmInstructionAccount } from "envio";
+import { expectType, type TypeEqual } from "ts-expect";
+
+indexer.onInstruction(
+  {
+    program: "Swapper",
+    instruction: "swap",
+    fields: { instruction: ["accounts"] },
+  },
+  async ({ instruction, context }) => {
+    context.Swap.set({
+      id: instruction.block.slot.toString(),
+      payer: instruction.accounts.payer.address,
+      authority: instruction.accounts.authority?.address ?? "absent",
+      mint: instruction.accounts.mint.address,
+    });
+  },
+);
+
+indexer.onInstruction(
+  {
+    program: "Swapper",
+    instruction: "swap",
+    where: { accounts: { authority: "${authorityPk}", mint: "${mintPk}" } },
+  },
+  async () => {},
+);
+
+type Fields = SvmAllFieldsSelection;
+type Accounts = SvmInstruction<Fields, "Swapper", "swap">["accounts"];
+
+expectType<TypeEqual<Accounts["payer"], SvmInstructionAccount<Fields, "payer">>>(true);
+expectType<
+  TypeEqual<Accounts["authority"], SvmInstructionAccount<Fields, "authority"> | undefined>
+>(true);
+// @ts-expect-error - an unnamed slot holds a position and surfaces nothing
+type _Unnamed = Accounts["_"];
+`,
+)
+
+let chainId = "7565164"
+
+let registrations = () =>
+  parsed.registrations()
+  ->Utils.Dict.dangerouslyGetNonOption(chainId)
+  ->Option.getOrThrow
+  ->((r: HandlerRegister.chainRegistrations) => r.onEventRegistrations)
+
+let namedAccountsOf = accounts => {
+  let reg = registrations()->Array.getUnsafe(0)
+  let eventConfig =
+    reg.eventConfig->(Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig)
+  let instruction = SvmHyperSyncSource.toSvmInstruction(
+    {
+      onEventRegistrationIndex: 0,
+      slot: 10,
+      transactionIndex: 1,
+      path: [0],
+      programId,
+      accounts,
+      data: Uint8Array.fromArray([0x09]),
+      isInner: false,
+      args: %raw(`{}`),
+      logs: Null.null,
+    },
+    ~programName="Swapper",
+    ~instructionName="swap",
+    ~eventConfig,
+    ~fieldSelection=reg.fieldSelection,
+  )
+  instruction.accounts
+  ->Option.getOrThrow
+  ->Dict.toArray
+  ->Array.map(((name, account)) => (
+    name,
+    account.address->SvmTypes.Pubkey.toString,
+    account.instructionAccountIndex,
+  ))
+}
+
+describe("SVM optional and unnamed account slots", () => {
+  it("names every declared slot but the unnamed one", t => {
+    t.expect(namedAccountsOf([payerPk, authorityPk, skippedPk, mintPk])).toEqual([
+      ("payer", payerPk, 0),
+      ("authority", authorityPk, 1),
+      ("mint", mintPk, 3),
+    ])
+  })
+
+  // Anchor's convention for an absent optional account: the slot carries the
+  // id of the program being invoked.
+  it("reads the program id in an optional slot as an absent account", t => {
+    t.expect(namedAccountsOf([payerPk, programId, skippedPk, mintPk])).toEqual([
+      ("payer", payerPk, 0),
+      ("mint", mintPk, 3),
+    ])
+  })
+
+  it("keeps the program id in a required slot", t => {
+    t.expect(namedAccountsOf([programId, authorityPk, skippedPk, mintPk])).toEqual([
+      ("payer", programId, 0),
+      ("authority", authorityPk, 1),
+      ("mint", mintPk, 3),
+    ])
+  })
+
+  it("drops the slots a short account list never reaches", t => {
+    t.expect(namedAccountsOf([payerPk, authorityPk])).toEqual([
+      ("payer", payerPk, 0),
+      ("authority", authorityPk, 1),
+    ])
+  })
+
+  it("resolves a filter on an optional account to its declared position", t => {
+    let reg =
+      registrations()
+      ->Array.getUnsafe(1)
+      ->(Utils.magic: Internal.onEventRegistration => Internal.svmOnEventRegistration)
+    t.expect(
+      reg.accountFilters->Array.map(
+        group =>
+          group->Array.map(filter => (filter.position, filter.values->SvmTypes.Pubkey.toStrings)),
+      ),
+    ).toEqual([[(1, [authorityPk]), (3, [mintPk])]])
+  })
+})

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -2058,10 +2058,21 @@ chains:
 ${instructions}
 `
 
+  // Account slots read back as the YAML tokens that declare them, so an
+  // expectation shows optionality and unnamed positions.
+  let slotTokens = (slots: array<Internal.svmAccountSlot>) =>
+    slots->Array.map(slot =>
+      switch slot {
+      | Unnamed => "_"
+      | Required(name) => name
+      | Optional(name) => "?" ++ name
+      }
+    )
+
   let catalog = (config: Config.t) =>
     firstContract(config).events->Array.map(event => {
       let svm = event->(Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig)
-      (svm.name, svm.discriminator, svm.accounts, svm.args)
+      (svm.name, svm.discriminator, svm.accounts->slotTokens, svm.args)
     })
 
   it("rejects a name-only YAML row next to idl", t => {

--- a/packages/envio/index.d.ts
+++ b/packages/envio/index.d.ts
@@ -1377,7 +1377,7 @@ type SvmNamedAccounts<
   Acc extends Readonly<Record<string, unknown>>,
   Fields extends SvmFieldsSelection,
 > = {
-  readonly [K in keyof Acc & string]: SvmInstructionAccount<Fields, K>;
+  readonly [K in keyof Acc]: SvmInstructionAccount<Fields, K & string>;
 };
 
 /** The parent transaction of a {@link SvmInstruction}, narrowed to the

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -174,10 +174,19 @@ let publicConfigChainSchema = S.schema(s =>
   }
 )
 
+// One positional account slot. No `name` is a slot that holds a position
+// without surfacing anything; see `Internal.svmAccountSlot`.
+let svmAccountSlotSchema = S.schema(s =>
+  {
+    "name": s.matches(S.option(S.string)),
+    "optional": s.matches(S.option(S.bool)),
+  }
+)
+
 let svmEventDescriptorSchema = S.schema(s =>
   {
     "discriminator": s.matches(S.option(S.string)),
-    "accounts": s.matches(S.option(S.array(S.string))),
+    "accounts": s.matches(S.option(S.array(svmAccountSlotSchema))),
     "args": s.matches(S.option(S.json(~validate=false))),
   }
 )
@@ -736,7 +745,7 @@ let fromPublic = (publicConfigJson: JSON.t) => {
               Utils.magic: _ => {
                 "svm": option<{
                   "discriminator": option<string>,
-                  "accounts": option<array<string>>,
+                  "accounts": option<array<{"name": option<string>, "optional": option<bool>}>>,
                   "args": option<JSON.t>,
                 }>,
               }
@@ -753,7 +762,15 @@ let fromPublic = (publicConfigJson: JSON.t) => {
             ~instructionName=eventName,
             ~programId,
             ~discriminator=svm["discriminator"],
-            ~accounts=svm["accounts"]->Option.getOr([]),
+            ~accounts=svm["accounts"]
+            ->Option.getOr([])
+            ->Array.map(slot =>
+              switch (slot["name"], slot["optional"]) {
+              | (None, _) => Internal.Unnamed
+              | (Some(name), Some(true)) => Optional(name)
+              | (Some(name), _) => Required(name)
+              }
+            ),
             ~args=svm["args"]->Option.getOr(JSON.Null),
             ~definedTypes=svmDefinedTypes,
           ) :> Internal.eventConfig)

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -174,14 +174,21 @@ let publicConfigChainSchema = S.schema(s =>
   }
 )
 
-// One positional account slot. No `name` is a slot that holds a position
-// without surfacing anything; see `Internal.svmAccountSlot`.
-let svmAccountSlotSchema = S.schema(s =>
+type svmAccountSlotItem = {"name": option<string>, "optional": option<bool>}
+
+let svmAccountSlotSchema: S.t<svmAccountSlotItem> = S.schema(s =>
   {
     "name": s.matches(S.option(S.string)),
     "optional": s.matches(S.option(S.bool)),
   }
 )
+
+let svmAccountSlotFromItem = (slot: svmAccountSlotItem): Internal.svmAccountSlot =>
+  switch (slot["name"], slot["optional"]) {
+  | (None, _) => Unnamed
+  | (Some(name), Some(true)) => Optional(name)
+  | (Some(name), _) => Required(name)
+  }
 
 let svmEventDescriptorSchema = S.schema(s =>
   {
@@ -745,7 +752,7 @@ let fromPublic = (publicConfigJson: JSON.t) => {
               Utils.magic: _ => {
                 "svm": option<{
                   "discriminator": option<string>,
-                  "accounts": option<array<{"name": option<string>, "optional": option<bool>}>>,
+                  "accounts": option<array<svmAccountSlotItem>>,
                   "args": option<JSON.t>,
                 }>,
               }
@@ -762,15 +769,7 @@ let fromPublic = (publicConfigJson: JSON.t) => {
             ~instructionName=eventName,
             ~programId,
             ~discriminator=svm["discriminator"],
-            ~accounts=svm["accounts"]
-            ->Option.getOr([])
-            ->Array.map(slot =>
-              switch (slot["name"], slot["optional"]) {
-              | (None, _) => Internal.Unnamed
-              | (Some(name), Some(true)) => Optional(name)
-              | (Some(name), _) => Required(name)
-              }
-            ),
+            ~accounts=svm["accounts"]->Option.getOr([])->Array.map(svmAccountSlotFromItem),
             ~args=svm["args"]->Option.getOr(JSON.Null),
             ~definedTypes=svmDefinedTypes,
           ) :> Internal.eventConfig)

--- a/packages/envio/src/Config.res
+++ b/packages/envio/src/Config.res
@@ -175,7 +175,7 @@ let publicConfigChainSchema = S.schema(s =>
 )
 
 // One positional account slot. No `name` is a slot that holds a position
-// without surfacing anything; see `Internal.svmAccountSlot`.
+// without surfacing anything.
 let svmAccountSlotSchema = S.schema(s =>
   {
     "name": s.matches(S.option(S.string)),

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -635,7 +635,7 @@ let buildSvmInstructionEventConfig = (
   ~instructionName: string,
   ~programId: SvmTypes.Pubkey.t,
   ~discriminator: option<string>,
-  ~accounts: array<string>=[],
+  ~accounts: array<Internal.svmAccountSlot>=[],
   ~args: JSON.t=JSON.Null,
   ~definedTypes: JSON.t=JSON.Null,
 ): Internal.svmInstructionEventConfig => {
@@ -699,7 +699,7 @@ let resolveSvmWhereOrThrow = (
   where: JSON.t,
   ~contractName: string,
   ~eventName: string,
-  ~accountNames: array<string>,
+  ~accounts: array<Internal.svmAccountSlot>,
 ): parsedSvmWhere => {
   let invalid = message =>
     JsError.throwWithMessage(
@@ -722,26 +722,30 @@ let resolveSvmWhereOrThrow = (
   | Some(_) => invalid(`The "isInner" filter must be a boolean.`)
   }
 
+  let namedAccounts = accounts->Array.filterMap(Internal.svmAccountSlotName)
+
   let parseGroup = (group: dict<JSON.t>): Internal.svmAccountFilterGroup =>
     group
     ->Dict.toArray
     ->Array.map(((name, value)) => {
-      let position = switch accountNames->Array.indexOf(name) {
-      | -1 if accountNames->Utils.Array.isEmpty =>
+      let position = switch accounts->Array.findIndexOpt(slot =>
+        slot->Internal.svmAccountSlotName == Some(name)
+      ) {
+      | None if namedAccounts->Utils.Array.isEmpty =>
         invalid(
           "The instruction has no named accounts to filter on. Add `accounts` and `args` to it in config.yaml, or attach an IDL.",
         )
-      | -1 =>
+      | None =>
         invalid(
           `The instruction has no account named "${name}" to filter on. Named accounts: ${Utils.Array.quotedJoin(
-              accountNames,
+              namedAccounts,
             )}.`,
         )
-      | position if position >= filterableAccountCount =>
+      | Some(position) if position >= filterableAccountCount =>
         invalid(
           `Account "${name}" is at position ${position->Int.toString}, and only the first ${filterableAccountCount->Int.toString} accounts of an instruction can be filtered.`,
         )
-      | position => position
+      | Some(position) => position
       }
       let values = value->normalizeOrThrow
       if values->Utils.Array.isEmpty {
@@ -817,7 +821,7 @@ let buildSvmOnEventRegistration = (
     where->resolveSvmWhereOrThrow(
       ~contractName=eventConfig.contractName,
       ~eventName=eventConfig.name,
-      ~accountNames=eventConfig.accounts,
+      ~accounts=eventConfig.accounts,
     )
   }
 

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -567,15 +567,29 @@ type svmAccountFilter = {
 /** AND-group: every entry must match the same instruction. */
 type svmAccountFilterGroup = array<svmAccountFilter>
 
+/** One positional account slot of an instruction. An `Optional` slot is absent
+ from the payload when the call carries no such slot, or fills it with the id of
+ the program being invoked. `Unnamed` holds a position and surfaces nothing. */
+type svmAccountSlot =
+  | Unnamed
+  | Required(string)
+  | Optional(string)
+
+let svmAccountSlotName = slot =>
+  switch slot {
+  | Unnamed => None
+  | Required(name) | Optional(name) => Some(name)
+  }
+
 type svmInstructionEventConfig = {
   ...eventConfig,
   /** Base58 Solana program id this instruction belongs to. */
   programId: SvmTypes.Pubkey.t,
   /** Hex-encoded discriminator. `None` matches every instruction in the program. */
   discriminator: option<string>,
-  /** Positional account names from the Borsh schema, in declared order.
-   `[]` means no schema is attached for this instruction. */
-  accounts: array<string>,
+  /** Positional account slots in declared order. `[]` means no schema is
+   attached for this instruction. */
+  accounts: array<svmAccountSlot>,
   /** Borsh args layout as `Vec<ArgDef>` JSON (see `human_config::svm::ArgDef`
    on the Rust side). `JSON.Null` means no schema is attached. */
   args: JSON.t,

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -358,12 +358,8 @@ let parse = (
       let path = item.path->Option.getOr([0])
       let programId =
         item.programId->Option.getOr(svmEventConfig.programId->SvmTypes.Pubkey.toString)
-      // Named accounts are placed back onto their declared positions, since
-      // that is what the runtime reads. A slot the item says nothing about
-      // carries the program id, the stand-in chain itself uses for an account
-      // a call leaves out — so an optional slot reads back as absent, and a
-      // required one as the program, rather than an item having to name every
-      // account to say something about one.
+      // A slot the item does not name carries the program id, so an optional
+      // slot reads back as absent without the item naming every account.
       let accountArguments = switch item.accountArguments {
       | Some(args) => args
       | None =>

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -359,26 +359,20 @@ let parse = (
       let programId =
         item.programId->Option.getOr(svmEventConfig.programId->SvmTypes.Pubkey.toString)
       // Named accounts are placed back onto their declared positions, since
-      // that is what the runtime reads. A slot with nothing to place carries
-      // the program id — how an absent account reaches an indexer from chain.
+      // that is what the runtime reads. A slot the item says nothing about
+      // carries the program id, the stand-in chain itself uses for an account
+      // a call leaves out — so an optional slot reads back as absent, and a
+      // required one as the program, rather than an item having to name every
+      // account to say something about one.
       let accountArguments = switch item.accountArguments {
       | Some(args) => args
       | None =>
         switch item.accounts {
         | Some(named) =>
           svmEventConfig.accounts->Array.map(slot =>
-            switch slot {
-            | Unnamed => programId
-            | Optional(name) =>
-              named->Dict.get(name)->Option.mapOr(programId, ({address}) => address)
-            | Required(name) =>
-              switch named->Dict.get(name) {
-              | Some({address}) => address
-              | None =>
-                JsError.throwWithMessage(
-                  `simulate: instruction "${instructionName}" on program "${programName}" declares the account "${name}", and the simulated item leaves it out. Add it to "accounts", or mark the slot optional with "?${name}" in config.yaml.`,
-                )
-              }
+            switch slot->Internal.svmAccountSlotName {
+            | None => programId
+            | Some(name) => named->Dict.get(name)->Option.mapOr(programId, ({address}) => address)
             }
           )
         | None => []

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -358,12 +358,13 @@ let parse = (
       let path = item.path->Option.getOr([0])
       let programId =
         item.programId->Option.getOr(svmEventConfig.programId->SvmTypes.Pubkey.toString)
-      // Named accounts are placed back onto their declared positions, since
-      // that is what the runtime reads. A slot the item says nothing about
-      // carries the program id, the stand-in chain itself uses for an account
-      // a call leaves out — so an optional slot reads back as absent, and a
-      // required one as the program, rather than an item having to name every
-      // account to say something about one.
+      // `accountArguments` is the list the call carries, so it stands as
+      // written: a short one leaves the later slots absent, the way a
+      // truncated instruction reads from chain. Named accounts speak about
+      // some slots instead, so they go back onto their declared positions and
+      // a slot the item leaves out carries the program id — chain's own
+      // stand-in for an absent account, which reads back as absent for an
+      // optional slot and as the program for a required one.
       let accountArguments = switch item.accountArguments {
       | Some(args) => args
       | None =>

--- a/packages/envio/src/SimulateItems.res
+++ b/packages/envio/src/SimulateItems.res
@@ -358,15 +358,27 @@ let parse = (
       let path = item.path->Option.getOr([0])
       let programId =
         item.programId->Option.getOr(svmEventConfig.programId->SvmTypes.Pubkey.toString)
+      // Named accounts are placed back onto their declared positions, since
+      // that is what the runtime reads. A slot with nothing to place carries
+      // the program id — how an absent account reaches an indexer from chain.
       let accountArguments = switch item.accountArguments {
       | Some(args) => args
       | None =>
         switch item.accounts {
         | Some(named) =>
-          svmEventConfig.accounts->Array.map(name =>
-            switch named->Dict.get(name) {
-            | Some({address}) => address
-            | None => ""
+          svmEventConfig.accounts->Array.map(slot =>
+            switch slot {
+            | Unnamed => programId
+            | Optional(name) =>
+              named->Dict.get(name)->Option.mapOr(programId, ({address}) => address)
+            | Required(name) =>
+              switch named->Dict.get(name) {
+              | Some({address}) => address
+              | None =>
+                JsError.throwWithMessage(
+                  `simulate: instruction "${instructionName}" on program "${programName}" declares the account "${name}", and the simulated item leaves it out. Add it to "accounts", or mark the slot optional with "?${name}" in config.yaml.`,
+                )
+              }
             }
           )
         | None => []

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -10,13 +10,21 @@ type options = {
   addressStore: AddressStore.t,
 }
 
-let namedAccounts = (~idlNames: array<string>, ~accountArguments: array<string>): dict<
-  Envio.svmInstructionAccount,
-> => {
+// Nothing on chain marks an account absent: a call either carries fewer
+// accounts than the layout declares, or fills the slot with the id of the
+// program it invokes — the convention Anchor and Codama both use. So an
+// optional slot holding that id is read as absent, and a required one is not.
+let namedAccounts = (
+  ~slots: array<Internal.svmAccountSlot>,
+  ~accountArguments: array<string>,
+  ~programId: string,
+): dict<Envio.svmInstructionAccount> => {
   let out = Dict.make()
-  idlNames->Array.forEachWithIndex((name, i) =>
-    switch accountArguments->Array.get(i) {
-    | Some(address) =>
+  slots->Array.forEachWithIndex((slot, i) =>
+    switch (slot, accountArguments->Array.get(i)) {
+    | (Unnamed, _) | (_, None) => ()
+    | (Optional(_), Some(address)) if address === programId => ()
+    | (Required(name), Some(address)) | (Optional(name), Some(address)) =>
       out->Dict.set(
         name,
         {
@@ -25,7 +33,6 @@ let namedAccounts = (~idlNames: array<string>, ~accountArguments: array<string>)
           instructionAccountIndex: i,
         },
       )
-    | None => ()
     }
   )
   out
@@ -94,7 +101,11 @@ let toSvmInstruction = (
   if hasSelection("accounts") {
     out->setField(
       "accounts",
-      namedAccounts(~idlNames=eventConfig.accounts, ~accountArguments=item.accounts),
+      namedAccounts(
+        ~slots=eventConfig.accounts,
+        ~accountArguments=item.accounts,
+        ~programId=item.programId,
+      ),
     )
   }
   if hasSelection("accountArguments") {

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -10,10 +10,6 @@ type options = {
   addressStore: AddressStore.t,
 }
 
-// Nothing on chain marks an account absent: a call either carries fewer
-// accounts than the layout declares, or fills the slot with the id of the
-// program it invokes — the convention Anchor and Codama both use. So an
-// optional slot holding that id is read as absent, and a required one is not.
 let namedAccounts = (
   ~slots: array<Internal.svmAccountSlot>,
   ~accountArguments: array<string>,

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -387,13 +387,13 @@
           ]
         },
         "accounts": {
-          "description": "Optional positional account names. The Nth entry names account slot N on the dispatched instruction; surfaces as `instruction.accounts.<name>` when `fields.instruction` includes `accounts`.",
+          "description": "Optional positional account slots, in the order the program expects them. The Nth entry names account slot N on the dispatched instruction; named slots surface as `instruction.accounts.<name>` when `fields.instruction` includes `accounts`.",
           "type": [
             "array",
             "null"
           ],
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/SvmAccountSlot"
           }
         },
         "args": {
@@ -410,6 +410,17 @@
       "additionalProperties": false,
       "required": [
         "name"
+      ]
+    },
+    "SvmAccountSlot": {
+      "title": "Account slot",
+      "description": "One positional account slot of the instruction.\n- `payer` names a slot the call always carries; it surfaces as `instruction.accounts.payer`.\n- `?authority` names an optional slot: the key is absent from `instruction.accounts` when the call leaves the slot out or fills it with the program id.\n- `_` holds a position without naming it, so the slots after it keep theirs. It is never surfaced and never filterable, and the list may not end with one.",
+      "type": "string",
+      "pattern": "^(?:_|\\??[A-Za-z0-9_]*[A-Za-z][A-Za-z0-9_]*)$",
+      "examples": [
+        "payer",
+        "?authority",
+        "_"
       ]
     },
     "ArgDef": {


### PR DESCRIPTION
## Summary

Adds support for optional and unnamed account slots in SVM instruction configurations, allowing indexers to handle Solana programs that use optional accounts (following Anchor/Codama conventions) and positional placeholders.

## Changes

- **Account slot grammar**: Introduces three slot types in YAML config:
  - `payer` — required account, surfaces as `instruction.accounts.payer`
  - `?authority` — optional account, absent from payload when call omits it or fills with program id
  - `_` — unnamed position, holds a slot without surfacing anything

- **Config parsing** (`human_config.rs`, `svm_catalog.rs`):
  - New `AccountSlot` type in human config that preserves YAML tokens verbatim
  - `SvmAccountSlot` enum in catalog with `Unnamed`, `Required(name)`, `Optional(name)` variants
  - Parser validates slot grammar: rejects `?_`, trailing `_`, duplicate names, invalid identifiers
  - Handles both block-style (`- payer`) and flow-style (`[payer]`) YAML, including explicit-key syntax (`? authority`)

- **Runtime** (`SvmHyperSyncSource.res`, `SimulateItems.res`, `EventConfigBuilder.res`):
  - Account resolution respects optionality: skips optional slots filled with program id
  - Unnamed slots hold positions without surfacing to handlers
  - Filter resolution maps optional account names to their declared positions
  - Simulate mode accepts both named and positional account formats, with validation that required accounts are present

- **Type generation** (`codegen_templates.rs`, `index.d.ts`):
  - Optional accounts become optional properties in TypeScript types
  - Unnamed slots don't appear in the accounts object

- **Tests**: Two new test files verify the feature end-to-end:
  - `SvmOptionalAccounts_test.res` — unit tests for parsing, resolution, and filtering
  - `SvmOptionalAccountsSimulate_test.res` — integration tests for simulate mode with both named and positional formats

## Implementation Details

- Account slots are stored as their YAML tokens (`"payer"`, `"?authority"`, `"_"`) in human config, then parsed into the canonical `SvmAccountSlot` enum during catalog resolution. This keeps the config surface stable and reports errors against the instruction that declares them.
- Optional slot detection follows Anchor/Codama convention: a slot is considered absent when the call carries fewer accounts than declared, or when it fills the slot with the program id.
- Unnamed slots are validated to never be optional (nothing can observe them) and never trail the list (nothing follows to keep positions).

https://claude.ai/code/session_012ca3kizxGMY29naWpwv7E2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SVM instruction configurations now support named, required, optional, and unnamed positional account slots.
  - YAML and JSON configurations provide structured account metadata with validation and clearer schemas.
  - Generated types preserve named accounts and mark optional accounts appropriately.
  - Event filters and account resolution understand positional and optional account layouts.
  - Omitted optional accounts are represented as absent, while unspecified slots fall back to the program ID.
  - SVM HyperSync connections now validate API tokens before connecting.

- **Bug Fixes**
  - Account handling now consistently preserves optional and unnamed slot semantics across configuration, simulation, and event processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->