### PR TITLE
Track response blocks from data sources for billing metrics

### DIFF
--- a/packages/cli/src/evm_hypersync_source/mod.rs
+++ b/packages/cli/src/evm_hypersync_source/mod.rs
@@ -258,6 +258,8 @@ impl EvmHyperSyncClient {
             RateLimitResponse::RateLimited(info) => return Err(make_rate_limit_err(&info)),
         };
 
+        let response_blocks = response.data.blocks.iter().map(Vec::len).sum::<usize>() as i64;
+
         let transaction_store = TransactionStore::new_evm(self.enable_checksum_addresses);
         let block_store = BlockStore::new_evm(self.enable_checksum_addresses);
         let items = tokio::task::block_in_place(|| {
@@ -307,6 +309,7 @@ impl EvmHyperSyncClient {
                 .context("convert next_block")
                 .map_err(map_err)?,
             items,
+            response_blocks,
         };
         Ok((event_items, transaction_store, block_store))
     }
@@ -378,6 +381,10 @@ pub struct EventItemsResponse {
     pub archive_height: Option<i64>,
     pub next_block: i64,
     pub items: Vec<EventItem>,
+    /// Blocks the server returned for this query, before routing drops the ones
+    /// no item joins to. The server returns one block per number, so this is a
+    /// distinct count.
+    pub response_blocks: i64,
 }
 
 fn convert_response(
@@ -540,16 +547,16 @@ fn process_response(
 
     // The server returns one block per number. Every returned block is
     // validated, items or not, and its number tracked for coverage.
-    let response_blocks: Vec<simple_types::Block> = blocks.into_iter().flatten().collect();
+    let returned_blocks: Vec<simple_types::Block> = blocks.into_iter().flatten().collect();
     let present_block_numbers: HashSet<u64> =
-        response_blocks.iter().filter_map(|b| b.number).collect();
+        returned_blocks.iter().filter_map(|b| b.number).collect();
 
     // Validate the requested block fields once per distinct block. The
     // always-required number/timestamp/hash back every header, so they are
     // checked on every returned block; the rest of the user's selection is only
     // ever read through the store, so it is checked only where an item can
     // reach it — same rule as transactions.
-    for block in &response_blocks {
+    for block in &returned_blocks {
         let referenced = block
             .number
             .is_some_and(|number| referenced_blocks.contains(&number));
@@ -589,7 +596,7 @@ fn process_response(
     // decode from the store like any other field. Blocks whose logs were all
     // dropped by client-side routing keep a hash-only row so every returned
     // header still backs reorg detection.
-    let store_blocks: Vec<simple_types::Block> = response_blocks
+    let store_blocks: Vec<simple_types::Block> = returned_blocks
         .into_iter()
         .map(|b| {
             if b.number

--- a/packages/envio-tests/test/HyperSyncSourceContract_test.res
+++ b/packages/envio-tests/test/HyperSyncSourceContract_test.res
@@ -368,6 +368,47 @@ describe("HyperSync source contract", () => {
     t.expect(heights).toEqual([7, 9])
   })
 
+  Async.it("counts the blocks the server returned, before any routing drops them", async t => {
+    let requestStats = await MockHyperSyncServer.withServer(~height=100, async server => {
+      let (source, addressSet) = makeSource(~url=server->MockHyperSyncServer.url)
+      server->MockHyperSyncServer.pushResponse({
+        ...page,
+        // Block 12 carries no log, so nothing routes to it. It is still a block
+        // the server scanned and returned, which is what the billing model
+        // counts — the metric follows the response, not the items.
+        blocks: page.blocks
+        ->Option.getOrThrow
+        ->Array.concat([
+          JSON.parseOrThrow(
+            `{"number":12,"timestamp":1700000024,"hash":"${blockHash(12)}","parent_hash":"${blockHash(
+                11,
+              )}","miner":"${minerAddress}","state_root":"${stateRoot}"}`,
+          ),
+        ]),
+      })
+      let page = await source->fetch(~addressSet, ~toBlock=Some(12))
+      page.requestStats->Array.map(({method, responseBlocks: ?responseBlocks}) => (
+        method,
+        responseBlocks,
+      ))
+    })
+
+    t.expect(requestStats).toEqual([("getLogs", Some(3))])
+  })
+
+  Async.it("counts zero blocks for a range the server matched nothing in", async t => {
+    let requestStats = await MockHyperSyncServer.withServer(~height=100, async server => {
+      let (source, addressSet) = makeSource(~url=server->MockHyperSyncServer.url)
+      let page = await source->fetch(~addressSet)
+      page.requestStats->Array.map(({method, responseBlocks: ?responseBlocks}) => (
+        method,
+        responseBlocks,
+      ))
+    })
+
+    t.expect(requestStats).toEqual([("getLogs", Some(0))])
+  })
+
   Async.it("surfaces a page that withholds a selected field", async t => {
     let result = await MockHyperSyncServer.withServer(~height=100, async server => {
       let (source, addressSet) = makeSource(~url=server->MockHyperSyncServer.url)

--- a/packages/envio-tests/test/ResponseBlocksMetric_test.res
+++ b/packages/envio-tests/test/ResponseBlocksMetric_test.res
@@ -1,0 +1,82 @@
+open Vitest
+
+// Groundwork for pricing HyperSync by the blocks it returns: the source reports
+// what came back per request, and the indexer exposes it per source and method
+// so a run can be costed against the requests that produced it.
+let scenario = Scenario.make(
+  ~configYaml=`
+name: response-blocks-metric
+rollback_on_reorg: false
+chains:
+  - id: 1337
+    rpc:
+      url: https://rpc.example.test
+      for: sync
+    start_block: 1
+    max_reorg_depth: 0
+    contracts:
+      - name: Gravatar
+        address: "0x2B2f78c5BF6D9C12Ee1225D5F374aa91204580c3"
+        events:
+          - event: "TestEvent()"
+`,
+  ~schema=`
+type Gravatar {
+  id: ID!
+  owner: String!
+}
+`,
+)
+
+describe("Source response block metrics", () => {
+  scenario->Scenario.it(
+    "Sums the blocks each response carried and counts the responses that carried none",
+    ~sources=[{chain: 1337, methods: [#getHeightOrThrow, #getItemsOrThrow], pollingInterval: 1}],
+    async (~t, ~indexer, ~source) => {
+      let sourceMock = source(1337)
+
+      let samples = async name =>
+        (await indexer.metric(name))->Array.map(({value, labels}: IndexerRunner.metric) => (
+          labels->Dict.get("method"),
+          value,
+        ))
+
+      sourceMock.resolveGetHeightOrThrow(100)
+      await MockSource.waitItemsQuery(sourceMock)
+      sourceMock.resolveGetItemsOrThrow(
+        [{blockNumber: 50, logIndex: 0}],
+        ~latestFetchedBlockNumber=50,
+        ~knownHeight=100,
+        ~requestStats=[{Source.method: "getLogs", seconds: 0.5, responseBlocks: 3}],
+      )
+      await indexer.getBatchWritePromise()
+
+      t.expect(await samples("envio_source_response_blocks_total")).toEqual([
+        (Some("getLogs"), "3"),
+      ])
+      t.expect(
+        await samples("envio_source_response_empty_total"),
+        ~message="a method that reports blocks reports its empty responses from the first request on",
+      ).toEqual([(Some("getLogs"), "0")])
+
+      // A range the source scanned and matched nothing in. It costs a request
+      // like any other, and under a per-block price it is the one billed at
+      // nothing.
+      await MockSource.waitItemsQuery(sourceMock)
+      sourceMock.resolveGetItemsOrThrow(
+        [],
+        ~latestFetchedBlockNumber=100,
+        ~knownHeight=100,
+        ~requestStats=[{Source.method: "getLogs", seconds: 0.25, responseBlocks: 0}],
+      )
+      await Utils.delay(0)
+
+      t.expect(await samples("envio_source_response_blocks_total")).toEqual([
+        (Some("getLogs"), "3"),
+      ])
+      t.expect(await samples("envio_source_response_empty_total")).toEqual([
+        (Some("getLogs"), "1"),
+      ])
+    },
+  )
+})

--- a/packages/envio-tests/test/helpers/MockSource.res
+++ b/packages/envio-tests/test/helpers/MockSource.res
@@ -197,6 +197,7 @@ type getItemsOrThrowCall = {
     ~latestFetchedBlockHash: string=?,
     ~knownHeight: int=?,
     ~prevRangeLastBlock: ReorgDetection.blockData=?,
+    ~requestStats: array<Source.requestStat>=?,
   ) => unit,
   reject: 'exn. 'exn => unit,
 }
@@ -237,6 +238,7 @@ type t = {
     ~latestFetchedBlockHash: string=?,
     ~knownHeight: int=?,
     ~prevRangeLastBlock: ReorgDetection.blockData=?,
+    ~requestStats: array<Source.requestStat>=?,
   ) => unit,
   // Empty-response every matching pending query. A statement about queries that
   // already exist, so unlike `resolveGetItemsOrThrow` it never waits for one.
@@ -435,6 +437,7 @@ let make = (
       ~latestFetchedBlockHash=?,
       ~knownHeight=?,
       ~prevRangeLastBlock=?,
+      ~requestStats=?,
     ) => {
       let respond = (call: getItemsOrThrowCall) =>
         call.resolve(
@@ -443,6 +446,7 @@ let make = (
           ~latestFetchedBlockHash?,
           ~knownHeight?,
           ~prevRangeLastBlock?,
+          ~requestStats?,
         )
       let matches = (call: getItemsOrThrowCall) =>
         switch filter {
@@ -586,6 +590,7 @@ let make = (
                 ~latestFetchedBlockHash=?,
                 ~knownHeight=knownHeight,
                 ~prevRangeLastBlock=?,
+                ~requestStats=[],
               ) => {
                 let latestFetchedBlockNumber =
                   latestFetchedBlockNumber->Option.getOr(toBlock->Option.getOr(fromBlock))
@@ -695,7 +700,7 @@ let make = (
                   stats: {
                     totalTimeElapsed: 0.,
                   },
-                  requestStats: [],
+                  requestStats,
                 })
               },
               reject: reject->Utils.magic,

--- a/packages/envio-tests/test/lib_tests/Metrics_test.res
+++ b/packages/envio-tests/test/lib_tests/Metrics_test.res
@@ -190,6 +190,50 @@ envio_info{version="${Utils.EnvioPackage.value.version}"} 1
     ])
   })
 
+  it("Aggregates source request samples that share a source name and chain", t => {
+    let sourceRequest = (
+      ~chainId=1,
+      ~method="getLogs",
+      ~responseBlocks,
+      ~emptyResponseCount,
+    ): Metrics.sourceRequestMetrics => {
+      source: "HyperSync",
+      chainId: chainId->ChainId.fromInt,
+      method,
+      count: 1,
+      seconds: 0.,
+      responseBlocks,
+      emptyResponseCount,
+    }
+    let metrics: Metrics.t = {
+      ...baseMetrics,
+      // Two urls on the same host share a source name, and duplicate samples
+      // would make Prometheus reject the whole scrape.
+      sourceRequests: [
+        sourceRequest(~responseBlocks=Some(30), ~emptyResponseCount=1),
+        sourceRequest(~responseBlocks=Some(12), ~emptyResponseCount=2),
+        // A chain whose every response carried blocks still renders the empty
+        // counter, flat at zero — a series that only appears once the first
+        // empty response lands is one nothing can alert on.
+        sourceRequest(~chainId=2, ~responseBlocks=Some(7), ~emptyResponseCount=0),
+        // A stream push is a response nothing measures in blocks, so it stays
+        // out of both series rather than reading as an empty response.
+        sourceRequest(~method="heightPush", ~responseBlocks=None, ~emptyResponseCount=0),
+      ],
+    }
+
+    t.expect(
+      Metrics.collect(~metrics=Some(metrics))
+      ->String.split("\n")
+      ->Array.filter(line => line->String.startsWith("envio_source_response")),
+    ).toStrictEqual([
+      `envio_source_response_blocks_total{source="HyperSync",chainId="1",method="getLogs"} 42`,
+      `envio_source_response_blocks_total{source="HyperSync",chainId="2",method="getLogs"} 7`,
+      `envio_source_response_empty_total{source="HyperSync",chainId="1",method="getLogs"} 3`,
+      `envio_source_response_empty_total{source="HyperSync",chainId="2",method="getLogs"} 0`,
+    ])
+  })
+
   it("Renders every metric family from a fully populated snapshot", t => {
     let metrics: Metrics.t = {
       startTime: Date.fromTime(1700000000000.),
@@ -299,6 +343,8 @@ envio_info{version="${Utils.EnvioPackage.value.version}"} 1
           method: "getLogs",
           count: 42,
           seconds: 33.75,
+          responseBlocks: Some(1234),
+          emptyResponseCount: 9,
         },
         {
           source: "HyperSync",
@@ -306,6 +352,8 @@ envio_info{version="${Utils.EnvioPackage.value.version}"} 1
           method: "heightPush",
           count: 7,
           seconds: 0.,
+          responseBlocks: None,
+          emptyResponseCount: 0,
         },
         {
           source: "HyperSync",
@@ -313,6 +361,8 @@ envio_info{version="${Utils.EnvioPackage.value.version}"} 1
           method: "heightPushIgnored",
           count: 0,
           seconds: 0.,
+          responseBlocks: None,
+          emptyResponseCount: 0,
         },
       ],
       sourceHeights: [
@@ -461,6 +511,14 @@ envio_source_request_total{source="HyperSync",chainId="1",method="heightPush"} 7
 # HELP envio_source_request_seconds_total Cumulative time spent on data source requests.
 # TYPE envio_source_request_seconds_total counter
 envio_source_request_seconds_total{source="HyperSync",chainId="1",method="getLogs"} 33.75
+
+# HELP envio_source_response_blocks_total The number of blocks a data source returned, summed over its responses. Counted as the source sent them, before the indexer drops the blocks no event needs. Only sources whose responses are measured in blocks report it.
+# TYPE envio_source_response_blocks_total counter
+envio_source_response_blocks_total{source="HyperSync",chainId="1",method="getLogs"} 1234
+
+# HELP envio_source_response_empty_total The number of responses that came back with no blocks at all — a range the source scanned and matched nothing in. Compare against envio_source_request_total for the share of requests that returned nothing.
+# TYPE envio_source_response_empty_total counter
+envio_source_response_empty_total{source="HyperSync",chainId="1",method="getLogs"} 9
 
 # HELP envio_source_height_stream_connects_total The number of times a source's height subscription connected. Compare against the disconnects total, which is absent until the first disconnect and counts as zero while it is: one more connect than disconnects means the stream is up, and equal counts mean it is down and the indexer is polling instead. Zero connects means the stream has not come up, which is the normal reading for a chain that is still backfilling: subscriptions are only opened once a chain reaches the head.
 # TYPE envio_source_height_stream_connects_total counter

--- a/packages/envio-tests/test/lib_tests/SourceManager_test.res
+++ b/packages/envio-tests/test/lib_tests/SourceManager_test.res
@@ -1563,6 +1563,44 @@ describe("SourceManager.executeQuery", () => {
     ).toEqual([("getLogs", 1, 0.5)])
   })
 
+  Async.it("Sums the blocks a source returned and counts its empty responses", async t => {
+    let sourceMock = MockSource.make([#getItemsOrThrow])
+    let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[sourceMock.source])
+    let query = (~fromBlock) =>
+      sourceManager->SourceManager.executeQuery(
+        ~query={...mockQuery(), fromBlock},
+        ~isRealtime=false,
+        ~knownHeight=100,
+      )
+
+    let first = query(~fromBlock=10)
+    (sourceMock.getItemsOrThrowCalls->Utils.Array.firstUnsafe).resolve(
+      [],
+      ~requestStats=[{Source.method: "getLogs", seconds: 0.5, responseBlocks: 3}],
+    )
+    let _ = await first
+
+    // A range the source scanned and found nothing in: it still costs a
+    // request, and under a per-block price it is the one that costs nothing.
+    let second = query(~fromBlock=20)
+    (sourceMock.getItemsOrThrowCalls->Utils.Array.lastUnsafe).resolve(
+      [],
+      ~requestStats=[{Source.method: "getLogs", seconds: 0.25, responseBlocks: 0}],
+    )
+    let _ = await second
+
+    t.expect(
+      sourceManager
+      ->SourceManager.getRequestStatSamples
+      ->Array.map(({method, count, responseBlocks, emptyResponseCount}) => (
+        method,
+        count,
+        responseBlocks,
+        emptyResponseCount,
+      )),
+    ).toEqual([("getLogs", 2, Some(3), 1)])
+  })
+
   Async.it("Rethrows unknown errors", async t => {
     let sourceMock = MockSource.make([#getItemsOrThrow])
     let sourceManager = SourceManager.make(~isRealtime=false, ~sources=[sourceMock.source])

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -533,6 +533,8 @@ let toMetrics = (state: t): Metrics.t => {
         method: s.method,
         count: s.count,
         seconds: s.seconds,
+        responseBlocks: s.responseBlocks,
+        emptyResponseCount: s.emptyResponseCount,
       })
     )
     sourceManager

--- a/packages/envio/src/Metrics.res
+++ b/packages/envio/src/Metrics.res
@@ -90,6 +90,10 @@ type sourceRequestMetrics = {
   method: string,
   count: int,
   seconds: float,
+  // None for methods whose responses aren't measured in blocks; they render no
+  // block series at all.
+  responseBlocks: option<int>,
+  emptyResponseCount: int,
 }
 
 type sourceHeightMetrics = {
@@ -249,7 +253,16 @@ let renderMetrics = (b: builder, metrics: t) => {
       | Some(existing) =>
         byLabels->Dict.set(
           labels,
-          {...existing, count: existing.count + s.count, seconds: existing.seconds +. s.seconds},
+          {
+            ...existing,
+            count: existing.count + s.count,
+            seconds: existing.seconds +. s.seconds,
+            responseBlocks: switch (existing.responseBlocks, s.responseBlocks) {
+            | (Some(a), Some(b)) => Some(a + b)
+            | (some, None) | (None, some) => some
+            },
+            emptyResponseCount: existing.emptyResponseCount + s.emptyResponseCount,
+          },
         )
       | None => byLabels->Dict.set(labels, s)
       }
@@ -508,6 +521,23 @@ let renderMetrics = (b: builder, metrics: t) => {
     ~kind="counter",
     ~entries=sourceRequests,
     ~value=s => s.seconds !== 0. ? Some(s.seconds) : None,
+  )
+  b->seriesOpt(
+    ~name="envio_source_response_blocks_total",
+    ~help="The number of blocks a data source returned, summed over its responses. Counted as the source sent them, before the indexer drops the blocks no event needs. Only sources whose responses are measured in blocks report it.",
+    ~kind="counter",
+    ~entries=sourceRequests,
+    ~value=s => s.responseBlocks->Option.map(Int.toFloat),
+  )
+  // Rendered flat at zero for any method that reports blocks: a chain scanning
+  // ranges it finds nothing in is the reading this exists for, and a series
+  // that only appears once the first empty response lands can't be alerted on.
+  b->seriesOpt(
+    ~name="envio_source_response_empty_total",
+    ~help="The number of responses that came back with no blocks at all — a range the source scanned and matched nothing in. Compare against envio_source_request_total for the share of requests that returned nothing.",
+    ~kind="counter",
+    ~entries=sourceRequests,
+    ~value=s => s.responseBlocks->Option.map(_ => s.emptyResponseCount->Int.toFloat),
   )
   if heightStreamConnects->Array.length > 0 {
     b->series(

--- a/packages/envio/src/sources/EvmHyperSyncSource.res
+++ b/packages/envio/src/sources/EvmHyperSyncSource.res
@@ -141,7 +141,9 @@ let make = (
     }
 
     let pageFetchTime = startFetchingBatchTimeRef->Performance.secondsSince
-    let requestStats = [{Source.method: "getLogs", seconds: pageFetchTime}]
+    let requestStats = [
+      {Source.method: "getLogs", seconds: pageFetchTime, responseBlocks: pageUnsafe.responseBlocks},
+    ]
 
     //set height and next from block
     let knownHeight = pageUnsafe.archiveHeight

--- a/packages/envio/src/sources/HyperSync.res
+++ b/packages/envio/src/sources/HyperSync.res
@@ -90,6 +90,7 @@ type logsQueryPage = {
   items: array<HyperSyncClient.EventItems.item>,
   nextBlock: int,
   archiveHeight: int,
+  responseBlocks: int,
   // Page store owning this page's raw transactions.
   transactionStore: TransactionStore.t,
   // Page store owning this page's raw blocks.
@@ -165,6 +166,7 @@ module GetLogs = {
     {
       items: res.items,
       nextBlock: res.nextBlock,
+      responseBlocks: res.responseBlocks,
       archiveHeight: res.archiveHeight->Option.getOr(0), //Archive Height is only None if height is 0
       transactionStore,
       blockStore,

--- a/packages/envio/src/sources/HyperSync.resi
+++ b/packages/envio/src/sources/HyperSync.resi
@@ -2,6 +2,7 @@ type logsQueryPage = {
   items: array<HyperSyncClient.EventItems.item>,
   nextBlock: int,
   archiveHeight: int,
+  responseBlocks: int,
   transactionStore: TransactionStore.t,
   blockStore: BlockStore.t,
 }

--- a/packages/envio/src/sources/HyperSyncClient.res
+++ b/packages/envio/src/sources/HyperSyncClient.res
@@ -283,6 +283,9 @@ module EventItems = {
     archiveHeight: option<int>,
     nextBlock: int,
     items: array<item>,
+    // Blocks the server returned for the query, counted before routing drops
+    // the ones no item joins to.
+    responseBlocks: int,
   }
 }
 

--- a/packages/envio/src/sources/RequestStat.res
+++ b/packages/envio/src/sources/RequestStat.res
@@ -2,4 +2,11 @@
 // in its own leaf module (rather than on `Source`) so the client FFI bindings
 // can name it without importing `Source` — which would form a dependency cycle
 // through `Env → HyperSyncClient → Source → FetchState → Env`.
-type t = {method: string, seconds: float}
+type t = {
+  method: string,
+  seconds: float,
+  // Blocks the backend returned for this request, before any client-side
+  // routing drops them. Absent for methods whose responses aren't measured in
+  // blocks, so a zero always means the request came back empty.
+  responseBlocks?: int,
+}

--- a/packages/envio/src/sources/Source.res
+++ b/packages/envio/src/sources/Source.res
@@ -8,9 +8,10 @@ type blockRangeFetchStats = {
 }
 
 // A single backend request a source method actually made (cache/dedup hits
-// aren't requests), with the time it took. SourceManager aggregates these
-// per (source, method) into the envio_source_request_* metrics.
-type requestStat = RequestStat.t = {method: string, seconds: float}
+// aren't requests), with the time it took and how much it brought back.
+// SourceManager aggregates these per (source, method) into the
+// envio_source_request_* and envio_source_response_* metrics.
+type requestStat = RequestStat.t = {method: string, seconds: float, responseBlocks?: int}
 
 // Native clients wrap a failure of a multi-request operation in a structured
 // payload, so the source can still return timings when SourceManager retries

--- a/packages/envio/src/sources/SourceManager.res
+++ b/packages/envio/src/sources/SourceManager.res
@@ -1,9 +1,14 @@
 type sourceManagerStatus = Idle | WaitingForNewBlock | Querying
 
-// Cumulative per-method request count/time for a source, aggregated from the
-// requestStat arrays returned by its methods. Rendered into
-// envio_source_request_* by Metrics.renderSourceRequests.
-type requestStatAgg = {mutable count: int, mutable seconds: float}
+// Cumulative per-method request stats for a source, aggregated from the
+// requestStat arrays returned by its methods. Rendered into the
+// envio_source_request_* and envio_source_response_* metrics.
+type requestStatAgg = {
+  mutable count: int,
+  mutable seconds: float,
+  mutable responseBlocks: option<int>,
+  mutable emptyResponseCount: int,
+}
 
 type sourceState = {
   source: Source.t,
@@ -19,12 +24,23 @@ let recordStatsInto = (
   aggregates: dict<requestStatAgg>,
   requestStats: array<Source.requestStat>,
 ) => {
-  requestStats->Array.forEach(({method, seconds}) => {
-    switch aggregates->Utils.Dict.dangerouslyGetNonOption(method) {
-    | Some(agg) =>
-      agg.count = agg.count + 1
-      agg.seconds = agg.seconds +. seconds
-    | None => aggregates->Dict.set(method, {count: 1, seconds})
+  requestStats->Array.forEach(({method, seconds, responseBlocks: ?responseBlocks}) => {
+    let agg = switch aggregates->Utils.Dict.dangerouslyGetNonOption(method) {
+    | Some(agg) => agg
+    | None =>
+      let agg = {count: 0, seconds: 0., responseBlocks: None, emptyResponseCount: 0}
+      aggregates->Dict.set(method, agg)
+      agg
+    }
+    agg.count = agg.count + 1
+    agg.seconds = agg.seconds +. seconds
+    switch responseBlocks {
+    | Some(responseBlocks) =>
+      agg.responseBlocks = Some(agg.responseBlocks->Option.getOr(0) + responseBlocks)
+      if responseBlocks === 0 {
+        agg.emptyResponseCount = agg.emptyResponseCount + 1
+      }
+    | None => ()
     }
   })
 }
@@ -40,6 +56,8 @@ type requestStatSample = {
   method: string,
   count: int,
   seconds: float,
+  responseBlocks: option<int>,
+  emptyResponseCount: int,
 }
 
 // Encapsulates the fetching logic for a chain's sources.
@@ -93,6 +111,8 @@ let getRequestStatSamples = (sourceManager: t): array<requestStatSample> => {
         method,
         count: agg.count,
         seconds: agg.seconds,
+        responseBlocks: agg.responseBlocks,
+        emptyResponseCount: agg.emptyResponseCount,
       })
       ->ignore
     })

--- a/packages/envio/src/sources/SourceManager.resi
+++ b/packages/envio/src/sources/SourceManager.resi
@@ -27,6 +27,8 @@ type requestStatSample = {
   method: string,
   count: int,
   seconds: float,
+  responseBlocks: option<int>,
+  emptyResponseCount: int,
 }
 
 let getRequestStatSamples: t => array<requestStatSample>


### PR DESCRIPTION
Add metrics to track the number of blocks returned by data sources per request, enabling per-block billing models for services like HyperSync.

## Summary

This change instruments data source requests to measure and expose how many blocks each response carried, before any client-side routing drops blocks that don't contain relevant events. Two new Prometheus metrics are introduced:
- `envio_source_response_blocks_total`: sum of blocks across all responses for a method
- `envio_source_response_empty_total`: count of responses that returned zero blocks

## Key Changes

- **RequestStat type**: Extended with optional `responseBlocks` field to track blocks per request
- **HyperSync client**: Counts distinct blocks in each response before routing
- **SourceManager**: Aggregates response block counts and empty response counts per (source, method) pair
- **Metrics**: New series render aggregated block counts and empty response counts, only for methods that report blocks
- **Tests**: Added integration tests verifying block counting across mock sources and end-to-end scenarios

## Implementation Details

- Response block counts are optional (`responseBlocks?: int`) since some methods (like `heightPush`) don't measure responses in blocks
- Empty response counter is only rendered for methods that report blocks, ensuring the series exists from the first empty response (required for alerting)
- Block counts reflect what the server returned, not what the indexer ultimately routes to handlers — this matches the billing model where the cost is incurred at the source
- Aggregation in `SourceManager.recordStatsInto` sums blocks across requests and tracks empty responses separately

https://claude.ai/code/session_01Gm37R2o82bJCprNt9V4gGN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added source request metrics for the number of response blocks returned by the server.
  - Added tracking for empty responses, including requests that return no matching blocks.
  - Prometheus metrics now expose returned-block totals and empty-response counts for applicable source methods.
  - HyperSync statistics preserve block counts even when returned blocks contain no routable logs.

- **Bug Fixes**
  - Improved accuracy of source request aggregation across responses, chains, methods, and sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->