### PR TITLE
Deduplicate events when one log routes to multiple handlers

### DIFF
--- a/packages/cli/src/executor/snapshots/envio__executor__tools__tests__fetch_docs_mcp_server_page.snap
+++ b/packages/cli/src/executor/snapshots/envio__executor__tools__tests__fetch_docs_mcp_server_page.snap
@@ -42,7 +42,7 @@ The MCP server exposes two tools:
 
 ## Envio CLI Tools
 
-Starting from Envio `3.1`, the same documentation search and retrieval is also available directly through the Envio CLI — no MCP server setup required. AI agents can call these tools out of the box:
+Starting from Envio `3.1`, the same documentation search and retrieval is also available directly through the Envio CLI - no MCP server setup required. AI agents can call these tools out of the box:
 
 | Tool                              | Description                                                                                              |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------- |

--- a/packages/envio-tests/test/ChainMeta_test.res
+++ b/packages/envio-tests/test/ChainMeta_test.res
@@ -21,6 +21,7 @@ let emptyBatch = (~checkpointId): Batch.t => {
   checkpointChainIds: [1->ChainId.fromInt],
   checkpointBlockNumbers: [checkpointId->BigInt.toInt],
   checkpointBlockHashes: [`0x${checkpointId->BigInt.toString}`->Null.make],
+  checkpointItemsCount: [0],
   checkpointEventsProcessed: [0],
   registeredAddresses: [],
 }

--- a/packages/envio-tests/test/ChainMeta_test.res
+++ b/packages/envio-tests/test/ChainMeta_test.res
@@ -21,7 +21,6 @@ let emptyBatch = (~checkpointId): Batch.t => {
   checkpointChainIds: [1->ChainId.fromInt],
   checkpointBlockNumbers: [checkpointId->BigInt.toInt],
   checkpointBlockHashes: [`0x${checkpointId->BigInt.toString}`->Null.make],
-  checkpointItemsCount: [0],
   checkpointEventsProcessed: [0],
   registeredAddresses: [],
 }

--- a/packages/envio-tests/test/ChainStateReorgThreshold_test.res
+++ b/packages/envio-tests/test/ChainStateReorgThreshold_test.res
@@ -138,6 +138,7 @@ describe("ChainState reorg threshold", () => {
       checkpointChainIds: [],
       checkpointBlockNumbers: [],
       checkpointBlockHashes: [],
+      checkpointItemsCount: [],
       checkpointEventsProcessed: [],
       registeredAddresses: [],
     }

--- a/packages/envio-tests/test/ChainStateReorgThreshold_test.res
+++ b/packages/envio-tests/test/ChainStateReorgThreshold_test.res
@@ -138,7 +138,6 @@ describe("ChainState reorg threshold", () => {
       checkpointChainIds: [],
       checkpointBlockNumbers: [],
       checkpointBlockHashes: [],
-      checkpointItemsCount: [],
       checkpointEventsProcessed: [],
       registeredAddresses: [],
     }

--- a/packages/envio-tests/test/EventsProcessedDedup_test.res
+++ b/packages/envio-tests/test/EventsProcessedDedup_test.res
@@ -1,0 +1,95 @@
+// One log routed to two registrations runs two handlers but is still one
+// processed event — the count is of logs, not of handler runs.
+let _ = InternalTestIndexer.fromUserApi(
+  ~configYaml=`
+name: events-processed-dedup
+contracts:
+  - name: Token
+    events:
+      - event: Transfer(address indexed from, address indexed to, uint256 value)
+chains:
+  - id: 1
+    start_block: 0
+    contracts:
+      - name: Token
+        address: "0x1111111111111111111111111111111111111111"
+`,
+  ~schema=`
+type Account {
+  id: ID!
+  balance: BigInt!
+}
+`,
+  ~handlers=`
+import { indexer } from "envio";
+
+indexer.onEvent({ contract: "Token", event: "Transfer" }, async ({ event, context }) => {
+  context.Account.set({ id: event.params.to, balance: event.params.value });
+});
+
+indexer.onEvent({ contract: "Token", event: "Transfer" }, async ({ event, context }) => {
+  context.Account.set({ id: event.params.from, balance: event.params.value });
+});
+`,
+  ~test=`
+import { describe, it } from "vitest";
+import { createTestIndexer, TestHelpers } from "envio";
+
+const { Addresses } = TestHelpers;
+
+const [from, to, other] = Addresses.mockAddresses;
+
+const transfer = (params: { from: typeof from; to: typeof to; value: bigint }) => ({
+  contract: "Token" as const,
+  event: "Transfer" as const,
+  params,
+});
+
+describe("events processed dedup", () => {
+  it("counts a log once when two registrations route it", async (t) => {
+    const indexer = createTestIndexer();
+    const result = await indexer.process({
+      chains: {
+        1: {
+          startBlock: 1,
+          endBlock: 100,
+          simulate: [transfer({ from, to, value: 5n })],
+        },
+      },
+    });
+
+    t.expect(result.changes).toEqual([
+      {
+        block: 1,
+        chainId: 1,
+        eventsProcessed: 1,
+        Account: {
+          sets: [
+            { id: to, balance: 5n },
+            { id: from, balance: 5n },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("counts every log of a block once", async (t) => {
+    const indexer = createTestIndexer();
+    const result = await indexer.process({
+      chains: {
+        1: {
+          startBlock: 1,
+          endBlock: 100,
+          simulate: [
+            transfer({ from, to, value: 5n }),
+            transfer({ from, to: other, value: 7n }),
+          ],
+        },
+      },
+    });
+
+    t.expect(result.changes.map((change) => change.eventsProcessed)).toEqual([2]);
+  });
+});
+`,
+)

--- a/packages/envio-tests/test/lib_tests/ChainState_test.res
+++ b/packages/envio-tests/test/lib_tests/ChainState_test.res
@@ -199,7 +199,6 @@ describe("ChainState chain density EMA (per batch)", () => {
     checkpointChainIds: [],
     checkpointBlockNumbers: [],
     checkpointBlockHashes: [],
-    checkpointItemsCount: [],
     checkpointEventsProcessed: [],
     registeredAddresses: [],
   }

--- a/packages/envio-tests/test/lib_tests/ChainState_test.res
+++ b/packages/envio-tests/test/lib_tests/ChainState_test.res
@@ -199,6 +199,7 @@ describe("ChainState chain density EMA (per batch)", () => {
     checkpointChainIds: [],
     checkpointBlockNumbers: [],
     checkpointBlockHashes: [],
+    checkpointItemsCount: [],
     checkpointEventsProcessed: [],
     registeredAddresses: [],
   }

--- a/packages/envio-tests/test/lib_tests/CrossChainState_test.res
+++ b/packages/envio-tests/test/lib_tests/CrossChainState_test.res
@@ -158,7 +158,6 @@ let emptyBatch: Batch.t = {
   checkpointChainIds: [],
   checkpointBlockNumbers: [],
   checkpointBlockHashes: [],
-  checkpointItemsCount: [],
   checkpointEventsProcessed: [],
   registeredAddresses: [],
 }

--- a/packages/envio-tests/test/lib_tests/CrossChainState_test.res
+++ b/packages/envio-tests/test/lib_tests/CrossChainState_test.res
@@ -158,6 +158,7 @@ let emptyBatch: Batch.t = {
   checkpointChainIds: [],
   checkpointBlockNumbers: [],
   checkpointBlockHashes: [],
+  checkpointItemsCount: [],
   checkpointEventsProcessed: [],
   registeredAddresses: [],
 }

--- a/packages/envio/src/Batch.res
+++ b/packages/envio/src/Batch.res
@@ -42,6 +42,8 @@ type t = {
   checkpointChainIds: array<ChainId.t>,
   checkpointBlockNumbers: array<int>,
   checkpointBlockHashes: array<Null.t<string>>,
+  // Items the checkpoint carries, which is what indexes `items`.
+  checkpointItemsCount: array<int>,
   // Logs the checkpoint carries: one log routed to several registrations is one
   // event, however many items it made.
   checkpointEventsProcessed: array<int>,
@@ -163,6 +165,7 @@ let addReorgCheckpoints = (
   ~mutCheckpointChainIds,
   ~mutCheckpointBlockNumbers,
   ~mutCheckpointBlockHashes,
+  ~mutCheckpointItemsCount,
   ~mutCheckpointEventsProcessed,
 ) => {
   if shouldRollbackOnReorg {
@@ -184,6 +187,7 @@ let addReorgCheckpoints = (
       mutCheckpointChainIds->Array.push(chainId)
       mutCheckpointBlockNumbers->Array.push(blockNumber)
       mutCheckpointBlockHashes->Array.push(Null.Value(hash))
+      mutCheckpointItemsCount->Array.push(0)
       mutCheckpointEventsProcessed->Array.push(0)
 
       idx := idx.contents + 1
@@ -221,6 +225,7 @@ let make = (
   let checkpointChainIds = []
   let checkpointBlockNumbers = []
   let checkpointBlockHashes = []
+  let checkpointItemsCount = []
   let checkpointEventsProcessed = []
 
   // Accumulate items for all actively indexing chains
@@ -247,7 +252,8 @@ let make = (
         // The buffer is sorted, so a log's items are consecutive: the first of
         // them is the only one that counts as an event.
         let isNewEvent =
-          idx === 0 || !(fetchState.buffer->Array.getUnsafe(idx - 1)->FetchState.isSameLog(item))
+          idx === 0 ||
+            !(fetchState.buffer->Array.getUnsafe(idx - 1)->FetchState.isSameLog(item))
         if isNewEvent {
           chainEventsProcessed := chainEventsProcessed.contents + 1
         }
@@ -265,6 +271,7 @@ let make = (
             ~mutCheckpointChainIds=checkpointChainIds,
             ~mutCheckpointBlockNumbers=checkpointBlockNumbers,
             ~mutCheckpointBlockHashes=checkpointBlockHashes,
+            ~mutCheckpointItemsCount=checkpointItemsCount,
             ~mutCheckpointEventsProcessed=checkpointEventsProcessed,
           )
 
@@ -283,14 +290,20 @@ let make = (
             },
           )
           ->ignore
+          checkpointItemsCount->Array.push(1)->ignore
           checkpointEventsProcessed->Array.push(1)->ignore
 
           prevBlockNumber := blockNumber
-        } else if isNewEvent {
-          let lastIndex = checkpointEventsProcessed->Array.length - 1
-          checkpointEventsProcessed
-          ->Array.setUnsafe(lastIndex, checkpointEventsProcessed->Array.getUnsafe(lastIndex) + 1)
+        } else {
+          let lastIndex = checkpointItemsCount->Array.length - 1
+          checkpointItemsCount
+          ->Array.setUnsafe(lastIndex, checkpointItemsCount->Array.getUnsafe(lastIndex) + 1)
           ->ignore
+          if isNewEvent {
+            checkpointEventsProcessed
+            ->Array.setUnsafe(lastIndex, checkpointEventsProcessed->Array.getUnsafe(lastIndex) + 1)
+            ->ignore
+          }
         }
 
         items->Array.push(item)->ignore
@@ -317,6 +330,7 @@ let make = (
       ~mutCheckpointChainIds=checkpointChainIds,
       ~mutCheckpointBlockNumbers=checkpointBlockNumbers,
       ~mutCheckpointBlockHashes=checkpointBlockHashes,
+      ~mutCheckpointItemsCount=checkpointItemsCount,
       ~mutCheckpointEventsProcessed=checkpointEventsProcessed,
     )
 
@@ -341,6 +355,7 @@ let make = (
     checkpointChainIds,
     checkpointBlockNumbers,
     checkpointBlockHashes,
+    checkpointItemsCount,
     checkpointEventsProcessed,
     registeredAddresses: [],
   }
@@ -356,30 +371,6 @@ let checkpointFrontier = (batch: t): Frontier.t => {
   frontier
 }
 
-// Exclusive end of the items belonging to the checkpoint at `checkpointIdx`,
-// starting from `fromItemIdx`. A checkpoint is one chain's one block, and a
-// batch takes whole blocks in order, so a checkpoint's items are the run at the
-// dispatch cursor that still carries its chain and block - a reorg-only
-// checkpoint's run is empty.
-let checkpointItemsEnd = (batch: t, ~checkpointIdx, ~fromItemIdx) => {
-  let chainId = batch.checkpointChainIds->Array.getUnsafe(checkpointIdx)
-  let blockNumber = batch.checkpointBlockNumbers->Array.getUnsafe(checkpointIdx)
-  let itemsLength = batch.items->Array.length
-  let idx = ref(fromItemIdx)
-  let isFinished = ref(false)
-  while !isFinished.contents && idx.contents < itemsLength {
-    let item = batch.items->Array.getUnsafe(idx.contents)
-    if (
-      item->Internal.getItemBlockNumber === blockNumber && item->Internal.getItemChainId === chainId
-    ) {
-      idx := idx.contents + 1
-    } else {
-      isFinished := true
-    }
-  }
-  idx.contents
-}
-
 let findFirstEventBlockNumber = (batch: t, ~chainId) => {
   let idx = ref(0)
   let result = ref(None)
@@ -388,7 +379,7 @@ let findFirstEventBlockNumber = (batch: t, ~chainId) => {
     let checkpointChainId = batch.checkpointChainIds->Array.getUnsafe(idx.contents)
     if (
       checkpointChainId === chainId &&
-        batch.checkpointEventsProcessed->Array.getUnsafe(idx.contents) > 0
+        batch.checkpointItemsCount->Array.getUnsafe(idx.contents) > 0
     ) {
       result := Some(batch.checkpointBlockNumbers->Array.getUnsafe(idx.contents))
     } else {

--- a/packages/envio/src/Batch.res
+++ b/packages/envio/src/Batch.res
@@ -42,8 +42,6 @@ type t = {
   checkpointChainIds: array<ChainId.t>,
   checkpointBlockNumbers: array<int>,
   checkpointBlockHashes: array<Null.t<string>>,
-  // Items the checkpoint carries, which is what indexes `items`.
-  checkpointItemsCount: array<int>,
   // Logs the checkpoint carries: one log routed to several registrations is one
   // event, however many items it made.
   checkpointEventsProcessed: array<int>,
@@ -165,7 +163,6 @@ let addReorgCheckpoints = (
   ~mutCheckpointChainIds,
   ~mutCheckpointBlockNumbers,
   ~mutCheckpointBlockHashes,
-  ~mutCheckpointItemsCount,
   ~mutCheckpointEventsProcessed,
 ) => {
   if shouldRollbackOnReorg {
@@ -187,7 +184,6 @@ let addReorgCheckpoints = (
       mutCheckpointChainIds->Array.push(chainId)
       mutCheckpointBlockNumbers->Array.push(blockNumber)
       mutCheckpointBlockHashes->Array.push(Null.Value(hash))
-      mutCheckpointItemsCount->Array.push(0)
       mutCheckpointEventsProcessed->Array.push(0)
 
       idx := idx.contents + 1
@@ -225,7 +221,6 @@ let make = (
   let checkpointChainIds = []
   let checkpointBlockNumbers = []
   let checkpointBlockHashes = []
-  let checkpointItemsCount = []
   let checkpointEventsProcessed = []
 
   // Accumulate items for all actively indexing chains
@@ -252,8 +247,7 @@ let make = (
         // The buffer is sorted, so a log's items are consecutive: the first of
         // them is the only one that counts as an event.
         let isNewEvent =
-          idx === 0 ||
-            !(fetchState.buffer->Array.getUnsafe(idx - 1)->FetchState.isSameLog(item))
+          idx === 0 || !(fetchState.buffer->Array.getUnsafe(idx - 1)->FetchState.isSameLog(item))
         if isNewEvent {
           chainEventsProcessed := chainEventsProcessed.contents + 1
         }
@@ -271,7 +265,6 @@ let make = (
             ~mutCheckpointChainIds=checkpointChainIds,
             ~mutCheckpointBlockNumbers=checkpointBlockNumbers,
             ~mutCheckpointBlockHashes=checkpointBlockHashes,
-            ~mutCheckpointItemsCount=checkpointItemsCount,
             ~mutCheckpointEventsProcessed=checkpointEventsProcessed,
           )
 
@@ -290,20 +283,14 @@ let make = (
             },
           )
           ->ignore
-          checkpointItemsCount->Array.push(1)->ignore
           checkpointEventsProcessed->Array.push(1)->ignore
 
           prevBlockNumber := blockNumber
-        } else {
-          let lastIndex = checkpointItemsCount->Array.length - 1
-          checkpointItemsCount
-          ->Array.setUnsafe(lastIndex, checkpointItemsCount->Array.getUnsafe(lastIndex) + 1)
+        } else if isNewEvent {
+          let lastIndex = checkpointEventsProcessed->Array.length - 1
+          checkpointEventsProcessed
+          ->Array.setUnsafe(lastIndex, checkpointEventsProcessed->Array.getUnsafe(lastIndex) + 1)
           ->ignore
-          if isNewEvent {
-            checkpointEventsProcessed
-            ->Array.setUnsafe(lastIndex, checkpointEventsProcessed->Array.getUnsafe(lastIndex) + 1)
-            ->ignore
-          }
         }
 
         items->Array.push(item)->ignore
@@ -330,7 +317,6 @@ let make = (
       ~mutCheckpointChainIds=checkpointChainIds,
       ~mutCheckpointBlockNumbers=checkpointBlockNumbers,
       ~mutCheckpointBlockHashes=checkpointBlockHashes,
-      ~mutCheckpointItemsCount=checkpointItemsCount,
       ~mutCheckpointEventsProcessed=checkpointEventsProcessed,
     )
 
@@ -355,7 +341,6 @@ let make = (
     checkpointChainIds,
     checkpointBlockNumbers,
     checkpointBlockHashes,
-    checkpointItemsCount,
     checkpointEventsProcessed,
     registeredAddresses: [],
   }
@@ -371,6 +356,30 @@ let checkpointFrontier = (batch: t): Frontier.t => {
   frontier
 }
 
+// Exclusive end of the items belonging to the checkpoint at `checkpointIdx`,
+// starting from `fromItemIdx`. A checkpoint is one chain's one block, and a
+// batch takes whole blocks in order, so a checkpoint's items are the run at the
+// dispatch cursor that still carries its chain and block - a reorg-only
+// checkpoint's run is empty.
+let checkpointItemsEnd = (batch: t, ~checkpointIdx, ~fromItemIdx) => {
+  let chainId = batch.checkpointChainIds->Array.getUnsafe(checkpointIdx)
+  let blockNumber = batch.checkpointBlockNumbers->Array.getUnsafe(checkpointIdx)
+  let itemsLength = batch.items->Array.length
+  let idx = ref(fromItemIdx)
+  let isFinished = ref(false)
+  while !isFinished.contents && idx.contents < itemsLength {
+    let item = batch.items->Array.getUnsafe(idx.contents)
+    if (
+      item->Internal.getItemBlockNumber === blockNumber && item->Internal.getItemChainId === chainId
+    ) {
+      idx := idx.contents + 1
+    } else {
+      isFinished := true
+    }
+  }
+  idx.contents
+}
+
 let findFirstEventBlockNumber = (batch: t, ~chainId) => {
   let idx = ref(0)
   let result = ref(None)
@@ -379,7 +388,7 @@ let findFirstEventBlockNumber = (batch: t, ~chainId) => {
     let checkpointChainId = batch.checkpointChainIds->Array.getUnsafe(idx.contents)
     if (
       checkpointChainId === chainId &&
-        batch.checkpointItemsCount->Array.getUnsafe(idx.contents) > 0
+        batch.checkpointEventsProcessed->Array.getUnsafe(idx.contents) > 0
     ) {
       result := Some(batch.checkpointBlockNumbers->Array.getUnsafe(idx.contents))
     } else {

--- a/packages/envio/src/Batch.res
+++ b/packages/envio/src/Batch.res
@@ -42,16 +42,24 @@ type t = {
   checkpointChainIds: array<ChainId.t>,
   checkpointBlockNumbers: array<int>,
   checkpointBlockHashes: array<Null.t<string>>,
+  // Items the checkpoint carries, which is what indexes `items`.
+  checkpointItemsCount: array<int>,
+  // Logs the checkpoint carries: one log routed to several registrations is one
+  // event, however many items it made.
   checkpointEventsProcessed: array<int>,
   registeredAddresses: array<AddressRows.staged>,
 }
+
+// What a chain contributed to the batch: items taken off its buffer, and the
+// logs behind them.
+type chainBatchCounts = {size: int, eventsProcessed: int}
 
 let getProgressedChainsById = {
   let getChainAfterBatchIfProgressed = (
     ~chainBeforeBatch: chainBeforeBatch,
     ~progressBlockNumberAfterBatch,
     ~fetchStateAfterBatch,
-    ~batchSize,
+    ~counts: chainBatchCounts,
   ) => {
     // The check is sufficient, since we guarantee to include a full block in a batch
     // Also, this might be true even if batchSize is 0,
@@ -60,10 +68,11 @@ let getProgressedChainsById = {
       Some(
         (
           {
-            batchSize,
+            batchSize: counts.size,
             progressBlockNumber: progressBlockNumberAfterBatch,
             sourceBlockNumber: chainBeforeBatch.sourceBlockNumber,
-            totalEventsProcessed: chainBeforeBatch.totalEventsProcessed +. batchSize->Int.toFloat,
+            totalEventsProcessed: chainBeforeBatch.totalEventsProcessed +.
+            counts.eventsProcessed->Int.toFloat,
             fetchState: fetchStateAfterBatch,
             isProgressAtHeadWhenBatchCreated: progressBlockNumberAfterBatch >=
             chainBeforeBatch.sourceBlockNumber - chainBeforeBatch.chainConfig.blockLag,
@@ -77,7 +86,7 @@ let getProgressedChainsById = {
 
   (
     ~chainsBeforeBatch: dict<chainBeforeBatch>,
-    ~batchSizePerChain: dict<int>,
+    ~countsPerChain: dict<chainBatchCounts>,
     ~progressBlockNumberPerChain: dict<int>,
   ) => {
     let progressedChainsById = Dict.make()
@@ -98,14 +107,14 @@ let getProgressedChainsById = {
       | None => chainBeforeBatch.progressBlockNumber
       }
 
-      switch switch batchSizePerChain->Utils.Dict.dangerouslyGetNonOption(
+      switch switch countsPerChain->Utils.Dict.dangerouslyGetNonOption(
         fetchState.chainId->ChainId.toString,
       ) {
-      | Some(batchSize) =>
-        let leftItems = fetchState.buffer->Array.slice(~start=batchSize)
+      | Some(counts) =>
+        let leftItems = fetchState.buffer->Array.slice(~start=counts.size)
         getChainAfterBatchIfProgressed(
           ~chainBeforeBatch,
-          ~batchSize,
+          ~counts,
           ~fetchStateAfterBatch=fetchState->FetchState.updateInternal(~mutItems=leftItems),
           ~progressBlockNumberAfterBatch,
         )
@@ -113,7 +122,7 @@ let getProgressedChainsById = {
       | None =>
         getChainAfterBatchIfProgressed(
           ~chainBeforeBatch,
-          ~batchSize=0,
+          ~counts={size: 0, eventsProcessed: 0},
           ~fetchStateAfterBatch=chainBeforeBatch.fetchState,
           ~progressBlockNumberAfterBatch,
         )
@@ -156,6 +165,7 @@ let addReorgCheckpoints = (
   ~mutCheckpointChainIds,
   ~mutCheckpointBlockNumbers,
   ~mutCheckpointBlockHashes,
+  ~mutCheckpointItemsCount,
   ~mutCheckpointEventsProcessed,
 ) => {
   if shouldRollbackOnReorg {
@@ -177,6 +187,7 @@ let addReorgCheckpoints = (
       mutCheckpointChainIds->Array.push(chainId)
       mutCheckpointBlockNumbers->Array.push(blockNumber)
       mutCheckpointBlockHashes->Array.push(Null.Value(hash))
+      mutCheckpointItemsCount->Array.push(0)
       mutCheckpointEventsProcessed->Array.push(0)
 
       idx := idx.contents + 1
@@ -206,7 +217,7 @@ let make = (
   let totalBatchSize = ref(0)
 
   let cursor = sequence->CheckpointSequence.cursor(~frontier)
-  let mutBatchSizePerChain = Dict.make()
+  let mutCountsPerChain = Dict.make()
   let mutProgressBlockNumberPerChain = Dict.make()
 
   let items = []
@@ -214,6 +225,7 @@ let make = (
   let checkpointChainIds = []
   let checkpointBlockNumbers = []
   let checkpointBlockHashes = []
+  let checkpointItemsCount = []
   let checkpointEventsProcessed = []
 
   // Accumulate items for all actively indexing chains
@@ -232,10 +244,19 @@ let make = (
       ->Option.getUnsafe
 
     let prevBlockNumber = ref(chainBeforeBatch.progressBlockNumber)
+    let chainEventsProcessed = ref(0)
     if chainBatchSize > 0 {
       for idx in 0 to chainBatchSize - 1 {
         let item = fetchState.buffer->Array.getUnsafe(idx)
         let blockNumber = item->Internal.getItemBlockNumber
+        // The buffer is sorted, so a log's items are consecutive: the first of
+        // them is the only one that counts as an event.
+        let isNewEvent =
+          idx === 0 ||
+            !(fetchState.buffer->Array.getUnsafe(idx - 1)->FetchState.isSameLog(item))
+        if isNewEvent {
+          chainEventsProcessed := chainEventsProcessed.contents + 1
+        }
 
         // Every new block we should create a new checkpoint
         if blockNumber !== prevBlockNumber.contents {
@@ -250,6 +271,7 @@ let make = (
             ~mutCheckpointChainIds=checkpointChainIds,
             ~mutCheckpointBlockNumbers=checkpointBlockNumbers,
             ~mutCheckpointBlockHashes=checkpointBlockHashes,
+            ~mutCheckpointItemsCount=checkpointItemsCount,
             ~mutCheckpointEventsProcessed=checkpointEventsProcessed,
           )
 
@@ -268,21 +290,30 @@ let make = (
             },
           )
           ->ignore
+          checkpointItemsCount->Array.push(1)->ignore
           checkpointEventsProcessed->Array.push(1)->ignore
 
           prevBlockNumber := blockNumber
         } else {
-          let lastIndex = checkpointEventsProcessed->Array.length - 1
-          checkpointEventsProcessed
-          ->Array.setUnsafe(lastIndex, checkpointEventsProcessed->Array.getUnsafe(lastIndex) + 1)
+          let lastIndex = checkpointItemsCount->Array.length - 1
+          checkpointItemsCount
+          ->Array.setUnsafe(lastIndex, checkpointItemsCount->Array.getUnsafe(lastIndex) + 1)
           ->ignore
+          if isNewEvent {
+            checkpointEventsProcessed
+            ->Array.setUnsafe(lastIndex, checkpointEventsProcessed->Array.getUnsafe(lastIndex) + 1)
+            ->ignore
+          }
         }
 
         items->Array.push(item)->ignore
       }
 
       totalBatchSize := totalBatchSize.contents + chainBatchSize
-      mutBatchSizePerChain->ChainId.Dict.set(fetchState.chainId, chainBatchSize)
+      mutCountsPerChain->ChainId.Dict.set(
+        fetchState.chainId,
+        {size: chainBatchSize, eventsProcessed: chainEventsProcessed.contents},
+      )
     }
 
     let progressBlockNumberAfterBatch =
@@ -299,6 +330,7 @@ let make = (
       ~mutCheckpointChainIds=checkpointChainIds,
       ~mutCheckpointBlockNumbers=checkpointBlockNumbers,
       ~mutCheckpointBlockHashes=checkpointBlockHashes,
+      ~mutCheckpointItemsCount=checkpointItemsCount,
       ~mutCheckpointEventsProcessed=checkpointEventsProcessed,
     )
 
@@ -315,7 +347,7 @@ let make = (
     items,
     progressedChainsById: getProgressedChainsById(
       ~chainsBeforeBatch,
-      ~batchSizePerChain=mutBatchSizePerChain,
+      ~countsPerChain=mutCountsPerChain,
       ~progressBlockNumberPerChain=mutProgressBlockNumberPerChain,
     ),
     history,
@@ -323,6 +355,7 @@ let make = (
     checkpointChainIds,
     checkpointBlockNumbers,
     checkpointBlockHashes,
+    checkpointItemsCount,
     checkpointEventsProcessed,
     registeredAddresses: [],
   }
@@ -346,7 +379,7 @@ let findFirstEventBlockNumber = (batch: t, ~chainId) => {
     let checkpointChainId = batch.checkpointChainIds->Array.getUnsafe(idx.contents)
     if (
       checkpointChainId === chainId &&
-        batch.checkpointEventsProcessed->Array.getUnsafe(idx.contents) > 0
+        batch.checkpointItemsCount->Array.getUnsafe(idx.contents) > 0
     ) {
       result := Some(batch.checkpointBlockNumbers->Array.getUnsafe(idx.contents))
     } else {

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -157,10 +157,10 @@ let preloadBatchOrThrow = async (
 
   for checkpointIdx in 0 to batch.checkpointIds->Array.length - 1 {
     let checkpointId = batch.checkpointIds->Array.getUnsafe(checkpointIdx)
-    let itemsEnd = batch->Batch.checkpointItemsEnd(~checkpointIdx, ~fromItemIdx=itemIdx.contents)
+    let checkpointItemsCount = batch.checkpointItemsCount->Array.getUnsafe(checkpointIdx)
 
-    for idx in itemIdx.contents to itemsEnd - 1 {
-      let item = batch.items->Array.getUnsafe(idx)
+    for idx in 0 to checkpointItemsCount - 1 {
+      let item = batch.items->Array.getUnsafe(itemIdx.contents + idx)
       switch item {
       | Event(_) =>
         let {handler, eventConfig: {contractName, name: eventName}} = (
@@ -233,7 +233,7 @@ let preloadBatchOrThrow = async (
       }
     }
 
-    itemIdx := itemsEnd
+    itemIdx := itemIdx.contents + checkpointItemsCount
   }
 
   let _ = await Promise.all(promises)
@@ -251,10 +251,10 @@ let runBatchHandlersOrThrow = async (
 
   for checkpointIdx in 0 to batch.checkpointIds->Array.length - 1 {
     let checkpointId = batch.checkpointIds->Array.getUnsafe(checkpointIdx)
-    let itemsEnd = batch->Batch.checkpointItemsEnd(~checkpointIdx, ~fromItemIdx=itemIdx.contents)
+    let checkpointItemsCount = batch.checkpointItemsCount->Array.getUnsafe(checkpointIdx)
 
-    for idx in itemIdx.contents to itemsEnd - 1 {
-      let item = batch.items->Array.getUnsafe(idx)
+    for idx in 0 to checkpointItemsCount - 1 {
+      let item = batch.items->Array.getUnsafe(itemIdx.contents + idx)
 
       await runHandlerOrThrow(
         item,
@@ -266,7 +266,7 @@ let runBatchHandlersOrThrow = async (
         ~chains,
       )
     }
-    itemIdx := itemsEnd
+    itemIdx := itemIdx.contents + checkpointItemsCount
   }
 }
 

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -157,10 +157,10 @@ let preloadBatchOrThrow = async (
 
   for checkpointIdx in 0 to batch.checkpointIds->Array.length - 1 {
     let checkpointId = batch.checkpointIds->Array.getUnsafe(checkpointIdx)
-    let checkpointItemsCount = batch.checkpointItemsCount->Array.getUnsafe(checkpointIdx)
+    let itemsEnd = batch->Batch.checkpointItemsEnd(~checkpointIdx, ~fromItemIdx=itemIdx.contents)
 
-    for idx in 0 to checkpointItemsCount - 1 {
-      let item = batch.items->Array.getUnsafe(itemIdx.contents + idx)
+    for idx in itemIdx.contents to itemsEnd - 1 {
+      let item = batch.items->Array.getUnsafe(idx)
       switch item {
       | Event(_) =>
         let {handler, eventConfig: {contractName, name: eventName}} = (
@@ -233,7 +233,7 @@ let preloadBatchOrThrow = async (
       }
     }
 
-    itemIdx := itemIdx.contents + checkpointItemsCount
+    itemIdx := itemsEnd
   }
 
   let _ = await Promise.all(promises)
@@ -251,10 +251,10 @@ let runBatchHandlersOrThrow = async (
 
   for checkpointIdx in 0 to batch.checkpointIds->Array.length - 1 {
     let checkpointId = batch.checkpointIds->Array.getUnsafe(checkpointIdx)
-    let checkpointItemsCount = batch.checkpointItemsCount->Array.getUnsafe(checkpointIdx)
+    let itemsEnd = batch->Batch.checkpointItemsEnd(~checkpointIdx, ~fromItemIdx=itemIdx.contents)
 
-    for idx in 0 to checkpointItemsCount - 1 {
-      let item = batch.items->Array.getUnsafe(itemIdx.contents + idx)
+    for idx in itemIdx.contents to itemsEnd - 1 {
+      let item = batch.items->Array.getUnsafe(idx)
 
       await runHandlerOrThrow(
         item,
@@ -266,7 +266,7 @@ let runBatchHandlersOrThrow = async (
         ~chains,
       )
     }
-    itemIdx := itemIdx.contents + checkpointItemsCount
+    itemIdx := itemsEnd
   }
 }
 

--- a/packages/envio/src/EventProcessing.res
+++ b/packages/envio/src/EventProcessing.res
@@ -157,9 +157,9 @@ let preloadBatchOrThrow = async (
 
   for checkpointIdx in 0 to batch.checkpointIds->Array.length - 1 {
     let checkpointId = batch.checkpointIds->Array.getUnsafe(checkpointIdx)
-    let checkpointEventsProcessed = batch.checkpointEventsProcessed->Array.getUnsafe(checkpointIdx)
+    let checkpointItemsCount = batch.checkpointItemsCount->Array.getUnsafe(checkpointIdx)
 
-    for idx in 0 to checkpointEventsProcessed - 1 {
+    for idx in 0 to checkpointItemsCount - 1 {
       let item = batch.items->Array.getUnsafe(itemIdx.contents + idx)
       switch item {
       | Event(_) =>
@@ -233,7 +233,7 @@ let preloadBatchOrThrow = async (
       }
     }
 
-    itemIdx := itemIdx.contents + checkpointEventsProcessed
+    itemIdx := itemIdx.contents + checkpointItemsCount
   }
 
   let _ = await Promise.all(promises)
@@ -251,9 +251,9 @@ let runBatchHandlersOrThrow = async (
 
   for checkpointIdx in 0 to batch.checkpointIds->Array.length - 1 {
     let checkpointId = batch.checkpointIds->Array.getUnsafe(checkpointIdx)
-    let checkpointEventsProcessed = batch.checkpointEventsProcessed->Array.getUnsafe(checkpointIdx)
+    let checkpointItemsCount = batch.checkpointItemsCount->Array.getUnsafe(checkpointIdx)
 
-    for idx in 0 to checkpointEventsProcessed - 1 {
+    for idx in 0 to checkpointItemsCount - 1 {
       let item = batch.items->Array.getUnsafe(itemIdx.contents + idx)
 
       await runHandlerOrThrow(
@@ -266,7 +266,7 @@ let runBatchHandlersOrThrow = async (
         ~chains,
       )
     }
-    itemIdx := itemIdx.contents + checkpointEventsProcessed
+    itemIdx := itemIdx.contents + checkpointItemsCount
   }
 }
 

--- a/packages/envio/src/FetchState.res
+++ b/packages/envio/src/FetchState.res
@@ -979,6 +979,20 @@ let compareBufferItem = (a: Internal.item, b: Internal.item): int => {
   }
 }
 
+// Whether two adjacent buffer items came from one log routed to two
+// registrations: everything `compareBufferItem` orders on except the
+// registration index is equal. Only meaningful on neighbours of a sorted
+// buffer, where such items sit next to each other.
+let isSameLog = (a: Internal.item, b: Internal.item): bool =>
+  a->Internal.getItemKind === 0 &&
+  b->Internal.getItemKind === 0 &&
+  a->Internal.getItemBlockNumber === b->Internal.getItemBlockNumber &&
+  a->Internal.getItemLogIndex === b->Internal.getItemLogIndex &&
+  switch (a->Internal.getItemOrderPath, b->Internal.getItemOrderPath) {
+  | (Value(pa), Value(pb)) => comparePath(pa, pb) === 0
+  | _ => true
+  }
+
 // Merge a maybe-unsorted `newItems` run into the already-sorted, already-deduped
 // `buffer`, dropping items equal on every component of `compareBufferItem`.
 // Single linear pass over both runs after ordering `newItems` in place; every

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -774,7 +774,6 @@ let drainBatchRun = (state: t): Batch.t => {
   let checkpointChainIds = []
   let checkpointBlockNumbers = []
   let checkpointBlockHashes = []
-  let checkpointItemsCount = []
   let checkpointEventsProcessed = []
   let registeredAddresses = []
   all->Array.forEach(batch => {
@@ -789,7 +788,6 @@ let drainBatchRun = (state: t): Batch.t => {
       checkpointChainIds->Array.pushMany(batch.checkpointChainIds)
       checkpointBlockNumbers->Array.pushMany(batch.checkpointBlockNumbers)
       checkpointBlockHashes->Array.pushMany(batch.checkpointBlockHashes)
-      checkpointItemsCount->Array.pushMany(batch.checkpointItemsCount)
       checkpointEventsProcessed->Array.pushMany(batch.checkpointEventsProcessed)
       registeredAddresses->Array.pushMany(batch.registeredAddresses)
     } else {
@@ -807,7 +805,6 @@ let drainBatchRun = (state: t): Batch.t => {
     checkpointChainIds,
     checkpointBlockNumbers,
     checkpointBlockHashes,
-    checkpointItemsCount,
     checkpointEventsProcessed,
     registeredAddresses,
   }

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -774,6 +774,7 @@ let drainBatchRun = (state: t): Batch.t => {
   let checkpointChainIds = []
   let checkpointBlockNumbers = []
   let checkpointBlockHashes = []
+  let checkpointItemsCount = []
   let checkpointEventsProcessed = []
   let registeredAddresses = []
   all->Array.forEach(batch => {
@@ -788,6 +789,7 @@ let drainBatchRun = (state: t): Batch.t => {
       checkpointChainIds->Array.pushMany(batch.checkpointChainIds)
       checkpointBlockNumbers->Array.pushMany(batch.checkpointBlockNumbers)
       checkpointBlockHashes->Array.pushMany(batch.checkpointBlockHashes)
+      checkpointItemsCount->Array.pushMany(batch.checkpointItemsCount)
       checkpointEventsProcessed->Array.pushMany(batch.checkpointEventsProcessed)
       registeredAddresses->Array.pushMany(batch.registeredAddresses)
     } else {
@@ -805,6 +807,7 @@ let drainBatchRun = (state: t): Batch.t => {
     checkpointChainIds,
     checkpointBlockNumbers,
     checkpointBlockHashes,
+    checkpointItemsCount,
     checkpointEventsProcessed,
     registeredAddresses,
   }

--- a/packages/envio/src/IndexerState.res
+++ b/packages/envio/src/IndexerState.res
@@ -776,6 +776,7 @@ let drainBatchRun = (state: t): Batch.t => {
   let checkpointChainIds = []
   let checkpointBlockNumbers = []
   let checkpointBlockHashes = []
+  let checkpointItemsCount = []
   let checkpointEventsProcessed = []
   let registeredAddresses = []
   all->Array.forEach(batch => {
@@ -790,6 +791,7 @@ let drainBatchRun = (state: t): Batch.t => {
       checkpointChainIds->Array.pushMany(batch.checkpointChainIds)
       checkpointBlockNumbers->Array.pushMany(batch.checkpointBlockNumbers)
       checkpointBlockHashes->Array.pushMany(batch.checkpointBlockHashes)
+      checkpointItemsCount->Array.pushMany(batch.checkpointItemsCount)
       checkpointEventsProcessed->Array.pushMany(batch.checkpointEventsProcessed)
       registeredAddresses->Array.pushMany(batch.registeredAddresses)
     } else {
@@ -807,6 +809,7 @@ let drainBatchRun = (state: t): Batch.t => {
     checkpointChainIds,
     checkpointBlockNumbers,
     checkpointBlockHashes,
+    checkpointItemsCount,
     checkpointEventsProcessed,
     registeredAddresses,
   }


### PR DESCRIPTION
## Summary

When a single log is routed to multiple event handler registrations, it now counts as one processed event rather than multiple. Previously, the `eventsProcessed` metric counted handler invocations; now it counts unique logs.

## Changes

- **Batch.res**: Introduced `chainBatchCounts` type to track both items (handler invocations) and events (unique logs) separately. Added `checkpointItemsCount` array to record items per checkpoint, while `checkpointEventsProcessed` now tracks only unique logs.

- **FetchState.res**: Added `isSameLog` function to detect when adjacent buffer items originated from the same log routed to different registrations by comparing block number, log index, and order path (all components except registration index).

- **Batch.make**: Modified batch construction to count unique events by checking if each item is the first occurrence of its log. Only the first item from a log increments `eventsProcessed`; all items increment `checkpointItemsCount`.

- **EventProcessing.res**: Updated preload and handler execution loops to iterate over `checkpointItemsCount` (items) instead of `checkpointEventsProcessed` (events), ensuring all handler invocations run while metrics reflect unique logs.

- **IndexerState.res**: Updated batch draining to include `checkpointItemsCount` when merging batches.

- **Test files**: Updated test batch fixtures to include the new `checkpointItemsCount` field.

- **EventsProcessedDedup_test.res**: Added comprehensive test verifying that one log routed to two handlers counts as 1 event but triggers 2 handler invocations, and that multiple logs in a block are counted correctly.

https://claude.ai/code/session_01QBYqZHkL9FVmSWfDDW1i1o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event processing for logs handled by multiple registrations, ensuring each log is counted once while all applicable updates are applied.
  - Improved checkpoint tracking to maintain accurate event and item processing across blocks, reorgs, and state recovery.
  - Corrected processing and accounting for multiple logs within the same block.

- **Tests**
  - Added coverage for duplicate handler routing, multiple events in a single block, and related checkpoint tracking scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->