### PR TITLE
Make an SVM instruction row say what it dispatches on and what it decodes

### DIFF
--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -1188,12 +1188,11 @@ pub mod svm {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         #[schemars(
             description = "Instructions to index. With `idl:`, omit this list to take the full \
-                           usable IDL catalog. A YAML row overwrites the IDL instruction of the \
-                           same name, or adds a new name to the catalog, and must set \
-                           `discriminator` plus both `accounts` and `args`. Without `idl:`, \
-                           omit `discriminator` to match every \
-                           instruction of the program; set both `accounts` and `args`, or omit \
-                           both."
+                           usable IDL catalog. A row whose name the IDL declares replaces that \
+                           instruction, and must spell out `discriminator`, `accounts` and \
+                           `args`. Every other row adds an instruction: omit `discriminator` to \
+                           match every instruction of the program, and give `accounts` or `args` \
+                           only where you want the names or the decoded payload."
         )]
         pub instructions: Vec<Instruction>,
     }
@@ -1210,8 +1209,8 @@ pub mod svm {
         #[schemars(
             description = "Hex-encoded instruction-data prefix used as the discriminator (\"0x\" \
                            optional), of any whole number of bytes; an 8-byte value matches the \
-                           standard Anchor discriminator. With `idl:` on the program, this field \
-                           is required on every YAML row. Without `idl:`, omit it to match every \
+                           standard Anchor discriminator. Required on a row that replaces an \
+                           instruction the IDL declares; otherwise omit it to match every \
                            instruction of the program. Every instruction whose prefix an \
                            on-chain call carries receives it, so a program-wide entry fires \
                            alongside a keyed one, and two entries may share a prefix (say, the \
@@ -1225,15 +1224,18 @@ pub mod svm {
             description = "Optional positional account names. The Nth entry names account slot N \
                            on the dispatched instruction; surfaces as \
                            `instruction.accounts.<name>` when `fields.instruction` includes \
-                           `accounts`."
+                           `accounts`. The raw slots are available either way, so this only adds \
+                           the names. Required on a row that replaces an instruction the IDL \
+                           declares."
         )]
         pub accounts: Option<Vec<String>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
             description = "Optional Borsh argument schema. Each entry names one arg and gives its \
                            type; the decoder walks the instruction data after the discriminator \
-                           in declared order. Must be set together with `accounts` when either is \
-                           present."
+                           in declared order. Omit it to leave the payload undecoded, reachable \
+                           as raw `instruction.data`. Required on a row that replaces an \
+                           instruction the IDL declares."
         )]
         pub args: Option<Vec<ArgDef>>,
     }

--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -1206,11 +1206,13 @@ pub mod svm {
         )]
         pub name: String,
         #[schemars(
-            description = "Hex-encoded instruction-data prefix to dispatch on (\"0x\" optional), \
-                           of any whole number of bytes; an 8-byte value matches the standard \
-                           Anchor discriminator. The empty prefix, written \"\", is carried by \
-                           every call, so it is how a row matches every instruction of the \
-                           program. Every instruction whose prefix an on-chain call carries \
+            description = "0x-prefixed hex instruction-data prefix to dispatch on, of any whole \
+                           number of bytes; an 8-byte value matches the standard Anchor \
+                           discriminator. The empty prefix, written \"0x\", is carried by every \
+                           call, so it is how a row matches every instruction of the program. \
+                           This is the form `instruction.discriminator` reads back, so a config \
+                           value and a handler comparison are the same string. Every instruction \
+                           whose prefix an on-chain call carries \
                            receives it, so a program-wide entry fires alongside a keyed one, and \
                            two entries may share a prefix (say, the layouts before and after a \
                            program upgrade): each decodes with its own `args`, and one whose \

--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -1231,11 +1231,16 @@ pub mod svm {
         pub accounts: Option<Vec<AccountSlot>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
-            description = "Optional Borsh argument schema. Each entry names one arg and gives its \
-                           type; the decoder walks the instruction data after the discriminator \
-                           in declared order. Omit it to leave the payload undecoded, reachable \
-                           as raw `instruction.data`. Required on a row that replaces an \
-                           instruction the IDL declares."
+            description = "Borsh argument schema. Each entry names one arg and gives its type; \
+                           the decoder walks the instruction data after the discriminator in \
+                           declared order, and a call whose data the layout rejects is skipped. \
+                           Setting it is therefore also a filter: `[]` says the instruction takes \
+                           no arguments, so only calls carrying nothing past the discriminator \
+                           are indexed. Omit it instead to attach no decoder at all — every \
+                           matched call is indexed and the payload stays raw, reachable as \
+                           `instruction.data`. An `idl` always declares the layout of the \
+                           instructions it names, empty included. Required on a row that replaces \
+                           an instruction the IDL declares."
         )]
         pub args: Option<Vec<ArgDef>>,
     }

--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -1191,9 +1191,8 @@ pub mod svm {
             description = "Instructions to index. With `idl:`, omit this list to take the full \
                            usable IDL catalog. A row whose name the IDL declares replaces that \
                            instruction, and must spell out `accounts` and `args`; every other row \
-                           adds one. Either way, omit `discriminator` to match every instruction \
-                           of the program, and give `accounts` or `args` only where you want the \
-                           names or the decoded payload."
+                           adds one. Give `accounts` or `args` only where you want the names or \
+                           the decoded payload."
         )]
         pub instructions: Vec<Instruction>,
     }
@@ -1206,19 +1205,18 @@ pub mod svm {
                            unique per program."
         )]
         pub name: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
-            description = "Hex-encoded instruction-data prefix used as the discriminator (\"0x\" \
-                           optional), of any whole number of bytes; an 8-byte value matches the \
-                           standard Anchor discriminator. Omit it to match every instruction of \
-                           the program, whether or not the row replaces one the IDL declares. Every instruction whose prefix an \
-                           on-chain call carries receives it, so a program-wide entry fires \
-                           alongside a keyed one, and two entries may share a prefix (say, the \
-                           layouts before and after a program upgrade): each decodes with its \
-                           own `args`, and one whose layout rejects the data is skipped for that \
-                           call."
+            description = "Hex-encoded instruction-data prefix to dispatch on (\"0x\" optional), \
+                           of any whole number of bytes; an 8-byte value matches the standard \
+                           Anchor discriminator. The empty prefix, written \"\", is carried by \
+                           every call, so it is how a row matches every instruction of the \
+                           program. Every instruction whose prefix an on-chain call carries \
+                           receives it, so a program-wide entry fires alongside a keyed one, and \
+                           two entries may share a prefix (say, the layouts before and after a \
+                           program upgrade): each decodes with its own `args`, and one whose \
+                           layout rejects the data is skipped for that call."
         )]
-        pub discriminator: Option<String>,
+        pub discriminator: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
             description = "Optional positional account slots, in the order the program expects \
@@ -1403,9 +1401,8 @@ pub mod svm {
     /// when one is misspelled.
     const PRIMITIVE_NAMES: &str = "bool, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, \
                                    f64, string, bytes, pubkey, publicKey";
-    /// The keys a one-key mapping may take. `defined` is deliberately absent:
-    /// it carries an IDL's nominal types through `internal_config.json`, and a
-    /// config.yaml naming one is answered by `validation::validate_svm_args`.
+    /// The keys a one-key mapping may take. `defined` is deliberately absent;
+    /// see `ArgComposite::Defined`.
     const COMPOSITE_NAMES: &str = "option, vec, array, struct, enum";
 
     /// User-facing Borsh type grammar. Mirrors
@@ -1523,11 +1520,11 @@ pub mod svm {
         /// `[ <element type>, <length> ]` — same shape Anchor IDLs use.
         #[serde(rename = "array")]
         Array(Box<ArgType>, usize),
-        /// Reference into the program-level `defined_types` registry, which is
-        /// only ever populated from an IDL's `types` block. Not part of the
-        /// config.yaml grammar — it exists to carry an IDL's nominal types
-        /// through `internal_config.json` — so it is kept out of the published
-        /// JSON schema and rejected by `validation::validate_svm_args`.
+        /// Reference into the program-level `defined_types` registry, which
+        /// only an IDL's `types` block ever populates. It exists to carry an
+        /// IDL's nominal types through `internal_config.json`, not as part of
+        /// the config.yaml grammar, so it stays out of the published JSON
+        /// schema and a config naming one is refused.
         #[serde(rename = "defined")]
         #[schemars(skip)]
         Defined(String),
@@ -2063,13 +2060,13 @@ chains:
                     instructions: vec![
                         Instruction {
                             name: "CreateMetadataAccountV3".to_string(),
-                            discriminator: Some("0x21".to_string()),
+                            discriminator: "0x21".to_string(),
                             accounts: None,
                             args: None,
                         },
                         Instruction {
                             name: "UpdateMetadataAccountV2".to_string(),
-                            discriminator: Some("0x0f".to_string()),
+                            discriminator: "0x0f".to_string(),
                             accounts: None,
                             args: None,
                         },

--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -1250,21 +1250,103 @@ pub mod svm {
         pub ty: ArgType,
     }
 
+    /// Elements an `array` may declare. The decoder preallocates from this
+    /// length rather than from the bytes on the wire, so an unbounded one is an
+    /// out-of-memory abort on every matched instruction, not a decode failure.
+    pub const MAX_ARRAY_LEN: usize = 65_536;
+
+    /// Borsh selects an enum variant with a one-byte tag, so a variant past
+    /// this many is unreachable.
+    pub const MAX_ENUM_VARIANTS: usize = 256;
+
+    /// The names a bare string may take, in the order they are offered back
+    /// when one is misspelled.
+    const PRIMITIVE_NAMES: &str = "bool, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, \
+                                   f64, string, bytes, pubkey, publicKey";
+    /// The keys a one-key mapping may take. `defined` is deliberately absent:
+    /// it carries an IDL's nominal types through `internal_config.json`, and a
+    /// config.yaml naming one is answered by `validation::validate_svm_args`.
+    const COMPOSITE_NAMES: &str = "option, vec, array, struct, enum";
+
     /// User-facing Borsh type grammar. Mirrors
     /// `hypersync_client_solana::decode::FieldType`. The YAML accepts either:
-    /// - A bare string for primitives (`"u64"`, `"pubkey"`, `"bool"`, ...).
-    /// - A tagged object for composites (`{ vec: u8 }`, `{ option: pubkey }`,
-    ///   `{ array: [u8, 32] }`, `{ defined: "DataV2" }`).
-    /// - An object with `kind: struct` or `kind: enum` for nominal types
-    ///   declared inline on this field. Most users will use `defined` and
-    ///   declare the nominal types under the program's `types:` block (Anchor
-    ///   IDL shape) once that lands; for now inline `struct` / `enum` is the
-    ///   only way to express nominal shapes ad-hoc.
-    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
+    /// - A bare string for a primitive (`u64`, `pubkey`, `bool`, ...).
+    /// - A one-key mapping for a composite (`{ vec: u8 }`, `{ option: pubkey }`,
+    ///   `{ array: [u8, 32] }`, `{ struct: [...] }`, `{ enum: [...] }`).
+    ///
+    /// A nominal type is declared inline with `struct` / `enum` at the field
+    /// that uses it. There is no way to name one and refer to it: attach an
+    /// `idl` to the program when its types are shared between instructions.
+    #[derive(Debug, Serialize, Clone, PartialEq, JsonSchema)]
     #[serde(untagged)]
     pub enum ArgType {
         Primitive(ArgPrimitive),
         Composite(ArgComposite),
+    }
+
+    /// Hand-written so a misspelled type is answered with the names it could
+    /// have been. `#[serde(untagged)]` would report only that the value
+    /// matched no variant, naming neither the type nor the alternatives.
+    impl<'de> Deserialize<'de> for ArgType {
+        fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            deserializer.deserialize_any(ArgTypeVisitor)
+        }
+    }
+
+    struct ArgTypeVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for ArgTypeVisitor {
+        type Value = ArgType;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "a Borsh type")
+        }
+
+        fn visit_str<E: serde::de::Error>(self, name: &str) -> Result<ArgType, E> {
+            let as_primitive: serde::de::value::StrDeserializer<E> =
+                serde::de::IntoDeserializer::into_deserializer(name);
+            ArgPrimitive::deserialize(as_primitive)
+                .map(ArgType::Primitive)
+                .map_err(|_: E| {
+                    E::custom(format!(
+                        "unknown type '{name}', expected one of {PRIMITIVE_NAMES}, or a composite \
+                         such as {{vec: u8}}, {{option: pubkey}}, {{array: [u8, 32]}}, {{struct: \
+                         [...]}}, {{enum: [...]}}"
+                    ))
+                })
+        }
+
+        fn visit_map<A: serde::de::MapAccess<'de>>(self, mut map: A) -> Result<ArgType, A::Error> {
+            use serde::de::Error;
+            let Some(key) = map.next_key::<String>()? else {
+                return Err(A::Error::custom(format!(
+                    "a composite type needs exactly one of {COMPOSITE_NAMES}"
+                )));
+            };
+            let composite = match key.as_str() {
+                "option" => ArgComposite::Option(map.next_value()?),
+                "vec" => ArgComposite::Vec(map.next_value()?),
+                "array" => {
+                    let (ty, len) = map.next_value::<(Box<ArgType>, usize)>()?;
+                    ArgComposite::Array(ty, len)
+                }
+                "struct" => ArgComposite::Struct(map.next_value()?),
+                "enum" => ArgComposite::Enum(map.next_value()?),
+                "defined" => ArgComposite::Defined(map.next_value()?),
+                other => {
+                    return Err(A::Error::custom(format!(
+                        "unknown composite type '{other}', expected one of {COMPOSITE_NAMES}"
+                    )))
+                }
+            };
+            if let Some(extra) = map.next_key::<String>()? {
+                return Err(A::Error::custom(format!(
+                    "a composite type takes exactly one of {COMPOSITE_NAMES}, got both '{key}' \
+                     and '{extra}'"
+                )));
+            }
+            Ok(ArgType::Composite(composite))
+        }
     }
 
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
@@ -1290,8 +1372,9 @@ pub mod svm {
         PublicKey,
     }
 
-    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
-    #[serde(deny_unknown_fields)]
+    // Deserialized through `ArgTypeVisitor` rather than by serde, so the
+    // variant names here only drive serialization and the JSON schema.
+    #[derive(Debug, Serialize, Clone, PartialEq, JsonSchema)]
     pub enum ArgComposite {
         #[serde(rename = "option")]
         Option(Box<ArgType>),
@@ -1300,17 +1383,21 @@ pub mod svm {
         /// `[ <element type>, <length> ]` — same shape Anchor IDLs use.
         #[serde(rename = "array")]
         Array(Box<ArgType>, usize),
-        /// Reference to a nominal type defined in the program-level
-        /// `defined_types` registry (populated from an Anchor IDL `types:`
-        /// block).
+        /// Reference into the program-level `defined_types` registry, which is
+        /// only ever populated from an IDL's `types` block. Not part of the
+        /// config.yaml grammar — it exists to carry an IDL's nominal types
+        /// through `internal_config.json` — so it is kept out of the published
+        /// JSON schema and rejected by `validation::validate_svm_args`.
         #[serde(rename = "defined")]
+        #[schemars(skip)]
         Defined(String),
-        /// Inline-or-registry struct. Used as a nominal type definition in
-        /// the `defined_types` registry; rarely seen at the field level.
+        /// A struct, declared inline at the field that uses it or held in the
+        /// `defined_types` registry.
         #[serde(rename = "struct")]
         Struct(Vec<ArgDef>),
-        /// Inline-or-registry enum. Same role as `Struct`: a nominal type
-        /// definition in the `defined_types` registry.
+        /// An enum, declared inline at the field that uses it or held in the
+        /// `defined_types` registry. Borsh selects a variant by its position
+        /// here, with a one-byte tag.
         #[serde(rename = "enum")]
         Enum(Vec<ArgEnumVariant>),
     }

--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -1191,8 +1191,10 @@ pub mod svm {
             description = "Instructions to index. With `idl:`, omit this list to take the full \
                            usable IDL catalog. A row whose name the IDL declares replaces that \
                            instruction, and must spell out `accounts` and `args`; every other row \
-                           adds one. Give `accounts` or `args` only where you want the names or \
-                           the decoded payload."
+                           adds one. Give `accounts` where you want the slots named — an empty \
+                           list names none, the same as leaving it out. `args` is not the same \
+                           shape: setting it attaches a decoder that also filters, so leaving it \
+                           out and setting it to `[]` are different asks."
         )]
         pub instructions: Vec<Instruction>,
     }

--- a/packages/cli/src/config_parsing/public_config.rs
+++ b/packages/cli/src/config_parsing/public_config.rs
@@ -422,10 +422,12 @@ struct SvmEventItem {
     /// raw `instruction.accounts[i]` array is still available.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     accounts: Vec<SvmAccountSlotItem>,
-    /// Borsh args layout. `[]` means the runtime won't expose
-    /// `decoded.args`; the raw `instruction.data` hex is still available.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    args: Vec<human_config::svm::ArgDef>,
+    /// Borsh args layout. Absent means no decoder is attached, so the runtime
+    /// won't expose `decoded.args` and every matched call is delivered with
+    /// the raw `instruction.data` hex. Present attaches one, `[]` included:
+    /// a call whose data the layout rejects never reaches a handler.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    args: Option<Vec<human_config::svm::ArgDef>>,
 }
 
 /// One account slot. An unnamed slot carries neither key, so it reaches the
@@ -639,11 +641,9 @@ impl SystemConfig {
                                             .iter()
                                             .map(SvmAccountSlotItem::from)
                                             .collect(),
-                                        args: svm_kind
-                                            .args
-                                            .iter()
-                                            .map(named_field_to_arg_def)
-                                            .collect(),
+                                        args: svm_kind.args.as_ref().map(|args| {
+                                            args.iter().map(named_field_to_arg_def).collect()
+                                        }),
                                     };
                                     (vec![], Some("svmInstruction".to_string()), Some(svm_item))
                                 }

--- a/packages/cli/src/config_parsing/svm_catalog.rs
+++ b/packages/cli/src/config_parsing/svm_catalog.rs
@@ -13,7 +13,11 @@ pub struct ResolvedInstruction {
     /// `None` matches every instruction of the program.
     pub discriminator: Option<Vec<u8>>,
     pub accounts: Vec<AccountSlot>,
-    pub args: Vec<SvmNamedField>,
+    /// `None` attaches no decoder, so every matched call is delivered with its
+    /// payload raw. `Some` attaches one, and a call whose data the layout
+    /// rejects is skipped — an empty layout therefore takes only the calls
+    /// that carry nothing past the discriminator.
+    pub args: Option<Vec<SvmNamedField>>,
 }
 
 impl ResolvedInstruction {
@@ -35,7 +39,9 @@ impl ResolvedInstruction {
                     }
                 })
                 .collect(),
-            args: ix.args.clone(),
+            // An IDL declares the layout of every instruction it names, and
+            // one that takes no arguments declares an empty one.
+            args: Some(ix.args.clone()),
         }
     }
 }
@@ -64,11 +70,13 @@ fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<Re
     let args = match &instr.args {
         Some(args) => {
             validate_svm_args(args)?;
-            args.iter()
-                .map(yaml_arg_to_named_field)
-                .collect::<Result<Vec<_>>>()?
+            Some(
+                args.iter()
+                    .map(yaml_arg_to_named_field)
+                    .collect::<Result<Vec<_>>>()?,
+            )
         }
-        None => Vec::new(),
+        None => None,
     };
     Ok(ResolvedInstruction {
         discriminator,

--- a/packages/cli/src/config_parsing/svm_catalog.rs
+++ b/packages/cli/src/config_parsing/svm_catalog.rs
@@ -6,6 +6,7 @@ use hypersync_client_solana::decode::NamedField as SvmNamedField;
 use super::human_config;
 use super::svm_idl::{IxIdl, ProgramIdl, Unusable};
 use super::system_config::yaml_arg_to_named_field;
+use super::validation::{validate_svm_accounts, validate_svm_args};
 
 /// What one configured instruction dispatches on and decodes into.
 pub struct ResolvedInstruction {
@@ -36,11 +37,14 @@ fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<Re
         .map(|d| crate::hex::decode_optionally_prefixed(d, "discriminator"))
         .transpose()?;
     let accounts = instr.accounts.clone().unwrap_or_default();
+    validate_svm_accounts(&accounts)?;
     let args = match &instr.args {
-        Some(args) => args
-            .iter()
-            .map(yaml_arg_to_named_field)
-            .collect::<Result<Vec<_>>>()?,
+        Some(args) => {
+            validate_svm_args(args)?;
+            args.iter()
+                .map(yaml_arg_to_named_field)
+                .collect::<Result<Vec<_>>>()?
+        }
         None => Vec::new(),
     };
     Ok(ResolvedInstruction {

--- a/packages/cli/src/config_parsing/svm_catalog.rs
+++ b/packages/cli/src/config_parsing/svm_catalog.rs
@@ -67,17 +67,14 @@ fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<Re
     let discriminator = (!discriminator.is_empty()).then_some(discriminator);
     let accounts = instr.accounts.clone().unwrap_or_default();
     validate_account_slots(&accounts)?;
-    let args = match &instr.args {
-        Some(args) => {
+    let args = instr
+        .args
+        .as_ref()
+        .map(|args| {
             validate_svm_args(args)?;
-            Some(
-                args.iter()
-                    .map(yaml_arg_to_named_field)
-                    .collect::<Result<Vec<_>>>()?,
-            )
-        }
-        None => None,
-    };
+            args.iter().map(yaml_arg_to_named_field).collect()
+        })
+        .transpose()?;
     Ok(ResolvedInstruction {
         discriminator,
         accounts,

--- a/packages/cli/src/config_parsing/svm_catalog.rs
+++ b/packages/cli/src/config_parsing/svm_catalog.rs
@@ -54,11 +54,12 @@ fn validate_account_slots(slots: &[AccountSlot]) -> Result<()> {
 }
 
 fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<ResolvedInstruction> {
-    let discriminator = instr
-        .discriminator
-        .as_deref()
-        .map(|d| crate::hex::decode_optionally_prefixed(d, "discriminator"))
-        .transpose()?;
+    // The empty prefix is carried by every call, which is how a row asks for
+    // every instruction of the program — the same reading `from_idl` gives an
+    // IDL that declares no discriminator.
+    let discriminator =
+        crate::hex::decode_optionally_prefixed(&instr.discriminator, "discriminator")?;
+    let discriminator = (!discriminator.is_empty()).then_some(discriminator);
     let accounts = instr.accounts.clone().unwrap_or_default();
     validate_account_slots(&accounts)?;
     let args = match &instr.args {
@@ -79,8 +80,8 @@ fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<Re
 
 /// What a row on a name the IDL declares still has to spell out, as the error
 /// the caller reports. `None` when the row is not an overwrite, or is complete.
-/// `discriminator` is not among them: absent, it means what it means anywhere
-/// else, a match on every instruction of the program.
+/// `discriminator` is not among them: every row carries one, and what it says
+/// about dispatch is the row's own business either way.
 fn overwrite_missing_fields(
     instr: &human_config::svm::Instruction,
     idl: &ProgramIdl,

--- a/packages/cli/src/config_parsing/svm_catalog.rs
+++ b/packages/cli/src/config_parsing/svm_catalog.rs
@@ -54,6 +54,35 @@ fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<Re
     })
 }
 
+/// What a row on a name the IDL declares still has to spell out, as the error
+/// the caller reports. `None` when the row is not an overwrite, or is complete.
+fn overwrite_missing_fields(
+    instr: &human_config::svm::Instruction,
+    idl: &ProgramIdl,
+) -> Option<anyhow::Error> {
+    let set_aside = idl.unusable.get(&instr.name);
+    if set_aside.is_none() && !idl.instructions.contains_key(&instr.name) {
+        return None;
+    }
+    let missing = missing_fields(instr);
+    if missing.is_empty() {
+        return None;
+    }
+    let declared = match set_aside {
+        Some(reason) => format!(
+            "the IDL declares this instruction too, but it cannot be indexed as declared: {reason}"
+        ),
+        None => "the IDL declares this instruction too, so this row replaces it rather than \
+                 adding to the catalog"
+            .to_string(),
+    };
+    Some(anyhow!(
+        "{declared}. Spell out {}: an overwrite takes nothing from the IDL, so a field left out \
+         here is absent, not inherited.",
+        and_list(&missing)
+    ))
+}
+
 fn missing_fields(instr: &human_config::svm::Instruction) -> Vec<&'static str> {
     [
         ("discriminator", instr.discriminator.is_none()),
@@ -81,33 +110,21 @@ pub fn instruction_catalog(
 ) -> Result<Vec<(String, ResolvedInstruction)>> {
     let mut catalog: Vec<(String, ResolvedInstruction)> = Vec::new();
     let mut index: HashMap<String, usize> = HashMap::new();
-    let has_idl = program.idl.is_some();
 
-    if has_idl {
-        for (name, ix) in &idl.instructions {
-            index.insert(name.clone(), catalog.len());
-            catalog.push((name.clone(), ResolvedInstruction::from_idl(ix)));
-        }
+    for (name, ix) in &idl.instructions {
+        index.insert(name.clone(), catalog.len());
+        catalog.push((name.clone(), ResolvedInstruction::from_idl(ix)));
     }
     for instr in &program.instructions {
         let at_instruction = || format!("Program '{}', instruction '{}'", program.name, instr.name);
-        // A row the IDL has no name for adds an instruction, and reads like an
-        // inline one: every field is the row's own business. A row that lands
-        // on a declared name replaces it whole, and the fields it leaves out
-        // would read as absent rather than as the IDL's — so it has to say all
-        // three, and the reader can see it is an overwrite without opening the
-        // IDL to check.
-        if idl.instructions.contains_key(&instr.name) {
-            let missing = missing_fields(instr);
-            if !missing.is_empty() {
-                return Err(anyhow!(
-                    "the IDL declares this instruction too, so this row replaces it rather than \
-                     adding to the catalog. Spell out {}: an overwrite takes nothing from the \
-                     IDL, so a field left out here is absent, not inherited.",
-                    and_list(&missing)
-                ))
-                .with_context(at_instruction);
-            }
+        // A row on a name the IDL declares replaces that instruction whole, so
+        // the fields it leaves out would read as absent rather than as the
+        // IDL's. A name the IDL was seen to declare but this runtime set aside
+        // counts the same: the row is answering that reason, not adding a
+        // program-wide catch-all under a name that looks like it selects one
+        // instruction.
+        if let Some(missing) = overwrite_missing_fields(instr, idl) {
+            return Err(missing).with_context(at_instruction);
         }
         let resolved = resolve_yaml_instruction(instr).with_context(at_instruction)?;
         if let Some(&i) = index.get(&instr.name) {

--- a/packages/cli/src/config_parsing/svm_catalog.rs
+++ b/packages/cli/src/config_parsing/svm_catalog.rs
@@ -54,6 +54,27 @@ fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<Re
     })
 }
 
+fn missing_fields(instr: &human_config::svm::Instruction) -> Vec<&'static str> {
+    [
+        ("discriminator", instr.discriminator.is_none()),
+        ("accounts", instr.accounts.is_none()),
+        ("args", instr.args.is_none()),
+    ]
+    .into_iter()
+    .filter_map(|(field, absent)| absent.then_some(field))
+    .collect()
+}
+
+/// `'a'`, `'a' and 'b'`, `'a', 'b' and 'c'`.
+fn and_list(fields: &[&str]) -> String {
+    let quoted: Vec<String> = fields.iter().map(|field| format!("'{field}'")).collect();
+    match quoted.split_last() {
+        None => String::new(),
+        Some((last, [])) => last.clone(),
+        Some((last, rest)) => format!("{} and {last}", rest.join(", ")),
+    }
+}
+
 pub fn instruction_catalog(
     program: &human_config::svm::Program,
     idl: &ProgramIdl,
@@ -70,22 +91,23 @@ pub fn instruction_catalog(
     }
     for instr in &program.instructions {
         let at_instruction = || format!("Program '{}', instruction '{}'", program.name, instr.name);
-        if has_idl && instr.discriminator.is_none() {
-            return Err(anyhow!(
-                "a YAML row next to 'idl' must set 'discriminator' to overwrite the IDL \
-                 definition, or omit this row."
-            ))
-            .with_context(at_instruction);
-        }
-        if has_idl && (instr.accounts.is_none() || instr.args.is_none()) {
-            return Err(anyhow!(
-                "set both 'accounts' and 'args' to overwrite the IDL layout."
-            ))
-            .with_context(at_instruction);
-        }
-        if !has_idl && instr.accounts.is_some() != instr.args.is_some() {
-            return Err(anyhow!("set both 'accounts' and 'args', or omit both."))
+        // A row the IDL has no name for adds an instruction, and reads like an
+        // inline one: every field is the row's own business. A row that lands
+        // on a declared name replaces it whole, and the fields it leaves out
+        // would read as absent rather than as the IDL's — so it has to say all
+        // three, and the reader can see it is an overwrite without opening the
+        // IDL to check.
+        if idl.instructions.contains_key(&instr.name) {
+            let missing = missing_fields(instr);
+            if !missing.is_empty() {
+                return Err(anyhow!(
+                    "the IDL declares this instruction too, so this row replaces it rather than \
+                     adding to the catalog. Spell out {}: an overwrite takes nothing from the \
+                     IDL, so a field left out here is absent, not inherited.",
+                    and_list(&missing)
+                ))
                 .with_context(at_instruction);
+            }
         }
         let resolved = resolve_yaml_instruction(instr).with_context(at_instruction)?;
         if let Some(&i) = index.get(&instr.name) {

--- a/packages/cli/src/config_parsing/svm_catalog.rs
+++ b/packages/cli/src/config_parsing/svm_catalog.rs
@@ -57,8 +57,7 @@ fn resolve_yaml_instruction(instr: &human_config::svm::Instruction) -> Result<Re
     // The empty prefix is carried by every call, which is how a row asks for
     // every instruction of the program — the same reading `from_idl` gives an
     // IDL that declares no discriminator.
-    let discriminator =
-        crate::hex::decode_optionally_prefixed(&instr.discriminator, "discriminator")?;
+    let discriminator = crate::hex::decode_prefixed(&instr.discriminator, "discriminator")?;
     let discriminator = (!discriminator.is_empty()).then_some(discriminator);
     let accounts = instr.accounts.clone().unwrap_or_default();
     validate_account_slots(&accounts)?;

--- a/packages/cli/src/config_parsing/svm_idl/anchor.rs
+++ b/packages/cli/src/config_parsing/svm_idl/anchor.rs
@@ -20,6 +20,7 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 use crate::config_parsing::field_types::to_snake_case;
+use crate::config_parsing::human_config::svm::MAX_ARRAY_LEN;
 use crate::utils::text::Capitalize;
 
 use super::{
@@ -205,10 +206,14 @@ fn parse_type(node: &Value, path: &str) -> Result<FieldType> {
         .ok_or_else(|| anyhow!("{path}: unsupported type {node}"))?;
 
     if let Some(inner) = obj.get("option") {
-        return Ok(FieldType::Option(Box::new(parse_type(
-            inner,
-            &format!("{path}.option"),
-        )?)));
+        let path = format!("{path}.option");
+        let inner = parse_type(inner, &path)?;
+        // Both levels are a one-byte tag, so `Some(None)` decodes to the same
+        // value as `None` and a handler cannot tell them apart.
+        if matches!(inner, FieldType::Option(_)) {
+            bail!("{path}: a nested `option` decodes ambiguously and cannot be indexed");
+        }
+        return Ok(FieldType::Option(Box::new(inner)));
     }
     // An SPL `COption` tags presence with four bytes where Borsh uses one, and
     // the runtime has no four-byte option to decode it with. Reading it as a
@@ -229,9 +234,16 @@ fn parse_type(node: &Value, path: &str) -> Result<FieldType> {
         let len = len
             .as_u64()
             .ok_or_else(|| anyhow!("{path}.array: expected a length, got {len}"))?;
+        let len = usize::try_from(len).unwrap_or(usize::MAX);
+        if len > MAX_ARRAY_LEN {
+            bail!(
+                "{path}.array: {len} elements is more than the {MAX_ARRAY_LEN} an array may \
+                 declare"
+            );
+        }
         return Ok(FieldType::Array {
             ty: Box::new(parse_type(item, &format!("{path}.array"))?),
-            len: len as usize,
+            len,
         });
     }
     if let Some(d) = obj.get("defined") {

--- a/packages/cli/src/config_parsing/svm_idl/codama.rs
+++ b/packages/cli/src/config_parsing/svm_idl/codama.rs
@@ -11,6 +11,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use hypersync_client_solana::decode::{EnumVariant, FieldType, NamedField};
 use serde_json::{Map, Value};
 
+use crate::config_parsing::human_config::svm::MAX_ARRAY_LEN;
+
 use super::{
     account_slot, collect_instructions, declared_array, le_bytes, parse_defined_types,
     required_str, IdlAccount, Positions, ProgramIdl,
@@ -502,10 +504,13 @@ fn parse_type(node: &Value, path: &str) -> Result<FieldType> {
                     "{path}: a fixed option pads its body when absent, which Borsh does not encode"
                 );
             }
-            Ok(FieldType::Option(Box::new(parse_type(
-                item(node, path)?,
-                &format!("{path}.item"),
-            )?)))
+            let inner = parse_type(item(node, path)?, &format!("{path}.item"))?;
+            // Both levels are a one-byte tag, so `Some(None)` decodes to the
+            // same value as `None` and a handler cannot tell them apart.
+            if matches!(inner, FieldType::Option(_)) {
+                bail!("{path}.item: a nested option decodes ambiguously and cannot be indexed");
+            }
+            Ok(FieldType::Option(Box::new(inner)))
         }
         // A zeroable option carries no tag at all — presence is encoded by the
         // value being non-zero. There is no Borsh shape for that, and reading
@@ -526,9 +531,16 @@ fn parse_type(node: &Value, path: &str) -> Result<FieldType> {
                         .get("value")
                         .and_then(Value::as_u64)
                         .ok_or_else(|| anyhow!("{path}: fixed count has no 'value'"))?;
+                    let len = usize::try_from(len).unwrap_or(usize::MAX);
+                    if len > MAX_ARRAY_LEN {
+                        bail!(
+                            "{path}: {len} elements is more than the {MAX_ARRAY_LEN} an array may \
+                             declare"
+                        );
+                    }
                     Ok(FieldType::Array {
                         ty: Box::new(item),
-                        len: len as usize,
+                        len,
                     })
                 }
                 // Borsh frames a vector with a u32 length prefix.

--- a/packages/cli/src/config_parsing/svm_idl/tests/validate.rs
+++ b/packages/cli/src/config_parsing/svm_idl/tests/validate.rs
@@ -30,6 +30,45 @@ fn records_each_defect_against_what_carries_it() {
                }] }"#,
         ),
         (
+            // Both levels are a one-byte tag, so the two shapes are one value
+            // on the wire and a handler could not tell them apart.
+            "anchor nested option",
+            r#"{ "instructions": [{
+                 "name": "swap",
+                 "discriminator": [1],
+                 "args": [{ "name": "maybe", "type": { "option": { "option": "u64" } } }]
+               }] }"#,
+        ),
+        (
+            // The decoder sizes its buffer from the declared length, not from
+            // the bytes on the wire, so this is an allocation before it is a
+            // decode failure.
+            "anchor array longer than the decoder will preallocate",
+            r#"{ "instructions": [{
+                 "name": "swap",
+                 "discriminator": [1],
+                 "args": [{ "name": "big", "type": { "array": ["u64", 70000] } }]
+               }] }"#,
+        ),
+        (
+            "codama nested option",
+            r#"{ "kind": "rootNode", "program": { "instructions": [{
+                 "kind": "instructionNode", "name": "swap",
+                 "arguments": [
+                   { "name": "maybe", "type": { "kind": "optionTypeNode", "item": {
+                       "kind": "optionTypeNode",
+                       "item": { "kind": "numberTypeNode", "format": "u64" } } } }] }] } }"#,
+        ),
+        (
+            "codama array longer than the decoder will preallocate",
+            r#"{ "kind": "rootNode", "program": { "instructions": [{
+                 "kind": "instructionNode", "name": "swap",
+                 "arguments": [
+                   { "name": "big", "type": { "kind": "arrayTypeNode",
+                       "item": { "kind": "numberTypeNode", "format": "u64" },
+                       "count": { "kind": "fixedCountNode", "value": 70000 } } }] }] } }"#,
+        ),
+        (
             "discriminator wider than dispatch probes",
             r#"{ "instructions": [{ "name": "swap", "discriminator": [1, 2, 3] }] }"#,
         ),
@@ -147,10 +186,10 @@ fn records_each_defect_against_what_carries_it() {
                                       "name": "tag", "offset": 0 }] }] } }"#,
         ),
         (
-            // A count is a number off the file, so the running total of
-            // argument widths is checked rather than trusted: unchecked it
-            // overflows and takes the CLI down with it.
-            "codama argument whose declared width overruns the address space",
+            // Counts are numbers off the file, and they nest, so the running
+            // total of argument widths is checked rather than trusted:
+            // unchecked it overflows and takes the CLI down with it.
+            "codama argument whose declared width overruns the discriminator",
             r#"{ "kind": "rootNode", "program": { "instructions": [{
                  "kind": "instructionNode", "name": "swap",
                  "arguments": [
@@ -158,9 +197,11 @@ fn records_each_defect_against_what_carries_it() {
                      "type": { "kind": "numberTypeNode", "format": "u8" } },
                    { "kind": "instructionArgumentNode", "name": "big",
                      "type": { "kind": "arrayTypeNode",
-                               "item": { "kind": "numberTypeNode", "format": "u8" },
+                               "item": { "kind": "arrayTypeNode",
+                                         "item": { "kind": "numberTypeNode", "format": "u8" },
+                                         "count": { "kind": "fixedCountNode", "value": 65536 } },
                                "count": { "kind": "fixedCountNode",
-                                          "value": 18446744073709551615 } } }],
+                                          "value": 65536 } } }],
                  "discriminators": [{ "kind": "constantDiscriminatorNode", "offset": 0,
                    "constant": { "value": { "kind": "bytesValueNode",
                                             "data": "0c02" } } }] }] } }"#,
@@ -296,6 +337,10 @@ fn records_each_defect_against_what_carries_it() {
             "duplicate instruction name: fatal: idl.json: IDL declares instruction 'swap' more than once",
             "anchor coption: initializeMint set aside: idl.json:1:20: args.freezeAuthority: `coption` is not Borsh-compatible and cannot be decoded",
             "unknown primitive type: swap set aside: idl.json:1:20: args.amount: unknown type 'u46'",
+            "anchor nested option: swap set aside: idl.json:1:20: args.maybe.option: a nested `option` decodes ambiguously and cannot be indexed",
+            "anchor array longer than the decoder will preallocate: swap set aside: idl.json:1:20: args.big.array: 70000 elements is more than the 65536 an array may declare",
+            "codama nested option: swap set aside: idl.json:1:53: args.maybe.item: a nested option decodes ambiguously and cannot be indexed",
+            "codama array longer than the decoder will preallocate: swap set aside: idl.json:1:53: args.big: 70000 elements is more than the 65536 an array may declare",
             "discriminator wider than dispatch probes: accepted",
             "instruction with no discriminator at all: accepted",
             "one discriminator a prefix of another: accepted",
@@ -308,7 +353,7 @@ fn records_each_defect_against_what_carries_it() {
             "one discriminator a prefix of several others: accepted",
             "instruction shadowed by one of an undispatchable width: accepted",
             "codama discriminator argument out of declaration order: swap set aside: idl.json:1:53: the 1-byte discriminator stops inside argument 'amount', which starts at byte 0 and is 8 bytes wide",
-            "codama argument whose declared width overruns the address space: swap set aside: idl.json:1:53: the 2-byte discriminator stops inside argument 'big', which starts at byte 1 and is 18446744073709551615 bytes wide",
+            "codama argument whose declared width overruns the discriminator: swap set aside: idl.json:1:53: the 2-byte discriminator stops inside argument 'big', which starts at byte 1 and is 4294967296 bytes wide",
             "duplicate type name: fatal: idl.json: IDL declares type 'Fee' more than once",
             "duplicate account name: swap set aside: idl.json:1:20: IDL declares account 'vault' more than once",
             "codama argument reusing a discriminator name: swap set aside: idl.json:1:53: IDL declares argument 'tag' more than once",

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -4027,7 +4027,7 @@ type Foo {
         fn rejects_an_overwrite_that_leaves_out_the_whole_layout() {
             let err = program_reading_idl(
                 LEGACY_ANCHOR_IDL,
-                "            - name: swap\n              discriminator: \"\"\n",
+                "            - name: swap\n              discriminator: \"0x\"\n",
             )
             .expect_err("missing the layout");
 
@@ -4044,7 +4044,7 @@ type Foo {
         fn an_overwrite_on_the_empty_prefix_is_program_wide() {
             let config = program_reading_idl(
                 LEGACY_ANCHOR_IDL,
-                "            - name: swap\n              discriminator: \"\"\n              \
+                "            - name: swap\n              discriminator: \"0x\"\n              \
                  accounts:\n                - source\n              args: []\n",
             )
             .expect("the empty prefix");
@@ -4232,7 +4232,7 @@ type Foo {
         fn a_row_the_idl_does_not_declare_needs_no_layout() {
             let config = program_reading_idl(
                 LEGACY_ANCHOR_IDL,
-                "            - name: anyCall\n              discriminator: \"\"\n",
+                "            - name: anyCall\n              discriminator: \"0x\"\n",
             )
             .expect("a row adding a name");
 
@@ -4263,7 +4263,7 @@ type Foo {
                        "accounts": [], "args": [{ "name": "amount", "type": { "coption": "u64" } }] },
                      { "name": "deposit", "discriminator": [4],
                        "accounts": [], "args": [] }] }"#,
-                "            - name: swap\n              discriminator: \"\"\n",
+                "            - name: swap\n              discriminator: \"0x\"\n",
             )
             .expect_err("a row on a set-aside name");
 

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -3895,22 +3895,21 @@ type Foo {
             );
         }
 
-        /// A YAML row next to `idl:` without `discriminator` is not an
-        /// allowlist and is not a program-wide overwrite.
+        /// A row on a name the IDL declares replaces it, so it says every
+        /// field. A name-only row leaves out all three.
         #[test]
-        fn rejects_a_yaml_row_next_to_idl_without_a_discriminator() {
+        fn rejects_a_name_only_row_shadowing_an_idl_instruction() {
             let err = program_reading_idl(LEGACY_ANCHOR_IDL, "            - name: swap\n")
-                .expect_err("missing discriminator");
+                .expect_err("missing every field");
 
             assert_eq!(
                 format!("{err:#}"),
-                "Program 'Pool', instruction 'swap': a YAML row next to 'idl' must set \
-                 'discriminator' to overwrite the IDL definition, or omit this row."
+                "Program 'Pool', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'discriminator', 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited."
             );
         }
 
         #[test]
-        fn rejects_an_idl_overwrite_that_sets_layout_without_a_discriminator() {
+        fn names_only_the_field_an_idl_overwrite_left_out() {
             let err = program_reading_idl(
                 LEGACY_ANCHOR_IDL,
                 "            - name: swap\n              accounts:\n                - source\n              \
@@ -3920,8 +3919,7 @@ type Foo {
 
             assert_eq!(
                 format!("{err:#}"),
-                "Program 'Pool', instruction 'swap': a YAML row next to 'idl' must set \
-                 'discriminator' to overwrite the IDL definition, or omit this row."
+                "Program 'Pool', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'discriminator': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited."
             );
         }
 
@@ -4078,8 +4076,30 @@ type Foo {
 
             assert_eq!(
                 format!("{err:#}"),
-                "Program 'Pool', instruction 'swap': set both 'accounts' and 'args' to \
-                 overwrite the IDL layout."
+                "Program 'Pool', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited."
+            );
+        }
+
+        /// The IDL has no name for this row, so it adds an instruction and is
+        /// read like an inline one: no discriminator matches every call.
+        #[test]
+        fn a_row_the_idl_does_not_declare_needs_no_fields() {
+            let config = program_reading_idl(LEGACY_ANCHOR_IDL, "            - name: anyCall\n")
+                .expect("a row adding a name");
+
+            assert_eq!(
+                svm_events(&config)
+                    .into_iter()
+                    .map(|(name, discriminator, _, _)| (name, discriminator))
+                    .collect::<Vec<_>>(),
+                vec![
+                    (
+                        "deposit".to_string(),
+                        Some("0xf223c68952e1f2b6".to_string())
+                    ),
+                    ("swap".to_string(), Some("0xf8c69e91e17587c8".to_string())),
+                    ("anyCall".to_string(), None),
+                ]
             );
         }
 

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -4021,12 +4021,15 @@ type Foo {
         }
 
         /// A row on a name the IDL declares replaces it, so it says the
-        /// fields that would otherwise read as absent. A name-only row leaves
-        /// out both.
+        /// fields that would otherwise read as absent rather than as the
+        /// IDL's. This one leaves out both.
         #[test]
-        fn rejects_a_name_only_row_shadowing_an_idl_instruction() {
-            let err = program_reading_idl(LEGACY_ANCHOR_IDL, "            - name: swap\n")
-                .expect_err("missing every field");
+        fn rejects_an_overwrite_that_leaves_out_the_whole_layout() {
+            let err = program_reading_idl(
+                LEGACY_ANCHOR_IDL,
+                "            - name: swap\n              discriminator: \"\"\n",
+            )
+            .expect_err("missing the layout");
 
             assert_eq!(
                 format!("{err:#}"),
@@ -4034,17 +4037,17 @@ type Foo {
             );
         }
 
-        /// An overwrite says what a row on any other name says: a missing
-        /// `discriminator` is a program-wide match, here replacing the prefix
-        /// the IDL declared for the name.
+        /// An overwrite says what a row on any other name says: the empty
+        /// prefix is a program-wide match, here replacing the prefix the IDL
+        /// declared for the name.
         #[test]
-        fn an_overwrite_without_a_discriminator_is_program_wide() {
+        fn an_overwrite_on_the_empty_prefix_is_program_wide() {
             let config = program_reading_idl(
                 LEGACY_ANCHOR_IDL,
-                "            - name: swap\n              accounts:\n                - source\n              \
-                 args: []\n",
+                "            - name: swap\n              discriminator: \"\"\n              \
+                 accounts:\n                - source\n              args: []\n",
             )
-            .expect("layout without discriminator");
+            .expect("the empty prefix");
 
             assert_eq!(
                 svm_events(&config),
@@ -4223,11 +4226,15 @@ type Foo {
         }
 
         /// The IDL has no name for this row, so it adds an instruction and is
-        /// read like an inline one: no discriminator matches every call.
+        /// read like an inline one: the empty prefix matches every call, and
+        /// the layout is the row's own business.
         #[test]
-        fn a_row_the_idl_does_not_declare_needs_no_fields() {
-            let config = program_reading_idl(LEGACY_ANCHOR_IDL, "            - name: anyCall\n")
-                .expect("a row adding a name");
+        fn a_row_the_idl_does_not_declare_needs_no_layout() {
+            let config = program_reading_idl(
+                LEGACY_ANCHOR_IDL,
+                "            - name: anyCall\n              discriminator: \"\"\n",
+            )
+            .expect("a row adding a name");
 
             assert_eq!(
                 svm_events(&config)
@@ -4249,14 +4256,14 @@ type Foo {
         /// overwrite: the IDL has a definition for it, and the reason it was
         /// set aside is what the row has to answer.
         #[test]
-        fn rejects_a_name_only_row_on_an_unusable_idl_instruction() {
+        fn rejects_an_overwrite_of_an_unusable_idl_instruction() {
             let err = program_reading_idl(
                 r#"{ "instructions": [
                      { "name": "swap", "discriminator": [1],
                        "accounts": [], "args": [{ "name": "amount", "type": { "coption": "u64" } }] },
                      { "name": "deposit", "discriminator": [4],
                        "accounts": [], "args": [] }] }"#,
-                "            - name: swap\n",
+                "            - name: swap\n              discriminator: \"\"\n",
             )
             .expect_err("a row on a set-aside name");
 

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -2063,12 +2063,17 @@ impl Contract {
         abi: Abi,
     ) -> Result<Self> {
         // Every ecosystem builds its contracts through here, unlike
-        // `validate_deserialized_config_yaml`, which only sees EVM configs.
-        validate_names_valid_rescript(std::slice::from_ref(&name), "contract".to_string())?;
-        validate_names_valid_rescript(
-            &events.iter().map(|e| e.name.clone()).collect::<Vec<_>>(),
-            "event".to_string(),
-        )?;
+        // `validate_deserialized_config_yaml`, which only sees EVM configs. Svm
+        // is the exception: it generates no ReScript, and its program and
+        // instruction names are held to the identifier rule in
+        // `validation::validate_deserialized_svm_config_yaml` instead.
+        if !matches!(abi, Abi::Svm(_)) {
+            validate_names_valid_rescript(std::slice::from_ref(&name), "contract".to_string())?;
+            validate_names_valid_rescript(
+                &events.iter().map(|e| e.name.clone()).collect::<Vec<_>>(),
+                "event".to_string(),
+            )?;
+        }
 
         // Codegen keys the generated event modules by name and routing looks
         // events up by name, so two events on one contract can't share a name.

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -3796,6 +3796,19 @@ type Foo {
                 .collect()
         }
 
+        /// The error a row on an IDL-declared name gets when it leaves fields
+        /// out, as one string so a wording change is one edit.
+        fn overwrite_error(instruction: &str, why: &str, spell_out: &str) -> String {
+            format!(
+                "Program 'Pool', instruction '{instruction}': {why}. Spell out {spell_out}: an \
+                 overwrite takes nothing from the IDL, so a field left out here is absent, not \
+                 inherited."
+            )
+        }
+
+        const DECLARED: &str = "the IDL declares this instruction too, so this row replaces it \
+                                rather than adding to the catalog";
+
         const LEGACY_ANCHOR_IDL: &str = r#"{
           "version": "0.1.0",
           "name": "pool",
@@ -3904,7 +3917,7 @@ type Foo {
 
             assert_eq!(
                 format!("{err:#}"),
-                "Program 'Pool', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'discriminator', 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited."
+                overwrite_error("swap", DECLARED, "'discriminator', 'accounts' and 'args'")
             );
         }
 
@@ -3919,7 +3932,7 @@ type Foo {
 
             assert_eq!(
                 format!("{err:#}"),
-                "Program 'Pool', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'discriminator': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited."
+                overwrite_error("swap", DECLARED, "'discriminator'")
             );
         }
 
@@ -4076,7 +4089,7 @@ type Foo {
 
             assert_eq!(
                 format!("{err:#}"),
-                "Program 'Pool', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited."
+                overwrite_error("swap", DECLARED, "'accounts' and 'args'")
             );
         }
 
@@ -4100,6 +4113,33 @@ type Foo {
                     ("swap".to_string(), Some("0xf8c69e91e17587c8".to_string())),
                     ("anyCall".to_string(), None),
                 ]
+            );
+        }
+
+        /// A row on a name the IDL declares but could not use is still an
+        /// overwrite: the IDL has a definition for it, and the reason it was
+        /// set aside is what the row has to answer.
+        #[test]
+        fn rejects_a_name_only_row_on_an_unusable_idl_instruction() {
+            let err = program_reading_idl(
+                r#"{ "instructions": [
+                     { "name": "swap", "discriminator": [1],
+                       "accounts": [], "args": [{ "name": "amount", "type": { "coption": "u64" } }] },
+                     { "name": "deposit", "discriminator": [4],
+                       "accounts": [], "args": [] }] }"#,
+                "            - name: swap\n",
+            )
+            .expect_err("a row on a set-aside name");
+
+            assert_eq!(
+                format!("{err:#}"),
+                overwrite_error(
+                    "swap",
+                    "the IDL declares this instruction too, but it cannot be indexed as declared: \
+                     idls/pool.json:2:22: args.amount: `coption` is not Borsh-compatible and \
+                     cannot be decoded",
+                    "'discriminator', 'accounts' and 'args'"
+                )
             );
         }
 

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -2174,9 +2174,12 @@ pub struct SvmEventKind {
     /// Positional account slots in declared order. Empty when the user supplied
     /// no schema and no IDL applies; in that case `decoded.accounts` is `{}`.
     pub accounts: Vec<human_config::svm::AccountSlot>,
-    /// Borsh argument layout in declared order. Empty for unknown
-    /// instructions; the raw `instruction.data` is still available.
-    pub args: Vec<SvmNamedField>,
+    /// Borsh argument layout in declared order. `None` when no layout is
+    /// attached, so nothing is decoded and every matched call is delivered
+    /// with `instruction.data` raw. `Some` filters: a call whose data the
+    /// layout rejects is skipped, and an empty layout takes only the calls
+    /// carrying nothing past the discriminator.
+    pub args: Option<Vec<SvmNamedField>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -3776,8 +3779,9 @@ type Foo {
             )
         }
 
-        /// Name, discriminator, account slots as YAML tokens, arg names.
-        type SvmEvent = (String, Option<String>, Vec<String>, Vec<String>);
+        /// Name, discriminator, account slots as YAML tokens, and the arg
+        /// names of the attached layout — `None` where none is attached.
+        type SvmEvent = (String, Option<String>, Vec<String>, Option<Vec<String>>);
 
         fn svm_events(config: &SystemConfig) -> Vec<SvmEvent> {
             config
@@ -3789,7 +3793,9 @@ type Foo {
                         e.name.clone(),
                         k.discriminator.clone(),
                         k.accounts.iter().map(ToString::to_string).collect(),
-                        k.args.iter().map(|a| a.name.clone()).collect(),
+                        k.args
+                            .as_ref()
+                            .map(|args| args.iter().map(|a| a.name.clone()).collect()),
                     ),
                     other => panic!("expected an Svm event kind, got {other:?}"),
                 })
@@ -3882,13 +3888,13 @@ type Foo {
                         "deposit".to_string(),
                         Some("0xf223c68952e1f2b6".to_string()),
                         vec!["vault".to_string()],
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                     (
                         "swap".to_string(),
                         Some("0xf8c69e91e17587c8".to_string()),
                         vec!["payer".to_string(), "pool".to_string()],
-                        vec!["amount".to_string()],
+                        Some(vec!["amount".to_string()]),
                     ),
                 ]
             );
@@ -3904,7 +3910,7 @@ type Foo {
 
             assert_eq!(
                 svm_events(&config),
-                vec![("swap".to_string(), None, Vec::new(), Vec::new(),)]
+                vec![("swap".to_string(), None, Vec::new(), Some(Vec::new()),)]
             );
         }
 
@@ -4056,13 +4062,13 @@ type Foo {
                         "deposit".to_string(),
                         Some("0xf223c68952e1f2b6".to_string()),
                         vec!["vault".to_string()],
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                     (
                         "swap".to_string(),
                         None,
                         vec!["source".to_string()],
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                 ]
             );
@@ -4093,19 +4099,19 @@ type Foo {
                         "deposit".to_string(),
                         Some("0x02".to_string()),
                         vec!["vault".to_string()],
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                     (
                         "swap".to_string(),
                         Some("0x09".to_string()),
                         vec!["source".to_string(), "dest".to_string()],
-                        vec!["amountIn".to_string()],
+                        Some(vec!["amountIn".to_string()]),
                     ),
                     (
                         "extra".to_string(),
                         Some("0xab".to_string()),
                         vec!["payer".to_string()],
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                 ]
             );
@@ -4134,13 +4140,13 @@ type Foo {
                         "deposit".to_string(),
                         Some("0x02".to_string()),
                         vec!["vault".to_string()],
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                     (
                         "swap".to_string(),
                         Some("0x09".to_string()),
                         vec!["source".to_string()],
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                 ]
             );
@@ -4164,13 +4170,13 @@ type Foo {
                         "deposit".to_string(),
                         Some("0xf223c68952e1f2b6".to_string()),
                         vec!["vault".to_string()],
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                     (
                         "swap".to_string(),
                         Some("0xf8c69e91e17587c8".to_string()),
                         vec!["payer".to_string(), "pool".to_string()],
-                        vec!["amount".to_string()],
+                        Some(vec!["amount".to_string()]),
                     ),
                 ]
             );
@@ -4199,13 +4205,13 @@ type Foo {
                         "deposit".to_string(),
                         Some("0x09".to_string()),
                         vec!["vault".to_string()],
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                     (
                         "swap".to_string(),
                         Some("0xdeadbeefdeadbeef".to_string()),
                         Vec::new(),
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                 ]
             );
@@ -4298,7 +4304,7 @@ type Foo {
                     "deposit".to_string(),
                     Some("0x04".to_string()),
                     Vec::new(),
-                    Vec::new(),
+                    Some(Vec::new()),
                 )]
             );
         }
@@ -4338,7 +4344,7 @@ type Foo {
                     "transfer".to_string(),
                     Some("0x03".to_string()),
                     vec!["source".to_string(), "destination".to_string()],
-                    vec!["amount".to_string()],
+                    Some(vec!["amount".to_string()]),
                 )]
             );
         }
@@ -4362,7 +4368,15 @@ type Foo {
                 .into_iter()
                 .filter(|(_, discriminator, ..)| discriminator.is_some())
                 .map(|(name, discriminator, accounts, args)| {
-                    (name, discriminator.unwrap(), accounts.len(), args.len())
+                    // `None` where the row attached no layout at all: the Orca
+                    // and Meteora swaps take every call and leave the payload
+                    // raw, which an empty layout would not do.
+                    (
+                        name,
+                        discriminator.unwrap(),
+                        accounts.len(),
+                        args.map(|a| a.len()),
+                    )
                 })
                 .collect();
 
@@ -4396,40 +4410,60 @@ type Foo {
                             "borrowObligationLiquidity".into(),
                             "0x797f12cc49f5e141".into(),
                             12,
-                            1
+                            Some(1)
                         ),
                         (
                             "depositReserveLiquidityAndObligationCollateral".into(),
                             "0x81c70402de271a2e".into(),
                             14,
-                            1
+                            Some(1)
                         ),
-                        ("fillPerpOrder".into(), "0x0dbcf86786d96af0".into(), 6, 2),
-                        ("liquidatePerp".into(), "0x4b2377f7bf128b02".into(), 6, 3),
-                        ("liquidateSpot".into(), "0x6b00802923e5fb12".into(), 6, 4),
-                        ("placePerpOrder".into(), "0x45a15dca787e4cb9".into(), 3, 1),
+                        (
+                            "fillPerpOrder".into(),
+                            "0x0dbcf86786d96af0".into(),
+                            6,
+                            Some(2)
+                        ),
+                        (
+                            "liquidatePerp".into(),
+                            "0x4b2377f7bf128b02".into(),
+                            6,
+                            Some(3)
+                        ),
+                        (
+                            "liquidateSpot".into(),
+                            "0x6b00802923e5fb12".into(),
+                            6,
+                            Some(4)
+                        ),
+                        (
+                            "placePerpOrder".into(),
+                            "0x45a15dca787e4cb9".into(),
+                            3,
+                            Some(1)
+                        ),
                         (
                             "repayObligationLiquidity".into(),
                             "0x91b20de14cf09348".into(),
                             9,
-                            1
+                            Some(1)
                         ),
-                        ("route".into(), "0xe517cb977ae3ad2a".into(), 9, 5),
-                        ("settlePnl".into(), "0x2b3dea2d0f5f9899".into(), 4, 1),
+                        ("route".into(), "0xe517cb977ae3ad2a".into(), 9, Some(5)),
+                        ("settlePnl".into(), "0x2b3dea2d0f5f9899".into(), 4, Some(1)),
                         (
                             "sharedAccountsRoute".into(),
                             "0xc1209b3341d69c81".into(),
                             13,
-                            6
+                            Some(6)
                         ),
-                        ("swap".into(), "0x09".into(), 18, 2),
-                        ("swap".into(), "0xf8c69e91e17587c8".into(), 0, 0),
-                        ("swap".into(), "0xf8c69e91e17587c8".into(), 0, 0),
+                        ("swap".into(), "0x09".into(), 18, Some(2)),
+                        ("swap".into(), "0xf8c69e91e17587c8".into(), 0, None),
+                        ("swap".into(), "0xf8c69e91e17587c8".into(), 0, None),
                         (
                             "withdrawObligationCollateralAndRedeemReserveCollateral".into(),
                             "0x4b5d5ddc2296dac4".into(),
                             14,
-                            1
+                            Some(1)
                         ),
                     ]
                 )
@@ -4454,13 +4488,13 @@ type Foo {
                         "swap".to_string(),
                         Some("0x01".to_string()),
                         Vec::new(),
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                     (
                         "wide".to_string(),
                         Some("0x090909".to_string()),
                         Vec::new(),
-                        Vec::new(),
+                        Some(Vec::new()),
                     ),
                 ]
             );

--- a/packages/cli/src/config_parsing/validation.rs
+++ b/packages/cli/src/config_parsing/validation.rs
@@ -202,10 +202,11 @@ pub fn is_valid_solana_pubkey(s: &str) -> bool {
 
 pub fn validate_svm_discriminator(s: &str) -> anyhow::Result<()> {
     let hex = crate::hex::strip_prefix(s).unwrap_or(s);
-    if hex.is_empty() || !hex.len().is_multiple_of(2) {
+    if !hex.len().is_multiple_of(2) {
         return Err(anyhow!(
-            "discriminator {:?} must be a whole number of bytes (an even, non-zero count of hex \
-             digits after stripping a `0x` prefix), got {} digits",
+            "discriminator {:?} must be a whole number of bytes (an even count of hex digits \
+             after stripping a `0x` prefix), got {} digits. Write \"\" to match every \
+             instruction of the program.",
             s,
             hex.len()
         ));
@@ -367,11 +368,9 @@ pub fn validate_deserialized_svm_config_yaml(
                         instr.name
                     ));
                 }
-                if let Some(discriminator) = &instr.discriminator {
-                    validate_svm_discriminator(discriminator).with_context(|| {
-                        format!("instruction {:?} in program {:?}", instr.name, program.name)
-                    })?;
-                }
+                validate_svm_discriminator(&instr.discriminator).with_context(|| {
+                    format!("instruction {:?} in program {:?}", instr.name, program.name)
+                })?;
             }
         }
     }
@@ -657,10 +656,22 @@ mod tests {
 
         #[test]
         fn discriminator_rejects_partial_bytes_and_non_hex() {
-            for s in ["0x", "0x0", "0x012", "0xgggggggg"] {
+            for s in ["0x0", "0x012", "0xgggggggg"] {
                 assert!(
                     validate_svm_discriminator(s).is_err(),
                     "expected {s:?} to be rejected"
+                );
+            }
+        }
+
+        /// The empty prefix is what every call carries, so it is the value a
+        /// row gives to match every instruction of the program.
+        #[test]
+        fn discriminator_accepts_the_empty_prefix() {
+            for s in ["", "0x"] {
+                assert!(
+                    validate_svm_discriminator(s).is_ok(),
+                    "expected {s:?} to be accepted"
                 );
             }
         }

--- a/packages/cli/src/config_parsing/validation.rs
+++ b/packages/cli/src/config_parsing/validation.rs
@@ -201,12 +201,19 @@ pub fn is_valid_solana_pubkey(s: &str) -> bool {
 }
 
 pub fn validate_svm_discriminator(s: &str) -> anyhow::Result<()> {
-    let hex = crate::hex::strip_prefix(s).unwrap_or(s);
+    // The prefix is what a handler reads back, so a config that carries it too
+    // compares equal to `instruction.discriminator` rather than off by "0x".
+    let Some(hex) = crate::hex::strip_prefix(s) else {
+        return Err(anyhow!(
+            "discriminator {s:?} must be written as 0x-prefixed hex. Write \"0x\" to match every \
+             instruction of the program"
+        ));
+    };
     if !hex.len().is_multiple_of(2) {
         return Err(anyhow!(
             "discriminator {:?} must be a whole number of bytes (an even count of hex digits \
-             after stripping a `0x` prefix), got {} digits. Write \"\" to match every \
-             instruction of the program.",
+             after the `0x` prefix), got {} digits. Write \"0x\" to match every instruction of \
+             the program.",
             s,
             hex.len()
         ));
@@ -650,13 +657,13 @@ mod tests {
                     "expected {s:?} to be valid"
                 );
             }
-            // Prefix is optional.
-            assert!(validate_svm_discriminator("0f").is_ok());
+            // Either spelling of the prefix, read the same way.
+            assert!(validate_svm_discriminator("0X0f").is_ok());
         }
 
         #[test]
-        fn discriminator_rejects_partial_bytes_and_non_hex() {
-            for s in ["0x0", "0x012", "0xgggggggg"] {
+        fn discriminator_rejects_anything_but_prefixed_whole_bytes() {
+            for s in ["", "21", "0x0", "0x012", "0xgggggggg"] {
                 assert!(
                     validate_svm_discriminator(s).is_err(),
                     "expected {s:?} to be rejected"
@@ -665,10 +672,12 @@ mod tests {
         }
 
         /// The empty prefix is what every call carries, so it is the value a
-        /// row gives to match every instruction of the program.
+        /// row gives to match every instruction of the program. It is spelled
+        /// the way every other value is, so there is one spelling and it is
+        /// the one a handler reads back for a zero-byte key.
         #[test]
         fn discriminator_accepts_the_empty_prefix() {
-            for s in ["", "0x"] {
+            for s in ["0x", "0X"] {
                 assert!(
                     validate_svm_discriminator(s).is_ok(),
                     "expected {s:?} to be accepted"

--- a/packages/cli/src/config_parsing/validation.rs
+++ b/packages/cli/src/config_parsing/validation.rs
@@ -1,4 +1,5 @@
 // use super::chain_helpers;
+use super::human_config::svm::{ArgDef, ArgType};
 use super::human_config::{self, evm::HumanConfig};
 use crate::constants::reserved_keywords::RESERVED_NAMES;
 use anyhow::{anyhow, Context};
@@ -215,6 +216,127 @@ pub fn validate_svm_discriminator(s: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Every name a config.yaml gives an Svm program, instruction, account or arg
+/// becomes a property of the generated types, so they are held to one rule.
+/// Unlike EVM and Fuel, none of them reaches generated ReScript, so the
+/// reserved-word list does not apply.
+fn validate_svm_name(name: &str, what: &str) -> anyhow::Result<()> {
+    if is_valid_identifier(name) {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "{what} must be an identifier: letters, digits and underscores only, not starting with a \
+         digit, got '{name}'"
+    ))
+}
+
+/// One instruction's positional account names, as a config.yaml row wrote them.
+pub fn validate_svm_accounts(accounts: &[String]) -> anyhow::Result<()> {
+    let mut seen = std::collections::HashSet::new();
+    for name in accounts {
+        validate_svm_name(name, "an account name").context("accounts")?;
+        if !seen.insert(name.as_str()) {
+            return Err(anyhow!("accounts: '{name}' is declared more than once"));
+        }
+    }
+    Ok(())
+}
+
+/// One instruction's Borsh args, as a config.yaml row wrote them. Every defect
+/// here would otherwise reach the decoder, which answers a layout it cannot
+/// walk by dropping the instruction — so a config that can never decode must
+/// not get past parsing. IDL-declared args come with their own checks in
+/// `svm_idl`, which set the instruction aside with a reason instead.
+pub fn validate_svm_args(args: &[ArgDef]) -> anyhow::Result<()> {
+    validate_svm_named_fields(args, "an arg name", "args")
+}
+
+fn validate_svm_named_fields(fields: &[ArgDef], what: &str, path: &str) -> anyhow::Result<()> {
+    let mut seen = std::collections::HashSet::new();
+    for field in fields {
+        validate_svm_name(&field.name, what).with_context(|| path.to_string())?;
+        if !seen.insert(field.name.as_str()) {
+            return Err(anyhow!(
+                "{path}: '{}' is declared more than once",
+                field.name
+            ));
+        }
+    }
+    for field in fields {
+        validate_svm_arg_type(&field.ty, &format!("{path}.{}", field.name))?;
+    }
+    Ok(())
+}
+
+fn validate_svm_arg_type(ty: &ArgType, path: &str) -> anyhow::Result<()> {
+    use super::human_config::svm::{ArgComposite as C, MAX_ARRAY_LEN, MAX_ENUM_VARIANTS};
+    let ArgType::Composite(composite) = ty else {
+        return Ok(());
+    };
+    match composite {
+        C::Defined(_) => Err(anyhow!(
+            "{path}: 'defined' is not supported in config.yaml: declare the type inline with \
+             'struct' or 'enum', or take the instruction from an 'idl'"
+        )),
+        C::Option(inner) => {
+            let path = format!("{path}.option");
+            if matches!(**inner, ArgType::Composite(C::Option(_))) {
+                return Err(anyhow!(
+                    "{path}: a nested 'option' is not supported: Borsh tags each level with one \
+                     byte, so Some(None) and None would decode the same"
+                ));
+            }
+            validate_svm_arg_type(inner, &path)
+        }
+        C::Vec(inner) => validate_svm_arg_type(inner, &format!("{path}.vec")),
+        C::Array(inner, len) => {
+            let path = format!("{path}.array");
+            if *len > MAX_ARRAY_LEN {
+                return Err(anyhow!(
+                    "{path}: {len} elements is more than the {MAX_ARRAY_LEN} an array may declare"
+                ));
+            }
+            validate_svm_arg_type(inner, &path)
+        }
+        C::Struct(fields) => {
+            validate_svm_named_fields(fields, "a field name", &format!("{path}.struct"))
+        }
+        C::Enum(variants) => {
+            let path = format!("{path}.enum");
+            if variants.is_empty() {
+                return Err(anyhow!("{path}: an enum needs at least one variant"));
+            }
+            if variants.len() > MAX_ENUM_VARIANTS {
+                return Err(anyhow!(
+                    "{path}: {} variants is more than the {MAX_ENUM_VARIANTS} a one-byte Borsh \
+                     tag can address",
+                    variants.len()
+                ));
+            }
+            let mut seen = std::collections::HashSet::new();
+            for variant in variants {
+                validate_svm_name(&variant.name, "a variant name").with_context(|| path.clone())?;
+                if !seen.insert(variant.name.as_str()) {
+                    return Err(anyhow!(
+                        "{path}: '{}' is declared more than once",
+                        variant.name
+                    ));
+                }
+            }
+            for variant in variants {
+                if let Some(fields) = &variant.fields {
+                    validate_svm_named_fields(
+                        fields,
+                        "a field name",
+                        &format!("{path}.{}", variant.name),
+                    )?;
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
 pub fn validate_deserialized_svm_config_yaml(
     svm_config: &super::human_config::svm::HumanConfig,
 ) -> anyhow::Result<()> {
@@ -234,6 +356,7 @@ pub fn validate_deserialized_svm_config_yaml(
             .map(|e| e.programs.as_slice())
             .unwrap_or(&[]);
         for program in programs {
+            validate_svm_name(&program.name, "a program name")?;
             if !is_valid_solana_pubkey(&program.program_id) {
                 return Err(anyhow!(
                     "Program {:?} has an invalid program_id {:?}: must be a base58-encoded \
@@ -246,6 +369,8 @@ pub fn validate_deserialized_svm_config_yaml(
 
             let mut instruction_names = std::collections::HashSet::new();
             for instr in &program.instructions {
+                validate_svm_name(&instr.name, "an instruction name")
+                    .with_context(|| format!("Program '{}'", program.name))?;
                 if !instruction_names.insert(instr.name.clone()) {
                     return Err(anyhow!(
                         "Program {:?} declares the instruction {:?} more than once",
@@ -268,7 +393,6 @@ pub fn validate_deserialized_svm_config_yaml(
              and are case-insensitive."
         ));
     }
-    validate_names_valid_rescript(&all_program_names, "program".to_string())?;
 
     Ok(())
 }

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -2292,21 +2292,22 @@ type testIndexer = {{
                             EventKind::Svm(k) => k,
                             _ => continue,
                         };
-                        // No declared args means nothing to decode; registration
+                        // No declared layout means nothing to decode; registration
                         // rejects selecting the field, and `never` keeps a
-                        // handler from reading it as an object.
-                        let args_ts = if svm_kind.args.is_empty() {
-                            "never".to_string()
-                        } else {
-                            let fields = svm_kind
-                                .args
-                                .iter()
-                                .map(|f| {
-                                    ts_svm_field(f, &svm_abi.idl.defined_types, &mut Vec::new())
-                                })
-                                .collect::<Vec<_>>()
-                                .join("; ");
-                            format!("{{ {fields} }}")
+                        // handler from reading it as an object. A declared but
+                        // empty one decodes to `{}`, which is selectable.
+                        let args_ts = match &svm_kind.args {
+                            None => "never".to_string(),
+                            Some(args) => {
+                                let fields = args
+                                    .iter()
+                                    .map(|f| {
+                                        ts_svm_field(f, &svm_abi.idl.defined_types, &mut Vec::new())
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("; ");
+                                format!("{{ {fields} }}")
+                            }
                         };
                         let accounts_ts = if svm_kind.accounts.is_empty() {
                             "Readonly<Record<string, string>>".to_string()

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -2322,17 +2322,17 @@ type testIndexer = {{
                             format!("{{ {fields} }}")
                         };
                         instruction_entries.push(format!(
-                            "          \"{instr}\": {{ readonly args: {args}; readonly accounts: \
+                            "          {instr}: {{ readonly args: {args}; readonly accounts: \
                              {accs} }};",
-                            instr = event.name,
+                            instr = ts_string_literal(&event.name),
                             args = args_ts,
                             accs = accounts_ts,
                         ));
                     }
                     if !instruction_entries.is_empty() {
                         program_entries.push(format!(
-                            "        \"{name}\": {{\n{body}\n        }};",
-                            name = contract.name,
+                            "        {name}: {{\n{body}\n        }};",
+                            name = ts_string_literal(&contract.name),
                             body = instruction_entries.join("\n"),
                         ));
                     }
@@ -2569,10 +2569,9 @@ struct ConfigBodies<'a> {
 /// `Defined("Name")`. `seen` tracks the recursion stack to break cycles.
 ///
 /// Locked conventions:
-/// - sub-64-bit integers → `number`
+/// - sub-64-bit integers / floats → `number`
 /// - 64-/128-bit integers → `bigint`
 /// - pubkey → `string` (base58)
-/// - `f32`/`f64` → `number | null`, since a non-finite float decodes to null
 /// - Borsh `bytes`, `vec<u8>`, `[u8; N]` → `Uint8Array`
 /// - `vec<T>` → `readonly T[]`; `[T; N]` → a readonly N-tuple
 /// - enum variant without fields → its name as a string literal; with fields
@@ -2585,10 +2584,7 @@ fn field_type_to_ts_type(
     use hypersync_client_solana::decode::FieldType as F;
     match ty {
         F::Bool => "boolean".to_string(),
-        F::U8 | F::U16 | F::U32 | F::I8 | F::I16 | F::I32 => "number".to_string(),
-        // Any 4 or 8 bytes are a float, NaN and the infinities included, and
-        // none of those survives the decoder's JSON hop — they arrive as null.
-        F::F32 | F::F64 => "number | null".to_string(),
+        F::U8 | F::U16 | F::U32 | F::I8 | F::I16 | F::I32 | F::F32 | F::F64 => "number".to_string(),
         F::U64 | F::U128 | F::I64 | F::I128 => "bigint".to_string(),
         F::String | F::Pubkey => "string".to_string(),
         F::Bytes => "Uint8Array".to_string(),
@@ -2735,8 +2731,12 @@ fn ts_safe_property_name(name: &str) -> String {
     }
 }
 
+/// JSON's string grammar is a subset of TypeScript's, so serde does the
+/// escaping. An IDL is a file the program's authors wrote, and its names are
+/// held to no identifier rule: a quote would end the literal early, and a
+/// control character would break the line it sits on.
 fn ts_string_literal(value: &str) -> String {
-    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+    serde_json::to_string(value).expect("a string always serializes")
 }
 
 #[cfg(test)]
@@ -3710,27 +3710,6 @@ type GlobalCounter @crossChain {
                 "/** 8 bytes */ readonly seed: (Uint8Array) | null",
                 "readonly payload: Uint8Array",
                 "readonly amount: bigint",
-            ]
-        );
-    }
-
-    // Any 4 or 8 bytes are a float, and the decoder renders a non-finite one
-    // as null rather than panicking, so the type has to admit it.
-    #[test]
-    fn svm_floats_render_as_nullable_numbers() {
-        use hypersync_client_solana::decode::FieldType;
-        let rendered = [
-            FieldType::F32,
-            FieldType::F64,
-            FieldType::Vec(Box::new(FieldType::F64)),
-        ]
-        .map(|ty| field_type_to_ts_type(&ty, &Default::default(), &mut vec![]));
-        assert_eq!(
-            rendered,
-            [
-                "number | null",
-                "number | null",
-                "readonly (number | null)[]"
             ]
         );
     }

--- a/packages/cli/src/hbs_templating/codegen_templates.rs
+++ b/packages/cli/src/hbs_templating/codegen_templates.rs
@@ -2569,9 +2569,10 @@ struct ConfigBodies<'a> {
 /// `Defined("Name")`. `seen` tracks the recursion stack to break cycles.
 ///
 /// Locked conventions:
-/// - sub-64-bit integers / floats → `number`
+/// - sub-64-bit integers → `number`
 /// - 64-/128-bit integers → `bigint`
 /// - pubkey → `string` (base58)
+/// - `f32`/`f64` → `number | null`, since a non-finite float decodes to null
 /// - Borsh `bytes`, `vec<u8>`, `[u8; N]` → `Uint8Array`
 /// - `vec<T>` → `readonly T[]`; `[T; N]` → a readonly N-tuple
 /// - enum variant without fields → its name as a string literal; with fields
@@ -2584,7 +2585,10 @@ fn field_type_to_ts_type(
     use hypersync_client_solana::decode::FieldType as F;
     match ty {
         F::Bool => "boolean".to_string(),
-        F::U8 | F::U16 | F::U32 | F::I8 | F::I16 | F::I32 | F::F32 | F::F64 => "number".to_string(),
+        F::U8 | F::U16 | F::U32 | F::I8 | F::I16 | F::I32 => "number".to_string(),
+        // Any 4 or 8 bytes are a float, NaN and the infinities included, and
+        // none of those survives the decoder's JSON hop — they arrive as null.
+        F::F32 | F::F64 => "number | null".to_string(),
         F::U64 | F::U128 | F::I64 | F::I128 => "bigint".to_string(),
         F::String | F::Pubkey => "string".to_string(),
         F::Bytes => "Uint8Array".to_string(),
@@ -3706,6 +3710,27 @@ type GlobalCounter @crossChain {
                 "/** 8 bytes */ readonly seed: (Uint8Array) | null",
                 "readonly payload: Uint8Array",
                 "readonly amount: bigint",
+            ]
+        );
+    }
+
+    // Any 4 or 8 bytes are a float, and the decoder renders a non-finite one
+    // as null rather than panicking, so the type has to admit it.
+    #[test]
+    fn svm_floats_render_as_nullable_numbers() {
+        use hypersync_client_solana::decode::FieldType;
+        let rendered = [
+            FieldType::F32,
+            FieldType::F64,
+            FieldType::Vec(Box::new(FieldType::F64)),
+        ]
+        .map(|ty| field_type_to_ts_type(&ty, &Default::default(), &mut vec![]));
+        assert_eq!(
+            rendered,
+            [
+                "number | null",
+                "number | null",
+                "readonly (number | null)[]"
             ]
         );
     }

--- a/packages/cli/src/svm_hypersync_source/borsh_decoder.rs
+++ b/packages/cli/src/svm_hypersync_source/borsh_decoder.rs
@@ -131,12 +131,16 @@ fn value_to_param(
         | SvmFieldType::U32
         | SvmFieldType::I8
         | SvmFieldType::I16
-        | SvmFieldType::I32 => ParamValue::Num(value.as_f64()?),
-        // The upstream decoder renders a non-finite float as `Null`.
-        SvmFieldType::F32 | SvmFieldType::F64 => match value {
-            Value::Null => ParamValue::Null,
-            value => ParamValue::Num(value.as_f64()?),
-        },
+        | SvmFieldType::I32
+        // Borsh refuses to serialize a NaN, so one on the wire says the bytes
+        // are not the float this layout claims and the instruction is dropped
+        // like any other layout mismatch. The upstream decoder renders every
+        // non-finite float as `Null`, which `as_f64` rejects; that takes a
+        // legitimate infinity with it, which no Solana program is known to
+        // send. Behind an `option` the ambiguity is unreachable: `None` is
+        // `Null` too, and there a non-finite float reads as absent.
+        | SvmFieldType::F32
+        | SvmFieldType::F64 => ParamValue::Num(value.as_f64()?),
         SvmFieldType::U64 | SvmFieldType::U128 => {
             ParamValue::from_u128(value.as_str()?.parse().ok()?)
         }
@@ -404,6 +408,24 @@ mod tests {
         assert_eq!(
             schema.decode(&data),
             Some(obj(vec![("text", ParamValue::Str("hello".to_string()))]))
+        );
+    }
+
+    #[test]
+    fn a_non_finite_float_is_rejected() {
+        let schema = schema_of(r#"[{"name":"ratio","type":"f64"}]"#, "{}");
+        let payload = |bits: f64| {
+            let mut data = vec![0x01];
+            data.extend_from_slice(&bits.to_le_bytes());
+            data
+        };
+        assert_eq!(
+            (
+                schema.decode(&payload(f64::NAN)),
+                schema.decode(&payload(f64::INFINITY)),
+                schema.decode(&payload(1.5)),
+            ),
+            (None, None, Some(obj(vec![("ratio", ParamValue::Num(1.5))])))
         );
     }
 

--- a/packages/cli/src/svm_hypersync_source/borsh_decoder.rs
+++ b/packages/cli/src/svm_hypersync_source/borsh_decoder.rs
@@ -429,6 +429,22 @@ mod tests {
         );
     }
 
+    /// A declared-but-empty layout is the assertion that the instruction takes
+    /// no arguments, so it accepts exactly the calls that carry nothing past
+    /// the discriminator. Attaching no layout at all is what takes every call.
+    #[test]
+    fn an_empty_layout_accepts_only_a_bare_discriminator() {
+        let schema = schema_of("[]", "{}");
+        assert_eq!(
+            (
+                schema.decode(&[0x01]),
+                schema.decode(&[0x01, 0x00]),
+                schema.decode(&[0x01, 0xde, 0xad])
+            ),
+            (Some(obj(vec![])), None, None)
+        );
+    }
+
     #[test]
     fn short_and_trailing_data_are_rejected() {
         let schema = schema_of(r#"[{"name":"amount","type":"u64"}]"#, "{}");

--- a/packages/cli/src/svm_hypersync_source/mod.rs
+++ b/packages/cli/src/svm_hypersync_source/mod.rs
@@ -1130,6 +1130,58 @@ mod tests {
         );
     }
 
+    // An empty layout is the assertion that the instruction takes no
+    // arguments, which is what separates the bare form of a call from the one
+    // carrying a payload under the same prefix. Declaring no layout takes both.
+    #[test]
+    fn an_empty_layout_takes_only_the_calls_that_carry_no_payload() {
+        let (store, set) = fixture(&["TokenMetadata"]);
+        let built = build(
+            &store,
+            &[program(
+                "TokenMetadata",
+                vec![
+                    instruction(
+                        "Bare",
+                        Some("0x09"),
+                        Some("[]"),
+                        vec![registration(0, false)],
+                    ),
+                    instruction(
+                        "WithAmount",
+                        Some("0x09"),
+                        Some(AMOUNT),
+                        vec![reads_args(registration(1, false))],
+                    ),
+                    instruction("Every", Some("0x09"), None, vec![registration(2, false)]),
+                ],
+            )],
+            &[0, 1, 2],
+        );
+        let mut with_amount = vec![0x09];
+        with_amount.extend_from_slice(&7u64.to_le_bytes());
+        let mut payload_call = committed_instruction(&with_amount);
+        payload_call.transaction_index = Some(8);
+        let items = route(
+            &store,
+            &set,
+            &[committed_instruction(&[0x09]), payload_call],
+            vec![],
+            &built,
+        )
+        .unwrap();
+
+        // The bare call reaches `Bare` and `Every`; the payload call reaches
+        // `WithAmount` and `Every`, never `Bare`.
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| (item.transaction_index, item.on_event_registration_index))
+                .collect::<Vec<_>>(),
+            vec![(7, 0), (7, 2), (8, 1), (8, 2)]
+        );
+    }
+
     // An Anchor upgrade keeps the discriminator (a hash of the name) while
     // changing the args, so two layouts share one prefix. Each call decodes
     // under exactly the layout that fits it.

--- a/packages/cli/src/svm_hypersync_source/selection.rs
+++ b/packages/cli/src/svm_hypersync_source/selection.rs
@@ -107,8 +107,10 @@ pub struct SvmInstructionInput {
     /// Hex-encoded instruction-data prefix of any length. Absent or empty
     /// matches every instruction of the program.
     pub discriminator: Option<String>,
-    /// Borsh args layout as `Vec<ArgDef>` JSON. Absent means the instruction
-    /// declares no args, so none of its registrations may select them.
+    /// Borsh args layout as `Vec<ArgDef>` JSON. Absent means no layout is
+    /// attached, so nothing is decoded and no registration may select `args`.
+    /// `"[]"` is a layout: it decodes to `{}` and rejects any call carrying a
+    /// payload past the discriminator.
     pub args_json: Option<String>,
     pub registrations: Vec<SvmOnEventRegistrationInput>,
 }

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/README.md
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/README.md
@@ -33,6 +33,6 @@ Open the GraphQL playground at `http://localhost:8080` and query:
 - Declaring a Solana program + its instructions in `config.yaml`
   (`ecosystem: svm`, `experimental.programs[].instructions[]`).
 - Using `indexer.onInstruction({program, instruction}, handler)` to receive
-  positional accounts + raw instruction data.
+  an instruction's accounts under the names `config.yaml` gives its slots.
 - Persisting per-instruction state to a typed entity (`TokenMetadataAccount`)
   and a counter (`ProgramStats`).

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
@@ -20,10 +20,8 @@ chains:
                 - update_authority
                 - system_program
                 - rent
-              args: []
             - name: UpdateMetadataAccountV2
               discriminator: "0x0f"
               accounts:
                 - metadata
                 - update_authority
-              args: []

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
@@ -10,6 +10,9 @@ chains:
         - name: TokenMetadata
           program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
           instructions:
+            # No `args`, so nothing decodes the payload and every call with
+            # this discriminator is indexed. `args: []` would say the opposite
+            # — that the instruction takes none — and skip these calls.
             - name: CreateMetadataAccountV3
               discriminator: "0x21"
               accounts:

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/config.yaml
@@ -10,9 +10,6 @@ chains:
         - name: TokenMetadata
           program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
           instructions:
-            # No `args`, so nothing decodes the payload and every call with
-            # this discriminator is indexed. `args: []` would say the opposite
-            # — that the instruction takes none — and skip these calls.
             - name: CreateMetadataAccountV3
               discriminator: "0x21"
               accounts:

--- a/packages/cli/templates/static/svm_metaplex_template/typescript/src/handlers/TokenMetadata.ts
+++ b/packages/cli/templates/static/svm_metaplex_template/typescript/src/handlers/TokenMetadata.ts
@@ -1,6 +1,5 @@
 /*
- * Metaplex Token Metadata demo handler.
- * See https://docs.envio.dev for a thorough guide on indexer features.
+ * Please refer to https://docs.envio.dev for a thorough guide on all Envio indexer features
  */
 import { indexer, type ProgramStats } from "envio";
 

--- a/packages/cli/test/configs/svm-metaplex-config.yaml
+++ b/packages/cli/test/configs/svm-metaplex-config.yaml
@@ -21,10 +21,8 @@ chains:
                 - update_authority
                 - system_program
                 - rent
-              args: []
             - name: UpdateMetadataAccountV2
               discriminator: "0x0f"
               accounts:
                 - metadata
                 - update_authority
-              args: []

--- a/packages/envio-tests/test/SvmInstructionLayout_test.res
+++ b/packages/envio-tests/test/SvmInstructionLayout_test.res
@@ -1,0 +1,176 @@
+// The three shapes a config.yaml row can now ask for, through the user API.
+// The empty prefix is what every call carries, so a row dispatching on it takes
+// the whole program — SPL Memo's shape. `accounts` and `args` are independent:
+// one names slots the call already carries, the other attaches a decoder, and a
+// row asks for either without the other.
+
+let memoId = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+let namesId = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"
+let argsId = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+let sourcePk = "So11111111111111111111111111111111111111112"
+let destinationPk = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+let _ = InternalTestIndexer.fromUserApi(
+  ~schema=`
+type Call {
+  id: ID!
+  discriminator: String!
+}
+type Named {
+  id: ID!
+  source: String!
+}
+type Decoded {
+  id: ID!
+  amount: BigInt!
+  firstAccount: String!
+}
+`,
+  ~configYaml=`
+name: svm-instruction-layout
+ecosystem: svm
+chains:
+  - id: solana
+    start_block: 0
+    experimental:
+      hypersync_config:
+        url: https://solana.hypersync.xyz
+      programs:
+        - name: Memo
+          program_id: ${memoId}
+          instructions:
+            - name: anyCall
+              discriminator: ""
+        - name: NamesOnly
+          program_id: ${namesId}
+          instructions:
+            - name: transfer
+              discriminator: "0x01"
+              accounts:
+                - source
+        - name: ArgsOnly
+          program_id: ${argsId}
+          instructions:
+            - name: transfer
+              discriminator: "0x02"
+              args:
+                - { name: amount, type: u64 }
+`,
+  ~handlers=`
+import { indexer } from "envio";
+
+// A row on the empty prefix declares no layout, so \`args\` is \`never\` and the
+// account names are whatever the call carried.
+indexer.onInstruction(
+  { program: "Memo", instruction: "anyCall" },
+  async ({ instruction, context }) => {
+    context.Call.set({
+      id: instruction.block.slot.toString(),
+      discriminator: instruction.discriminator,
+    });
+  },
+);
+
+indexer.onInstruction(
+  { program: "NamesOnly", instruction: "transfer", fields: { instruction: ["accounts"] } },
+  async ({ instruction, context }) => {
+    instruction.accounts.source.address satisfies string;
+    context.Named.set({
+      id: instruction.block.slot.toString(),
+      source: instruction.accounts.source.address,
+    });
+  },
+);
+
+indexer.onInstruction(
+  {
+    program: "ArgsOnly",
+    instruction: "transfer",
+    fields: { instruction: ["args", "accountArguments"] },
+  },
+  async ({ instruction, context }) => {
+    instruction.args.amount satisfies bigint;
+    context.Decoded.set({
+      id: instruction.block.slot.toString(),
+      amount: instruction.args.amount,
+      firstAccount: instruction.accountArguments[0]!,
+    });
+  },
+);
+`,
+  ~test=`
+import { describe, it } from "vitest";
+import { createTestIndexer } from "envio";
+
+describe("SVM instruction layout through the user API", () => {
+  // Nothing was dispatched on, so there is no prefix to report and the whole
+  // data is what the call was keyed by — a different value per call, where a
+  // row with a prefix reports the same one every time.
+  it("reports the whole data as the key of a row on the empty prefix", async (t) => {
+    const indexer = createTestIndexer();
+    await indexer.process({
+      chains: {
+        7565164: {
+          simulate: [
+            { program: "Memo", instruction: "anyCall", slot: 1, data: new Uint8Array([0x09, 0xab]) },
+            { program: "Memo", instruction: "anyCall", slot: 2, data: new Uint8Array([0xff]) },
+          ],
+        },
+      },
+    });
+    t.expect([
+      await indexer.Call.getOrThrow("1"),
+      await indexer.Call.getOrThrow("2"),
+    ]).toEqual([
+      { id: "1", discriminator: "0x09ab" },
+      { id: "2", discriminator: "0xff" },
+    ]);
+  });
+
+  // \`accounts\` alone names the slots; nothing decodes the payload.
+  it("names accounts on a row that declares no args", async (t) => {
+    const indexer = createTestIndexer();
+    await indexer.process({
+      chains: {
+        7565164: {
+          simulate: [
+            {
+              program: "NamesOnly",
+              instruction: "transfer",
+              slot: 1,
+              accounts: { source: { address: "${sourcePk}" } },
+            },
+          ],
+        },
+      },
+    });
+    t.expect(await indexer.Named.getOrThrow("1")).toEqual({ id: "1", source: "${sourcePk}" });
+  });
+
+  // \`args\` alone attaches the decoder; the slots stay positional.
+  it("decodes args on a row that names no accounts", async (t) => {
+    const indexer = createTestIndexer();
+    await indexer.process({
+      chains: {
+        7565164: {
+          simulate: [
+            {
+              program: "ArgsOnly",
+              instruction: "transfer",
+              slot: 1,
+              args: { amount: 42n },
+              accountArguments: ["${destinationPk}"],
+            },
+          ],
+        },
+      },
+    });
+    t.expect(await indexer.Decoded.getOrThrow("1")).toEqual({
+      id: "1",
+      amount: 42n,
+      firstAccount: "${destinationPk}",
+    });
+  });
+});
+`,
+)

--- a/packages/envio-tests/test/SvmInstructionLayout_test.res
+++ b/packages/envio-tests/test/SvmInstructionLayout_test.res
@@ -1,12 +1,15 @@
-// The three shapes a config.yaml row can now ask for, through the user API.
+// The four shapes a config.yaml row can now ask for, through the user API.
 // The empty prefix is what every call carries, so a row dispatching on it takes
 // the whole program — SPL Memo's shape. `accounts` and `args` are independent:
 // one names slots the call already carries, the other attaches a decoder, and a
-// row asks for either without the other.
+// row asks for either without the other. Omitting `args` attaches no decoder;
+// writing `args: []` attaches an empty one, which asserts the instruction takes
+// no arguments and so indexes only the calls that carry none.
 
 let memoId = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
 let namesId = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"
 let argsId = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+let bareId = "SysvarC1ock11111111111111111111111111111111"
 let sourcePk = "So11111111111111111111111111111111111111112"
 let destinationPk = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 
@@ -24,6 +27,9 @@ type Decoded {
   id: ID!
   amount: BigInt!
   firstAccount: String!
+}
+type Bare {
+  id: ID!
 }
 `,
   ~configYaml=`
@@ -55,6 +61,12 @@ chains:
               discriminator: "0x02"
               args:
                 - { name: amount, type: u64 }
+        - name: NoArgs
+          program_id: ${bareId}
+          instructions:
+            - name: tick
+              discriminator: "0x03"
+              args: []
 `,
   ~handlers=`
 import { indexer } from "envio";
@@ -95,6 +107,16 @@ indexer.onInstruction(
       amount: instruction.args.amount,
       firstAccount: instruction.accountArguments[0]!,
     });
+  },
+);
+
+// An empty layout is still a layout, so \`args\` is selectable and decodes to an
+// empty object — where a row that omits \`args\` types it \`never\`.
+indexer.onInstruction(
+  { program: "NoArgs", instruction: "tick", fields: { instruction: ["args"] } },
+  async ({ instruction, context }) => {
+    instruction.args satisfies {};
+    context.Bare.set({ id: instruction.block.slot.toString() });
   },
 );
 `,
@@ -170,6 +192,20 @@ describe("SVM instruction layout through the user API", () => {
       amount: 42n,
       firstAccount: "${destinationPk}",
     });
+  });
+
+  // Writing the empty layout is an assertion about the call, not a no-op: it
+  // says the instruction takes no arguments.
+  it("selects args as an empty object on a row that declares an empty layout", async (t) => {
+    const indexer = createTestIndexer();
+    await indexer.process({
+      chains: {
+        7565164: {
+          simulate: [{ program: "NoArgs", instruction: "tick", slot: 1, args: {} }],
+        },
+      },
+    });
+    t.expect(await indexer.Bare.getOrThrow("1")).toEqual({ id: "1" });
   });
 });
 `,

--- a/packages/envio-tests/test/SvmInstructionLayout_test.res
+++ b/packages/envio-tests/test/SvmInstructionLayout_test.res
@@ -40,7 +40,7 @@ chains:
           program_id: ${memoId}
           instructions:
             - name: anyCall
-              discriminator: ""
+              discriminator: "0x"
         - name: NamesOnly
           program_id: ${namesId}
           instructions:

--- a/packages/envio-tests/test/SvmInstructionShapes_test.res
+++ b/packages/envio-tests/test/SvmInstructionShapes_test.res
@@ -68,8 +68,7 @@ indexer.onInstruction(
   { program: "Serum", instruction: "newOrderV3", fields: { instruction: ["args"] } },
   async ({ instruction }) => {
     instruction.args.side satisfies number;
-    // A non-finite float has no JSON number to decode into, so it arrives null.
-    instruction.args.ratio satisfies number | null;
+    instruction.args.ratio satisfies number;
   },
 );
 indexer.onInstruction(

--- a/packages/envio-tests/test/SvmInstructionShapes_test.res
+++ b/packages/envio-tests/test/SvmInstructionShapes_test.res
@@ -35,6 +35,7 @@ chains:
                 - market
               args:
                 - { name: side, type: u32 }
+                - { name: ratio, type: f64 }
         - name: Swapper
           program_id: 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8
           instructions:
@@ -67,6 +68,8 @@ indexer.onInstruction(
   { program: "Serum", instruction: "newOrderV3", fields: { instruction: ["args"] } },
   async ({ instruction }) => {
     instruction.args.side satisfies number;
+    // A non-finite float has no JSON number to decode into, so it arrives null.
+    instruction.args.ratio satisfies number | null;
   },
 );
 indexer.onInstruction(

--- a/packages/envio-tests/test/SvmInstructionShapes_test.res
+++ b/packages/envio-tests/test/SvmInstructionShapes_test.res
@@ -1,7 +1,8 @@
 open Vitest
 
-// Instruction shapes the ecosystem actually ships: SPL Memo has no
-// discriminator and its whole data is the args; Serum v3 dispatches on a
+// Instruction shapes the ecosystem actually ships: SPL Memo dispatches on
+// nothing, so it takes the empty prefix and its whole data is the args; Serum
+// v3 dispatches on a
 // version byte plus a 4-byte tag, a 5-byte prefix; an Anchor program upgrade
 // keeps the discriminator (a hash of the name) while changing the args, so
 // two layouts share one prefix. Each is a separate instruction with its own
@@ -23,6 +24,7 @@ chains:
           program_id: MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr
           instructions:
             - name: memo
+              discriminator: ""
               accounts: []
               args:
                 - { name: text, type: string }
@@ -53,7 +55,9 @@ chains:
                 - { name: amountIn, type: u64 }
                 - { name: minAmountOut, type: u64 }
             - name: any
+              discriminator: ""
             - name: anyAgain
+              discriminator: ""
 `,
   ~handlers=`
 import { indexer } from "envio";

--- a/packages/envio-tests/test/SvmInstructionShapes_test.res
+++ b/packages/envio-tests/test/SvmInstructionShapes_test.res
@@ -24,7 +24,7 @@ chains:
           program_id: MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr
           instructions:
             - name: memo
-              discriminator: ""
+              discriminator: "0x"
               accounts: []
               args:
                 - { name: text, type: string }
@@ -55,9 +55,9 @@ chains:
                 - { name: amountIn, type: u64 }
                 - { name: minAmountOut, type: u64 }
             - name: any
-              discriminator: ""
+              discriminator: "0x"
             - name: anyAgain
-              discriminator: ""
+              discriminator: "0x"
 `,
   ~handlers=`
 import { indexer } from "envio";

--- a/packages/envio-tests/test/SvmWhereErrors_test.res
+++ b/packages/envio-tests/test/SvmWhereErrors_test.res
@@ -173,7 +173,7 @@ describe("SVM onInstruction where", () => {
         async () => {},
       ),
     ).toThrowError(
-      \`Invalid where configuration for the "bare" instruction on program "Swapper". The instruction has no named accounts to filter on. Add \\\`accounts\\\` and \\\`args\\\` to it in config.yaml, or attach an IDL.\`,
+      \`Invalid where configuration for the "bare" instruction on program "Swapper". The instruction has no named accounts to filter on. Add \\\`accounts\\\` to it in config.yaml, or attach an IDL.\`,
     );
   });
 

--- a/packages/envio-tests/test/SvmWhereErrors_test.res
+++ b/packages/envio-tests/test/SvmWhereErrors_test.res
@@ -79,7 +79,7 @@ describe("SVM onInstruction where", () => {
         async () => {},
       ),
     ).toThrowError(
-      \`Invalid "args" field in the fields.instruction option of the "bare" instruction on program "Swapper". The instruction declares no args in config.yaml, so there is nothing to decode. Remove "args" from the selection, or declare the instruction's args.\`,
+      \`Invalid "args" field in the fields.instruction option of the "bare" instruction on program "Swapper". The instruction attaches no args layout in config.yaml, so there is nothing to decode. Remove "args" from the selection, or give the instruction an \\\`args\\\` layout — \\\`args: []\\\` if it takes none.\`,
     );
   });
 

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -1259,6 +1259,16 @@ chains:
       programs:
 `
 
+  // One `swap` instruction of one program, with the body under test.
+  let instruction = body =>
+    prefix ++
+    `        - name: Program
+          program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+          instructions:
+            - name: swap
+              discriminator: "0x09"` ++
+    body ++ "\n"
+
   [
     (
       "rejects invalid program ids",
@@ -1299,8 +1309,175 @@ chains:
 `,
       "instruction \"Transfer\" in program \"Program\": discriminator \"0x012\" must be a whole number of bytes (an even, non-zero count of hex digits after stripping a \`0x\` prefix), got 3 digits",
     ),
+    (
+      "rejects a program name that is not an identifier",
+      prefix ++ `
+        - name: my-program
+          program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+          instructions: []
+`,
+      "a program name must be an identifier: letters, digits and underscores only, not starting with a digit, got 'my-program'",
+    ),
+    (
+      "rejects an instruction name that is not an identifier",
+      prefix ++ `
+        - name: Program
+          program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+          instructions:
+            - {name: "transfer!", discriminator: "0x0f"}
+`,
+      "Program 'Program': an instruction name must be an identifier: letters, digits and underscores only, not starting with a digit, got 'transfer!'",
+    ),
+    (
+      "rejects `defined`, which has no registry to resolve against",
+      instruction(`
+              accounts: []
+              args:
+                - {name: side, type: {defined: Side}}`),
+      "Program 'Program', instruction 'swap': args.side: 'defined' is not supported in config.yaml: declare the type inline with 'struct' or 'enum', or take the instruction from an 'idl'",
+    ),
+    (
+      "rejects `defined` nested inside a composite",
+      instruction(`
+              accounts: []
+              args:
+                - {name: sides, type: {vec: {option: {defined: Side}}}}`),
+      "Program 'Program', instruction 'swap': args.sides.vec.option: 'defined' is not supported in config.yaml: declare the type inline with 'struct' or 'enum', or take the instruction from an 'idl'",
+    ),
+    (
+      "rejects a nested option, which decodes ambiguously",
+      instruction(`
+              accounts: []
+              args:
+                - {name: maybe, type: {option: {option: u64}}}`),
+      "Program 'Program', instruction 'swap': args.maybe.option: a nested 'option' is not supported: Borsh tags each level with one byte, so Some(None) and None would decode the same",
+    ),
+    (
+      "rejects duplicate arg names",
+      instruction(`
+              accounts: []
+              args:
+                - {name: amount, type: u64}
+                - {name: amount, type: string}`),
+      "Program 'Program', instruction 'swap': args: 'amount' is declared more than once",
+    ),
+    (
+      "rejects duplicate field names inside a struct",
+      instruction(`
+              accounts: []
+              args:
+                - {name: pair, type: {struct: [{name: a, type: u64}, {name: a, type: u64}]}}`),
+      "Program 'Program', instruction 'swap': args.pair.struct: 'a' is declared more than once",
+    ),
+    (
+      "rejects an arg name that is not an identifier",
+      instruction(`
+              accounts: []
+              args:
+                - {name: "a-b", type: u64}`),
+      "Program 'Program', instruction 'swap': args: an arg name must be an identifier: letters, digits and underscores only, not starting with a digit, got 'a-b'",
+    ),
+    (
+      "rejects an empty arg name",
+      instruction(`
+              accounts: []
+              args:
+                - {name: "", type: u64}`),
+      "Program 'Program', instruction 'swap': args: an arg name must be an identifier: letters, digits and underscores only, not starting with a digit, got ''",
+    ),
+    (
+      "rejects an account name that is not an identifier",
+      instruction(`
+              accounts: ["source pool"]
+              args: []`),
+      "Program 'Program', instruction 'swap': accounts: an account name must be an identifier: letters, digits and underscores only, not starting with a digit, got 'source pool'",
+    ),
+    (
+      "rejects duplicate account names",
+      instruction(`
+              accounts: [source, source]
+              args: []`),
+      "Program 'Program', instruction 'swap': accounts: 'source' is declared more than once",
+    ),
+    (
+      "rejects an empty enum, which no tag can select",
+      instruction(`
+              accounts: []
+              args:
+                - {name: side, type: {enum: []}}`),
+      "Program 'Program', instruction 'swap': args.side.enum: an enum needs at least one variant",
+    ),
+    (
+      "rejects duplicate enum variant names",
+      instruction(`
+              accounts: []
+              args:
+                - {name: side, type: {enum: [{name: Bid}, {name: Bid}]}}`),
+      "Program 'Program', instruction 'swap': args.side.enum: 'Bid' is declared more than once",
+    ),
+    (
+      "rejects an enum variant name that is not an identifier",
+      instruction(`
+              accounts: []
+              args:
+                - {name: side, type: {enum: [{name: "Bid/Ask"}]}}`),
+      "Program 'Program', instruction 'swap': args.side.enum: a variant name must be an identifier: letters, digits and underscores only, not starting with a digit, got 'Bid/Ask'",
+    ),
+    (
+      "rejects more enum variants than a one-byte tag can address",
+      instruction(
+        `
+              accounts: []
+              args:
+                - {name: side, type: {enum: [` ++
+        Array.make(~length=257, 0)
+        ->Array.mapWithIndex((_, i) => `{name: V${i->Int.toString}}`)
+        ->Array.join(", ") ++ `]}}`,
+      ),
+      "Program 'Program', instruction 'swap': args.side.enum: 257 variants is more than the 256 a one-byte Borsh tag can address",
+    ),
+    (
+      "rejects an array longer than the decoder will preallocate",
+      instruction(`
+              accounts: []
+              args:
+                - {name: big, type: {array: [u64, 65537]}}`),
+      "Program 'Program', instruction 'swap': args.big.array: 65537 elements is more than the 65536 an array may declare",
+    ),
+    (
+      "names the primitive it could not read",
+      instruction(`
+              accounts: []
+              args:
+                - {name: amount, type: u46}`),
+      "Failed to deserialize config. Visit the docs for more information https://docs.envio.dev/docs/configuration-file: chains[0].experimental.programs[0].instructions[0].args[0].type: unknown type 'u46', expected one of bool, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, string, bytes, pubkey, publicKey, or a composite such as {vec: u8}, {option: pubkey}, {array: [u8, 32]}, {struct: [...]}, {enum: [...]} at line 18 column 40",
+    ),
+    (
+      "names the composite it could not read",
+      instruction(`
+              accounts: []
+              args:
+                - {name: amount, type: {set: u64}}`),
+      "Failed to deserialize config. Visit the docs for more information https://docs.envio.dev/docs/configuration-file: chains[0].experimental.programs[0].instructions[0].args[0].type: unknown composite type 'set', expected one of option, vec, array, struct, enum at line 18 column 40",
+    ),
   ]->Array.forEach(((name, yaml, message)) => {
     it(name, t => expectParseError(t, yaml, message))
+  })
+
+  // Svm generates no ReScript, so a name only has to be an identifier the
+  // generated TypeScript can carry.
+  it("accepts program and instruction names that ReScript reserves", t => {
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=prefix ++
+      `        - name: type
+          program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+          instructions:
+            - {name: switch, discriminator: "0x0f"}
+`,
+    )
+    let chain = config.chainMap->ChainMap.values->Array.getUnsafe(0)
+    let contract = chain.contracts->Array.getUnsafe(0)
+    t.expect((contract.name, contract.events->Array.map(e => e.name))).toEqual(("Type", ["switch"]))
   })
 
   it("rejects duplicate program names across chains", t => {

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -2176,11 +2176,14 @@ chains:
     )
   })
 
-  it("requires SVM inline accounts and args together", t => {
-    expectParseError(
-      t,
-      `
-name: incomplete-svm-layout
+  // `accounts` names the slots the raw `accountArguments` array already
+  // carries, and `args` attaches a decoder. Neither implies the other, and an
+  // empty list means the same as an absent one, so a row asks for whichever it
+  // wants.
+  it("takes SVM inline accounts and args independently", t => {
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~configYaml=`
+name: independent-svm-layout
 ecosystem: svm
 chains:
   - id: solana
@@ -2192,11 +2195,21 @@ chains:
         - name: Program
           program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
           instructions:
-            - name: Transfer
-              accounts: []
+            - {name: namesOnly, discriminator: "0x01", accounts: [source]}
+            - {name: argsOnly, discriminator: "0x02", args: [{name: amount, type: u64}]}
+            - {name: neither, discriminator: "0x03"}
 `,
-      "Program 'Program', instruction 'Transfer': set both 'accounts' and 'args', or omit both.",
     )
+    t.expect(
+      firstContract(config).events->Array.map(event => {
+        let svm = event->(Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig)
+        (svm.name, svm.accounts, svm.args)
+      }),
+    ).toEqual([
+      ("namesOnly", ["source"], JSON.Null),
+      ("argsOnly", [], JSON.parseOrThrow(`[{"name":"amount","type":"u64"}]`)),
+      ("neither", [], JSON.Null),
+    ])
   })
 })
 
@@ -2282,15 +2295,32 @@ indexer.onInstruction(
     ])
   })
 
-  it("rejects a name-only YAML row next to idl", t => {
+  it("rejects a name-only YAML row that shadows an IDL instruction", t => {
     expectParseError(
       t,
       ~files,
       yaml(`          instructions:
             - name: swap
 `),
-      "Program 'Program', instruction 'swap': a YAML row next to 'idl' must set 'discriminator' to overwrite the IDL definition, or omit this row.",
+      "Program 'Program', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'discriminator', 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited.",
     )
+  })
+
+  // Nothing in the catalog carries this name, so the row adds an instruction
+  // and is read like any inline one: no discriminator matches every call the
+  // program receives.
+  it("adds a program-wide instruction next to an IDL", t => {
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~files,
+      ~configYaml=yaml(`          instructions:
+            - name: anyCall
+`),
+    )
+    t.expect(catalog(config)).toEqual([
+      ("deposit", Some("0x02"), ["vault"], JSON.Null),
+      ("swap", Some("0x01"), ["payer", "pool"], JSON.parseOrThrow(`[{"name":"amount","type":"u64"}]`)),
+      ("anyCall", None, [], JSON.Null),
+    ])
   })
 
   it("keeps the full IDL catalog when YAML overwrites one instruction and adds another", t => {
@@ -2353,11 +2383,11 @@ indexer.onInstruction({ program: "Program", instruction: "extra" }, async () => 
               accounts: [source]
               args: []
 `),
-      "Program 'Program', instruction 'swap': a YAML row next to 'idl' must set 'discriminator' to overwrite the IDL definition, or omit this row.",
+      "Program 'Program', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'discriminator': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited.",
     )
   })
 
-  it("rejects a discriminator-only YAML row next to idl", t => {
+  it("rejects a discriminator-only YAML row that shadows an IDL instruction", t => {
     expectParseError(
       t,
       ~files,
@@ -2365,11 +2395,11 @@ indexer.onInstruction({ program: "Program", instruction: "extra" }, async () => 
             - name: swap
               discriminator: "0x09"
 `),
-      "Program 'Program', instruction 'swap': set both 'accounts' and 'args' to overwrite the IDL layout.",
+      "Program 'Program', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited.",
     )
   })
 
-  it("requires accounts and args together when overwriting an IDL instruction", t => {
+  it("names only the field an overwrite left out", t => {
     expectParseError(
       t,
       ~files,
@@ -2378,7 +2408,7 @@ indexer.onInstruction({ program: "Program", instruction: "extra" }, async () => 
               discriminator: "0x09"
               accounts: [source]
 `),
-      "Program 'Program', instruction 'swap': set both 'accounts' and 'args' to overwrite the IDL layout.",
+      "Program 'Program', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited.",
     )
   })
 })

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -1307,7 +1307,7 @@ chains:
           instructions:
             - {name: Transfer, discriminator: "0x012"}
 `,
-      "instruction \"Transfer\" in program \"Program\": discriminator \"0x012\" must be a whole number of bytes (an even, non-zero count of hex digits after stripping a \`0x\` prefix), got 3 digits",
+      "instruction \"Transfer\" in program \"Program\": discriminator \"0x012\" must be a whole number of bytes (an even count of hex digits after stripping a \`0x\` prefix), got 3 digits. Write \"\" to match every instruction of the program.",
     ),
     (
       "rejects a program name that is not an identifier",
@@ -2292,22 +2292,23 @@ indexer.onInstruction(
     ])
   })
 
-  it("rejects a name-only YAML row that shadows an IDL instruction", t => {
+  it("rejects an overwrite that leaves out the whole layout", t => {
     expectParseError(
       t,
       ~files,
       yaml(`          instructions:
             - name: swap
+              discriminator: ""
 `),
       "Program 'Program', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited.",
     )
   })
 
   // The IDL declares this name, so the row is an overwrite even though the
-  // catalog has no entry for it. Read as an addition, a bare name would turn
-  // into a program-wide catch-all, and the warning naming the reason is
-  // suppressed for exactly the names a row mentions.
-  it("rejects a name-only YAML row on an instruction the IDL could not use", t => {
+  // catalog has no entry for it. Read as an addition, it would take the empty
+  // prefix and index every call the program receives, and the warning naming
+  // the reason is suppressed for exactly the names a row mentions.
+  it("rejects an overwrite of an instruction the IDL could not use", t => {
     expectParseError(
       t,
       ~files=Dict.fromArray([
@@ -2325,19 +2326,34 @@ indexer.onInstruction(
       ]),
       yaml(`          instructions:
             - name: swap
+              discriminator: ""
 `),
       "Program 'Program', instruction 'swap': the IDL declares this instruction too, but it cannot be indexed as declared: idls/program.json:2:30: args.amount: `coption` is not Borsh-compatible and cannot be decoded. Spell out 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited.",
     )
   })
 
+  // Absence used to mean "every instruction of the program", so a misspelled
+  // name next to an IDL silently became a firehose instead of an error.
+  it("requires a discriminator on every instruction row", t => {
+    expectParseError(
+      t,
+      ~files,
+      yaml(`          instructions:
+            - name: anyCall
+`),
+      "Failed to deserialize config. Visit the docs for more information https://docs.envio.dev/docs/configuration-file: chains[0].experimental.programs[0].instructions[0]: missing field `discriminator` at line 15 column 15",
+    )
+  })
+
   // Nothing in the catalog carries this name, so the row adds an instruction
-  // and is read like any inline one: no discriminator matches every call the
+  // and is read like any inline one: the empty prefix matches every call the
   // program receives.
   it("adds a program-wide instruction next to an IDL", t => {
     let {config} = InternalTestIndexer.fromUserApi(
       ~files,
       ~configYaml=yaml(`          instructions:
             - name: anyCall
+              discriminator: ""
 `),
     )
     t.expect(catalog(config)).toEqual([
@@ -2398,14 +2414,15 @@ indexer.onInstruction({ program: "Program", instruction: "extra" }, async () => 
     ])
   })
 
-  // An overwrite says what a row on any other name says: a missing
-  // `discriminator` matches every instruction of the program, here in place of
-  // the prefix the IDL declared for the name.
-  it("makes an overwrite without a discriminator program-wide", t => {
+  // An overwrite says what a row on any other name says: the empty prefix
+  // matches every instruction of the program, here in place of the prefix the
+  // IDL declared for the name.
+  it("makes an overwrite on the empty prefix program-wide", t => {
     let {config} = InternalTestIndexer.fromUserApi(
       ~files,
       ~configYaml=yaml(`          instructions:
             - name: swap
+              discriminator: ""
               accounts: [source]
               args: []
 `),

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -1300,6 +1300,16 @@ chains:
       "Program \"Program\" declares the instruction \"Transfer\" more than once",
     ),
     (
+      "rejects a discriminator that does not carry the 0x prefix",
+      prefix ++ `
+        - name: Program
+          program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+          instructions:
+            - {name: Transfer, discriminator: "21"}
+`,
+      "instruction \"Transfer\" in program \"Program\": discriminator \"21\" must be written as 0x-prefixed hex. Write \"0x\" to match every instruction of the program",
+    ),
+    (
       "rejects a discriminator with a partial byte",
       prefix ++ `
         - name: Program
@@ -1307,7 +1317,7 @@ chains:
           instructions:
             - {name: Transfer, discriminator: "0x012"}
 `,
-      "instruction \"Transfer\" in program \"Program\": discriminator \"0x012\" must be a whole number of bytes (an even count of hex digits after stripping a \`0x\` prefix), got 3 digits. Write \"\" to match every instruction of the program.",
+      "instruction \"Transfer\" in program \"Program\": discriminator \"0x012\" must be a whole number of bytes (an even count of hex digits after the \`0x\` prefix), got 3 digits. Write \"0x\" to match every instruction of the program.",
     ),
     (
       "rejects a program name that is not an identifier",
@@ -2298,7 +2308,7 @@ indexer.onInstruction(
       ~files,
       yaml(`          instructions:
             - name: swap
-              discriminator: ""
+              discriminator: "0x"
 `),
       "Program 'Program', instruction 'swap': the IDL declares this instruction too, so this row replaces it rather than adding to the catalog. Spell out 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited.",
     )
@@ -2326,7 +2336,7 @@ indexer.onInstruction(
       ]),
       yaml(`          instructions:
             - name: swap
-              discriminator: ""
+              discriminator: "0x"
 `),
       "Program 'Program', instruction 'swap': the IDL declares this instruction too, but it cannot be indexed as declared: idls/program.json:2:30: args.amount: `coption` is not Borsh-compatible and cannot be decoded. Spell out 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited.",
     )
@@ -2353,7 +2363,7 @@ indexer.onInstruction(
       ~files,
       ~configYaml=yaml(`          instructions:
             - name: anyCall
-              discriminator: ""
+              discriminator: "0x"
 `),
     )
     t.expect(catalog(config)).toEqual([
@@ -2422,7 +2432,7 @@ indexer.onInstruction({ program: "Program", instruction: "extra" }, async () => 
       ~files,
       ~configYaml=yaml(`          instructions:
             - name: swap
-              discriminator: ""
+              discriminator: "0x"
               accounts: [source]
               args: []
 `),

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -2194,6 +2194,7 @@ chains:
             - {name: namesOnly, discriminator: "0x01", accounts: [source]}
             - {name: argsOnly, discriminator: "0x02", args: [{name: amount, type: u64}]}
             - {name: neither, discriminator: "0x03"}
+            - {name: emptyArgs, discriminator: "0x04", args: []}
 `,
     )
     t.expect(
@@ -2205,6 +2206,7 @@ chains:
       ("namesOnly", [Internal.Required("source")], JSON.Null),
       ("argsOnly", [], JSON.parseOrThrow(`[{"name":"amount","type":"u64"}]`)),
       ("neither", [], JSON.Null),
+      ("emptyArgs", [], JSON.parseOrThrow("[]")),
     ])
   })
 })
@@ -2367,7 +2369,7 @@ indexer.onInstruction(
 `),
     )
     t.expect(catalog(config)).toEqual([
-      ("deposit", Some("0x02"), ["vault"], JSON.Null),
+      ("deposit", Some("0x02"), ["vault"], JSON.parseOrThrow("[]")),
       ("swap", Some("0x01"), ["payer", "pool"], JSON.parseOrThrow(`[{"name":"amount","type":"u64"}]`)),
       ("anyCall", None, [], JSON.Null),
     ])
@@ -2397,7 +2399,7 @@ indexer.onInstruction({ program: "Program", instruction: "extra" }, async () => 
 `,
     )
     t.expect(catalog(config)).toEqual([
-      ("deposit", Some("0x02"), ["vault"], JSON.Null),
+      ("deposit", Some("0x02"), ["vault"], JSON.parseOrThrow("[]")),
       (
         "swap",
         Some("0x09"),
@@ -2419,8 +2421,8 @@ indexer.onInstruction({ program: "Program", instruction: "extra" }, async () => 
 `),
     )
     t.expect(catalog(config)).toEqual([
-      ("deposit", Some("0x02"), ["vault"], JSON.Null),
-      ("swap", Some("0x09"), ["source"], JSON.Null),
+      ("deposit", Some("0x02"), ["vault"], JSON.parseOrThrow("[]")),
+      ("swap", Some("0x09"), ["source"], JSON.parseOrThrow("[]")),
     ])
   })
 
@@ -2438,8 +2440,8 @@ indexer.onInstruction({ program: "Program", instruction: "extra" }, async () => 
 `),
     )
     t.expect(catalog(config)).toEqual([
-      ("deposit", Some("0x02"), ["vault"], JSON.Null),
-      ("swap", None, ["source"], JSON.Null),
+      ("deposit", Some("0x02"), ["vault"], JSON.parseOrThrow("[]")),
+      ("swap", None, ["source"], JSON.parseOrThrow("[]")),
     ])
   })
 

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -2306,6 +2306,33 @@ indexer.onInstruction(
     )
   })
 
+  // The IDL declares this name, so the row is an overwrite even though the
+  // catalog has no entry for it. Read as an addition, a bare name would turn
+  // into a program-wide catch-all, and the warning naming the reason is
+  // suppressed for exactly the names a row mentions.
+  it("rejects a name-only YAML row on an instruction the IDL could not use", t => {
+    expectParseError(
+      t,
+      ~files=Dict.fromArray([
+        (
+          "idls/program.json",
+          `{
+            "instructions": [{
+              "name": "swap",
+              "discriminator": [1],
+              "accounts": [],
+              "args": [{"name": "amount", "type": {"coption": "u64"}}]
+            }]
+          }`,
+        ),
+      ]),
+      yaml(`          instructions:
+            - name: swap
+`),
+      "Program 'Program', instruction 'swap': the IDL declares this instruction too, but it cannot be indexed as declared: idls/program.json:2:30: args.amount: `coption` is not Borsh-compatible and cannot be decoded. Spell out 'discriminator', 'accounts' and 'args': an overwrite takes nothing from the IDL, so a field left out here is absent, not inherited.",
+    )
+  })
+
   // Nothing in the catalog carries this name, so the row adds an instruction
   // and is read like any inline one: no discriminator matches every call the
   // program receives.

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -2241,6 +2241,47 @@ ${instructions}
       (svm.name, svm.discriminator, svm.accounts, svm.args)
     })
 
+  // An IDL is a file the program's authors wrote, and nothing holds its names
+  // to the identifier rule config.yaml names are held to. They reach the
+  // generated types as string literals, where an unescaped quote would end the
+  // literal early and leave the rest of the file as syntax.
+  it("escapes an IDL instruction name that carries a quote", t => {
+    let {config} = InternalTestIndexer.fromUserApi(
+      ~files=Dict.fromArray([
+        (
+          "idls/program.json",
+          `{
+            "instructions": [{
+              "name": "say\\"hi",
+              "discriminator": [7],
+              "accounts": [{"name": "payer"}],
+              "args": [{"name": "amount", "type": "u64"}]
+            }]
+          }`,
+        ),
+      ]),
+      ~configYaml=yaml("          instructions: []\n"),
+      ~handlers=`
+import { indexer } from "envio";
+indexer.onInstruction(
+  { program: "Program", instruction: "say\\"hi", fields: { instruction: ["args", "accounts"] } },
+  async ({ instruction }) => {
+    instruction.args.amount satisfies bigint;
+    instruction.accounts.payer.toString();
+  },
+);
+`,
+    )
+    t.expect(catalog(config)).toEqual([
+      (
+        `say\"hi`,
+        Some("0x07"),
+        ["payer"],
+        JSON.parseOrThrow(`[{"name":"amount","type":"u64"}]`),
+      ),
+    ])
+  })
+
   it("rejects a name-only YAML row next to idl", t => {
     expectParseError(
       t,

--- a/packages/envio/src/EventConfigBuilder.res
+++ b/packages/envio/src/EventConfigBuilder.res
@@ -729,7 +729,7 @@ let resolveSvmWhereOrThrow = (
       let position = switch accountNames->Array.indexOf(name) {
       | -1 if accountNames->Utils.Array.isEmpty =>
         invalid(
-          "The instruction has no named accounts to filter on. Add `accounts` and `args` to it in config.yaml, or attach an IDL.",
+          "The instruction has no named accounts to filter on. Add `accounts` to it in config.yaml, or attach an IDL.",
         )
       | -1 =>
         invalid(

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -340,8 +340,11 @@ let addOnEventRegistration = (
         | (Svm, Some(fieldSelection)) if fieldSelection.instructionFields->Utils.Set.has("args") =>
           let svmEventConfig =
             eventConfig->(Utils.magic: Internal.eventConfig => Internal.svmInstructionEventConfig)
+          // An empty layout is still a layout: it decodes to `{}` and filters
+          // out the calls that carry a payload. Only an absent one has nothing
+          // to decode.
           let declaresArgs = switch svmEventConfig.args {
-          | JSON.Array(args) => args->Array.length > 0
+          | JSON.Array(_) => true
           | _ => false
           }
           if !declaresArgs {

--- a/packages/envio/src/HandlerRegister.res
+++ b/packages/envio/src/HandlerRegister.res
@@ -349,7 +349,7 @@ let addOnEventRegistration = (
           }
           if !declaresArgs {
             JsError.throwWithMessage(
-              `Invalid "args" field in the fields.instruction option of the "${eventName}" instruction on program "${contractName}". The instruction declares no args in config.yaml, so there is nothing to decode. Remove "args" from the selection, or declare the instruction's args.`,
+              `Invalid "args" field in the fields.instruction option of the "${eventName}" instruction on program "${contractName}". The instruction attaches no args layout in config.yaml, so there is nothing to decode. Remove "args" from the selection, or give the instruction an \`args\` layout — \`args: []\` if it takes none.`,
             )
           }
         | _ => ()

--- a/packages/envio/src/Internal.res
+++ b/packages/envio/src/Internal.res
@@ -591,7 +591,9 @@ type svmInstructionEventConfig = {
    attached for this instruction. */
   accounts: array<svmAccountSlot>,
   /** Borsh args layout as `Vec<ArgDef>` JSON (see `human_config::svm::ArgDef`
-   on the Rust side). `JSON.Null` means no schema is attached. */
+   on the Rust side). `JSON.Null` attaches no decoder, so every matched call is
+   delivered with its payload raw. An array attaches one, `[]` included: a call
+   whose data the layout rejects is skipped. */
   args: JSON.t,
   /** Program-level nominal-type registry (`BTreeMap<String, ArgType>` JSON).
    Duplicated on every event of the same program — the runtime dedups by

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -380,7 +380,7 @@
           "type": "string"
         },
         "discriminator": {
-          "description": "Hex-encoded instruction-data prefix to dispatch on (\"0x\" optional), of any whole number of bytes; an 8-byte value matches the standard Anchor discriminator. The empty prefix, written \"\", is carried by every call, so it is how a row matches every instruction of the program. Every instruction whose prefix an on-chain call carries receives it, so a program-wide entry fires alongside a keyed one, and two entries may share a prefix (say, the layouts before and after a program upgrade): each decodes with its own `args`, and one whose layout rejects the data is skipped for that call.",
+          "description": "0x-prefixed hex instruction-data prefix to dispatch on, of any whole number of bytes; an 8-byte value matches the standard Anchor discriminator. The empty prefix, written \"0x\", is carried by every call, so it is how a row matches every instruction of the program. This is the form `instruction.discriminator` reads back, so a config value and a handler comparison are the same string. Every instruction whose prefix an on-chain call carries receives it, so a program-wide entry fires alongside a keyed one, and two entries may share a prefix (say, the layouts before and after a program upgrade): each decodes with its own `args`, and one whose layout rejects the data is skipped for that call.",
           "type": "string"
         },
         "accounts": {

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -359,7 +359,7 @@
           ]
         },
         "instructions": {
-          "description": "Instructions to index. With `idl:`, omit this list to take the full usable IDL catalog. A YAML row overwrites the IDL instruction of the same name, or adds a new name to the catalog, and must set `discriminator` plus both `accounts` and `args`. Without `idl:`, omit `discriminator` to match every instruction of the program; set both `accounts` and `args`, or omit both.",
+          "description": "Instructions to index. With `idl:`, omit this list to take the full usable IDL catalog. A row whose name the IDL declares replaces that instruction, and must spell out `discriminator`, `accounts` and `args`. Every other row adds an instruction: omit `discriminator` to match every instruction of the program, and give `accounts` or `args` only where you want the names or the decoded payload.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/Instruction"
@@ -380,14 +380,14 @@
           "type": "string"
         },
         "discriminator": {
-          "description": "Hex-encoded instruction-data prefix used as the discriminator (\"0x\" optional), of any whole number of bytes; an 8-byte value matches the standard Anchor discriminator. With `idl:` on the program, this field is required on every YAML row. Without `idl:`, omit it to match every instruction of the program. Every instruction whose prefix an on-chain call carries receives it, so a program-wide entry fires alongside a keyed one, and two entries may share a prefix (say, the layouts before and after a program upgrade): each decodes with its own `args`, and one whose layout rejects the data is skipped for that call.",
+          "description": "Hex-encoded instruction-data prefix used as the discriminator (\"0x\" optional), of any whole number of bytes; an 8-byte value matches the standard Anchor discriminator. Required on a row that replaces an instruction the IDL declares; otherwise omit it to match every instruction of the program. Every instruction whose prefix an on-chain call carries receives it, so a program-wide entry fires alongside a keyed one, and two entries may share a prefix (say, the layouts before and after a program upgrade): each decodes with its own `args`, and one whose layout rejects the data is skipped for that call.",
           "type": [
             "string",
             "null"
           ]
         },
         "accounts": {
-          "description": "Optional positional account names. The Nth entry names account slot N on the dispatched instruction; surfaces as `instruction.accounts.<name>` when `fields.instruction` includes `accounts`.",
+          "description": "Optional positional account names. The Nth entry names account slot N on the dispatched instruction; surfaces as `instruction.accounts.<name>` when `fields.instruction` includes `accounts`. The raw slots are available either way, so this only adds the names. Required on a row that replaces an instruction the IDL declares.",
           "type": [
             "array",
             "null"
@@ -397,7 +397,7 @@
           }
         },
         "args": {
-          "description": "Optional Borsh argument schema. Each entry names one arg and gives its type; the decoder walks the instruction data after the discriminator in declared order. Must be set together with `accounts` when either is present.",
+          "description": "Optional Borsh argument schema. Each entry names one arg and gives its type; the decoder walks the instruction data after the discriminator in declared order. Omit it to leave the payload undecoded, reachable as raw `instruction.data`. Required on a row that replaces an instruction the IDL declares.",
           "type": [
             "array",
             "null"

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -359,7 +359,7 @@
           ]
         },
         "instructions": {
-          "description": "Instructions to index. With `idl:`, omit this list to take the full usable IDL catalog. A row whose name the IDL declares replaces that instruction, and must spell out `accounts` and `args`; every other row adds one. Either way, omit `discriminator` to match every instruction of the program, and give `accounts` or `args` only where you want the names or the decoded payload.",
+          "description": "Instructions to index. With `idl:`, omit this list to take the full usable IDL catalog. A row whose name the IDL declares replaces that instruction, and must spell out `accounts` and `args`; every other row adds one. Give `accounts` or `args` only where you want the names or the decoded payload.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/Instruction"
@@ -380,11 +380,8 @@
           "type": "string"
         },
         "discriminator": {
-          "description": "Hex-encoded instruction-data prefix used as the discriminator (\"0x\" optional), of any whole number of bytes; an 8-byte value matches the standard Anchor discriminator. Omit it to match every instruction of the program, whether or not the row replaces one the IDL declares. Every instruction whose prefix an on-chain call carries receives it, so a program-wide entry fires alongside a keyed one, and two entries may share a prefix (say, the layouts before and after a program upgrade): each decodes with its own `args`, and one whose layout rejects the data is skipped for that call.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "Hex-encoded instruction-data prefix to dispatch on (\"0x\" optional), of any whole number of bytes; an 8-byte value matches the standard Anchor discriminator. The empty prefix, written \"\", is carried by every call, so it is how a row matches every instruction of the program. Every instruction whose prefix an on-chain call carries receives it, so a program-wide entry fires alongside a keyed one, and two entries may share a prefix (say, the layouts before and after a program upgrade): each decodes with its own `args`, and one whose layout rejects the data is skipped for that call.",
+          "type": "string"
         },
         "accounts": {
           "description": "Optional positional account slots, in the order the program expects them. The Nth entry names account slot N on the dispatched instruction; named slots surface as `instruction.accounts.<name>` when `fields.instruction` includes `accounts`. The raw slots are available either way, so this only adds the names. Required on a row that replaces an instruction the IDL declares.",
@@ -409,7 +406,8 @@
       },
       "additionalProperties": false,
       "required": [
-        "name"
+        "name",
+        "discriminator"
       ]
     },
     "SvmAccountSlot": {

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -359,7 +359,7 @@
           ]
         },
         "instructions": {
-          "description": "Instructions to index. With `idl:`, omit this list to take the full usable IDL catalog. A row whose name the IDL declares replaces that instruction, and must spell out `accounts` and `args`; every other row adds one. Give `accounts` or `args` only where you want the names or the decoded payload.",
+          "description": "Instructions to index. With `idl:`, omit this list to take the full usable IDL catalog. A row whose name the IDL declares replaces that instruction, and must spell out `accounts` and `args`; every other row adds one. Give `accounts` where you want the slots named — an empty list names none, the same as leaving it out. `args` is not the same shape: setting it attaches a decoder that also filters, so leaving it out and setting it to `[]` are different asks.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/Instruction"

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -432,7 +432,7 @@
       ]
     },
     "ArgType": {
-      "description": "User-facing Borsh type grammar. Mirrors\n`hypersync_client_solana::decode::FieldType`. The YAML accepts either:\n- A bare string for primitives (`\"u64\"`, `\"pubkey\"`, `\"bool\"`, ...).\n- A tagged object for composites (`{ vec: u8 }`, `{ option: pubkey }`,\n  `{ array: [u8, 32] }`, `{ defined: \"DataV2\" }`).\n- An object with `kind: struct` or `kind: enum` for nominal types\n  declared inline on this field. Most users will use `defined` and\n  declare the nominal types under the program's `types:` block (Anchor\n  IDL shape) once that lands; for now inline `struct` / `enum` is the\n  only way to express nominal shapes ad-hoc.",
+      "description": "User-facing Borsh type grammar. Mirrors\n`hypersync_client_solana::decode::FieldType`. The YAML accepts either:\n- A bare string for a primitive (`u64`, `pubkey`, `bool`, ...).\n- A one-key mapping for a composite (`{ vec: u8 }`, `{ option: pubkey }`,\n  `{ array: [u8, 32] }`, `{ struct: [...] }`, `{ enum: [...] }`).\n\nA nominal type is declared inline with `struct` / `enum` at the field\nthat uses it. There is no way to name one and refer to it: attach an\n`idl` to the program when its types are shared between instructions.",
       "anyOf": [
         {
           "$ref": "#/$defs/ArgPrimitive"
@@ -516,20 +516,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Reference to a nominal type defined in the program-level\n`defined_types` registry (populated from an Anchor IDL `types:`\nblock).",
-          "type": "object",
-          "properties": {
-            "defined": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "defined"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "description": "Inline-or-registry struct. Used as a nominal type definition in\nthe `defined_types` registry; rarely seen at the field level.",
+          "description": "A struct, declared inline at the field that uses it or held in the\n`defined_types` registry.",
           "type": "object",
           "properties": {
             "struct": {
@@ -545,7 +532,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Inline-or-registry enum. Same role as `Struct`: a nominal type\ndefinition in the `defined_types` registry.",
+          "description": "An enum, declared inline at the field that uses it or held in the\n`defined_types` registry. Borsh selects a variant by its position\nhere, with a one-byte tag.",
           "type": "object",
           "properties": {
             "enum": {

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -394,7 +394,7 @@
           }
         },
         "args": {
-          "description": "Optional Borsh argument schema. Each entry names one arg and gives its type; the decoder walks the instruction data after the discriminator in declared order. Omit it to leave the payload undecoded, reachable as raw `instruction.data`. Required on a row that replaces an instruction the IDL declares.",
+          "description": "Borsh argument schema. Each entry names one arg and gives its type; the decoder walks the instruction data after the discriminator in declared order, and a call whose data the layout rejects is skipped. Setting it is therefore also a filter: `[]` says the instruction takes no arguments, so only calls carrying nothing past the discriminator are indexed. Omit it instead to attach no decoder at all — every matched call is indexed and the payload stays raw, reachable as `instruction.data`. An `idl` always declares the layout of the instructions it names, empty included. Required on a row that replaces an instruction the IDL declares.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
## Summary

Reworks how an SVM `instructions:` row describes itself, so that each field says one thing and says it the same way everywhere. Four rules changed; a user only ever sees the end state.

**⚠️ Breaking for existing SVM configs.** SVM is behind `experimental:`, and no config, template or fixture in this repo needed changing beyond what's in this PR — but see *Migration* below.

## The rules

**1. `accounts` and `args` are independent.** They were required together or not at all, which forbade nothing: an empty list already resolved the same as an absent one, so the rule only made you type `args: []`. They answer different questions — `accounts` names slots the call already carries, `args` attaches a decoder — and a row now asks for either.

**2. `discriminator` is required, and `"0x"` is the catch-all.** Absence used to mean "match every instruction of the program", which made a misspelled name next to an `idl:` a silent firehose rather than an error. Dispatch is prefix matching and the empty prefix is the one every call carries, so `discriminator: "0x"` isn't a sentinel — it *is* the catch-all. `ResolvedInstruction::from_idl` already read an IDL that declares no discriminator this way; the same reading is now spellable from YAML.

**3. The prefix must be written `0x`-prefixed.** A handler always reads `instruction.discriminator` as `0x`-prefixed lowercase hex, so `discriminator: "21"` in config came back as `"0x21"` and a handler comparing the value against its own config value got a silent `false`. Requiring the prefix makes them the same string, and collapses the two spellings of the empty prefix into one — `"0x"` is already what a zero-byte key reads back as.

**4. `args: []` is an assertion, not an absence.** Omitting `args` attaches no decoder: every matched call is indexed with its payload raw. Writing `args: []` attaches an empty layout, which says the instruction takes no arguments and therefore indexes only the calls carrying nothing past the discriminator. That makes it a real disambiguator between the bare and payload forms of a call sharing one prefix. An IDL declares the layout of every instruction it names, empty included.

`accounts` is deliberately *not* symmetric here: an empty account list names nothing, the same as omitting it, because account names don't filter.

## Bug fixed

The overwrite rule was keyed on `idl.instructions`, which holds only the instructions this runtime can dispatch and decode. A name the IDL declares but that was **set aside** — a `coption` arg, a nested `option`, an over-long array — isn't in that map, so a row naming it fell through to the "adds an instruction" path and became a program-wide catch-all. `warn_about_unindexable` skips exactly the names a row mentions, so the warning was suppressed too: total silence. It's now keyed on the name being declared at all, and an incomplete row is answered with the reason the IDL entry was dropped.

## Also in here

- **Config-time validation of Borsh arg types**, so a layout that can never decode is refused at parse rather than dropping instructions at runtime: `defined` (no registry to resolve against), nested `option` (Borsh tags each level with one byte, so `Some(None)` and `None` decode alike), arrays past 65536 elements (the decoder preallocates from the declared length), enums past 256 variants, duplicate and non-identifier names. The array and nested-option limits apply to IDLs too.
- **A hand-written `Deserialize` for `ArgType`**, so a misspelled type is answered with the names it could have been instead of `untagged`'s "matched no variant".
- **Non-finite floats** are rejected as a layout mismatch — Borsh refuses to serialize a NaN, so one on the wire says the bytes aren't the float the layout claims.
- **IDL names are escaped** in generated TypeScript via `serde_json`; an IDL is a file the program's authors wrote and its names are held to no identifier rule.
- Program, instruction and arg names must be identifiers. Account slots carry their own grammar from #1628. SVM generates no ReScript, so the reserved-word list no longer applies to program names.

## Migration

```yaml
instructions:
  - name: swap
    discriminator: "0x09"      # now required, and 0x-prefixed
  - name: everything
    discriminator: "0x"        # was: omit `discriminator`
    accounts: [source]         # may now appear without `args`
```

Two changes can reduce what an existing indexer records, both silently:

- **`args: []` now filters.** If you wrote it to mean "I don't care about args", delete the line instead. Left in place, it asserts the instruction takes no arguments and skips every call that carries a payload.
- **IDL-declared empty args now filter too.** An accurate IDL changes nothing — an instruction it says takes no arguments really does carry only its discriminator. A stale or under-specified one will drop every call for that instruction. This is 90 of 344 instructions across the three IDLs in `scenarios/svm_flow_xray`, and 38 of Jupiter's 44.

The metaplex template is the shape to copy: its instructions carry a payload, so it declares no `args`.

## Testing

- `packages/envio-tests` — `SvmInstructionLayout_test.res` covers the four row shapes through `fromUserApi` with type-checked handler source and instructions executed against `createTestIndexer`; `UserApiValidation_test.res` covers the validation errors and the catalog shapes.
- Rust — an empty layout accepts a bare discriminator and rejects a payload (`borsh_decoder`); an empty layout separates the bare and payload forms of a call sharing a prefix while a layout-less row takes both (`svm_hypersync_source`); catalog and overwrite semantics (`system_config`).
- 755 Rust · 1505 ReScript across 164 files · clippy, rustfmt, `pnpm lint` clean · `svm_test` scenario green · all three scenario configs and the metaplex template codegen clean · `svm.schema.json` regenerated and in sync.

## Known gaps

- Nested arrays skip the preallocation bound: `MAX_ARRAY_LEN` is checked per level, so `{array: [{array: [X, 65536]}, 65536]}` declares 4.29e9 elements. Bounded in practice because decoding fails fast on short data — except for an element consuming zero bytes, such as an empty inline `struct`.
- The account-filter error doesn't mention that an unnamed `_` slot can't be filtered on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121GAYsBVCzREN8CA3q2Q6J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SVM instruction configurations now require a discriminator; use `0x` for program-wide instructions.
  - Account layouts support required, optional, and unnamed positional slots.
  - Account and argument decoding can be configured independently, including raw payload access.
  - Expanded support for inline or registry-backed struct and enum types.

- **Bug Fixes**
  - Improved validation for names, types, arrays, enums, options, discriminators, and instruction overrides.
  - Safely handles escaped instruction names and rejects invalid numeric values such as NaN and infinity.
  - Updated filtering guidance for instructions without named accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
