### PR TITLE
Add height subscription support to SVM HyperSync source

### DIFF
--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -116,7 +116,11 @@ let mockClient = makeMockClient()
 // The source captures its client at construction, so the mock addon only
 // needs to be in place for the `make` call; restore the previous addon right
 // after to avoid leaking the mock into other tests.
-let makeSource = (~onEventRegistrations=[makeReg()], ~client=mockClient) => {
+let makeSource = (
+  ~onEventRegistrations=[makeReg()],
+  ~client=mockClient,
+  ~endpointUrl="https://solana.hypersync.xyz",
+) => {
   let prevAddon = Core.addonRef.contents
   Core.addonRef :=
     Some(
@@ -136,7 +140,7 @@ let makeSource = (~onEventRegistrations=[makeReg()], ~client=mockClient) => {
     )
   let source = try SvmHyperSyncSource.make({
     chainId,
-    endpointUrl: "https://solana.hypersync.xyz",
+    endpointUrl,
     apiToken: None,
     onEventRegistrations,
     clientTimeoutMillis: 10_000,
@@ -331,5 +335,54 @@ describe("SvmHyperSyncSource.getItemsOrThrow (mocked client)", () => {
       "argsJson": Some(`[{"name":"amount","type":"u64"}]`),
       "definedTypesJson": None,
     })
+  })
+})
+
+describe("SvmHyperSyncSource height subscription", () => {
+  Async.it("Streams heights over HyperSync SSE the same way the EVM source does", async t => {
+    let (server, url) = await Promise.make((resolve, _reject) => {
+      let server = MockRpcServer.createServer((_req, res) => {
+        res->MockRpcServer.writeHead(
+          200,
+          Dict.fromArray([("Content-Type", "text/event-stream"), ("Cache-Control", "no-cache")]),
+        )
+        res->MockRpcServer.write("event: height\ndata: 445073332\n\n")
+        res->MockRpcServer.write("event: ping\ndata: \n\n")
+        res->MockRpcServer.write("event: height\ndata: 445073335\n\n")
+      })
+      server->MockRpcServer.listenOnHost(0, "127.0.0.1", () =>
+        resolve((
+          server,
+          `http://127.0.0.1:${(server->MockRpcServer.address).port->Int.toString}`,
+        ))
+      )
+    })
+
+    let source = makeSource(~endpointUrl=url)
+    let statuses = []
+    let heights = []
+    let unsubscribe =
+      (source.createHeightSubscription->Option.getOrThrow)(
+        ~onHeight=height => heights->Array.push(height)->ignore,
+        ~onStatus=status =>
+          statuses
+          ->Array.push(
+            switch status {
+            | Live => "live"
+            | Down({reason}) => `down:${reason->Source.downReasonLabel}`
+            },
+          )
+          ->ignore,
+      )
+
+    await Scenario.waitUntil(
+      () => heights->Array.length === 2,
+      ~message="the SVM height stream",
+    )
+    unsubscribe()
+    server->MockRpcServer.closeAllConnections
+    await Promise.make((resolve, _reject) => server->MockRpcServer.close(() => resolve()))
+
+    t.expect((statuses, heights)).toStrictEqual((["live"], [445073332, 445073335]))
   })
 })

--- a/packages/envio-tests/test/SvmHyperSyncSource_test.res
+++ b/packages/envio-tests/test/SvmHyperSyncSource_test.res
@@ -120,6 +120,7 @@ let makeSource = (
   ~onEventRegistrations=[makeReg()],
   ~client=mockClient,
   ~endpointUrl="https://solana.hypersync.xyz",
+  ~apiToken=Some("test-token"),
 ) => {
   let prevAddon = Core.addonRef.contents
   Core.addonRef :=
@@ -141,7 +142,7 @@ let makeSource = (
   let source = try SvmHyperSyncSource.make({
     chainId,
     endpointUrl,
-    apiToken: None,
+    apiToken,
     onEventRegistrations,
     clientTimeoutMillis: 10_000,
     addressStore,
@@ -384,5 +385,16 @@ describe("SvmHyperSyncSource height subscription", () => {
     await Promise.make((resolve, _reject) => server->MockRpcServer.close(() => resolve()))
 
     t.expect((statuses, heights)).toStrictEqual((["live"], [445073332, 445073335]))
+  })
+})
+
+describe("SvmHyperSyncSource api token", () => {
+  it("Throws the same actionable error as the EVM source when the token is missing", t => {
+    t->toThrowErrorEqual(
+      () => makeSource(~apiToken=None)->ignore,
+      `An Envio API token is required for using HyperSync as a data-source.
+Set the ENVIO_API_TOKEN environment variable in your .env file.
+Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`,
+    )
   })
 })

--- a/packages/envio/src/sources/EvmHyperSyncSource.res
+++ b/packages/envio/src/sources/EvmHyperSyncSource.res
@@ -37,13 +37,7 @@ let make = (
 ): t => {
   let name = "HyperSync"
 
-  let apiToken = switch apiToken {
-  | Some(token) => token
-  | None =>
-    JsError.throwWithMessage(`An Envio API token is required for using HyperSync as a data-source.
-Set the ENVIO_API_TOKEN environment variable in your .env file.
-Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
-  }
+  let apiToken = apiToken->HyperSync.requireApiToken
 
   let client = switch HyperSyncClient.make(
     ~url=endpointUrl,

--- a/packages/envio/src/sources/FuelHyperSyncSource.res
+++ b/packages/envio/src/sources/FuelHyperSyncSource.res
@@ -15,7 +15,7 @@ type options = {
 let make = ({chainId, endpointUrl, apiToken, onEventRegistrations, addressStore}: options): t => {
   let name = "HyperFuel"
 
-  let apiToken = apiToken->HyperSync.requireApiToken(~service=name)
+  let apiToken = apiToken->HyperSync.requireApiToken
 
   let client = switch FuelHyperSyncClient.make(
     {url: endpointUrl, apiToken},

--- a/packages/envio/src/sources/FuelHyperSyncSource.res
+++ b/packages/envio/src/sources/FuelHyperSyncSource.res
@@ -15,13 +15,7 @@ type options = {
 let make = ({chainId, endpointUrl, apiToken, onEventRegistrations, addressStore}: options): t => {
   let name = "HyperFuel"
 
-  let apiToken = switch apiToken {
-  | Some(token) => token
-  | None =>
-    JsError.throwWithMessage(`An Envio API token is required for using HyperFuel as a data-source.
-Set the ENVIO_API_TOKEN environment variable in your .env file.
-Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
-  }
+  let apiToken = apiToken->HyperSync.requireApiToken(~service=name)
 
   let client = switch FuelHyperSyncClient.make(
     {url: endpointUrl, apiToken},

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -9,11 +9,11 @@ let pollingInterval = 400
 let rateLimitedPrefix = "RATE_LIMITED:"
 let behindHeadPrefix = "SOURCE_BEHIND_HEAD:"
 
-let requireApiToken = (apiToken, ~service="HyperSync") =>
+let requireApiToken = apiToken =>
   switch apiToken {
   | Some(token) => token
   | None =>
-    JsError.throwWithMessage(`An Envio API token is required for using ${service} as a data-source.
+    JsError.throwWithMessage(`An Envio API token is required for using HyperSync as a data-source.
 Set the ENVIO_API_TOKEN environment variable in your .env file.
 Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
   }

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -9,6 +9,15 @@ let pollingInterval = 400
 let rateLimitedPrefix = "RATE_LIMITED:"
 let behindHeadPrefix = "SOURCE_BEHIND_HEAD:"
 
+let requireApiToken = apiToken =>
+  switch apiToken {
+  | Some(token) => token
+  | None =>
+    JsError.throwWithMessage(`An Envio API token is required for using HyperSync as a data-source.
+Set the ENVIO_API_TOKEN environment variable in your .env file.
+Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
+  }
+
 let markerValue = (msg, ~prefix) =>
   msg->String.slice(~start=prefix->String.length, ~end=msg->String.length)->Int.fromString
 

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -9,11 +9,11 @@ let pollingInterval = 400
 let rateLimitedPrefix = "RATE_LIMITED:"
 let behindHeadPrefix = "SOURCE_BEHIND_HEAD:"
 
-let requireApiToken = apiToken =>
+let requireApiToken = (apiToken, ~service="HyperSync") =>
   switch apiToken {
   | Some(token) => token
   | None =>
-    JsError.throwWithMessage(`An Envio API token is required for using HyperSync as a data-source.
+    JsError.throwWithMessage(`An Envio API token is required for using ${service} as a data-source.
 Set the ENVIO_API_TOKEN environment variable in your .env file.
 Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`)
   }

--- a/packages/envio/src/sources/HyperSync.resi
+++ b/packages/envio/src/sources/HyperSync.resi
@@ -12,8 +12,8 @@ let pollingInterval: int
 
 // Every HyperSync-backed source needs a token to reach the service, so a
 // missing one fails at construction with the message that says how to get one,
-// rather than as a 401 per request.
-let requireApiToken: option<string> => string
+// rather than as a 401 per request. `service` names the product in it.
+let requireApiToken: (option<string>, ~service: string=?) => string
 
 // Map a native client's `PREFIX:<int>` failure marker onto the exception
 // SourceManager retries on (`RateLimited` / `SourceBehindHead`), falling back to

--- a/packages/envio/src/sources/HyperSync.resi
+++ b/packages/envio/src/sources/HyperSync.resi
@@ -10,6 +10,11 @@ type logsQueryPage = {
 // one. Every ecosystem's client talks to the same service, so they wait alike.
 let pollingInterval: int
 
+// Every HyperSync-backed source needs a token to reach the service, so a
+// missing one fails at construction with the message that says how to get one,
+// rather than as a 401 per request.
+let requireApiToken: option<string> => string
+
 // Map a native client's `PREFIX:<int>` failure marker onto the exception
 // SourceManager retries on (`RateLimited` / `SourceBehindHead`), falling back to
 // the original cause.

--- a/packages/envio/src/sources/HyperSync.resi
+++ b/packages/envio/src/sources/HyperSync.resi
@@ -12,8 +12,8 @@ let pollingInterval: int
 
 // Every HyperSync-backed source needs a token to reach the service, so a
 // missing one fails at construction with the message that says how to get one,
-// rather than as a 401 per request. `service` names the product in it.
-let requireApiToken: (option<string>, ~service: string=?) => string
+// rather than as a 401 per request.
+let requireApiToken: option<string> => string
 
 // Map a native client's `PREFIX:<int>` failure marker onto the exception
 // SourceManager retries on (`RateLimited` / `SourceBehindHead`), falling back to

--- a/packages/envio/src/sources/HyperSyncSSE.res
+++ b/packages/envio/src/sources/HyperSyncSSE.res
@@ -14,19 +14,19 @@ let failure = (error: EventSource.errorEvent): (
   | (None, None) => (Closed, None)
   }
 
-let subscribe = (~hyperSyncUrl, ~apiToken, ~onHeight, ~onStatus) =>
+let subscribe = (~hyperSyncUrl, ~apiToken: option<string>=?, ~onHeight, ~onStatus) =>
   HeightStream.subscribe(~staleTimeout, ~onHeight, ~onStatus, ~connect=driver => {
     let userAgent = `hyperindex/${Utils.EnvioPackage.value.version}`
     let es = EventSource.create(
       ~url=`${hyperSyncUrl}/height/sse`,
       ~options={
         fetch: (url, ~args) => {
-          let headers =
-            args.headers
-            ->Option.getOr(Dict.make())
-            ->Utils.Dict.merge(
-              Dict.fromArray([("Authorization", `Bearer ${apiToken}`), ("User-Agent", userAgent)]),
-            )
+          let extra = Dict.fromArray([("User-Agent", userAgent)])
+          switch apiToken {
+          | Some(apiToken) => extra->Dict.set("Authorization", `Bearer ${apiToken}`)
+          | None => ()
+          }
+          let headers = args.headers->Option.getOr(Dict.make())->Utils.Dict.merge(extra)
           EventSource.Fetch.fetch(url, ~args={...args, headers: headers})
         },
       },

--- a/packages/envio/src/sources/HyperSyncSSE.res
+++ b/packages/envio/src/sources/HyperSyncSSE.res
@@ -14,19 +14,19 @@ let failure = (error: EventSource.errorEvent): (
   | (None, None) => (Closed, None)
   }
 
-let subscribe = (~hyperSyncUrl, ~apiToken: option<string>=?, ~onHeight, ~onStatus) =>
+let subscribe = (~hyperSyncUrl, ~apiToken, ~onHeight, ~onStatus) =>
   HeightStream.subscribe(~staleTimeout, ~onHeight, ~onStatus, ~connect=driver => {
     let userAgent = `hyperindex/${Utils.EnvioPackage.value.version}`
     let es = EventSource.create(
       ~url=`${hyperSyncUrl}/height/sse`,
       ~options={
         fetch: (url, ~args) => {
-          let extra = Dict.fromArray([("User-Agent", userAgent)])
-          switch apiToken {
-          | Some(apiToken) => extra->Dict.set("Authorization", `Bearer ${apiToken}`)
-          | None => ()
-          }
-          let headers = args.headers->Option.getOr(Dict.make())->Utils.Dict.merge(extra)
+          let headers =
+            args.headers
+            ->Option.getOr(Dict.make())
+            ->Utils.Dict.merge(
+              Dict.fromArray([("Authorization", `Bearer ${apiToken}`), ("User-Agent", userAgent)]),
+            )
           EventSource.Fetch.fetch(url, ~args={...args, headers: headers})
         },
       },

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -123,12 +123,14 @@ let make = (
 ): t => {
   let name = "SvmHyperSync"
 
+  let apiToken = apiToken->HyperSync.requireApiToken
+
   // The whole per-(instruction, chain) registration set crosses the boundary
   // once at construction; the client derives instruction selections, field
   // selections, Borsh decoders, and the routing index from it.
   let client = SvmHyperSyncClient.make(
     ~url=endpointUrl,
-    ~apiToken?,
+    ~apiToken,
     ~httpReqTimeoutMillis=clientTimeoutMillis,
     ~programs=SvmHyperSyncClient.Registration.fromOnEventRegistrations(onEventRegistrations),
     ~addressStore,
@@ -258,6 +260,6 @@ let make = (
     },
     getItemsOrThrow,
     createHeightSubscription: (~onHeight, ~onStatus) =>
-      HyperSyncSSE.subscribe(~hyperSyncUrl=endpointUrl, ~apiToken?, ~onHeight, ~onStatus),
+      HyperSyncSSE.subscribe(~hyperSyncUrl=endpointUrl, ~apiToken, ~onHeight, ~onStatus),
   }
 }

--- a/packages/envio/src/sources/SvmHyperSyncSource.res
+++ b/packages/envio/src/sources/SvmHyperSyncSource.res
@@ -257,5 +257,7 @@ let make = (
       {height, requestStats: [{method: "getHeight", seconds}]}
     },
     getItemsOrThrow,
+    createHeightSubscription: (~onHeight, ~onStatus) =>
+      HyperSyncSSE.subscribe(~hyperSyncUrl=endpointUrl, ~apiToken?, ~onHeight, ~onStatus),
   }
 }

--- a/scenarios/fuel_test/test/FuelHyperSyncSourceHeight_test.res
+++ b/scenarios/fuel_test/test/FuelHyperSyncSourceHeight_test.res
@@ -79,7 +79,7 @@ describe("FuelHyperSyncSource - getHeightOrThrow", () => {
     })
   })
 
-  it("Throws with the HyperFuel token instructions when no token is configured", t => {
+  it("Throws with the token instructions when no token is configured", t => {
     t->toThrowErrorEqual(
       () =>
         FuelHyperSyncSource.make({
@@ -89,7 +89,7 @@ describe("FuelHyperSyncSource - getHeightOrThrow", () => {
           onEventRegistrations: [],
           addressStore,
         })->ignore,
-      `An Envio API token is required for using HyperFuel as a data-source.
+      `An Envio API token is required for using HyperSync as a data-source.
 Set the ENVIO_API_TOKEN environment variable in your .env file.
 Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`,
     )

--- a/scenarios/fuel_test/test/FuelHyperSyncSourceHeight_test.res
+++ b/scenarios/fuel_test/test/FuelHyperSyncSourceHeight_test.res
@@ -79,6 +79,22 @@ describe("FuelHyperSyncSource - getHeightOrThrow", () => {
     })
   })
 
+  it("Throws with the HyperFuel token instructions when no token is configured", t => {
+    t->toThrowErrorEqual(
+      () =>
+        FuelHyperSyncSource.make({
+          chainId,
+          endpointUrl: "http://127.0.0.1:1",
+          apiToken: None,
+          onEventRegistrations: [],
+          addressStore,
+        })->ignore,
+      `An Envio API token is required for using HyperFuel as a data-source.
+Set the ENVIO_API_TOKEN environment variable in your .env file.
+Learn more or get a free Envio API token at: https://envio.dev/app/api-tokens`,
+    )
+  })
+
   Async.it("Blocks forever on 401 instead of throwing for a retry", async t => {
     await withServer((_req, res) => {
       res->writeHead(401)


### PR DESCRIPTION
Adds height subscription capability to the SVM HyperSync source, enabling it to stream block heights via HyperSync's Server-Sent Events (SSE) endpoint, matching the functionality already available in the EVM source.

## Changes

- **SvmHyperSyncSource**: Added `createHeightSubscription` field to the source interface, which delegates to `HyperSyncSSE.subscribe` with the configured endpoint URL and optional API token.

- **HyperSyncSSE**: Made `apiToken` parameter optional (defaults to `None`). When no token is provided, the Authorization header is omitted from SSE requests, allowing connections to public endpoints without authentication.

- **Test coverage**: Added integration test that verifies the SVM height subscription correctly parses SSE events and streams heights, using a mock HTTP server to simulate the HyperSync SSE endpoint.

- **Test infrastructure**: Updated `makeSource` test helper to accept `endpointUrl` as a parameter, enabling tests to point to custom endpoints (e.g., mock servers).

## Implementation details

The height subscription reuses the existing `HeightStream` infrastructure and `HyperSyncSSE` module, ensuring consistent behavior across EVM and SVM sources. The optional API token handling allows the same subscription mechanism to work with both authenticated and public HyperSync endpoints.

https://claude.ai/code/session_01SEZ6AzArLwUahMVgKtsQ1g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized HyperSync API-token validation across EVM, SVM, and Fuel data sources.
  - Improved missing-token errors with instructions to configure `ENVIO_API_TOKEN` and obtain an API token.
  - Ensured SVM height-streaming connections authenticate correctly when using an API token.

- **Tests**
  - Added coverage for SVM height streaming and missing-token error messages across supported HyperSync sources.
  - Verified Fuel source setup provides actionable guidance when no API token is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->