### PR TITLE
SVM: handlers from directory only, reject per-program handler

### DIFF
--- a/packages/cli/src/config_parsing/human_config.rs
+++ b/packages/cli/src/config_parsing/human_config.rs
@@ -1430,11 +1430,6 @@ pub mod svm {
         )]
         pub program_id: ProgramId,
         #[serde(skip_serializing_if = "Option::is_none")]
-        #[schemars(description = "Optional relative path to a file where handlers are \
-                                  registered for the given program. If not provided, handlers \
-                                  can be auto-loaded from the src directory.")]
-        pub handler: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         #[schemars(
             description = "Optional path (relative to config.yaml) to an IDL JSON file (Anchor \
                            0.30+, legacy Anchor, Shank, or Codama). When present, every usable \
@@ -2342,7 +2337,6 @@ programs:
                     program_id: ProgramId::Single(
                         "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s".to_string()
                     ),
-                    handler: None,
                     idl: None,
                     instructions: vec![
                         Instruction {

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -2961,41 +2961,32 @@ mod test {
         assert_eq!(ids, vec![SOLANA_MAINNET_CHAIN_ID, SOLANA_DEVNET_CHAIN_ID]);
     }
 
-    // SVM handlers are registered from the `handlers` directory alone, so the
-    // directory has to reach the runtime config and a per-program `handler`
-    // path has to be rejected.
+    // svm parsed `handlers` and then dropped it, so a custom directory never
+    // reached the runtime config. Rejecting a per-program `handler` is covered
+    // at the user-API rung in UserApiValidation_test.
     #[test]
-    fn svm_handlers_come_from_the_handlers_directory_only() {
+    fn svm_carries_the_handlers_directory_through() {
         let schema = "type Foo @entity { id: ID! }";
-        let yaml = |base: &str, program: &str| {
+        let yaml = |base: &str| {
             format!(
                 "name: x\necosystem: svm\n{base}chains:\n  - id: solana\n    start_slot: \
                  0\nprograms:\n  - name: TokenMetadata\n    program_id: \
-                 metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s\n{program}    instructions:\n      \
-                 - name: UpdateMetadataAccountV2\n        discriminator: \"0x0f\"\n"
+                 metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s\n    instructions:\n      - name: \
+                 UpdateMetadataAccountV2\n        discriminator: \"0x0f\"\n"
             )
         };
         let parse = |yaml: &str| {
             SystemConfig::parse_yaml(yaml, Some(schema), &HashMap::new(), &HashMap::new(), false)
+                .expect("svm config")
+                .handlers
         };
-
-        let default_dir = parse(&yaml("", "")).expect("svm config").handlers;
-        let custom_dir = parse(&yaml("handlers: src/svm-handlers\n", ""))
-            .expect("svm config")
-            .handlers;
-        let per_program = format!(
-            "{:#}",
-            parse(&yaml("", "    handler: ./src/Handlers.ts\n"))
-                .expect_err("per-program handler must be rejected")
-        );
 
         assert_eq!(
             (
-                default_dir,
-                custom_dir,
-                per_program.contains("unknown field `handler`")
+                parse(&yaml("")),
+                parse(&yaml("handlers: src/svm-handlers\n"))
             ),
-            (None, Some("src/svm-handlers".to_string()), true)
+            (None, Some("src/svm-handlers".to_string()))
         );
     }
 

--- a/packages/cli/src/config_parsing/system_config.rs
+++ b/packages/cli/src/config_parsing/system_config.rs
@@ -1396,12 +1396,8 @@ impl SystemConfig {
                         .collect();
                     warn_about_unindexable(program, &svm_abi.idl.unusable);
 
-                    let contract = Contract::new(
-                        program.name.clone(),
-                        program.handler.clone(),
-                        events,
-                        Abi::Svm(svm_abi),
-                    )?;
+                    let contract =
+                        Contract::new(program.name.clone(), None, events, Abi::Svm(svm_abi))?;
                     contracts.insert(contract.name.clone(), contract);
 
                     for (chain_id, address) in &program_addresses[&program.name] {
@@ -1475,7 +1471,7 @@ impl SystemConfig {
                     enable_raw_events: false,
                     storage,
                     lowercase_addresses: false,
-                    handlers: None,
+                    handlers: svm_config.base.handlers.clone(),
                     human_config,
                     is_rescript,
                 })
@@ -2963,6 +2959,44 @@ mod test {
         let mut ids: Vec<_> = config.chains.keys().copied().collect();
         ids.sort();
         assert_eq!(ids, vec![SOLANA_MAINNET_CHAIN_ID, SOLANA_DEVNET_CHAIN_ID]);
+    }
+
+    // SVM handlers are registered from the `handlers` directory alone, so the
+    // directory has to reach the runtime config and a per-program `handler`
+    // path has to be rejected.
+    #[test]
+    fn svm_handlers_come_from_the_handlers_directory_only() {
+        let schema = "type Foo @entity { id: ID! }";
+        let yaml = |base: &str, program: &str| {
+            format!(
+                "name: x\necosystem: svm\n{base}chains:\n  - id: solana\n    start_slot: \
+                 0\nprograms:\n  - name: TokenMetadata\n    program_id: \
+                 metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s\n{program}    instructions:\n      \
+                 - name: UpdateMetadataAccountV2\n        discriminator: \"0x0f\"\n"
+            )
+        };
+        let parse = |yaml: &str| {
+            SystemConfig::parse_yaml(yaml, Some(schema), &HashMap::new(), &HashMap::new(), false)
+        };
+
+        let default_dir = parse(&yaml("", "")).expect("svm config").handlers;
+        let custom_dir = parse(&yaml("handlers: src/svm-handlers\n", ""))
+            .expect("svm config")
+            .handlers;
+        let per_program = format!(
+            "{:#}",
+            parse(&yaml("", "    handler: ./src/Handlers.ts\n"))
+                .expect_err("per-program handler must be rejected")
+        );
+
+        assert_eq!(
+            (
+                default_dir,
+                custom_dir,
+                per_program.contains("unknown field `handler`")
+            ),
+            (None, Some("src/svm-handlers".to_string()), true)
+        );
     }
 
     // `start_block: latest` has to survive the whole config pipeline on every

--- a/packages/envio-tests/test/UserApiValidation_test.res
+++ b/packages/envio-tests/test/UserApiValidation_test.res
@@ -560,7 +560,24 @@ programs:
     bogus_extra: true
     instructions: []
 `,
-      "Failed to deserialize config. Visit the docs for more information https://docs.envio.dev/docs/configuration-file: programs[0]: unknown field \`bogus_extra\`, expected one of \`name\`, \`program_id\`, \`handler\`, \`idl\`, \`instructions\` at line 10 column 5",
+      "Failed to deserialize config. Visit the docs for more information https://docs.envio.dev/docs/configuration-file: programs[0]: unknown field \`bogus_extra\`, expected one of \`name\`, \`program_id\`, \`idl\`, \`instructions\` at line 10 column 5",
+    ),
+    (
+      // SVM registers handlers from the `handlers` directory alone.
+      "rejects a per-program handler path on SVM",
+      `
+name: svm-program-handler
+ecosystem: svm
+chains:
+  - id: solana
+    start_slot: 1
+programs:
+  - name: Program
+    program_id: metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
+    handler: ./src/Handlers.ts
+    instructions: []
+`,
+      "Failed to deserialize config. Visit the docs for more information https://docs.envio.dev/docs/configuration-file: programs[0]: unknown field \`handler\`, expected one of \`name\`, \`program_id\`, \`idl\`, \`instructions\` at line 10 column 5",
     ),
   ]->Array.forEach(((name, yaml, message)) => {
     it(name, t => expectParseError(t, yaml, message))

--- a/packages/envio/svm.schema.json
+++ b/packages/envio/svm.schema.json
@@ -341,13 +341,6 @@
           "description": "Base58-encoded program id (32 bytes). A single value is allowed only when the config defines one chain; with several, give a mapping keyed by chain id that names every one of them, writing `_` for a chain the program is not deployed on.",
           "$ref": "#/$defs/SvmProgramId"
         },
-        "handler": {
-          "description": "Optional relative path to a file where handlers are registered for the given program. If not provided, handlers can be auto-loaded from the src directory.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "idl": {
           "description": "Optional path (relative to config.yaml) to an IDL JSON file (Anchor 0.30+, legacy Anchor, Shank, or Codama). When present, every usable instruction is in the catalog and `onInstruction` selects by name. Omit YAML `instructions` to take that catalog as-is. A YAML row overwrites the IDL instruction of the same name, or adds a name the IDL did not declare.",
           "type": [


### PR DESCRIPTION
SVM programs now load handlers exclusively from the configured `handlers` directory (or `src` by default), rather than supporting per-program `handler` paths. This aligns SVM with the design principle that handler discovery is ecosystem-wide, not per-program.

**Changes:**

- Removed `handler` field from SVM program config schema (`svm.schema.json`) and human config struct (`human_config.rs`)
- Updated `Contract::new()` call to pass `None` instead of `program.handler` when building SVM contracts
- Propagated the base `handlers` directory to runtime config instead of `None`, enabling the runtime to locate handlers
- Added test case verifying that per-program `handler` is rejected and handlers come from the directory alone

The runtime now receives the handlers directory path and can discover handlers via standard module resolution, eliminating the need for explicit per-program handler registration.

https://claude.ai/code/session_01MRoxbt8uMQwmaB1f8SRCpM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Removed support for specifying a handler path per SVM program.
  - SVM programs now use the configured base handlers directory.
  - Configuration validation rejects unsupported per-program handler settings.
- **Bug Fixes**
  - Improved propagation of the default and custom handlers directory settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->