### PR TITLE
Mask API token input in interactive init prompt

### DIFF
--- a/packages/cli/src/cli_args/interactive_init/mod.rs
+++ b/packages/cli/src/cli_args/interactive_init/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     init_config::{evm, fuel, Ecosystem},
 };
 use anyhow::{Context, Result};
-use inquire::{Select, Text};
+use inquire::{Password, PasswordDisplayMode, Select, Text};
 use strum::{Display, EnumIter, IntoEnumIterator};
 use validation::{
     contains_no_whitespace_validator, is_directory_new_validator, is_valid_folder_name,
@@ -340,7 +340,9 @@ pub async fn prompt_missing_init_args(
             .prompt()
             .context("Prompting for add API token")?;
 
-            let token_prompt = Text::new("Add your API token: ")
+            let token_prompt = Password::new("Add your API token: ")
+                .with_display_mode(PasswordDisplayMode::Masked)
+                .without_confirmation()
                 .with_help_message("See tokens at: https://envio.dev/app/api-tokens");
 
             match select {


### PR DESCRIPTION
## Summary
Improve security of the interactive initialization flow by masking the API token input, preventing the token from being visible on screen as it's typed.

## Changes
- Replace `Text` input with `Password` input for the API token prompt
- Configure password field to use masked display mode (characters hidden as typed)
- Disable confirmation prompt (single entry sufficient for token input)
- Maintain existing help message pointing to token management page

## Implementation Details
The API token prompt now uses `inquire::Password` with `PasswordDisplayMode::Masked` and `.without_confirmation()` to provide a secure input experience similar to password fields in typical CLI applications.

https://claude.ai/code/session_01TA18oyMNZJgtDyh3rv5MBw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * API tokens are now entered through a masked password prompt for improved privacy.
  * Token confirmation is no longer required during interactive setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->